### PR TITLE
[NETBEANS-2274] Remove special casing of JComboBox handling in language chooser

### DIFF
--- a/ide/options.editor/src/org/netbeans/modules/options/colors/SyntaxColoringPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/SyntaxColoringPanel.java
@@ -26,10 +26,8 @@ import java.awt.Font;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
-import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyEditor;
@@ -121,14 +119,6 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
         cbEffectColor.getAccessibleContext ().setAccessibleName (loc ("AN_Efects_Color"));
         cbEffectColor.getAccessibleContext ().setAccessibleDescription (loc ("AD_Efects_Color"));
         cbLanguage.addActionListener (this);
-        cbLanguage.addKeyListener(new java.awt.event.KeyAdapter() {
-            @Override
-            public void keyReleased(KeyEvent evt) {
-                if (evt.getKeyCode() == KeyEvent.VK_ENTER || evt.getKeyCode() == KeyEvent.VK_SPACE) {
-                    updateLanguageCombobox();
-                }
-            }
-        });
         lCategories.setSelectionMode (ListSelectionModel.SINGLE_SELECTION);
         lCategories.setVisibleRowCount (3);
         lCategories.setCellRenderer (new CategoryRenderer ());
@@ -369,9 +359,7 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
             updateData ();
 	} else
 	if (evt.getSource () == cbLanguage) {
-            if(evt.getModifiers() == InputEvent.BUTTON1_MASK) { // mouse clicked
-                updateLanguageCombobox();
-            }
+            updateLanguageCombobox();
 	} else
         if (evt.getSource () == bFont) {
             PropertyEditor pe = PropertyEditorManager.findEditor (Font.class);


### PR DESCRIPTION
In the Options Dialog, the Panel "Fonts & Colors" and there the subpanel
Syntax Pane relies on undocumented ActionEvent#getModifiers behavior.

The currently choosen language is only updated when:

- the new language is acknowledged with a space/enter keypress
- or choosen with a left mouse click

Two problems:
1. The language in the combobox and the currently select language can
   drift apart. (use only cursor keys to change selection)
2. On Ubuntu Linux (OpenJDK 1.8u191) it was observed, that the
   undocumented behaviour, the action handler relied on, was not
   present.

Both problems are solved by using the default behaviour of the JComboBox:

Everytime the selection changes and action event is fired, regardless
of the source of the selection change.