### PR TITLE
[NETBEANS-1937]: extends/implements for anonymous classes must be rec…

### DIFF
--- a/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/ClipboardHandlerTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/imports/ClipboardHandlerTest.java
@@ -36,7 +36,6 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
 import org.openide.loaders.DataObjectNotFoundException;
-import org.openide.util.Exceptions;
 
 /**
  *
@@ -50,7 +49,7 @@ public class ClipboardHandlerTest extends NbTestCase {
 
     @Override
     protected void setUp() throws Exception {
-        SourceUtilsTestUtil.prepareTest(new String[] {"META-INF/generated-layer.xml", "org/netbeans/modules/java/source/resources/layer.xml", "org/netbeans/modules/java/editor/resources/layer.xml"}, new Object[0]);
+        SourceUtilsTestUtil.prepareTest(new String[] {"META-INF/generated-layer.xml", "org/netbeans/modules/java/source/resources/layer.xml", "org/netbeans/modules/java/editor/resources/layer.xml", "org/netbeans/modules/editor/settings/storage/layer.xml"}, new Object[0]);
         ClipboardHandler.autoImport = true;
         super.setUp();
     }
@@ -88,6 +87,10 @@ public class ClipboardHandlerTest extends NbTestCase {
                 "package test;\n^public class Target {\n\n}", "package test;\n\nimport java.util.List;\n\n@Test.R(List.class) public class Target {\n\n}");
     }
     
+    public void testAnonymousClass() throws Exception {
+        copyAndPaste("package test;\nimport java.util.ArrayList;\npublic class Test { void t() { |new ArrayList<String>() {};| } }\n", "package test;\npublic class Target {\nvoid t() { ^ }\n}", "package test;\n\nimport java.util.ArrayList;\n\npublic class Target {\nvoid t() { new ArrayList<String>() {}; }\n}");
+    }
+
     private void copyAndPaste(String from, final String to, String golden) throws Exception {
         final int pastePos = to.indexOf('^');
 

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -196,7 +196,19 @@ public final class TreeUtilities {
         while (path != null) {
             if (isSynthetic(path.getCompilationUnit(), path.getLeaf()))
                 return true;
-            
+            if (path.getParentPath() != null &&
+                path.getParentPath().getParentPath() != null &&
+                path.getParentPath().getParentPath().getLeaf().getKind() == Kind.NEW_CLASS) {
+                NewClassTree nct = (NewClassTree) path.getParentPath().getParentPath().getLeaf();
+                ClassTree body = nct.getClassBody();
+
+                if (body != null &&
+                    (body.getExtendsClause() == path.getLeaf() ||
+                     body.getImplementsClause().contains(path.getLeaf()))) {
+                    return true;
+                }
+            }
+
             path = path.getParentPath();
         }
         

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TreeUtilitiesTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TreeUtilitiesTest.java
@@ -26,6 +26,7 @@ import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Scope;
 import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
@@ -121,6 +122,27 @@ public class TreeUtilitiesTest extends NbTestCase {
         tp = new TreePath(tp, bt.getStatements().get(0));
         
         assertFalse(info.getTreeUtilities().isSynthetic(tp));
+    }
+
+    public void testIsSyntheticNewClassExtends() throws Exception {
+        prepareTest("Test", "package test; import java.util.*; public class Test { void t() { new ArrayList<String>() { private int i; }; } }");
+
+        TreePath tp = info.getTreeUtilities().pathFor(67);
+        NewClassTree nct = (NewClassTree) tp.getLeaf();
+
+        assertTrue(info.getTreeUtilities().isSynthetic(new TreePath(new TreePath(tp, nct.getClassBody()), nct.getClassBody().getExtendsClause())));
+        assertFalse(info.getTreeUtilities().isSynthetic(new TreePath(new TreePath(tp, nct.getClassBody()), nct.getClassBody().getMembers().get(1))));
+        assertFalse(info.getTreeUtilities().isSynthetic(new TreePath(tp, nct.getIdentifier())));
+    }
+
+    public void testIsSyntheticNewClassImplements() throws Exception {
+        prepareTest("Test", "package test; import java.io.*; public class Test { void t() { new Serializable() { }; } }");
+
+        TreePath tp = info.getTreeUtilities().pathFor(65);
+        NewClassTree nct = (NewClassTree) tp.getLeaf();
+        TreePath toTest = new TreePath(new TreePath(tp, nct.getClassBody()), nct.getClassBody().getImplementsClause().get(0));
+
+        assertTrue(info.getTreeUtilities().isSynthetic(toTest));
     }
 
     public void testFindNameSpan1() throws Exception {


### PR DESCRIPTION
…ognized as synthetic, even without nb-javac.

Otherwise, while walking through the AST, the code may visit the supertype twice (once as the "identifier" of the NewClassTree, and once as getExtendsClause/getImplementsClause for the embedded ClassTree), which leads to errors like:
https://issues.apache.org/jira/browse/NETBEANS-1937
