### PR TITLE
Fix NPE if PAC cannot be resolved

### DIFF
--- a/platform/core.network/src/org/netbeans/core/network/proxy/ProxyAutoConfig.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/ProxyAutoConfig.java
@@ -138,6 +138,9 @@ public class ProxyAutoConfig {
                 }
             }
         }
+        if (evaluator == null) {
+            return Collections.singletonList(Proxy.NO_PROXY);
+        }
         try {
             return evaluator.findProxyForURL(u);
         } catch (PacValidationException ex) {


### PR DESCRIPTION
Fix NPE if PAC cannot be resolved, e.g. UnknownHostException if the proxy pac url is configured but not reachable.