### PR TITLE
Separate Truffle source caches between multiple debugging sessions.

### DIFF
--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/Source.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/Source.java
@@ -54,13 +54,13 @@ public final class Source {
     private final long hash;
     private String content;
     
-    private Source(String name, URI uri, long hash, StringReference codeRef) {
+    private Source(JPDADebugger jpda, String name, URI uri, long hash, StringReference codeRef) {
         this.name = name;
         this.codeRef = codeRef;
         URL url = null;
         if (uri == null || !"file".equalsIgnoreCase(uri.getScheme())) {
             try {
-                url = SourceFilesCache.getDefault().getSourceFile(name, hash, uri, getContent());
+                url = SourceFilesCache.get(jpda).getSourceFile(name, hash, uri, getContent());
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
             }
@@ -135,7 +135,7 @@ public final class Source {
                                        URI uri,
                                        StringReference codeRef) {
         
-        Source src = new Source(name, uri, id, codeRef);
+        Source src = new Source(debugger, name, uri, id, codeRef);
         synchronized (KNOWN_SOURCES) {
             Map<Long, Source> dbgSources = KNOWN_SOURCES.get(debugger);
             if (dbgSources == null) {

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/SourceFilesCache.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/SourceFilesCache.java
@@ -22,12 +22,15 @@ package org.netbeans.modules.debugger.jpda.truffle.source;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.util.Map;
+import java.util.WeakHashMap;
+import org.netbeans.api.debugger.jpda.JPDADebugger;
 
 import org.openide.filesystems.FileObject;
 
 final class SourceFilesCache {
     
-    private static final SourceFilesCache DEFAULT = new SourceFilesCache();
+    private static final Map<JPDADebugger, SourceFilesCache> MAP = new WeakHashMap<>();
     
     private final SourceFS fs;
     
@@ -35,8 +38,13 @@ final class SourceFilesCache {
         fs = new SourceFS();
     }
     
-    public static SourceFilesCache getDefault() {
-        return DEFAULT;
+    public static synchronized SourceFilesCache get(JPDADebugger jpda) {
+        SourceFilesCache sfc = MAP.get(jpda);
+        if (sfc == null) {
+            sfc = new SourceFilesCache();
+            MAP.put(jpda, sfc);
+        }
+        return sfc;
     }
     
     public URL getSourceFile(String name, long hash, URI uri, String content) throws IOException {


### PR DESCRIPTION
Separate Truffle source caches between multiple runs of the JPDA debugger.

When debugging Truffle script that is changing (after restarting the debugee process), the debugger doesn't reflect the code change and shows always the previous code.

This fix addresses that by using different SourceFilesCache per each debugging session. CC @entlicher 