### PR TITLE
[NETBEANS-1936] Usage of remainderDelimiter

### DIFF
--- a/ide/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
@@ -84,7 +84,7 @@ public class VersionCommand extends SvnCommand {
             if (pos > -1) {
                 String vString = string.substring(pos + 9);
                 Subversion.LOG.log(Level.INFO, "Commandline client version: {0}", vString);
-                Version version = Version.parse(vString.replace("-dev", ""));
+                Version version = Version.parse(vString, "-");
                 if (version.lowerThan(VERSION_15)) {
                     unsupportedVersion = true;
                     return false;

--- a/ide/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommand.java
@@ -84,7 +84,7 @@ public class VersionCommand extends SvnCommand {
             if (pos > -1) {
                 String vString = string.substring(pos + 9);
                 Subversion.LOG.log(Level.INFO, "Commandline client version: {0}", vString);
-                Version version = Version.parse(vString, "-");
+                Version version = Version.parse(vString);
                 if (version.lowerThan(VERSION_15)) {
                     unsupportedVersion = true;
                     return false;
@@ -143,24 +143,8 @@ public class VersionCommand extends SvnCommand {
          * @throws IllegalArgumentException if one of parameters was null
          */
         public static Version parse(String version) throws NumberFormatException, IllegalArgumentException {
-            return parse(version, " ");
-        }
-
-        /**
-         * Parse version string into container. String must be in
-         * "MAJOR.MINOR.PATCH-reminder" format. Reminder part is optional.
-         *
-         * @param version non null string with version, say 1.1.1-SNAPSHOT
-         * @param remainderDelimiter a symbol to separate semantic version from
-         * reminder, say "-" for "1.1.1-SNAPSHOT"
-         * @return non null version
-         * @throws NumberFormatException should parse error occur
-         * @throws IllegalArgumentException if one of parameters was null
-         */
-        public static Version parse(String version, String remainderDelimiter) throws NumberFormatException, IllegalArgumentException {
             assertNotNullArg(version, "Version parameter must not be null");
-            assertNotNullArg(remainderDelimiter, "reminderDelimiter parameter must not be null");
-            String[] versionMajorParts = version.split(Pattern.quote(remainderDelimiter), 2);
+            String[] versionMajorParts = version.split("[^\\d.]", 2);
 
             String[] stringParts = versionMajorParts[0].split("\\.");
             int[] parts = new int[stringParts.length];

--- a/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
+++ b/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
@@ -33,26 +33,26 @@ public class VersionCommandTest {
     
     @Test
     public void testSplitting() {
-        assertFalse(Version.parse("1.2.3", "-").lowerThan(Version.parse("1.2.3")));
-        assertFalse(Version.parse("1.2.3", "-").greaterThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse("1.2.3").lowerThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse("1.2.3").greaterThan(Version.parse("1.2.3")));
         
-        assertFalse(Version.parse("0-dev", "-").lowerThan(Version.parse("0")));
-        assertFalse(Version.parse("0-dev", "-").greaterThan(Version.parse("0")));
+        assertFalse(Version.parse("0-dev").lowerThan(Version.parse("0")));
+        assertFalse(Version.parse("0-dev").greaterThan(Version.parse("0")));
         
-        assertFalse(Version.parse("1.2.3-dev", "-").lowerThan(Version.parse("1.2.3")));
-        assertFalse(Version.parse("1.2.3-dev", "-").greaterThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse("1.2.3-dev").lowerThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse("1.2.3-dev").greaterThan(Version.parse("1.2.3")));
         
-        assertFalse(Version.parse("1.2.3-SNAPSHOT", "-").lowerThan(Version.parse("1.2.3")));
-        assertFalse(Version.parse("1.2.3-SNAPSHOT", "-").greaterThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse("1.2.3-SNAPSHOT").lowerThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse("1.2.3-SNAPSHOT").greaterThan(Version.parse("1.2.3")));
         
-        assertFalse(Version.parse("1.2-SNAPSHOT", "-").lowerThan(Version.parse("1.2")));
-        assertFalse(Version.parse("1.2-SNAPSHOT", "-").greaterThan(Version.parse("1.2")));
+        assertFalse(Version.parse("1.2-SNAPSHOT").lowerThan(Version.parse("1.2")));
+        assertFalse(Version.parse("1.2-SNAPSHOT").greaterThan(Version.parse("1.2")));
         
-        assertFalse(Version.parse("1-SNAPSHOT", "-").lowerThan(Version.parse("1")));
-        assertFalse(Version.parse("1-SNAPSHOT", "-").greaterThan(Version.parse("1")));
+        assertFalse(Version.parse("1-SNAPSHOT").lowerThan(Version.parse("1")));
+        assertFalse(Version.parse("1-SNAPSHOT").greaterThan(Version.parse("1")));
         
-        assertFalse(Version.parse("1.9.7-SlikSvn (SlikSvn/1.9.7)", "-").lowerThan(Version.parse("1.9.7")));
-        assertFalse(Version.parse("1.9.7-SlikSvn (SlikSvn/1.9.7)", "-").greaterThan(Version.parse("1.9.7")));
+        assertFalse(Version.parse("1.9.7-SlikSvn (SlikSvn/1.9.7)").lowerThan(Version.parse("1.9.7")));
+        assertFalse(Version.parse("1.9.7-SlikSvn (SlikSvn/1.9.7)").greaterThan(Version.parse("1.9.7")));
 
         assertFalse(Version.parse("1.10.0 (r1827917)").lowerThan(Version.parse("1.10.0")));
         assertFalse(Version.parse("1.10.0 (r1827917)").greaterThan(Version.parse("1.10.0")));
@@ -80,7 +80,7 @@ public class VersionCommandTest {
     @Test
     public void testRemainder() {
         assertEquals("(r1827917)", Version.parse("1.10.0 (r1827917)").remainder);
-        assertEquals("SNAPSHOT", Version.parse("1.1.1-SNAPSHOT", "-").remainder);
+        assertEquals("SNAPSHOT", Version.parse("1.1.1-SNAPSHOT").remainder);
     }
 
     @Test
@@ -91,12 +91,7 @@ public class VersionCommandTest {
         } catch (IllegalArgumentException ex) {
         }
         try {
-            Version.parse(null, null);
-            fail("Null argument should not be accepted");
-        } catch (IllegalArgumentException ex) {
-        }
-        try {
-            Version.parse("1.1.1", null);
+            Version.parse(null);
             fail("Null argument should not be accepted");
         } catch (IllegalArgumentException ex) {
         }

--- a/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
+++ b/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
@@ -33,16 +33,26 @@ public class VersionCommandTest {
     
     @Test
     public void testSplitting() {
-        assertFalse(Version.parse(" version 1.2.3").lowerThan(Version.parse("1.2.3")));
-        assertFalse(Version.parse(" version 1.2.3").greaterThan(Version.parse("1.2.3")));
-        assertFalse(Version.parse(" version 0-dev").lowerThan(Version.parse("0")));
-        assertFalse(Version.parse(" version 0-dev").greaterThan(Version.parse("0")));
-        assertFalse(Version.parse(" version 1.2.3-dev").lowerThan(Version.parse("1.2.3")));
-        assertFalse(Version.parse(" version 1.2.3-dev").greaterThan(Version.parse("1.2.3")));
-        assertFalse(Version.parse(" version 1.2.3-SNAPSHOT").lowerThan(Version.parse("1.2.3")));
-        assertFalse(Version.parse(" version 1.2.3-SNAPSHOT").greaterThan(Version.parse("1.2.3")));
-        assertFalse(Version.parse("svn, version 1.9.7-SlikSvn (SlikSvn/1.9.7)").lowerThan(Version.parse("1.9.7")));
-        assertFalse(Version.parse("svn, version 1.9.7-SlikSvn (SlikSvn/1.9.7)").greaterThan(Version.parse("1.9.7")));
+        assertFalse(Version.parse("1.2.3", "-").lowerThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse("1.2.3", "-").greaterThan(Version.parse("1.2.3")));
+        
+        assertFalse(Version.parse("0-dev", "-").lowerThan(Version.parse("0")));
+        assertFalse(Version.parse("0-dev", "-").greaterThan(Version.parse("0")));
+        
+        assertFalse(Version.parse("1.2.3-dev", "-").lowerThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse("1.2.3-dev", "-").greaterThan(Version.parse("1.2.3")));
+        
+        assertFalse(Version.parse("1.2.3-SNAPSHOT", "-").lowerThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse("1.2.3-SNAPSHOT", "-").greaterThan(Version.parse("1.2.3")));
+        
+        assertFalse(Version.parse("1.2-SNAPSHOT", "-").lowerThan(Version.parse("1.2")));
+        assertFalse(Version.parse("1.2-SNAPSHOT", "-").greaterThan(Version.parse("1.2")));
+        
+        assertFalse(Version.parse("1-SNAPSHOT", "-").lowerThan(Version.parse("1")));
+        assertFalse(Version.parse("1-SNAPSHOT", "-").greaterThan(Version.parse("1")));
+        
+        assertFalse(Version.parse("1.9.7-SlikSvn (SlikSvn/1.9.7)", "-").lowerThan(Version.parse("1.9.7")));
+        assertFalse(Version.parse("1.9.7-SlikSvn (SlikSvn/1.9.7)", "-").greaterThan(Version.parse("1.9.7")));
     }
 
     @Test

--- a/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
+++ b/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
@@ -30,6 +30,20 @@ public class VersionCommandTest {
         assertNotNull(Version.parse("1.2"));
         assertNotNull(Version.parse("1.10.0 (r1827917)"));
     }
+    
+    @Test
+    public void testSplitting() {
+        assertFalse(Version.parse(" version 1.2.3").lowerThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse(" version 1.2.3").greaterThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse(" version 0-dev").lowerThan(Version.parse("0")));
+        assertFalse(Version.parse(" version 0-dev").greaterThan(Version.parse("0")));
+        assertFalse(Version.parse(" version 1.2.3-dev").lowerThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse(" version 1.2.3-dev").greaterThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse(" version 1.2.3-SNAPSHOT").lowerThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse(" version 1.2.3-SNAPSHOT").greaterThan(Version.parse("1.2.3")));
+        assertFalse(Version.parse("svn, version 1.9.7-SlikSvn (SlikSvn/1.9.7)").lowerThan(Version.parse("1.9.7")));
+        assertFalse(Version.parse("svn, version 1.9.7-SlikSvn (SlikSvn/1.9.7)").greaterThan(Version.parse("1.9.7")));
+    }
 
     @Test
     public void testComparison() {

--- a/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
+++ b/ide/subversion/test/unit/src/org/netbeans/modules/subversion/client/cli/commands/VersionCommandTest.java
@@ -53,6 +53,12 @@ public class VersionCommandTest {
         
         assertFalse(Version.parse("1.9.7-SlikSvn (SlikSvn/1.9.7)", "-").lowerThan(Version.parse("1.9.7")));
         assertFalse(Version.parse("1.9.7-SlikSvn (SlikSvn/1.9.7)", "-").greaterThan(Version.parse("1.9.7")));
+
+        assertFalse(Version.parse("1.10.0 (r1827917)").lowerThan(Version.parse("1.10.0")));
+        assertFalse(Version.parse("1.10.0 (r1827917)").greaterThan(Version.parse("1.10.0")));
+
+        assertFalse(Version.parse("1.9.7 (r1800392)").lowerThan(Version.parse("1.9.7")));
+        assertFalse(Version.parse("1.9.7 (r1800392)").greaterThan(Version.parse("1.9.7")));
     }
 
     @Test


### PR DESCRIPTION
Usage of remainderDelimiter instead of filtering just "-dev" from a version number, for example when using SlikSvn 1.9.7-SlikSvn