### PR TITLE
NETBEANS-1744: Support Run/Debug Focused Test Method for @Nested JUni…

### DIFF
--- a/ide/projectapi/src/org/netbeans/spi/project/SingleMethod.java
+++ b/ide/projectapi/src/org/netbeans/spi/project/SingleMethod.java
@@ -19,6 +19,8 @@
 
 package org.netbeans.spi.project;
 
+import java.util.Objects;
+import java.util.Optional;
 import org.openide.filesystems.FileObject;
 
 /**
@@ -29,8 +31,9 @@ import org.openide.filesystems.FileObject;
  */
 public final class SingleMethod {
 
-    private FileObject file;
-    private String methodName;
+    private final FileObject file;
+    private final String methodName;
+    private String binaryClassName;
 
     /**
      * Creates a new instance holding the specified identification
@@ -43,7 +46,20 @@ public final class SingleMethod {
      * @since 1.19
      */
     public SingleMethod(FileObject file, String methodName) {
-        super();
+        this(file, null, methodName);
+    }
+    
+    /**
+     * Creates a new instance holding the specified identification
+     * of a method/function in a file.
+     *
+     * @param file file to be kept in the object
+     * @param binaryClassName The binary class name of the class containing the method (as returned by {@link Class#getName()})
+     * @param methodName name of a method inside the file
+     * @exception  java.lang.IllegalArgumentException
+     *             if the file or method name is {@code null}
+     */
+    public SingleMethod(FileObject file, String binaryClassName, String methodName) {
         if (file == null) {
             throw new IllegalArgumentException("file is <null>");
         }
@@ -51,6 +67,7 @@ public final class SingleMethod {
             throw new IllegalArgumentException("methodName is <null>");
         }
         this.file = file;
+        this.binaryClassName = binaryClassName;
         this.methodName = methodName;
     }
 
@@ -64,6 +81,15 @@ public final class SingleMethod {
         return file;
     }
 
+    /**
+     * Returns the binary class name of the class containing the method.
+     
+     * @return Class name held by this object
+     */
+    public Optional<String> getBinaryClassName() {
+        return Optional.ofNullable(binaryClassName);
+    }
+    
     /**
      * Returns name of a method/function within the file.
      *
@@ -94,13 +120,16 @@ public final class SingleMethod {
             return false;
         }
         SingleMethod other = (SingleMethod) obj;
-        return other.file.equals(file) && other.methodName.equals(methodName);
+        return other.file.equals(file)
+            && Objects.equals(other.binaryClassName, binaryClassName)
+            && other.methodName.equals(methodName);
     }
 
     @Override
     public int hashCode() {
         int hash = 7;
         hash = 29 * hash + this.file.hashCode();
+        hash = 29 * hash + Objects.hashCode(binaryClassName);
         hash = 29 * hash + this.methodName.hashCode();
         return hash;
     }

--- a/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/UIJavaUtils.java
+++ b/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/api/UIJavaUtils.java
@@ -326,7 +326,7 @@ public final class UIJavaUtils {
                 try {
                     EditorCookie ed = file.getLookup().lookup(EditorCookie.class);
                     if (ed != null) {
-                        if (lineNum == -1) {
+                        if (lineNum <= 0) {
                             // OK, just open it.
                             ed.open();
                         } else {

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestSingleMethodSupport.java
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/actions/TestSingleMethodSupport.java
@@ -85,7 +85,7 @@ public class TestSingleMethodSupport {
             try {
                 Future<Void> f = js.runWhenScanFinished(task, true);
                 if (f.isDone() && task.getFileObject() != null && task.getMethodName() != null){
-                    sm = new SingleMethod(task.getFileObject(), task.getMethodName());
+                    sm = new SingleMethod(task.getFileObject(), task.getClassName(), task.getMethodName());
                 }
             } catch (IOException ex) {
                 LOGGER.log(Level.WARNING, null, ex);

--- a/java/junit/src/org/netbeans/modules/junit/api/JUnitTestcase.java
+++ b/java/junit/src/org/netbeans/modules/junit/api/JUnitTestcase.java
@@ -60,7 +60,7 @@ public class JUnitTestcase extends Testcase{
         }
         String suiteName = currentSuite.getName();
         // if the running suite is actually a test file return just the method name
-        if(suiteName == null || suiteName.equals(className)) {
+        if(suiteName == null || suiteName.equals(className.split("\\$")[0])) {
             return super.getName();
         }
         // the running suite is actually a suite, so return method's full path

--- a/java/maven.junit.ui/nbproject/project.properties
+++ b/java/maven.junit.ui/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 requires.nb.javac=true

--- a/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitTestMethodNode.java
+++ b/java/maven.junit.ui/src/org/netbeans/modules/maven/junit/ui/MavenJUnitTestMethodNode.java
@@ -89,7 +89,7 @@ public class MavenJUnitTestMethodNode extends JUnitTestMethodNode {
                         }
                     }
 
-                    SingleMethod methodSpec = new SingleMethod(testFO, testcase.getName());
+                    SingleMethod methodSpec = new SingleMethod(testFO, testcase.getClassName(), testcase.getName());
                     Lookup nodeContext = Lookups.singleton(methodSpec);
                     if (runSupported && actionProvider.isActionEnabled(COMMAND_RUN_SINGLE_METHOD,
                             nodeContext)) {
@@ -119,7 +119,7 @@ public class MavenJUnitTestMethodNode extends JUnitTestMethodNode {
             Logger.getLogger(MavenJUnitTestMethodNode.class.getName()).log(Level.WARNING, "no LineConvertors.FileLocator available for project {0}", getProject().getProjectDirectory());
         }
         if(testcase == null) {
-            Logger.getLogger(MavenJUnitTestMethodNode.class.getName()).log(Level.WARNING, "null tescase in MavenJUnitTestMethodNode for project {0}", getProject().getProjectDirectory());            
+            Logger.getLogger(MavenJUnitTestMethodNode.class.getName()).log(Level.WARNING, "null testcase in MavenJUnitTestMethodNode for project {0}", getProject().getProjectDirectory());            
         }
         String location = testcase != null ? testcase.getLocation() : null;
         return fileLocator != null && location != null ? fileLocator.find(location) : null;

--- a/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
+++ b/java/maven.junit/src/org/netbeans/modules/maven/junit/JUnitOutputListenerProvider.java
@@ -652,7 +652,11 @@ public class JUnitOutputListenerProvider implements OutputProcessor {
                         classname = classname.substring(0, classname.length() - nameSuffix.length());
                     }
                     test.setClassName(classname);
-                    test.setLocation(test.getClassName().replace('.', '/') + ".java");
+                    String location = classname.replace('.', '/');
+                    //Anonymous classes are located in the file of the outermost class
+                    location = location.split("\\$")[0];
+                    location += ".java";
+                    test.setLocation(location);
                 }
                 session.addTestCase(test);
             }

--- a/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
@@ -230,6 +230,7 @@ public class DefaultReplaceTokenProvider implements ReplaceTokenProvider, Action
             //sort of hack to push the method name through the current apis..
             SingleMethod method = methods.iterator().next();
             replaceMap.put(METHOD_NAME, method.getMethodName());
+            method.getBinaryClassName().ifPresent(className -> replaceMap.put(PACK_CLASSNAME, className));
         }
 
         if (group != null &&


### PR DESCRIPTION
…t 5 test classes in Maven projects

The reason this doesn't work currently is that Netbeans assumes all test methods are in the top level class in a file. For `@Nested` tests, the tests are in an inner class.

The changes here make Netbeans use the immediately enclosing class instead of the top level class when doing run/debug for Maven projects.

Note that this only fixes run/debug for single test methods. Running `@Nested` classes is broken in Surefire https://github.com/junit-team/junit5/issues/1343. 