### PR TITLE
[NETBEANS-320] Mac modal dialogs pop-under non-modal dialogs

### DIFF
--- a/core.windows/src/org/netbeans/core/windows/Constants.java
+++ b/core.windows/src/org/netbeans/core/windows/Constants.java
@@ -21,6 +21,7 @@ package org.netbeans.core.windows;
 
 import java.awt.Dimension;
 import javax.swing.JSplitPane;
+import org.netbeans.core.windows.services.DialogDisplayerImpl;
 import org.netbeans.swing.tabcontrol.TabbedContainer;
 import org.openide.windows.TopComponent;
 
@@ -157,6 +158,14 @@ public abstract class Constants {
      *  When JDK-8163591 is fixed, the default may be revisited.
      *  @see java.awt.Window#isAutoRequestFocus() */
     public static final boolean AUTO_FOCUS = System.getProperty("netbeans.winsys.auto_focus") == null || Boolean.getBoolean("netbeans.winsys.auto_focus"); // NOI18N
+
+    /**
+     * Whether or not we should avoid using Dialogs as Dialog parents in
+     * {@link DialogDisplayerImpl}. For backwards compatability. See
+     * NETBEANS-320 (Mac modal dialogs pop-under non-modal dialogs)
+     */
+    public static final boolean DISALLOW_DIALOG_PARENTS = Boolean.
+            getBoolean("netbeans.winsys.disallow_dialog_parents");//NOI18N
 
     private Constants() {}
 }

--- a/core.windows/src/org/netbeans/core/windows/services/DialogDisplayerImpl.java
+++ b/core.windows/src/org/netbeans/core/windows/services/DialogDisplayerImpl.java
@@ -40,6 +40,7 @@ import javax.swing.JRootPane;
 import javax.swing.SwingUtilities;
 import org.netbeans.core.windows.Constants;
 import org.netbeans.core.windows.view.ui.DefaultSeparateContainer;
+import org.openide.Leafable;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -125,7 +126,7 @@ public class DialogDisplayerImpl extends DialogDisplayer {
                                     w = WindowManager.getDefault ().getMainWindow ();
                                 }
                             }
-                        } else if (w instanceof NbPresenter && ((NbPresenter) w).isLeaf ()) {
+                        } else if (isWindowLeaf(w)) {
                             w = WindowManager.getDefault ().getMainWindow ();
                         }
                     }
@@ -206,8 +207,9 @@ public class DialogDisplayerImpl extends DialogDisplayer {
                                 getActiveWindow();
                         Window w = activeWindow != null ? activeWindow :
                                 WindowManager.getDefault().getMainWindow();
-                        if (Constants.DISALLOW_DIALOG_PARENTS &&
-                                w instanceof Dialog){
+                        boolean isLeaf = isWindowLeaf(w);
+                        if (isLeaf || (Constants.DISALLOW_DIALOG_PARENTS &&
+                                w instanceof Dialog)){
                             w = WindowManager.getDefault().getMainWindow();
                         }
                         if (noParent) {
@@ -236,8 +238,13 @@ public class DialogDisplayerImpl extends DialogDisplayer {
                                 getActiveWindow();
                         Window w = activeWindow != null ? activeWindow :
                                 WindowManager.getDefault().getMainWindow();
-                        if (Constants.DISALLOW_DIALOG_PARENTS &&
-                                w instanceof Dialog){
+                        if (!w.isVisible() || !w.isDisplayable()){
+                            //why is an invisible window the active window?
+                            w = WindowManager.getDefault().getMainWindow();
+                        }
+                        boolean isLeaf = isWindowLeaf(w);
+                        if (isLeaf || (Constants.DISALLOW_DIALOG_PARENTS &&
+                                w instanceof Dialog)){
                             w = WindowManager.getDefault().getMainWindow();
                         }
                         if (noParent) {
@@ -337,5 +344,17 @@ public class DialogDisplayerImpl extends DialogDisplayer {
         for (PresenterDecorator p : Lookup.getDefault().lookupAll(PresenterDecorator.class)) {
             p.customizePresenter(presenter);
         }
+    }
+    /**
+     * Should the given window ever be considered a dialog parent?
+     * @param w
+     * @return 
+     */
+    private boolean isWindowLeaf(Window w) {
+        boolean isLeaf = w instanceof Leafable && ((Leafable)w).isLeaf();
+        if (!isLeaf && !(w instanceof Frame || w instanceof Dialog)){
+            isLeaf = true;
+        }
+        return isLeaf;
     }
 }

--- a/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
+++ b/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
@@ -84,6 +84,7 @@ import javax.swing.plaf.basic.BasicLookAndFeel;
 import javax.swing.plaf.metal.MetalLookAndFeel;
 import org.netbeans.core.windows.Constants;
 import org.openide.DialogDescriptor;
+import org.openide.Leafable;
 import org.openide.NotificationLineSupport;
 import org.openide.NotifyDescriptor;
 import org.openide.WizardDescriptor;
@@ -103,7 +104,8 @@ import org.openide.util.Utilities;
  * @author Ian Formanek, Jaroslav Tulach
  */
 class NbPresenter extends JDialog
-implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparator<Object> {
+        implements PropertyChangeListener, WindowListener, Mutex.Action<Void>,
+        Comparator<Object>, Leafable {
     
     /** variable holding current modal dialog in the system */
     public static NbPresenter currentModalDialog;
@@ -188,7 +190,8 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         initialize(d);
     }
     
-    boolean isLeaf () {
+    @Override
+    public boolean isLeaf () {
         return leaf;
     }
     

--- a/openide.dialogs/manifest.mf
+++ b/openide.dialogs/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.dialogs
-OpenIDE-Module-Specification-Version: 7.43
+OpenIDE-Module-Specification-Version: 7.44
 OpenIDE-Module-Localizing-Bundle: org/openide/Bundle.properties
 AutoUpdate-Essential-Module: true
 

--- a/openide.dialogs/nbproject/project.properties
+++ b/openide.dialogs/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 #javadoc.main.page=org/openide/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/openide.dialogs/src/org/openide/Leafable.java
+++ b/openide.dialogs/src/org/openide/Leafable.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide;
+
+import java.awt.Window;
+
+/**
+ * An interface that determines whether or not a {@link Window} may be a parent
+ * for a dialog created by a {@link DialogDisplayer}
+ * @author astephens
+ */
+public interface Leafable {
+    default boolean isLeaf(){
+        return true;
+    }
+}

--- a/progress.ui/src/org/netbeans/modules/progress/ui/StatusLineComponent.java
+++ b/progress.ui/src/org/netbeans/modules/progress/ui/StatusLineComponent.java
@@ -68,6 +68,7 @@ import org.netbeans.modules.progress.spi.ProgressEvent;
 import org.netbeans.modules.progress.spi.ProgressUIWorkerWithModel;
 import org.netbeans.modules.progress.spi.TaskModel;
 import org.openide.DialogDisplayer;
+import org.openide.Leafable;
 import org.openide.NotifyDescriptor;
 import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
@@ -502,7 +503,18 @@ public class StatusLineComponent extends JPanel implements ProgressUIWorkerWithM
         // 2. on mac, needs an owner frame otherwise hiding tooltip also hides the popup. (linux requires no owner frame to force heavyweight)
         // 3. the created window is not focusable window
         if (popupWindow == null) {
-            popupWindow = new JWindow(WindowManager.getDefault().getMainWindow());
+            class ProgressPopUpWindow extends JWindow implements Leafable{
+                ProgressPopUpWindow(Frame parent) {
+                    super(parent);
+                }
+                @Override
+                public boolean isLeaf() {
+                    //never a parent
+                    return true;
+                }
+            }
+            popupWindow = new ProgressPopUpWindow(WindowManager.getDefault().
+                    getMainWindow());
             popupWindow.getContentPane().add(pane);
         }
         Toolkit.getDefaultToolkit().addAWTEventListener(hideListener, AWTEvent.MOUSE_EVENT_MASK);


### PR DESCRIPTION
Fixed that bug. To use the old behavior set the property “netbeans.winsys.disallow_dialog_parents” to true
Would write test, but I don’t know how one would write a test for that…