### PR TITLE
[NETBEANS-2466] Guard JavaSource.create() result against possible NPE.

### DIFF
--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ActionProviderSupport.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ActionProviderSupport.java
@@ -912,9 +912,11 @@ final class ActionProviderSupport {
             ClassPathSupport.createClassPath(new URL[0]),
             ClassPathSupport.createClassPath(new URL[0]));
         final JavaSource js = JavaSource.create(info);
-        js.runWhenScanFinished((final CompilationController controller) -> {
-            runnable.run();
-        }, true);
+        if (js != null) {
+            js.runWhenScanFinished((final CompilationController controller) -> {
+                runnable.run();
+            }, true);
+        }
     }
 
     @CheckForNull


### PR DESCRIPTION
Well a null check would be trivial to place there, however the JavaSource.create() method can return null an it is called at least 779 places all over the IDE. Almost none of them being guarded against the case when it returns null.
Instead of null, shan't we return some dummy instance?