### PR TITLE
Added support for per-project platform for mx projects.

### DIFF
--- a/java/java.project/apichanges.xml
+++ b/java/java.project/apichanges.xml
@@ -85,6 +85,18 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="ProjectPlatformNoPE">
+            <api name="java_project"/>
+            <summary>Added support for per-project platform for projects which don't use PropertyEvaluator.</summary>
+            <version major="1" minor="77"/>
+            <date day="19" month="6" year="2019"/>
+            <author login="tzezula"/>
+            <compatibility addition="yes"/>
+            <description>
+                Added support for per-project platform for projects which don't use <code>PropertyEvaluator</code>.
+            </description>
+            <class package="org.netbeans.spi.java.project.support" name="ProjectPlatform"/>
+        </change>
         <change id="ProjectModulesModifier">
             <api name="java_project"/>
             <summary>Added a SPI to manipulate with project's <code>module-info.java</code> declarations</summary>

--- a/java/java.project/manifest.mf
+++ b/java/java.project/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.java.project/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/project/Bundle.properties
 OpenIDE-Module-Needs: javax.script.ScriptEngine.freemarker
-OpenIDE-Module-Specification-Version: 1.76
+OpenIDE-Module-Specification-Version: 1.77
 AutoUpdate-Show-In-Client: false
 


### PR DESCRIPTION
The mx project are not Ant based, they do not have `PropertyEvaluator`.
Added a new `ProjectPlatform.forProject` method for non Ant based projects.