### PR TITLE
[NETBEANS-1781] Fix ClassCastException viewing .class files w/ newer javac

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/builder/TreeFactory.java
@@ -54,7 +54,6 @@ import static com.sun.tools.javac.code.Flags.*;
 import com.sun.tools.javac.code.Kinds;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
-import com.sun.tools.javac.code.Type.ErrorType;
 import com.sun.tools.javac.code.Type.WildcardType;
 import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.jvm.ClassReader;
@@ -842,6 +841,7 @@ public class TreeFactory {
                 break;
             }
             case DECLARED:
+            case ERROR:
                 JCExpression clazz = (JCExpression) QualIdent(t.tsym);
                 tp = t.getTypeArguments().isEmpty()
                 ? clazz
@@ -853,9 +853,6 @@ public class TreeFactory {
                 break;
             case NULL:
                 tp = make.at(NOPOS).Literal(TypeTag.BOT, null);
-                break;
-            case ERROR:
-                tp = make.at(NOPOS).Ident(((ErrorType) type).tsym.name);
                 break;
             default:
                 return make.at(NOPOS).Type((Type)type);


### PR DESCRIPTION
In JDK 11's javac and nb-javac 1.51, an unresolvable ClassType now has a getKind() of TypeKind.ERROR: http://hg.openjdk.java.net/jdk/jdk/rev/cc2673fa8c20#l9.1

This causes NetBeans's TreeFactory to throw a ClassCastException because it tries to cast to ErrorType.

The type should be formatted the same as a declared class (qualified name with type arguments).

The TypeKind.ERROR case was originally added for generating getters and setters of members whose class name isn't imported yet. https://netbeans.org/bugzilla/show_bug.cgi?id=112164 However, the TypeKind.DECLARED code works just as well for that purpose.