### PR TITLE
[NETBEANS-2577] Prevent Maven libraries from being exluded

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/ModuleSelector.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ModuleSelector.java
@@ -78,24 +78,6 @@ public final class ModuleSelector extends BaseExtendSelector {
         }
         
         String module = null;
-        if (file.getName().endsWith(".jar")) {
-            try (JarFile jar = new JarFile(file)) {
-                Manifest m = jar.getManifest();
-                if (m != null) {
-                    module = m.getMainAttributes().getValue("OpenIDE-Module"); // NOI18N
-                    if (module == null && !isExt(file)) {
-                        module = m.getMainAttributes().getValue("Bundle-SymbolicName"); // NOI18N
-                        int semicolon = module == null ? -1 : module.indexOf(';');
-                        if (semicolon >= 0) {
-                            module = module.substring(0, semicolon);
-                        }
-                    }
-                }
-            } catch (IOException ex) {
-                throw new BuildException("Problem with " + file + ": " + ex, ex, getLocation());
-            }
-        }
-
         String name = file.getName();
         File p = file.getParentFile();
         for(;;) {
@@ -123,6 +105,24 @@ public final class ModuleSelector extends BaseExtendSelector {
             }
             name = p.getName() + '/' + name;
             p = p.getParentFile();
+        }
+
+        if (module == null && name.endsWith(".jar")) {
+            try (JarFile jar = new JarFile(file)) {
+                Manifest m = jar.getManifest();
+                if (m != null) {
+                    module = m.getMainAttributes().getValue("OpenIDE-Module"); // NOI18N
+                    if (module == null && !isExt(file)) {
+                        module = m.getMainAttributes().getValue("Bundle-SymbolicName"); // NOI18N
+                        int semicolon = module == null ? -1 : module.indexOf(';');
+                        if (semicolon >= 0) {
+                            module = module.substring(0, semicolon);
+                        }
+                    }
+                }
+            } catch (IOException ex) {
+                throw new BuildException("Problem with " + file + ": " + ex, ex, getLocation());
+            }
         }
         
         if (module == null) {


### PR DESCRIPTION
I have essentially swapped two pieces of code: the *explicit* information from NB installation (`update_tracking/*.xml`) takes precedence.

Original behaviour:
- if a file that *just happens* to be an OSGi bundle (or NB module) is present anywhere, it's filtered according to excluded modules
- filters out also `mave/lib` contents, which is not managed by NB module system, but contains libraries supporting embedded maven

New behaviour:
- the Platform defines what module the file belongs to. Maven libraries, although OSGi bundles themselves, will be attributed to maven embedder module
- if not defined, and the file contains NB module or OSGi bundle manifest, it will be recognized as a module itself
