### PR TITLE
[NETBEANS-2172] & [NETBEANS-2398] Fix for web.xml errors

### DIFF
--- a/enterprise/j2ee.dd/licenseinfo.xml
+++ b/enterprise/j2ee.dd/licenseinfo.xml
@@ -23,6 +23,13 @@
 
 <licenseinfo>
     <fileset>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/batchXML_1_0.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/beans_1_0.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/beans_1_1.xsd</file>
+        <license ref="Apache-2.0" />
+        <comment type="COMMENT_UNSUPPORTED"/>
+    </fileset>
+    <fileset>
         <file>doc/dd_api_schema.jpg</file>
         <license ref="Apache-2.0-ASF" />
         <comment type="COMMENT_UNSUPPORTED"/>
@@ -35,7 +42,6 @@
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application_6.mdd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application_6.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application_7.mdd</file>
-        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application_7.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application-client_1_4.mdd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application-client_1_4.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application-client_5.mdd</file>
@@ -43,7 +49,7 @@
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application-client_6.mdd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application-client_6.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application-client_7.mdd</file>
-        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application-client_7.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/connector_1_5.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/ejb-jar_2_1.mdd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/ejb-jar_2_1.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/ejb-jar_3_0.mdd</file>
@@ -51,23 +57,22 @@
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/ejb-jar_3_1.mdd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/ejb-jar_3_1.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/ejb-jar_3_2.mdd</file>
-        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/ejb-jar_3_2.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/j2ee_1_4.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/j2ee_web_services_1_1.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/j2ee_web_services_client_1_1.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_5.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_6.xsd</file>
-        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_7.xsd</file>
-        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_4.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_2.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_3.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_client_1_2.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_client_1_3.xsd</file>
-        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_client_1_4.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/jsp_2_0.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/jsp_2_1.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/jsp_2_2.xsd</file>
-        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/jsp_2_3.xsd</file>
-        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/permissions_7.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_2.dtd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_2_1.dtd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_3.dtd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_3_1.dtd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_4.mdd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_4.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_5.mdd</file>
@@ -75,12 +80,26 @@
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_3_0.mdd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_3_0.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_3_1.mdd</file>
-        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_3_1.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-common_3_0.xsd</file>
-        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-common_3_1.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-fragment_3_0.mdd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-fragment_3_0.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-fragment_3_1.mdd</file>
+        <license ref="CDDL-1.0" />
+        <comment type="CATEGORY_B" />
+    </fileset>
+    <fileset>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application_7.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/application-client_7.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/connector_1_7.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/ejb-jar_3_2.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_7.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_4.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_4_1.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_client_1_4.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/jsp_2_3.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/permissions_7.xsd</file>        
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_3_1.xsd</file>
+        <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-common_3_1.xsd</file>
         <file>src/org/netbeans/modules/j2ee/dd/impl/resources/web-fragment_3_1.xsd</file>
         <license ref="CDDL-1.1" />
         <comment type="CATEGORY_B" />

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/batchXML_1_0.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/batchXML_1_0.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright 2012 International Business Machines Corp.
+
+  See the NOTICE file distributed with this work for additional information
+  regarding copyright ownership. Licensed under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+	targetNamespace="http://xmlns.jcp.org/xml/ns/javaee" xmlns:jbatch="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+
+	<xs:element name="batch-artifacts" type="jbatch:BatchArtifacts" />
+
+	<xs:complexType name="BatchArtifacts">
+		<xs:sequence>
+			<xs:element name="ref" type="jbatch:BatchArtifactRef" minOccurs="0" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="BatchArtifactRef">
+		<xs:attribute name="id" use="required" type="xs:string" />
+		<xs:attribute name="class" use="required" type="xs:string" />
+	</xs:complexType>
+
+</xs:schema>

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/beans_1_0.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/beans_1_0.xsd
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+   <!--
+      JBoss, Home of Professional Open Source Copyright 2008, Red Hat
+      Middleware LLC, and individual contributors by the @authors tag.
+      See the copyright.txt in the distribution for a full listing of
+      individual contributors. Licensed under the Apache License,
+      Version 2.0 (the "License"); you may not use this file except in
+      compliance with the License. You may obtain a copy of the License
+      at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+      applicable law or agreed to in writing, software distributed under
+      the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+      OR CONDITIONS OF ANY KIND, either express or implied. See the
+      License for the specific language governing permissions and
+      limitations under the License.
+   -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified" targetNamespace="http://java.sun.com/xml/ns/javaee"
+   xmlns:javaee="http://java.sun.com/xml/ns/javaee" version="1.0">
+
+   <xs:annotation>
+      <xs:documentation>
+         Contexts and Dependency Injection (CDI) defines
+         a set of complementary services that help improve the structure
+         of application code. beans.xml is used to enable CDI services
+         for the current bean archive as well as to enable named
+         interceptors, decorators and alternatives for the current bean
+         archive.
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:element name="beans">
+      <xs:annotation>
+         <xs:documentation>
+            Bean classes of enabled beans must be
+            deployed in bean archives. A library jar, EJB jar,
+            application client jar or rar archive is a bean archive if
+            it has a file named beans.xml in the META-INF directory. The
+            WEB-INF/classes directory of a war is a bean archive if
+            there is a file named beans.xml in the WEB-INF directory of
+            the war. A directory in the JVM classpath is a bean archive
+            if it has a file named beans.xml in the META-INF directory.
+         </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:all>
+            <xs:element ref="javaee:interceptors" minOccurs="0" />
+            <xs:element ref="javaee:decorators" minOccurs="0" />
+            <xs:element ref="javaee:alternatives" minOccurs="0" />
+         </xs:all>
+      </xs:complexType>
+   </xs:element>
+
+   <xs:element name="interceptors">
+      <xs:annotation>
+         <xs:documentation>
+            By default, a bean archive has no enabled
+            interceptors bound via interceptor bindings. An interceptor
+            must be explicitly enabled by listing its class under the
+            &lt;interceptors&gt; element of the beans.xml file of the
+            bean archive. The order of the interceptor declarations
+            determines the interceptor ordering. Interceptors which
+            occur earlier in the list are called first. If the same
+            class is listed twice under the &lt;interceptors&gt;
+            element, the container automatically detects the problem and
+            treats it as a deployment problem.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="class" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation>
+                     Each child &lt;class&gt; element
+                     must specify the name of an interceptor class. If
+                     there is no class with the specified name, or if
+                     the class with the specified name is not an
+                     interceptor class, the container automatically
+                     detects the problem and treats it as a deployment
+                     problem.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+      </xs:complexType>
+   </xs:element>
+
+   <xs:element name="decorators">
+      <xs:annotation>
+         <xs:documentation>
+            By default, a bean archive has no enabled
+            decorators. A decorator must be explicitly enabled by
+            listing its bean class under the &lt;decorators&gt; element
+            of the beans.xml file of the bean archive. The order of the
+            decorator declarations determines the decorator ordering.
+            Decorators which occur earlier in the list are called first.
+            If the same class is listed twice under the
+            &lt;decorators&gt; element, the container automatically
+            detects the problem and treats it as a deployment problem.
+         </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="class" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation>
+                     Each child &lt;class&gt; element
+                     must specify the name of a decorator class. If
+                     there is no class with the specified name, or if
+                     the class with the specified name is not a
+                     decorator class, the container automatically
+                     detects the problem and treats it as a deployment
+                     problem.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+      </xs:complexType>
+   </xs:element>
+
+   <xs:element name="alternatives">
+      <xs:annotation>
+         <xs:documentation>
+            An alternative is a bean that must be
+            explicitly declared in the beans.xml file if it should be
+            available for lookup, injection or EL resolution. By
+            default, a bean archive has no selected alternatives. An
+            alternative must be explicitly declared using the
+            &lt;alternatives&gt; element of the beans.xml file of the
+            bean archive. The &lt;alternatives&gt; element contains a
+            list of bean classes and stereotypes. An alternative is
+            selected for the bean archive if either: the alternative is
+            a managed bean or session bean and the bean class of the
+            bean is listed, or the alternative is a producer method,
+            field or resource, and the bean class that declares the
+            method or field is listed, or any @Alternative stereotype of
+            the alternative is listed.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="class" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation>
+                     Each child &lt;class&gt; element
+                     must specify the name of an alternative bean class.
+                     If there is no class with the specified name, or if
+                     the class with the specified name is not an
+                     alternative bean class, the container automatically
+                     detects the problem and treats it as a deployment
+                     problem. If the same class is listed twice under
+                     the &lt;alternatives&gt; element, the container
+                     automatically detects the problem and treats it as
+                     a deployment problem.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+
+            <xs:element name="stereotype" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation>
+                     Each child &lt;stereotype&gt;
+                     element must specify the name of an @Alternative
+                     stereotype annotation. If there is no annotation
+                     with the specified name, or the annotation is not
+                     an @Alternative stereotype, the container
+                     automatically detects the problem and treats it as
+                     a deployment problem. If the same stereotype is
+                     listed twice under the &lt;alternatives&gt;
+                     element, the container automatically detects the
+                     problem and treats it as a deployment problem.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+      </xs:complexType>
+   </xs:element>
+
+</xs:schema>

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/beans_1_1.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/beans_1_1.xsd
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+   <!--
+      JBoss, Home of Professional Open Source Copyright 2008, Red Hat
+      Middleware LLC, and individual contributors by the @authors tag.
+      See the copyright.txt in the distribution for a full listing of
+      individual contributors. Licensed under the Apache License,
+      Version 2.0 (the "License"); you may not use this file except in
+      compliance with the License. You may obtain a copy of the License
+      at http://www.apache.org/licenses/LICENSE-2.0 Unless required by
+      applicable law or agreed to in writing, software distributed under
+      the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+      OR CONDITIONS OF ANY KIND, either express or implied. See the
+      License for the specific language governing permissions and
+      limitations under the License.
+   -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+   elementFormDefault="qualified" 
+   targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+   xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+   version="1.1">
+
+   <xs:annotation>
+      <xs:documentation>
+         <![CDATA[[
+         Contexts and Dependency Injection (CDI) defines
+         a set of complementary services that help improve the structure
+         of application code. beans.xml is used to enable CDI services
+         for the current bean archive as well as to enable named
+         interceptors, decorators and alternatives for the current bean
+         archive.
+         
+
+         This is the XML Schema for the beans.xml deployment
+         descriptor for CDI 1.1.  The deployment descriptor must be named
+         "META-INF/beans.xml" or "WEB-INF/beans.xml" in a war file.
+         All application deployment descriptors may indicate
+         the application schema by using the Java EE namespace:
+
+         http://xmlns.jcp.org/xml/ns/javaee
+
+         and may indicate the version of the schema by
+         using the version element as shown below:
+
+         <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+         version="1.1">
+            ...
+         </beans>
+
+        The deployment descriptor may indicate the published version of
+        the schema using the xsi:schemaLocation attribute for the Java EE
+        namespace with the following location:
+
+        http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd
+
+     ]]>
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:element name="beans">
+      <xs:annotation>
+         <xs:documentation>
+            Bean classes of enabled beans must be
+            deployed in bean archives. A library jar, EJB jar,
+            application client jar or rar archive is a bean archive if
+            it has a file named beans.xml in the META-INF directory. The
+            WEB-INF/classes directory of a war is a bean archive if
+            there is a file named beans.xml in the WEB-INF directory of
+            the war. A directory in the JVM classpath is a bean archive
+            if it has a file named beans.xml in the META-INF directory.
+         </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element ref="javaee:interceptors" />
+            <xs:element ref="javaee:decorators" />
+            <xs:element ref="javaee:alternatives" />
+            <xs:element ref="javaee:scan" />
+            <xs:any namespace="##other" processContents="lax"/>
+         </xs:choice>
+         <xs:attribute name="version" default="1.1">
+            <xs:annotation>
+                <xs:documentation>
+                    The version of CDI this beans.xml is for. If the version is "1.1" (or 
+                    later), then the attribute bean-discovery-mode must be added.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:token">
+                  <xs:pattern value="\.?[0-9]+(\.[0-9]+)*"/>
+               </xs:restriction>
+            </xs:simpleType>   
+         </xs:attribute>
+         <xs:attribute name="bean-discovery-mode" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                   It is strongly recommended you use "annotated". 
+                   
+                   If the bean discovery mode is "all", then all types in this
+                   archive will be considered. If the bean discovery mode is
+                   "annotated", then only those types with bean defining annotations will be
+                   considered. If the bean discovery mode is "none", then no
+                   types will be considered.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+               <xs:restriction base="xs:string">
+                  <xs:enumeration value="annotated">
+                     <xs:annotation>
+                        <xs:documentation>
+                           Only those types with bean defining annotations will be
+                           considered.
+                        </xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="all">
+                     <xs:annotation>
+                        <xs:documentation>
+                           All types in this archive will be considered.
+                        </xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+                  <xs:enumeration value="none">
+                     <xs:annotation>
+                        <xs:documentation>
+                           This archive will be ignored.
+                        </xs:documentation>
+                     </xs:annotation>
+                  </xs:enumeration>
+               </xs:restriction>
+            </xs:simpleType>
+         </xs:attribute>
+      </xs:complexType>
+   </xs:element>
+   
+   <xs:element name="scan">
+      <xs:annotation>
+         <xs:documentation>
+            <![CDATA[The <scan> element allows exclusion of classes and packages from consideration. Various filters may be applied, and may be conditionally activated.]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:sequence maxOccurs="unbounded" minOccurs="0">
+            <xs:element name="exclude">
+                <xs:annotation>
+                   <xs:documentation>
+                      <![CDATA[The exclude filter allows exclusion of classes and packages through the use of Ant-style glob matches. For example, <exclude name="com.acme.**"> would exclude all classes and subpackages of com.acme.]]> 
+                   </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                      <xs:choice maxOccurs="unbounded" minOccurs="0">
+                         <xs:element name="if-class-available">
+                            <xs:annotation>
+                               <xs:documentation>
+                                  <![CDATA[Activates the filter only if the class specified can be loaded.]]>
+                               </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:attribute name="name" type="xs:string" use="required">
+                                   <xs:annotation>
+                                      <xs:documentation>
+                                         <![CDATA[If the named class can be loaded then, then the filter will be activated.]]>
+                                      </xs:documentation>
+                                   </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                         </xs:element>
+                         <xs:element name="if-class-not-available">
+                            <xs:annotation>
+                               <xs:documentation>
+                                  <![CDATA[Activates the filter only if the class specified cannot be loaded.]]>
+                               </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:attribute name="name" type="xs:string" use="required">
+                                   <xs:annotation>
+                                      <xs:documentation>
+                                         <![CDATA[If the named class cannot be loaded then, then the filter will be activated.]]>
+                                      </xs:documentation>
+                                   </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                         </xs:element>
+                         <xs:element name="if-system-property">
+                            <xs:annotation>
+                               <xs:documentation>
+                                  <![CDATA[If both name and value are specified, then the named system property must be set, and have the specified value for the filter to be activated. If only the name is specified, then the named system property must be set for the filter to be activated.]]>
+                               </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:attribute name="name" type="xs:string" use="required">
+                                   <xs:annotation>
+                                      <xs:documentation>
+                                         <![CDATA[The name of the system property that must be set for the filter to be active.]]>
+                                      </xs:documentation>
+                                   </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="value" type="xs:string" use="optional">
+                                   <xs:annotation>
+                                      <xs:documentation>
+                                         <![CDATA[Optional. The value that the system property must have for the filter to be active.]]>
+                                      </xs:documentation>
+                                   </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                         </xs:element>
+                      </xs:choice>
+                   <xs:attribute name="name" use="required">
+                      <xs:annotation>
+                         <xs:documentation>
+                            <![CDATA[The name of the class or package to exclude. Ant-style glob matches are supported. For example, <exclude name="com.acme.**"> would exclude all classes and subpackages of com.acme.]]>
+                         </xs:documentation>
+                      </xs:annotation>
+                      <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                           <xs:pattern value="([a-zA-Z_$][a-zA-Z\d_$]*\.)*([a-zA-Z_$][a-zA-Z\d_$]*|\*|\*\*)" />
+                        </xs:restriction>
+                      </xs:simpleType>
+                   </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+         </xs:sequence>
+      </xs:complexType>
+   </xs:element>
+
+   <xs:element name="interceptors">
+      <xs:annotation>
+         <xs:documentation>
+            By default, a bean archive has no enabled
+            interceptors bound via interceptor bindings. An interceptor
+            must be explicitly enabled by listing its class under the
+            &lt;interceptors&gt; element of the beans.xml file of the
+            bean archive. The order of the interceptor declarations
+            determines the interceptor ordering. Interceptors which
+            occur earlier in the list are called first. If the same
+            class is listed twice under the &lt;interceptors&gt;
+            element, the container automatically detects the problem and
+            treats it as a deployment problem.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="class" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation>
+                     Each child &lt;class&gt; element
+                     must specify the name of an interceptor class. If
+                     there is no class with the specified name, or if
+                     the class with the specified name is not an
+                     interceptor class, the container automatically
+                     detects the problem and treats it as a deployment
+                     problem.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+      </xs:complexType>
+   </xs:element>
+
+   <xs:element name="decorators">
+      <xs:annotation>
+         <xs:documentation>
+            By default, a bean archive has no enabled
+            decorators. A decorator must be explicitly enabled by
+            listing its bean class under the &lt;decorators&gt; element
+            of the beans.xml file of the bean archive. The order of the
+            decorator declarations determines the decorator ordering.
+            Decorators which occur earlier in the list are called first.
+            If the same class is listed twice under the
+            &lt;decorators&gt; element, the container automatically
+            detects the problem and treats it as a deployment problem.
+         </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="class" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation>
+                     Each child &lt;class&gt; element
+                     must specify the name of a decorator class. If
+                     there is no class with the specified name, or if
+                     the class with the specified name is not a
+                     decorator class, the container automatically
+                     detects the problem and treats it as a deployment
+                     problem.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+      </xs:complexType>
+   </xs:element>
+
+   <xs:element name="alternatives">
+      <xs:annotation>
+         <xs:documentation>
+            An alternative is a bean that must be
+            explicitly declared in the beans.xml file if it should be
+            available for lookup, injection or EL resolution. By
+            default, a bean archive has no selected alternatives. An
+            alternative must be explicitly declared using the
+            &lt;alternatives&gt; element of the beans.xml file of the
+            bean archive. The &lt;alternatives&gt; element contains a
+            list of bean classes and stereotypes. An alternative is
+            selected for the bean archive if either: the alternative is
+            a managed bean or session bean and the bean class of the
+            bean is listed, or the alternative is a producer method,
+            field or resource, and the bean class that declares the
+            method or field is listed, or any @Alternative stereotype of
+            the alternative is listed.
+        </xs:documentation>
+      </xs:annotation>
+      <xs:complexType>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="class" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation>
+                     Each child &lt;class&gt; element
+                     must specify the name of an alternative bean class.
+                     If there is no class with the specified name, or if
+                     the class with the specified name is not an
+                     alternative bean class, the container automatically
+                     detects the problem and treats it as a deployment
+                     problem. If the same class is listed twice under
+                     the &lt;alternatives&gt; element, the container
+                     automatically detects the problem and treats it as
+                     a deployment problem.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+
+            <xs:element name="stereotype" type="xs:string">
+               <xs:annotation>
+                  <xs:documentation>
+                     Each child &lt;stereotype&gt;
+                     element must specify the name of an @Alternative
+                     stereotype annotation. If there is no annotation
+                     with the specified name, or the annotation is not
+                     an @Alternative stereotype, the container
+                     automatically detects the problem and treats it as
+                     a deployment problem. If the same stereotype is
+                     listed twice under the &lt;alternatives&gt;
+                     element, the container automatically detects the
+                     problem and treats it as a deployment problem.
+                  </xs:documentation>
+               </xs:annotation>
+            </xs:element>
+         </xs:choice>
+      </xs:complexType>
+   </xs:element>
+
+</xs:schema>

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/connector_1_5.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/connector_1_5.xsd
@@ -1,0 +1,1044 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+	    targetNamespace="http://java.sun.com/xml/ns/j2ee"
+	    xmlns:j2ee="http://java.sun.com/xml/ns/j2ee"
+	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	    elementFormDefault="qualified"
+	    attributeFormDefault="unqualified"
+	    version="1.5">
+  <xsd:annotation>
+    <xsd:documentation>
+      @(#)connector_1_5.xsds	1.27 06/17/03
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+      Copyright 2003-2007 Sun Microsystems, Inc. All rights reserved.
+
+      The contents of this file are subject to the terms of either the
+      GNU General Public License Version 2 only ("GPL") or the Common
+      Development and Distribution License("CDDL") (collectively, the
+      "License").  You may not use this file except in compliance with
+      the License. You can obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL.html or
+      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
+      specific language governing permissions and limitations under the
+      License.
+
+      When distributing the software, include this License Header
+      Notice in each file and include the License file at
+      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
+      particular file as subject to the "Classpath" exception as
+      provided by Sun in the GPL Version 2 section of the License file
+      that accompanied this code.  If applicable, add the following
+      below the License Header, with the fields enclosed by brackets []
+      replaced by your own identifying information:
+      "Portions Copyrighted [year] [name of copyright owner]"
+
+      Contributor(s):
+
+      If you wish your version of this file to be governed by only the
+      CDDL or only the GPL Version 2, indicate your decision by adding
+      "[Contributor] elects to include this software in this
+      distribution under the [CDDL or GPL Version 2] license."  If you
+      don't indicate a single choice of license, a recipient has the
+      option to distribute your version of this file under either the
+      CDDL, the GPL Version 2 or to extend the choice of license to its
+      licensees as provided above.  However, if you add GPL Version 2
+      code and therefore, elected the GPL Version 2 license, then the
+      option applies only if the new code is made subject to such
+      option by the copyright holder.
+
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+
+	This is the XML Schema for the Connector 1.5 deployment
+	descriptor.  The deployment descriptor must be named
+	"META-INF/ra.xml" in the connector's rar file.  All Connector
+	deployment descriptors must indicate the connector resource
+	adapter schema by using the J2EE namespace:
+
+	http://java.sun.com/xml/ns/j2ee
+
+	and by indicating the version of the schema by
+	using the version element as shown below:
+
+	    <connector xmlns="http://java.sun.com/xml/ns/j2ee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
+		 http://java.sun.com/xml/ns/j2ee/connector_1_5.xsd"
+	      version="1.5">
+	      ...
+	    </connector>
+
+	The instance documents may indicate the published version of
+	the schema using the xsi:schemaLocation attribute for J2EE
+	namespace with the following location:
+
+	http://java.sun.com/xml/ns/j2ee/connector_1_5.xsd
+
+	]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all J2EE
+      deployment descriptor elements unless indicated otherwise.
+
+      - In elements that specify a pathname to a file within the
+	same JAR file, relative filenames (i.e., those not
+	starting with "/") are considered relative to the root of
+	the JAR file's namespace.  Absolute filenames (i.e., those
+	starting with "/") also specify names in the root of the
+	JAR file's namespace.  In general, relative names are
+	preferred.  The exception is .war files where absolute
+	names are preferred for consistency with the Servlet API.
+
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="j2ee_1_4.xsd"/>
+
+
+<!-- **************************************************** -->
+
+
+  <xsd:element name="connector" type="j2ee:connectorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The connector element is the root element of the deployment
+	descriptor for the resource adapter. This element includes
+	general information - vendor name, resource adapter version,
+	icon - about the resource adapter module. It also includes
+	information specific to the implementation of the resource
+	adapter library as specified through the element
+	resourceadapter.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+  </xsd:element>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="activationspecType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The activationspecType specifies an activation
+	specification.  The information includes fully qualified
+	Java class name of an activation specification and a set of
+	required configuration property names.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="activationspec-class"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The element activationspec-class specifies the fully
+	      qualified Java class name of the activation
+	      specification class. This class must implement the
+	      javax.resource.spi.ActivationSpec interface. The
+	      implementation of this class is required to be a
+	      JavaBean.
+
+	      Example:
+		  <activationspec-class>com.wombat.ActivationSpecImpl
+		  </activationspec-class>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="required-config-property"
+		   type="j2ee:required-config-propertyType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="adminobjectType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The adminobjectType specifies information about an
+	administered object.  Administered objects are specific to a
+	messaging style or message provider.  This contains
+	information on the Java type of the interface implemented by
+	an administered object, its Java class name and its
+	configuration properties.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="adminobject-interface"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The element adminobject-interface specifies the
+	      fully qualified name of the Java type of the
+	      interface implemented by an administered object.
+
+	      Example:
+		<adminobject-interface>javax.jms.Destination
+		</adminobject-interface>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+
+      </xsd:element>
+      <xsd:element name="adminobject-class"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The element adminobject-class specifies the fully
+	      qualified Java class name of an administered object.
+
+	      Example:
+		  <adminobject-class>com.wombat.DestinationImpl
+		  </adminobject-class>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="config-property"
+		   type="j2ee:config-propertyType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="authentication-mechanismType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The authentication-mechanismType specifies an authentication
+	mechanism supported by the resource adapter. Note that this
+	support is for the resource adapter and not for the
+	underlying EIS instance. The optional description specifies
+	any resource adapter specific requirement for the support of
+	security contract and authentication mechanism.
+
+	Note that BasicPassword mechanism type should support the
+	javax.resource.spi.security.PasswordCredential interface.
+	The Kerbv5 mechanism type should support the
+	org.ietf.jgss.GSSCredential interface or the deprecated
+	javax.resource.spi.security.GenericCredential interface.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="description"
+		   type="j2ee:descriptionType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+      <xsd:element name="authentication-mechanism-type"
+		   type="j2ee:xsdStringType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The element authentication-mechanism-type specifies
+	      type of an authentication mechanism.
+
+	      The example values are:
+
+	      <authentication-mechanism-type>BasicPassword
+	      </authentication-mechanism-type>
+
+	      <authentication-mechanism-type>Kerbv5
+	      </authentication-mechanism-type>
+
+	      Any additional security mechanisms are outside the
+	      scope of the Connector architecture specification.
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+
+      </xsd:element>
+      <xsd:element name="credential-interface"
+		   type="j2ee:credential-interfaceType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="config-property-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+	<![CDATA[
+
+	  The config-property-nameType contains the name of a
+	  configuration property.
+
+	  The connector architecture defines a set of well-defined
+	  properties all of type java.lang.String. These are as
+	  follows.
+
+	       ServerName
+	       PortNumber
+	       UserName
+	       Password
+	       ConnectionURL
+
+	  A resource adapter provider can extend this property set to
+	  include properties specific to the resource adapter and its
+	  underlying EIS.
+
+	  Possible values include
+		  ServerName
+		  PortNumber
+		  UserName
+		  Password
+		  ConnectionURL
+
+	  Example: <config-property-name>ServerName</config-property-name>
+
+	  ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="j2ee:xsdStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="config-property-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+	<![CDATA[
+
+	  The config-property-typeType contains the fully
+	  qualified Java type of a configuration property.
+
+	  The following are the legal values:
+	     java.lang.Boolean, java.lang.String, java.lang.Integer,
+	     java.lang.Double, java.lang.Byte, java.lang.Short,
+	     java.lang.Long, java.lang.Float, java.lang.Character
+
+	  Used in: config-property
+
+	  Example:
+	  <config-property-type>java.lang.String</config-property-type>
+
+	  ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="j2ee:string">
+	<xsd:enumeration value="java.lang.Boolean"/>
+	<xsd:enumeration value="java.lang.String"/>
+	<xsd:enumeration value="java.lang.Integer"/>
+	<xsd:enumeration value="java.lang.Double"/>
+	<xsd:enumeration value="java.lang.Byte"/>
+	<xsd:enumeration value="java.lang.Short"/>
+	<xsd:enumeration value="java.lang.Long"/>
+	<xsd:enumeration value="java.lang.Float"/>
+	<xsd:enumeration value="java.lang.Character"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="config-propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The config-propertyType contains a declaration of a single
+	configuration property that may be used for providing
+	configuration information.
+
+	The declaration consists of an optional description, name,
+	type and an optional value of the configuration property. If
+	the resource adapter provider does not specify a value than
+	the deployer is responsible for providing a valid value for
+	a configuration property.
+
+	Any bounds or well-defined values of properties should be
+	described in the description element.
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+		   type="j2ee:descriptionType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+      <xsd:element name="config-property-name"
+		   type="j2ee:config-property-nameType"/>
+      <xsd:element name="config-property-type"
+		   type="j2ee:config-property-typeType"/>
+      <xsd:element name="config-property-value"
+		   type="j2ee:xsdStringType"
+		   minOccurs="0">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The element config-property-value contains the value
+	      of a configuration entry. Note, it is possible for a
+	      resource adapter deployer to override this
+	      configuration information during deployment.
+
+	      Example:
+	      <config-property-value>WombatServer</config-property-value>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="connection-definitionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The connection-definitionType defines a set of connection
+	interfaces and classes pertaining to a particular connection
+	type. This also includes configurable properties for
+	ManagedConnectionFactory instances that may be produced out
+	of this set.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="managedconnectionfactory-class"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The element managedconnectionfactory-class specifies
+	      the fully qualified name of the Java class that
+	      implements the
+	      javax.resource.spi.ManagedConnectionFactory interface.
+	      This Java class is provided as part of resource
+	      adapter's implementation of connector architecture
+	      specified contracts. The implementation of this
+	      class is required to be a JavaBean.
+
+	      Example:
+	      <managedconnectionfactory-class>
+		  com.wombat.ManagedConnectionFactoryImpl
+	      </managedconnectionfactory-class>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="config-property"
+		   type="j2ee:config-propertyType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+      <xsd:element name="connectionfactory-interface"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The element connectionfactory-interface specifies
+	      the fully qualified name of the ConnectionFactory
+	      interface supported by the resource adapter.
+
+	      Example:
+	      <connectionfactory-interface>com.wombat.ConnectionFactory
+	      </connectionfactory-interface>
+
+	      OR
+
+	      <connectionfactory-interface>javax.resource.cci.ConnectionFactory
+	      </connectionfactory-interface>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="connectionfactory-impl-class"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The element connectionfactory-impl-class specifies
+	      the fully qualified name of the ConnectionFactory
+	      class that implements resource adapter
+	      specific ConnectionFactory interface.
+
+	      Example:
+
+	      <connectionfactory-impl-class>com.wombat.ConnectionFactoryImpl
+	      </connectionfactory-impl-class>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="connection-interface"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The connection-interface element specifies the fully
+	      qualified name of the Connection interface supported
+	      by the resource adapter.
+
+	      Example:
+
+		  <connection-interface>javax.resource.cci.Connection
+		  </connection-interface>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="connection-impl-class"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The connection-impl-classType specifies the fully
+	      qualified name of the Connection class that
+	      implements resource adapter specific Connection
+	      interface.  It is used by the connection-impl-class
+	      elements.
+
+	      Example:
+
+		  <connection-impl-class>com.wombat.ConnectionImpl
+		  </connection-impl-class>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="connectorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The connectorType defines a resource adapter.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:group ref="j2ee:descriptionGroup"/>
+      <xsd:element name="vendor-name"
+		   type="j2ee:xsdStringType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The element vendor-name specifies the name of
+	    resource adapter provider vendor.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="eis-type"
+		   type="j2ee:xsdStringType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The element eis-type contains information about the
+	    type of the EIS. For example, the type of an EIS can
+	    be product name of EIS independent of any version
+	    info.
+
+	    This helps in identifying EIS instances that can be
+	    used with this resource adapter.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resourceadapter-version"
+		   type="j2ee:xsdStringType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The element resourceadapter-version specifies a string-based version
+	    of the resource adapter from the resource adapter
+	    provider.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+
+      </xsd:element>
+      <xsd:element name="license"
+		   type="j2ee:licenseType"
+		   minOccurs="0"/>
+      <xsd:element name="resourceadapter"
+		   type="j2ee:resourceadapterType"/>
+
+    </xsd:sequence>
+    <xsd:attribute name="version"
+		   type="j2ee:dewey-versionType"
+		   fixed="1.5"
+		   use="required">
+      <xsd:annotation>
+	<xsd:documentation>
+
+	  The version specifies the version of the
+	  connector architecture specification that is
+	  supported by this resource adapter. This information
+	  enables deployer to configure the resource adapter to
+	  support deployment and runtime requirements of the
+	  corresponding connector architecture specification.
+
+	</xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="credential-interfaceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The credential-interfaceType specifies the
+	interface that the resource adapter implementation
+	supports for the representation of the
+	credentials. This element(s) that use this type,
+	i.e. credential-interface,  should be used by
+	application server to find out the Credential
+	interface it should use as part of the security
+	contract.
+
+	The possible values are:
+
+	javax.resource.spi.security.PasswordCredential
+	org.ietf.jgss.GSSCredential
+	javax.resource.spi.security.GenericCredential
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="j2ee:fully-qualified-classType">
+	<xsd:enumeration
+	     value="javax.resource.spi.security.PasswordCredential"/>
+	<xsd:enumeration
+	     value="org.ietf.jgss.GSSCredential"/>
+	<xsd:enumeration
+	     value="javax.resource.spi.security.GenericCredential"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="inbound-resourceadapterType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The inbound-resourceadapterType specifies information
+	about an inbound resource adapter. This contains information
+	specific to the implementation of the resource adapter
+	library as specified through the messageadapter element.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="messageadapter"
+		   type="j2ee:messageadapterType"
+		   minOccurs="0">
+	<xsd:unique name="messagelistener-type-uniqueness">
+	  <xsd:annotation>
+	    <xsd:documentation>
+
+	      The messagelistener-type element content must be
+	      unique in the messageadapter. Several messagelisteners
+	      can not use the same messagelistener-type.
+
+	    </xsd:documentation>
+	  </xsd:annotation>
+	  <xsd:selector xpath="j2ee:messagelistener"/>
+	  <xsd:field    xpath="j2ee:messagelistener-type"/>
+	</xsd:unique>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="licenseType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The licenseType specifies licensing requirements for the
+	resource adapter module. This type specifies whether a
+	license is required to deploy and use this resource adapter,
+	and an optional description of the licensing terms
+	(examples: duration of license, number of connection
+	restrictions). It is used by the license element.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="description"
+		   type="j2ee:descriptionType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+      <xsd:element name="license-required"
+		   type="j2ee:true-falseType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The element license-required specifies whether a
+	    license is required to deploy and use the
+	    resource adapter. This element must be one of
+	    the following, "true" or "false".
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="messageadapterType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The messageadapterType specifies information about the
+	messaging capabilities of the resource adapter. This
+	contains information specific to the implementation of the
+	resource adapter library as specified through the
+	messagelistener element.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="messagelistener"
+		   type="j2ee:messagelistenerType"
+		   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="messagelistenerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The messagelistenerType specifies information about a
+	specific message listener supported by the messaging
+	resource adapter. It contains information on the Java type
+	of the message listener interface and an activation
+	specification.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="messagelistener-type"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The element messagelistener-type specifies the fully
+	      qualified name of the Java type of a message
+	      listener interface.
+
+	      Example:
+
+		<messagelistener-type>javax.jms.MessageListener
+		</messagelistener-type>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+
+      </xsd:element>
+      <xsd:element name="activationspec"
+		   type="j2ee:activationspecType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="outbound-resourceadapterType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The outbound-resourceadapterType specifies information about
+	an outbound resource adapter. The information includes fully
+	qualified names of classes/interfaces required as part of
+	the connector architecture specified contracts for
+	connection management, level of transaction support
+	provided, one or more authentication mechanisms supported
+	and additional required security permissions.
+
+	If there is no authentication-mechanism specified as part of
+	resource adapter element then the resource adapter does not
+	support any standard security authentication mechanisms as
+	part of security contract. The application server ignores
+	the security part of the system contracts in this case.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="connection-definition"
+		   type="j2ee:connection-definitionType"
+		   maxOccurs="unbounded"/>
+      <xsd:element name="transaction-support"
+		   type="j2ee:transaction-supportType"/>
+      <xsd:element name="authentication-mechanism"
+		   type="j2ee:authentication-mechanismType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+      <xsd:element name="reauthentication-support"
+		   type="j2ee:true-falseType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The element reauthentication-support specifies
+	    whether the resource adapter implementation supports
+	    re-authentication of existing Managed- Connection
+	    instance. Note that this information is for the
+	    resource adapter implementation and not for the
+	    underlying EIS instance. This element must have
+	    either a "true" or "false" value.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="required-config-propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+	<![CDATA[
+
+	  The required-config-propertyType contains a declaration
+	  of a single configuration property used for specifying a
+	  required configuration property name. It is used
+	  by required-config-property elements.
+
+	  Example:
+
+	  <required-config-property>Destination</required-config-property>
+
+	  ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="description"
+		   type="j2ee:descriptionType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+      <xsd:element name="config-property-name"
+		   type="j2ee:config-property-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resourceadapterType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The resourceadapterType specifies information about the
+	resource adapter. The information includes fully qualified
+	resource adapter Java class name, configuration properties,
+	information specific to the implementation of the resource
+	adapter library as specified through the
+	outbound-resourceadapter and inbound-resourceadapter
+	elements, and an optional set of administered objects.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="resourceadapter-class"
+		   type="j2ee:fully-qualified-classType"
+		   minOccurs="0">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The element resourceadapter-class specifies the
+	    fully qualified name of a Java class that implements
+	    the javax.resource.spi.ResourceAdapter
+	    interface. This Java class is provided as part of
+	    resource adapter's implementation of connector
+	    architecture specified contracts. The implementation
+	    of this class is required to be a JavaBean.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+
+      </xsd:element>
+      <xsd:element name="config-property"
+		   type="j2ee:config-propertyType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+      <xsd:element name="outbound-resourceadapter"
+		   type="j2ee:outbound-resourceadapterType"
+		   minOccurs="0">
+	<xsd:unique name="connectionfactory-interface-uniqueness">
+	  <xsd:annotation>
+	    <xsd:documentation>
+
+	      The connectionfactory-interface element content
+	      must be unique in the outbound-resourceadapter.
+	      Multiple connection-definitions can not use the
+	      same connectionfactory-type.
+
+	    </xsd:documentation>
+	  </xsd:annotation>
+	  <xsd:selector xpath="j2ee:connection-definition"/>
+	  <xsd:field    xpath="j2ee:connectionfactory-interface"/>
+	</xsd:unique>
+      </xsd:element>
+      <xsd:element name="inbound-resourceadapter"
+		   type="j2ee:inbound-resourceadapterType"
+		   minOccurs="0"/>
+      <xsd:element name="adminobject"
+		   type="j2ee:adminobjectType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+      <xsd:element name="security-permission"
+		   type="j2ee:security-permissionType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-permissionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The security-permissionType specifies a security
+	permission that is required by the resource adapter code.
+
+	The security permission listed in the deployment descriptor
+	are ones that are different from those required by the
+	default permission set as specified in the connector
+	specification. The optional description can mention specific
+	reason that resource adapter requires a given security
+	permission.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="description"
+		   type="j2ee:descriptionType"
+		   minOccurs="0"
+		   maxOccurs="unbounded"/>
+      <xsd:element name="security-permission-spec"
+		   type="j2ee:xsdStringType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The element security-permission-spec specifies a security
+	    permission based on the Security policy file
+	    syntax. Refer to the following URL for Sun's
+	    implementation of the security permission
+	    specification:
+
+	    http://java.sun.com/products/jdk/1.4/docs/guide/security/PolicyFiles.html#FileSyntax
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="transaction-supportType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The transaction-supportType specifies the level of
+	transaction support provided by the resource adapter. It is
+	used by transaction-support elements.
+
+	The value must be one of the following:
+
+	    NoTransaction
+	    LocalTransaction
+	    XATransaction
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="j2ee:string">
+	<xsd:enumeration value="NoTransaction"/>
+	<xsd:enumeration value="LocalTransaction"/>
+	<xsd:enumeration value="XATransaction"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>
+

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/connector_1_7.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/connector_1_7.xsd
@@ -1,0 +1,1233 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.7">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2003-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[[
+      This is the XML Schema for the Connector 1.7 deployment
+      descriptor.  The deployment descriptor must be named
+      "META-INF/ra.xml" in the connector's rar file.  All Connector
+      deployment descriptors must indicate the connector resource
+      adapter schema by using the Java EE namespace:
+      
+      http://xmlns.jcp.org/xml/ns/javaee
+      
+      and by indicating the version of the schema by
+      using the version element as shown below:
+      
+      <connector xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+      	 http://xmlns.jcp.org/xml/ns/javaee/connector_1_7.xsd"
+      version="1.7">
+      ...
+      </connector>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Java EE
+      namespace with the following location:
+      
+      http://xmlns.jcp.org/xml/ns/javaee/connector_1_7.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Java EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="javaee_7.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="connector"
+               type="javaee:connectorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The connector element is the root element of the deployment
+        descriptor for the resource adapter. This element includes
+        general information - vendor name, resource adapter version,
+        icon - about the resource adapter module. It also includes
+        information specific to the implementation of the resource
+        adapter library as specified through the element
+        resourceadapter.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="activationspecType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The activationspecType specifies an activation
+        specification.  The information includes fully qualified
+        Java class name of an activation specification and a set of
+        required configuration property names.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="activationspec-class"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The element activationspec-class specifies the fully
+            qualified Java class name of the activation
+            specification class. This class must implement the
+            javax.resource.spi.ActivationSpec interface. The
+            implementation of this class is required to be a
+            JavaBean.
+            
+            Example:
+            	  <activationspec-class>com.wombat.ActivationSpecImpl
+            	  </activationspec-class>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="required-config-property"
+                   type="javaee:required-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The required-config-property element is deprecated since
+            Connectors 1.6 specification. The resource adapter 
+            implementation is recommended to use the @NotNull
+            Bean Validation annotation or its XML validation
+            descriptor equivalent to indicate that a configuration
+            property is required to be specified by the deployer.
+            See the Connectors specification for more information. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="config-property"
+                   type="javaee:config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="adminobjectType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The adminobjectType specifies information about an
+        administered object.  Administered objects are specific to a
+        messaging style or message provider.  This contains
+        information on the Java type of the interface implemented by
+        an administered object, its Java class name and its
+        configuration properties.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="adminobject-interface"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The element adminobject-interface specifies the
+            fully qualified name of the Java type of the
+            interface implemented by an administered object.
+            
+            Example:
+            	<adminobject-interface>javax.jms.Destination
+            	</adminobject-interface>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="adminobject-class"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The element adminobject-class specifies the fully
+            qualified Java class name of an administered object.
+            
+            Example:
+            	  <adminobject-class>com.wombat.DestinationImpl
+            	  </adminobject-class>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="config-property"
+                   type="javaee:config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="authentication-mechanismType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The authentication-mechanismType specifies an authentication
+        mechanism supported by the resource adapter. Note that this
+        support is for the resource adapter and not for the
+        underlying EIS instance. The optional description specifies
+        any resource adapter specific requirement for the support of
+        security contract and authentication mechanism.
+        
+        Note that BasicPassword mechanism type should support the
+        javax.resource.spi.security.PasswordCredential interface.
+        The Kerbv5 mechanism type should support the
+        org.ietf.jgss.GSSCredential interface or the deprecated
+        javax.resource.spi.security.GenericCredential interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="authentication-mechanism-type"
+                   type="javaee:xsdStringType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The element authentication-mechanism-type specifies
+            type of an authentication mechanism.
+            
+            The example values are:
+            
+            <authentication-mechanism-type>BasicPassword
+            </authentication-mechanism-type>
+            
+            <authentication-mechanism-type>Kerbv5
+            </authentication-mechanism-type>
+            
+            Any additional security mechanisms are outside the
+            scope of the Connector architecture specification.
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="credential-interface"
+                   type="javaee:credential-interfaceType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="config-property-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The config-property-nameType contains the name of a
+        configuration property.
+        
+        The connector architecture defines a set of well-defined
+        properties all of type java.lang.String. These are as
+        follows.
+        
+        ServerName
+        PortNumber
+        UserName
+        Password
+        ConnectionURL
+        
+        A resource adapter provider can extend this property set to
+        include properties specific to the resource adapter and its
+        underlying EIS.
+        
+        Possible values include
+        	  ServerName
+        	  PortNumber
+        	  UserName
+        	  Password
+        	  ConnectionURL
+        
+        Example: <config-property-name>ServerName</config-property-name>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:xsdStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="config-property-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The config-property-typeType contains the fully
+        qualified Java type of a configuration property.
+        
+        The following are the legal values:
+        java.lang.Boolean, java.lang.String, java.lang.Integer,
+        java.lang.Double, java.lang.Byte, java.lang.Short,
+        java.lang.Long, java.lang.Float, java.lang.Character
+        
+        Used in: config-property
+        
+        Example:
+        <config-property-type>java.lang.String</config-property-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="java.lang.Boolean"/>
+        <xsd:enumeration value="java.lang.String"/>
+        <xsd:enumeration value="java.lang.Integer"/>
+        <xsd:enumeration value="java.lang.Double"/>
+        <xsd:enumeration value="java.lang.Byte"/>
+        <xsd:enumeration value="java.lang.Short"/>
+        <xsd:enumeration value="java.lang.Long"/>
+        <xsd:enumeration value="java.lang.Float"/>
+        <xsd:enumeration value="java.lang.Character"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="config-propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The config-propertyType contains a declaration of a single
+        configuration property that may be used for providing
+        configuration information.
+        
+        The declaration consists of an optional description, name,
+        type and an optional value of the configuration property. If
+        the resource adapter provider does not specify a value than
+        the deployer is responsible for providing a valid value for
+        a configuration property.
+        
+        Any bounds or well-defined values of properties should be
+        described in the description element.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="config-property-name"
+                   type="javaee:config-property-nameType"/>
+      <xsd:element name="config-property-type"
+                   type="javaee:config-property-typeType"/>
+      <xsd:element name="config-property-value"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The element config-property-value contains the value
+            of a configuration entry. Note, it is possible for a
+            resource adapter deployer to override this
+            configuration information during deployment.
+            
+            Example:
+            <config-property-value>WombatServer</config-property-value>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="config-property-ignore"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element config-property-ignore is used to specify 
+            whether the configuration tools must ignore considering the 
+            configuration property during auto-discovery of
+            Configuration properties. See the Connector specification for
+            more details. If unspecified, the container must not ignore
+            the configuration property during auto-discovery.
+            This element must be one of the following, "true" or "false".
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="config-property-supports-dynamic-updates"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element config-property-supports-dynamic-updates is used to specify 
+            whether the configuration property allows its value to be updated, by
+            application server's configuration tools, during the lifetime of
+            the JavaBean instance. See the Connector specification for
+            more details. If unspecified, the container must not dynamically
+            reconfigure the property.
+            This element must be one of the following, "true" or "false".
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="config-property-confidential"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element config-property-confidential is used to specify 
+            whether the configuration property is confidential and
+            recommends application server's configuration tools to use special 
+            visual aids for editing them. See the Connector specification for
+            more details. If unspecified, the container must not treat the
+            property as confidential.
+            This element must be one of the following, "true" or "false".
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="connection-definitionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The connection-definitionType defines a set of connection
+        interfaces and classes pertaining to a particular connection
+        type. This also includes configurable properties for
+        ManagedConnectionFactory instances that may be produced out
+        of this set.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="managedconnectionfactory-class"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The element managedconnectionfactory-class specifies
+            the fully qualified name of the Java class that
+            implements the
+            javax.resource.spi.ManagedConnectionFactory interface.
+            This Java class is provided as part of resource
+            adapter's implementation of connector architecture
+            specified contracts. The implementation of this
+            class is required to be a JavaBean.
+            
+            Example:
+            <managedconnectionfactory-class>
+            	  com.wombat.ManagedConnectionFactoryImpl
+            </managedconnectionfactory-class>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="config-property"
+                   type="javaee:config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="connectionfactory-interface"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The element connectionfactory-interface specifies
+            the fully qualified name of the ConnectionFactory
+            interface supported by the resource adapter.
+            
+            Example:
+            <connectionfactory-interface>com.wombat.ConnectionFactory
+            </connectionfactory-interface>
+            
+            OR
+            
+            <connectionfactory-interface>javax.resource.cci.ConnectionFactory
+            </connectionfactory-interface>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="connectionfactory-impl-class"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The element connectionfactory-impl-class specifies
+            the fully qualified name of the ConnectionFactory
+            class that implements resource adapter
+            specific ConnectionFactory interface.
+            
+            Example:
+            
+            <connectionfactory-impl-class>com.wombat.ConnectionFactoryImpl
+            </connectionfactory-impl-class>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="connection-interface"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The connection-interface element specifies the fully
+            qualified name of the Connection interface supported
+            by the resource adapter.
+            
+            Example:
+            
+            	  <connection-interface>javax.resource.cci.Connection
+            	  </connection-interface>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="connection-impl-class"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The connection-impl-classType specifies the fully
+            qualified name of the Connection class that
+            implements resource adapter specific Connection
+            interface.  It is used by the connection-impl-class
+            elements.
+            
+            Example:
+            
+            	  <connection-impl-class>com.wombat.ConnectionImpl
+            	  </connection-impl-class>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="connectorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The connectorType defines a resource adapter.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="module-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element module-name specifies the name of the
+            resource adapter.
+            
+            If there is no module-name specified, the module-name
+            is determined as defined in Section EE.8.1.1 and EE.8.1.2 
+            of the Java Platform, Enterprise Edition (Java EE) 
+            Specification, version 6.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="vendor-name"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element vendor-name specifies the name of
+            resource adapter provider vendor.
+            
+            If there is no vendor-name specified, the application 
+            server must consider the default "" (empty string) as
+            the name of the resource adapter provider vendor.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="eis-type"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element eis-type contains information about the
+            type of the EIS. For example, the type of an EIS can
+            be product name of EIS independent of any version
+            info.
+            
+            This helps in identifying EIS instances that can be
+            used with this resource adapter.
+            
+            If there is no eis-type specified, the application 
+            server must consider the default "" (empty string) as
+            the type of the EIS.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resourceadapter-version"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element resourceadapter-version specifies a string-based version
+            of the resource adapter from the resource adapter
+            provider.
+            
+            If there is no resourceadapter-version specified, the application 
+            server must consider the default "" (empty string) as
+            the version of the resource adapter.
+            	
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="license"
+                   type="javaee:licenseType"
+                   minOccurs="0"/>
+      <xsd:element name="resourceadapter"
+                   type="javaee:resourceadapterType"/>
+      <xsd:element name="required-work-context"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element required-work-context specifies a fully qualified class 
+            name that implements WorkContext interface, that the resource adapter 
+            requires the application server to support.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="javaee:dewey-versionType"
+                   fixed="1.7"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The version indicates the version of the schema to be used by the
+          deployment tool. This element doesn't have a default, and the resource adapter 
+          developer/deployer is required to specify it. The element allows the deployment 
+          tool to choose which schema to validate the descriptor against.
+          	  
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether the deployment 
+          descriptor for the resource adapter module is complete, or whether
+          the class files available to the module and packaged with the resource 
+          adapter should be examined for annotations that specify deployment 
+          information.
+          
+          If metadata-complete is set to "true", the deployment tool of the 
+          application server must ignore any annotations that specify deployment 
+          information, which might be present in the class files of the 
+          application.If metadata-complete is not specified or is set to "false", 
+          the deployment tool must examine the class files of the application for 
+          annotations, as specified by this specification. If the 
+          deployment descriptor is not included or is included but not marked 
+          metadata-complete, the deployment tool will process annotations.
+          
+          Application servers must assume that metadata-complete is true for 
+          resource adapter modules with deployment descriptor version 
+          lower than 1.6.
+          		
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="credential-interfaceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The credential-interfaceType specifies the
+        interface that the resource adapter implementation
+        supports for the representation of the
+        credentials. This element(s) that use this type,
+        i.e. credential-interface,  should be used by
+        application server to find out the Credential
+        interface it should use as part of the security
+        contract.
+        
+        The possible values are:
+        
+        javax.resource.spi.security.PasswordCredential
+        org.ietf.jgss.GSSCredential
+        javax.resource.spi.security.GenericCredential
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType">
+        <xsd:enumeration value="javax.resource.spi.security.PasswordCredential"/>
+        <xsd:enumeration value="org.ietf.jgss.GSSCredential"/>
+        <xsd:enumeration value="javax.resource.spi.security.GenericCredential"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="inbound-resourceadapterType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The inbound-resourceadapterType specifies information
+        about an inbound resource adapter. This contains information
+        specific to the implementation of the resource adapter
+        library as specified through the messageadapter element.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="messageadapter"
+                   type="javaee:messageadapterType"
+                   minOccurs="0">
+        <xsd:unique name="messagelistener-type-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The messagelistener-type element content must be
+              unique in the messageadapter. Several messagelisteners
+              can not use the same messagelistener-type.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="javaee:messagelistener"/>
+          <xsd:field xpath="javaee:messagelistener-type"/>
+        </xsd:unique>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="licenseType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The licenseType specifies licensing requirements for the
+        resource adapter module. This type specifies whether a
+        license is required to deploy and use this resource adapter,
+        and an optional description of the licensing terms
+        (examples: duration of license, number of connection
+        restrictions). It is used by the license element.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="license-required"
+                   type="javaee:true-falseType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element license-required specifies whether a
+            license is required to deploy and use the
+            resource adapter. This element must be one of
+            the following, "true" or "false".
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="messageadapterType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The messageadapterType specifies information about the
+        messaging capabilities of the resource adapter. This
+        contains information specific to the implementation of the
+        resource adapter library as specified through the
+        messagelistener element.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="messagelistener"
+                   type="javaee:messagelistenerType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="messagelistenerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The messagelistenerType specifies information about a
+        specific message listener supported by the messaging
+        resource adapter. It contains information on the Java type
+        of the message listener interface and an activation
+        specification.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="messagelistener-type"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The element messagelistener-type specifies the fully
+            qualified name of the Java type of a message
+            listener interface.
+            
+            Example:
+            
+            	<messagelistener-type>javax.jms.MessageListener
+            	</messagelistener-type>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="activationspec"
+                   type="javaee:activationspecType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="outbound-resourceadapterType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The outbound-resourceadapterType specifies information about
+        an outbound resource adapter. The information includes fully
+        qualified names of classes/interfaces required as part of
+        the connector architecture specified contracts for
+        connection management, level of transaction support
+        provided, one or more authentication mechanisms supported
+        and additional required security permissions.
+        
+        If any of the outbound resource adapter elements (transaction-support,
+        authentication-mechanism, reauthentication-support) is specified through
+        this element or metadata annotations, and no  connection-definition is 
+        specified as part of this element or through annotations, the 
+        application server must consider this an error and fail deployment. 
+        
+        If there is no authentication-mechanism specified as part of
+        this element or metadata annotations, then the resource adapter does 
+        not support any standard security authentication mechanisms as 
+        part of security contract. The application server ignores the security 
+        part of the system contracts in this case.
+        
+        If there is no transaction-support specified as part of this element 
+        or metadata annotation, then the application server must consider that 
+        the resource adapter does not support either the resource manager local 
+        or JTA transactions and must consider the transaction support as 
+        NoTransaction. Note that resource adapters may specify the level of 
+        transaction support to be used at runtime for a ManagedConnectionFactory 
+        through the TransactionSupport interface.
+        
+        If there is no reauthentication-support specified as part of
+        this element or metadata annotation, then the application server must consider 
+        that the resource adapter does not support re-authentication of 
+        ManagedConnections.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="connection-definition"
+                   type="javaee:connection-definitionType"
+                   maxOccurs="unbounded"
+                   minOccurs="0"/>
+      <xsd:element name="transaction-support"
+                   type="javaee:transaction-supportType"
+                   minOccurs="0"/>
+      <xsd:element name="authentication-mechanism"
+                   type="javaee:authentication-mechanismType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="reauthentication-support"
+                   type="javaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            	    The element reauthentication-support specifies
+            	    whether the resource adapter implementation supports
+            	    re-authentication of existing Managed- Connection
+            	    instance. Note that this information is for the
+            	    resource adapter implementation and not for the
+            	    underlying EIS instance. This element must have
+            	    either a "true" or "false" value.
+            
+            	  
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="required-config-propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The required-config-propertyType contains a declaration
+        of a single configuration property used for specifying a
+        required configuration property name. It is used
+        by required-config-property elements.
+        
+        Usage of this type is deprecated from Connectors 1.6 specification. 
+        Refer to required-config-property element for more information.
+        
+        Example:
+        
+        <required-config-property>
+        <config-property-name>Destination</config-property-name>
+        </required-config-property>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="config-property-name"
+                   type="javaee:config-property-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resourceadapterType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The resourceadapterType specifies information about the
+        resource adapter. The information includes fully qualified
+        resource adapter Java class name, configuration properties,
+        information specific to the implementation of the resource
+        adapter library as specified through the
+        outbound-resourceadapter and inbound-resourceadapter
+        elements, and an optional set of administered objects.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="resourceadapter-class"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element resourceadapter-class specifies the
+            fully qualified name of a Java class that implements
+            the javax.resource.spi.ResourceAdapter
+            interface. This Java class is provided as part of
+            resource adapter's implementation of connector
+            architecture specified contracts. The implementation
+            of this class is required to be a JavaBean.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="config-property"
+                   type="javaee:config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="outbound-resourceadapter"
+                   type="javaee:outbound-resourceadapterType"
+                   minOccurs="0">
+        <xsd:unique name="connectionfactory-interface-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The connectionfactory-interface element content
+              must be unique in the outbound-resourceadapter.
+              Multiple connection-definitions can not use the
+              same connectionfactory-type.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="javaee:connection-definition"/>
+          <xsd:field xpath="javaee:connectionfactory-interface"/>
+        </xsd:unique>
+      </xsd:element>
+      <xsd:element name="inbound-resourceadapter"
+                   type="javaee:inbound-resourceadapterType"
+                   minOccurs="0"/>
+      <xsd:element name="adminobject"
+                   type="javaee:adminobjectType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:unique name="adminobject-type-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The adminobject-interface and adminobject-class element content must be
+              unique in the resourceadapterType. Several admin objects
+              can not use the same adminobject-interface and adminobject-class.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="javaee:adminobject"/>
+          <xsd:field xpath="javaee:adminobject-interface"/>
+          <xsd:field xpath="javaee:adminobject-class"/>
+        </xsd:unique>
+      </xsd:element>
+      <xsd:element name="security-permission"
+                   type="javaee:security-permissionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-permissionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The security-permissionType specifies a security
+        permission that is required by the resource adapter code.
+        
+        The security permission listed in the deployment descriptor
+        are ones that are different from those required by the
+        default permission set as specified in the connector
+        specification. The optional description can mention specific
+        reason that resource adapter requires a given security
+        permission.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="security-permission-spec"
+                   type="javaee:xsdStringType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element security-permission-spec specifies a security
+            permission based on the Security policy file
+            syntax. Refer to the following URL for Sun's
+            implementation of the security permission
+            specification:
+            
+            http://docs.oracle.com/javase/6/docs/technotes/guides/security/PolicyFiles.html
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/j2ee_web_services_1_1.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/j2ee_web_services_1_1.xsd
@@ -1,0 +1,499 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+	    targetNamespace="http://java.sun.com/xml/ns/j2ee"
+	    xmlns:j2ee="http://java.sun.com/xml/ns/j2ee"
+	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	    elementFormDefault="qualified"
+	    attributeFormDefault="unqualified"
+	    version="1.1">
+  <xsd:annotation>
+    <xsd:documentation>
+      @(#)j2ee_web_services_1_1.xsds	1.11 02/11/03
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+      Copyright 2003-2007 Sun Microsystems, Inc. All rights reserved.
+
+      The contents of this file are subject to the terms of either the
+      GNU General Public License Version 2 only ("GPL") or the Common
+      Development and Distribution License("CDDL") (collectively, the
+      "License").  You may not use this file except in compliance with
+      the License. You can obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL.html or
+      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
+      specific language governing permissions and limitations under the
+      License.
+
+      When distributing the software, include this License Header
+      Notice in each file and include the License file at
+      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
+      particular file as subject to the "Classpath" exception as
+      provided by Sun in the GPL Version 2 section of the License file
+      that accompanied this code.  If applicable, add the following
+      below the License Header, with the fields enclosed by brackets []
+      replaced by your own identifying information:
+      "Portions Copyrighted [year] [name of copyright owner]"
+
+      Contributor(s):
+
+      If you wish your version of this file to be governed by only the
+      CDDL or only the GPL Version 2, indicate your decision by adding
+      "[Contributor] elects to include this software in this
+      distribution under the [CDDL or GPL Version 2] license."  If you
+      don't indicate a single choice of license, a recipient has the
+      option to distribute your version of this file under either the
+      CDDL, the GPL Version 2 or to extend the choice of license to its
+      licensees as provided above.  However, if you add GPL Version 2
+      code and therefore, elected the GPL Version 2 license, then the
+      option applies only if the new code is made subject to such
+      option by the copyright holder.
+
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      (C) Copyright International Business Machines Corporation 2002
+
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+
+	The webservices element is the root element for the web services
+	deployment descriptor.  It specifies the set of web service
+	descriptions that are to be deployed into the J2EE Application
+	Server and the dependencies they have on container resources and
+	services.  The deployment descriptor must be named
+	"META-INF/webservices.xml" in the web services' jar file.
+
+	Used in: webservices.xml
+
+	All webservices deployment descriptors must indicate the
+	webservices schema by using the J2EE namespace:
+
+	http://java.sun.com/xml/ns/j2ee
+
+	and by indicating the version of the schema by using the version
+	element as shown below:
+
+	    <webservices xmlns="http://java.sun.com/xml/ns/j2ee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
+		http://www.ibm.com/webservices/xsd/j2ee_web_services_1_1.xsd"
+	      version="1.1">
+	      ...
+	    </webservices>
+
+	The instance documents may indicate the published version of the
+	schema using the xsi:schemaLocation attribute for the J2EE
+	namespace with the following location:
+
+	http://www.ibm.com/webservices/xsd/j2ee_web_services_1_1.xsd
+
+	]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all J2EE
+      deployment descriptor elements unless indicated otherwise.
+
+      - In elements that specify a pathname to a file within the
+	same JAR file, relative filenames (i.e., those not
+	starting with "/") are considered relative to the root of
+	the JAR file's namespace.  Absolute filenames (i.e., those
+	starting with "/") also specify names in the root of the
+	JAR file's namespace.  In general, relative names are
+	preferred.  The exception is .war files where absolute
+	names are preferred for consistency with the Servlet API.
+
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="j2ee_1_4.xsd"/>
+
+
+<!-- **************************************************** -->
+
+
+  <xsd:element name="webservices" type="j2ee:webservicesType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The webservices element is the root element for the web services
+	deployment descriptor.  It specifies the set of web service
+	descriptions that are to be deployed into the J2EE Application Server
+	and the dependencies they have on container resources and services.
+
+	Used in: webservices.xml
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:key name="webservice-description-name-key">
+      <xsd:annotation>
+	<xsd:documentation>
+
+	  The webservice-description-name identifies the collection of
+	  port-components associated with a WSDL file and JAX-RPC mapping. The
+	  name must be unique within the deployment descriptor.
+
+	</xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="j2ee:webservice-description"/>
+      <xsd:field xpath="j2ee:webservice-description-name"/>
+    </xsd:key>
+  </xsd:element>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The port-component element associates a WSDL port with a web service
+	interface and implementation.  It defines the name of the port as a
+	component, optional description, optional display name, optional iconic
+	representations, WSDL port QName, Service Endpoint Interface, Service
+	Implementation Bean.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="description"
+		   type="j2ee:descriptionType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="display-name"
+		   type="j2ee:display-nameType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="icon"
+		   type="j2ee:iconType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="port-component-name"
+		   type="j2ee:string">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The port-component-name element specifies a port component's
+	      name.  This name is assigned by the module producer to name
+	      the service implementation bean in the module's deployment
+	      descriptor. The name must be unique among the port component
+	      names defined in the same module.
+
+	      Used in: port-component
+
+	      Example:
+		      <port-component-name>EmployeeService
+		      </port-component-name>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-port"
+		   type="j2ee:xsdQNameType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    Defines the name space and local name part of the WSDL port QName.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-endpoint-interface"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The service-endpoint-interface element contains the
+	      fully-qualified name of the port component's Service Endpoint
+	      Interface.
+
+	      Used in: port-component
+
+	      Example:
+		      <remote>com.wombat.empl.EmployeeService</remote>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-impl-bean"
+		   type="j2ee:service-impl-beanType"/>
+
+      <xsd:element name="handler"
+		   type="j2ee:port-component_handlerType"
+		   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-component_handlerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	Declares the handler for a port-component. Handlers can access the
+	init-param name/value pairs using the HandlerInfo interface.
+
+	Used in: port-component
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="j2ee:descriptionGroup"/>
+      <xsd:element name="handler-name"
+		   type="j2ee:string">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    Defines the name of the handler. The name must be unique within the
+	    module.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="handler-class"
+		   type="j2ee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    Defines a fully qualified class name for the handler implementation.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="init-param"
+		   type="j2ee:param-valueType"
+		   minOccurs="0" maxOccurs="unbounded"/>
+
+      <xsd:element name="soap-header"
+		   type="j2ee:xsdQNameType"
+		   minOccurs="0" maxOccurs="unbounded">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    Defines the QName of a SOAP header that will be processed by the
+	    handler.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="soap-role"
+		   type="j2ee:string"
+		   minOccurs="0" maxOccurs="unbounded">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The soap-role element contains a SOAP actor definition that the
+	    Handler will play as a role.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="service-impl-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The service-impl-bean element defines the web service implementation.
+	A service implementation can be an EJB bean class or JAX-RPC web
+	component.  Existing EJB implementations are exposed as a web service
+	using an ejb-link.
+
+	Used in: port-component
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice>
+      <xsd:element name="ejb-link"
+		   type="j2ee:ejb-linkType"/>
+      <xsd:element name="servlet-link"
+		   type="j2ee:servlet-linkType"/>
+    </xsd:choice>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servlet-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+	<![CDATA[
+
+	  The servlet-link element is used in the service-impl-bean element
+	  to specify that a Service Implementation Bean is defined as a
+	  JAX-RPC Service Endpoint.
+
+	  The value of the servlet-link element must be the servlet-name of
+	  a JAX-RPC Service Endpoint in the same WAR file.
+
+	  Used in: service-impl-bean
+
+	  Example:
+		  <servlet-link>StockQuoteService</servlet-link>
+
+	  ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="j2ee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webservice-descriptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The webservice-description element defines a WSDL document file
+	and the set of Port components associated with the WSDL ports
+	defined in the WSDL document.  There may be multiple
+	webservice-descriptions defined within a module.
+
+	All WSDL file ports must have a corresponding port-component element
+	defined.
+
+	Used in: webservices
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="description"
+		   type="j2ee:descriptionType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="display-name"
+		   type="j2ee:display-nameType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="icon"
+		   type="j2ee:iconType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="webservice-description-name"
+		   type="j2ee:string">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The webservice-description-name identifies the collection of
+	    port-components associated with a WSDL file and JAX-RPC
+	    mapping. The name must be unique within the deployment descriptor.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-file"
+		   type="j2ee:pathType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The wsdl-file element contains the name of a WSDL file in the
+	    module.  The file name is a relative path within the module.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="jaxrpc-mapping-file"
+		   type="j2ee:pathType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The jaxrpc-mapping-file element contains the name of a file that
+	    describes the JAX-RPC mapping between the Java interaces used by
+	    the application and the WSDL description in the wsdl-file.  The
+	    file name is a relative path within the module.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component"
+		   type="j2ee:port-componentType"
+		   minOccurs="1" maxOccurs="unbounded">
+	<xsd:key name="port-component_handler-name-key">
+	  <xsd:annotation>
+	    <xsd:documentation>
+
+	      Defines the name of the handler. The name must be unique
+	      within the module.
+
+	    </xsd:documentation>
+	  </xsd:annotation>
+	  <xsd:selector xpath="j2ee:handler"/>
+	  <xsd:field xpath="j2ee:handler-name"/>
+	</xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webservicesType">
+    <xsd:sequence>
+      <xsd:group ref="j2ee:descriptionGroup"/>
+      <xsd:element name="webservice-description"
+		   type="j2ee:webservice-descriptionType"
+		   minOccurs="1" maxOccurs="unbounded">
+	<xsd:key name="port-component-name-key">
+	  <xsd:annotation>
+	    <xsd:documentation>
+	      <![CDATA[
+
+		The port-component-name element specifies a port
+		component's name.  This name is assigned by the module
+		producer to name the service implementation bean in the
+		module's deployment descriptor. The name must be unique
+		among the port component names defined in the same module.
+
+		Used in: port-component
+
+		Example:
+			<port-component-name>EmployeeService
+			</port-component-name>
+
+		]]>
+	    </xsd:documentation>
+	  </xsd:annotation>
+	  <xsd:selector xpath="j2ee:port-component"/>
+	  <xsd:field xpath="j2ee:port-component-name"/>
+	</xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="version"
+		   type="j2ee:dewey-versionType"
+		   fixed="1.1"
+		   use="required">
+      <xsd:annotation>
+	<xsd:documentation>
+
+	  The required value for the version is 1.1.
+
+	</xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>
+

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_2.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_2.xsd
@@ -1,0 +1,754 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+	    targetNamespace="http://java.sun.com/xml/ns/javaee"
+	    xmlns:javaee="http://java.sun.com/xml/ns/javaee"
+	    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	    elementFormDefault="qualified"
+	    attributeFormDefault="unqualified"
+	    version="1.2">
+  <xsd:annotation>
+    <xsd:documentation>
+      @(#)javaee_web_services_1_2.xsds	1.18 02/13/06
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+      Copyright 2003-2007 Sun Microsystems, Inc. All rights reserved.
+
+      The contents of this file are subject to the terms of either the
+      GNU General Public License Version 2 only ("GPL") or the Common
+      Development and Distribution License("CDDL") (collectively, the
+      "License").  You may not use this file except in compliance with
+      the License. You can obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL.html or
+      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
+      specific language governing permissions and limitations under the
+      License.
+
+      When distributing the software, include this License Header
+      Notice in each file and include the License file at
+      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
+      particular file as subject to the "Classpath" exception as
+      provided by Sun in the GPL Version 2 section of the License file
+      that accompanied this code.  If applicable, add the following
+      below the License Header, with the fields enclosed by brackets []
+      replaced by your own identifying information:
+      "Portions Copyrighted [year] [name of copyright owner]"
+
+      Contributor(s):
+
+      If you wish your version of this file to be governed by only the
+      CDDL or only the GPL Version 2, indicate your decision by adding
+      "[Contributor] elects to include this software in this
+      distribution under the [CDDL or GPL Version 2] license."  If you
+      don't indicate a single choice of license, a recipient has the
+      option to distribute your version of this file under either the
+      CDDL, the GPL Version 2 or to extend the choice of license to its
+      licensees as provided above.  However, if you add GPL Version 2
+      code and therefore, elected the GPL Version 2 license, then the
+      option applies only if the new code is made subject to such
+      option by the copyright holder.
+
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      (C) Copyright International Business Machines Corporation 2002
+
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+
+	The webservices element is the root element for the web services
+	deployment descriptor.  It specifies the set of web service
+	descriptions that are to be deployed into the Java EE Application
+	Server and the dependencies they have on container resources and
+	services.  The deployment descriptor must be named
+	"META-INF/webservices.xml" in the web services' jar file.
+
+	Used in: webservices.xml
+
+	All webservices deployment descriptors must indicate the
+	webservices schema by using the Java EE namespace:
+
+	http://java.sun.com/xml/ns/javaee
+
+	and by indicating the version of the schema by using the version
+	element as shown below:
+
+	    <webservices xmlns="http://java.sun.com/xml/ns/javaee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+		http://java.sun.com/xml/ns/javaee/javaee_web_services_1_2.xsd"
+	      version="1.2">
+	      ...
+	    </webservices>
+
+	The instance documents may indicate the published version of the
+	schema using the xsi:schemaLocation attribute for the Java EE
+	namespace with the following location:
+
+	http://java.sun.com/xml/ns/javaee/javaee_web_services_1_2.xsd
+
+	]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Java EE
+      deployment descriptor elements unless indicated otherwise.
+
+      - In elements that specify a pathname to a file within the
+	same JAR file, relative filenames (i.e., those not
+	starting with "/") are considered relative to the root of
+	the JAR file's namespace.  Absolute filenames (i.e., those
+	starting with "/") also specify names in the root of the
+	JAR file's namespace.  In general, relative names are
+	preferred.  The exception is .war files where absolute
+	names are preferred for consistency with the Servlet API.
+
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="javaee_5.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="webservices" type="javaee:webservicesType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The webservices element is the root element for the web services
+	deployment descriptor.  It specifies the set of web service
+	descriptions that are to be deployed into the Java EE Application Server
+	and the dependencies they have on container resources and services.
+
+	Used in: webservices.xml
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:key name="webservice-description-name-key">
+      <xsd:annotation>
+	<xsd:documentation>
+
+	  The webservice-description-name identifies the collection of
+	  port-components associated with a WSDL file and JAX-RPC mapping. The
+	  name must be unique within the deployment descriptor.
+
+	</xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:webservice-description"/>
+      <xsd:field xpath="javaee:webservice-description-name"/>
+    </xsd:key>
+  </xsd:element>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handler-chainType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+      The handler-chain element defines the handlerchain.
+      Handlerchain can be defined such that the handlers in the
+      handlerchain operate,all ports of a service, on a specific
+      port or on a list of protocol-bindings. The choice of elements
+      service-name-pattern, port-name-pattern and protocol-bindings
+      are used to specify whether the handlers in handler-chain are
+      for a service, port or protocol binding. If none of these
+      choices are specified with the handler-chain element then the
+      handlers specified in the handler-chain will be applied on
+      everything.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+
+      <xsd:choice minOccurs="0" maxOccurs="1">
+         <xsd:element name="service-name-pattern"
+		      type="javaee:qname-pattern" />
+         <xsd:element name="port-name-pattern"
+		      type="javaee:qname-pattern" />
+         <xsd:element name="protocol-bindings"
+		      type="javaee:protocol-bindingListType"/>
+      </xsd:choice>
+
+      <xsd:element name="handler"
+                   type="javaee:port-component_handlerType"
+		   minOccurs="1" maxOccurs="unbounded"/>
+    </xsd:sequence>
+
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handler-chainsType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+      The handler-chains element defines the handlerchains associated
+      with this service or service endpoint.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="handler-chain"
+                   type="javaee:handler-chainType"
+		   minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The port-component element associates a WSDL port with a web service
+	interface and implementation.  It defines the name of the port as a
+	component, optional description, optional display name, optional iconic
+	representations, WSDL port QName, Service Endpoint Interface, Service
+	Implementation Bean.
+
+	This element also associates a WSDL service with a JAX-WS Provider
+	implementation.
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="description"
+		   type="javaee:descriptionType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="display-name"
+		   type="javaee:display-nameType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="icon"
+		   type="javaee:iconType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="port-component-name"
+		   type="javaee:string">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The port-component-name element specifies a port component's
+	      name.  This name is assigned by the module producer to name
+	      the service implementation bean in the module's deployment
+	      descriptor. The name must be unique among the port component
+	      names defined in the same module.
+
+	      Used in: port-component
+
+	      Example:
+		      <port-component-name>EmployeeService
+		      </port-component-name>
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-service"
+		   type="javaee:xsdQNameType"
+		   minOccurs="0" maxOccurs="1">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    Defines the name space and local name part of the WSDL
+	    service QName. This is required to be specified for
+	    port components that are JAX-WS Provider implementations.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-port"
+		   type="javaee:xsdQNameType"
+		   minOccurs="0" maxOccurs="1">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    Defines the name space and local name part of the WSDL
+	    port QName. This is not required to be specified for port
+	    components that are JAX-WS Provider implementations
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="enable-mtom"
+                   type="javaee:true-falseType"
+		   minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to enable or disable SOAP MTOM/XOP mechanism for an
+            endpoint implementation.
+
+	    Not to be specified for JAX-RPC runtime
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="protocol-binding"
+                   type="javaee:protocol-bindingType"
+		   minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to specify the protocol binding used by the port-component.
+	    If this element is not specified, then the default binding is
+            used (SOAP 1.1 over HTTP)
+
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+
+      <xsd:element name="service-endpoint-interface"
+		   type="javaee:fully-qualified-classType"
+		   minOccurs="0" maxOccurs="1">
+	<xsd:annotation>
+	  <xsd:documentation>
+	    <![CDATA[
+
+	      The service-endpoint-interface element contains the
+	      fully-qualified name of the port component's Service Endpoint
+	      Interface.
+
+	      Used in: port-component
+
+	      Example:
+		      <remote>com.wombat.empl.EmployeeService</remote>
+
+	      This may not be specified in case there is no Service
+	      Enpoint Interface as is the case with directly using an
+	      implementation class with the @WebService annotation.
+
+	      When the port component is a Provider implementation
+	      this is not specified.
+
+	      ]]>
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-impl-bean"
+		   type="javaee:service-impl-beanType"/>
+
+      <xsd:choice>
+	<xsd:element name="handler"
+		     type="javaee:port-component_handlerType"
+		     minOccurs="0" maxOccurs="unbounded">
+	  <xsd:annotation>
+	    <xsd:documentation>
+		 To be used with JAX-RPC based runtime only.
+	    </xsd:documentation>
+	  </xsd:annotation>
+	</xsd:element>
+	<xsd:element name="handler-chains"
+		     type="javaee:handler-chainsType"
+		     minOccurs="0" maxOccurs="1">
+	  <xsd:annotation>
+	    <xsd:documentation>
+		 To be used with JAX-WS based runtime only.
+	    </xsd:documentation>
+	  </xsd:annotation>
+	</xsd:element>
+      </xsd:choice>
+
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-component_handlerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	Declares the handler for a port-component. Handlers can access the
+	init-param name/value pairs using the HandlerInfo interface.
+
+	Used in: port-component
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="handler-name"
+		   type="javaee:string">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    Defines the name of the handler. The name must be unique within the
+	    module.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="handler-class"
+		   type="javaee:fully-qualified-classType">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    Defines a fully qualified class name for the handler implementation.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="init-param"
+		   type="javaee:param-valueType"
+		   minOccurs="0" maxOccurs="unbounded"/>
+
+      <xsd:element name="soap-header"
+		   type="javaee:xsdQNameType"
+		   minOccurs="0" maxOccurs="unbounded">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    Defines the QName of a SOAP header that will be processed by the
+	    handler.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="soap-role"
+		   type="javaee:string"
+		   minOccurs="0" maxOccurs="unbounded">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The soap-role element contains a SOAP actor definition that the
+	    Handler will play as a role.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="protocol-URIAliasType">
+     <xsd:annotation>
+        <xsd:documentation>
+	   Defines the type that is used for specifying tokens that
+	   start with ## which are used to alias existing standard
+	   protocol bindings and support aliases for new standard
+	   binding URIs that are introduced in future specifications.
+
+	   The following tokens alias the standard protocol binding
+	   URIs:
+
+	   ##SOAP11_HTTP = "http://schemas.xmlsoap.org/wsdl/soap/http"
+	   ##SOAP11_HTTP_MTOM =
+                 "http://schemas.xmlsoap.org/wsdl/soap/http?mtom=true"
+           ##SOAP12_HTTP = "http://www.w3.org/2003/05/soap/bindings/HTTP/"
+           ##SOAP12_HTTP_MTOM =
+		 "http://www.w3.org/2003/05/soap/bindings/HTTP/?mtom=true"
+           ##XML_HTTP = "http://www.w3.org/2004/08/wsdl/http"
+
+        </xsd:documentation>
+     </xsd:annotation>
+     <xsd:restriction base="xsd:token">
+        <xsd:pattern value="##.+"/>
+     </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="protocol-bindingListType">
+     <xsd:annotation>
+        <xsd:documentation>
+	   Defines the type used for specifying a list of
+	   protocol-bindingType(s). For e.g.
+
+	    ##SOAP11_HTTP ##SOAP12_HTTP ##XML_HTTP
+
+        </xsd:documentation>
+     </xsd:annotation>
+     <xsd:list itemType="javaee:protocol-bindingType"/>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="protocol-bindingType">
+     <xsd:annotation>
+        <xsd:documentation>
+	   Defines the type used for specifying the URI for the
+	   protocol binding used by the port-component.  For
+	   portability one could use one of the following tokens that
+	   alias the standard binding types:
+
+	    ##SOAP11_HTTP
+	    ##SOAP11_HTTP_MTOM
+	    ##SOAP12_HTTP
+	    ##SOAP12_HTTP_MTOM
+	    ##XML_HTTP
+
+	   Other specifications could define tokens that start with ##
+	   to alias new standard binding URIs that are introduced.
+
+        </xsd:documentation>
+     </xsd:annotation>
+     <xsd:union memberTypes="xsd:anyURI javaee:protocol-URIAliasType"/>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="qname-pattern">
+     <xsd:annotation>
+        <xsd:documentation>
+	     This is used to specify the QName pattern in the
+	     attribute service-name-pattern and port-name-pattern in
+	     the handler-chain element
+
+	     For example, the various forms acceptable here for
+	     service-name-pattern attribute in handler-chain element
+	     are :
+
+	     Exact Name: service-name-pattern="ns1:EchoService"
+
+		 In this case, handlers specified in this
+		 handler-chain element will apply to all ports with
+		 this exact service name. The namespace prefix must
+		 have been declared in a namespace declaration
+		 attribute in either the start-tag of the element
+		 where the prefix is used or in an an ancestor
+		 element (i.e. an element in whose content the
+		 prefixed markup occurs)
+
+	     Pattern : service-name-pattern="ns1:EchoService*"
+
+		 In this case, handlers specified in this
+		 handler-chain element will apply to all ports whose
+		 Service names are like EchoService1, EchoServiceFoo
+		 etc. The namespace prefix must have been declared in
+		 a namespace declaration attribute in either the
+		 start-tag of the element where the prefix is used or
+		 in an an ancestor element (i.e. an element in whose
+		 content the prefixed markup occurs)
+
+	     Wild Card : service-name-pattern="*"
+
+		In this case, handlers specified in this handler-chain
+		element will apply to ports of all service names.
+
+	    The same can be applied to port-name attribute in
+	    handler-chain element.
+
+        </xsd:documentation>
+     </xsd:annotation>
+
+     <xsd:restriction base="xsd:token">
+        <xsd:pattern value="\*|([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*\*?"/>
+     </xsd:restriction>
+
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="service-impl-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The service-impl-bean element defines the web service implementation.
+	A service implementation can be an EJB bean class or JAX-RPC web
+	component.  Existing EJB implementations are exposed as a web service
+	using an ejb-link.
+
+	Used in: port-component
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice>
+      <xsd:element name="ejb-link"
+		   type="javaee:ejb-linkType"/>
+      <xsd:element name="servlet-link"
+		   type="javaee:servlet-linkType"/>
+    </xsd:choice>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servlet-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+	<![CDATA[
+
+	  The servlet-link element is used in the service-impl-bean element
+	  to specify that a Service Implementation Bean is defined as a
+	  JAX-RPC Service Endpoint.
+
+	  The value of the servlet-link element must be the servlet-name of
+	  a JAX-RPC Service Endpoint in the same WAR file.
+
+	  Used in: service-impl-bean
+
+	  Example:
+		  <servlet-link>StockQuoteService</servlet-link>
+
+	  ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webservice-descriptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+	The webservice-description element defines a WSDL document file
+	and the set of Port components associated with the WSDL ports
+	defined in the WSDL document.  There may be multiple
+	webservice-descriptions defined within a module.
+
+	All WSDL file ports must have a corresponding port-component element
+	defined.
+
+	Used in: webservices
+
+      </xsd:documentation>
+    </xsd:annotation>
+
+    <xsd:sequence>
+      <xsd:element name="description"
+		   type="javaee:descriptionType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="display-name"
+		   type="javaee:display-nameType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="icon"
+		   type="javaee:iconType"
+		   minOccurs="0" maxOccurs="1"/>
+      <xsd:element name="webservice-description-name"
+		   type="javaee:string">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The webservice-description-name identifies the collection of
+	    port-components associated with a WSDL file and JAX-RPC
+	    mapping. The name must be unique within the deployment descriptor.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-file"
+		   type="javaee:pathType"
+		   minOccurs="0" maxOccurs="1">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The wsdl-file element contains the name of a WSDL file in the
+	    module.  The file name is a relative path within the module.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="jaxrpc-mapping-file"
+		   type="javaee:pathType"
+		   minOccurs="0" maxOccurs="1">
+	<xsd:annotation>
+	  <xsd:documentation>
+
+	    The jaxrpc-mapping-file element contains the name of a file that
+	    describes the JAX-RPC mapping between the Java interaces used by
+	    the application and the WSDL description in the wsdl-file.  The
+	    file name is a relative path within the module.
+
+	    This is not required when JAX-WS based runtime is used.
+
+	  </xsd:documentation>
+	</xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component"
+		   type="javaee:port-componentType"
+		   minOccurs="1" maxOccurs="unbounded">
+	<xsd:key name="port-component_handler-name-key">
+	  <xsd:annotation>
+	    <xsd:documentation>
+
+	      Defines the name of the handler. The name must be unique
+	      within the module.
+
+	    </xsd:documentation>
+	  </xsd:annotation>
+	  <xsd:selector xpath="javaee:handler"/>
+	  <xsd:field xpath="javaee:handler-name"/>
+	</xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webservicesType">
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="webservice-description"
+		   type="javaee:webservice-descriptionType"
+		   minOccurs="1" maxOccurs="unbounded">
+	<xsd:key name="port-component-name-key">
+	  <xsd:annotation>
+	    <xsd:documentation>
+	      <![CDATA[
+
+		The port-component-name element specifies a port
+		component's name.  This name is assigned by the module
+		producer to name the service implementation bean in the
+		module's deployment descriptor. The name must be unique
+		among the port component names defined in the same module.
+
+		Used in: port-component
+
+		Example:
+			<port-component-name>EmployeeService
+			</port-component-name>
+
+		]]>
+	    </xsd:documentation>
+	  </xsd:annotation>
+	  <xsd:selector xpath="javaee:port-component"/>
+	  <xsd:field xpath="javaee:port-component-name"/>
+	</xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="version"
+		   type="javaee:dewey-versionType"
+		   fixed="1.2"
+		   use="required">
+      <xsd:annotation>
+	<xsd:documentation>
+
+	  The required value for the version is 1.2.
+
+	</xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+
+    <xsd:attribute name="id" type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>
+

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_3.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_3.xsd
@@ -1,0 +1,572 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://java.sun.com/xml/ns/javaee"
+            xmlns:javaee="http://java.sun.com/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.3">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright 2003-2009 Sun Microsystems, Inc. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the
+      GNU General Public License Version 2 only ("GPL") or the Common
+      Development and Distribution License("CDDL") (collectively, the
+      "License").  You may not use this file except in compliance with
+      the License. You can obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL.html or
+      glassfish/bootstrap/legal/LICENSE.txt.  See the License for the
+      specific language governing permissions and limitations under the
+      License.
+      
+      When distributing the software, include this License Header
+      Notice in each file and include the License file at
+      glassfish/bootstrap/legal/LICENSE.txt.  Sun designates this
+      particular file as subject to the "Classpath" exception as
+      provided by Sun in the GPL Version 2 section of the License file
+      that accompanied this code.  If applicable, add the following
+      below the License Header, with the fields enclosed by brackets []
+      replaced by your own identifying information:
+      "Portions Copyrighted [year] [name of copyright owner]"
+      
+      Contributor(s):
+      
+      If you wish your version of this file to be governed by only the
+      CDDL or only the GPL Version 2, indicate your decision by adding
+      "[Contributor] elects to include this software in this
+      distribution under the [CDDL or GPL Version 2] license."  If you
+      don't indicate a single choice of license, a recipient has the
+      option to distribute your version of this file under either the
+      CDDL, the GPL Version 2 or to extend the choice of license to its
+      licensees as provided above.  However, if you add GPL Version 2
+      code and therefore, elected the GPL Version 2 license, then the
+      option applies only if the new code is made subject to such
+      option by the copyright holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      (C) Copyright International Business Machines Corporation 2002
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[[
+      The webservices element is the root element for the web services
+      deployment descriptor.  It specifies the set of web service
+      descriptions that are to be deployed into the Java EE Application
+      Server and the dependencies they have on container resources and
+      services.  The deployment descriptor must be named
+      "META-INF/webservices.xml" in the web services' jar file.
+      
+      Used in: webservices.xml
+      
+      All webservices deployment descriptors must indicate the
+      webservices schema by using the Java EE namespace:
+      
+      http://java.sun.com/xml/ns/javaee
+      
+      and by indicating the version of the schema by using the version
+      element as shown below:
+      
+      <webservices xmlns="http://java.sun.com/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+      	http://java.sun.com/xml/ns/javaee/javaee_web_services_1_3.xsd"
+      version="1.3">
+      ...
+      </webservices>
+      
+      The instance documents may indicate the published version of the
+      schema using the xsi:schemaLocation attribute for the Java EE
+      namespace with the following location:
+      
+      http://java.sun.com/xml/ns/javaee/javaee_web_services_1_3.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Java EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="javaee_6.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="webservices"
+               type="javaee:webservicesType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The webservices element is the root element for the web services
+        deployment descriptor.  It specifies the set of web service
+        descriptions that are to be deployed into the Java EE Application Server
+        and the dependencies they have on container resources and services.
+        
+        Used in: webservices.xml
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:key name="webservice-description-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The webservice-description-name identifies the collection of
+          port-components associated with a WSDL file and JAX-RPC mapping. The
+          name must be unique within the deployment descriptor.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:webservice-description"/>
+      <xsd:field xpath="javaee:webservice-description-name"/>
+    </xsd:key>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The port-component element associates a WSDL port with a web service
+        interface and implementation.  It defines the name of the port as a
+        component, optional description, optional display name, optional iconic
+        representations, WSDL port QName, Service Endpoint Interface, Service
+        Implementation Bean.
+        
+        This element also associates a WSDL service with a JAX-WS Provider
+        implementation.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="display-name"
+                   type="javaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="icon"
+                   type="javaee:iconType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="port-component-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The port-component-name element specifies a port component's
+            name.  This name is assigned by the module producer to name
+            the service implementation bean in the module's deployment
+            descriptor. The name must be unique among the port component
+            names defined in the same module.
+            
+            Used in: port-component
+            
+            Example:
+            	      <port-component-name>EmployeeService
+            	      </port-component-name>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-service"
+                   type="javaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the name space and local name part of the WSDL
+            service QName. This is required to be specified for
+            port components that are JAX-WS Provider implementations.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-port"
+                   type="javaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the name space and local name part of the WSDL
+            port QName. This is not required to be specified for port
+            components that are JAX-WS Provider implementations
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="enable-mtom"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to enable or disable SOAP MTOM/XOP mechanism for an
+            endpoint implementation.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mtom-threshold"
+                   type="javaee:xsdNonNegativeIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When MTOM is enabled, binary data above this size in bytes
+            will be XOP encoded or sent as attachment. Default value is 0.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="addressing"
+                   type="javaee:addressingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            This specifies the WS-Addressing requirements for a JAX-WS
+            web service. It corresponds to javax.xml.ws.soap.Addressing
+            annotation or its feature javax.xml.ws.soap.AddressingFeature.
+            
+            See the addressingType for more information.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="respect-binding"
+                   type="javaee:respect-bindingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Corresponds to the javax.xml.ws.RespectBinding annotation
+            or its corresponding javax.xml.ws.RespectBindingFeature web
+            service feature. This is used to control whether a JAX-WS
+            implementation must respect/honor the contents of the
+            wsdl:binding in the WSDL that is associated with the service.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="protocol-binding"
+                   type="javaee:protocol-bindingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to specify the protocol binding used by the port-component.
+            If this element is not specified, then the default binding is
+            used (SOAP 1.1 over HTTP)
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-endpoint-interface"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The service-endpoint-interface element contains the
+            fully-qualified name of the port component's Service Endpoint
+            Interface.
+            
+            Used in: port-component
+            
+            Example:
+            	      <remote>com.wombat.empl.EmployeeService</remote>
+            
+            This may not be specified in case there is no Service
+            Enpoint Interface as is the case with directly using an
+            implementation class with the @WebService annotation.
+            
+            When the port component is a Provider implementation
+            this is not specified.
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-impl-bean"
+                   type="javaee:service-impl-beanType"/>
+      <xsd:choice>
+        <xsd:element name="handler"
+                     type="javaee:handlerType"
+                     minOccurs="0"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	 To be used with JAX-RPC based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="handler-chains"
+                     type="javaee:handler-chainsType"
+                     minOccurs="0"
+                     maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	 To be used with JAX-WS based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="service-impl-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The service-impl-bean element defines the web service implementation.
+        A service implementation can be an EJB bean class or JAX-RPC web
+        component.  Existing EJB implementations are exposed as a web service
+        using an ejb-link.
+        
+        Used in: port-component
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice>
+      <xsd:element name="ejb-link"
+                   type="javaee:ejb-linkType"/>
+      <xsd:element name="servlet-link"
+                   type="javaee:servlet-linkType"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servlet-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The servlet-link element is used in the service-impl-bean element
+        to specify that a Service Implementation Bean is defined as a
+        JAX-RPC Service Endpoint.
+        
+        The value of the servlet-link element must be the servlet-name of
+        a JAX-RPC Service Endpoint in the same WAR file.
+        
+        Used in: service-impl-bean
+        
+        Example:
+        	  <servlet-link>StockQuoteService</servlet-link>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webservice-descriptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The webservice-description element defines a WSDL document file
+        and the set of Port components associated with the WSDL ports
+        defined in the WSDL document.  There may be multiple
+        webservice-descriptions defined within a module.
+        
+        All WSDL file ports must have a corresponding port-component element
+        defined.
+        
+        Used in: webservices
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="display-name"
+                   type="javaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="icon"
+                   type="javaee:iconType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="webservice-description-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The webservice-description-name identifies the collection of
+            port-components associated with a WSDL file and JAX-RPC
+            mapping. The name must be unique within the deployment descriptor.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-file"
+                   type="javaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The wsdl-file element contains the name of a WSDL file in the
+            module.  The file name is a relative path within the module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="jaxrpc-mapping-file"
+                   type="javaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The jaxrpc-mapping-file element contains the name of a file that
+            describes the JAX-RPC mapping between the Java interaces used by
+            the application and the WSDL description in the wsdl-file.  The
+            file name is a relative path within the module.
+            
+            This is not required when JAX-WS based runtime is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component"
+                   type="javaee:port-componentType"
+                   minOccurs="1"
+                   maxOccurs="unbounded">
+        <xsd:key name="port-component_handler-name-key">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Defines the name of the handler. The name must be unique
+              within the module.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="javaee:handler"/>
+          <xsd:field xpath="javaee:handler-name"/>
+        </xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webservicesType">
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="webservice-description"
+                   type="javaee:webservice-descriptionType"
+                   minOccurs="1"
+                   maxOccurs="unbounded">
+        <xsd:key name="port-component-name-key">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[[
+              	The port-component-name element specifies a port
+              	component's name.  This name is assigned by the module
+              	producer to name the service implementation bean in the
+              	module's deployment descriptor. The name must be unique
+              	among the port component names defined in the same module.
+              
+              	Used in: port-component
+              
+              	Example:
+              		<port-component-name>EmployeeService
+              		</port-component-name>
+              
+              	
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="javaee:port-component"/>
+          <xsd:field xpath="javaee:port-component-name"/>
+        </xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="javaee:dewey-versionType"
+                   fixed="1.3"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The required value for the version is 1.3.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_4_1.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_web_services_1_4_1.xsd
@@ -1,0 +1,572 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.4">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      (C) Copyright International Business Machines Corporation 2002
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[[
+      The webservices element is the root element for the web services
+      deployment descriptor.  It specifies the set of web service
+      descriptions that are to be deployed into the Java EE Application
+      Server and the dependencies they have on container resources and
+      services.  The deployment descriptor must be named
+      "META-INF/webservices.xml" in the web services' jar file.
+      
+      Used in: webservices.xml
+      
+      All webservices deployment descriptors must indicate the
+      webservices schema by using the Java EE namespace:
+      
+      http://xmlns.jcp.org/xml/ns/javaee
+      
+      and by indicating the version of the schema by using the version
+      element as shown below:
+      
+      <webservices xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+      	http://xmlns.jcp.org/xml/ns/javaee/javaee_web_services_1_4.xsd"
+      version="1.4">
+      ...
+      </webservices>
+      
+      The instance documents may indicate the published version of the
+      schema using the xsi:schemaLocation attribute for the Java EE
+      namespace with the following location:
+      
+      http://xmlns.jcp.org/xml/ns/javaee/javaee_web_services_1_4.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Java EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="javaee_7.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="webservices"
+               type="javaee:webservicesType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The webservices element is the root element for the web services
+        deployment descriptor.  It specifies the set of web service
+        descriptions that are to be deployed into the Java EE Application Server
+        and the dependencies they have on container resources and services.
+        
+        Used in: webservices.xml
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:key name="webservice-description-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The webservice-description-name identifies the collection of
+          port-components associated with a WSDL file and JAX-RPC mapping. The
+          name must be unique within the deployment descriptor.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:webservice-description"/>
+      <xsd:field xpath="javaee:webservice-description-name"/>
+    </xsd:key>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The port-component element associates a WSDL port with a web service
+        interface and implementation.  It defines the name of the port as a
+        component, optional description, optional display name, optional iconic
+        representations, WSDL port QName, Service Endpoint Interface, Service
+        Implementation Bean.
+        
+        This element also associates a WSDL service with a JAX-WS Provider
+        implementation.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="display-name"
+                   type="javaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="icon"
+                   type="javaee:iconType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="port-component-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The port-component-name element specifies a port component's
+            name.  This name is assigned by the module producer to name
+            the service implementation bean in the module's deployment
+            descriptor. The name must be unique among the port component
+            names defined in the same module.
+            
+            Used in: port-component
+            
+            Example:
+            	      <port-component-name>EmployeeService
+            	      </port-component-name>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-service"
+                   type="javaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the name space and local name part of the WSDL
+            service QName. This is required to be specified for
+            port components that are JAX-WS Provider implementations.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-port"
+                   type="javaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the name space and local name part of the WSDL
+            port QName. This is not required to be specified for port
+            components that are JAX-WS Provider implementations
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="enable-mtom"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to enable or disable SOAP MTOM/XOP mechanism for an
+            endpoint implementation.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mtom-threshold"
+                   type="javaee:xsdNonNegativeIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When MTOM is enabled, binary data above this size in bytes
+            will be XOP encoded or sent as attachment. Default value is 0.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="addressing"
+                   type="javaee:addressingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            This specifies the WS-Addressing requirements for a JAX-WS
+            web service. It corresponds to javax.xml.ws.soap.Addressing
+            annotation or its feature javax.xml.ws.soap.AddressingFeature.
+            
+            See the addressingType for more information.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="respect-binding"
+                   type="javaee:respect-bindingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Corresponds to the javax.xml.ws.RespectBinding annotation
+            or its corresponding javax.xml.ws.RespectBindingFeature web
+            service feature. This is used to control whether a JAX-WS
+            implementation must respect/honor the contents of the
+            wsdl:binding in the WSDL that is associated with the service.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="protocol-binding"
+                   type="javaee:protocol-bindingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to specify the protocol binding used by the port-component.
+            If this element is not specified, then the default binding is
+            used (SOAP 1.1 over HTTP)
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-endpoint-interface"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The service-endpoint-interface element contains the
+            fully-qualified name of the port component's Service Endpoint
+            Interface.
+            
+            Used in: port-component
+            
+            Example:
+            	      <remote>com.wombat.empl.EmployeeService</remote>
+            
+            This may not be specified in case there is no Service
+            Enpoint Interface as is the case with directly using an
+            implementation class with the @WebService annotation.
+            
+            When the port component is a Provider implementation
+            this is not specified.
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-impl-bean"
+                   type="javaee:service-impl-beanType"/>
+      <xsd:choice>
+        <xsd:element name="handler"
+                     type="javaee:handlerType"
+                     minOccurs="0"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	 To be used with JAX-RPC based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="handler-chains"
+                     type="javaee:handler-chainsType"
+                     minOccurs="0"
+                     maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	 To be used with JAX-WS based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="service-impl-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The service-impl-bean element defines the web service implementation.
+        A service implementation can be an EJB bean class or JAX-RPC web
+        component.  Existing EJB implementations are exposed as a web service
+        using an ejb-link.
+        
+        Used in: port-component
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice>
+      <xsd:element name="ejb-link"
+                   type="javaee:ejb-linkType"/>
+      <xsd:element name="servlet-link"
+                   type="javaee:servlet-linkType"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servlet-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The servlet-link element is used in the service-impl-bean element
+        to specify that a Service Implementation Bean is defined as a
+        JAX-RPC Service Endpoint.
+        
+        The value of the servlet-link element must be the servlet-name of
+        a JAX-RPC Service Endpoint in the same WAR file.
+        
+        Used in: service-impl-bean
+        
+        Example:
+        	  <servlet-link>StockQuoteService</servlet-link>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webservice-descriptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The webservice-description element defines a WSDL document file
+        and the set of Port components associated with the WSDL ports
+        defined in the WSDL document.  There may be multiple
+        webservice-descriptions defined within a module.
+        
+        All WSDL file ports must have a corresponding port-component element
+        defined.
+        
+        Used in: webservices
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="display-name"
+                   type="javaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="icon"
+                   type="javaee:iconType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="webservice-description-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The webservice-description-name identifies the collection of
+            port-components associated with a WSDL file and JAX-RPC
+            mapping. The name must be unique within the deployment descriptor.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-file"
+                   type="javaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The wsdl-file element contains the name of a WSDL file in the
+            module.  The file name is a relative path within the module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="jaxrpc-mapping-file"
+                   type="javaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The jaxrpc-mapping-file element contains the name of a file that
+            describes the JAX-RPC mapping between the Java interaces used by
+            the application and the WSDL description in the wsdl-file.  The
+            file name is a relative path within the module.
+            
+            This is not required when JAX-WS based runtime is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component"
+                   type="javaee:port-componentType"
+                   minOccurs="1"
+                   maxOccurs="unbounded">
+        <xsd:key name="port-component_handler-name-key">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Defines the name of the handler. The name must be unique
+              within the module.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="javaee:handler"/>
+          <xsd:field xpath="javaee:handler-name"/>
+        </xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webservicesType">
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="webservice-description"
+                   type="javaee:webservice-descriptionType"
+                   minOccurs="1"
+                   maxOccurs="unbounded">
+        <xsd:key name="port-component-name-key">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[[
+              	The port-component-name element specifies a port
+              	component's name.  This name is assigned by the module
+              	producer to name the service implementation bean in the
+              	module's deployment descriptor. The name must be unique
+              	among the port component names defined in the same module.
+              
+              	Used in: port-component
+              
+              	Example:
+              		<port-component-name>EmployeeService
+              		</port-component-name>
+              
+              	
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="javaee:port-component"/>
+          <xsd:field xpath="javaee:port-component-name"/>
+        </xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="javaee:dewey-versionType"
+                   fixed="1.4"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The required value for the version is 1.4.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_2_1.dtd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_2_1.dtd
@@ -1,0 +1,602 @@
+<!--
+
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 1999-2007 Sun Microsystems, Inc. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 2 only ("GPL") or the Common Development
+and Distribution License("CDDL") (collectively, the "License").  You
+may not use this file except in compliance with the License. You can obtain
+a copy of the License at https://glassfish.dev.java.net/public/CDDL+GPL.html
+or glassfish/bootstrap/legal/LICENSE.txt.  See the License for the specific
+language governing permissions and limitations under the License.
+
+When distributing the software, include this License Header Notice in each
+file and include the License file at glassfish/bootstrap/legal/LICENSE.txt.
+Sun designates this particular file as subject to the "Classpath" exception
+as provided by Sun in the GPL Version 2 section of the License file that
+accompanied this code.  If applicable, add the following below the License
+Header, with the fields enclosed by brackets [] replaced by your own
+identifying information: "Portions Copyrighted [year]
+[name of copyright owner]"
+
+Contributor(s):
+
+If you wish your version of this file to be governed by only the CDDL or
+only the GPL Version 2, indicate your decision by adding "[Contributor]
+elects to include this software in this distribution under the [CDDL or GPL
+Version 2] license."  If you don't indicate a single choice of license, a
+recipient has the option to distribute your version of this file under
+either the CDDL, the GPL Version 2 or to extend the choice of license to
+its licensees as provided above.  However, if you add GPL Version 2 code
+and therefore, elected the GPL Version 2 license, then the option applies
+only if the new code is made subject to such option by the copyright
+holder.
+
+-->
+
+<!--
+The web-app element is the root of the deployment descriptor for
+a web application
+-->
+
+<!ELEMENT web-app (icon?, display-name?, description?, distributable?,
+context-param*, servlet*, servlet-mapping*, session-config?,
+mime-mapping*, welcome-file-list?, error-page*, taglib*,
+resource-ref*, security-constraint*, login-config?, security-role*,
+env-entry*, ejb-ref*)>
+
+<!--
+The icon element contains a small-icon and a large-icon element
+which specify the location within the web application for a small and
+large image used to represent the web application in a GUI tool. At a
+minimum, tools must accept GIF and JPEG format images.
+-->
+
+<!ELEMENT icon (small-icon?, large-icon?)>
+
+<!--
+The small-icon element contains the location within the web
+application of a file containing a small (16x16 pixel) icon image.
+-->
+
+<!ELEMENT small-icon (#PCDATA)>
+
+<!--
+The large-icon element contains the location within the web
+application of a file containing a large (32x32 pixel) icon image.
+-->
+
+<!ELEMENT large-icon (#PCDATA)>
+
+<!--
+The display-name element contains a short name that is intended
+to be displayed by GUI tools
+-->
+
+<!ELEMENT display-name (#PCDATA)>
+
+<!--
+The description element is used to provide descriptive text about
+the parent element.
+-->
+
+<!ELEMENT description (#PCDATA)>
+
+<!--
+The distributable element, by its presence in a web application
+deployment descriptor, indicates that this web application is
+programmed appropriately to be deployed into a distributed servlet
+container
+-->
+
+<!ELEMENT distributable EMPTY>
+
+<!--
+The context-param element contains the declaration of a web
+application's servlet context initialization parameters.
+-->
+
+<!ELEMENT context-param (param-name, param-value, description?)>
+
+<!--
+The param-name element contains the name of a parameter.
+-->
+
+<!ELEMENT param-name (#PCDATA)>
+
+<!--
+The param-value element contains the value of a parameter.
+-->
+
+<!ELEMENT param-value (#PCDATA)>
+
+<!--
+The servlet element contains the declarative data of a
+servlet. If a jsp-file is specified and the load-on-startup element is
+present, then the JSP should be precompiled and loaded.
+-->
+
+<!ELEMENT servlet (icon?, servlet-name, display-name?, description?,
+(servlet-class|jsp-file), init-param*, load-on-startup?, security-role-ref*)>
+
+<!--
+The servlet-name element contains the canonical name of the
+servlet.
+-->
+
+<!ELEMENT servlet-name (#PCDATA)>
+
+<!--
+The servlet-class element contains the fully qualified class name
+of the servlet.
+-->
+
+<!ELEMENT servlet-class (#PCDATA)>
+
+<!--
+The jsp-file element contains the full path to a JSP file within
+the web application.
+-->
+
+<!ELEMENT jsp-file (#PCDATA)>
+
+<!--
+The init-param element contains a name/value pair as an
+initialization param of the servlet
+-->
+
+<!ELEMENT init-param (param-name, param-value, description?)>
+
+<!--
+The load-on-startup element indicates that this servlet should be
+loaded on the startup of the web application. The optional contents of
+these element must be a positive integer indicating the order in which
+the servlet should be loaded. Lower integers are loaded before higher
+integers. If no value is specified, or if the value specified is not a
+positive integer, the container is free to load it at any time in the
+startup sequence.
+-->
+
+<!ELEMENT load-on-startup (#PCDATA)>
+
+<!--
+The servlet-mapping element defines a mapping between a servlet
+and a url pattern
+-->
+
+<!ELEMENT servlet-mapping (servlet-name, url-pattern)>
+
+<!--
+The url-pattern element contains the url pattern of the
+mapping. Must follow the rules specified in Section 10 of the Servlet
+API Specification.
+-->
+
+<!ELEMENT url-pattern (#PCDATA)>
+
+<!--
+The session-config element defines the session parameters for
+this web application.
+-->
+
+<!ELEMENT session-config (session-timeout?)>
+
+<!--
+The session-timeout element defines the default session timeout
+interval for all sessions created in this web application. The
+specified timeout must be expressed in a whole number of minutes.
+-->
+
+<!ELEMENT session-timeout (#PCDATA)>
+
+<!--
+The mime-mapping element defines a mapping between an extension
+and a mime type.
+-->
+
+<!ELEMENT mime-mapping (extension, mime-type)>
+
+<!--
+The extension element contains a string describing an
+extension. example: "txt"
+-->
+
+<!ELEMENT extension (#PCDATA)>
+
+<!--
+The mime-type element contains a defined mime type. example:
+"text/plain"
+-->
+
+<!ELEMENT mime-type (#PCDATA)>
+
+<!--
+The welcome-file-list contains an ordered list of welcome files
+elements.
+-->
+
+<!ELEMENT welcome-file-list (welcome-file+)>
+
+<!--
+The welcome-file element contains file name to use as a default
+welcome file, such as index.html
+-->
+
+<!ELEMENT welcome-file (#PCDATA)>
+
+<!--
+The taglib element is used to describe a JSP tag library.
+-->
+
+<!ELEMENT taglib (taglib-uri, taglib-location)>
+
+<!--
+The taglib-uri element describes a URI, relative to the location
+of the web.xml document, identifying a Tag Library used in the Web
+Application.
+-->
+
+<!ELEMENT taglib-uri (#PCDATA)>
+
+<!--
+the taglib-location element contains the location (as a resource
+relative to the root of the web application) where to find the Tag
+Libary Description file for the tag library.
+-->
+
+<!ELEMENT taglib-location (#PCDATA)>
+
+<!--
+The error-page element contains a mapping between an error code
+or exception type to the path of a resource in the web application
+-->
+
+<!ELEMENT error-page ((error-code | exception-type), location)>
+
+<!--
+The error-code contains an HTTP error code, ex: 404
+-->
+
+<!ELEMENT error-code (#PCDATA)>
+
+<!--
+The exception type contains a fully qualified class name of a
+Java exception type.
+-->
+
+<!ELEMENT exception-type (#PCDATA)>
+
+<!--
+The location element contains the location of the resource in the
+web application
+-->
+
+<!ELEMENT location (#PCDATA)>
+
+<!--
+The resource-ref element contains a declaration of a Web
+Application's reference to an external resource.
+-->
+
+<!ELEMENT resource-ref (description?, res-ref-name, res-type, res-auth)>
+
+<!--
+The res-ref-name element specifies the name of the resource
+factory reference name.
+-->
+
+<!ELEMENT res-ref-name (#PCDATA)>
+
+<!--
+The res-type element specifies the (Java class) type of the data
+source.
+-->
+
+<!ELEMENT res-type (#PCDATA)>
+
+<!--
+The res-auth element indicates whether the application component
+code performs resource signon programmatically or whether the
+container signs onto the resource based on the principle mapping
+information supplied by the deployer. Must be CONTAINER or SERVLET
+-->
+
+<!ELEMENT res-auth (#PCDATA)>
+
+<!--
+The security-constraint element is used to associate security
+constraints with one or more web resource collections
+-->
+
+<!ELEMENT security-constraint (web-resource-collection+,
+auth-constraint?, user-data-constraint?)>
+
+<!--
+The web-resource-collection element is used to identify a subset
+of the resources and HTTP methods on those resources within a web
+application to which a security constraint applies. If no HTTP methods
+are specified, then the security constraint applies to all HTTP
+methods.
+-->
+
+<!ELEMENT web-resource-collection (web-resource-name, description?,
+url-pattern*, http-method*)>
+
+<!--
+The web-resource-name contains the name of this web resource
+collection
+-->
+
+<!ELEMENT web-resource-name (#PCDATA)>
+
+<!--
+The http-method contains an HTTP method (GET | POST |...)
+-->
+
+<!ELEMENT http-method (#PCDATA)>
+
+<!--
+The user-data-constraint element is used to indicate how data
+communicated between the client and container should be protected
+-->
+
+<!ELEMENT user-data-constraint (description?, transport-guarantee)>
+
+<!--
+The transport-guarantee element specifies that the communication
+between client and server should be NONE, INTEGRAL, or
+CONFIDENTIAL. NONE means that the application does not require any
+transport guarantees. A value of INTEGRAL means that the application
+requires that the data sent between the client and server be sent in
+such a way that it can't be changed in transit. CONFIDENTIAL means
+that the application requires that the data be transmitted in a
+fashion that prevents other entities from observing the contents of
+the transmission. In most cases, the presence of the INTEGRAL or
+CONFIDENTIAL flag will indicate that the use of SSL is required.
+-->
+
+<!ELEMENT transport-guarantee (#PCDATA)>
+
+<!--
+The auth-constraint element indicates the user roles that should
+be permitted access to this resource collection. The role used here
+must appear in a security-role-ref element.
+-->
+
+<!ELEMENT auth-constraint (description?, role-name*)>
+
+<!--
+The role-name element contains the name of a security role.
+-->
+
+<!ELEMENT role-name (#PCDATA)>
+
+<!--
+The login-config element is used to configure the authentication
+method that should be used, the realm name that should be used for
+this application, and the attributes that are needed by the form login
+mechanism.
+-->
+
+<!ELEMENT login-config (auth-method?, realm-name?, form-login-config?)>
+
+<!--
+The realm name element specifies the realm name to use in HTTP
+Basic authorization
+-->
+
+<!ELEMENT realm-name (#PCDATA)>
+
+<!--
+The form-login-config element specifies the login and error pages
+that should be used in form based login. If form based authentication
+is not used, these elements are ignored.
+-->
+
+<!ELEMENT form-login-config (form-login-page, form-error-page)>
+
+<!--
+The form-login-page element defines the location in the web app
+where the page that can be used for login can be found
+-->
+
+<!ELEMENT form-login-page (#PCDATA)>
+
+<!--
+The form-error-page element defines the location in the web app
+where the error page that is displayed when login is not successful
+can be found
+-->
+
+<!ELEMENT form-error-page (#PCDATA)>
+
+<!--
+The auth-method element is used to configure the authentication
+mechanism for the web application. As a prerequisite to gaining access
+to any web resources which are protected by an authorization
+constraint, a user must have authenticated using the configured
+mechanism. Legal values for this element are "BASIC", "DIGEST",
+"FORM", or "CLIENT-CERT".
+-->
+
+<!ELEMENT auth-method (#PCDATA)>
+
+<!--
+The security-role element contains the declaration of a security
+role which is used in the security-constraints placed on the web
+application.
+-->
+
+<!ELEMENT security-role (description?, role-name)>
+
+<!--
+The role-name element contains the name of a role. This element
+must contain a non-empty string.
+-->
+
+<!ELEMENT security-role-ref (description?, role-name, role-link)>
+
+<!--
+The role-link element is used to link a security role reference
+to a defined security role. The role-link element must contain the
+name of one of the security roles defined in the security-role
+elements.
+-->
+
+<!ELEMENT role-link (#PCDATA)>
+
+<!--
+The env-entry element contains the declaration of an
+application's environment entry. This element is required to be
+honored on in J2EE compliant servlet containers.
+-->
+
+<!ELEMENT env-entry (description?, env-entry-name, env-entry-value?,
+env-entry-type)>
+
+<!--
+The env-entry-name contains the name of an application's
+environment entry
+-->
+
+<!ELEMENT env-entry-name (#PCDATA)>
+
+<!--
+The env-entry-value element contains the value of an
+application's environment entry
+-->
+
+<!ELEMENT env-entry-value (#PCDATA)>
+
+<!--
+The env-entry-type element contains the fully qualified Java type
+of the environment entry value that is expected by the application
+code. The following are the legal values of env-entry-type:
+java.lang.Boolean, java.lang.String, java.lang.Integer,
+java.lang.Double, java.lang.Float.
+-->
+
+<!ELEMENT env-entry-type (#PCDATA)>
+
+<!--
+The ejb-ref element is used to declare a reference to an
+enterprise bean. 
+-->
+
+<!ELEMENT ejb-ref (description?, ejb-ref-name, ejb-ref-type, home, remote,
+ejb-link?)>
+
+<!--
+The ejb-ref-name element contains the name of an EJB
+reference. This is the JNDI name that the servlet code uses to get a
+reference to the enterprise bean.
+-->
+
+<!ELEMENT ejb-ref-name (#PCDATA)>
+
+<!--
+The ejb-ref-type element contains the expected java class type of
+the referenced EJB.
+-->
+
+<!ELEMENT ejb-ref-type (#PCDATA)>
+
+<!--
+The ejb-home element contains the fully qualified name of the
+EJB's home interface
+-->
+
+<!ELEMENT home (#PCDATA)>
+
+<!--
+The ejb-remote element contains the fully qualified name of the
+EJB's remote interface
+-->
+
+<!ELEMENT remote (#PCDATA)>
+
+<!--
+The ejb-link element is used in the ejb-ref element to specify
+that an EJB reference is linked to an EJB in an encompassing Java2
+Enterprise Edition (J2EE) application package. The value of the
+ejb-link element must be the ejb-name of and EJB in the J2EE
+application package.
+-->
+
+<!ELEMENT ejb-link (#PCDATA)>
+
+<!--
+The ID mechanism is to allow tools to easily make tool-specific
+references to the elements of the deployment descriptor. This allows
+tools that produce additional deployment information (i.e information
+beyond the standard deployment descriptor information) to store the
+non-standard information in a separate file, and easily refer from
+these tools-specific files to the information in the standard web-app
+deployment descriptor.
+-->
+
+<!ATTLIST web-app id ID #IMPLIED>
+<!ATTLIST icon id ID #IMPLIED>
+<!ATTLIST small-icon id ID #IMPLIED>
+<!ATTLIST large-icon id ID #IMPLIED>
+<!ATTLIST display-name id ID #IMPLIED>
+<!ATTLIST description id ID #IMPLIED>
+<!ATTLIST distributable id ID #IMPLIED>
+<!ATTLIST context-param id ID #IMPLIED>
+<!ATTLIST param-name id ID #IMPLIED>
+<!ATTLIST param-value id ID #IMPLIED>
+<!ATTLIST servlet id ID #IMPLIED>
+<!ATTLIST servlet-name id ID #IMPLIED>
+<!ATTLIST servlet-class id ID #IMPLIED>
+<!ATTLIST jsp-file id ID #IMPLIED>
+<!ATTLIST init-param id ID #IMPLIED>
+<!ATTLIST load-on-startup id ID #IMPLIED>
+<!ATTLIST servlet-mapping id ID #IMPLIED>
+<!ATTLIST url-pattern id ID #IMPLIED>
+<!ATTLIST session-config id ID #IMPLIED>
+<!ATTLIST session-timeout id ID #IMPLIED>
+<!ATTLIST mime-mapping id ID #IMPLIED>
+<!ATTLIST extension id ID #IMPLIED>
+<!ATTLIST mime-type id ID #IMPLIED>
+<!ATTLIST welcome-file-list id ID #IMPLIED>
+<!ATTLIST welcome-file id ID #IMPLIED>
+<!ATTLIST taglib id ID #IMPLIED>
+<!ATTLIST taglib-uri id ID #IMPLIED>
+<!ATTLIST taglib-location id ID #IMPLIED>
+<!ATTLIST error-page id ID #IMPLIED>
+<!ATTLIST error-code id ID #IMPLIED>
+<!ATTLIST exception-type id ID #IMPLIED>
+<!ATTLIST location id ID #IMPLIED>
+<!ATTLIST resource-ref id ID #IMPLIED>
+<!ATTLIST res-ref-name id ID #IMPLIED>
+<!ATTLIST res-type id ID #IMPLIED>
+<!ATTLIST res-auth id ID #IMPLIED>
+<!ATTLIST security-constraint id ID #IMPLIED>
+<!ATTLIST web-resource-collection id ID #IMPLIED>
+<!ATTLIST web-resource-name id ID #IMPLIED>
+<!ATTLIST http-method id ID #IMPLIED>
+<!ATTLIST user-data-constraint id ID #IMPLIED>
+<!ATTLIST transport-guarantee id ID #IMPLIED>
+<!ATTLIST auth-constraint id ID #IMPLIED>
+<!ATTLIST role-name id ID #IMPLIED>
+<!ATTLIST login-config id ID #IMPLIED>
+<!ATTLIST realm-name id ID #IMPLIED>
+<!ATTLIST form-login-config id ID #IMPLIED>
+<!ATTLIST form-login-page id ID #IMPLIED>
+<!ATTLIST form-error-page id ID #IMPLIED>
+<!ATTLIST auth-method id ID #IMPLIED>
+<!ATTLIST security-role id ID #IMPLIED>
+<!ATTLIST security-role-ref id ID #IMPLIED>
+<!ATTLIST role-link id ID #IMPLIED>
+<!ATTLIST env-entry id ID #IMPLIED>
+<!ATTLIST env-entry-name id ID #IMPLIED>
+<!ATTLIST env-entry-value id ID #IMPLIED>
+<!ATTLIST env-entry-type id ID #IMPLIED>
+<!ATTLIST ejb-ref id ID #IMPLIED>
+<!ATTLIST ejb-ref-name id ID #IMPLIED>
+<!ATTLIST ejb-ref-type id ID #IMPLIED>
+<!ATTLIST home id ID #IMPLIED>
+<!ATTLIST remote id ID #IMPLIED>
+<!ATTLIST ejb-link id ID #IMPLIED>

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_3_1.dtd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/web-app_2_3_1.dtd
@@ -1,0 +1,1022 @@
+<!--
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+
+Copyright 2000-2007 Sun Microsystems, Inc. All rights reserved.
+
+The contents of this file are subject to the terms of either the GNU
+General Public License Version 2 only ("GPL") or the Common Development
+and Distribution License("CDDL") (collectively, the "License").  You
+may not use this file except in compliance with the License. You can obtain
+a copy of the License at https://glassfish.dev.java.net/public/CDDL+GPL.html
+or glassfish/bootstrap/legal/LICENSE.txt.  See the License for the specific
+language governing permissions and limitations under the License.
+
+When distributing the software, include this License Header Notice in each
+file and include the License file at glassfish/bootstrap/legal/LICENSE.txt.
+Sun designates this particular file as subject to the "Classpath" exception
+as provided by Sun in the GPL Version 2 section of the License file that
+accompanied this code.  If applicable, add the following below the License
+Header, with the fields enclosed by brackets [] replaced by your own
+identifying information: "Portions Copyrighted [year]
+[name of copyright owner]"
+
+Contributor(s):
+
+If you wish your version of this file to be governed by only the CDDL or
+only the GPL Version 2, indicate your decision by adding "[Contributor]
+elects to include this software in this distribution under the [CDDL or GPL
+Version 2] license."  If you don't indicate a single choice of license, a
+recipient has the option to distribute your version of this file under
+either the CDDL, the GPL Version 2 or to extend the choice of license to
+its licensees as provided above.  However, if you add GPL Version 2 code
+and therefore, elected the GPL Version 2 license, then the option applies
+only if the new code is made subject to such option by the copyright
+holder.
+-->
+
+<!--
+This is the XML DTD for the Servlet 2.3 deployment descriptor.
+All Servlet 2.3 deployment descriptors must include a DOCTYPE
+of the following form:
+
+  <!DOCTYPE web-app PUBLIC
+	"-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
+	"http://java.sun.com/dtd/web-app_2_3.dtd">
+
+-->
+
+<!--
+The following conventions apply to all J2EE deployment descriptor
+elements unless indicated otherwise.
+
+- In elements that contain PCDATA, leading and trailing whitespace
+  in the data may be ignored.
+
+- In elements whose value is an "enumerated type", the value is
+  case sensitive.
+
+- In elements that specify a pathname to a file within the same
+  JAR file, relative filenames (i.e., those not starting with "/")
+  are considered relative to the root of the JAR file's namespace.
+  Absolute filenames (i.e., those starting with "/") also specify
+  names in the root of the JAR file's namespace.  In general, relative
+  names are preferred.  The exception is .war files where absolute
+  names are preferred for consistency with the servlet API.
+-->
+
+
+<!--
+The web-app element is the root of the deployment descriptor for
+a web application.
+-->
+<!ELEMENT web-app (icon?, display-name?, description?, distributable?,
+context-param*, filter*, filter-mapping*, listener*, servlet*,
+servlet-mapping*, session-config?, mime-mapping*, welcome-file-list?,
+error-page*, taglib*, resource-env-ref*, resource-ref*, security-constraint*,
+login-config?, security-role*, env-entry*, ejb-ref*,  ejb-local-ref*)>
+
+<!--
+The auth-constraint element indicates the user roles that should
+be permitted access to this resource collection. The role-name
+used here must either correspond to the role-name of one of the
+security-role elements defined for this web application, or be
+the specially reserved role-name "*" that is a compact syntax for
+indicating all roles in the web application. If both "*" and
+rolenames appear, the container interprets this as all roles.
+If no roles are defined, no user is allowed access to the portion of
+the web application described by the containing security-constraint.
+The container matches role names case sensitively when determining
+access.
+
+
+Used in: security-constraint
+-->
+<!ELEMENT auth-constraint (description?, role-name*)>
+
+<!--
+The auth-method element is used to configure the authentication
+mechanism for the web application. As a prerequisite to gaining access to any web resources which are protected by an authorization
+constraint, a user must have authenticated using the configured
+mechanism. Legal values for this element are "BASIC", "DIGEST",
+"FORM", or "CLIENT-CERT".
+
+Used in: login-config
+-->
+<!ELEMENT auth-method (#PCDATA)>
+
+<!--
+The context-param element contains the declaration of a web
+application's servlet context initialization parameters.
+
+Used in: web-app
+-->
+<!ELEMENT context-param (param-name, param-value, description?)>
+
+<!--
+The description element is used to provide text describing the parent
+element.  The description element should include any information that
+the web application war file producer wants to provide to the consumer of
+the web application war file (i.e., to the Deployer). Typically, the tools
+used by the web application war file consumer will display the description
+when processing the parent element that contains the description.
+
+Used in: auth-constraint, context-param, ejb-local-ref, ejb-ref,
+env-entry, filter, init-param, resource-env-ref, resource-ref, run-as,
+security-role, security-role-ref, servlet, user-data-constraint,
+web-app, web-resource-collection
+-->
+<!ELEMENT description (#PCDATA)>
+
+<!--
+The display-name element contains a short name that is intended to be
+displayed by tools.  The display name need not be unique.
+
+Used in: filter, security-constraint, servlet, web-app
+
+Example:
+
+<display-name>Employee Self Service</display-name>
+-->
+<!ELEMENT display-name (#PCDATA)>
+
+<!--
+The distributable element, by its presence in a web application
+deployment descriptor, indicates that this web application is
+programmed appropriately to be deployed into a distributed servlet
+container
+
+Used in: web-app
+-->
+<!ELEMENT distributable EMPTY>
+
+<!--
+The ejb-link element is used in the ejb-ref or ejb-local-ref
+elements to specify that an EJB reference is linked to an
+enterprise bean.
+
+The name in the ejb-link element is composed of a
+path name specifying the ejb-jar containing the referenced enterprise
+bean with the ejb-name of the target bean appended and separated from
+the path name by "#".  The path name is relative to the war file
+containing the web application that is referencing the enterprise bean.
+This allows multiple enterprise beans with the same ejb-name to be
+uniquely identified.
+
+Used in: ejb-local-ref, ejb-ref
+
+Examples:
+
+	<ejb-link>EmployeeRecord</ejb-link>
+
+	<ejb-link>../products/product.jar#ProductEJB</ejb-link>
+
+-->
+<!ELEMENT ejb-link (#PCDATA)>
+
+<!--
+The ejb-local-ref element is used for the declaration of a reference to
+an enterprise bean's local home. The declaration consists of:
+
+	- an optional description
+	- the EJB reference name used in the code of the web application
+	  that's referencing the enterprise bean
+	- the expected type of the referenced enterprise bean
+	- the expected local home and local interfaces of the referenced
+	  enterprise bean
+	- optional ejb-link information, used to specify the referenced
+	  enterprise bean
+
+Used in: web-app
+-->
+<!ELEMENT ejb-local-ref (description?, ejb-ref-name, ejb-ref-type,
+		local-home, local, ejb-link?)>
+
+<!--
+The ejb-ref element is used for the declaration of a reference to
+an enterprise bean's home. The declaration consists of:
+
+	- an optional description
+	- the EJB reference name used in the code of
+	  the web application that's referencing the enterprise bean
+	- the expected type of the referenced enterprise bean
+	- the expected home and remote interfaces of the referenced
+	  enterprise bean
+	- optional ejb-link information, used to specify the referenced
+	  enterprise bean
+
+Used in: web-app
+-->
+<!ELEMENT ejb-ref (description?, ejb-ref-name, ejb-ref-type,
+		home, remote, ejb-link?)>
+
+<!--
+The ejb-ref-name element contains the name of an EJB reference. The
+EJB reference is an entry in the web application's environment and is
+relative to the java:comp/env context.  The name must be unique
+within the web application.
+
+It is recommended that name is prefixed with "ejb/".
+
+Used in: ejb-local-ref, ejb-ref
+
+Example:
+
+<ejb-ref-name>ejb/Payroll</ejb-ref-name>
+-->
+<!ELEMENT ejb-ref-name (#PCDATA)>
+
+<!--
+The ejb-ref-type element contains the expected type of the
+referenced enterprise bean.
+
+The ejb-ref-type element must be one of the following:
+
+	<ejb-ref-type>Entity</ejb-ref-type>
+	<ejb-ref-type>Session</ejb-ref-type>
+
+Used in: ejb-local-ref, ejb-ref
+-->
+<!ELEMENT ejb-ref-type (#PCDATA)>
+
+<!--
+The env-entry element contains the declaration of a web application's
+environment entry. The declaration consists of an optional
+description, the name of the environment entry, and an optional
+value.  If a value is not specified, one must be supplied
+during deployment.
+-->
+<!ELEMENT env-entry (description?, env-entry-name, env-entry-value?,
+env-entry-type)>
+
+<!--
+The env-entry-name element contains the name of a web applications's
+environment entry.  The name is a JNDI name relative to the
+java:comp/env context.  The name must be unique within a web application.
+
+Example:
+
+<env-entry-name>minAmount</env-entry-name>
+
+Used in: env-entry
+-->
+<!ELEMENT env-entry-name (#PCDATA)>
+
+<!--
+The env-entry-type element contains the fully-qualified Java type of
+the environment entry value that is expected by the web application's
+code.
+
+The following are the legal values of env-entry-type:
+
+	java.lang.Boolean
+	java.lang.Byte
+	java.lang.Character
+	java.lang.String
+	java.lang.Short
+	java.lang.Integer
+	java.lang.Long
+	java.lang.Float
+	java.lang.Double
+
+Used in: env-entry
+-->
+<!ELEMENT env-entry-type (#PCDATA)>
+
+<!--
+The env-entry-value element contains the value of a web application's
+environment entry. The value must be a String that is valid for the
+constructor of the specified type that takes a single String
+parameter, or for java.lang.Character, a single character.
+
+Example:
+
+<env-entry-value>100.00</env-entry-value>
+
+Used in: env-entry
+-->
+<!ELEMENT env-entry-value (#PCDATA)>
+
+<!--
+The error-code contains an HTTP error code, ex: 404
+
+Used in: error-page
+-->
+<!ELEMENT error-code (#PCDATA)>
+
+<!--
+The error-page element contains a mapping between an error code
+or exception type to the path of a resource in the web application
+
+Used in: web-app
+-->
+<!ELEMENT error-page ((error-code | exception-type), location)>
+
+<!--
+The exception type contains a fully qualified class name of a
+Java exception type.
+
+Used in: error-page
+-->
+<!ELEMENT exception-type (#PCDATA)>
+
+<!--
+The extension element contains a string describing an
+extension. example: "txt"
+
+Used in: mime-mapping
+-->
+<!ELEMENT extension (#PCDATA)>
+
+<!--
+Declares a filter in the web application. The filter is mapped to
+either a servlet or a URL pattern in the filter-mapping element, using
+the filter-name value to reference. Filters can access the
+initialization parameters declared in the deployment descriptor at
+runtime via the FilterConfig interface.
+
+Used in: web-app
+-->
+<!ELEMENT filter (icon?, filter-name, display-name?, description?,
+filter-class, init-param*)>
+
+<!--
+The fully qualified classname of the filter.
+
+Used in: filter
+-->
+<!ELEMENT filter-class (#PCDATA)>
+
+<!--
+Declaration of the filter mappings in this web application. The
+container uses the filter-mapping declarations to decide which filters
+to apply to a request, and in what order. The container matches the
+request URI to a Servlet in the normal way. To determine which filters
+to apply it matches filter-mapping declarations either on servlet-name,
+or on url-pattern for each filter-mapping element, depending on which
+style is used. The order in which filters are invoked is the order in
+which filter-mapping declarations that match a request URI for a
+servlet appear in the list of filter-mapping elements.The filter-name
+value must be the value of the <filter-name> sub-elements of one of the
+<filter> declarations in the deployment descriptor.
+
+Used in: web-app
+-->
+<!ELEMENT filter-mapping (filter-name, (url-pattern | servlet-name))>
+
+<!--
+The logical name of the filter. This name is used to map the filter.
+Each filter name is unique within the web application.
+
+Used in: filter, filter-mapping
+-->
+<!ELEMENT filter-name (#PCDATA)>
+
+<!--
+The form-error-page element defines the location in the web app
+where the error page that is displayed when login is not successful
+can be found. The path begins with a leading / and is interpreted
+relative to the root of the WAR.
+
+Used in: form-login-config
+-->
+<!ELEMENT form-error-page (#PCDATA)>
+
+<!--
+The form-login-config element specifies the login and error pages
+that should be used in form based login. If form based authentication
+is not used, these elements are ignored.
+
+Used in: login-config
+-->
+<!ELEMENT form-login-config (form-login-page, form-error-page)>
+
+<!--
+The form-login-page element defines the location in the web app
+where the page that can be used for login can be found. The path
+begins with a leading / and is interpreted relative to the root of the WAR.
+
+Used in: form-login-config
+-->
+<!ELEMENT form-login-page (#PCDATA)>
+
+<!--
+The home element contains the fully-qualified name of the enterprise
+bean's home interface.
+
+Used in: ejb-ref
+
+Example:
+
+<home>com.aardvark.payroll.PayrollHome</home>
+-->
+<!ELEMENT home (#PCDATA)>
+
+<!--
+The http-method contains an HTTP method (GET | POST |...).
+
+Used in: web-resource-collection
+-->
+<!ELEMENT http-method (#PCDATA)>
+
+<!--
+The icon element contains small-icon and large-icon elements that
+specify the file names for small and a large GIF or JPEG icon images
+used to represent the parent element in a GUI tool.
+
+Used in: filter, servlet, web-app
+-->
+<!ELEMENT icon (small-icon?, large-icon?)>
+
+<!--
+The init-param element contains a name/value pair as an
+initialization param of the servlet
+
+Used in: filter, servlet
+-->
+<!ELEMENT init-param (param-name, param-value, description?)>
+
+<!--
+The jsp-file element contains the full path to a JSP file within
+the web application beginning with a `/'.
+
+Used in: servlet
+-->
+<!ELEMENT jsp-file (#PCDATA)>
+
+<!--
+The large-icon element contains the name of a file
+containing a large (32 x 32) icon image. The file
+name is a relative path within the web application's
+war file.
+
+The image may be either in the JPEG or GIF format.
+The icon can be used by tools.
+
+Used in: icon
+
+Example:
+
+<large-icon>employee-service-icon32x32.jpg</large-icon>
+-->
+<!ELEMENT large-icon (#PCDATA)>
+
+<!--
+The listener element indicates the deployment properties for a web
+application listener bean.
+
+Used in: web-app
+-->
+<!ELEMENT listener (listener-class)>
+
+<!--
+The listener-class element declares a class in the application must be
+registered as a web application listener bean. The value is the fully qualified classname of the listener class.
+
+
+Used in: listener
+-->
+<!ELEMENT listener-class (#PCDATA)>
+
+<!--
+The load-on-startup element indicates that this servlet should be
+loaded (instantiated and have its init() called) on the startup
+of the web application. The optional contents of
+these element must be an integer indicating the order in which
+the servlet should be loaded. If the value is a negative integer,
+or the element is not present, the container is free to load the
+servlet whenever it chooses. If the value is a positive integer
+or 0, the container must load and initialize the servlet as the
+application is deployed. The container must guarantee that
+servlets marked with lower integers are loaded before servlets
+marked with higher integers. The container may choose the order
+of loading of servlets with the same load-on-start-up value.
+
+Used in: servlet
+-->
+<!ELEMENT load-on-startup (#PCDATA)>
+
+<!--
+
+The local element contains the fully-qualified name of the
+enterprise bean's local interface.
+
+Used in: ejb-local-ref
+
+-->
+<!ELEMENT local (#PCDATA)>
+
+<!--
+
+The local-home element contains the fully-qualified name of the
+enterprise bean's local home interface.
+
+Used in: ejb-local-ref
+-->
+<!ELEMENT local-home (#PCDATA)>
+
+<!--
+The location element contains the location of the resource in the web
+application relative to the root of the web application. The value of
+the location must have a leading `/'.
+
+Used in: error-page
+-->
+<!ELEMENT location (#PCDATA)>
+
+<!--
+The login-config element is used to configure the authentication
+method that should be used, the realm name that should be used for
+this application, and the attributes that are needed by the form login
+mechanism.
+
+Used in: web-app
+-->
+<!ELEMENT login-config (auth-method?, realm-name?, form-login-config?)>
+
+<!--
+The mime-mapping element defines a mapping between an extension
+and a mime type.
+
+Used in: web-app
+-->
+<!ELEMENT mime-mapping (extension, mime-type)>
+
+<!--
+The mime-type element contains a defined mime type. example:
+"text/plain"
+
+Used in: mime-mapping
+-->
+<!ELEMENT mime-type (#PCDATA)>
+
+<!--
+The param-name element contains the name of a parameter. Each parameter
+name must be unique in the web application.
+
+
+Used in: context-param, init-param
+-->
+<!ELEMENT param-name (#PCDATA)>
+
+<!--
+The param-value element contains the value of a parameter.
+
+Used in: context-param, init-param
+-->
+<!ELEMENT param-value (#PCDATA)>
+
+<!--
+The realm name element specifies the realm name to use in HTTP
+Basic authorization.
+
+Used in: login-config
+-->
+<!ELEMENT realm-name (#PCDATA)>
+
+<!--
+The remote element contains the fully-qualified name of the enterprise
+bean's remote interface.
+
+Used in: ejb-ref
+
+Example:
+
+<remote>com.wombat.empl.EmployeeService</remote>
+-->
+<!ELEMENT remote (#PCDATA)>
+
+<!--
+The res-auth element specifies whether the web application code signs
+on programmatically to the resource manager, or whether the Container
+will sign on to the resource manager on behalf of the web application. In the
+latter case, the Container uses information that is supplied by the
+Deployer.
+
+The value of this element must be one of the two following:
+
+	<res-auth>Application</res-auth>
+	<res-auth>Container</res-auth>
+
+Used in: resource-ref
+-->
+<!ELEMENT res-auth (#PCDATA)>
+
+<!--
+The res-ref-name element specifies the name of a resource manager
+connection factory reference.  The name is a JNDI name relative to the
+java:comp/env context.  The name must be unique within a web application.
+
+Used in: resource-ref
+-->
+<!ELEMENT res-ref-name (#PCDATA)>
+
+<!--
+The res-sharing-scope element specifies whether connections obtained
+through the given resource manager connection factory reference can be
+shared. The value of this element, if specified, must be one of the
+two following:
+
+	<res-sharing-scope>Shareable</res-sharing-scope>
+	<res-sharing-scope>Unshareable</res-sharing-scope>
+
+The default value is Shareable.
+
+Used in: resource-ref
+-->
+<!ELEMENT res-sharing-scope (#PCDATA)>
+
+<!--
+The res-type element specifies the type of the data source. The type
+is specified by the fully qualified Java language class or interface
+expected to be implemented by the data source.
+
+Used in: resource-ref
+-->
+<!ELEMENT res-type (#PCDATA)>
+
+<!--
+The resource-env-ref element contains a declaration of a web application's
+reference to an administered object associated with a resource
+in the web application's environment.  It consists of an optional
+description, the resource environment reference name, and an
+indication of the resource environment reference type expected by
+the web application code.
+
+Used in: web-app
+
+Example:
+
+<resource-env-ref>
+    <resource-env-ref-name>jms/StockQueue</resource-env-ref-name>
+    <resource-env-ref-type>javax.jms.Queue</resource-env-ref-type>
+</resource-env-ref>
+-->
+<!ELEMENT resource-env-ref (description?, resource-env-ref-name,
+		resource-env-ref-type)>
+
+<!--
+The resource-env-ref-name element specifies the name of a resource
+environment reference; its value is the environment entry name used in
+the web application code.  The name is a JNDI name relative to the
+java:comp/env context and must be unique within a web application.
+
+Used in: resource-env-ref
+-->
+<!ELEMENT resource-env-ref-name (#PCDATA)>
+
+<!--
+The resource-env-ref-type element specifies the type of a resource
+environment reference.  It is the fully qualified name of a Java
+language class or interface.
+
+Used in: resource-env-ref
+-->
+<!ELEMENT resource-env-ref-type (#PCDATA)>
+
+<!--
+The resource-ref element contains a declaration of a web application's
+reference to an external resource. It consists of an optional
+description, the resource manager connection factory reference name,
+the indication of the resource manager connection factory type
+expected by the web application code, the type of authentication
+(Application or Container), and an optional specification of the
+shareability of connections obtained from the resource (Shareable or
+Unshareable).
+
+Used in: web-app
+
+Example:
+
+    <resource-ref>
+	<res-ref-name>jdbc/EmployeeAppDB</res-ref-name>
+	<res-type>javax.sql.DataSource</res-type>
+	<res-auth>Container</res-auth>
+	<res-sharing-scope>Shareable</res-sharing-scope>
+    </resource-ref>
+-->
+<!ELEMENT resource-ref (description?, res-ref-name, res-type, res-auth,
+		res-sharing-scope?)>
+
+<!--
+The role-link element is a reference to a defined security role. The
+role-link element must contain the name of one of the security roles
+defined in the security-role elements.
+
+Used in: security-role-ref
+-->
+<!ELEMENT role-link (#PCDATA)>
+
+<!--
+The role-name element contains the name of a security role.
+
+The name must conform to the lexical rules for an NMTOKEN.
+
+Used in: auth-constraint, run-as, security-role, security-role-ref
+-->
+<!ELEMENT role-name (#PCDATA)>
+
+<!--
+The run-as element specifies the run-as identity to be used for the
+execution of the web application. It contains an optional description, and
+the name of a security role.
+
+Used in: servlet
+-->
+<!ELEMENT run-as (description?, role-name)>
+
+<!--
+The security-constraint element is used to associate security
+constraints with one or more web resource collections
+
+Used in: web-app
+-->
+<!ELEMENT security-constraint (display-name?, web-resource-collection+,
+auth-constraint?, user-data-constraint?)>
+
+<!--
+The security-role element contains the definition of a security
+role. The definition consists of an optional description of the
+security role, and the security role name.
+
+Used in: web-app
+
+Example:
+
+    <security-role>
+	<description>
+	    This role includes all employees who are authorized
+	    to access the employee service application.
+	</description>
+	<role-name>employee</role-name>
+    </security-role>
+-->
+<!ELEMENT security-role (description?, role-name)>
+
+<!--
+The security-role-ref element contains the declaration of a security
+role reference in the web application's code. The declaration consists
+of an optional description, the security role name used in the code,
+and an optional link to a security role. If the security role is not
+specified, the Deployer must choose an appropriate security role.
+
+The value of the role-name element must be the String used as the
+parameter to the EJBContext.isCallerInRole(String roleName) method
+or the HttpServletRequest.isUserInRole(String role) method.
+
+Used in: servlet
+
+-->
+<!ELEMENT security-role-ref (description?, role-name, role-link?)>
+
+<!--
+The servlet element contains the declarative data of a
+servlet. If a jsp-file is specified and the load-on-startup element is
+present, then the JSP should be precompiled and loaded.
+
+Used in: web-app
+-->
+<!ELEMENT servlet (icon?, servlet-name, display-name?, description?,
+(servlet-class|jsp-file), init-param*, load-on-startup?, run-as?, security-role-ref*)>
+
+<!--
+The servlet-class element contains the fully qualified class name
+of the servlet.
+
+Used in: servlet
+-->
+<!ELEMENT servlet-class (#PCDATA)>
+
+<!--
+The servlet-mapping element defines a mapping between a servlet
+and a url pattern
+
+Used in: web-app
+-->
+<!ELEMENT servlet-mapping (servlet-name, url-pattern)>
+
+<!--
+The servlet-name element contains the canonical name of the
+servlet. Each servlet name is unique within the web application.
+
+Used in: filter-mapping, servlet, servlet-mapping
+-->
+<!ELEMENT servlet-name (#PCDATA)>
+
+<!--
+The session-config element defines the session parameters for
+this web application.
+
+Used in: web-app
+-->
+<!ELEMENT session-config (session-timeout?)>
+
+<!--
+The session-timeout element defines the default session timeout
+interval for all sessions created in this web application. The
+specified timeout must be expressed in a whole number of minutes.
+If the timeout is 0 or less, the container ensures the default
+behaviour of sessions is never to time out.
+
+Used in: session-config
+-->
+<!ELEMENT session-timeout (#PCDATA)>
+
+<!--
+The small-icon element contains the name of a file
+containing a small (16 x 16) icon image. The file
+name is a relative path within the web application's
+war file.
+
+The image may be either in the JPEG or GIF format.
+The icon can be used by tools.
+
+Used in: icon
+
+Example:
+
+<small-icon>employee-service-icon16x16.jpg</small-icon>
+-->
+<!ELEMENT small-icon (#PCDATA)>
+
+<!--
+The taglib element is used to describe a JSP tag library.
+
+Used in: web-app
+-->
+<!ELEMENT taglib (taglib-uri, taglib-location)>
+
+<!--
+the taglib-location element contains the location (as a resource
+relative to the root of the web application) where to find the Tag
+Libary Description file for the tag library.
+
+Used in: taglib
+-->
+<!ELEMENT taglib-location (#PCDATA)>
+
+<!--
+The taglib-uri element describes a URI, relative to the location
+of the web.xml document, identifying a Tag Library used in the Web
+Application.
+
+Used in: taglib
+-->
+<!ELEMENT taglib-uri (#PCDATA)>
+
+<!--
+The transport-guarantee element specifies that the communication
+between client and server should be NONE, INTEGRAL, or
+CONFIDENTIAL. NONE means that the application does not require any
+transport guarantees. A value of INTEGRAL means that the application
+requires that the data sent between the client and server be sent in
+such a way that it can't be changed in transit. CONFIDENTIAL means
+that the application requires that the data be transmitted in a
+fashion that prevents other entities from observing the contents of
+the transmission. In most cases, the presence of the INTEGRAL or
+CONFIDENTIAL flag will indicate that the use of SSL is required.
+
+Used in: user-data-constraint
+-->
+<!ELEMENT transport-guarantee (#PCDATA)>
+
+<!--
+The url-pattern element contains the url pattern of the mapping. Must
+follow the rules specified in Section 11.2 of the Servlet API
+Specification.
+
+Used in: filter-mapping, servlet-mapping, web-resource-collection
+-->
+<!ELEMENT url-pattern (#PCDATA)>
+
+<!--
+The user-data-constraint element is used to indicate how data
+communicated between the client and container should be protected.
+
+Used in: security-constraint
+-->
+<!ELEMENT user-data-constraint (description?, transport-guarantee)>
+
+<!--
+The web-resource-collection element is used to identify a subset
+of the resources and HTTP methods on those resources within a web
+application to which a security constraint applies. If no HTTP methods
+are specified, then the security constraint applies to all HTTP
+methods.
+
+Used in: security-constraint
+-->
+<!ELEMENT web-resource-collection (web-resource-name, description?,
+url-pattern*, http-method*)>
+
+<!--
+The web-resource-name contains the name of this web resource
+collection.
+
+Used in: web-resource-collection
+-->
+<!ELEMENT web-resource-name (#PCDATA)>
+
+<!--
+The welcome-file element contains file name to use as a default
+welcome file, such as index.html
+
+Used in: welcome-file-list
+-->
+<!ELEMENT welcome-file (#PCDATA)>
+
+<!--
+The welcome-file-list contains an ordered list of welcome files
+elements.
+
+Used in: web-app
+-->
+<!ELEMENT welcome-file-list (welcome-file+)>
+
+<!--
+The ID mechanism is to allow tools that produce additional deployment
+information (i.e., information beyond the standard deployment
+descriptor information) to store the non-standard information in a
+separate file, and easily refer from these tool-specific files to the
+information in the standard deployment descriptor.
+
+Tools are not allowed to add the non-standard information into the
+standard deployment descriptor.
+-->
+
+<!ATTLIST auth-constraint id ID #IMPLIED>
+<!ATTLIST auth-method id ID #IMPLIED>
+<!ATTLIST context-param id ID #IMPLIED>
+<!ATTLIST description id ID #IMPLIED>
+<!ATTLIST display-name id ID #IMPLIED>
+<!ATTLIST distributable id ID #IMPLIED>
+<!ATTLIST ejb-link id ID #IMPLIED>
+<!ATTLIST ejb-local-ref id ID #IMPLIED>
+<!ATTLIST ejb-ref id ID #IMPLIED>
+<!ATTLIST ejb-ref-name id ID #IMPLIED>
+<!ATTLIST ejb-ref-type id ID #IMPLIED>
+<!ATTLIST env-entry id ID #IMPLIED>
+<!ATTLIST env-entry-name id ID #IMPLIED>
+<!ATTLIST env-entry-type id ID #IMPLIED>
+<!ATTLIST env-entry-value id ID #IMPLIED>
+<!ATTLIST error-code id ID #IMPLIED>
+<!ATTLIST error-page id ID #IMPLIED>
+<!ATTLIST exception-type id ID #IMPLIED>
+<!ATTLIST extension id ID #IMPLIED>
+<!ATTLIST filter id ID #IMPLIED>
+<!ATTLIST filter-class id ID #IMPLIED>
+<!ATTLIST filter-mapping id ID #IMPLIED>
+<!ATTLIST filter-name id ID #IMPLIED>
+<!ATTLIST form-error-page id ID #IMPLIED>
+<!ATTLIST form-login-config id ID #IMPLIED>
+<!ATTLIST form-login-page id ID #IMPLIED>
+<!ATTLIST home id ID #IMPLIED>
+<!ATTLIST http-method id ID #IMPLIED>
+<!ATTLIST icon id ID #IMPLIED>
+<!ATTLIST init-param id ID #IMPLIED>
+<!ATTLIST jsp-file id ID #IMPLIED>
+<!ATTLIST large-icon id ID #IMPLIED>
+<!ATTLIST listener id ID #IMPLIED>
+<!ATTLIST listener-class id ID #IMPLIED>
+<!ATTLIST load-on-startup id ID #IMPLIED>
+<!ATTLIST local id ID #IMPLIED>
+<!ATTLIST local-home id ID #IMPLIED>
+<!ATTLIST location id ID #IMPLIED>
+<!ATTLIST login-config id ID #IMPLIED>
+<!ATTLIST mime-mapping id ID #IMPLIED>
+<!ATTLIST mime-type id ID #IMPLIED>
+<!ATTLIST param-name id ID #IMPLIED>
+<!ATTLIST param-value id ID #IMPLIED>
+<!ATTLIST realm-name id ID #IMPLIED>
+<!ATTLIST remote id ID #IMPLIED>
+<!ATTLIST res-auth id ID #IMPLIED>
+<!ATTLIST res-ref-name id ID #IMPLIED>
+<!ATTLIST res-sharing-scope id ID #IMPLIED>
+<!ATTLIST res-type id ID #IMPLIED>
+<!ATTLIST resource-env-ref id ID #IMPLIED>
+<!ATTLIST resource-env-ref-name id ID #IMPLIED>
+<!ATTLIST resource-env-ref-type id ID #IMPLIED>
+<!ATTLIST resource-ref id ID #IMPLIED>
+<!ATTLIST role-link id ID #IMPLIED>
+<!ATTLIST role-name id ID #IMPLIED>
+<!ATTLIST run-as id ID #IMPLIED>
+<!ATTLIST security-constraint id ID #IMPLIED>
+<!ATTLIST security-role id ID #IMPLIED>
+<!ATTLIST security-role-ref id ID #IMPLIED>
+<!ATTLIST servlet id ID #IMPLIED>
+<!ATTLIST servlet-class id ID #IMPLIED>
+<!ATTLIST servlet-mapping id ID #IMPLIED>
+<!ATTLIST servlet-name id ID #IMPLIED>
+<!ATTLIST session-config id ID #IMPLIED>
+<!ATTLIST session-timeout id ID #IMPLIED>
+<!ATTLIST small-icon id ID #IMPLIED>
+<!ATTLIST taglib id ID #IMPLIED>
+<!ATTLIST taglib-location id ID #IMPLIED>
+<!ATTLIST taglib-uri id ID #IMPLIED>
+<!ATTLIST transport-guarantee id ID #IMPLIED>
+<!ATTLIST url-pattern id ID #IMPLIED>
+<!ATTLIST user-data-constraint id ID #IMPLIED>
+<!ATTLIST web-app id ID #IMPLIED>
+<!ATTLIST web-resource-collection id ID #IMPLIED>
+<!ATTLIST web-resource-name id ID #IMPLIED>
+<!ATTLIST welcome-file id ID #IMPLIED>
+<!ATTLIST welcome-file-list id ID #IMPLIED>

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/catalog/EnterpriseCatalog.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/catalog/EnterpriseCatalog.java
@@ -47,7 +47,7 @@ public final class EnterpriseCatalog implements CatalogReader, CatalogDescriptor
     private static final String JAVAEE_NS = "http://java.sun.com/xml/ns/javaee"; //NOI18N
     private static final String XML_NS = "http://www.w3.org/2001/XMLSchema"; //NOI18N
     private static final String NEW_JAVAEE_NS = "http://xmlns.jcp.org/xml/ns/javaee"; //NOI18N
-    private static final String RESOURCE_PATH = "nbres:/org/netbeans/modules/j2ee/ddloaders/catalog/resources/"; //NO18N 
+    private static final String RESOURCE_PATH = "nbres:/org/netbeans/modules/j2ee/dd/impl/resources/"; //NO18N 
     
     private List<SchemaInfo> schemas = new ArrayList<SchemaInfo>();
     
@@ -119,7 +119,6 @@ public final class EnterpriseCatalog implements CatalogReader, CatalogDescriptor
         schemas.add(new SchemaInfo("permissions_7.xsd", NEW_JAVAEE_NS));
         // batch API
         schemas.add(new SchemaInfo("batchXML_1_0.xsd", NEW_JAVAEE_NS));
-        schemas.add(new SchemaInfo("jobXML_1_0.xsd", NEW_JAVAEE_NS));
 
     }
     


### PR DESCRIPTION
*What this pull request does*
Fixes the errors when creating a web.xml file.  Before this fix, the parser will warn about the <web-app> tag not being recognized and XML validation will fail due to the .xsd files not being known

*Root Cause Analysis*
It seems that the JavaEE Deployment Descriptor .xsd files used to be a part of the JavaEE Deployment Descriptor loader module, but are now part of the J2EE Deployment Descriptor API module.

Possibly they moved / removed & re-added during the licencing of JavaEE for Apache?  I'm assuming that their new location is the correct/intended one.

The Netbeans XML catalog "Enterprise Deployment Descriptor Catalog" was still pointing to the .xsd files being part of the JEE DD Loader module, so various things were falling over when trying to access them

* Files Changed*
* /enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/catalog/EnterpriseCatalog.java
Resource Path constant changed from nbres:/org/netbeans/modules/j2ee/ddloaders/catalog/resources/ to nbres:/org/netbeans/modules/j2ee/dd/impl/resources/

*Testing*
* Make sure Java EE plugin activated
* Tools-> DTD & XML Schemas -> Expand Enterprise Deployment Descriptors catalog
* Chose any .xsd and click Open in Editor
Before this PR: An error will be thrown "Could not connect to URL nbres:/org/netbeans/modules/j2ee/ddloaders/catalog/resources/web-app_3_1.xsd. No such resource was found."
After this PR: .xsd file will be opened in Netbeans Editor
* Create a new Java Web Project, add a new web.xml file
Before this PR: File will be highlighted with errors / validate XML will fail
After this PR: No errors