### PR TITLE
Let Gradle Frontend Application run on JDK11

### DIFF
--- a/groovy/gradle.htmlui/src/org/netbeans/modules/gradle/htmlui/resources/desktop_build.gradle.fmk
+++ b/groovy/gradle.htmlui/src/org/netbeans/modules/gradle/htmlui/resources/desktop_build.gradle.fmk
@@ -18,10 +18,14 @@
     under the License.
 
 -->
-apply plugin: 'java'
-apply plugin: 'application'
+plugins {
+    id 'java'
+    id 'application'
+    id 'org.openjfx.javafxplugin' version '0.0.7' apply false
+}
 
 def commonProject = project.parent
+def jdk8 = System.getProperty("java.version").startsWith("1.8")
 
 mainClassName = '${packageBase}.DesktopMain'
 
@@ -36,6 +40,13 @@ distributions {
 }
 tasks.run {
     jvmArgs "-Dbrowser.rootdir=${commonProject.projectDir}/src/main/webapp/"
+}
+if (!jdk8) {
+    apply plugin: 'org.openjfx.javafxplugin'
+    javafx {
+        version = "11"
+        modules = ["javafx.web"]
+    }
 }
 </#noparse>
 dependencies {

--- a/groovy/gradle.htmlui/src/org/netbeans/modules/gradle/htmlui/resources/root_build.gradle.fmk
+++ b/groovy/gradle.htmlui/src/org/netbeans/modules/gradle/htmlui/resources/root_build.gradle.fmk
@@ -20,7 +20,7 @@
 -->
 <#noparse>
 plugins {
-    id "me.tatarka.retrolambda" version "3.7.0"
+    id "me.tatarka.retrolambda" version "3.7.1"
 }
 
 apply plugin: 'java'

--- a/groovy/gradle.htmlui/src/org/netbeans/modules/gradle/htmlui/resources/web_build.gradle.fmk
+++ b/groovy/gradle.htmlui/src/org/netbeans/modules/gradle/htmlui/resources/web_build.gradle.fmk
@@ -32,6 +32,9 @@ buildscript {
 apply plugin: 'java'
 apply plugin: 'bck2brwsr'
 
+targetCompatibility = '1.8'
+sourceCompatibility = '1.8'
+
 mainClassName = '${packageBase}.BrowserMain'
 
 <#noparse>


### PR DESCRIPTION
While testing the NetBeans 11.1 vc1 it turned out that Gradle Frontend Application project cannot be executed on JDK11, only on JDK8. The workaround is to run the IDE on JDK8, or change the project's JDK to JDK8, but given that many users use newer JDKs, having the support only on JDK8 would cause a lot of confusion when trying this new great NetBeans feature!

If possible, let's backport this to 11.1 next voting candidate (if any). CCing @neilcsmith-net , @lkishalmi 

The steps to reproduce the error are:
* start NetBeans 11.1 vc1 with an empty user directory and on JDK11: `/netbeans-11.1-vc1/bin/netbeans --userdir /tmp/ud11 --jdkhome /jdk-11`
* New Project/Java with Gradle/Java Frontend Application
* Download and Activate - installs NbJavac and JavaFX wrapper modules
* Generate the project somewhere
* Build the project - fails on `Task: compileRetrolambdaMain FAILED` - d46c11b fixes that
* Debug the project - fails with `NoClassDefFoundError: javafx/application/Application` - 1b5db1e fixes that
* Run the project - works but prints exception `IllegalArgumentException at net.orfjackal.retrolambda.asm.ClassReader` -  f3095c1 fixes that.

Sorry for being so late with this bugfix. At the time of creation of the skeleton project the retrolamda plugin 3.7.1 wasn't yet available and  support for JDK11 wasn't possible at all. Now it would be unfortunate to not have it in NetBeans 11.1. Please consider backporting it. Thanks for your consideration.
