### PR TITLE
[NETBEANS-1074] Module Review j2ee.ant

### DIFF
--- a/j2ee.ant/l10n.list
+++ b/j2ee.ant/l10n.list
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 # j2ee/samples
 read global
 ${l10n-module}/antsrc/**/Bundle*.properties


### PR DESCRIPTION
Please Advise: 

The file changed is "l10n.list" 
In the [document](https://cwiki.apache.org/confluence/display/NETBEANS/List+of+Modules+to+Review), this type of files listed under "Problems to be solved centrally" and crossed out saying "(done)"
Does it mean the file needs not to be committed separately and can be licensed centrally?
By referring to several other modules of the first donation, noticed the license is present in those files, So decided to submit this PR and ask for an advise.