### PR TITLE
NETBEANS-2656 remove old JDK migrators under Inspect and Transform

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/resources/jdk11.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/resources/jdk11.properties
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-display.name=Migrate to JDK 10
+display.name=Migrate to JDK 11

--- a/java/java.hints/src/org/netbeans/modules/java/hints/resources/layer.xml
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/resources/layer.xml
@@ -359,23 +359,6 @@
         <folder name="org"><folder name="netbeans"><folder name="modules"><folder name="java"><folder name="hints">
             <folder name="rule_config_default">
             </folder>
-            <folder name="rule_config_jdk5">
-                <file name="org.netbeans.modules.java.hints.jdk.IteratorToFor.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.jdk.UnnecessaryUnboxing.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.jdk.UnnecessaryBoxing.run.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.StaticImport.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.jdk.ConvertToStringSwitch.properties" url="enabled.properties"/>
-            </folder>
-            <folder name="rule_config_jdk7">
-                <file name="Javac_canUseDiamond.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.jdk.IteratorToFor.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.jdk.Tiny.containsForIndexOf.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.jdk.UnnecessaryUnboxing.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.jdk.ConvertToARM.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.jdk.JoinCatches.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.StaticImport.properties" url="enabled.properties"/>
-                <file name="org.netbeans.modules.java.hints.jdk.UnnecessaryBoxing.run.properties" url="enabled.properties"/>
-            </folder>
             <folder name="rule_config_jdk8">
                 <file name="Javac_canUseDiamond.properties" url="enabled.properties"/>
                 <file name="Javac_canUseLambda.properties" url="enabled.properties"/>
@@ -388,7 +371,7 @@
                 <file name="org.netbeans.modules.java.hints.jdk.ConvertToStringSwitch.properties" url="enabled.properties"/>
                 <file name="org.netbeans.modules.java.hints.jdk.UnnecessaryBoxing.run.properties" url="enabled.properties"/>
             </folder>
-            <folder name="rule_config_jdk10">
+            <folder name="rule_config_jdk11">
                 <file name="Javac_canUseDiamond.properties" url="enabled.properties"/>
                 <file name="Javac_canUseLambda.properties" url="enabled.properties"/>
                 <file name="org.netbeans.modules.java.hints.jdk.IteratorToFor.properties" url="enabled.properties"/>
@@ -417,10 +400,8 @@
             </folder>
             <folder name="ui">
                 <file name="rule_config_default.properties" url="nbresloc:/org/netbeans/modules/java/hints/resources/default.properties"/>
-                <file name="rule_config_jdk5.properties" url="nbresloc:/org/netbeans/modules/java/hints/resources/jdk5.properties"/>
-                <file name="rule_config_jdk7.properties" url="nbresloc:/org/netbeans/modules/java/hints/resources/jdk7.properties"/>
                 <file name="rule_config_jdk8.properties" url="nbresloc:/org/netbeans/modules/java/hints/resources/jdk8.properties"/>
-                <file name="rule_config_jdk10.properties" url="nbresloc:/org/netbeans/modules/java/hints/resources/jdk10.properties"/>
+                <file name="rule_config_jdk11.properties" url="nbresloc:/org/netbeans/modules/java/hints/resources/jdk11.properties"/>
                 <file name="rule_config_jdk12.properties" url="nbresloc:/org/netbeans/modules/java/hints/resources/jdk12.properties"/>
             </folder>
         </folder></folder></folder></folder></folder>


### PR DESCRIPTION
Removed Configurations for JDK5, 7. Renamed JDK 10 config as JDK11. No new hints were added for JDK 11 hence no config was added but since it's LTS release, it's better to support config for JDK 11.
