### PR TITLE
[NETBEANS-2409](partial): attempting to avoid FileUtil.normalizeFile …

### DIFF
--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureProjectFactory.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureProjectFactory.java
@@ -140,7 +140,15 @@ implements ProjectFactory, PropertyChangeListener, Runnable {
         }
 
         final boolean hasFile(String relative) {
-            return dir.getFileObject(relative) != null;
+            FileObject d = dir;
+            int pos = 0;
+
+            while (relative.startsWith("../", pos) && d != null) {
+                d = d.getParent();
+                pos += 3;
+            }
+
+            return d != null && d.getFileObject(relative) != null;
         }
 
         final boolean isDeepCheck() {

--- a/java/java.openjdk.project/src/META-INF/upgrade/BuildUtils.hint
+++ b/java/java.openjdk.project/src/META-INF/upgrade/BuildUtils.hint
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+<!suppress-warnings="org.netbeans.modules.java.openjdk.common.BuildUtils.getFileObject">
+$fileObject.getFileObject($relpath) :: $fileObject instanceof org.openide.filesystems.FileObject && $relpath instanceof java.lang.String
+=>
+org.netbeans.modules.java.openjdk.common.BuildUtils.getFileObject($fileObject, $relpath)
+;;

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/common/BuildUtils.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/common/BuildUtils.java
@@ -72,7 +72,7 @@ public class BuildUtils {
 
     public static File getBuildTargetDir(Project prj) {
         for (String possibleRootLocation : new String[] {"../../..", "../.."}) {
-            FileObject possibleJDKRoot = prj.getProjectDirectory().getFileObject(possibleRootLocation);
+            FileObject possibleJDKRoot = BuildUtils.getFileObject(prj.getProjectDirectory(), possibleRootLocation);
             Object buildAttr = possibleJDKRoot != null ? possibleJDKRoot.getAttribute(NB_JDK_PROJECT_BUILD) : null;
 
             if (buildAttr instanceof File) {
@@ -85,4 +85,18 @@ public class BuildUtils {
 
     public static final String NB_JDK_PROJECT_BUILD = "nb-jdk-project-build";
 
+    @SuppressWarnings("org.netbeans.modules.java.openjdk.common.BuildUtils.getFileObject")
+    public static FileObject getFileObject(FileObject dir, String relpath) {
+        int pos = 0;
+
+        while ((relpath.startsWith("../", pos)) || (relpath.endsWith("..") && pos + 2 == relpath.length())) {
+            dir = dir.getParent();
+            if (dir == null) {
+                return null;
+            }
+            pos += 3;
+        }
+
+        return pos < relpath.length() ? dir.getFileObject(relpath.substring(pos)) : dir;
+    }
 }

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ActionProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ActionProviderImpl.java
@@ -328,21 +328,21 @@ public class ActionProviderImpl implements ActionProvider {
         FileObject jdkRoot;
         List<String> sourceDirPaths;
 
-        if (prj.getProjectDirectory().getFileObject("../../../modules.xml") != null ||
-            prj.getProjectDirectory().getFileObject("share/classes/module-info.java") != null) {
+        if (BuildUtils.getFileObject(prj.getProjectDirectory(), "../../../modules.xml") != null ||
+            BuildUtils.getFileObject(prj.getProjectDirectory(), "share/classes/module-info.java") != null) {
             File buildTarget = BuildUtils.getBuildTargetDir(file);
             jdkRoot = buildTarget != null ? FileUtil.toFileObject(buildTarget.getParentFile().getParentFile()) : null;
             if (jdkRoot == null) {
                 //should not happen, just last resort:
-                jdkRoot = prj.getProjectDirectory().getFileObject("../../..");
+                jdkRoot = BuildUtils.getFileObject(prj.getProjectDirectory(), "../../..");
             }
-            if (jdkRoot.getFileObject("src/java.base/share/classes/module-info.java") != null) {
+            if (BuildUtils.getFileObject(jdkRoot, "src/java.base/share/classes/module-info.java") != null) {
                 sourceDirPaths = Arrays.asList("src", "*", "*", "classes");
             } else {
                 sourceDirPaths = Arrays.asList("*", "src", "*", "*", "classes");
             }
         } else {
-            jdkRoot = prj.getProjectDirectory().getFileObject("../../..");
+            jdkRoot = BuildUtils.getFileObject(prj.getProjectDirectory(), "../../..");
             sourceDirPaths = Arrays.asList("src", "*", "*", "classes");
         }
 
@@ -367,7 +367,7 @@ public class ActionProviderImpl implements ActionProvider {
                 listAllRoots(c, remainders, roots);
             }
         } else {
-            FileObject child = currentDir.getFileObject(current);
+            FileObject child = BuildUtils.getFileObject(currentDir, current);
 
             if (child != null) {
                 listAllRoots(child, remainders, roots);
@@ -384,13 +384,13 @@ public class ActionProviderImpl implements ActionProvider {
     private static boolean newStyleXPatch(FileObject testFile) {
         Project prj = FileOwnerQuery.getOwner(testFile);
 
-        if (prj.getProjectDirectory().getFileObject("../../src/java.base/share/classes/java/lang/Object.java") != null &&
-            prj.getProjectDirectory().getFileObject("../../src/java.compiler/share/classes/javax/tools/ToolProvider.java") != null) {
+        if (BuildUtils.getFileObject(prj.getProjectDirectory(), "../../src/java.base/share/classes/java/lang/Object.java") != null &&
+            BuildUtils.getFileObject(prj.getProjectDirectory(), "../../src/java.compiler/share/classes/javax/tools/ToolProvider.java") != null) {
             //consolidated repo:
             return true;
         }
 
-        FileObject testRoot = prj.getProjectDirectory().getFileObject("../../test/TEST.ROOT");
+        FileObject testRoot = BuildUtils.getFileObject(prj.getProjectDirectory(), "../../test/TEST.ROOT");
 
         if (testRoot == null)
             return false;
@@ -414,14 +414,14 @@ public class ActionProviderImpl implements ActionProvider {
             FileObject repo = prj.getProjectDirectory().getParent().getParent();
             if (repo.getNameExt().equals("langtools") &&
                 ShortcutUtils.getDefault().shouldUseCustomTest(repo.getNameExt(), FileUtil.getRelativePath(repo, testFile))) {
-                listAllRoots(prj.getProjectDirectory().getFileObject("../.."), new LinkedList<>(Arrays.asList("build", "classes")), roots);
-                listAllRoots(prj.getProjectDirectory().getFileObject("../.."), new LinkedList<>(Arrays.asList("build", "*", "classes")), roots);
+                listAllRoots(BuildUtils.getFileObject(prj.getProjectDirectory(), "../.."), new LinkedList<>(Arrays.asList("build", "classes")), roots);
+                listAllRoots(BuildUtils.getFileObject(prj.getProjectDirectory(), "../.."), new LinkedList<>(Arrays.asList("build", "*", "classes")), roots);
             } else {
                 listAllRoots(FileUtil.toFileObject(buildDir), new LinkedList<>(Arrays.asList("jdk", "modules", "*")), roots);
             }
         } else {
-            listAllRoots(prj.getProjectDirectory().getFileObject("../../.."), new LinkedList<>(Arrays.asList("build", "classes")), roots);
-            listAllRoots(prj.getProjectDirectory().getFileObject("../../.."), new LinkedList<>(Arrays.asList("build", "*", "classes")), roots);
+            listAllRoots(BuildUtils.getFileObject(prj.getProjectDirectory(), "../../.."), new LinkedList<>(Arrays.asList("build", "classes")), roots);
+            listAllRoots(BuildUtils.getFileObject(prj.getProjectDirectory(), "../../.."), new LinkedList<>(Arrays.asList("build", "*", "classes")), roots);
         }
 
         StringBuilder built = new StringBuilder();
@@ -458,10 +458,10 @@ public class ActionProviderImpl implements ActionProvider {
         FileObject repo = prj.getProjectDirectory().getParent().getParent();
         if (repo.getNameExt().equals("langtools") &&
             ShortcutUtils.getDefault().shouldUseCustomTest(repo.getNameExt(), FileUtil.getRelativePath(repo, testFile))) {
-            buildClasses = prj.getProjectDirectory().getFileObject("../../build/modules");
+            buildClasses = BuildUtils.getFileObject(prj.getProjectDirectory(), "../../build/modules");
             if (buildClasses == null) {
                 //old style:
-                buildClasses = prj.getProjectDirectory().getFileObject("../../build/classes");
+                buildClasses = BuildUtils.getFileObject(prj.getProjectDirectory(), "../../build/classes");
             }
         } else {
             String inferredRepoName = ShortcutUtils.getDefault().inferLegacyRepository(prj);
@@ -469,11 +469,11 @@ public class ActionProviderImpl implements ActionProvider {
                 ShortcutUtils.getDefault().shouldUseCustomTest(inferredRepoName, FileUtil.getRelativePath(repo, testFile))) {
                 File buildDir = BuildUtils.getBuildTargetDir(testFile);
                 FileObject buildDirFO = FileUtil.toFileObject(buildDir);
-                buildClasses = buildDirFO != null ? buildDirFO.getFileObject("../langtools/modules") : null;
+                buildClasses = buildDirFO != null ? BuildUtils.getFileObject(buildDirFO, "../langtools/modules") : null;
             } else {
                 File buildDir = BuildUtils.getBuildTargetDir(testFile);
                 FileObject buildDirFO = FileUtil.toFileObject(buildDir);
-                buildClasses = buildDirFO != null ? buildDirFO.getFileObject("jdk/modules") : null;
+                buildClasses = buildDirFO != null ? BuildUtils.getFileObject(buildDirFO, "jdk/modules") : null;
             }
         }
 
@@ -483,7 +483,7 @@ public class ActionProviderImpl implements ActionProvider {
     static void printJTR(InputOutput io, File jtregWork, ClassPath fullSourcePath, FileObject testFile) {
         try {
             FileObject testRoot = testFile;
-            while (testRoot != null && testRoot.getFileObject("TEST.ROOT") == null)
+            while (testRoot != null && BuildUtils.getFileObject(testRoot, "TEST.ROOT") == null)
                 testRoot = testRoot.getParent();
             if (testRoot != null) {
                 String relPath = FileUtil.getRelativePath(testRoot, testFile);

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ClassPathProviderImpl.java
@@ -40,6 +40,7 @@ import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.project.libraries.Library;
 import org.netbeans.api.project.libraries.LibraryManager;
 import org.netbeans.api.queries.FileEncodingQuery;
+import org.netbeans.modules.java.openjdk.common.BuildUtils;
 import org.netbeans.modules.java.openjdk.common.ShortcutUtils;
 import org.netbeans.spi.java.classpath.ClassPathProvider;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
@@ -62,10 +63,10 @@ public class ClassPathProviderImpl implements ClassPathProvider {
 
         while (search != null) {
             if (testProperties == null) {
-                testProperties =  search.getFileObject("TEST.properties");
+                testProperties =  BuildUtils.getFileObject(search, "TEST.properties");
             }
 
-            FileObject testRoot = search.getFileObject("TEST.ROOT");
+            FileObject testRoot = BuildUtils.getFileObject(search, "TEST.ROOT");
 
             if (testRoot != null) {
                 boolean javac = (Utilities.isLangtoolsRepository(search.getParent()) || search.getNameExt().equals("langtools")) &&
@@ -150,7 +151,7 @@ public class ClassPathProviderImpl implements ClassPathProvider {
                                 String externalLibRoots = p.getProperty("external.lib.roots");
                                 if (externalLibRoots != null) {
                                     for (String extLib : externalLibRoots.split("\\s+")) {
-                                        FileObject libDir = search.getFileObject(extLib);
+                                        FileObject libDir = BuildUtils.getFileObject(search, extLib);
 
                                         if (libDir != null) {
                                             libDirs.add(libDir);
@@ -191,9 +192,9 @@ public class ClassPathProviderImpl implements ClassPathProvider {
 
     private FileObject resolve(FileObject file, FileObject root, String spec) {
         if (spec.startsWith("/")) {
-            return root.getFileObject(spec.substring(1));
+            return BuildUtils.getFileObject(root, spec.substring(1));
         } else {
-            return file.getParent().getFileObject(spec);
+            return BuildUtils.getFileObject(file.getParent(), spec);
         }
     }
 

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ModulesHint.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/ModulesHint.java
@@ -49,6 +49,7 @@ import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.SourceUtils;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
+import org.netbeans.modules.java.openjdk.common.BuildUtils;
 import org.netbeans.modules.java.openjdk.jtreg.TagParser.Result;
 import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.Fix;
@@ -273,7 +274,7 @@ public class ModulesHint {
         }
 
         for (Map.Entry<FileObject, Set<String>> e : module2Packages.entrySet()) {
-            FileObject moduleInfo = e.getKey().getFileObject("share/classes/module-info.java");
+            FileObject moduleInfo = BuildUtils.getFileObject(e.getKey(), "share/classes/module-info.java");
             if (moduleInfo == null) { //XXX
                 continue;
             }

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/Utilities.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/Utilities.java
@@ -37,16 +37,16 @@ public class Utilities {
         if (root == null)
             return false;
 
-        FileObject srcDir = root.getFileObject("src");
+        FileObject srcDir = BuildUtils.getFileObject(root, "src");
 
         if (srcDir == null)
             return false;
 
-        if (srcDir.getFileObject("share/classes") != null)
+        if (BuildUtils.getFileObject(srcDir, "share/classes") != null)
             return true;
 
         for (FileObject mod : srcDir.getChildren()) {
-            if (mod.getFileObject("share/classes") != null)
+            if (BuildUtils.getFileObject(mod, "share/classes") != null)
                 return true;
         }
 
@@ -54,18 +54,18 @@ public class Utilities {
     }
 
     public static boolean isLangtoolsRepository(FileObject root) {
-        return (root.getFileObject("src/share/classes/com/sun/tools/javac/main/Main.java") != null ||
-                root.getFileObject("src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java") != null) &&
-                root.getFileObject("src/java.base/share/classes/java/lang/Object.java") == null;
+        return (BuildUtils.getFileObject(root, "src/share/classes/com/sun/tools/javac/main/Main.java") != null ||
+                BuildUtils.getFileObject(root, "src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java") != null) &&
+                BuildUtils.getFileObject(root, "src/java.base/share/classes/java/lang/Object.java") == null;
     }
 
     public static FileObject getLangtoolsKeyRoot(FileObject root) {
-        FileObject javaBase = root.getFileObject("src/jdk.compiler/share/classes");
+        FileObject javaBase = BuildUtils.getFileObject(root, "src/jdk.compiler/share/classes");
 
         if (javaBase != null)
             return javaBase;
 
-        return root.getFileObject("src/share/classes");
+        return BuildUtils.getFileObject(root, "src/share/classes");
     }
     
     public static File jtregOutputDir(FileObject testFile) {

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ActionProviderImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ActionProviderImpl.java
@@ -206,7 +206,7 @@ public class ActionProviderImpl implements ActionProvider {
                         sourceCP = ClassPath.getClassPath(file, ClassPath.SOURCE);
                         break;
                     case TEST:
-                        sourceCP = ClassPathSupport.createClassPath(project.getProjectDirectory().getFileObject("../../test"));
+                        sourceCP = ClassPathSupport.createClassPath(BuildUtils.getFileObject(project.getProjectDirectory(), "../../test"));
                         break;
                     default:
                         throw new IllegalStateException(kind.name());
@@ -214,7 +214,7 @@ public class ActionProviderImpl implements ActionProvider {
                 value.append(singleFileProperty.valueType.convert(sourceCP, file));
                 sep = singleFileProperty.separator;
                 FileObject ownerRoot = sourceCP.findOwnerRoot(file);
-                srcdir = FileUtil.getRelativePath(project.getProjectDirectory().getFileObject("../.."), ownerRoot);
+                srcdir = FileUtil.getRelativePath(BuildUtils.getFileObject(project.getProjectDirectory(), "../.."), ownerRoot);
                 moduleName = ownerRoot.getParent().getParent().getNameExt();
             }
             props.put(singleFileProperty.propertyName, value.toString());
@@ -253,7 +253,7 @@ public class ActionProviderImpl implements ActionProvider {
 
     private RootKind getKind(Lookup context) {
         FileObject aFile = context.lookup(FileObject.class);
-        FileObject testDir = project.getProjectDirectory().getFileObject("../../test");
+        FileObject testDir = BuildUtils.getFileObject(project.getProjectDirectory(), "../../test");
         return aFile != null && testDir != null && FileUtil.isParentOf(testDir, aFile) ? RootKind.TEST : RootKind.SOURCE;
     }
 

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ConfigurationImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ConfigurationImpl.java
@@ -215,9 +215,9 @@ public class ConfigurationImpl implements ProjectConfiguration {
         }
 
         private Preferences prefs() {
-            FileObject javaBase = jdkRoot.getFileObject("jdk/src/java.base");
+            FileObject javaBase = BuildUtils.getFileObject(jdkRoot, "jdk/src/java.base");
             if (javaBase == null)
-                javaBase = jdkRoot.getFileObject("jdk");
+                javaBase = BuildUtils.getFileObject(jdkRoot, "jdk");
             Project javaBaseProject = javaBase != null ? FileOwnerQuery.getOwner(javaBase) : null;
 
             if (javaBaseProject != null) {
@@ -232,7 +232,7 @@ public class ConfigurationImpl implements ProjectConfiguration {
                 return ;
             String name = jdkRoot.getNameExt() + " - " + active.getDisplayName();
             FileObject target = FileUtil.toFileObject(new File(active.getLocation(), "jdk"));
-            if (target == null || target.getFileObject("bin/java") == null) {
+            if (target == null || BuildUtils.getFileObject(target, "bin/java") == null) {
                 return ;
             }
             for (JavaPlatform platform : JavaPlatformManager.getDefault().getInstalledPlatforms()) {

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/FilterStandardProjects.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/FilterStandardProjects.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.openjdk.project;
 import java.io.IOException;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.modules.java.openjdk.common.BuildUtils;
 import org.netbeans.spi.project.ProjectFactory;
 import org.netbeans.spi.project.ProjectState;
 import org.openide.filesystems.FileObject;
@@ -38,10 +39,10 @@ public class FilterStandardProjects implements ProjectFactory {
     @Override
     public boolean isProject(FileObject projectDirectory) {
         FileObject jdkRoot;
-        return projectDirectory.getFileObject("nbproject/project.xml") != null &&
-               (jdkRoot = projectDirectory.getFileObject("../../..")) != null &&
-               (JDKProject.isJDKProject(jdkRoot) || jdkRoot.getFileObject("../modules.xml") != null) &&
-               projectDirectory.getParent().equals(jdkRoot.getFileObject("make/netbeans")) &&
+        return BuildUtils.getFileObject(projectDirectory, "nbproject/project.xml") != null &&
+               (jdkRoot = BuildUtils.getFileObject(projectDirectory, "../../..")) != null &&
+               (JDKProject.isJDKProject(jdkRoot) || BuildUtils.getFileObject(jdkRoot, "../modules.xml") != null) &&
+               projectDirectory.getParent().equals(BuildUtils.getFileObject(jdkRoot, "make/netbeans")) &&
                "netbeans".equals(projectDirectory.getParent().getName());
     }
 
@@ -57,16 +58,16 @@ public class FilterStandardProjects implements ProjectFactory {
         if ("langtools".equals(projectDirectory.getNameExt())) {
             if (!BLOCK_LANGTOOLS_PROJECT)
                 return null;
-            repository = projectDirectory.getFileObject("../../../../langtools");
+            repository = BuildUtils.getFileObject(projectDirectory, "../../../../langtools");
             project2Repository = "../..";
         } else {
-            repository = projectDirectory.getFileObject("../../..");
+            repository = BuildUtils.getFileObject(projectDirectory, "../../..");
             project2Repository = "";
         }
         
         if (repository != null) {
             for (Project prj : OpenProjects.getDefault().getOpenProjects()) {
-                if (repository.equals(prj.getProjectDirectory().getFileObject(project2Repository))) {
+                if (repository.equals(BuildUtils.getFileObject(prj.getProjectDirectory(), project2Repository))) {
                     throw new IOException(MSG_FILTER);
                 }
             }

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/JDKProject.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/JDKProject.java
@@ -44,6 +44,7 @@ import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectInformation;
 import org.netbeans.api.project.ProjectManager;
+import org.netbeans.modules.java.openjdk.common.BuildUtils;
 import org.netbeans.modules.java.openjdk.project.ConfigurationImpl.ProviderImpl;
 import org.netbeans.modules.java.openjdk.project.ModuleDescription.ModuleRepository;
 import org.netbeans.modules.java.openjdk.project.customizer.CustomizerProviderImpl;
@@ -123,7 +124,7 @@ public class JDKProject implements Project {
         properties.setProperty("os", osKey);
         properties.setProperty("generalized-os", generalizedOsKey);
         properties.setProperty("legacy-os", legacyOsKey);
-        FileObject jdkRoot = moduleRepository != null ? moduleRepository.getJDKRoot() : projectDir.getFileObject("..");
+        FileObject jdkRoot = moduleRepository != null ? moduleRepository.getJDKRoot() : BuildUtils.getFileObject(projectDir, "..");
         properties.setProperty("jdkRoot", stripTrailingSlash(jdkRoot.toURI().toString()));
         configurations = ConfigurationImpl.getProvider(jdkRoot);
 
@@ -139,7 +140,7 @@ public class JDKProject implements Project {
         
         evaluator = PropertyUtils.sequentialPropertyEvaluator(properties);
         
-        boolean closed = projectDir.getFileObject("src/closed/share/classes/javax/swing/plaf/basic/icons/JavaCup16.png") != null;
+        boolean closed = BuildUtils.getFileObject(projectDir, "src/closed/share/classes/javax/swing/plaf/basic/icons/JavaCup16.png") != null;
         boolean modular = currentModule != null;
         Configuration configuration =  modular ? MODULAR_CONFIGURATION
                                                : closed ? LEGACY_CLOSED_CONFIGURATION : LEGACY_OPEN_CONFIGURATION;
@@ -173,7 +174,7 @@ public class JDKProject implements Project {
                     break;
             }
 
-            FileObject shareClasses = projectDir.getFileObject("share/classes");
+            FileObject shareClasses = BuildUtils.getFileObject(projectDir, "share/classes");
 
             if (shareClasses != null && Arrays.stream(shareClasses.getChildren()).anyMatch(c -> c.isFolder() && c.getNameExt().contains("."))) {
                 List<String> submodules = Arrays.stream(shareClasses.getChildren()).filter(c -> c.isFolder()).map(c -> c.getNameExt()).collect(Collectors.toList());
@@ -384,7 +385,7 @@ public class JDKProject implements Project {
             if (repository != null) {
                 return repository.findModule(projectDirectory.getNameExt()) != null;
             } else {
-                return projectDirectory.getFileObject("src/share/classes/java/lang/Object.java") != null;
+                return BuildUtils.getFileObject(projectDirectory, "src/share/classes/java/lang/Object.java") != null;
             }
         } catch (Exception ex) {
             Logger.getLogger(JDKProject.class.getName()).log(Level.FINE, null, ex);
@@ -408,7 +409,7 @@ public class JDKProject implements Project {
                 if (prj != null)
                     return prj;
 
-                if (projectDirectory.getFileObject("src/share/classes/java/lang/Object.java") != null) {
+                if (BuildUtils.getFileObject(projectDirectory, "src/share/classes/java/lang/Object.java") != null) {
                     //legacy project:
                     return new JDKProject(projectDirectory, null, null);
                 }

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ModuleDescription.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/ModuleDescription.java
@@ -44,6 +44,7 @@ import org.netbeans.api.lexer.InputAttributes;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenSequence;
 import org.netbeans.api.project.Project;
+import org.netbeans.modules.java.openjdk.common.BuildUtils;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Pair;
 import org.openide.xml.XMLUtil;
@@ -96,12 +97,12 @@ public class ModuleDescription {
 
         boolean hasModuleInfos;
         List<ModuleDescription> moduleDescriptions;
-        FileObject modulesXML = jdkRoot.getFileObject("modules.xml");
+        FileObject modulesXML = BuildUtils.getFileObject(jdkRoot, "modules.xml");
 
         if (modulesXML != null) {
             moduleDescriptions = new ArrayList<>();
             readModulesXml(modulesXML, moduleDescriptions);
-            readModulesXml(jdkRoot.getFileObject("closed/modules.xml"), moduleDescriptions);
+            readModulesXml(BuildUtils.getFileObject(jdkRoot, "closed/modules.xml"), moduleDescriptions);
             hasModuleInfos = false;
         } else {
             moduleDescriptions = readModuleInfos(jdkRoot);
@@ -123,19 +124,19 @@ public class ModuleDescription {
     }
 
     private static Pair<FileObject, Pair<Boolean, Boolean>> findJDKRoot(FileObject projectDirectory) {
-        if (projectDirectory.getFileObject("../../../open/src/java.base/share/classes/module-info.java") != null && 
-            projectDirectory.getFileObject("../../../open/src/java.base/share/classes/module-info.java") != null &&
-            projectDirectory.getFileObject("../../../open/src/java.compiler/share/classes/module-info.java") != null)
-            return Pair.of(projectDirectory.getFileObject("../../.."), Pair.of(true, true));
-        if (projectDirectory.getFileObject("../../src/java.base/share/classes/module-info.java") != null &&
-            projectDirectory.getFileObject("../../src/java.compiler/share/classes/module-info.java") != null)
-            return Pair.of(projectDirectory.getFileObject("../.."), Pair.of(true, false));
-        if (projectDirectory.getFileObject("../../../modules.xml") != null ||
-            (projectDirectory.getFileObject("../../../jdk/src/java.base/share/classes/module-info.java") != null && projectDirectory.getFileObject("../../../langtools/src/java.compiler/share/classes/module-info.java") != null))
-            return Pair.of(projectDirectory.getFileObject("../../.."), Pair.of(false, false));
-        if (projectDirectory.getFileObject("../../../../modules.xml") != null ||
-            (projectDirectory.getFileObject("../../../../jdk/src/java.base/share/classes/module-info.java") != null && projectDirectory.getFileObject("../../../langtools/src/java.compiler/share/classes/module-info.java") != null))
-            return Pair.of(projectDirectory.getFileObject("../../../.."), Pair.of(false, false));
+        if (BuildUtils.getFileObject(projectDirectory, "../../../open/src/java.base/share/classes/module-info.java") != null && 
+            BuildUtils.getFileObject(projectDirectory, "../../../open/src/java.base/share/classes/module-info.java") != null &&
+            BuildUtils.getFileObject(projectDirectory, "../../../open/src/java.compiler/share/classes/module-info.java") != null)
+            return Pair.of(BuildUtils.getFileObject(projectDirectory, "../../.."), Pair.of(true, true));
+        if (BuildUtils.getFileObject(projectDirectory, "../../src/java.base/share/classes/module-info.java") != null &&
+            BuildUtils.getFileObject(projectDirectory, "../../src/java.compiler/share/classes/module-info.java") != null)
+            return Pair.of(BuildUtils.getFileObject(projectDirectory, "../.."), Pair.of(true, false));
+        if (BuildUtils.getFileObject(projectDirectory, "../../../modules.xml") != null ||
+            (BuildUtils.getFileObject(projectDirectory, "../../../jdk/src/java.base/share/classes/module-info.java") != null && BuildUtils.getFileObject(projectDirectory, "../../../langtools/src/java.compiler/share/classes/module-info.java") != null))
+            return Pair.of(BuildUtils.getFileObject(projectDirectory, "../../.."), Pair.of(false, false));
+        if (BuildUtils.getFileObject(projectDirectory, "../../../../modules.xml") != null ||
+            (BuildUtils.getFileObject(projectDirectory, "../../../../jdk/src/java.base/share/classes/module-info.java") != null && BuildUtils.getFileObject(projectDirectory, "../../../langtools/src/java.compiler/share/classes/module-info.java") != null))
+            return Pair.of(BuildUtils.getFileObject(projectDirectory, "../../../.."), Pair.of(false, false));
 
         return null;
     }
@@ -235,7 +236,7 @@ public class ModuleDescription {
                 }
             }
 
-            if (current.getFileObject("TEST.ROOT") != null) {
+            if (BuildUtils.getFileObject(current, "TEST.ROOT") != null) {
                 continue; //do not look inside test folders
             }
 
@@ -247,7 +248,7 @@ public class ModuleDescription {
 
     private static FileObject getModuleInfo(FileObject project) {
         for (FileObject c : project.getChildren()) {
-            FileObject moduleInfo = c.getFileObject("classes/module-info.java");
+            FileObject moduleInfo = BuildUtils.getFileObject(c, "classes/module-info.java");
 
             if (moduleInfo != null)
                 return moduleInfo;
@@ -262,7 +263,7 @@ public class ModuleDescription {
         try (Reader r = new InputStreamReader(f.getInputStream())) {
             ModuleDescription desc = parseModuleInfo(r);
 
-            if (desc == null || !desc.name.equals(f.getFileObject("../../..").getNameExt()))
+            if (desc == null || !desc.name.equals(BuildUtils.getFileObject(f, "../../..").getNameExt()))
                 return null;
 
             return desc;
@@ -369,22 +370,22 @@ public class ModuleDescription {
                 FileObject module;
 
                 if (explicitOpen) {
-                    module = root.getFileObject("open/src/" + moduleName);
+                    module = BuildUtils.getFileObject(root, "open/src/" + moduleName);
                     if (module == null) {
-                        module = root.getFileObject("closed/src/" + moduleName);
+                        module = BuildUtils.getFileObject(root, "closed/src/" + moduleName);
                     }
                 } else {
-                    module = root.getFileObject("src/" + moduleName);
+                    module = BuildUtils.getFileObject(root, "src/" + moduleName);
                 }
 
                 if (module != null && module.isFolder())
                     return module;
             } else {
                 for (FileObject repo : root.getChildren()) {
-                    FileObject module = repo.getFileObject("src/" + moduleName);
+                    FileObject module = BuildUtils.getFileObject(repo, "src/" + moduleName);
 
                     if (module == null)
-                        module = repo.getFileObject("src/closed/" + moduleName);
+                        module = BuildUtils.getFileObject(repo, "src/closed/" + moduleName);
 
                     if (module != null && module.isFolder() && validate(repo, module))
                         return module;

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/SourceLevelQueryImpl.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/project/SourceLevelQueryImpl.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 import org.netbeans.api.java.lexer.JavaTokenId;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenSequence;
+import org.netbeans.modules.java.openjdk.common.BuildUtils;
 
 import org.netbeans.spi.java.queries.SourceLevelQueryImplementation;
 import org.openide.filesystems.FileObject;
@@ -45,11 +46,11 @@ public class SourceLevelQueryImpl implements SourceLevelQueryImplementation  {
     private final String sourceLevel;
 
     public SourceLevelQueryImpl(FileObject jdkRoot) {
-        FileObject sourceVersion = jdkRoot.getFileObject("src/java.compiler/share/classes/javax/lang/model/SourceVersion.java");
+        FileObject sourceVersion = BuildUtils.getFileObject(jdkRoot, "src/java.compiler/share/classes/javax/lang/model/SourceVersion.java");
         int sl = DEFAULT_SOURCE_LEVEL;
 
         if (sourceVersion == null) {
-            sourceVersion = jdkRoot.getFileObject("langtools/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java");
+            sourceVersion = BuildUtils.getFileObject(jdkRoot, "langtools/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java");
         }
         if (sourceVersion != null) {
             try {

--- a/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/jtreg/ActionProviderImplTest.java
+++ b/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/jtreg/ActionProviderImplTest.java
@@ -253,7 +253,7 @@ public class ActionProviderImplTest extends NbTestCase {
 
         @Override
         public Project loadProject(FileObject projectDirectory, ProjectState state) throws IOException {
-            if (projectDirectory.getFileObject("../../../modules.xml") != null) {
+            if (BuildUtils.getFileObject(projectDirectory, "../../../modules.xml") != null) {
                 return new ProjectImpl(projectDirectory);
             }
 

--- a/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/ClassPathProviderImplTest.java
+++ b/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/ClassPathProviderImplTest.java
@@ -28,6 +28,7 @@ import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.hints.test.Utilities.TestLookup;
+import org.netbeans.modules.java.openjdk.common.BuildUtils;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.modules.InstalledFileLocator;
@@ -91,8 +92,8 @@ public class ClassPathProviderImplTest extends NbTestCase {
     }
 
     private void checkCompileClassPath(String module, String expected) {
-        FileObject prj = root.getFileObject(module);
-        FileObject src = prj.getFileObject("share/classes");
+        FileObject prj = BuildUtils.getFileObject(root, module);
+        FileObject src = BuildUtils.getFileObject(prj, "share/classes");
 
         Project project = FileOwnerQuery.getOwner(src);
 

--- a/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/SourceLevelQueryImplTest.java
+++ b/java/java.openjdk.project/test/unit/src/org/netbeans/modules/java/openjdk/project/SourceLevelQueryImplTest.java
@@ -26,6 +26,7 @@ import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.hints.test.Utilities.TestLookup;
+import org.netbeans.modules.java.openjdk.common.BuildUtils;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
@@ -57,7 +58,7 @@ public class SourceLevelQueryImplTest extends NbTestCase {
         copyString2File(jlObject, "");
         copyString2File(FileUtil.createData(root, ".jcheck/conf"), "project=jdk8\n");
 
-        Project legacyProject = FileOwnerQuery.getOwner(root.getFileObject("jdk"));
+        Project legacyProject = FileOwnerQuery.getOwner(BuildUtils.getFileObject(root, "jdk"));
 
         assertNotNull(legacyProject);
 


### PR DESCRIPTION
…inside FileObject.getFileObject in java.openjdk.project related cases.

I tried to avoid the normalizeFile call inside FolderObj.getFileObject (in masterfs), but I don't seem to have enough knowledge for that. But OpenJDK project is responsible for invocation of getFileObject("../<something>"), so avoid that call inside OpenJDK project should help. Unless someone knowledgeable of FileSystems wants to speed up them.
