### PR TITLE
Get OpenJFX samples working in release branch.

### DIFF
--- a/javafx/javafx2.kit/nbproject/project.xml
+++ b/javafx/javafx2.kit/nbproject/project.xml
@@ -80,6 +80,12 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.openjfx.samples</code-name-base>
+                    <run-dependency>
+                        <specification-version>1.0</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.maven.kit</code-name-base>
                     <run-dependency>
                         <release-version>1</release-version>

--- a/javafx/openjfx.samples/nbproject/project.properties
+++ b/javafx/openjfx.samples/nbproject/project.properties
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+javac.source=1.6
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -1565,7 +1565,8 @@ nb.cluster.javafx=\
         javafx2.platform,\
         javafx2.project,\
         javafx2.samples,\
-        javafx2.scenebuilder
+        javafx2.scenebuilder,\
+        openjfx.samples
 
 nb.cluster.remote.dir=extra
 nb.cluster.remote.depends=\


### PR DESCRIPTION
Add OpenJFX samples module to JavaFX cluster, and add as dependency to javafx2.kit to enable via ergonomics.  Again against release branch - review and add to master post-release when plugin centers for dev are fixed.