### PR TITLE
Fixed livelock in APTUtils happening for huge number of dependent prjs.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java
@@ -105,6 +105,7 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
     private static final boolean DISABLE_CLASSLOADER_CACHE = Boolean.getBoolean("java.source.aptutils.disable.classloader.cache");
     private static final int SLIDING_WINDOW = 1000; //1s
     private static final RequestProcessor RP = new RequestProcessor(APTUtils.class);
+    private static final RequestProcessor ROOT_CHANGE_RP = new RequestProcessor(APTUtils.class);
     private final FileObject root;
     private volatile ClassPath bootPath;
     private volatile ClassPath compilePath;
@@ -298,9 +299,11 @@ public class APTUtils implements ChangeListener, PropertyChangeListener {
     public void propertyChange(PropertyChangeEvent evt) {
         if (ClassPath.PROP_ROOTS.equals(evt.getPropertyName())) {
             classLoaderCache = null;
-            if (verifyProcessorPath(root, usedRoots, PROCESSOR_MODULE_PATH) || verifyProcessorPath(root, usedRoots, PROCESSOR_PATH)) {
-                slidingRefresh.schedule(SLIDING_WINDOW);
-            }
+            ROOT_CHANGE_RP.execute(()-> {
+                if (verifyProcessorPath(root, usedRoots, PROCESSOR_MODULE_PATH) || verifyProcessorPath(root, usedRoots, PROCESSOR_PATH)) {
+                    slidingRefresh.schedule(SLIDING_WINDOW);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Fixed a livelock in `APTUtils` reported by @JaroslavTulach happening for huge number of dependent projects (GraalVM J2SE Projects). See [stack.txt](https://github.com/apache/netbeans/files/3301837/stack.txt).

