### PR TITLE
[NETBEANS-2343]: Only use the LSP HyperlinkProvider for files that ar…

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/HyperlinkProviderImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/HyperlinkProviderImpl.java
@@ -69,6 +69,11 @@ public class HyperlinkProviderImpl implements HyperlinkProviderExt {
 
     @Override
     public int[] getHyperlinkSpan(Document doc, int offset, HyperlinkType type) {
+        if (doc.getProperty(HyperlinkProviderImpl.class) != Boolean.TRUE) {
+            //not handled by a LSP handler
+            return null;
+        }
+
         try {
             //XXX: not really using the server, are we?
             return Utilities.getIdentifierBlock((BaseDocument) doc, offset);

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/TextDocumentSyncServerCapabilityHandler.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/TextDocumentSyncServerCapabilityHandler.java
@@ -86,6 +86,8 @@ public class TextDocumentSyncServerCapabilityHandler {
                 if (server == null)
                     return ; //ignore
 
+                doc.putProperty(HyperlinkProviderImpl.class, Boolean.TRUE);
+
                 String uri = Utils.toURI(file);
                 String[] text = new String[1];
 


### PR DESCRIPTION
…e covered by some LSPBindings.

(Avoid highlighting everything as a hyperlink.)