### PR TITLE
[NETBEANS-2119] Let the netbeans-dev Snapcraft package happen

### DIFF
--- a/nbbuild/packaging/snap/gui/netbeans.desktop
+++ b/nbbuild/packaging/snap/gui/netbeans.desktop
@@ -17,9 +17,10 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=NetBeans Dev
+Name=Apache NetBeans (development)
 Comment=Apache NetBeans, The Smarter Way to Code
-Exec=netbeans %F
-Categories=Application;Development;Java;PHP;JS;JavaScript;IDE
+Exec=netbeans-dev.netbeans %F
+Categories=Development;IDE
 Icon=${SNAP}/meta/gui/icon.png
 Terminal=false
+

--- a/nbbuild/packaging/snap/snapcraft.yaml
+++ b/nbbuild/packaging/snap/snapcraft.yaml
@@ -14,45 +14,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: netbeans
-version: "Dev"
-summary: NetBeans Java IDE
+name: netbeans-dev
+
+summary: Apache NetBeans IDE
 description: |
-  NetBeans IDE lets you quickly and easily develop Java desktop, mobile, and 
-  web applications, as well as HTML5 applications with HTML, JavaScript, and
-  CSS. The IDE also provides a great set of tools for PHP and C/C++ developers.
+  Disclaimer:
+  This is an in Development Version of Apache NetBeans IDE , this is for sole
+  testing purposes and shall be not considered as an official release.
+
+  Apache NetBeans IDE (incubating) lets you quickly and easily develop Java
+  desktop, enterprise, and  web applications, as well as HTML5 applications
+  with HTML, JavaScript, and CSS. The IDE also provides a great set of tools for
+  PHP and C/C++ developers.
   It is free and open source and has a large community of users and developers
-  around the world. 
+  around the world.
+
+  It requires Java 8 or later Java Development Kit installed.
+
 icon: ../../platform/core.startup/src/org/netbeans/core/startup/frame512.png
 confinement: classic
 grade: devel
 architectures: [ amd64 ]
+adopt-info: netbeans-version
 
 parts:
+  netbeans-version:
+    plugin: dump 
+    source: .
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(date +%Y%m%d)"
+      
   build:
-    build-packages:
-        - openjdk-8-jdk-headless
-        - ant
-    build: |
-        JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
-        export JAVA_HOME
-        ant -quiet -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false
     build-attributes: [ no-patchelf ]
-    plugin: nil
+    build-packages:
+      - unzip
+      - openjdk-8-jdk-headless
+    plugin: ant
     source: ../../
     filesets:
         netbeans: [ netbeans/*, -netbeans/*.built ]
-    install: |
+    override-build: |
+        export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+        ant -quiet -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false
         mv nbbuild/netbeans $SNAPCRAFT_PART_INSTALL/netbeans
         # Make the default cache and data directory relative to Snap user directory
         sed -i 's/${HOME}\/.netbeans/${SNAP_USER_COMMON}\/data/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
         sed -i 's/${HOME}\/.cache\/netbeans/${SNAP_USER_COMMON}\/cache/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
-        sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dapple.laf.useScreenMenuBar=true -J-Dawt.useSystemAAFontSettings=on/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
+        sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dplugin.manager.install.global=false/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
     stage:
         - $netbeans
 
 apps:
   netbeans:
     command: netbeans/bin/netbeans
-
-


### PR DESCRIPTION
Well, i did not give up on having a "rolling" release for testing from the master branch. It needs a different snap package name: netbeans-dev, so it could be private or public but hidden from the store (those who knew the name would be able to install it). Right now the package is being kept private.

So having these files in place and: https://builds.apache.org/job/netbeans-snap-weekly-master
We could have an auto updated test version from master by every Saturday morning. (Unfortunately Linux only)