### PR TITLE
Add position info to gradle extension registration

### DIFF
--- a/groovy/gradle/src/org/netbeans/modules/gradle/GradleDataObject.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/GradleDataObject.java
@@ -54,7 +54,8 @@ import org.openide.windows.CloneableOpenSupport;
 @MIMEResolver.ExtensionRegistration(
         displayName = "#LBL_GradleFile_LOADER",
         mimeType = GradleDataObject.MIME_TYPE,
-        extension = {"gradle"}
+        extension = {"gradle"},
+        position = 290
 )
 @DataObject.Registration(
         mimeType = GradleDataObject.MIME_TYPE,


### PR DESCRIPTION
This fixes the startup message:

> WARNING [org.openide.filesystems.Ordering]: Not all children in Services/MIMEResolver/ marked with the position attribute: [org-netbeans-modules-gradle-GradleDataObject-Extension.xml], but some are: [org-openide-loaders-DataLoaderPool$InstanceLoaderSystem-Extension.xml, org-netbeans-core-startup-layers-SystemFileSystem-Extension.xml, org-netbeans-modules-java-JavaDataObject-Extension.xml, [...]
