### PR TITLE
[NETBEANS-2614,NETBEANS-1586] Improve icon scaling on HiDPI displays, and prepare ImageUtilities for HiDPI icons

### DIFF
--- a/ide/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java
+++ b/ide/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java
@@ -64,7 +64,8 @@ import org.openide.util.WeakListeners;
  */
 public class BreadCrumbComponent<T extends JLabel&Renderer> extends JComponent implements PropertyChangeListener {
 
-    private final Image SEPARATOR = ImageUtilities.loadImage("org/netbeans/modules/editor/breadcrumbs/resources/separator.png");
+    private final Icon SEPARATOR =
+        ImageUtilities.image2Icon(ImageUtilities.loadImage("org/netbeans/modules/editor/breadcrumbs/resources/separator.png"));
     
     public BreadCrumbComponent() {
         setPreferredSize(new Dimension(0, COMPONENT_HEIGHT));
@@ -119,7 +120,7 @@ public class BreadCrumbComponent<T extends JLabel&Renderer> extends JComponent i
         int height = getHeight();
         
         if (nodes.length == 0) {
-            g.drawImage(SEPARATOR, START_INSET, (height - SEPARATOR.getHeight(null)) / 2, null);
+            SEPARATOR.paintIcon(this, g, START_INSET, (height - SEPARATOR.getIconHeight()) / 2);
             return ;
         }
         
@@ -135,10 +136,10 @@ public class BreadCrumbComponent<T extends JLabel&Renderer> extends JComponent i
             g.translate(-x, -labelY);
 
             x += sizes[i];
-            
-            g.drawImage(SEPARATOR, x + LEFT_SEPARATOR_INSET, (height - SEPARATOR.getHeight(null)) / 2, null);
 
-            x += LEFT_SEPARATOR_INSET + SEPARATOR.getWidth(null) + RIGHT_SEPARATOR_INSET;
+            SEPARATOR.paintIcon(this, g, x + LEFT_SEPARATOR_INSET, (height - SEPARATOR.getIconHeight()) / 2);
+
+            x += LEFT_SEPARATOR_INSET + SEPARATOR.getIconWidth() + RIGHT_SEPARATOR_INSET;
         }
     }
 
@@ -169,7 +170,7 @@ public class BreadCrumbComponent<T extends JLabel&Renderer> extends JComponent i
             i++;
         }
 
-        setPreferredSize(new Dimension((int) (xTotal + (nodes.length - 1) * (LEFT_SEPARATOR_INSET + SEPARATOR.getWidth(null) + RIGHT_SEPARATOR_INSET) + START_INSET), USABLE_HEIGHT/*(int) (height + 2 * INSET_HEIGHT)*/));
+        setPreferredSize(new Dimension((int) (xTotal + (nodes.length - 1) * (LEFT_SEPARATOR_INSET + SEPARATOR.getIconWidth() + RIGHT_SEPARATOR_INSET) + START_INSET), USABLE_HEIGHT/*(int) (height + 2 * INSET_HEIGHT)*/));
     }
     
     @Override
@@ -206,7 +207,7 @@ public class BreadCrumbComponent<T extends JLabel&Renderer> extends JComponent i
             }
             
             startX = elemX;
-            elemX += SEPARATOR.getWidth(null);
+            elemX += SEPARATOR.getIconWidth();
             
             if (clickX <= elemX) {
                 //found:

--- a/java/java.source/src/org/netbeans/modules/java/ui/Icons.java
+++ b/java/java.source/src/org/netbeans/modules/java/ui/Icons.java
@@ -50,7 +50,7 @@ public final class Icons {
             return null;
         }
         else {
-            return new ImageIcon (img);
+            return ImageUtilities.image2Icon (img);
         }
     }
             
@@ -101,7 +101,7 @@ public final class Icons {
 	    default:	
 	        img = null;
         }
-	return img == null ? null : new ImageIcon (img);
+	return img == null ? null : ImageUtilities.image2Icon (img);
         
     }
     

--- a/java/jshell.support/src/org/netbeans/modules/jshell/editor/CommandCompletionProvider.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/editor/CommandCompletionProvider.java
@@ -337,7 +337,7 @@ public class CommandCompletionProvider implements CompletionProvider{
                             n = f.getLookup().lookup(Node.class);
                         }
                         if (n != null) {
-                            return (ImageIcon)ImageUtilities.image2Icon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
+                            return new ImageIcon(n.getIcon(BeanInfo.ICON_COLOR_16x16));
                         }
                     }
                 }

--- a/platform/core.windows/src/org/netbeans/core/windows/view/EditorView.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/EditorView.java
@@ -202,7 +202,7 @@ public class EditorView extends ViewElement {
             if(imageSource != null) {
                 Image image = ImageUtilities.loadImage(imageSource);
                 if(image != null) {
-                    JLabel label = new JLabel(new ImageIcon(image));
+                    JLabel label = new JLabel(ImageUtilities.image2Icon(image));
                     label.setMinimumSize(new Dimension(0, 0)); // XXX To be able shrink the area.
                     add(label, BorderLayout.CENTER);
                 } else {

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/TabbedHandler.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/TabbedHandler.java
@@ -48,6 +48,7 @@ import org.netbeans.core.windows.Switches;
 import org.netbeans.core.windows.view.ui.slides.SlideBar;
 import org.netbeans.core.windows.view.ui.slides.SlideBarActionEvent;
 import org.netbeans.core.windows.view.ui.slides.SlideOperationFactory;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 
 
@@ -163,7 +164,7 @@ public final class TabbedHandler implements ChangeListener, ActionListener {
             }
             tabbed.addTopComponent(
                 title,
-                icon == null ? null : new ImageIcon(icon),
+                icon == null ? null : ImageUtilities.image2Icon(icon),
                 tc, tc.getToolTipText());
         } finally {
             ignoreChange = false;
@@ -205,7 +206,7 @@ public final class TabbedHandler implements ChangeListener, ActionListener {
 
         Image icon = tc.getIcon();
         if( null != icon ) {
-            tabbed.setIconAt(index, new ImageIcon(tc.getIcon()));
+            tabbed.setIconAt(index, ImageUtilities.image2Icon(tc.getIcon()));
         } else {
             Logger.getLogger(TabbedHandler.class.getName()).log(Level.INFO, "TopComponent has no icon: " + tc);
             tabbed.setIconAt(index, null);

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/slides/TabbedSlideAdapter.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/slides/TabbedSlideAdapter.java
@@ -33,7 +33,6 @@ import java.util.List;
 import javax.swing.Action;
 import javax.swing.DefaultSingleSelectionModel;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.SingleSelectionModel;
 import javax.swing.event.ChangeListener;
 import org.netbeans.core.windows.Constants;
@@ -48,6 +47,7 @@ import org.netbeans.swing.tabcontrol.TabDataModel;
 import org.netbeans.swing.tabcontrol.TabbedContainer;
 import org.netbeans.swing.tabcontrol.customtabs.Tabbed;
 import org.openide.util.ChangeSupport;
+import org.openide.util.ImageUtilities;
 import org.openide.windows.TopComponent;
 
 /*
@@ -227,7 +227,7 @@ public final class TabbedSlideAdapter extends Tabbed {
             String displayName = WindowManagerImpl.getInstance().getTopComponentDisplayName(tc);
             data[i] = new TabData(
                 tc,
-                icon == null ? null : new ImageIcon(icon),
+                icon == null ? null : ImageUtilities.image2Icon(icon),
                 displayName == null ? "" : displayName, // NOI18N
                 tc.getToolTipText());
             if (selected == tcs[i]) {

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/AbstractTabbedImpl.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/tabcontrol/AbstractTabbedImpl.java
@@ -34,6 +34,7 @@ import org.netbeans.swing.tabcontrol.TabDataModel;
 import org.netbeans.swing.tabcontrol.customtabs.Tabbed;
 import org.netbeans.swing.tabcontrol.plaf.EqualPolygon;
 import org.openide.util.ChangeSupport;
+import org.openide.util.ImageUtilities;
 import org.openide.util.WeakListeners;
 import org.openide.windows.TopComponent;
 
@@ -184,7 +185,7 @@ public abstract class AbstractTabbedImpl extends Tabbed {
             String displayName = WindowManagerImpl.getInstance().getTopComponentDisplayName( tc );
             data[i] = new TabData(
                     tc,
-                    icon == null ? null : new ImageIcon( icon ),
+                    icon == null ? null : ImageUtilities.image2Icon( icon ),
                     displayName == null ? "" : displayName, // NOI18N
                     tc.getToolTipText() );
             if( selected == tcs[i] ) {

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/DnDSupport.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/DnDSupport.java
@@ -367,7 +367,7 @@ final class DnDSupport implements DragSourceListener, DragGestureListener, DropT
 
     private Window createDragWindow( Image dragImage, Rectangle bounds ) {
         Window w = new Window( SwingUtilities.windowForComponent(sourceRow) );
-        w.add(new JLabel(new ImageIcon(dragImage)));
+        w.add(new JLabel(ImageUtilities.image2Icon(dragImage)));
         w.setBounds(bounds);
         w.setVisible(true);
         NativeWindowSystem nws = NativeWindowSystem.getDefault();

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarRow.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarRow.java
@@ -35,11 +35,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import org.openide.util.ImageUtilities;
 
 /**
  * Panel which holds one row of toolbars. The order of toolbars is defined
@@ -183,7 +183,7 @@ class ToolbarRow extends JPanel {
         if( dropContainter != container ) {
             //create image of dragged toolbar and show it in the area where toolbar will be dropped
             dropContainter = container;
-            dropReplacement.setIcon(new ImageIcon(dragImage));
+            dropReplacement.setIcon(ImageUtilities.image2Icon(dragImage));
         }
         
         if( null != targetComp ) {

--- a/platform/openide.explorer/src/org/openide/explorer/view/NodeRenderDataProvider.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/NodeRenderDataProvider.java
@@ -23,13 +23,13 @@ import java.awt.Graphics;
 import java.util.ArrayList;
 import java.util.Collections;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.tree.AbstractLayoutCache;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import org.netbeans.swing.outline.CheckRenderDataProvider;
 import org.netbeans.swing.outline.Outline;
 import org.openide.nodes.Node;
+import org.openide.util.ImageUtilities;
 
 /**
  *
@@ -103,7 +103,7 @@ class NodeRenderDataProvider implements CheckRenderDataProvider {
         } else {
             image = n.getIcon(java.beans.BeanInfo.ICON_COLOR_16x16);
         }
-        return new ImageIcon(image);
+        return ImageUtilities.image2Icon(image);
     }
 
     public String getTooltipText(Object o) {

--- a/platform/openide.util.ui/src/org/openide/util/CachedHiDPIIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/CachedHiDPIIcon.java
@@ -34,7 +34,7 @@ import javax.swing.ImageIcon;
 /**
  * Abstract base class for {@link javax.swing.Icon} implementations that need to cache scaled bitmap
  * representations for HiDPI displays. Bitmaps for multiple HiDPI scaling factors can be cached at
- * the same time, e.g. for multi-monitor setups.
+ * the same time, e.g. for multi-monitor setups. Thread-safe.
  */
 abstract class CachedHiDPIIcon extends ImageIcon {
     /**
@@ -143,7 +143,7 @@ abstract class CachedHiDPIIcon extends ImageIcon {
      *        Future implementations might also elect to simply pass a dummy Component instance
      *        here.
      * @param graphicsConfiguration the configuration of the surface on which the image will be
-     * painted
+     *        painted
      * @param deviceWidth the required width of the image, with scaling already applied
      * @param deviceHeight the required height of the image, with scaling already applied
      * @param scale the HiDPI scaling factor detected in {@code graphicsConfiguration}

--- a/platform/openide.util.ui/src/org/openide/util/CachedHiDPIIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/CachedHiDPIIcon.java
@@ -29,14 +29,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 
 /**
  * Abstract base class for {@link javax.swing.Icon} implementations that need to cache scaled bitmap
  * representations for HiDPI displays. Bitmaps for multiple HiDPI scaling factors can be cached at
  * the same time, e.g. for multi-monitor setups. Thread-safe.
  */
-abstract class CachedHiDPIIcon extends ImageIcon {
+abstract class CachedHiDPIIcon implements Icon {
     /**
      * The maximum size of the cache, as a multiple of the size of the icon at 100% scaling. For
      * example, storing three images at 100%, 150%, and 200% scaling, respectively, yields a total

--- a/platform/openide.util.ui/src/org/openide/util/CachedHiDPIIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/CachedHiDPIIcon.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.util;
+
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.Image;
+import java.awt.geom.AffineTransform;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+
+/**
+ * Abstract base class for {@link javax.swing.Icon} implementations that need to cache scaled bitmap
+ * representations for HiDPI displays. Bitmaps for multiple HiDPI scaling factors can be cached at
+ * the same time, e.g. for multi-monitor setups.
+ */
+abstract class CachedHiDPIIcon extends ImageIcon {
+    /**
+     * The maximum size of the cache, as a multiple of the size of the icon at 100% scaling. For
+     * example, storing three images at 100%, 150%, and 200% scaling, respectively, yields a total
+     * cache size of 1.0^2 + 1.5^2 + 2^2 = 7.2.
+     */
+    private static final double MAX_CACHE_SIZE = 10.0;
+    private final int width;
+    private final int height;
+    /**
+     * Cache map with least-recently-used iteration order.
+     */
+    private final Map<CachedImageKey, Image> cache =
+            new LinkedHashMap<CachedImageKey, Image>(16, 0.75f, true);
+    /**
+     * Total size of the images currently in the cache, in the same units as
+     * {@link #MAX_CACHE_SIZE}.
+     */
+    private double cacheSize = 0.0;
+
+    /**
+     * Constructor to be used by subclasses.
+     */
+    protected CachedHiDPIIcon(int width, int height) {
+        if (width < 0) {
+            throw new IllegalArgumentException();
+        }
+        if (height < 0) {
+            throw new IllegalArgumentException();
+        }
+        this.width = width;
+        this.height = height;
+    }
+
+    private synchronized Image getScaledImageCached(Component c, CachedImageKey key) {
+        Image ret = cache.get(key);
+        if (ret != null) {
+            return ret;
+        }
+        final double scale = key.getScale();
+        final int deviceWidth = (int) Math.ceil(getIconWidth() * scale);
+        final int deviceHeight = (int) Math.ceil(getIconHeight() * scale);
+        final Image img =
+                createImage(c, key.getGraphicsConfiguration(), deviceWidth, deviceHeight, scale);
+        final double imgSize = key.getSize();
+        if (imgSize <= MAX_CACHE_SIZE) {
+            /* Evict least-recently-used images from the cache until we have space for the latest
+            image. */
+            final Iterator<CachedImageKey> iter = cache.keySet().iterator();
+            while (cacheSize + imgSize > MAX_CACHE_SIZE && iter.hasNext()) {
+                CachedImageKey removeKey = iter.next();
+                iter.remove();
+                cacheSize -= removeKey.getSize();
+            }
+            cache.put(key, img);
+            cacheSize += imgSize;
+        }
+        return img;
+    }
+
+    @Override
+    public final void paintIcon(Component c, Graphics g0, int x, int y) {
+        final Graphics2D g = (Graphics2D) g0;
+        CachedImageKey key = CachedImageKey.create(g);
+        final AffineTransform oldTransform = g.getTransform();
+        try {
+            g.translate(x, y);
+            Image scaledImage = getScaledImageCached(c, key);
+            /* Scale the image down to its logical dimensions, then draw it at the device pixel
+            boundary. In VectorIcon, we tried to be a lot more conservative, taking great care not
+            to draw on any device pixels that were only partially bounded by the icon (due to
+            non-integral scaling factors, e.g. 150%). That was probably overkill; it's a lot easier
+            to assume that partially bounded pixels are OK to draw on, since all icon bitmaps of a
+            given scaling factor then end up being the same number of device pixels wide and tall.
+            And we need consistent dimensions to be able keep cached images in any case. For these
+            reasons, round the X and Y translations (which denote the position in device pixels)
+            _down_ here.*/
+            AffineTransform tx2 = g.getTransform();
+            g.setTransform(new AffineTransform(1, 0, 0, 1,
+                    (int) tx2.getTranslateX(),
+                    (int) tx2.getTranslateY()));
+            g.drawImage(scaledImage, 0, 0, null);
+        } finally {
+            g.setTransform(oldTransform);
+        }
+    }
+
+    @Override
+    public final int getIconWidth() {
+        return width;
+    }
+
+    @Override
+    public final int getIconHeight() {
+        return height;
+    }
+
+    /**
+     * Create a scaled image containing the graphics of this icon. The result may be cached.
+     *
+     * @param c the component that was passed to {@link Icon#paintIcon(Component,Graphics,int,int)}.
+     *        The cache will <em>not</em> be invalidated if {@code c} or its state changes, so 
+     *        subclasses should avoid depending on it if possible. This parameter exists mainly to
+     *        ensure compatibility with existing Icon implementations that may be used as delegates.
+     *        Future implementations might also elect to simply pass a dummy Component instance
+     *        here.
+     * @param graphicsConfiguration the configuration of the surface on which the image will be
+     * painted
+     * @param deviceWidth the required width of the image, with scaling already applied
+     * @param deviceHeight the required height of the image, with scaling already applied
+     * @param scale the HiDPI scaling factor detected in {@code graphicsConfiguration}
+     */
+    protected abstract Image createImage(Component c, GraphicsConfiguration graphicsConfiguration,
+            int deviceWidth, int deviceHeight, double scale);
+
+    private static final class CachedImageKey {
+        private final GraphicsConfiguration gconf;
+        private final double scale;
+
+        public CachedImageKey(GraphicsConfiguration gconf, double scale) {
+            Parameters.notNull("gconf", gconf);
+            if (scale <= 0.0) {
+                throw new IllegalArgumentException();
+            }
+            this.gconf = gconf;
+            this.scale = scale;
+        }
+
+        public static CachedImageKey create(Graphics2D g) {
+            final AffineTransform tx = g.getTransform();
+            final int txType = tx.getType();
+            final double scale;
+            if (txType == AffineTransform.TYPE_UNIFORM_SCALE ||
+                txType == (AffineTransform.TYPE_UNIFORM_SCALE | AffineTransform.TYPE_TRANSLATION))
+            {
+                scale = tx.getScaleX();
+            } else {
+                scale = 1.0;
+            }
+            return new CachedImageKey(g.getDeviceConfiguration(), scale);
+        }
+
+        public double getScale() {
+            return scale;
+        }
+
+        /**
+         * Get the size of this image as a multiple of the original image's size at 100% scaling.
+         */
+        public double getSize() {
+            return Math.pow(getScale(), 2.0);
+        }
+
+        public GraphicsConfiguration getGraphicsConfiguration() {
+            return gconf;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(gconf, scale);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof CachedImageKey)) {
+                return false;
+            }
+            final CachedImageKey other = (CachedImageKey) obj;
+            return this.gconf.equals(other.gconf) &&
+                   this.scale == other.scale;
+        }
+    }
+}

--- a/platform/openide.util.ui/src/org/openide/util/FilteredIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/FilteredIcon.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.util;
+
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.Image;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.Transparency;
+import java.awt.image.BufferedImage;
+import java.awt.image.FilteredImageSource;
+import java.awt.image.RGBImageFilter;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+
+/**
+ * A filtered variation of a provided delegate icon. Any kind of delegate implementation can be
+ * used. In particular, this class preserves the full fidelity of HiDPI icons, such as instances
+ * of {@link VectorIcon}, or {@link ImageIcon} instances delegating to a
+ * {@code java.awt.image.MultiResolutionImage} (available since Java 9 and above).
+ *
+ * <p>Note that state passed through the {code Component} parameter of the
+ * {@link Icon#paintIcon(Component,Graphics,int,int)} method will only be current as of the time the
+ * icon is initially entered into the cache.
+ */
+final class FilteredIcon extends CachedHiDPIIcon {
+    private final RGBImageFilter filter;
+    private final Icon delegate;
+
+    private FilteredIcon(RGBImageFilter filter, Icon delegate) {
+        super(delegate.getIconWidth(), delegate.getIconHeight());
+        Parameters.notNull("filter", filter);
+        Parameters.notNull("delegate", delegate);
+        this.filter = filter;
+        this.delegate = delegate;
+    }
+
+    public static Icon create(RGBImageFilter filter, Icon delegate) {
+        return new FilteredIcon(filter, delegate);
+    }
+
+    @Override
+    protected Image createImage(
+            Component c, GraphicsConfiguration graphicsConfiguration,
+            int deviceWidth, int deviceHeight, double scale)
+    {
+        final BufferedImage img = graphicsConfiguration.createCompatibleImage(
+                deviceWidth, deviceHeight, Transparency.TRANSLUCENT);
+        final Graphics2D imgG = img.createGraphics();
+        try {
+            imgG.clip(new Rectangle(0, 0, img.getWidth(), img.getHeight()));
+            imgG.scale(scale, scale);
+            delegate.paintIcon(c, imgG, 0, 0);
+        } finally {
+            imgG.dispose();
+        }
+        return Toolkit.getDefaultToolkit().createImage(
+                new FilteredImageSource(img.getSource(), filter));
+    }
+}

--- a/platform/openide.util.ui/src/org/openide/util/FilteredIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/FilteredIcon.java
@@ -38,7 +38,7 @@ import javax.swing.ImageIcon;
  * of {@link VectorIcon}, or {@link ImageIcon} instances delegating to a
  * {@code java.awt.image.MultiResolutionImage} (available since Java 9 and above).
  *
- * <p>Note that state passed through the {code Component} parameter of the
+ * <p>Note that state passed through the {@code Component} parameter of the
  * {@link Icon#paintIcon(Component,Graphics,int,int)} method will only be current as of the time the
  * icon is initially entered into the cache.
  */

--- a/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
@@ -303,10 +303,11 @@ public final class ImageUtilities {
         } else if (icon instanceof IconImageIcon) {
             return icon2Image(((IconImageIcon) icon).getDelegateIcon());
         } else if (icon instanceof ImageIcon) {
-            return ((ImageIcon) icon).getImage();
-        } else {
-            return icon2ToolTipImage(icon);
+            Image ret = ((ImageIcon) icon).getImage();
+            if (ret != null)
+                return ret;
         }
+        return icon2ToolTipImage(icon);
     }
 
     private static ToolTipImage icon2ToolTipImage(Icon icon) {

--- a/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
@@ -224,7 +224,7 @@ public final class ImageUtilities {
         }
         
         CompositeImageKey k = new CompositeImageKey(image1, image2, x, y);
-        Image cached;
+        ToolTipImage cached;
 
         synchronized (compositeCache) {
             ActiveRef<CompositeImageKey> r = compositeCache.get(k);
@@ -282,10 +282,15 @@ public final class ImageUtilities {
      * @return Image with attached tool tip 
      */    
     public static final Image assignToolTipToImage(Image image, String text) {
+        return assignToolTipToImageInternal(image, text);
+    }
+
+    // Private version with more specific return type.
+    private static ToolTipImage assignToolTipToImageInternal(Image image, String text) {
         Parameters.notNull("image", image);
         Parameters.notNull("text", text);
         ToolTipImageKey key = new ToolTipImageKey(image, text);
-        Image cached;
+        ToolTipImage cached;
         synchronized (imageToolTipCache) {
             ActiveRef<ToolTipImageKey> r = imageToolTipCache.get(key);
             if (r != null) {
@@ -411,14 +416,14 @@ public final class ImageUtilities {
         }
     }
 
-    static Image getIcon(String resource, boolean localized) {
+    static ToolTipImage getIcon(String resource, boolean localized) {
         if (localized) {
             if (resource == null) {
                 return null;
             }
             synchronized (localizedCache) {
                 ActiveRef<String> ref = localizedCache.get(resource);
-                Image img = null;
+                ToolTipImage img = null;
 
                 // no icon for this name (already tested)
                 if (ref == NO_ICON) {
@@ -460,7 +465,7 @@ public final class ImageUtilities {
                 
                 while (it.hasNext()) {
                     String suffix = it.next();
-                    Image i;
+                    ToolTipImage i;
 
                     if (suffix.length() == 0) {
                         i = getIcon(resource, loader, false);
@@ -487,12 +492,12 @@ public final class ImageUtilities {
     * @param localizedQuery whether the name contains some localization suffix
     *  and is not optimized/interned
     */
-    private static Image getIcon(String name, ClassLoader loader, boolean localizedQuery) {
+    private static ToolTipImage getIcon(String name, ClassLoader loader, boolean localizedQuery) {
         if (name == null) {
             return null;
         }
         ActiveRef<String> ref = cache.get(name);
-        Image img = null;
+        ToolTipImage img = null;
 
         // no icon for this name (already tested)
         if (ref == NO_ICON) {
@@ -596,9 +601,9 @@ public final class ImageUtilities {
                     ERR.log(Level.FINE, "loading icon {0} = {1}", new Object[] {n, result});
                 }
                 name = new String(name).intern(); // NOPMD
-                result = ToolTipImage.createNew("", result, url);
-                cache.put(name, new ActiveRef<String>(result, cache, name));
-                return result;
+                ToolTipImage toolTipImage = ToolTipImage.createNew("", result, url);
+                cache.put(name, new ActiveRef<String>(toolTipImage, cache, name));
+                return toolTipImage;
             } else { // no icon found
                 if (!localizedQuery) {
                     cache.put(name, NO_ICON);
@@ -651,7 +656,7 @@ public final class ImageUtilities {
         }
     }
     
-    private static final Image doMergeImages(Image image1, Image image2, int x, int y) {
+    private static final ToolTipImage doMergeImages(Image image1, Image image2, int x, int y) {
         ensureLoaded(image1);
         ensureLoaded(image2);
 
@@ -788,11 +793,11 @@ public final class ImageUtilities {
     }
 
     /** Cleaning reference. */
-    private static final class ActiveRef<T> extends SoftReference<Image> implements Runnable {
+    private static final class ActiveRef<T> extends SoftReference<ToolTipImage> implements Runnable {
         private final Map<T,ActiveRef<T>> holder;
         private final T key;
 
-        public ActiveRef(Image o, Map<T,ActiveRef<T>> holder, T key) {
+        public ActiveRef(ToolTipImage o, Map<T,ActiveRef<T>> holder, T key) {
             super(o, Utilities.activeReferenceQueue());
             this.holder = holder;
             this.key = key;

--- a/platform/openide.util.ui/src/org/openide/util/VectorIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/VectorIcon.java
@@ -178,7 +178,7 @@ public abstract class VectorIcon implements Icon, Serializable {
      * Paint the icon at the given width and height. The dimensions given are the device pixels onto
      * which the icon must be drawn after it has been scaled up from its originally constant logical
      * dimensions and aligned onto the device pixel grid. Painting onto the supplied
-     * {@code Graphics2D} instance using whole number coordinates (for horizontal and veritcal
+     * {@code Graphics2D} instance using whole number coordinates (for horizontal and vertical
      * lines) will encourage sharp and well-aligned icons.
      *
      * <p>The icon should be painted with its upper left-hand corner at position (0, 0). Icons need

--- a/platform/openide.util.ui/test/unit/src/org/openide/util/ImageUtilitiesTest.java
+++ b/platform/openide.util.ui/test/unit/src/org/openide/util/ImageUtilitiesTest.java
@@ -19,13 +19,22 @@
 package org.openide.util;
 
 import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.Image;
+import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
+import java.util.function.Function;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import junit.framework.*;
+import static org.openide.util.ImageUtilities.icon2Image;
+import static org.openide.util.ImageUtilities.image2Icon;
 
 /**
  *
@@ -234,23 +243,224 @@ public class ImageUtilitiesTest extends TestCase {
     }
 
     public void testConversions() {
-        Image image = ImageUtilities.loadImage("org/openide/util/testimage.png", false);
-        Icon icon = ImageUtilities.loadImageIcon("org/openide/util/testimage.png", false);
+        /* Note: these are rather implementation-oriented tests. Implementation changes in
+        ImageUtilities (addition or removal of caches etc.) might require this test to be
+        updated, even when the API is unchanged. */
 
-        assertNotNull("Should not be null", icon);
-        assertNotNull("Should not be null", image);
+        for (boolean useExternalImage : new boolean[] {false, true}) {
+            Object urlProperty;
+            Image image;
+            ImageIcon imageIcon;
+            if (useExternalImage) {
+                // Test an Image and ImageIcon instance that did not originate from ImageUtilities.
+                urlProperty = null;
+                image = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+                imageIcon = new ImageIcon(image);
+            } else {
+                urlProperty = getClass().getResource("/org/openide/util/testimage.png");
+                image = ImageUtilities.loadImage("org/openide/util/testimage.png", false);
+                imageIcon = ImageUtilities.loadImageIcon("org/openide/util/testimage.png", false);
+                assertNotNull("URL found", urlProperty);
+                assertNotNull("Should not be null", imageIcon);
+                assertNotNull("Should not be null", image);
+                assertEquals("URL obtained", urlProperty, image.getProperty("url", null));
+            }
 
-        URL u = getClass().getResource("/org/openide/util/testimage.png");
-        assertNotNull("URL found", u);
-        assertEquals("URL obtained", u, image.getProperty("url", null));
+            /* These instances will no longer be the same; loadImage will now return a ToolTipImage,
+            while loadImageIcon will return a IconImageIcon. (Implementation detail only; could be
+            changed in the future.) */
+            assertNotSame("Expected different instances in current implementation",
+                    imageIcon,
+                    image2Icon(image));
 
-        Icon icon2 = ImageUtilities.image2Icon(image);
-        Image image2 = ImageUtilities.icon2Image(icon);
+            /* An Icon/Image loaded via loadImage can be freely passed through icon2Image/image2Icon
+            without a new instance being created. */
+            assertEquals("Should be same instance",
+                    image,
+                    icon2Image(imageIcon));
 
-        assertEquals("Should be same instance", icon, icon2);
-        assertEquals("Should be same instance", image, image2);
+            assertEquals("Should be same instance",
+                    icon2Image(imageIcon),
+                    icon2Image(imageIcon));
 
-        assertEquals("Url is still there", u, image2.getProperty("url", null));
+            if (!useExternalImage) {
+              /* In the useExternalImage case, the original instance will be converted to a
+              ToolTipImage, so we won't have the same instance here. */
+              assertEquals("Should be same instance",
+                      image,
+                      icon2Image(image2Icon(image)));
+            }
+
+            /* Again, loadImageIcon has to wrap its result in an IconImageIcon, so the instances below
+            won't be the same. (Implementation detail only; could be changed in the future.) */
+            assertNotSame("Expected different instances in current implementation",
+                    imageIcon,
+                    image2Icon(icon2Image(imageIcon)));
+
+            Icon iconFromImage2Icon = image2Icon(image);
+            assertEquals("Should be same instance",
+                    iconFromImage2Icon,
+                    image2Icon(icon2Image(iconFromImage2Icon)));
+
+            Icon iconFromImageIconRoundabout = image2Icon(icon2Image(imageIcon));
+            assertEquals("Should be same instance",
+                    iconFromImageIconRoundabout,
+                    image2Icon(icon2Image(iconFromImageIconRoundabout)));
+
+            // An actual BufferedImage will return Image.UndefinedProperty rather than null.
+            assertEquals("Url is still there",
+                    urlProperty != null ? urlProperty : Image.UndefinedProperty,
+                    icon2Image(imageIcon).getProperty("url", null));
+            assertEquals("Url is still there", urlProperty, icon2Image(iconFromImage2Icon).getProperty("url", null));
+            assertEquals("Url is still there", urlProperty, icon2Image(iconFromImageIconRoundabout).getProperty("url", null));
+        }
+    }
+
+    public void testConvertNullImageIcon() {
+        // A corner case which occured during development.
+        ImageIcon imageIcon = new ImageIcon();
+        Image image = ImageUtilities.icon2Image(imageIcon);
+        if (image == null) {
+            throw new AssertionError(
+                    "icon2Image should work even with an ImageIcon for which the image is null");
+        }
+        // Just ensure there are no NPEs.
+        image.getProperty("url", null);
+    }
+
+    /**
+     * @param expectZeroedXY if the implementation is expected to paint the icon at (0,0) rather
+     *        than on the supplied coordinates (e.g. because the paint happens on a cached
+     *        backbuffer rather than directly on the original Graphics2D).
+     */
+    private static void testLosslessCustomIconTransformations(
+            Function<CustomIcon, Icon> transformation, boolean expectZeroedXY)
+    {
+        /* Make sure that a custom Icon implementation that is passed through
+        the transformation is stilled called on to paint after the icon/image conversions. */
+        final CustomIcon origIcon = new CustomIcon();
+        Icon iconAgain = transformation.apply(origIcon);
+        origIcon.clear();
+        BufferedImage img = new BufferedImage(100, 100, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = img.createGraphics();
+        final int TEST_X = 45;
+        final int TEST_Y = 23;
+        // Also check that we don't unnecessarily crash if the Component parameter is null.
+        iconAgain.paintIcon(null, g, TEST_X, TEST_Y);
+        g.dispose();
+        assertTrue(origIcon.wasPaintCalled);
+        assertNull(origIcon.lastObservedComponent);
+        if (expectZeroedXY) {
+            assertEquals(0.0, origIcon.lastSeenX);
+            assertEquals(0.0, origIcon.lastSeenY);
+        } else {
+            assertEquals((double) TEST_X, origIcon.lastSeenX);
+            assertEquals((double) TEST_Y, origIcon.lastSeenY);
+        }
+    }
+
+    public void testCustomIconImplementationRetained() {
+        testLosslessCustomIconTransformations(new Function<CustomIcon, Icon>() {
+            @Override
+            public Icon apply(CustomIcon origIcon) {
+                Image image = ImageUtilities.icon2Image(origIcon);
+                assertTrue(origIcon.wasPaintCalled);
+                origIcon.clear();
+                Icon iconAgain = ImageUtilities.image2Icon(image);
+                assertFalse(origIcon.wasPaintCalled);
+                return iconAgain;
+            }
+        }, false);
+        testLosslessCustomIconTransformations(new Function<CustomIcon, Icon>() {
+            @Override
+            public Icon apply(CustomIcon origIcon) {
+                return ImageUtilities.createDisabledIcon(origIcon);
+            }
+        }, true);
+        testLosslessCustomIconTransformations(new Function<CustomIcon, Icon>() {
+            @Override
+            public Icon apply(CustomIcon origIcon) {
+                BufferedImage otherImage =
+                        new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+                // The offset is for otherImage, so should not cause the test to fail.
+                return image2Icon(
+                        ImageUtilities.mergeImages(icon2Image(origIcon), otherImage, 4, 12));
+            }
+        }, true);
+        testLosslessCustomIconTransformations(new Function<CustomIcon, Icon>() {
+            @Override
+            public Icon apply(CustomIcon origIcon) {
+                BufferedImage otherImage =
+                        new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+                return image2Icon(
+                        ImageUtilities.mergeImages(otherImage, icon2Image(origIcon), 0, 0));
+            }
+        }, true);
+    }
+
+    public void testCustomIconImplementationGetsValidComponent()
+            throws InterruptedException, InvocationTargetException
+    {
+        final CustomIcon origIcon = new CustomIcon();
+        /* The dummy Component parameter that is fed to Icon.paintIcon is only guaranteed to be
+        initialized once the Event Dispatch Thread has had a chance to run. */
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                assertFalse(origIcon.wasPaintCalled);
+                assertNull(origIcon.lastObservedComponent);
+                ImageUtilities.icon2Image(origIcon);
+                assertTrue(origIcon.wasPaintCalled);
+                assertNotNull(origIcon.lastObservedComponent);
+            }
+        });
+        /* Once ImageUtilities has initialized its dummy Component, paintIcon should keep receiving
+        a valid instance no matter which thread it is running on. */
+        final CustomIcon origIcon2 = new CustomIcon();
+        ImageUtilities.icon2Image(origIcon2);
+        assertTrue(origIcon2.wasPaintCalled);
+        assertNotNull(origIcon2.lastObservedComponent);
+    }
+
+    private static final class CustomIcon implements Icon {
+        public volatile Component lastObservedComponent;
+        public volatile boolean wasPaintCalled;
+        public volatile double lastSeenX;
+        public volatile double lastSeenY;
+
+        private void clear() {
+            lastObservedComponent = null;
+            wasPaintCalled = false;
+            lastSeenX = Double.NaN;
+            lastSeenY = Double.NaN;
+        }
+
+        public CustomIcon() {
+            clear();
+        }
+
+        @Override
+        public void paintIcon(Component c, Graphics g0, int x, int y) {
+            this.lastObservedComponent = c;
+            wasPaintCalled = true;
+            Graphics2D g = (Graphics2D) g0;
+            g.translate(x, y);
+            AffineTransform tx = g.getTransform();
+            final int txType = tx.getType();
+            assertTrue(txType == 0 || txType == AffineTransform.TYPE_TRANSLATION);
+            lastSeenX = tx.getTranslateX();
+            lastSeenY = tx.getTranslateY();
+        }
+
+        @Override
+        public int getIconWidth() {
+          return 16;
+        }
+
+        @Override
+        public int getIconHeight() {
+          return 16;
+        }
     }
 
     public void testLoadingNonExisting() {


### PR DESCRIPTION
This PR contains most of the changes that are needed to make ImageUtilities work with HiDPI icons. No publicly visible API changes are needed; the old javax.swing.Icon interface is actually well-suited for providing scalable graphics. The main challenge is to ensure that conversions between javax.swing.Icon and java.awt.Image, which are frequent throughout the NetBeans codebase, always retain the underlying scalable Icon instance.

The main motivation for this PR is to enable SVG icon support, which I will contribute in a separate PR. There's an added bonus, though: With all icon painting now centralized through ImageUtilities.ToolTipImage.paintIcon, we can add some rendering tweaks that make existing low-resolution icons look slightly better on HiDPI displays. See the attached before/after screenshots.

This issue is tracked under https://issues.apache.org/jira/browse/NETBEANS-2614 . SVG icon support is tracked under https://issues.apache.org/jira/browse/NETBEANS-2604 .

Credit: Emilian Bold did a lot of initial work on this before, at https://github.com/emilianbold/nextbeans/commit/0f99dba0c1b3e8e0bc4e7cec407b53d30e85ead1 . The main improvement in this PR is that arbitrary HiDPI scaling factors are supported. This is important on Windows, where non-integral scaling factors such as 150% can occur (MacOS, in contrast, always uses 200% for Retina screens). This PR also avoids the use of MultiResolutionImage, which does not work properly on Windows (see https://bugs.openjdk.java.net/browse/JDK-8212226 ).

To make reviewing easier, I have split up this PR into several commits, which can be reviewed one-at-a-time.

(To compare before/after screenshots, be sure to view the images at 100% scaling.)
![Windows 150pct HiDPI Scaling, Before Patch](https://user-images.githubusercontent.com/886243/58670470-347e0b80-830d-11e9-95be-ffa639af71a1.png)
![Windows 150pct HiDPI Scaling, After Patch](https://user-images.githubusercontent.com/886243/58670469-347e0b80-830d-11e9-833c-0a5a6f05aa73.png)
![Windows 200pct HiDPI Scaling, Before Patch](https://user-images.githubusercontent.com/886243/58670472-347e0b80-830d-11e9-9958-3af50e2a4be1.png)
![Windows 200pct HiDPI Scaling, After Patch](https://user-images.githubusercontent.com/886243/58670471-347e0b80-830d-11e9-8bb9-3f374a5d92aa.png)
