### PR TITLE
[NETBEANS-1157] Changed NBI Native Launcher compiler options

### DIFF
--- a/nbi/engine/native/launcher/windows/.dep.inc
+++ b/nbi/engine/native/launcher/windows/.dep.inc
@@ -1,5 +1,5 @@
 # This code depends on make tool being used
-DEPFILES=$(wildcard $(addsuffix .d, ${OBJECTFILES}))
+DEPFILES=$(wildcard $(addsuffix .d, ${OBJECTFILES} ${TESTOBJECTFILES}))
 ifneq (${DEPFILES},)
 include ${DEPFILES}
 endif

--- a/nbi/engine/native/launcher/windows/nbproject/configurations.xml
+++ b/nbi/engine/native/launcher/windows/nbproject/configurations.xml
@@ -19,7 +19,7 @@
     under the License.
 
 -->
-<configurationDescriptor version="84">
+<configurationDescriptor version="100">
   <logicalFolder name="root" displayName="root" projectFiles="true" kind="ROOT">
     <logicalFolder name="HeaderFiles"
                    displayName="Header Files"
@@ -64,13 +64,13 @@
   <confs>
     <conf name="Debug" type="1">
       <toolsSet>
-        <remote-sources-mode>LOCAL_SOURCES</remote-sources-mode>
-        <compilerSet>Cygwin|Cygwin</compilerSet>
+        <compilerSet>Cygwin64|Cygwin</compilerSet>
+        <dependencyChecking>true</dependencyChecking>
+        <rebuildPropChanged>false</rebuildPropChanged>
       </toolsSet>
       <compileType>
         <cTool>
           <stripSymbols>true</stripSymbols>
-          <commandLine>-mno-cygwin</commandLine>
           <warningLevel>3</warningLevel>
         </cTool>
         <ccTool>
@@ -82,14 +82,57 @@
           <linkerLibItems>
             <linkerOptionItem>-lole32 -luuid -lkernel32 -lcomctl32 -luserenv</linkerOptionItem>
           </linkerLibItems>
-          <commandLine>-mwindows -mno-cygwin build/icon.o</commandLine>
+          <commandLine>-mwindows build/icon.o</commandLine>
         </linkerTool>
       </compileType>
+      <item path="resources/res.rc" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/Errors.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/ExtractUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/ExtractUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/FileUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/FileUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/JavaUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/JavaUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/Launcher.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/Launcher.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/Main.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/Main.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/ProcessUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/ProcessUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/RegistryUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/RegistryUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/StringUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/StringUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/SystemUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/SystemUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/Types.h" ex="false" tool="3" flavor2="0">
+      </item>
     </conf>
     <conf name="Release" type="1">
       <toolsSet>
-        <remote-sources-mode>LOCAL_SOURCES</remote-sources-mode>
         <compilerSet>Cygwin|Cygwin</compilerSet>
+        <dependencyChecking>true</dependencyChecking>
+        <rebuildPropChanged>false</rebuildPropChanged>
       </toolsSet>
       <compileType>
         <cTool>
@@ -102,6 +145,48 @@
           <developmentMode>5</developmentMode>
         </fortranCompilerTool>
       </compileType>
+      <item path="resources/res.rc" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/Errors.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/ExtractUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/ExtractUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/FileUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/FileUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/JavaUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/JavaUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/Launcher.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/Launcher.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/Main.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/Main.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/ProcessUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/ProcessUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/RegistryUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/RegistryUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/StringUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/StringUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/SystemUtils.c" ex="false" tool="0" flavor2="0">
+      </item>
+      <item path="src/SystemUtils.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="src/Types.h" ex="false" tool="3" flavor2="0">
+      </item>
     </conf>
   </confs>
 </configurationDescriptor>

--- a/nbi/engine/native/launcher/windows/nbproject/project.xml
+++ b/nbi/engine/native/launcher/windows/nbproject/project.xml
@@ -41,6 +41,9 @@
                     <type>1</type>
                 </confElem>
             </confList>
+            <formatting>
+                <project-formatting-style>false</project-formatting-style>
+            </formatting>
         </data>
     </configuration>
 </project>


### PR DESCRIPTION
Removed Compiler and Linkeroption -mno-cygwin since the x86_64-w64-mingw32-gcc needs to be used
a Cygwin64 Tool collection has to be configured in Netbeans before compiling (with the compilers $CYGWIN64_PATH$\bin\x86_64-w64-mingw32-gcc.exe and $CYGWIN64_PATH$ \bin\x86_64-w64-mingw32-g++.exe)

Steps to compile:
1. Download and install Cygwin on a Windows machine (with the latest version of gcc-core, gcc-g++, mingw64-x86_64-gcc-core, mingw64-x86_64-gcc-g++, gdb, make)
2. Download and run Netbeans with C/C++ support
3. Open the Netbeans C/C++ project (.../nbi/engine/native/launcher/windows)
4. Create a new Netbeans C/C++ configuration "Cygwin64" (Tools -> Options -> C/C++)
   Add $CYGWIN64_PATH$\bin\x86_64-w64-mingw32-gcc.exe as C compiler and $CYGWIN64_PATH$\bin\x86_64-w64-mingw32-g++.exe as C++ compiler
5. Clean and Build the project
6. The nlw.exe is in the folder ...\nbi\engine\native\launcher\windows\dist\nlw.exe

Hint: Do compile with the with configuration "Debug". The options are only added here, especially the needed libraries. In my opinion there are no real debug compiler options set in the "Debug" configuration. The Release configuration is not set up. 