### PR TITLE
Fixing an IllegalStateException when trying to remove excess entries …

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ParameterNameProviderImpl.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ParameterNameProviderImpl.java
@@ -98,7 +98,7 @@ public class ParameterNameProviderImpl {
         }
     }
 
-    private static final int MAX_CACHE_SIZE = 100;
+            static final int MAX_CACHE_SIZE = 100;
     private static final LinkedHashMap<String, Map<String, List<String>>> source_toplevelClass2method2Parameters = new LinkedHashMap<>();
     private static final LinkedHashMap<String, Map<String, List<String>>> javadoc_class2method2Parameters = new LinkedHashMap<>();
     private static final LinkedHashMap<String, List<String>> artificial_method2Parameters = new LinkedHashMap<>();
@@ -183,9 +183,10 @@ public class ParameterNameProviderImpl {
         return Arrays.stream(SourceUtils.getJVMSignature(ElementHandle.create(el))).collect(Collectors.joining(":"));
     }
 
-    private void capCache(LinkedHashMap<String, ?> map) {
+    static void capCache(LinkedHashMap<String, ?> map) {
         Iterator<String> it = map.keySet().iterator();
         while (map.size() > MAX_CACHE_SIZE) {
+            it.next();
             it.remove();
         }
     }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ParameterNameProviderImplTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/ParameterNameProviderImplTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.source.parsing;
+
+import java.util.LinkedHashMap;
+import org.netbeans.junit.NbTestCase;
+
+public class ParameterNameProviderImplTest extends NbTestCase {
+    
+    public ParameterNameProviderImplTest(String name) {
+        super(name);
+    }
+
+    public void testCapCache() {
+        LinkedHashMap<String, ?> map = new LinkedHashMap<>();
+        String key = "";
+        for (int i = 0; i < 2 * ParameterNameProviderImpl.MAX_CACHE_SIZE; i++) {
+            map.put(key, null);
+            key += "x";
+        }
+        ParameterNameProviderImpl.capCache(map);
+        
+        assertEquals(ParameterNameProviderImpl.MAX_CACHE_SIZE, map.size());
+    }    
+}


### PR DESCRIPTION
…from the in memory parameter name caches.

(Avoids possible crashes while running on JDK 13.)
