### PR TITLE
[NETBEANS-2785] Move NIO2 File Watcher implementation into the front.

### DIFF
--- a/platform/masterfs.macosx/src/org/netbeans/modules/masterfs/watcher/macosx/OSXNotifier.java
+++ b/platform/masterfs.macosx/src/org/netbeans/modules/masterfs/watcher/macosx/OSXNotifier.java
@@ -41,7 +41,7 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @author Tomas Zezula
  */
-@ServiceProvider(service=Notifier.class, position=300)
+@ServiceProvider(service=Notifier.class, position=100)
 public final class OSXNotifier extends Notifier<Void> {
     private static final Level DEBUG_LOG_LEVEL = Level.FINE;
     private static final Level PERF_LOG_LEVEL = Level.FINE;

--- a/platform/masterfs.nio2/src/org/netbeans/modules/masterfs/watcher/nio2/NioNotifier.java
+++ b/platform/masterfs.nio2/src/org/netbeans/modules/masterfs/watcher/nio2/NioNotifier.java
@@ -37,7 +37,7 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @author Egor Ushakov <gorrus@netbeans.org>
  */
-@ServiceProvider(service=Notifier.class, position=1010)
+@ServiceProvider(service=Notifier.class, position=200)
 public class NioNotifier extends Notifier<WatchKey> {
     private final WatchService watcher;
 

--- a/platform/masterfs.windows/src/org/netbeans/modules/masterfs/watcher/windows/WindowsNotifier.java
+++ b/platform/masterfs.windows/src/org/netbeans/modules/masterfs/watcher/windows/WindowsNotifier.java
@@ -53,7 +53,7 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @author nenik
  */
-@ServiceProvider(service=Notifier.class, position=100)
+@ServiceProvider(service=Notifier.class, position=400)
 public final class WindowsNotifier extends Notifier<Void> {
     static final Logger LOG = Logger.getLogger(WindowsNotifier.class.getName());
 


### PR DESCRIPTION
Well, this change makes the existing NIO2 based file notifier implementation in fornt of the platform dependent ones (Positions: Windows: 100, MacOS: 300, Linux: 500)
However this is trivial change, I feel a bit late for 11.1, so I propose to merge it into master after the 11.1 is out.
If it works we can get rid of the platform specific implementations in NB 12.0