### PR TITLE
[NETBEANS-2783] Fix missing dependencies nodes in Project view when editing POM file

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/nodes/DependenciesNode.java
+++ b/java/maven/src/org/netbeans/modules/maven/nodes/DependenciesNode.java
@@ -242,6 +242,7 @@ public class DependenciesNode extends AbstractNode {
                         lst.add(new DependencyWrapper(a, longLiving, () -> moduleInfoSupport != null ? moduleInfoSupport.canAddToModuleInfo(name) : false));
                     } else {
                         LOG.log(Level.WARNING, "Could not determine module name for artifact {0}", new Object[]{url}); // NOI18N
+                        lst.add(new DependencyWrapper(a, longLiving, () -> false));
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes [NETBEANS-2783](https://issues.apache.org/jira/browse/NETBEANS-2783).

One liner, no side effects introduced as far I can tell. Tested also with a maven modular project under JDK-11.