### PR TITLE
[NETBEANS-2361] Fix app.conf and launcher on macOS after changes in #573

### DIFF
--- a/harness/apisupport.harness/release/etc/app.conf
+++ b/harness/apisupport.harness/release/etc/app.conf
@@ -54,7 +54,7 @@
 #
 
 default_userdir="${DEFAULT_USERDIR_ROOT}/dev"
-default_cachedir=""${DEFAULT_CACHEDIR_ROOT}/dev"
+default_cachedir="${DEFAULT_CACHEDIR_ROOT}/dev"
 
 # options used by the launcher by default, can be overridden by explicit
 # command line switches

--- a/harness/apisupport.harness/release/launchers/app.sh
+++ b/harness/apisupport.harness/release/launchers/app.sh
@@ -57,7 +57,11 @@ args=""
 
 case "`uname`" in
     Darwin*)
-        userdir="${default_mac_userdir}"
+        if [ ! -z "$default_mac_userdir" ]; then
+          userdir="${default_mac_userdir}"
+        else
+          userdir="${default_userdir}"
+        fi
         ;;
     *)
         userdir="${default_userdir}"


### PR DESCRIPTION
#573 removed the variable `default_mac_userdir` from the app.conf, but the shell script was still using that variable which results in incorrect userdir. It also should check for the old variable in case the RCP app was build with a custom app.conf that has the old variable.

* Remove extra " in app.conf 
* Check for old `default_mac_userdir` variable in case RCP has a custom app.conf with old settings; otherwise use `default_userdir`