### PR TITLE
[NETBEANS-2306] Fix for missing resource AmazonJ2EEServerWizardComponent.containerLabel.text

### DIFF
--- a/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/ui/serverplugin/Bundle.properties
+++ b/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/ui/serverplugin/Bundle.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 AmazonJ2EEServerWizardComponent.endNameLabel.text=Environment Name:
-AmazonJ2EEServerWizardComponent.envFullURLLabel.text=\ \
+AmazonJ2EEServerWizardComponent.envFullURLLabel.text=
 AmazonJ2EEServerWizardComponent.containerLabel.text=Container Type:
 
 AmazonJ2EEServerWizardComponent.name=Create new virtual application or environment


### PR DESCRIPTION
*What this PR does*
Fixes an exception preventing the Server wizard panel being displayed for AWS Elastic Beanstalk servers

*Root cause*
In the file `/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/ui/serverplugin/Bundle.properties` there are the following entries:
```
AmazonJ2EEServerWizardComponent.envFullURLLabel.text=\ \
AmazonJ2EEServerWizardComponent.containerLabel.text=Container Type:
```
Having a \ as the last character on the `AmazonJ2EEServerWizardComponent.envFullURLLabel.text=\ \` entry causes Java to consider the text on the following line as part of the value of the AmazonJ2EEServerWizardComponent.envFullURLLabel.text property.

Hence the AmazonJ2EEServerWizardComponent.containerLabel.text property can't be found when the Server Wizard tries to render

*Files changed*
* /enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/ui/serverplugin/Bundle.properties
Removed `\ \` so the AmazonJ2EEServerWizardComponent.envFullURLLabel.text property will have empty String as it's default value.

*Testing*
* Create a new JavaEE Application
* Choose to add a server.  Choose Amazon Beanstalk.  Click Next >
Before this PR:
* Server Wizard will not be displayed.
* Checking the Notifications window will reveal the exception 'java.util.MissingResourceException: Can't find resource for bundle org.openide.util.NbBundle$PBundle, key AmazonJ2EEServerWizardComponent.containerLabel.text'
After this PR:
* AWS Beanstalk server wizard displayed as expected