### PR TITLE
[NETBEANS-2866]: Fix java.lang.RuntimeException: file name is too lon…

### DIFF
--- a/ide/docker.api/src/org/netbeans/modules/docker/FolderUploader.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/FolderUploader.java
@@ -34,6 +34,7 @@ import org.apache.commons.compress.archivers.ArchiveException;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.netbeans.modules.docker.api.DockerInstance;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -67,8 +68,8 @@ public class FolderUploader {
                 try {
                     GZIPOutputStream gzos = new GZIPOutputStream(cos);
                     try {
-                        ArchiveOutputStream aos = new ArchiveStreamFactory().createArchiveOutputStream(
-                                ArchiveStreamFactory.TAR, gzos);
+                        TarArchiveOutputStream aos = new TarArchiveOutputStream(gzos);
+                        aos.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
                         try {
                             // FIXME exclude dockerignored files
                             FileObject context = folder;


### PR DESCRIPTION
Now we able to creating Tar archive for Docker image build context again
