### PR TITLE
[NETBEANS-2516]Warnings hints for Convert rule switch to Traditional …

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertSwitchToTraditionalSwitch.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertSwitchToTraditionalSwitch.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.hints.jdk;
+
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.CaseTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.StatementTree;
+import com.sun.source.tree.SwitchTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
+import com.sun.tools.javac.tree.JCTree;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.TreeMaker;
+import org.netbeans.api.java.source.WorkingCopy;
+import org.netbeans.modules.java.source.TreeShims;
+import org.netbeans.spi.editor.hints.ErrorDescription;
+import org.netbeans.spi.java.hints.ErrorDescriptionFactory;
+import org.netbeans.spi.java.hints.Hint;
+import org.netbeans.spi.java.hints.HintContext;
+import org.netbeans.spi.java.hints.JavaFix;
+import org.netbeans.spi.java.hints.TriggerTreeKind;
+import org.openide.util.NbBundle.Messages;
+
+@Hint(displayName = "#DN_org.netbeans.modules.java.hints.jdk.ConvertSwitchToTraditionalSwitch",
+        description = "#DESC_org.netbeans.modules.java.hints.jdk.ConvertSwitchToTraditionalSwitch", category = "rules15",
+        minSourceVersion = "12")
+@Messages({
+    "DN_org.netbeans.modules.java.hints.jdk.ConvertSwitchToTraditionalSwitch=Convert switch to traditional switch",
+    "DESC_org.netbeans.modules.java.hints.jdk.ConvertSwitchToTraditionalSwitch=Convert switch to traditional switch",})
+public class ConvertSwitchToTraditionalSwitch {
+
+    @TriggerTreeKind(Tree.Kind.SWITCH)
+    @Messages({"ERR_ConvertSwitchToTraditionalSwitch=Convert switch to traditional switch"})
+    public static ErrorDescription ruleSwitch2TraditionalSwitch(HintContext ctx) {
+        SwitchTree st = (SwitchTree) ctx.getPath().getLeaf();
+        for (CaseTree ct : st.getCases()) {
+            if (!TreeShims.RULE_CASE_KIND.equals(TreeShims.getCaseKind(ct))) {
+                return null;
+            }
+        }
+        return ErrorDescriptionFactory.forName(ctx, ctx.getPath(), Bundle.ERR_ConvertSwitchToTraditionalSwitch(), new FixImpl(ctx.getInfo(), ctx.getPath()).toEditorFix());
+
+    }
+
+    private static final class FixImpl extends JavaFix {
+
+        public FixImpl(CompilationInfo info, TreePath switchStatement) {
+            super(info, switchStatement);
+        }
+
+        @Override
+        @Messages("FIX_ConvertSwitchToTraditionalSwitch=Convert to traditional switch")
+        protected String getText() {
+            return Bundle.FIX_ConvertSwitchToTraditionalSwitch();
+        }
+
+        @Override
+        protected void performRewrite(TransformationContext ctx) {
+            TreePath tp = ctx.getPath();
+            SwitchTree st = (SwitchTree) tp.getLeaf();
+            WorkingCopy wc = ctx.getWorkingCopy();
+            TreeMaker make = wc.getTreeMaker();
+            List<CaseTree> newCases = new ArrayList<>();
+            List<? extends CaseTree> cases;
+            List<ExpressionTree> patterns = new ArrayList<>();
+            boolean switchExpressionFlag = st.getKind().toString().equals(TreeShims.SWITCH_EXPRESSION);
+            if (switchExpressionFlag) {
+                cases = TreeShims.getCases(st);
+            } else {
+                cases = ((SwitchTree) st).getCases();
+            }
+            for (Iterator<? extends CaseTree> it = cases.iterator(); it.hasNext();) {
+                CaseTree ct = it.next();
+                patterns.addAll(TreeShims.getExpressions(ct));
+                List<StatementTree> statements;
+                if (ct.getStatements() == null) {
+                    statements = new ArrayList<>(((JCTree.JCCase) ct).stats);
+                    if (statements.size() == 1 && statements.get(0).getKind() == Tree.Kind.BLOCK) {
+                        statements = new ArrayList<>(((BlockTree) statements.get(0)).getStatements());
+                    }
+                } else {
+                    statements = new ArrayList<>(ct.getStatements());
+                }
+                statements.add(make.Break(null));
+                if (patterns.isEmpty()) {
+                    newCases.add(make.Case(null, statements));
+                } else {
+                    for (int i = 0; i < patterns.size() - 1; i++) {
+                        newCases.add(make.Case(patterns.get(i), new ArrayList<>()));
+                    }
+                    newCases.add(make.Case(patterns.get(patterns.size() - 1), statements));
+                }
+
+                patterns = new ArrayList<>();
+            }
+
+            wc.rewrite((SwitchTree) st, make.Switch(((SwitchTree) st).getExpression(), newCases));
+        }
+    }
+
+}

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertSwitchToTraditionalSwitchTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertSwitchToTraditionalSwitchTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.hints.jdk;
+
+import com.sun.tools.javac.tree.JCTree;
+import javax.lang.model.SourceVersion;
+import junit.framework.Test;
+import junit.framework.TestSuite;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.hints.test.api.HintTest;
+
+
+public class ConvertSwitchToTraditionalSwitchTest extends NbTestCase {
+
+    public ConvertSwitchToTraditionalSwitchTest(String name) {
+        super(name);
+    }
+
+    public void testSwitch2RuleSwitch() throws Exception {
+        HintTest.create()
+                .input("package test;"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 1 -> System.out.println(\"one\"); \n"
+                        + "             case 2 -> System.out.println(\"two\"); \n"
+                        + "             default -> System.out.println(\"default\");\n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n")
+                .sourceLevel(SourceVersion.latest().name())
+                .options("--enable-preview")
+                .run(ConvertSwitchToTraditionalSwitch.class)
+                .findWarning("3:9-3:15:verifier:" + Bundle.ERR_ConvertSwitchToTraditionalSwitch())
+                .applyFix()
+                .assertCompilable()
+                .assertOutput("package test;"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 1 : System.out.println(\"one\"); break; \n"
+                        + "             case 2 : System.out.println(\"two\"); break; \n"
+                        + "             default : System.out.println(\"default\"); break; \n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n");
+    }
+
+    public void testRuleSwitch2TraditionalSwitchMultiLevel() throws Exception {
+        HintTest.create()
+                .input("package test;"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 0,1 -> System.out.println(\"one\"); \n"
+                        + "             case 2 -> System.out.println(\"two\"); \n"
+                        + "             default -> System.out.println(\"default\");\n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n")
+                .sourceLevel(SourceVersion.latest().name())
+                .options("--enable-preview")
+                .run(ConvertSwitchToTraditionalSwitch.class)
+                .findWarning("3:9-3:15:verifier:" + Bundle.ERR_ConvertSwitchToTraditionalSwitch())
+                .applyFix()
+                .assertCompilable()
+                .assertOutput("package test;"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 0 : \n"
+                        + "             case 1 : System.out.println(\"one\"); break; \n"
+                        + "             case 2 : System.out.println(\"two\"); break; \n"
+                        + "             default : System.out.println(\"default\"); break; \n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n");
+    }
+
+    public void testRuleSwitch2TraditionalSwitchBlockCase() throws Exception {
+        HintTest.create()
+                .input("package test;"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 1 -> result = \"1\";\n"
+                        + "             case 2 -> { if (true) result = \"2\"; }\n"
+                        + "             case 3 -> { System.err.println(3); result = \"3\"; }\n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n")
+                .sourceLevel(SourceVersion.latest().name())
+                .options("--enable-preview")
+                .run(ConvertSwitchToTraditionalSwitch.class)
+                .findWarning("3:9-3:15:verifier:" + Bundle.ERR_ConvertSwitchToTraditionalSwitch())
+                .applyFix()
+                .assertCompilable()
+                .assertOutput("package test;"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 1: result = \"1\"; break;\n"
+                        + "             case 2: if (true) result = \"2\"; break;\n"
+                        + "             case 3: System.err.println(3); result = \"3\"; break;\n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n");
+    }
+
+    public void testRuleSwitch2TraditionalSwitchWithBreak() throws Exception {
+        HintTest.create()
+                .input("package test;"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 1 -> { if (p == 1) { result = \"1\"; } else { result = \"2\"; } }\n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n")
+                .sourceLevel(SourceVersion.latest().name())
+                .options("--enable-preview")
+                .run(ConvertSwitchToTraditionalSwitch.class)
+                .findWarning("3:9-3:15:verifier:" + Bundle.ERR_ConvertSwitchToTraditionalSwitch())
+                .applyFix()
+                .assertCompilable()
+                .assertOutput("package test;"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 1: if (p == 1) { result = \"1\"; } else { result = \"2\"; } break; \n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n");
+    }
+
+    public void testRuleSwitch2TraditionalDefault() throws Exception {
+        HintTest.create()
+                .input("package test;"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 0 -> result = \"1\";\n"
+                        + "             default -> {\n"
+                        + "                 result = \"d\"; System.out.println(result);\n"
+                        + "             }\n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n")
+                .sourceLevel(SourceVersion.latest().name())
+                .options("--enable-preview")
+                .run(ConvertSwitchToTraditionalSwitch.class)
+                .findWarning("3:9-3:15:verifier:" + Bundle.ERR_ConvertSwitchToTraditionalSwitch())
+                .applyFix()
+                .assertCompilable()
+                .assertOutput("package test;"
+                        + "public class Test {\n"
+                        + "     private void test(int p) {\n"
+                        + "         String result;\n"
+                        + "         switch (p) {\n"
+                        + "             case 0: result = \"1\"; break;\n"
+                        + "             default: result = \"d\"; System.out.println(result); break;\n"
+                        + "         }\n"
+                        + "     }\n"
+                        + "}\n");
+    }
+
+    public static Test suite() {
+        TestSuite suite = new TestSuite();
+        try {
+            Class.forName("com.sun.source.tree.CaseTree$CaseKind", false, JCTree.class.getClassLoader());
+            suite.addTestSuite(ConvertSwitchToTraditionalSwitchTest.class);
+        } catch (ClassNotFoundException ex) {
+            //OK
+            suite.addTest(new ConvertSwitchToTraditionalSwitchTest("noop"));
+        }
+        return suite;
+    }
+
+    public void noop() {
+    }
+}

--- a/java/java.source.base/src/org/netbeans/modules/java/source/TreeShims.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/TreeShims.java
@@ -35,6 +35,7 @@ import java.util.List;
 public class TreeShims {
 
     public static final String SWITCH_EXPRESSION = "SWITCH_EXPRESSION"; //NOI18N
+    public static final String RULE_CASE_KIND = "RULE"; //NOI18N
 
     public static List<? extends ExpressionTree> getExpressions(CaseTree node) {
         try {
@@ -51,6 +52,17 @@ public class TreeShims {
         try {
             Method getBody = CaseTree.class.getDeclaredMethod("getBody");
             return (Tree) getBody.invoke(node);
+        } catch (NoSuchMethodException ex) {
+            return null;
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+            throw TreeShims.<RuntimeException>throwAny(ex);
+        }
+    }
+
+    public static String getCaseKind(CaseTree node) {
+        try {
+            Method getCaseKind = CaseTree.class.getDeclaredMethod("getCaseKind");
+            return getCaseKind.invoke(node).toString();
         } catch (NoSuchMethodException ex) {
             return null;
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {


### PR DESCRIPTION
…switch
Implementation of warning hints for  "Convert rule switch to Traditional switch"

Use case:

Actual code:

public void test(int i){
String result;
switch

{ case 1 -> System.out.println("One"); case 2 -> System.out.println("Two"); default -> System.out.println("Default"); }
}

Warning Hints : "Convert to traditional switch"

After Fix:

public void test(int i){
String result;
switch

{ case 1 : System.out.println("One"); break; case 2 : System.out.println("Two"); break; default: System.out.println("Default"); break; }
}