### PR TITLE
Add Payara Micro dependency in j2ee.kit

### DIFF
--- a/enterprise/j2ee.kit/nbproject/project.xml
+++ b/enterprise/j2ee.kit/nbproject/project.xml
@@ -95,6 +95,12 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.payara.micro</code-name-base>
+                    <run-dependency>
+                        <release-version>0-1</release-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.web.kit</code-name-base>
                     <run-dependency>
                         <specification-version>1.0</specification-version>


### PR DESCRIPTION
It seems that ergonomics is not triggering enabling of the Payara Micro module and ends up in some sort of loop in the wizard iterator.  This adds the Payara Micro module as a dependency in j2ee.kit.  It seems to fix the issue, but I'm not sure it's the right approach to this problem?  PR against release branch for now in case we want to use this in NB 11.1 and fix differently in master.  Can re-roll against master if required.