### PR TITLE
Fixes the 8.2 Plugin Portal URL and sets it to the certified plugins

### DIFF
--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
@@ -34,7 +34,7 @@ URL_Default_N=http://updates.netbeans.org/netbeans/updates/dev/uc/final/main/cat
 #NOI18N
 URL_PluginPortal=http://plugins.netbeans.org/nbpluginportal/updates/10.0/catalog.xml.gz
 #NOI18N
-URL_82PluginPortal=http://updates.netbeans.org/netbeans/updates/8.2/uc/final/distribution/catalog.xml.gz
+URL_82PluginPortal=http://updates.netbeans.org/netbeans/updates/8.2/uc/final/certified/catalog.xml.gz
 
 3rdparty=3rd Party Libraries
 #NOI18N


### PR DESCRIPTION
The old URL was the 8.2 distribution (not plugin) URL as far as I can tell.