### PR TITLE
Fix ClassPathTest in ide/api.java.classpath module

### DIFF
--- a/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/ClassPathTest.java
+++ b/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/ClassPathTest.java
@@ -655,10 +655,7 @@ public class ClassPathTest extends NbTestCase {
             try {
                 final Class<?> c = loader.loadClass(className);
                 noLoaded++;
-            } catch (ClassNotFoundException e) {
-                noFailed++;
-            }
-            catch (NoClassDefFoundError e) {
+            } catch (ClassNotFoundException | NoClassDefFoundError | SecurityException e) {
                 noFailed++;
             }
         }


### PR DESCRIPTION
Fix ClassPathTest in ide/api.java.classpath module.

Command to run this test.
```bash
ant -f ide/api.java.classpath -Dtest.type=unit -Dcontinue.after.failing.tests=true -Dtest.includes=org/netbeans/api/java/classpath/ClassPathTest.java test-single
```