### PR TITLE
Using SourceFile attribute when indexing

### DIFF
--- a/ide/projectapi/test/unit/src/org/netbeans/modules/projectapi/nb/NbProjectManagerAccessor.java
+++ b/ide/projectapi/test/unit/src/org/netbeans/modules/projectapi/nb/NbProjectManagerAccessor.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.projectapi.nb;
 
-import org.netbeans.modules.projectapi.nb.NbProjectManager;
 import org.netbeans.spi.project.ProjectManagerImplementation;
 import org.openide.util.Lookup;
 

--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ListeningDICookie.java
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ListeningDICookie.java
@@ -56,7 +56,7 @@ public final class ListeningDICookie extends AbstractDICookie {
      */
     public static final String ID = "netbeans-jpda-ListeningDICookie";
 
-    private ListeningConnector listeningConnector;
+    private final ListeningConnector listeningConnector;
     private Map<String, ? extends Argument> args;
     private boolean isListening = false;
 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaBinaryIndexer.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaBinaryIndexer.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.java.source.indexing;
 
 import com.sun.tools.javac.api.JavacTaskImpl;
-import com.sun.tools.javac.model.JavacElements;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -49,6 +49,7 @@ import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.ElementHandle;
+import org.netbeans.modules.classfile.ClassFile;
 import org.netbeans.modules.java.source.ElementUtils;
 import org.netbeans.modules.java.source.NoJavacHelper;
 import org.netbeans.modules.java.source.base.Module;
@@ -82,10 +83,10 @@ public class JavaBinaryIndexer extends BinaryIndexer {
 
     @Override
     protected void index(final Context context) {
-        doIndex(context, context.getRootURI());
+        doIndex(context, context.getRootURI(), null);
     }
 
-    static void doIndex(final Context context, URL rootURI) {
+    static void doIndex(final Context context, URL rootURI, Predicate<ClassFile> accept) {
         LOG.log(Level.FINE, "index({0})", rootURI);
         try {
             final ClassIndexManager cim = ClassIndexManager.getDefault();
@@ -97,7 +98,7 @@ public class JavaBinaryIndexer extends BinaryIndexer {
             if (context.isAllFilesIndexing()) {
                 final BinaryAnalyser ba = uq.getBinaryAnalyser();
                 if (ba != null) { //ba == null => IDE is exiting, indexing will be done on IDE restart
-                    final BinaryAnalyser.Changes changes = ba.analyse(context, rootURI);
+                    final BinaryAnalyser.Changes changes = ba.analyse(context, rootURI, accept);
                     if (changes.done) {
                         final Map<URL, List<URL>> binDeps = IndexingController.getDefault().getBinaryRootDependencies();
                         final Map<URL, List<URL>> srcDeps = IndexingController.getDefault().getRootDependencies();

--- a/java/java.source.base/test/unit/src/annotations/AnnotationArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/AnnotationArgAnnotation.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+
+public @interface AnnotationArgAnnotation {
+    
+    ArrayOfStringArgAnnotation value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/ArrayOfAnnotationArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/ArrayOfAnnotationArgAnnotation.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+public @interface ArrayOfAnnotationArgAnnotation {
+  public abstract ArrayOfStringArgAnnotation[] value();
+}

--- a/java/java.source.base/test/unit/src/annotations/ArrayOfBooleanArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/ArrayOfBooleanArgAnnotation.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+
+public @interface ArrayOfBooleanArgAnnotation {
+    
+    boolean[] value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/ArrayOfClassArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/ArrayOfClassArgAnnotation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+public @interface ArrayOfClassArgAnnotation {
+
+    public Class<?>[] value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/ArrayOfEnumArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/ArrayOfEnumArgAnnotation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+public @interface ArrayOfEnumArgAnnotation {
+    
+    TestEnum[] value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/ArrayOfIntArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/ArrayOfIntArgAnnotation.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+public interface ArrayOfIntArgAnnotation extends java.lang.annotation.Annotation {
+
+    public abstract int[] value();
+}

--- a/java/java.source.base/test/unit/src/annotations/ArrayOfStringArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/ArrayOfStringArgAnnotation.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+public @interface ArrayOfStringArgAnnotation {
+    String[] value() default {};
+}

--- a/java/java.source.base/test/unit/src/annotations/BooleanArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/BooleanArgAnnotation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+
+public @interface BooleanArgAnnotation {
+    
+    boolean value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/ByteArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/ByteArgAnnotation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+
+public @interface ByteArgAnnotation {
+    
+    byte value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/CharArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/CharArgAnnotation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+
+public @interface CharArgAnnotation {
+    
+    char value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/ClassArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/ClassArgAnnotation.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+public @interface ClassArgAnnotation {
+
+    public Class<?> value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/DoubleArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/DoubleArgAnnotation.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+public interface DoubleArgAnnotation extends java.lang.annotation.Annotation {
+
+    public abstract double value();
+}

--- a/java/java.source.base/test/unit/src/annotations/EnumArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/EnumArgAnnotation.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+public @interface EnumArgAnnotation {
+  public abstract TestEnum value();
+}

--- a/java/java.source.base/test/unit/src/annotations/FloatArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/FloatArgAnnotation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+
+public @interface FloatArgAnnotation {
+    
+    float value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/IntArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/IntArgAnnotation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+
+public @interface IntArgAnnotation {
+    
+    int value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/LongArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/LongArgAnnotation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+
+public @interface LongArgAnnotation {
+    
+    long value();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/NoArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/NoArgAnnotation.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.CLASS)
+public @interface NoArgAnnotation {
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/NoArgAnnotationSource.java
+++ b/java/java.source.base/test/unit/src/annotations/NoArgAnnotationSource.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.CLASS)
+public @interface NoArgAnnotationSource {
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/NonTrivialArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/NonTrivialArgAnnotation.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+
+public @interface NonTrivialArgAnnotation {
+    
+    TestEnum something();
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/OptionalArgsAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/OptionalArgsAnnotation.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+
+public @interface OptionalArgsAnnotation {
+    
+    String value() default "<default>";
+    
+    TestEnum something() default TestEnum.X;
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/RequestProcessor.java
+++ b/java/java.source.base/test/unit/src/annotations/RequestProcessor.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+public class RequestProcessor {
+    public RequestProcessor() {
+    }
+
+    public final class Task {
+        Task(RequestProcessor r0, Runnable r1) {}
+        Task(RequestProcessor r0, Runnable r1, int i) {};
+    }
+    
+}

--- a/java/java.source.base/test/unit/src/annotations/ShortArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/ShortArgAnnotation.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package annotations;
+
+public interface ShortArgAnnotation extends java.lang.annotation.Annotation {
+
+    public abstract short value();
+}

--- a/java/java.source.base/test/unit/src/annotations/StringArgAnnotation.java
+++ b/java/java.source.base/test/unit/src/annotations/StringArgAnnotation.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+public interface StringArgAnnotation extends java.lang.annotation.Annotation {
+  public abstract java.lang.String value();
+}

--- a/java/java.source.base/test/unit/src/annotations/TestEnum.java
+++ b/java/java.source.base/test/unit/src/annotations/TestEnum.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package annotations;
+
+public enum TestEnum {
+    
+    X, Y;
+    
+}

--- a/java/java.source.base/test/unit/src/usages/ClassAnnotations.java
+++ b/java/java.source.base/test/unit/src/usages/ClassAnnotations.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package usages;
+
+import annotations.AnnotationArgAnnotation;
+import annotations.ArrayOfStringArgAnnotation;
+import annotations.ClassArgAnnotation;
+import annotations.EnumArgAnnotation;
+import annotations.NoArgAnnotation;
+import annotations.TestEnum;
+import java.util.List;
+
+@NoArgAnnotation
+@AnnotationArgAnnotation(@ArrayOfStringArgAnnotation())
+@EnumArgAnnotation(TestEnum.X)
+@ClassArgAnnotation(List.class)
+public class ClassAnnotations {
+
+}

--- a/java/java.source.base/test/unit/src/usages/ClassArrayAnnotations.java
+++ b/java/java.source.base/test/unit/src/usages/ClassArrayAnnotations.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package usages;
+
+import annotations.ArrayOfAnnotationArgAnnotation;
+import annotations.ArrayOfClassArgAnnotation;
+import annotations.ArrayOfEnumArgAnnotation;
+import annotations.ArrayOfStringArgAnnotation;
+import annotations.TestEnum;
+import java.util.List;
+
+@ArrayOfAnnotationArgAnnotation(@ArrayOfStringArgAnnotation())
+@ArrayOfEnumArgAnnotation({TestEnum.X})
+@ArrayOfClassArgAnnotation({List.class})
+public class ClassArrayAnnotations {
+
+}

--- a/java/java.source.base/test/unit/src/usages/FieldAnnotations.java
+++ b/java/java.source.base/test/unit/src/usages/FieldAnnotations.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package usages;
+
+import annotations.AnnotationArgAnnotation;
+import annotations.ArrayOfStringArgAnnotation;
+import annotations.ClassArgAnnotation;
+import annotations.EnumArgAnnotation;
+import annotations.NoArgAnnotation;
+import annotations.TestEnum;
+import java.util.List;
+
+public class FieldAnnotations {
+    @NoArgAnnotation
+    @AnnotationArgAnnotation(@ArrayOfStringArgAnnotation())
+    @EnumArgAnnotation(TestEnum.X)
+    @ClassArgAnnotation(List.class)
+    public static int test;
+}

--- a/java/java.source.base/test/unit/src/usages/FieldArrayAnnotations.java
+++ b/java/java.source.base/test/unit/src/usages/FieldArrayAnnotations.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package usages;
+
+import annotations.TestEnum;
+import java.util.List;
+
+public class FieldArrayAnnotations {
+
+    @annotations.ArrayOfAnnotationArgAnnotation(
+            @annotations.ArrayOfStringArgAnnotation(value = "")
+    )
+    @annotations.ArrayOfEnumArgAnnotation(TestEnum.X)
+    @annotations.ArrayOfClassArgAnnotation(List.class)
+    @annotations.NoArgAnnotation
+    public static int test;
+
+}

--- a/java/java.source.base/test/unit/src/usages/MethodAnnotations.java
+++ b/java/java.source.base/test/unit/src/usages/MethodAnnotations.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package usages;
+
+import annotations.AnnotationArgAnnotation;
+import annotations.ArrayOfStringArgAnnotation;
+import annotations.ClassArgAnnotation;
+import annotations.EnumArgAnnotation;
+import annotations.NoArgAnnotation;
+import annotations.TestEnum;
+import java.util.List;
+
+public class MethodAnnotations {
+    @NoArgAnnotation
+    @AnnotationArgAnnotation(@ArrayOfStringArgAnnotation())
+    @EnumArgAnnotation(TestEnum.X)
+    @ClassArgAnnotation(List.class)
+    public static void test() {}
+}

--- a/java/java.source.base/test/unit/src/usages/MethodArrayAnnotations.java
+++ b/java/java.source.base/test/unit/src/usages/MethodArrayAnnotations.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package usages;
+
+import annotations.TestEnum;
+import java.util.List;
+
+public class MethodArrayAnnotations {
+    @annotations.ArrayOfAnnotationArgAnnotation(
+        @annotations.ArrayOfStringArgAnnotation(value = "")
+    )
+    @annotations.ArrayOfEnumArgAnnotation(TestEnum.X)
+    @annotations.ArrayOfClassArgAnnotation (List.class)
+    public void test() {
+    }
+}

--- a/platform/core.startup/src/org/netbeans/core/startup/CLICoreBridge.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/CLICoreBridge.java
@@ -33,9 +33,9 @@ import org.netbeans.Module;
 import org.netbeans.core.startup.layers.ModuleLayeredFileSystem;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.XMLFileSystem;
+import org.openide.util.BaseUtilities;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
-import org.openide.util.Utilities;
 import org.openide.util.lookup.Lookups;
 
 /**
@@ -93,7 +93,7 @@ public class CLICoreBridge extends CLIHandler {
         for (Module m : moduleSystem.getManager().getModules()) {
             for (File f : m.getAllJars()) {
                 try {
-                    urls.add(Utilities.toURI(f).toURL());
+                    urls.add(BaseUtilities.toURI(f).toURL());
                 }
                 catch (MalformedURLException ex) {
                     Exceptions.printStackTrace(ex);

--- a/platform/core.startup/src/org/netbeans/core/startup/CoreBridge.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/CoreBridge.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
 import org.openide.util.Lookup;
-import org.openide.util.Utilities;
+import org.openide.util.BaseUtilities;
 import org.openide.util.lookup.Lookups;
 
 /** Interface to environment that the Module system needs around itself.
@@ -139,25 +139,25 @@ public abstract class CoreBridge {
      * @param provides a collection that may be added to
      */
     public static void defineOsTokens(Collection<? super String> provides) {
-        if (Utilities.isUnix()) {
+        if (BaseUtilities.isUnix()) {
             provides.add("org.openide.modules.os.Unix"); // NOI18N
-            if (!Utilities.isMac()) {
+            if (!BaseUtilities.isMac()) {
                 provides.add("org.openide.modules.os.PlainUnix"); // NOI18N
             }
         }
-        if (Utilities.isWindows()) {
+        if (BaseUtilities.isWindows()) {
             provides.add("org.openide.modules.os.Windows"); // NOI18N
         }
-        if (Utilities.isMac()) {
+        if (BaseUtilities.isMac()) {
             provides.add("org.openide.modules.os.MacOSX"); // NOI18N
         }
-        if ((Utilities.getOperatingSystem() & Utilities.OS_OS2) != 0) {
+        if ((BaseUtilities.getOperatingSystem() & BaseUtilities.OS_OS2) != 0) {
             provides.add("org.openide.modules.os.OS2"); // NOI18N
         }
-        if ((Utilities.getOperatingSystem() & Utilities.OS_LINUX) != 0) {
+        if ((BaseUtilities.getOperatingSystem() & BaseUtilities.OS_LINUX) != 0) {
             provides.add("org.openide.modules.os.Linux"); // NOI18N
         }
-        if ((Utilities.getOperatingSystem() & Utilities.OS_SOLARIS) != 0) {
+        if ((BaseUtilities.getOperatingSystem() & BaseUtilities.OS_SOLARIS) != 0) {
             provides.add("org.openide.modules.os.Solaris"); // NOI18N
         }
         

--- a/platform/core.startup/src/org/netbeans/core/startup/Main.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Main.java
@@ -37,11 +37,11 @@ import org.openide.LifecycleManager;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.Repository;
+import org.openide.util.BaseUtilities;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.UserCancelException;
-import org.openide.util.Utilities;
 
 /**
  * Main class for NetBeans when run in GUI mode.
@@ -203,7 +203,7 @@ public final class Main extends Object {
     if (jdkHome == null) {
         jdkHome = System.getProperty("java.home");  // NOI18N
 
-        if (!Utilities.isMac()) {
+        if (!BaseUtilities.isMac()) {
             jdkHome += File.separator + "..";  // NOI18N
         }
 

--- a/platform/core.startup/src/org/netbeans/core/startup/ModuleList.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/ModuleList.java
@@ -68,10 +68,10 @@ import org.openide.filesystems.FileUtil;
 import org.openide.modules.Dependency;
 import org.openide.modules.InstalledFileLocator;
 import org.openide.modules.SpecificationVersion;
+import org.openide.util.BaseUtilities;
 import org.openide.util.Parameters;
 import org.openide.util.RequestProcessor;
 import org.openide.util.RequestProcessor.Task;
-import org.openide.util.Utilities;
 import org.openide.util.WeakSet;
 import org.openide.xml.EntityCatalog;
 import org.openide.xml.XMLUtil;
@@ -1466,7 +1466,7 @@ final class ModuleList implements Stamps.Updater {
                     String prop = toCheck[i];
                     Object onDisk = props.get(prop);
                     Object inMem = diskProps.get(prop);
-                    if (! Utilities.compareObjects(onDisk, inMem)) {
+                    if (! BaseUtilities.compareObjects(onDisk, inMem)) {
                         ev.log(Events.MISC_PROP_MISMATCH, status.module, prop, onDisk, inMem);
                     }
                 }

--- a/platform/core.startup/src/org/netbeans/core/startup/ModuleSystem.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/ModuleSystem.java
@@ -50,8 +50,8 @@ import org.openide.filesystems.FileSystem;
 import org.openide.filesystems.FileUtil;
 import org.openide.modules.ModuleInfo;
 import org.openide.modules.OnStop;
+import org.openide.util.BaseUtilities;
 import org.openide.util.Exceptions;
-import org.openide.util.Utilities;
 
 /** Controller of the IDE's whole module system.
  * Contains higher-level convenience methods to
@@ -237,7 +237,7 @@ public final class ModuleSystem {
                     /* #121777 */ jarURL.getPath().startsWith("/")) {
                 LOG.log(Level.FINE, "Considering JAR: {0}", jarURL);
                 try {
-                    if (ignoredJars.contains(Utilities.toFile(jarURL.toURI()))) {
+                    if (ignoredJars.contains(BaseUtilities.toFile(jarURL.toURI()))) {
                         LOG.log(Level.FINE, "ignoring JDK/JRE manifest: {0}", manifestUrl);
                         continue;
                     }

--- a/platform/core.startup/src/org/netbeans/core/startup/NbInstaller.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/NbInstaller.java
@@ -59,11 +59,11 @@ import org.openide.modules.Dependency;
 import org.openide.modules.ModuleInfo;
 import org.openide.modules.ModuleInstall;
 import org.openide.modules.SpecificationVersion;
+import org.openide.util.BaseUtilities;
 import org.openide.util.NbCollections;
 import org.openide.util.SharedClassObject;
 import org.openide.util.NbBundle;
 import org.openide.util.Task;
-import org.openide.util.Utilities;
 import org.openide.util.lookup.InstanceContent;
 
 
@@ -1253,7 +1253,7 @@ final class NbInstaller extends ModuleInstaller {
                 return moduleProperties.getProperty(name);
             } else {
                 final Object prevValue = moduleProperties.get(name);
-                if (Utilities.compareObjects(expValue, prevValue)) {
+                if (BaseUtilities.compareObjects(expValue, prevValue)) {
                     moduleProperties.put(name, replaceValue);
                 }
                 Stamps.getModulesJARs().scheduleSave(this, CACHE, false);

--- a/platform/core.startup/src/org/netbeans/core/startup/NbProblemDisplayer.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/NbProblemDisplayer.java
@@ -31,10 +31,10 @@ import org.netbeans.InvalidException;
 import org.netbeans.Module;
 import org.openide.modules.Dependency;
 import org.openide.modules.SpecificationVersion;
+import org.openide.util.BaseUtilities;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.openide.util.TopologicalSortException;
-import org.openide.util.Utilities;
 
 // XXX public for reflection from contrib/modulemanager; should be changed to friend dep!
 
@@ -218,7 +218,7 @@ public final class NbProblemDisplayer {
                 edges.put(m, m.getManager().getModuleInterdependencies(m, true, false, false));
             }
             try {
-                for (Module m : Utilities.topologicalSort(edges.keySet(), edges)) {
+                for (Module m : BaseUtilities.topologicalSort(edges.keySet(), edges)) {
                     reports.get(m).write();
                 }
             } catch (TopologicalSortException x) {

--- a/platform/core.startup/src/org/netbeans/core/startup/layers/BinaryFS.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/layers/BinaryFS.java
@@ -57,13 +57,12 @@ import org.openide.filesystems.FileChangeListener;
 import org.openide.filesystems.FileLock;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileSystem;
+import org.openide.util.BaseUtilities;
 import org.openide.util.Enumerations;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.SharedClassObject;
-import org.openide.util.Utilities;
-import org.openide.util.actions.SystemAction;
 import org.openide.util.io.NbObjectInputStream;
 
 /**
@@ -84,9 +83,6 @@ final class BinaryFS extends FileSystem implements DataInput {
      */
 
     static final byte[] MAGIC = "org.netbeans.core.projects.cache.BinaryV6".getBytes(); // NOI18N
-
-    /** An empty array of SystemActions. */
-    static final SystemAction[] NO_ACTIONS = new SystemAction[0];
 
     /** An empty array of FileObjects. */
     static final FileObject[] NO_CHILDREN = new FileObject[0];
@@ -178,20 +174,6 @@ final class BinaryFS extends FileSystem implements DataInput {
         return fo;
     }
 
-    /** Returns an array of actions that can be invoked on any file in
-     * this filesystem.
-     * These actions should preferably
-     * support the {@link org.openide.util.actions.Presenter.Menu Menu},
-     * {@link org.openide.util.actions.Presenter.Popup Popup},
-     * and {@link org.openide.util.actions.Presenter.Toolbar Toolbar} presenters.
-     *
-     * @return array of available actions
-     *
-     */
-    public SystemAction[] getActions() {
-        return NO_ACTIONS;
-    }
-
     /** Provides a name for the system that can be presented to the user.
      * <P>
      * This call should <STRONG>never</STRONG> be used to attempt to identify the file root
@@ -278,7 +260,7 @@ final class BinaryFS extends FileSystem implements DataInput {
                 return this;
             }
         }
-        String ret = "jar:" + Utilities.toURI(new DirFile(path)).toString(); // NOI18N
+        String ret = "jar:" + BaseUtilities.toURI(new DirFile(path)).toString(); // NOI18N
         assert !ret.contains("//") : ret;
         return ret;
     }
@@ -815,7 +797,7 @@ final class BinaryFS extends FileSystem implements DataInput {
          */
         private Class findClass (String name) throws ClassNotFoundException {
             ClassLoader c = Lookup.getDefault().lookup(ClassLoader.class);
-            String tname = org.openide.util.Utilities.translate (name);
+            String tname = BaseUtilities.translate (name);
             try {
                 if (c == null) {
                     return Class.forName (tname);


### PR DESCRIPTION
Often multiple source roots share a single target directory. With `preferBinaries()` being `true` the index (used by Go to Type dialog) incorrectly reports classes being in all source roots.

This PR fixes that by checking the `SourceFile` attribute of each `.class` and indexes only those that come from the correct source root.

The PR also fixes the `BinaryAnalyserTest` by adding missing annotation sources.