### PR TITLE
[NETBEANS-39] Fix for no code completion in Jade files while typing

### DIFF
--- a/webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/JadeCodeCompletion.java
+++ b/webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/JadeCodeCompletion.java
@@ -159,6 +159,13 @@ public class JadeCodeCompletion implements CodeCompletionHandler2 {
 
     @Override
     public QueryType getAutoQuery(JTextComponent component, String typedText) {
+        if(typedText != null) {
+            int length = typedText.length();
+            if(length > 0 &&  !Character.isWhitespace(typedText.charAt(length - 1))) {
+                return QueryType.COMPLETION;
+            }
+        }
+        
         return QueryType.NONE;
     }
 

--- a/webcommon/javascript2.jade/test/unit/src/org/netbeans/modules/javascript2/jade/editor/JadeAutoCompletionTest.java
+++ b/webcommon/javascript2.jade/test/unit/src/org/netbeans/modules/javascript2/jade/editor/JadeAutoCompletionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.jade.editor;
+
+import org.netbeans.modules.csl.api.CodeCompletionHandler.QueryType;
+
+/**
+ *
+ * @author peedeeboy
+ */
+public class JadeAutoCompletionTest extends JadeTestBase {
+    
+    public JadeAutoCompletionTest(String testName) {
+        super(testName);
+    }
+    
+    public void testAutoCompletion() {
+        QueryType expected = QueryType.COMPLETION;
+        assertAutoQuery(expected, "^ ", "B");
+    }
+    
+    public void testAutoCompletionWhitespace() {
+        QueryType expected = QueryType.NONE;
+        assertAutoQuery(expected, "^ ", "   ");
+    }
+    
+    public void testAutoCompletionEmptyString() {
+        QueryType expected = QueryType.NONE;
+        assertAutoQuery(expected, "^ ", "");
+    }
+    
+    public void testAutoCompletionNull() {
+        QueryType expected = QueryType.NONE;
+        assertAutoQuery(expected, "^ ", null);
+    }
+    
+    public void testAutoCompletionNewLine() {
+        QueryType expected = QueryType.NONE;
+        String newline = System.lineSeparator();
+        assertAutoQuery(expected, "^ ", newline);
+    }
+}


### PR DESCRIPTION
*What this PR does*
Enables auto-completion pop-up when typing in a Jade template file

*Files Changed*
* webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/JadeCodeCompletion.java
getAutoQuery() method updated to check that typed text is not null, is greater than length of 0 and does not have whitespace at the end (because the dialog popping up after a space, tab or newline would be annoying).  If these criteria are met, code completion dialog will pop up

* webcommon/javascript2.jade/test/unit/src/org/netbeans/modules/javascript2/jade/editor/JadeAutoCompletionTest.java
Tests that the code completion pop-up is only activated if the correct criteria are met (i.e. one or more characters are typed, and the final character isn't a whitespace character)