### PR TITLE
Support for Debugging single source java files (JEP-330)

### DIFF
--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/LaunchingDICookie.java
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/LaunchingDICookie.java
@@ -124,11 +124,11 @@ public final class LaunchingDICookie extends AbstractDICookie {
         // TODO: This code is likely wrong, we need to run debuggee on JDK that
         //       is set on the project.
         // XXX: This method is likely not called from anywhere.
-        //      But it's an impl. of API method JPDADebugger.launch().
-        String commandLine = System.getProperty ("java.home") + 
-            "\\bin\\java -agentlib:jdwp=transport=" +
+        //      But it's an impl. of API m  ethod JPDADebugger.launch().
+        String commandLine = "\"" + System.getProperty ("java.home") + 
+            "\\bin\\java\"" + " -agentlib:jdwp=transport=" +
             getTransportName () + 
-            ",address=name,suspend=" + 
+            ",address=name,server=y,suspend=" + 
             (suspend ? "y" : "n") +
             " -classpath \"" + 
             classPath + 

--- a/java/debugger.jpda/nbproject/project.xml
+++ b/java/debugger.jpda/nbproject/project.xml
@@ -94,6 +94,24 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.extexecution</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>1.53</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.java.openjdk.project</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.2</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.java.source.base</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -140,6 +158,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>8.0</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.13</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/java/java.openjdk.project/nbproject/project.xml
+++ b/java/java.openjdk.project/nbproject/project.xml
@@ -340,7 +340,9 @@
                     </test-dependency>
                 </test-type>
             </test-dependencies>
-            <public-packages/>
+            <public-packages>
+                <package>org.netbeans.modules.java.openjdk.jtreg</package>
+            </public-packages>
         </data>
     </configuration>
 </project>

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/SingleJavaSourceDebugActionProvider.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/SingleJavaSourceDebugActionProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.openjdk.jtreg;
+
+import java.io.File;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.windows.IOProvider;
+import org.openide.windows.InputOutput;
+import org.openide.filesystems.FileObject;
+import org.openide.loaders.DataObject;
+import org.netbeans.modules.java.openjdk.project.JDKProject;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+
+/**
+ *
+ * @author Sarvesh Kesharwani
+ */
+@ServiceProvider(service = ActionProvider.class)
+public class SingleJavaSourceDebugActionProvider implements ActionProvider {
+    
+    private FileObject fileObject;
+    
+    @Override
+    public String[] getSupportedActions() {
+        return new String[]{ActionProvider.COMMAND_DEBUG_SINGLE};
+    }
+
+    @Override
+    public void invokeAction(String command, Lookup context) throws IllegalArgumentException {
+        InputOutput io = IOProvider.getDefault().getIO("Opening Debugger Port", false);
+        JPDAStart start = new JPDAStart(io, "debug.single");
+        try {
+            FileObject fileObject = getJavaFileWithoutProjectFromLookup(context);
+            File classFile = new File(fileObject.getParent().getPath() + File.separator + fileObject.getName() + ".class");
+            if (classFile.exists()) {
+                classFile.delete();
+            }
+            File javacPath = new File(new File(new File(System.getProperty("java.home")), "bin"), "javac");
+            Runtime.getRuntime().exec("\"" + javacPath.getAbsolutePath() + "\" " + "\"" + fileObject.getPath() + "\"");
+            long startTime = System.currentTimeMillis();
+            long fintime = startTime + 6000;
+            while (!classFile.exists() && fintime < System.currentTimeMillis()) {
+                //
+            }
+            if (classFile.exists()) {
+                this.fileObject = fileObject;
+                start.execute(new JDKProject(fileObject.getParent(), null, null));
+            }
+        } catch (Throwable ex) {
+            Exceptions.printStackTrace(ex);
+        }
+    }
+
+    @Override
+    public boolean isActionEnabled(String command, Lookup context) throws IllegalArgumentException {
+        return command.equalsIgnoreCase(ActionProvider.COMMAND_DEBUG_SINGLE);
+    }
+    
+    public FileObject getFileObject() {
+        return fileObject;
+    }
+    
+    private FileObject getJavaFileWithoutProjectFromLookup(Lookup lookup) {
+        for (DataObject dObj : lookup.lookupAll(DataObject.class)) {
+            FileObject fObj = dObj.getPrimaryFile();
+            Project p = FileOwnerQuery.getOwner(fObj);
+            if (p == null && fObj.getExt().equalsIgnoreCase("java")) {
+                return fObj;
+            }
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
This feature allows the user to debug any Java File which is not a part of any project.
Although it mentions JEP-330, this feature works fine for JDK versions lower than 11 too.