### PR TITLE
[NETBEANS-2657] - Removing obsolete update centers from daily builds

### DIFF
--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
@@ -23,19 +23,9 @@ OpenIDE-Module-Display-Category=Infrastructure
 OpenIDE-Module-Long-Description=It's module which contains the declaration of NetBeans update centers for Autoupdate module.
 OpenIDE-Module-Short-Description=Declares NetBeans autoupdate centers.
 
-Services/AutoupdateType/dev-update-provider.instance=Additional Development Plugins
-Services/AutoupdateType/standard-update-provider.instance=Latest Development Build
-Services/AutoupdateType/pluginportal-update-provider.instance=Plugin Portal
-Services/AutoupdateType/82pluginportal-update-provider.instance=NetBeans 8.2 Plugin Portal
+Services/AutoupdateType/distribution-update-provider.instance=NetBeans Distribution
+Services/AutoupdateType/pluginportal-update-provider.instance=NetBeans Plugin Portal
 #NOI18N
-URL_LatestBuild=http://bits.netbeans.org/dev/nbms-and-javadoc/lastSuccessfulBuild/artifact/nbbuild/nbms/updates.xml.gz
+URL_Distribution=https://builds.apache.org/job/netbeans-linux/lastSuccessfulBuild/artifact/nbbuild/nbms/updates.xml.gz?{$netbeans.hash.code}
 #NOI18N
-URL_Default_N=http://updates.netbeans.org/netbeans/updates/dev/uc/final/main/catalog.xml.gz?{$netbeans.hash.code}
-#NOI18N
-URL_PluginPortal=http://plugins.netbeans.org/nbpluginportal/updates/11.0/catalog.xml.gz
-#NOI18N
-URL_82PluginPortal=http://updates.netbeans.org/netbeans/updates/8.2/uc/final/distribution/catalog.xml.gz
-
-3rdparty=3rd Party Libraries
-#NOI18N
-URL_3rdparty=nbresloc:/org/netbeans/modules/updatecenters/resources/3rdparty-catalog.xml
+URL_PluginPortal=http://netbeans-vm.apache.org/pluginportal/data/latest/catalog-experimental.xml.gz

--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
@@ -25,25 +25,14 @@
   <folder name="Services">
 
     <folder name="AutoupdateType">
-      <!-- this ordering left because backward compatibility with deserialized autoupdate types -->
-      <file name="standard-update-provider.instance">
-        <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/standard-update-provider.instance"/>
-        <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>
-        <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_LatestBuild"/>
-        <attr name="category" stringvalue="STANDARD"/>
-        <attr name="enabled" boolvalue="true"/>
-        <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider" />
-        <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider" />
-      </file>
-
-      <file name="dev-update-provider.instance">
-          <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/dev-update-provider.instance"/>
+      <file name="distribution-update-provider.instance">
+          <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/distribution-update-provider.instance"/>
           <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>
-          <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_Default_N"/>
+          <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_Distribution"/>
           <attr name="category" stringvalue="STANDARD"/>
           <attr name="enabled" boolvalue="true"/>
           <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider" />
-          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider" />
+          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
       </file>
 
       <file name="pluginportal-update-provider.instance">
@@ -56,25 +45,6 @@
          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
       </file>
       
-      <file name="82pluginportal-update-provider.instance">
-          <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/82pluginportal-update-provider.instance"/>
-          <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>
-          <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_82PluginPortal"/>
-          <attr name="category" stringvalue="STANDARD"/>
-          <attr name="enabled" boolvalue="false"/>
-          <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider"/>
-          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
-      </file>
-
-      <file name="3rdparty.instance">
-          <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#3rdparty"/>
-          <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>
-          <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_3rdparty"/>
-          <attr name="category" stringvalue="STANDARD"/>
-          <attr name="enabled" boolvalue="true"/>
-          <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider"/>
-          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
-      </file>
    </folder>
     
   </folder> <!-- Services -->


### PR DESCRIPTION
NetBeans daily builds contain obsolete and no longer working update centres. This pull request attempts to resolve the problems by removing the useless UCs and leaving just two: one for modules from the latest standard distribution and one for modules from the latest plugin portal version.
More details in #[NETBEANS-2657](https://issues.apache.org/jira/browse/NETBEANS-2657)