### PR TITLE
HashMap is not thread safe. Field map is typically synchronized by this. However, in two places, field map is not protected with synchronized.

### DIFF
--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -204,10 +204,14 @@ final class XMLMapAttr implements Map {
 
         Object retVal = null;
         if (attr == null && origAttrName.startsWith("class:")) { // NOI18N
-            attr = (Attr) map.get(origAttrName.substring(6));
+            synchronized (this) {
+                attr = (Attr) map.get(origAttrName.substring(6));
+            }
             retVal = attr != null ? attr.getType(params) : null;
         } else if (attr == null && origAttrName.startsWith("raw:")) { // NOI18N
-            attr = (Attr) map.get(origAttrName.substring(4));
+            synchronized (this) {
+                attr = (Attr) map.get(origAttrName.substring(4));
+            }
             if (attr != null && attr.keyIndex == 9) {
                 return attr.methodValue(attr.value, params).getMethod();
             }


### PR DESCRIPTION
The current field

```map```

https://github.com/apache/netbeans/blob/master/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java#L112

is typically protected by synchronization on ```this```, e.g., 

https://github.com/apache/netbeans/blob/master/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java#L386

https://github.com/apache/netbeans/blob/master/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java#L390

https://github.com/apache/netbeans/blob/master/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java#L426

For a total of 16 locations.

However, in these two places, ```map``` is not protected by synchronization:

https://github.com/apache/netbeans/blob/master/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java#L207

https://github.com/apache/netbeans/blob/master/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java#L210

Note that in the same method, only 4 lines above:

https://github.com/apache/netbeans/blob/master/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java#L202

```map``` is again protected by synchronization:

```
synchronized (this) {
    attr = (Attr) map.get(attrName);
}
```

This CR protected the two instances motioned above (line 207 and
line 210) with synchronization like in line 202.
