### PR TITLE
Listening on random port made possible with ListeningDICookie.create(-1)

### DIFF
--- a/ide/api.debugger/manifest.mf
+++ b/ide/api.debugger/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.debugger/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/debugger/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.59
+OpenIDE-Module-Specification-Version: 1.60
 OpenIDE-Module-Layer: org/netbeans/api/debugger/layer.xml

--- a/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerInfo.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerInfo.java
@@ -38,7 +38,7 @@ public final class DebuggerInfo implements ContextProvider {
 
 
     /**
-     * Creates a new instance of DebuggerInfo.
+     * Creates a new instance of DebuggerInfo. Takes varargs since version 1.60.
      *
      * @param typeID identification of DebuggerInfo type. Is used for 
      *      registration of external services.
@@ -48,7 +48,7 @@ public final class DebuggerInfo implements ContextProvider {
      */
     public static DebuggerInfo create (
         String typeID,
-        Object[] services
+        Object... services
     ) {
         return new DebuggerInfo (
             typeID, 

--- a/java/api.debugger.jpda/apichanges.xml
+++ b/java/api.debugger.jpda/apichanges.xml
@@ -53,6 +53,19 @@
 <changes>
     <change>
         <api name="JPDADebuggerAPI"/>
+        <summary>Randomly select listening port</summary>
+        <version major="3" minor="12"/>
+        <date day="15" month="6" year="2019"/>
+        <author login="jtulach"/>
+        <compatibility addition="yes"/>
+        <description>
+            Enhanced behavior of 
+            <a href="@TOP@/org/netbeans/api/debugger/jpda/ListeningDICookie.html">ListeningDICookie.create(-1)</a>
+            method.
+        </description>
+    </change>
+    <change>
+        <api name="JPDADebuggerAPI"/>
         <summary>JPDADebugger.getException() method added.</summary>
         <date day="20" month="4" year="2004"/>
         <author login="jjancura"/>

--- a/java/api.debugger.jpda/manifest.mf
+++ b/java/api.debugger.jpda/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.debugger.jpda/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/debugger/jpda/Bundle.properties
-OpenIDE-Module-Specification-Version: 3.11
+OpenIDE-Module-Specification-Version: 3.12
 OpenIDE-Module-Package-Dependencies: com.sun.jdi[VirtualMachineManager]
 

--- a/java/api.debugger.jpda/nbproject/project.properties
+++ b/java/api.debugger.jpda/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 cp.extra=${tools.jar}
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/java/api.debugger.jpda/nbproject/project.xml
+++ b/java/api.debugger.jpda/nbproject/project.xml
@@ -22,7 +22,7 @@
 <project xmlns="http://www.netbeans.org/ns/project/1">
     <type>org.netbeans.modules.apisupport.project</type>
     <configuration>
-        <data xmlns="http://www.netbeans.org/ns/nb-module-project/2">
+        <data xmlns="http://www.netbeans.org/ns/nb-module-project/3">
             <code-name-base>org.netbeans.api.debugger.jpda</code-name-base>
             <module-dependencies>
                 <dependency>
@@ -31,7 +31,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.35</specification-version>
+                        <specification-version>1.60</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -77,6 +77,20 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <recursive></recursive>
+                        <compile-dependency/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
             <public-packages>
                 <package>org.netbeans.api.debugger.jpda</package>
                 <package>org.netbeans.api.debugger.jpda.event</package>

--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ListeningDICookie.java
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ListeningDICookie.java
@@ -36,17 +36,8 @@ import java.util.Map;
  *
  * <br><br>
  * <b>How to use it:</b>
- * <pre style="background-color: rgb(255, 255, 153);">
- *    DebuggerInfo di = DebuggerInfo.create (
- *        "My First Listening Debugger Info",
- *        new Object [] {
- *            ListeningDICookie.create (
- *                1234
- *            )
- *        }
- *    );
- *    DebuggerManager.getDebuggerManager ().startDebugging (di);</pre>
- *
+ * {@codesnippet org.netbeans.api.debugger.jpda.StartListeningTest}
+ * 
  * @author Jan Jancura
  */
 public final class ListeningDICookie extends AbstractDICookie {
@@ -86,9 +77,13 @@ public final class ListeningDICookie extends AbstractDICookie {
     }
 
     /**
-     * Creates a new instance of ListeningDICookie for given parameters.
+     * Creates a new instance of ListeningDICookie for given parameters. Example
+     * showing how to tell the IDE to start listening on a random port:
+     * 
+     * {@codesnippet org.netbeans.api.debugger.jpda.StartListeningTest}
      *
-     * @param portNumber a number of port to listen on
+     * @param portNumber a number of port to listen on, use {@code -1} to
+     *    let the system select a random port since 3.12
      * @return a new instance of ListeningDICookie for given parameters
      */
     public static ListeningDICookie create (
@@ -137,7 +132,7 @@ public final class ListeningDICookie extends AbstractDICookie {
         int portNumber
     ) {
         Map<String, ? extends Argument> args = listeningConnector.defaultArguments ();
-        args.get ("port").setValue ("" + portNumber);
+        args.get ("port").setValue (portNumber > 0 ? "" + portNumber : "");
         return args;
     }
 

--- a/java/api.debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/StartListeningTest.java
+++ b/java/api.debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/StartListeningTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.debugger.jpda;
+
+import java.util.concurrent.Executor;
+import org.netbeans.api.debugger.DebuggerInfo;
+import org.netbeans.api.debugger.DebuggerManager;
+import org.netbeans.junit.NbTestCase;
+import org.openide.util.RequestProcessor;
+
+public class StartListeningTest extends NbTestCase {
+
+    public StartListeningTest(String name) {
+        super(name);
+    }
+
+    public void testStartListeningOnRandomPort() throws Exception {
+        startListening();
+    }
+
+    // BEGIN: org.netbeans.api.debugger.jpda.StartListeningTest
+    private static final Executor LISTENING = new RequestProcessor("Listening");
+
+    int startListening() throws Exception {
+        ListeningDICookie config = ListeningDICookie.create(-1);
+        DebuggerInfo info = DebuggerInfo.create(ListeningDICookie.ID, config);
+        LISTENING.execute(() -> {
+            DebuggerManager.getDebuggerManager().startDebugging(info);
+        });
+        int port = config.getPortNumber();
+        assertNotSame("Listening on a real port", -1, port);
+        return port;
+    }
+    // END: org.netbeans.api.debugger.jpda.StartListeningTest
+}

--- a/java/debugger.jpda/nbproject/project.xml
+++ b/java/debugger.jpda/nbproject/project.xml
@@ -168,6 +168,12 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.api.debugger.jpda</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.debugger.jpda.projects</code-name-base>
                         <recursive/>
                     </test-dependency>

--- a/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ListeningDICookieTest.java
+++ b/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ListeningDICookieTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.debugger.jpda;
+
+public class ListeningDICookieTest extends StartListeningTest {
+    public ListeningDICookieTest(String name) {
+        super(name);
+    }
+}


### PR DESCRIPTION
It's possible to create a JPDA connection listener on a random port via standard API.