### PR TITLE
[NETBEANS-2667] Manage JOptionPane border

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
@@ -15,9 +15,6 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
- * Contains a bug fix contributed by Experian. © Experian, 2019. Licensed under Apache 2.0.
- *
  */
 
 package org.netbeans.core.windows.services;
@@ -108,14 +105,14 @@ import org.openide.util.Utilities;
  */
 class NbPresenter extends JDialog
 implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparator<Object> {
-    
+
     /** variable holding current modal dialog in the system */
     public static NbPresenter currentModalDialog;
     private static final ChangeSupport cs = new ChangeSupport(NbPresenter.class);
     private static Boolean isJava17 = null;
-    
+
     protected NotifyDescriptor descriptor;
-    
+
     private final JButton stdYesButton = new JButton(NbBundle.getBundle(NbPresenter.class).getString("YES_OPTION_CAPTION")); // NOI18N
     private final JButton stdNoButton = new JButton(NbBundle.getBundle(NbPresenter.class).getString("NO_OPTION_CAPTION")); // NOI18N
     private final JButton stdOKButton = new JButton(NbBundle.getBundle(NbPresenter.class).getString("OK_OPTION_CAPTION")); // NOI18N
@@ -138,12 +135,12 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         stdDetailButton.setDefaultCapable(true);
         stdDetailButton.putClientProperty( "defaultButton", Boolean.FALSE ); //NOI18N
         Mnemonics.setLocalizedText (stdHelpButton, NbBundle.getBundle(NbPresenter.class).getString("HELP_OPTION_CAPTION")); // NOI18N
-        
+
         /** Initilizes accessible contexts */
         initAccessibility();
     }
     private final static String ESCAPE_COMMAND = "Escape"; // NOI18N
-    
+
     private Component currentMessage;
     private JScrollPane currentScrollPane;
     private boolean leaf = false;
@@ -151,7 +148,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
     private JLabel notificationLine;
     private Component[] currentPrimaryButtons;
     private Component[] currentSecondaryButtons;
-    
+
     private static final int MSG_TYPE_ERROR = 1;
     private static final int MSG_TYPE_WARNING = 2;
     private static final int MSG_TYPE_INFO = 3;
@@ -161,7 +158,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
 
     /** useful only for DialogDescriptor */
     private int currentAlign;
-    
+
     private ButtonListener buttonListener;
     /** Help context to actually associate with the dialog, as it is currently known. */
     private transient HelpCtx currentHelp = null;
@@ -169,11 +166,11 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
     private transient boolean haveCalledInitializeButtons = false;
 
     static final Logger LOG = Logger.getLogger(NbPresenter.class.getName());
-    
+
     static final long serialVersionUID =-4508637164126678997L;
-    
+
     private JButton initialDefaultButton;
-    
+
     /** Creates a new Dialog from specified NotifyDescriptor,
      * with given frame owner.
      * @param d The NotifyDescriptor to create the dialog from
@@ -182,7 +179,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         super(owner, d.getTitle(), modal); // modal
         initialize(d);
     }
-    
+
     /** Creates a new Dialog from specified NotifyDescriptor,
      * with given dialog owner.
      * @param d The NotifyDescriptor to create the dialog from
@@ -191,45 +188,45 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         super(owner, d.getTitle(), modal); // modal
         initialize(d);
     }
-    
+
     boolean isLeaf () {
         return leaf;
     }
-    
+
     private void initAccessibility(){
-        
+
         ResourceBundle bundle;
         bundle = NbBundle.getBundle(NbPresenter.class);
-        
+
         stdYesButton.getAccessibleContext().setAccessibleName(bundle.getString("ACS_YES_OPTION_NAME")); // NOI18N
         stdYesButton.getAccessibleContext().setAccessibleDescription(bundle.getString("ACS_YES_OPTION_DESC")); // NOI18N
-        
+
         stdNoButton.getAccessibleContext().setAccessibleName(bundle.getString("ACS_NO_OPTION_NAME")); // NOI18N
         stdNoButton.getAccessibleContext().setAccessibleDescription(bundle.getString("ACS_NO_OPTION_DESC")); // NOI18N
-        
+
         stdOKButton.getAccessibleContext().setAccessibleName(bundle.getString("ACS_OK_OPTION_NAME")); // NOI18N
         stdOKButton.getAccessibleContext().setAccessibleDescription(bundle.getString("ACS_OK_OPTION_DESC")); // NOI18N
-        
+
         stdCancelButton.getAccessibleContext().setAccessibleName(bundle.getString("ACS_CANCEL_OPTION_NAME")); // NOI18N
         stdCancelButton.getAccessibleContext().setAccessibleDescription(bundle.getString("ACS_CANCEL_OPTION_DESC")); // NOI18N
-        
+
         stdClosedButton.getAccessibleContext().setAccessibleName(bundle.getString("ACS_CLOSED_OPTION_NAME")); // NOI18N
         stdClosedButton.getAccessibleContext().setAccessibleDescription(bundle.getString("ACS_CLOSED_OPTION_DESC")); // NOI18N
-        
+
         stdHelpButton.getAccessibleContext().setAccessibleName(bundle.getString("ACS_HELP_OPTION_NAME")); // NOI18N
         stdHelpButton.getAccessibleContext().setAccessibleDescription(bundle.getString("ACS_HELP_OPTION_DESC")); // NOI18N
-        
+
         stdDetailButton.getAccessibleContext().setAccessibleName(bundle.getString("ACS_HELP_OPTION_NAME")); // NOI18N
         stdDetailButton.getAccessibleContext().setAccessibleDescription(bundle.getString("ACS_HELP_OPTION_DESC")); // NOI18N
     }
-    
+
     private void initialize(NotifyDescriptor d) {
         //Optimization related to jdk bug 4393857 - on pre 1.5 jdk's an
         //extra repaint is caused by the search for an opaque component up
         //to the component root. Post 1.5, root pane will automatically be
         //opaque.
         getRootPane().setOpaque(true);
-        
+
         if (d instanceof WizardDescriptor || d.isNoDefaultClose() ) {
             // #81938: wizard close button shouln't work during finish progress
             setDefaultCloseOperation (WindowConstants.DO_NOTHING_ON_CLOSE);
@@ -246,7 +243,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         buttonListener = new ButtonListener();
         // set leaf by DialogDescriptor, NotifyDescriptor is leaf as default
         leaf = d instanceof DialogDescriptor ? ((DialogDescriptor)d).isLeaf () : true;
-        
+
         getRootPane().getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
                 KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), ESCAPE_COMMAND);
         getRootPane().getActionMap().put(ESCAPE_COMMAND, new EscapeAction());
@@ -263,7 +260,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
      * request first. */
     private void requestFocusForMessage() {
         Component comp = currentMessage;
-        
+
         if(comp == null) {
             return;
         }
@@ -289,7 +286,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             }
         }
     }
-    
+
     private void initializeMessage() {
         Object newMessage = descriptor.getMessage();
         boolean isDefaultOptionPane = false;
@@ -309,7 +306,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             }
             Dimension prefSize = currentMessage.getPreferredSize();
             final Rectangle screenBounds = Utilities.getUsableScreenBounds();
-            
+
             if (prefSize.width > screenBounds.width - 100
                 || prefSize.height > screenBounds.height- 100
                 ) {
@@ -330,7 +327,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             } else {
                 toAdd = currentMessage;
             }
-            
+
             if (! (descriptor instanceof WizardDescriptor) && descriptor.getNotificationLineSupport () != null) {
                 JPanel enlargedToAdd = new JPanel (new BorderLayout ());
                 enlargedToAdd.add (toAdd, BorderLayout.CENTER);
@@ -386,7 +383,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             getContentPane ().add (toAdd, BorderLayout.CENTER);
         }
     }
-    
+
     private static final class FixedHeightLabel extends JLabel {
 
         private static final int ESTIMATED_HEIGHT = 16;
@@ -418,24 +415,24 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
     }
 
     private void initializePresenter() {
-        if (currentMessage != null) 
+        if (currentMessage != null)
             return;
-            
+
         initialDefaultButton = getRootPane().getDefaultButton();
         initializeMessage();
-        
+
         updateHelp();
-        
+
         initializeButtons();
         haveCalledInitializeButtons = true;
-        
+
         descriptor.addPropertyChangeListener(this);
         addWindowListener(this);
-        
+
         initializeClosingOptions ();
     }
-    
-    /** Descriptor can be cached and reused. We need to remove listeners 
+
+    /** Descriptor can be cached and reused. We need to remove listeners
      *  from descriptor, buttons and disconnect componets from container hierarchy.
      */
     private void uninitializePresenter() {
@@ -445,13 +442,13 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         uninitializeClosingOptions ();
         initialDefaultButton = null;
     }
-    
+
     private final HackTypeAhead hack = new HackTypeAhead();
     @Override
     public void addNotify() {
         super.addNotify();
         initializePresenter();
-        
+
         hack.activate();
     }
 
@@ -459,7 +456,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
     public void removeNotify() {
         super.removeNotify();
         uninitializePresenter();
-        
+
     }
 
     /** Creates option pane message.
@@ -468,7 +465,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         Object msg = descriptor.getMessage();
         boolean override = true;
         String strMsg = null, strMsgLower;
-        
+
         if (msg instanceof String) {
             msg = ((String) msg).replace("\t", "    "); // NOI18N
             msg = ((String) msg).replace("\r", ""); // NOI18N
@@ -510,7 +507,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             null // value
             );
         }
-        
+
         if (UIManager.getLookAndFeel().getClass() == MetalLookAndFeel.class ||
             UIManager.getLookAndFeel().getClass() == BasicLookAndFeel.class) {
             optionPane.setUI(new javax.swing.plaf.basic.BasicOptionPaneUI() {
@@ -555,7 +552,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
 
             } );
         }
-        
+
         // Netbeans-2667 : bug fix contributed by Experian.
         // The goal of this change is to retrieve the border which is supposed to be applied at the OptionPane.border
         // which is displayed around the message area and the button area.
@@ -567,7 +564,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             ((JComponent) getContentPane()).setBorder(optionPaneBorder);
             optionPane.setBorder(null);
         }
-        
+
         return optionPane;
     }
 
@@ -583,29 +580,29 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                     modifyListener(currentSecondaryButtons[i], buttonListener, false);
                 }
             }
-            
+
             getContentPane().remove(currentButtonsPanel);
             currentButtonsPanel = null;
         }
     }
-    
+
     private void initializeClosingOptions (boolean init) {
         Object[] options = getClosingOptions ();
-        
+
         if (options == null) return ;
         for (int i = 0; i < options.length; i++) {
             modifyListener (options[i], buttonListener, init);
         }
     }
-    
+
     private void initializeClosingOptions () {
         initializeClosingOptions (true);
     }
-    
+
     private void uninitializeClosingOptions () {
         initializeClosingOptions (false);
     }
-    
+
     /**
      * On Aqua look and feel, options should be sorted such that the default
      * button is always rightmost, and 'yes' options appear to thr right of
@@ -619,7 +616,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         } else {
             result = 0;
         }
-        
+
         if (isDefaultButton) {
             result++;
         } else if( b.equals(descriptor.getDefaultValue ()) ) {
@@ -627,28 +624,28 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         }
         return result;
     }
-    
+
     protected final void initializeButtons() {
         // -----------------------------------------------------------------------------
         // If there were any buttons previously, remove them and removeActionListener from them
-        
+
         Component focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager ().getFocusOwner ();
 
         boolean dontShowHelp = Constants.DO_NOT_SHOW_HELP_IN_DIALOGS ||
                 ( descriptor instanceof WizardDescriptor && ( Boolean.FALSE.equals (((WizardDescriptor)descriptor).getProperty (WizardDescriptor.PROP_HELP_DISPLAYED)) )); // NOI18N
         boolean helpButtonShown =
             stdHelpButton.isShowing() || ( descriptor instanceof WizardDescriptor && !dontShowHelp );
-        
-        
+
+
         uninitializeButtons();
-        
+
         Object[] primaryOptions = descriptor.getOptions();
         Object[] secondaryOptions = descriptor.getAdditionalOptions();
         currentAlign = getOptionsAlign();
-        
+
         // -----------------------------------------------------------------------------
         // Obtain main (primary) and additional (secondary) buttons
-        
+
         currentPrimaryButtons = null;
         currentSecondaryButtons = null;
 
@@ -658,7 +655,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             //No mac dialogs with buttons on side
             currentAlign = DialogDescriptor.BOTTOM_ALIGN;
         }
-        
+
         // explicitly provided options (AKA buttons)
         // JST: The following line causes only problems,
         //      I hope that my change will not cause additional ones ;-)
@@ -734,7 +731,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                     break;
             }
         }
-        
+
         if ((secondaryOptions != null) && (secondaryOptions.length != 0)) {
             currentSecondaryButtons = new Component [secondaryOptions.length];
             Arrays.sort (secondaryOptions, this);
@@ -762,9 +759,9 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                 }
             }
         }
-        
+
         // Automatically add a help button if needed.
-        
+
         if (!dontShowHelp && (currentHelp != null || helpButtonShown)) {
             if (helpButtonLeft()) {
                 if (currentSecondaryButtons == null) currentSecondaryButtons = new Component[] { };
@@ -787,15 +784,15 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             }
             stdHelpButton.setEnabled(currentHelp != null);
         }
-        
+
         // -----------------------------------------------------------------------------
         // Create panels for main (primary) and additional (secondary) buttons and add to content pane
-        
+
         if (currentAlign == DialogDescriptor.BOTTOM_ALIGN || currentAlign == -1) {
-            
+
             JPanel panelForPrimary = null;
             JPanel panelForSecondary = null;
-            
+
 
             if (currentPrimaryButtons != null) {
                 panelForPrimary = new JPanel();
@@ -810,7 +807,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                     panelForPrimary.add(currentPrimaryButtons[i]);
                 }
             }
-            
+
             if (currentSecondaryButtons != null) {
                 panelForSecondary = new JPanel();
                 panelForSecondary.setLayout(new org.openide.awt.EqualFlowLayout(FlowLayout.LEFT));
@@ -819,7 +816,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                     panelForSecondary.add(currentSecondaryButtons[i]);
                 }
             }
-            
+
             // both primary and secondary buttons are used
             if ((panelForPrimary != null) && (panelForSecondary != null)) {
                 currentButtonsPanel = new JPanel();
@@ -831,7 +828,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             } else {
                 currentButtonsPanel = panelForSecondary;
             }
-            
+
             // add final button panel to the dialog
             if ((currentButtonsPanel != null)&&(currentButtonsPanel.getComponentCount() != 0)) {
                 if (currentButtonsPanel.getBorder() == null) {
@@ -839,7 +836,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                 }
                 getContentPane().add(currentButtonsPanel, BorderLayout.SOUTH);
             }
-            
+
         } else if (currentAlign == DialogDescriptor.RIGHT_ALIGN) {
             currentButtonsPanel = new JPanel();
             currentButtonsPanel.setLayout(new GridBagLayout());
@@ -848,21 +845,21 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             gbc.weightx = 1.0f;
             gbc.insets = new Insets(5, 4, 2, 5);
             gbc.fill = GridBagConstraints.HORIZONTAL;
-            
+
             if (currentPrimaryButtons != null) {
                 for (int i = 0; i < currentPrimaryButtons.length; i++) {
                     modifyListener(currentPrimaryButtons[i], buttonListener, true); // add button listener
                     currentButtonsPanel.add(currentPrimaryButtons[i], gbc);
                 }
             }
-            
+
             GridBagConstraints padding = new GridBagConstraints();
             padding.gridwidth = GridBagConstraints.REMAINDER;
             padding.weightx = 1.0f;
             padding.weighty = 1.0f;
             padding.fill = GridBagConstraints.BOTH;
             currentButtonsPanel.add(new JPanel(), padding);
-            
+
             gbc.insets = new Insets(2, 4, 5, 5);
             if (currentSecondaryButtons != null) {
                 for (int i = 0; i < currentSecondaryButtons.length; i++) {
@@ -870,7 +867,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                     currentButtonsPanel.add(currentSecondaryButtons[i], gbc);
                 }
             }
-            
+
             // add final button panel to the dialog
             if (currentButtonsPanel != null) {
                 if (currentButtonsPanel.getBorder() == null) {
@@ -878,18 +875,18 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                 }
                 getContentPane().add(currentButtonsPanel, BorderLayout.EAST);
             }
-            
+
         }
         updateDefaultButton();
-        
-        
+
+
         Component fo = KeyboardFocusManager.getCurrentKeyboardFocusManager ().getFocusOwner ();
-        
+
         if (fo != focusOwner && focusOwner != null) {
             focusOwner.requestFocus();
         }
     }
-    
+
     /** @return returns true if the Help button should be at the left side
      */
     private boolean helpButtonLeft() {
@@ -902,7 +899,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         }
         return result;
     }
-    
+
     /** Checks default button and updates it
      */
     private void updateDefaultButton() {
@@ -910,7 +907,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         if (descriptor.getDefaultValue () != null) {
             if (descriptor.getDefaultValue () instanceof JButton) {
                 JButton b = (JButton)descriptor.getDefaultValue ();
-            if (b.isVisible() && b.isEnabled () && b.isDefaultCapable () 
+            if (b.isVisible() && b.isEnabled () && b.isDefaultCapable ()
                     && !Boolean.FALSE.equals(b.getClientProperty("defaultButton")) ) { //NOI18N
                     getRootPane ().setDefaultButton (b);
                     return ;
@@ -963,7 +960,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         else
             getRootPane().setDefaultButton(null);
     }
-    
+
     private void updateNotificationLine (int msgType, Object o) {
         String msg = o == null ? null : o.toString ();
         if (msg != null && msg.trim().length() > 0) {
@@ -1019,12 +1016,12 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             }
         }
     }
-    
+
     private void modifyListener(Object comp, ButtonListener l, boolean add) {
         // on JButtons attach simply by method call
         if (comp instanceof JButton) {
             JButton b = (JButton)comp;
-            if (add) { 
+            if (add) {
                 List listeners;
                 listeners = Arrays.asList (b.getActionListeners ());
                 if (!listeners.contains (l)) {
@@ -1069,14 +1066,14 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             }
         }
     }
-    
+
     /** Shows the dialog, used in method show so no inner class is needed.
      */
     private void superShow() {
         assert SwingUtilities.isEventDispatchThread () : "Invoked super.show() in AWT event thread."; // NOI18N
         super.show();
     }
-    
+
     @Override @Deprecated
     public void show() {
         //Bugfix #29993: Call show() asynchronously for non modal dialogs.
@@ -1094,12 +1091,12 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             }
         }
     }
-    
+
     public Void run() {
         doShow();
         return null;
     }
-    
+
     private void doShow () {
         //#206802 - dialog windows are hidden behind full screen window
         Window fullScreenWindow = null;
@@ -1123,18 +1120,18 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             currentModalDialog = this;
             fireChangeEvent();
         }
-        
+
         superShow();
 
         if( null != fullScreenWindow )
             getGraphicsConfiguration().getDevice().setFullScreenWindow( fullScreenWindow );
-        
+
         if (currentModalDialog != prev) {
             currentModalDialog = prev;
             fireChangeEvent();
         }
     }
-    
+
     public void propertyChange(final java.beans.PropertyChangeEvent evt) {
         if( !SwingUtilities.isEventDispatchThread() ) {
             SwingUtilities.invokeLater(new Runnable() {
@@ -1145,7 +1142,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             return;
         }
         boolean update = false;
-        
+
         if (DialogDescriptor.PROP_OPTIONS.equals(evt.getPropertyName())) {
             initializeButtons();
             update = true;
@@ -1195,7 +1192,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             // XXX: need set update on true?
             updateNotificationLine (MSG_TYPE_ERROR, evt.getNewValue ());
         }
-        
+
         if (update) {
             Dimension sz = getSize();
             Dimension prefSize = getPreferredSize();
@@ -1208,7 +1205,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             repaint();
         }
     }
-    
+
     private void updateHelp() {
         //System.err.println ("Updating help for NbDialog...");
         HelpCtx help = getHelpCtx();
@@ -1231,32 +1228,32 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             if (haveCalledInitializeButtons) initializeButtons();
         }
     }
-    
+
     /** Options align.
      */
     protected int getOptionsAlign() {
         return DialogDescriptor.DEFAULT_ALIGN;
     }
-    
+
     /** Getter for button listener or null
      */
     protected ActionListener getButtonListener() {
         return null;
     }
-    
+
     /** Closing options.
      */
     protected Object[] getClosingOptions() {
         return null;
     }
-    
+
     /** Updates help.
      */
     protected HelpCtx getHelpCtx() {
         return null;
     }
-    
-    
+
+
     public void windowDeactivated(final java.awt.event.WindowEvent p1) {
     }
     public void windowClosed(final java.awt.event.WindowEvent p1) {
@@ -1276,7 +1273,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
     }
     public void windowActivated(final java.awt.event.WindowEvent p1) {
     }
-    
+
     // Used by JavaHelp:
     public static void addChangeListener(ChangeListener l) {
         cs.addChangeListener(l);
@@ -1291,7 +1288,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             }
         });
     }
-    
+
     private final class EscapeAction extends AbstractAction {
 
         public EscapeAction () {
@@ -1302,9 +1299,9 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             if( !descriptor.isNoDefaultClose() )
             buttonListener.actionPerformed(e);
         }
-        
+
     }
-    
+
     /** Button listener
      */
     private class ButtonListener implements ActionListener, ComponentListener, PropertyChangeListener {
@@ -1312,7 +1309,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         public void actionPerformed(ActionEvent evt) {
             boolean isAqua = "Aqua".equals (UIManager.getLookAndFeel().getID()) || //NOI18N
                             "true".equalsIgnoreCase (System.getProperty ("xtest.looks_as_mac"));
-            
+
             Object pressedOption = evt.getSource();
             // handle ESCAPE
             if (ESCAPE_COMMAND.equals (evt.getActionCommand ())) {
@@ -1330,16 +1327,16 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                     showHelp(currentHelp);
                     return;
                 }
-                
+
                 Object[] options = descriptor.getOptions();
                 if (isAqua && options != null) {
                     Arrays.sort (options, NbPresenter.this);
                 }
-                
+
                 if (
                 options != null &&
                 currentPrimaryButtons != null &&
-                options.length == (currentPrimaryButtons.length - 
+                options.length == (currentPrimaryButtons.length -
                     ((currentHelp != null) ? 1 : 0))
                 ) {
                     int offset = currentHelp != null && isAqua ?
@@ -1350,12 +1347,12 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                         }
                     }
                 }
-                
+
                 options = descriptor.getAdditionalOptions();
                 if (isAqua && options != null) {
                     Arrays.sort (options, NbPresenter.this);
                 }
-                
+
                 if (
                 options != null &&
                 currentSecondaryButtons != null &&
@@ -1367,7 +1364,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                         }
                     }
                 }
-                
+
                 if (evt.getSource() == stdYesButton) {
                     pressedOption = NotifyDescriptor.YES_OPTION;
                 } else if (evt.getSource() == stdNoButton) {
@@ -1382,10 +1379,10 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             }
 
             descriptor.setValue(pressedOption);
-            
+
             ActionListener al = getButtonListener();
             if (al != null) {
-                
+
                 if (pressedOption == evt.getSource()) {
                     al.actionPerformed(evt);
                 } else {
@@ -1394,14 +1391,14 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
                     ));
                 }
             }
-            
+
             Object[] arr = getClosingOptions();
             if (arr == null || pressedOption == NotifyDescriptor.CLOSED_OPTION) {
                 // all options should close
                 dispose();
             } else {
                 java.util.List l = java.util.Arrays.asList(arr);
-                
+
                 if (l.contains(pressedOption)) {
                     dispose();
                 }
@@ -1412,21 +1409,21 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         }
         public void componentResized(final java.awt.event.ComponentEvent p1) {
         }
-        
+
         public void componentHidden(final java.awt.event.ComponentEvent p1) {
             updateDefaultButton();
         }
-        
+
         public void componentMoved(final java.awt.event.ComponentEvent p1) {
         }
-        
+
         public void propertyChange(final java.beans.PropertyChangeEvent p1) {
             if ("enabled".equals(p1.getPropertyName())) {
                 updateDefaultButton();
             }
         }
     }
-    
+
     @Override
     public javax.accessibility.AccessibleContext getAccessibleContext() {
         if (accessibleContext == null) {
@@ -1434,7 +1431,7 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
         }
         return accessibleContext;
     }
-    
+
     private static String getMessageTypeDescription(int messageType) {
         switch(messageType) {
         case NotifyDescriptor.ERROR_MESSAGE:
@@ -1500,20 +1497,20 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
             }
         }
     }
-    
+
     private final class HackTypeAhead implements Runnable {
         private RequestProcessor.Task task = RequestProcessor.getDefault().create(this);
-        
-        
+
+
         public HackTypeAhead() {
         }
-        
+
         public void activate() {
             if (markers != null) {
                 task.schedule(1000);
             }
         }
-        
+
         public void run() {
             if (!SwingUtilities.isEventDispatchThread()) {
                 SwingUtilities.invokeLater(this);

--- a/platform/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/NbPresenter.java
@@ -15,6 +15,9 @@
  * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
+ *
+ * Contains a bug fix contributed by Experian. © Experian, 2019. Licensed under Apache 2.0.
+ *
  */
 
 package org.netbeans.core.windows.services;
@@ -79,6 +82,7 @@ import javax.swing.MenuSelectionManager;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.WindowConstants;
+import javax.swing.border.Border;
 import javax.swing.event.ChangeListener;
 import javax.swing.plaf.basic.BasicLookAndFeel;
 import javax.swing.plaf.metal.MetalLookAndFeel;
@@ -551,6 +555,19 @@ implements PropertyChangeListener, WindowListener, Mutex.Action<Void>, Comparato
 
             } );
         }
+        
+        // Netbeans-2667 : bug fix contributed by Experian.
+        // The goal of this change is to retrieve the border which is supposed to be applied at the OptionPane.border
+        // which is displayed around the message area and the button area.
+        // As the JOptionPane is now wrapped on a JPanel and the buttons moved on another panel, we need to
+        // retrieve the border which is applied on the JOptionPane and apply it at the content pane level.
+        // Doing that we reduce inconsistencies between dialogs opened through the Java APIs or through the Netbeans APIs.
+        Border optionPaneBorder = optionPane.getBorder();
+        if (optionPaneBorder != null && getContentPane() instanceof JComponent) {
+            ((JComponent) getContentPane()).setBorder(optionPaneBorder);
+            optionPane.setBorder(null);
+        }
+        
         return optionPane;
     }
 


### PR DESCRIPTION
In the NB Dialog API, the JOptionPane is wrapped on a JPanel and the buttons moved on another panel. This leads to UI issues when the Look & Feel defines a special border for JOptionPane. The goal of this change is to retrieve the border defined by the L&F and apply it at the content pane level. Doing that we reduce inconsistencies between dialogs opened through the Java APIs or through the Netbeans APIs.