### PR TITLE
[NETBEANS-2764] NoClassDefFoundError: com/oracle/truffle/api/library/Library

### DIFF
--- a/webcommon/libs.graaljs/nbproject/project.xml
+++ b/webcommon/libs.graaljs/nbproject/project.xml
@@ -38,7 +38,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.0</specification-version>
+                        <specification-version>1.2</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>
@@ -57,6 +57,12 @@
                         <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
                         <recursive/>
                         <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.graalsdk</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                        <test/>
                     </test-dependency>
                 </test-type>
             </test-dependencies>

--- a/webcommon/libs.truffleapi/manifest.mf
+++ b/webcommon/libs.truffleapi/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.libs.truffleapi
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/truffle/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.1
+OpenIDE-Module-Specification-Version: 1.2
 OpenIDE-Module-Provides: com.oracle.truffle.polyglot.PolyglotImpl

--- a/webcommon/libs.truffleapi/nbproject/project.xml
+++ b/webcommon/libs.truffleapi/nbproject/project.xml
@@ -41,6 +41,7 @@
                 <package>com.oracle.truffle.api.frame</package>
                 <package>com.oracle.truffle.api.instrumentation</package>
                 <package>com.oracle.truffle.api.interop</package>
+                <package>com.oracle.truffle.api.library</package>
                 <package>com.oracle.truffle.api.nodes</package>
                 <package>com.oracle.truffle.api.object</package>
                 <package>com.oracle.truffle.api.object.dsl</package>


### PR DESCRIPTION
@lbruun reported that the PAC proxy configuration is broken after my #1092. Alas, it is. The problem isn't in the code, but in the packaging. One NetBeans wrapper module forget to export new API package `com.oracle.truffle.api.library`.

The fix exports the package and enhances the tests to verify that the `GraalVM:js` is capable to execute JavaScript even inside of the NetBeans Runtime Container with all the ClassLoader checks being on. 

Sorry for the trouble.
