### PR TITLE
 [NETBEANS-2509] Bring back docker plugin support for unix sockets

### DIFF
--- a/ide/docker.api/nbproject/project.xml
+++ b/ide/docker.api/nbproject/project.xml
@@ -26,6 +26,15 @@
             <code-name-base>org.netbeans.modules.docker.api</code-name-base>
             <module-dependencies>
                 <dependency>
+                    <code-name-base>libs.c.kohlschutter.junixsocket</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>2.20</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.annotations.common</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/ide/docker.api/src/org/netbeans/modules/docker/DirectStreamResult.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/DirectStreamResult.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.docker;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.Socket;
 import java.nio.charset.Charset;
 
 /**

--- a/ide/docker.api/src/org/netbeans/modules/docker/IgnoreFileFilter.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/IgnoreFileFilter.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.docker;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileFilter;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;

--- a/ide/docker.api/src/org/netbeans/modules/docker/MuxedStreamResult.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/MuxedStreamResult.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.docker;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.Socket;
 import java.nio.charset.Charset;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -57,14 +56,17 @@ public class MuxedStreamResult implements StreamResult {
         this.stdErr = new ResultInputStream(true);
     }
 
+    @Override
     public OutputStream getStdIn() {
         return outputStream;
     }
 
+    @Override
     public InputStream getStdOut() {
         return stdOut;
     }
 
+    @Override
     public InputStream getStdErr() {
         return stdErr;
     }

--- a/ide/docker.api/src/org/netbeans/modules/docker/api/DockerAction.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/api/DockerAction.java
@@ -30,6 +30,7 @@ import org.netbeans.modules.docker.HttpUtils;
 import org.netbeans.modules.docker.DirectStreamResult;
 import org.netbeans.modules.docker.Demuxer;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -77,6 +78,8 @@ import org.netbeans.modules.docker.DockerConfig;
 import org.netbeans.modules.docker.DockerUtils;
 import org.netbeans.modules.docker.Endpoint;
 import org.netbeans.modules.docker.StreamResult;
+import org.newsclub.net.unix.AFUNIXSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Pair;
 import org.openide.util.Parameters;
@@ -1251,6 +1254,11 @@ public class DockerAction {
                     port = realUrl.getDefaultPort();
                 }
                 s.connect(new InetSocketAddress(realUrl.getHost(), port));
+                return Endpoint.forSocket(s);
+            } else if ("file".equals(realUrl.getProtocol())) {
+                AFUNIXSocket s = AFUNIXSocket.newInstance();
+                AFUNIXSocketAddress sockAdd = new AFUNIXSocketAddress(new File(realUrl.getFile()));
+                s.connect(sockAdd);
                 return Endpoint.forSocket(s);
             } else {
                 throw new IOException("Unknown protocol: " + realUrl.getProtocol());

--- a/ide/docker.api/src/org/netbeans/modules/docker/api/DockerContainer.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/api/DockerContainer.java
@@ -19,8 +19,6 @@
 package org.netbeans.modules.docker.api;
 
 import java.util.Objects;
-import javax.swing.event.ChangeListener;
-import org.openide.util.ChangeSupport;
 
 /**
  *

--- a/ide/docker.api/src/org/netbeans/modules/docker/api/DockerEvent.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/api/DockerEvent.java
@@ -127,6 +127,7 @@ public final class DockerEvent extends EventObject {
         return time;
     }
 
+    @Override
     public DockerInstance getSource() {
         return instance;
     }

--- a/ide/docker.api/src/org/netbeans/modules/docker/api/DockerImage.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/api/DockerImage.java
@@ -18,9 +18,6 @@
  */
 package org.netbeans.modules.docker.api;
 
-import java.io.BufferedOutputStream;
-import java.io.FileOutputStream;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;

--- a/ide/docker.api/src/org/netbeans/modules/docker/api/DockerSupport.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/api/DockerSupport.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.NodeChangeEvent;
 import java.util.prefs.NodeChangeListener;
@@ -129,12 +128,12 @@ public final class DockerSupport {
     }
 
     public boolean isSocketSupported() {
-        return false;
-//        if (BaseUtilities.getOperatingSystem() != BaseUtilities.OS_LINUX) {
-//            return false;
-//        }
-//        String arch = System.getProperty("os.arch"); // NOI18N
-//        return arch != null && (arch.contains("x86") || arch.contains("amd64")); // NOI18N
+        if (BaseUtilities.getOperatingSystem() != BaseUtilities.OS_LINUX
+                && BaseUtilities.getOperatingSystem() != BaseUtilities.OS_MAC) {
+            return false;
+        }
+        String arch = System.getProperty("os.arch"); // NOI18N
+        return arch != null && (arch.contains("x86") || arch.contains("amd64")); // NOI18N
     }
 
     private boolean isInitialized() {

--- a/ide/docker.api/src/org/netbeans/modules/docker/tls/PrivateKeyParser.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/tls/PrivateKeyParser.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.PrivateKey;

--- a/ide/libs.c.kohlschutter.junixsocket/build.xml
+++ b/ide/libs.c.kohlschutter.junixsocket/build.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="ide/libs.c.kohlschutter.junixsocket" default="build" basedir=".">
+    <import file="../../nbbuild/templates/projectized.xml"/>
+</project>

--- a/ide/libs.c.kohlschutter.junixsocket/external/binaries-list
+++ b/ide/libs.c.kohlschutter.junixsocket/external/binaries-list
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+8EF93DCAACE57F1EC4E165777C32BF5DBE4E7F30 com.kohlschutter.junixsocket:junixsocket-native-common:2.2.0
+BC02CB0A193C0B5881833A579C631C6DA8CD40C8 com.kohlschutter.junixsocket:junixsocket-common:2.2.0
+F747577CF77B76C88079279A50CC6EAE87E5582D com.kohlschutter.junixsocket:junixsocket-core:2.2.0

--- a/ide/libs.c.kohlschutter.junixsocket/external/junixsocket-2.2.0-license.txt
+++ b/ide/libs.c.kohlschutter.junixsocket/external/junixsocket-2.2.0-license.txt
@@ -1,0 +1,210 @@
+Name: junixsocket
+License: Apache-2.0
+Description: junixsocket is a Java/JNI library that allows the use of Unix Domain Sockets (AF_UNIX sockets) from Java.
+Origin: https://github.com/kohlschutter/junixsocket/
+Version: 2.2.0
+Files: junixsocket-common-2.2.0.jar, junixsocket-core-2.2.0.jar, junixsocket-native-common-2.2.0.jar
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/ide/libs.c.kohlschutter.junixsocket/external/junixsocket-2.2.0-notice.txt
+++ b/ide/libs.c.kohlschutter.junixsocket/external/junixsocket-2.2.0-notice.txt
@@ -1,0 +1,6 @@
+junixsocket
+Unix Domain Sockets for Java + RMI-over-AF_UNIX. 
+
+Copyright (c) 2009-2018 Dr. Christian Kohlschütter
+See https://github.com/kohlschutter/junixsocket for more information
+

--- a/ide/libs.c.kohlschutter.junixsocket/manifest.mf
+++ b/ide/libs.c.kohlschutter.junixsocket/manifest.mf
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+OpenIDE-Module: libs.c.kohlschutter.junixsocket/1
+OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/c/kohlschutter/junixsocket/Bundle.properties
+OpenIDE-Module-Specification-Version: 2.20
+

--- a/ide/libs.c.kohlschutter.junixsocket/nbproject/project.properties
+++ b/ide/libs.c.kohlschutter.junixsocket/nbproject/project.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+release.external/junixsocket-common-2.2.0.jar=modules/ext/junixsocket-common-2.2.0.jar
+release.external/junixsocket-core-2.2.0.jar=modules/ext/junixsocket-core-2.2.0.jar
+release.external/junixsocket-native-common-2.2.0.jar=modules/ext/junixsocket-native-common-2.2.0.jar
+is.autoload=true

--- a/ide/libs.c.kohlschutter.junixsocket/nbproject/project.xml
+++ b/ide/libs.c.kohlschutter.junixsocket/nbproject/project.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.apisupport.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/nb-module-project/2">
+            <code-name-base>libs.c.kohlschutter.junixsocket</code-name-base>
+            <module-dependencies/>
+            <friend-packages>
+                <friend>org.netbeans.modules.docker.api</friend>
+                <package>org.newsclub.net.unix</package>
+            </friend-packages>
+            <class-path-extension>
+                <runtime-relative-path>ext/junixsocket-native-common-2.2.0.jar</runtime-relative-path>
+                <binary-origin>external/junixsocket-native-common-2.2.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/junixsocket-core-2.2.0.jar</runtime-relative-path>
+                <binary-origin>external/junixsocket-core-2.2.0.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/junixsocket-common-2.2.0.jar</runtime-relative-path>
+                <binary-origin>external/junixsocket-common-2.2.0.jar</binary-origin>
+            </class-path-extension>
+        </data>
+    </configuration>
+</project>

--- a/ide/libs.c.kohlschutter.junixsocket/src/org/netbeans/libs/c/kohlschutter/junixsocket/Bundle.properties
+++ b/ide/libs.c.kohlschutter.junixsocket/src/org/netbeans/libs/c/kohlschutter/junixsocket/Bundle.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+OpenIDE-Module-Name=c.kohlschutter.junixsocket
+OpenIDE-Module-Display-Category=Libraries
+OpenIDE-Module-Short-Description=Bundles com.kohlschutter.junixsocket
+OpenIDE-Module-Long-Description=Bundles com.kohlschutter.junixsocket libs for work with unix sockets on various platforms and architectures.

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -408,6 +408,7 @@ nb.cluster.ide=\
         libs.antlr3.runtime,\
         libs.antlr4.runtime,\
         libs.bytelist,\
+        libs.c.kohlschutter.junixsocket,\
         libs.commons_compress,\
         libs.commons_net,\
         libs.freemarker,\


### PR DESCRIPTION
Restore ability to connect to docker via unix socket, replaced no-longer existing socket access library with (wrapped) [com.kohlschutter.junixsocket](https://github.com/kohlschutter/junixsocket) (Apache License).

Checked on `linux/amd64` - I was able to connect and list images/containers.

_ps. according to junixsocket docs this should also work on `linux/aarch64` and `macos`, but since I don't have ability to test on these I'm not enabling them (yet)_