### PR TITLE
[NETBEANS-2639] Compile mavensrc to Java 7, not 8

### DIFF
--- a/java/maven/build.xml
+++ b/java/maven/build.xml
@@ -30,8 +30,8 @@
         <javac srcdir="mavensrc" destdir="build/mavenclasses" 
             debug="${build.compiler.debug}" 
             deprecation="${build.compiler.deprecation}" 
-            source="${javac.source}" 
-            target="${javac.target}" 
+            source="1.7"
+            target="1.7"
             includeantruntime="false">
             <classpath>
                 <fileset dir="${maven.embedder.dir}/maven/lib">


### PR DESCRIPTION
[NETBEANS-2639](https://issues.apache.org/jira/browse/NETBEANS-2639)

The bundled Maven is [built to Java 7](https://github.com/apache/maven/blob/maven-3.3.9/pom.xml#L46-L47) so we cannot build the spy module against Java 8 as https://github.com/apache/netbeans/pull/1144 did—it will not link. Same for the [current release](https://github.com/apache/maven/blob/maven-3.6.1/pom.xml#L50-L51). Java 5 is too old for JDK 11 javac, which only supports 6 and later, so we can choose 6 or 7.