### PR TITLE
Updating README to point to point to job

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ ant tryme
 
 ### Download
 
-Developer builds can be downloaded: https://builds.apache.org/job/incubator-netbeans-linux.
+Developer builds can be downloaded: https://builds.apache.org/job/netbeans-linux.
 
 Convenience binary of released source artifacts: https://netbeans.apache.org/download/index.html.
 


### PR DESCRIPTION
Point to https://builds.apache.org/job/netbeans-linux, not https://builds.apache.org/job/incubator-netbeans-linux.