### PR TITLE
Fix SAXEntityParserTest test class in api.xml module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,8 @@ matrix:
             RUN_TESTS_JDK9PLUS=false 
             RUN_TESTS_JDK8=true 
             OPTS="-Dcluster.config=minimal -quiet build -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true"
-            TEST_MODULES="ide/api.xml.ui
+            TEST_MODULES="ide/api.xml
+             ide/api.xml.ui
              ide/bugtracking
              ide/bugtracking.bridge
              ide/bugtracking.commons

--- a/ide/api.xml/test/unit/src/org/netbeans/api/xml/parsers/SAXEntityParserTest.java
+++ b/ide/api.xml/test/unit/src/org/netbeans/api/xml/parsers/SAXEntityParserTest.java
@@ -49,15 +49,14 @@ public class SAXEntityParserTest extends NbTestCase {
     }
     
     /** Test of parse method, of class org.netbeans.api.xml.parsers.SAXEntityParser. */
-    public void testParse() throws Exception {
-        System.out.println("testParse");
-        
+    public void testParse() throws Exception {        
         // DTD parser test        
         
         InputSource input = new InputSource(new StringReader("<!ELEMENT x ANY>"));
         input.setSystemId("StringReader");
                 
-        XMLReader peer = XMLReaderFactory.createXMLReader("org.apache.crimson.parser.XMLReaderImpl");
+        XMLReader peer = XMLReaderFactory.createXMLReader();
+        
         TestDeclHandler dtdHandler = new TestDeclHandler();
         peer.setProperty("http://xml.org/sax/properties/declaration-handler", dtdHandler);
         SAXEntityParser parser = new SAXEntityParser(peer, false);
@@ -79,21 +78,18 @@ public class SAXEntityParserTest extends NbTestCase {
             assertTrue("Parser may not be reused!", exceptionThrown);
         }
         
-        relativeReferenceTest();
-    }        
+    }  
     
     /**
      * Wrapping used to broke relative references.
      */
-    private void relativeReferenceTest() throws Exception {
-
+    public void testParseRelativeReference() throws Exception {
         final boolean pass[] = {false};
 
         try {
             URL url = getClass().getResource("data/RelativeTest.dtd");
-            System.out.println("URL:" + url);
             InputSource input = new InputSource(url.toExternalForm());
-            XMLReader peer = XMLReaderFactory.createXMLReader("org.apache.crimson.parser.XMLReaderImpl");
+            XMLReader peer = XMLReaderFactory.createXMLReader();
             peer.setDTDHandler(new DefaultHandler() {
                 public void notationDecl(String name, String publicId, String systemId) {
                     if ("notation".equals(name)) pass[0] = true;


### PR DESCRIPTION
Fix SAXEntityParserTest test class in api.xml module.

```
Testcase: testParse(org.netbeans.api.xml.parsers.SAXEntityParserTest):	Caused an ERROR
SAX2 driver class org.apache.crimson.parser.XMLReaderImpl not found
org.xml.sax.SAXException: SAX2 driver class org.apache.crimson.parser.XMLReaderImpl not found
java.lang.ClassNotFoundException: org.apache.crimson.parser.XMLReaderImpl
	at org.xml.sax.helpers.XMLReaderFactory.loadClass(XMLReaderFactory.java:230)
	at org.xml.sax.helpers.XMLReaderFactory.createXMLReader(XMLReaderFactory.java:221)
	at org.netbeans.api.xml.parsers.SAXEntityParserTest.testParse(SAXEntityParserTest.java:60)
	at org.netbeans.junit.NbTestCase.access$200(NbTestCase.java:77)
	at org.netbeans.junit.NbTestCase$2.doSomething(NbTestCase.java:460)
	at org.netbeans.junit.NbTestCase$1Guard.run(NbTestCase.java:386)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: org.apache.crimson.parser.XMLReaderImpl
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at org.xml.sax.helpers.NewInstance.newInstance(NewInstance.java:82)
	at org.xml.sax.helpers.XMLReaderFactory.loadClass(XMLReaderFactory.java:228)
```
Load the default XML reader instead `org.apache.crimson.parser.XMLReaderImpl`