### PR TITLE
Java with Maven -> Java Frontend App + MOE is broken since Gradle support introduced

### DIFF
--- a/groovy/gradle/nbproject/project.xml
+++ b/groovy/gradle/nbproject/project.xml
@@ -330,6 +330,11 @@
                         <code-name-base>org.netbeans.libs.junit4</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
                 </test-type>
             </test-dependencies>
             <public-packages>

--- a/groovy/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
@@ -47,24 +47,31 @@ public final class NbGradleProjectFactory implements ProjectFactory2 {
 
     @Override
     public boolean isProject(FileObject dir) {
-        boolean ret = FileUtil.toFile(dir) != null;
-        if (ret) {
-            FileObject pom = dir.getFileObject("pom.xml"); //NOI18N
-            if ((pom != null) && pom.isData() && GradleSettings.getDefault().isPreferMaven()) {
-                ret = false;
-            } else {
-                File suspect = FileUtil.toFile(dir);
-                GradleFiles files = new GradleFiles(suspect);
-                if (!files.isRootProject()) {
-                    Boolean inSubDirCache = GradleProjectCache.isKnownSubProject(files.getRootDir(), suspect);
-                    ret = inSubDirCache != null ? inSubDirCache : files.isProject();
-                } else {
-                    ret = true;
-                }
+        return isProjectCheck(dir, GradleSettings.getDefault().isPreferMaven());
+    }
+
+    static boolean isProjectCheck(FileObject dir, final boolean preferMaven) {
+        if (dir == null || FileUtil.toFile(dir) == null) {
+            return false;
+        }
+        FileObject pom = dir.getFileObject("pom.xml"); //NOI18N
+        if (pom != null && pom.isData()) {
+            if (preferMaven) {
+                return false;
+            }
+            final FileObject parent = dir.getParent();
+            if (parent != null && parent.getFileObject("pom.xml") != null) { // NOI18N
+                return isProjectCheck(parent, preferMaven);
             }
         }
-
-        return ret;
+        File suspect = FileUtil.toFile(dir);
+        GradleFiles files = new GradleFiles(suspect);
+        if (!files.isRootProject()) {
+            Boolean inSubDirCache = GradleProjectCache.isKnownSubProject(files.getRootDir(), suspect);
+            return inSubDirCache != null ? inSubDirCache : files.isProject();
+        } else {
+            return true;
+        }
     }
 
     @Override

--- a/groovy/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectFactoryTest.java
+++ b/groovy/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectFactoryTest.java
@@ -61,7 +61,7 @@ public class NbGradleProjectFactoryTest extends NbTestCase {
         assertFalse("Pom wins", NbGradleProjectFactory.isProjectCheck(prj, true));
     }
 
-    public void testPomAndGradleNested() throws Exception {
+    public void testPomNestedAndGradleNot() throws Exception {
         FileObject parentPrj = root;
         FileObject parentPom = FileUtil.createData(parentPrj, "pom.xml");
         FileObject prj = FileUtil.createFolder(parentPrj, "child");
@@ -70,6 +70,21 @@ public class NbGradleProjectFactoryTest extends NbTestCase {
 
         assertFalse("Pom wins on settings", NbGradleProjectFactory.isProjectCheck(prj, true));
         assertFalse("Pom wins on parent pom", NbGradleProjectFactory.isProjectCheck(prj, false));
+    }
+
+    public void testPomAndGradleBothNested() throws Exception {
+        FileObject parentPrj = root;
+        FileObject parentPom = FileUtil.createData(parentPrj, "pom.xml");
+        FileObject parentGradle = FileUtil.createData(parentPrj, "build.gradle");
+        FileObject prj = FileUtil.createFolder(parentPrj, "child");
+        FileObject pom = FileUtil.createData(prj, "pom.xml");
+        FileObject gradle = FileUtil.createData(prj, "build.gradle");
+
+        assertFalse("Parent Pom wins on settings", NbGradleProjectFactory.isProjectCheck(parentPrj, true));
+        assertTrue("Parent Gradle wins", NbGradleProjectFactory.isProjectCheck(parentPrj, false));
+
+        assertFalse("Pom wins on settings", NbGradleProjectFactory.isProjectCheck(prj, true));
+        assertTrue("Gradle wins on parent build.gradle", NbGradleProjectFactory.isProjectCheck(prj, false));
     }
 
 }

--- a/groovy/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectFactoryTest.java
+++ b/groovy/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectFactoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.spi.project.ProjectState;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.LocalFileSystem;
+
+public class NbGradleProjectFactoryTest extends NbTestCase {
+    private FileObject root;
+
+    public NbGradleProjectFactoryTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        clearWorkDir();
+        LocalFileSystem fs = new LocalFileSystem();
+        fs.setRootDirectory(getWorkDir());
+        root = fs.getRoot();
+    }
+
+    public void testNull() throws Exception {
+        assertFalse(NbGradleProjectFactory.isProjectCheck(null, false));
+        assertFalse(NbGradleProjectFactory.isProjectCheck(null, true));
+    }
+
+    public void testPomAndGradle() throws Exception {
+        FileObject prj = root;
+        FileObject pom = FileUtil.createData(prj, "pom.xml");
+        FileObject gradle = FileUtil.createData(prj, "build.gradle");
+
+        assertTrue("Gradle wins", NbGradleProjectFactory.isProjectCheck(prj, false));
+        assertFalse("Pom wins", NbGradleProjectFactory.isProjectCheck(prj, true));
+    }
+
+    public void testPomAndGradleNested() throws Exception {
+        FileObject parentPrj = root;
+        FileObject parentPom = FileUtil.createData(parentPrj, "pom.xml");
+        FileObject prj = FileUtil.createFolder(parentPrj, "child");
+        FileObject pom = FileUtil.createData(prj, "pom.xml");
+        FileObject gradle = FileUtil.createData(prj, "build.gradle");
+
+        assertFalse("Pom wins on settings", NbGradleProjectFactory.isProjectCheck(prj, true));
+        assertFalse("Pom wins on parent pom", NbGradleProjectFactory.isProjectCheck(prj, false));
+    }
+
+}


### PR DESCRIPTION
Try NetBeans 11 and do: New project -> Java with Maven -> Java Frontend Application -> ... -> Run on iOS devices + Use Multi OS Engine (needs Mac). Then create the project...

Nested `client-moe` project is recognized as Gradle, while it is a nested Maven project. The IDE gets totally confused by that.

This fix mitigates the situation by preferring Maven over Gradle, if parent folder is also Maven, but not Gradle. Is it OK this way, @lkishalmi?