### PR TITLE
[NETBEANS-2688] Update the Snap descriptors for 11.1

### DIFF
--- a/nbbuild/packaging/snap/gui/netbeans.desktop
+++ b/nbbuild/packaging/snap/gui/netbeans.desktop
@@ -17,9 +17,9 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=Apache NetBeans (development)
+Name=Apache NetBeans 11.1
 Comment=Apache NetBeans, The Smarter Way to Code
-Exec=netbeans-dev.netbeans %F
+Exec=netbeans %F
 Categories=Development;IDE
 Icon=${SNAP}/meta/gui/icon.png
 Terminal=false

--- a/nbbuild/packaging/snap/gui/netbeans.desktop
+++ b/nbbuild/packaging/snap/gui/netbeans.desktop
@@ -17,7 +17,7 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=Apache NetBeans 11.1
+Name=Apache NetBeans
 Comment=Apache NetBeans, The Smarter Way to Code
 Exec=netbeans %F
 Categories=Development;IDE

--- a/nbbuild/packaging/snap/snapcraft.yaml
+++ b/nbbuild/packaging/snap/snapcraft.yaml
@@ -56,7 +56,7 @@ parts:
         # Make the default cache and data directory relative to Snap user directory
         sed -i 's/${HOME}\/.netbeans/${SNAP_USER_COMMON}\/data/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
         sed -i 's/${HOME}\/.cache\/netbeans/${SNAP_USER_COMMON}\/cache/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
-        sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dplugin.manager.install.global=false/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
+        sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dplugin.manager.install.global=false -J-Dawt.useSystemAAFontSettings=on/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
     stage:
         - $netbeans
 

--- a/nbbuild/packaging/snap/snapcraft.yaml
+++ b/nbbuild/packaging/snap/snapcraft.yaml
@@ -14,18 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: netbeans-dev
+name: netbeans
 
-summary: Apache NetBeans IDE (Development Build)
+version: "11.1"
+summary: Apache NetBeans IDE
 description: |
-  Disclaimer:
-  This is an in Development Build of Apache NetBeans IDE , this is for sole
-  testing purposes and shall be not considered as a release.
-  
-  This package is refreshed weekly automatically from the NetBeans master
-  repository. Take it as it is, there are no additional testing is being
-  made on these builds.
-  
   Apache NetBeans IDE lets you quickly and easily develop Java
   desktop, enterprise, and  web applications, as well as HTML5 applications
   with HTML, JavaScript, and CSS. The IDE also provides a great set of tools for
@@ -37,9 +30,8 @@ description: |
 
 icon: ../../platform/core.startup/src/org/netbeans/core/startup/frame512.png
 confinement: classic
-grade: devel
+grade: stable
 architectures: [ amd64 ]
-adopt-info: netbeans-version
 
 parts:
   netbeans-version:
@@ -47,7 +39,6 @@ parts:
     source: .
     override-pull: |
       snapcraftctl pull
-      snapcraftctl set-version "$(date +%Y%m%d)"
       
   build:
     build-attributes: [ no-patchelf ]


### PR DESCRIPTION
These changes are required to be able to release NetBeans 11.1 as a Snap package.