### PR TITLE
Popupswitcher npe fixes

### DIFF
--- a/platform/o.n.swing.tabcontrol/manifest.mf
+++ b/platform/o.n.swing.tabcontrol/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Localizing-Bundle: org/netbeans/swing/tabcontrol/Bundle.properties
 OpenIDE-Module: org.netbeans.swing.tabcontrol
-OpenIDE-Module-Specification-Version: 1.60
+OpenIDE-Module-Specification-Version: 1.61
 AutoUpdate-Essential-Module: true
 

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/ButtonPopupSwitcher.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/ButtonPopupSwitcher.java
@@ -186,7 +186,9 @@ final class ButtonPopupSwitcher implements MouseInputListener, AWTEventListener,
     @Override
     public void valueChanged( ListSelectionEvent e ) {
         SwitcherTableItem item = pTable.getSelectedItem();
-        StatusDisplayer.getDefault().setStatusText( null == item ? null : item.getDescription() );
+        if (item != null) {
+            StatusDisplayer.getDefault().setStatusText( item.getDescription() );
+        }
     }
     
     @Override

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/DocumentSwitcherTable.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/DocumentSwitcherTable.java
@@ -163,7 +163,7 @@ class DocumentSwitcherTable extends SwitcherTable {
     }
 
     boolean isClosable( Item item ) {
-        if( !SHOW_CLOSE_BUTTON )
+        if( !SHOW_CLOSE_BUTTON || item == null)
             return false;
 
         WinsysInfoForTabbedContainer winsysInfo = displayer.getContainerWinsysInfo();


### PR DESCRIPTION
The attached patch fixes two rare but irritating NPEs from the popup switcher: If enough files are open that the popup switcher has two columns, but there is an odd number of files open, then the final item in the right column of the table has no item - but the code assumed it would always be non-null, so hovering or clicking the close button area on that spot generates a NullPointerException.