### PR TITLE
When printing types, print intersection types properly.

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/TypeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TypeUtilities.java
@@ -466,7 +466,7 @@ public final class TypeUtilities {
             while (it.hasNext()) {
                 visit(it.next(), p);
                 if (it.hasNext()) {
-                    DEFAULT_VALUE.append("&");
+                    DEFAULT_VALUE.append(" & ");
                 }
             }
             return DEFAULT_VALUE;

--- a/java/java.source.base/src/org/netbeans/api/java/source/TypeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TypeUtilities.java
@@ -38,6 +38,7 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ErrorType;
 import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.IntersectionType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
@@ -455,6 +456,18 @@ public final class TypeUtilities {
             } else {
                 DEFAULT_VALUE.append(" super "); //NOI18N
                 visit(bound, p);
+            }
+            return DEFAULT_VALUE;
+        }
+
+        @Override
+        public StringBuilder visitIntersection(IntersectionType t, Boolean p) {
+            Iterator<? extends TypeMirror> it = t.getBounds().iterator();
+            while (it.hasNext()) {
+                visit(it.next(), p);
+                if (it.hasNext()) {
+                    DEFAULT_VALUE.append("&");
+                }
             }
             return DEFAULT_VALUE;
         }

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TypeUtilitiesTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TypeUtilitiesTest.java
@@ -147,7 +147,7 @@ public class TypeUtilitiesTest extends NbTestCase {
                 ExpressionStatementTree var = (ExpressionStatementTree) init.getStatements().get(0);
                 ExpressionTree getInvocation = ((MemberSelectTree) ((MethodInvocationTree) var.getExpression()).getMethodSelect()).getExpression();
                 TypeMirror intersectionType = info.getTrees().getTypeMirror(info.getTrees().getPath(info.getCompilationUnit(), getInvocation));
-                assertEquals("Exception&Runnable", info.getTypeUtilities().getTypeName(intersectionType));
+                assertEquals("Exception & Runnable", info.getTypeUtilities().getTypeName(intersectionType));
             }
         }, true);
         

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TypeUtilitiesTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TypeUtilitiesTest.java
@@ -18,6 +18,12 @@
  */
 package org.netbeans.api.java.source;
 
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -125,7 +131,7 @@ public class TypeUtilitiesTest extends NbTestCase {
     public void testTypeName() throws Exception {
         FileObject root = FileUtil.createMemoryFileSystem().getRoot();
         FileObject src  = root.createData("Test.java");
-        TestUtilities.copyStringToFile(src, "package test; public class Test {}");
+        TestUtilities.copyStringToFile(src, "package test; public class Test { { get().run(); } private <Z extends Exception&Runnable> Z get() { return null; } }");
         JavaSource js = JavaSource.create(ClasspathInfo.create(ClassPathSupport.createClassPath(SourceUtilsTestUtil.getBootClassPath().toArray(new URL[0])), ClassPathSupport.createClassPath(new URL[0]), ClassPathSupport.createClassPath(new URL[0])), src);
         
         js.runUserActionTask(new Task<CompilationController>() {
@@ -136,6 +142,12 @@ public class TypeUtilitiesTest extends NbTestCase {
                 assertEquals("List<String>[]", info.getTypeUtilities().getTypeName(info.getTreeUtilities().parseType("java.util.List<java.lang.String>[]", context)));
                 assertEquals("java.util.List<java.lang.String>...", info.getTypeUtilities().getTypeName(info.getTreeUtilities().parseType("java.util.List<java.lang.String>[]", context), TypeUtilities.TypeNameOptions.PRINT_FQN, TypeUtilities.TypeNameOptions.PRINT_AS_VARARG));
                 assertEquals("List<String>...", info.getTypeUtilities().getTypeName(info.getTreeUtilities().parseType("java.util.List<java.lang.String>[]", context), TypeUtilities.TypeNameOptions.PRINT_AS_VARARG));
+                ClassTree clazz = (ClassTree) info.getCompilationUnit().getTypeDecls().get(0);
+                BlockTree init = (BlockTree) clazz.getMembers().get(1);
+                ExpressionStatementTree var = (ExpressionStatementTree) init.getStatements().get(0);
+                ExpressionTree getInvocation = ((MemberSelectTree) ((MethodInvocationTree) var.getExpression()).getMethodSelect()).getExpression();
+                TypeMirror intersectionType = info.getTrees().getTypeMirror(info.getTrees().getPath(info.getCompilationUnit(), getInvocation));
+                assertEquals("Exception&Runnable", info.getTypeUtilities().getTypeName(intersectionType));
             }
         }, true);
         


### PR DESCRIPTION
Consider this code:
---
public class TestVar {

    public static void main(String[] args) {
        var v = get();
    }

    private static <Z extends C & I> Z get() {
        return null;
    }
    public static class C {}
    public static interface I {}
}
---

Now, press Ctrl and hover over the "v" in "var v = get();". There will be a tooltip saying "<unknown>", which is wrong. The type of the variable is an intersection type, and the type printer does not know how to print it. With this patch, the printed type will be "TestVar.C & TestVar.I".