### PR TITLE
[NETBEANS-2437] Unit tests of php.editor fail

### DIFF
--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -78,5 +78,5 @@ test.config.stableBTD.excludes=\
     **/ParamDeclTypes68Test.class,\
     **/SemanticAnalyzerTest.class,\
     **/ToggleBlockCommentActionTest.class
-nashorn.prepend=${basedir}/../libs.nashorn/external/nashorn-02f810c26ff9-patched.jar
-bootclasspath.prepend=${nashorn.prepend}${path.separator}${basedir}/../libs.nashorn/external/asm-all-4.0.jar
+nashorn.prepend=${basedir}/../../webcommon/libs.nashorn/external/com.oracle.js.parser-ba7a8bc42268.jar
+bootclasspath.prepend=${nashorn.prepend}

--- a/php/php.editor/nbproject/project.xml
+++ b/php/php.editor/nbproject/project.xml
@@ -474,6 +474,12 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.libs.nashorn</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.csl.api</code-name-base>
                         <recursive/>
                         <compile-dependency/>

--- a/webcommon/javascript2.editor/nbproject/project.properties
+++ b/webcommon/javascript2.editor/nbproject/project.properties
@@ -29,5 +29,5 @@ extra.module.files=\
     jsstubs/reststubs.zip
 jnlp.indirect.jars=jsstubs/*.zip
 
-nashorn.prepend=${basedir}/../libs.nashorn/external/nashorn-02f810c26ff9-patched.jar
-bootclasspath.prepend=${nashorn.prepend}${path.separator}${basedir}/../libs.nashorn/external/asm-all-4.0.jar
+nashorn.prepend=${basedir}/../libs.nashorn/external/com.oracle.js.parser-ba7a8bc42268.jar
+bootclasspath.prepend=${nashorn.prepend}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-2437

- Fix nashorn.prepend and bootclasspath.prepend of project.properties

I've fixed the project.properties. However, `org.netbeans.modules.php.editor.js.JsFormatterEmbeddedTest` fail yet. Other than that, tests passed.
(Once I've installed Oracle JS Parser Implementation manually, `JsFormatterEmbeddedTest` passed. i.e. Ran the module then installed the plugin)

Do you have any ideas?

<details>
<summary>Warning</summary>

```
Warning - could not install some modules:
	org.netbeans.libs.nashorn - No module providing the capability com.oracle.js.parser.implementation could be found.
	org.netbeans.modules.javascript2.doc - The module org.netbeans.libs.nashorn would also need to be installed.
	org.netbeans.modules.javascript2.model - The module org.netbeans.libs.nashorn would also need to be installed.
	org.netbeans.modules.javascript2.model - The module org.netbeans.modules.javascript2.doc would also need to be installed.
	org.netbeans.modules.javascript2.prototypejs - The module org.netbeans.modules.javascript2.model would also need to be installed.
	org.netbeans.modules.javascript2.sdoc - The module org.netbeans.modules.javascript2.doc would also need to be installed.
	org.netbeans.modules.javascript2.editor - The module org.netbeans.libs.nashorn would also need to be installed.
	org.netbeans.modules.javascript2.editor - The module org.netbeans.modules.javascript2.model would also need to be installed.
	org.netbeans.modules.javascript2.editor - The module org.netbeans.modules.javascript2.doc would also need to be installed.
	org.netbeans.modules.javascript2.extjs - The module org.netbeans.modules.javascript2.editor would also need to be installed.
	org.netbeans.modules.javascript2.extjs - The module org.netbeans.modules.javascript2.model would also need to be installed.
	org.netbeans.modules.javascript2.jsdoc - The module org.netbeans.modules.javascript2.doc would also need to be installed.
	org.netbeans.modules.javascript2.jquery - The module org.netbeans.modules.javascript2.editor would also need to be installed.
	org.netbeans.modules.javascript2.jquery - The module org.netbeans.modules.javascript2.model would also need to be installed.
	org.netbeans.modules.javascript2.knockout - The module org.netbeans.modules.javascript2.model would also need to be installed.
	org.netbeans.modules.html.knockout - The module org.netbeans.modules.javascript2.editor would also need to be installed.
	org.netbeans.modules.html.knockout - The module org.netbeans.modules.javascript2.knockout would also need to be installed.
	org.netbeans.modules.javascript2.nodejs - The module org.netbeans.modules.javascript2.editor would also need to be installed.
	org.netbeans.modules.javascript2.nodejs - The module org.netbeans.modules.javascript2.model would also need to be installed.
	org.netbeans.modules.javascript.nodejs - The module org.netbeans.modules.javascript2.nodejs would also need to be installed.
	org.netbeans.modules.javascript2.extdoc - The module org.netbeans.modules.javascript2.doc would also need to be installed.
	org.netbeans.modules.cordova.platforms.android - The module named org.apache.tools.ant.module/3 was needed and not found.
	org.netbeans.modules.cordova - The module named org.apache.tools.ant.module/3 was needed and not found.
	org.netbeans.modules.cordova - The module org.netbeans.modules.cordova.platforms.android would also need to be installed.
	org.netbeans.modules.javascript2.requirejs - The module org.netbeans.modules.javascript2.editor would also need to be installed.
	org.netbeans.modules.javascript2.requirejs - The module org.netbeans.modules.javascript2.model would also need to be installed.
	org.netbeans.modules.javascript2.kit - The module org.netbeans.modules.javascript2.prototypejs would also need to be installed.
	org.netbeans.modules.javascript2.kit - The module org.netbeans.modules.javascript2.editor would also need to be installed.
	org.netbeans.modules.javascript2.kit - The module org.netbeans.modules.javascript2.nodejs would also need to be installed.
	org.netbeans.modules.javascript2.kit - The module org.netbeans.modules.javascript2.requirejs would also need to be installed.
	org.netbeans.modules.javascript2.kit - The module org.netbeans.modules.javascript2.knockout would also need to be installed.
	org.netbeans.modules.javascript2.kit - The module org.netbeans.modules.javascript2.jsdoc would also need to be installed.
	org.netbeans.modules.javascript2.kit - The module org.netbeans.modules.javascript2.extjs would also need to be installed.
	org.netbeans.modules.javascript2.kit - The module org.netbeans.modules.javascript2.jquery would also need to be installed.
	org.netbeans.modules.javascript2.kit - The module org.netbeans.modules.javascript2.extdoc would also need to be installed.
	org.netbeans.modules.javascript2.kit - The module org.netbeans.modules.javascript2.sdoc would also need to be installed.
	org.netbeans.modules.javascript2.source.query - The module org.netbeans.modules.javascript2.model would also need to be installed.
	org.netbeans.modules.web.client.kit - The module org.netbeans.modules.javascript.nodejs would also need to be installed.
	org.netbeans.modules.web.client.kit - The module org.netbeans.modules.javascript2.source.query would also need to be installed.
	org.netbeans.modules.html.ojet - The module org.netbeans.modules.javascript2.editor would also need to be installed.
	org.netbeans.modules.html.ojet - The module org.netbeans.modules.html.knockout would also need to be installed.
	org.netbeans.modules.html.ojet - The module org.netbeans.modules.web.client.kit would also need to be installed.
	org.netbeans.modules.html.ojet - The module org.netbeans.modules.javascript2.model would also need to be installed.
	org.netbeans.modules.html.angular - The module org.netbeans.modules.javascript2.editor would also need to be installed.
	org.netbeans.modules.html.angular - The module org.netbeans.modules.javascript2.model would also need to be installed.
Warning - could not install some modules:
	Nashorn Integration - No module providing the capability com.oracle.js.parser.implementation could be found.
	Android Platform - The module named org.apache.tools.ant.module/3 was needed and not found.
	Cordova Support - The module named org.apache.tools.ant.module/3 was needed and not found.
	20 further modules could not be installed due to the above problems.
```
</details>