### PR TITLE
[NETBEANS-97] Don't add braces around try/synchronized blocks when reformatting

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/Braces.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/Braces.java
@@ -54,19 +54,19 @@ import org.openide.util.NbBundle;
 public class Braces {
 
     static final EnumSet<JavaTokenId> nonRelevant = EnumSet.<JavaTokenId>of(
-            JavaTokenId.LINE_COMMENT, 
+            JavaTokenId.LINE_COMMENT,
             JavaTokenId.BLOCK_COMMENT,
             JavaTokenId.JAVADOC_COMMENT,
             JavaTokenId.WHITESPACE
     );
-    
+
     private static final String BRACES_ID = "Braces_"; // NOI18N
-    
+
     @Hint(displayName="#LBL_Braces_For", description="#DSC_Braces_For", category="braces", id=BRACES_ID + "FOR_LOOP", enabled=false, suppressWarnings={"", "ControlFlowStatementWithoutBraces"})
     @TriggerTreeKind({Tree.Kind.FOR_LOOP, Tree.Kind.ENHANCED_FOR_LOOP})
     public static ErrorDescription checkFor(HintContext ctx) {
         StatementTree st;
-        
+
         switch (ctx.getPath().getLeaf().getKind()){
             case FOR_LOOP: st = ((ForLoopTree) ctx.getPath().getLeaf()).getStatement(); break;
             case ENHANCED_FOR_LOOP: st = ((EnhancedForLoopTree) ctx.getPath().getLeaf()).getStatement(); break;
@@ -75,34 +75,37 @@ public class Braces {
         }
         return checkStatement(ctx, "LBL_Braces_For", st, ctx.getPath());
     }
-    
+
     @Hint(displayName="#LBL_Braces_While", description="#DSC_Braces_While", category="braces", id=BRACES_ID + "WHILE_LOOP", enabled=false, suppressWarnings={"", "ControlFlowStatementWithoutBraces"})
     @TriggerTreeKind(Tree.Kind.WHILE_LOOP)
     public static ErrorDescription checkWhile(HintContext ctx) {
         WhileLoopTree wlt = (WhileLoopTree) ctx.getPath().getLeaf();
         return checkStatement(ctx, "LBL_Braces_While", wlt.getStatement(), ctx.getPath());
     }
-    
+
     @Hint(displayName="#LBL_Braces_DoWhile", description="#DSC_Braces_DoWhile", category="braces", id=BRACES_ID + "DO_WHILE_LOOP", enabled=false, suppressWarnings={"", "ControlFlowStatementWithoutBraces"})
     @TriggerTreeKind(Tree.Kind.DO_WHILE_LOOP)
     public static ErrorDescription checkDoWhile(HintContext ctx) {
         DoWhileLoopTree dwlt = (DoWhileLoopTree) ctx.getPath().getLeaf();
         return checkStatement(ctx, "LBL_Braces_DoWhile", dwlt.getStatement(), ctx.getPath());
     }
-    
+
     @Hint(displayName="#LBL_Braces_If", description="#DSC_Braces_If", category="braces", id=BRACES_ID + "IF", enabled=false, suppressWarnings={"", "ControlFlowStatementWithoutBraces"})
     @TriggerTreeKind(Tree.Kind.IF)
     public static List<ErrorDescription> checkIf(HintContext ctx) {
         IfTree it = (IfTree) ctx.getPath().getLeaf();
         return checkifStatements(ctx, "LBL_Braces_If", it.getThenStatement(), it.getElseStatement(), ctx.getPath());
     }
-    
+
     // Private methods ---------------------------------------------------------
-    
+
     private static ErrorDescription checkStatement(HintContext ctx, String dnKey, StatementTree statement, TreePath tp)  {
-        if ( statement != null && 
-             statement.getKind() != Tree.Kind.EMPTY_STATEMENT && 
+        if ( statement != null &&
+             statement.getKind() != Tree.Kind.EMPTY_STATEMENT &&
              statement.getKind() != Tree.Kind.BLOCK &&
+             statement.getKind() != Tree.Kind.TRY &&
+             statement.getKind() != Tree.Kind.SYNCHRONIZED &&
+             statement.getKind() != Tree.Kind.SWITCH &&
              statement.getKind() != Tree.Kind.ERRONEOUS &&
              !isErroneousExpression( statement )) {
             return ErrorDescriptionFactory.forTree(
@@ -110,37 +113,43 @@ public class Braces {
                         statement,
                         NbBundle.getMessage(Braces.class, dnKey),
                         new BracesFix(ctx.getInfo().getFileObject(), TreePathHandle.create(tp, ctx.getInfo())).toEditorFix());
-                    
-        }        
+
+        }
         return null;
     }
-    
-    
+
+
     private static List<ErrorDescription> checkifStatements(HintContext ctx, String dnKey, StatementTree thenSt, StatementTree elseSt, TreePath tp)  {
-        
+
         boolean fixThen = false;
         boolean fixElse = false;
-        
-        if ( thenSt != null && 
-             thenSt.getKind() != Tree.Kind.EMPTY_STATEMENT && 
+
+        if ( thenSt != null &&
+             thenSt.getKind() != Tree.Kind.EMPTY_STATEMENT &&
              thenSt.getKind() != Tree.Kind.BLOCK &&
+             thenSt.getKind() != Tree.Kind.TRY &&
+             thenSt.getKind() != Tree.Kind.SYNCHRONIZED &&
+             thenSt.getKind() != Tree.Kind.SWITCH &&
              thenSt.getKind() != Tree.Kind.ERRONEOUS &&
              !isErroneousExpression( thenSt )) {
             fixThen = true;
         }
-        
-        if ( elseSt != null && 
-             elseSt.getKind() != Tree.Kind.EMPTY_STATEMENT && 
+
+        if ( elseSt != null &&
+             elseSt.getKind() != Tree.Kind.EMPTY_STATEMENT &&
              elseSt.getKind() != Tree.Kind.BLOCK &&
              elseSt.getKind() != Tree.Kind.ERRONEOUS &&
+             elseSt.getKind() != Tree.Kind.TRY &&
+             elseSt.getKind() != Tree.Kind.SYNCHRONIZED &&
+             elseSt.getKind() != Tree.Kind.SWITCH &&
              elseSt.getKind() != Tree.Kind.IF &&
              !isErroneousExpression( elseSt )) {
             fixElse = true;
         }
-        
-        List<ErrorDescription> result = new ArrayList<ErrorDescription>();
+
+        List<ErrorDescription> result = new ArrayList<>();
         int[] span;
-        
+
         if (fixThen) {
             BracesFix bf  = new BracesFix( ctx.getInfo().getFileObject(), TreePathHandle.create(tp, ctx.getInfo()));
             bf.fixThen = fixThen;
@@ -148,24 +157,24 @@ public class Braces {
             result.add( ErrorDescriptionFactory.forTree(
                 ctx,
                 thenSt,
-                NbBundle.getMessage(Braces.class, dnKey), 
+                NbBundle.getMessage(Braces.class, dnKey),
                 bf.toEditorFix()));
         }
-        
+
         if ( fixElse) {
             BracesFix bf  = new BracesFix( ctx.getInfo().getFileObject(), TreePathHandle.create(tp, ctx.getInfo()));
             bf.fixThen = fixThen;
             bf.fixElse = fixElse;
             result.add( ErrorDescriptionFactory.forTree(
-                ctx, 
+                ctx,
                 elseSt,
-                NbBundle.getMessage(Braces.class, dnKey), 
+                NbBundle.getMessage(Braces.class, dnKey),
                 bf.toEditorFix()));
         }
-                
+
         return result;
     }
-    
+
     private static boolean isErroneousExpression(StatementTree statement) {
         if ( statement instanceof ExpressionStatementTree ) {
             if ( ((ExpressionStatementTree)statement).getExpression().getKind() == Kind.ERRONEOUS ) {
@@ -179,11 +188,11 @@ public class Braces {
 
         boolean fixThen;
         boolean fixElse;
-        
+
         public BracesFix(FileObject file, TreePathHandle tph) {
             super(tph);
         }
-        
+
         public String getText() {
             return NbBundle.getMessage(Braces.class, "LBL_Braces_Fix"); // NOI18N
         }
@@ -193,12 +202,12 @@ public class Braces {
             WorkingCopy copy = ctx.getWorkingCopy();
             TreePath path = ctx.getPath();
             if ( path != null ) {
-                
+
                 TreeMaker make = copy.getTreeMaker();
-                Tree oldTree = path.getLeaf();                 
-                
+                Tree oldTree = path.getLeaf();
+
                 oldTree = GeneratorUtilities.get(copy).importComments(oldTree, copy.getCompilationUnit());
-                
+
                 switch( oldTree.getKind() ) {
                 case FOR_LOOP:
                     ForLoopTree oldFor = (ForLoopTree)oldTree;
@@ -209,19 +218,19 @@ public class Braces {
                 case ENHANCED_FOR_LOOP:
                     EnhancedForLoopTree oldEnhancedFor = (EnhancedForLoopTree)oldTree;
                     oldBlock = oldEnhancedFor.getStatement();
-                    newBlock = make.Block(Collections.<StatementTree>singletonList(oldBlock), false);                    
+                    newBlock = make.Block(Collections.<StatementTree>singletonList(oldBlock), false);
                     copy.rewrite(oldBlock, newBlock);
                     break;
                 case WHILE_LOOP:
                     WhileLoopTree oldWhile = (WhileLoopTree)oldTree;
                     oldBlock = oldWhile.getStatement();
-                    newBlock = make.Block(Collections.<StatementTree>singletonList(oldBlock), false);                    
+                    newBlock = make.Block(Collections.<StatementTree>singletonList(oldBlock), false);
                     copy.rewrite(oldBlock, newBlock);
                     break;
                 case DO_WHILE_LOOP:
                     DoWhileLoopTree oldDoWhile = (DoWhileLoopTree)oldTree;
                     oldBlock = oldDoWhile.getStatement();
-                    newBlock = make.Block(Collections.<StatementTree>singletonList(oldBlock), false);                    
+                    newBlock = make.Block(Collections.<StatementTree>singletonList(oldBlock), false);
                     copy.rewrite(oldBlock, newBlock);
                     break;
                 case IF:
@@ -235,14 +244,14 @@ public class Braces {
                         oldBlock = oldIf.getElseStatement();
                         newBlock = make.Block(Collections.<StatementTree>singletonList(oldBlock), false);
                         copy.rewrite(oldBlock, newBlock);
-                    } 
-                    
+                    }
+
                 }
             }
         }
-                
+
     }
 
-    
-    
+
+
 }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -29,7 +29,6 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
-import java.io.IOException;
 import java.net.URL;
 import java.util.*;
 import javax.lang.model.element.Name;
@@ -72,7 +71,7 @@ import org.openide.util.Pair;
  * @author Dusan Balek
  */
 public class Reformatter implements ReformatTask {
-    
+
     private static final Object CT_HANDLER_DOC_PROPERTY = "code-template-insert-handler"; // NOI18N
 
     private Source source;
@@ -101,7 +100,7 @@ public class Reformatter implements ReformatTask {
             }
         }
     }
-    
+
     public static String reformat(String text, CodeStyle style) {
         return reformat(text, style, style.getRightMargin());
     }
@@ -128,7 +127,7 @@ public class Reformatter implements ReformatTask {
 
         return sb.toString();
     }
-    
+
     private boolean initRegionData(final Context.Region region) {
         if (controller == null || (currentEmbedding != null
                 && !(currentEmbedding.containsOriginalOffset(region.getStartOffset())
@@ -145,7 +144,7 @@ public class Reformatter implements ReformatTask {
                                 controller = CompilationController.get(result);
                             }
                         }
-                        
+
                         private Parser.Result findEmbeddedJava(final ResultIterator theMess) throws ParseException {
                             final Collection<Embedding> todo = new LinkedList<Embedding>();
                             //BFS should perform better than DFS in this dark.
@@ -360,7 +359,7 @@ public class Reformatter implements ReformatTask {
             }
         };
     }
-    
+
     private TreePath getCommonPath(int startOffset, int endOffset) {
         TreeUtilities tu = controller.getTreeUtilities();
         TreePath startPath = tu.pathFor(startOffset);
@@ -390,7 +389,7 @@ public class Reformatter implements ReformatTask {
                 return null;
             Source source = Source.create(context.document());
             return source != null ? new Reformatter(source, context) : null;
-        }        
+        }
     }
 
     private static class Pretty extends ErrorAwareTreePathScanner<Boolean, Void> {
@@ -429,7 +428,7 @@ public class Reformatter implements ReformatTask {
         private final int continuationIndentSize;
         private final boolean expandTabToSpaces;
 
-        private TokenSequence<JavaTokenId> tokens;    
+        private TokenSequence<JavaTokenId> tokens;
         private int indent;
         private boolean continuationIndent;
         private int col;
@@ -444,7 +443,7 @@ public class Reformatter implements ReformatTask {
         private WrapAbort checkWrap;
         private boolean fieldGroup;
         private boolean templateEdit;
-        private LinkedList<Diff> diffs = new LinkedList<Diff>();
+        private final LinkedList<Diff> diffs = new LinkedList<>();
         private DanglingElseChecker danglingElseChecker = new DanglingElseChecker();
         private CompilationUnitTree root;
         private int startOffset;
@@ -461,7 +460,7 @@ public class Reformatter implements ReformatTask {
                     path, info.getTrees().getSourcePositions(), cs, startOffset, endOffset, cs.getRightMargin());
             this.templateEdit = templateEdit;
         }
-        
+
         private Pretty(String text, TokenSequence<JavaTokenId> tokens, TreePath path, SourcePositions sp, CodeStyle cs, int startOffset, int endOffset, int rightMargin) {
             this.fText = text;
             this.sp = sp;
@@ -556,7 +555,7 @@ public class Reformatter implements ReformatTask {
         @Override
         public Boolean scan(Tree tree, Void p) {
             int lastEndPos = endPos;
-            if (tree != null && tree.getKind() != Tree.Kind.COMPILATION_UNIT) {                
+            if (tree != null && tree.getKind() != Tree.Kind.COMPILATION_UNIT) {
                 if (tree instanceof FakeBlock) {
                     endPos = Integer.MAX_VALUE;
                 } else {
@@ -651,7 +650,7 @@ public class Reformatter implements ReformatTask {
                 continuationIndent = true;
                 space();
                 scan(node.getName(), p);
-            } finally {                
+            } finally {
                 continuationIndent = old;
             }
             CodeStyle.BracePlacement bracePlacement = cs.getModuleDeclBracePlacement();
@@ -710,7 +709,7 @@ public class Reformatter implements ReformatTask {
                         diff.text = getIndent();
                     else
                         diff.text = diff.text.substring(0, idx + 1) + getIndent();
-                    
+
                 }
                 String spaces = diff.text != null ? diff.text : getIndent();
                 if (spaces.equals(fText.substring(diff.start, diff.end)))
@@ -1079,7 +1078,7 @@ public class Reformatter implements ReformatTask {
                         diff.text = getIndent();
                     else
                         diff.text = diff.text.substring(0, idx + 1) + getIndent();
-                    
+
                 }
                 String spaces = diff.text != null ? diff.text : getIndent();
                 if (spaces.equals(fText.substring(diff.start, diff.end)))
@@ -1162,7 +1161,7 @@ public class Reformatter implements ReformatTask {
                         int index = tokens.index();
                         int c = col;
                         Diff d = diffs.isEmpty() ? null :diffs.getFirst();
-                        spaces(cs.spaceBeforeMethodCallParen() ? 1 : 0);            
+                        spaces(cs.spaceBeforeMethodCallParen() ? 1 : 0);
                         JavaTokenId id = accept(LPAREN);
                         if (id != LPAREN)
                             rollback(index, c, d);
@@ -1183,7 +1182,7 @@ public class Reformatter implements ReformatTask {
                                 lastIndent = oldLastIndent;
                                 continuationIndent = isLastIndentContinuation = continuation;
                             }
-                            spaces(cs.spaceWithinMethodCallParens() ? 1 : 0, true);            
+                            spaces(cs.spaceWithinMethodCallParens() ? 1 : 0, true);
                         }
                         if (id == LPAREN)
                             accept(RPAREN);
@@ -1847,7 +1846,7 @@ public class Reformatter implements ReformatTask {
             maxPreservedBlankLines = lastMaxPreservedBlankLines;
             indent = lastIndent = old;
             return true;
-        }       
+        }
 
         @Override
         public Boolean visitMemberSelect(MemberSelectTree node, Void p) {
@@ -1874,9 +1873,9 @@ public class Reformatter implements ReformatTask {
         @Override
         public Boolean visitMemberReference(MemberReferenceTree node, Void p) {
             scan(node.getQualifierExpression(), p);
-            spaces(cs.spaceAroundMethodReferenceDoubleColon() ? 1 : 0); 
+            spaces(cs.spaceAroundMethodReferenceDoubleColon() ? 1 : 0);
             accept(COLONCOLON);
-            spaces(cs.spaceAroundMethodReferenceDoubleColon() ? 1 : 0); 
+            spaces(cs.spaceAroundMethodReferenceDoubleColon() ? 1 : 0);
             int index = tokens.index();
             int c = col;
             Diff d = diffs.isEmpty() ? null : diffs.getFirst();
@@ -1938,7 +1937,7 @@ public class Reformatter implements ReformatTask {
             }
             return true;
         }
-        
+
         @Override
         public Boolean visitLambdaExpression(LambdaExpressionTree node, Void p) {
             List<? extends VariableTree> params = node.getParameters();
@@ -1959,7 +1958,7 @@ public class Reformatter implements ReformatTask {
                             wrapList(cs.wrapLambdaParams(), cs.alignMultilineLambdaParams(), false, COMMA, params);
                         } finally {
                             indent = oldIndent;
-                            lastIndent = oldLastIndent; 
+                            lastIndent = oldLastIndent;
                             continuationIndent = isLastIndentContinuation = continuation;
                         }
                         spaces(cs.spaceWithinLambdaParens() ? 1 : 0);
@@ -2029,7 +2028,7 @@ public class Reformatter implements ReformatTask {
                     indent += continuationIndentSize;
                     isLastIndentContinuation = false;
                 }
-                ExpressionTree exp = ((MemberSelectTree)ms).getExpression();                
+                ExpressionTree exp = ((MemberSelectTree)ms).getExpression();
                 scan(exp, p);
                 WrapStyle wrapStyle = cs.wrapChainedMethodCalls();
                 if (wrapStyle == WrapStyle.WRAP_ALWAYS && exp.getKind() != Tree.Kind.METHOD_INVOCATION)
@@ -2139,7 +2138,7 @@ public class Reformatter implements ReformatTask {
                         isLastIndentContinuation = false;
                     }
                     try {
-                        spaces(cs.spaceWithinMethodCallParens() ? 1 : 0, true); 
+                        spaces(cs.spaceWithinMethodCallParens() ? 1 : 0, true);
                         wrapList(cs.wrapMethodCallArgs(), cs.alignMultilineCallArgs(), false, COMMA, args);
                     } finally {
                         indent = oldIndent;
@@ -2301,12 +2300,12 @@ public class Reformatter implements ReformatTask {
             }
             return true;
         }
-        
+
         /**
          * Finds the end of the line (for brace insertion) after the statement Tree, provided
          * the statement is followed nu whitespace only.
          * @param statement
-         * @return 
+         * @return
          */
         private int findNewlineAfterStatement(Tree statement) {
             int pos = (int)sp.getEndPosition(root, statement);
@@ -2441,7 +2440,7 @@ public class Reformatter implements ReformatTask {
             accept(WHILE);
             boolean old = continuationIndent;
             try {
-                continuationIndent = true;            
+                continuationIndent = true;
                 spaces(cs.spaceBeforeWhileParen() ? 1 : 0);
                 scan(node.getCondition(), p);
             } finally {
@@ -2518,7 +2517,7 @@ public class Reformatter implements ReformatTask {
                 redundantForBraces = CodeStyle.BracesGenerationStyle.LEAVE_ALONE;
             }
             wrapStatement(cs.wrapForStatement(), redundantForBraces, cs.spaceBeforeForLeftBrace() ? 1 : 0, node.getStatement());
-            return true;            
+            return true;
         }
 
         @Override
@@ -2648,7 +2647,7 @@ public class Reformatter implements ReformatTask {
                 Diff diff = diffs.isEmpty() ? null : diffs.getFirst();
                 if (diff != null && diff.end == tokens.offset()) {
                     if (diff.text != null) {
-                        int idx = diff.text.lastIndexOf('\n'); //NOI18N                                                                                                                
+                        int idx = diff.text.lastIndexOf('\n'); //NOI18N
                         if (idx < 0) {
                             diff.text = getIndent();
                         } else {
@@ -2831,7 +2830,7 @@ public class Reformatter implements ReformatTask {
             case FLOAT:
                 accept(FLOAT);
                 break;
-            case INT: 
+            case INT:
                 accept(INT);
                 break;
             case LONG:
@@ -3123,7 +3122,7 @@ public class Reformatter implements ReformatTask {
         @Override
         public Boolean visitLabeledStatement(LabeledStatementTree node, Void p) {
             if (!ERROR.contentEquals(node.getLabel()))
-                accept(IDENTIFIER, UNDERSCORE);            
+                accept(IDENTIFIER, UNDERSCORE);
             accept(COLON);
             int old = indent;
             if (!cs.absoluteLabelIndent()) {
@@ -3425,7 +3424,7 @@ public class Reformatter implements ReformatTask {
         private void spaces(int count) {
             spaces(count, false);
         }
-        
+
         private boolean spaces(int count, boolean preserveNewline) {
             if (checkWrap != null && col > rightMargin && checkWrap.pos >= lastNewLineOffset) {
                 throw checkWrap;
@@ -3894,7 +3893,7 @@ public class Reformatter implements ReformatTask {
                 lastBlankLinesTokenIndex = -1;
             }
         }
-        
+
         private void appendToDiff(String s) {
             int offset = tokens.offset();
             Diff d = diffs.isEmpty() ? null : diffs.getFirst();
@@ -3902,7 +3901,7 @@ public class Reformatter implements ReformatTask {
                 d.text += s;
             } else {
                 addDiff(new Diff(offset, offset, s));
-            }    
+            }
         }
 
         private void addDiff(Diff diff) {
@@ -4217,7 +4216,7 @@ public class Reformatter implements ReformatTask {
                                         tokens.moveNext();
                                     }
                                     spaces(spacesCntAfterOp);
-                                }                            
+                                }
                                 continuationIndent = isLastIndentContinuation;
                             }
                         } else if (tree.getKind() != Tree.Kind.NEW_ARRAY
@@ -4265,12 +4264,13 @@ public class Reformatter implements ReformatTask {
         }
 
         private boolean wrapStatement(CodeStyle.WrapStyle wrapStyle, CodeStyle.BracesGenerationStyle bracesGenerationStyle, int spacesCnt, boolean preserveNewLine, StatementTree tree) {
-            if (tree.getKind() == Tree.Kind.EMPTY_STATEMENT) {
+            Tree.Kind kind = tree.getKind();
+            if (kind == Tree.Kind.EMPTY_STATEMENT) {
                 scan(tree, null);
                 return true;
             }
-            if (tree.getKind() == Tree.Kind.BLOCK) {
-                if (bracesGenerationStyle == CodeStyle.BracesGenerationStyle.ELIMINATE) {
+            if (kind == Tree.Kind.BLOCK || kind == Tree.Kind.TRY || kind == Tree.Kind.SYNCHRONIZED ) {
+                if (kind == Tree.Kind.BLOCK && bracesGenerationStyle == CodeStyle.BracesGenerationStyle.ELIMINATE) {
                     Iterator<? extends StatementTree> stats = ((BlockTree)tree).getStatements().iterator();
                     if (stats.hasNext()) {
                         StatementTree stat = stats.next();
@@ -4358,7 +4358,7 @@ public class Reformatter implements ReformatTask {
                 } else if (first) {
                     int index = tokens.index();
                     int c = col;
-                    Diff d = diffs.isEmpty() ? null : diffs.getFirst();                    
+                    Diff d = diffs.isEmpty() ? null : diffs.getFirst();
                     spaces(prependSpace ? 1 : 0, true);
                     if (align)
                         alignIndent = col;
@@ -4394,7 +4394,7 @@ public class Reformatter implements ReformatTask {
                 first = false;
             }
         }
-        
+
         private void scanMethodCall(MethodInvocationTree node) {
             List<? extends Tree> targs = node.getTypeArguments();
             if (targs != null && !targs.isEmpty()) {
@@ -4446,14 +4446,14 @@ public class Reformatter implements ReformatTask {
                         lastIndent = oldLastIndent;
                         continuationIndent = continuation;
                     }
-                    spaces(cs.spaceWithinMethodCallParens() ? 1 : 0, true);                    
+                    spaces(cs.spaceWithinMethodCallParens() ? 1 : 0, true);
                 }
                 accept(RPAREN);
             } finally {
                 continuationIndent = old;
             }
         }
-        
+
         private void reformatComment() {
             if (tokens.token().id() != BLOCK_COMMENT && tokens.token().id() != JAVADOC_COMMENT)
                 return;
@@ -4586,7 +4586,7 @@ public class Reformatter implements ReformatTask {
                         case OTHER_TEXT:
                             lastWSOffset = currWSOffset = -1;
                             if (cseq == null)
-                                cseq = new StringBuilder();                                        
+                                cseq = new StringBuilder();
                             cseq.append(javadocTokens.token().text());
                             int nlNum = 1;
                             int insideTagEndOffset = -1;
@@ -4772,7 +4772,7 @@ public class Reformatter implements ReformatTask {
                             lastNewLinePos = i;
                             align = -1;
                         } else {
-                            lastNewLinePos = currWSPos >= 0 ? currWSPos : i;                            
+                            lastNewLinePos = currWSPos >= 0 ? currWSPos : i;
                         }
                         firstLine = false;
                     }
@@ -4960,7 +4960,7 @@ public class Reformatter implements ReformatTask {
                                             }
                                         } else if (c == '*' || c == '/') {
                                             col++;
-                                            lastNewLinePos = -1;                                            
+                                            lastNewLinePos = -1;
                                             break;
                                         } else {
                                             if (i >= checkOffset && actionType == 6) {
@@ -4982,7 +4982,7 @@ public class Reformatter implements ReformatTask {
                                                     } else {
                                                         pendingDiff = new Diff(offset + lastNewLinePos + 1, currWSPos >= 0 ? offset + currWSPos + 1 : offset + i, indentString + SPACE);
                                                     }
-                                                    
+
                                                 } else {
                                                     if (pendingDiff != null) {
                                                         pendingDiff.end = offset + i;
@@ -4991,7 +4991,7 @@ public class Reformatter implements ReformatTask {
                                                     }
                                                     col = getCol(indentString + SPACE);
                                                 }
-                                            } else { 
+                                            } else {
                                                 if (currWSPos < 0) {
                                                     currWSPos = i;
                                                     col++;
@@ -5005,7 +5005,7 @@ public class Reformatter implements ReformatTask {
                                                             addDiff(pendingDiff);
                                                         }
                                                     }
-                                                    pendingDiff = new Diff(offset + currWSPos, offset + i, s);                                                    
+                                                    pendingDiff = new Diff(offset + currWSPos, offset + i, s);
                                                 }
                                             }
                                             lastNewLinePos = -1;
@@ -5031,7 +5031,7 @@ public class Reformatter implements ReformatTask {
                                         } else {
                                             pendingDiff = new Diff(offset + i, offset + i, s);
                                         }
-                                        col += num;                                        
+                                        col += num;
                                     }
                                     lastNewLinePos = -1;
                                 }
@@ -5086,13 +5086,13 @@ public class Reformatter implements ReformatTask {
                 }
             }
         }
-        
+
         private void addMark(Pair<Integer, Integer> mark, List<Pair<Integer, Integer>> marks, int state) {
             if (state != 6) {
                 marks.add(mark);
             }
         }
-        
+
         private int indent() {
             return continuationIndent ? indent + continuationIndentSize : indent;
         }
@@ -5102,7 +5102,7 @@ public class Reformatter implements ReformatTask {
                 return EMPTY;
             if (count == 1)
                 return SPACE;
-            StringBuilder sb = new StringBuilder(); 
+            StringBuilder sb = new StringBuilder();
             while (count-- > 0)
                 sb.append(' '); //NOI18N
             return sb.toString();
@@ -5113,14 +5113,14 @@ public class Reformatter implements ReformatTask {
                 return EMPTY;
             if (count == 1)
                 return NEWLINE;
-            StringBuilder sb = new StringBuilder(); 
+            StringBuilder sb = new StringBuilder();
             while (count-- > 0)
                 sb.append('\n'); //NOI18N
             return sb.toString();
         }
 
         private String getIndent() {
-            StringBuilder sb = new StringBuilder(); 
+            StringBuilder sb = new StringBuilder();
             int col = 0;
             if (!expandTabToSpaces) {
                 while (col + tabSize <= indent()) {
@@ -5213,7 +5213,7 @@ public class Reformatter implements ReformatTask {
             }
             return col;
         }
-        
+
         private boolean insideBlock(TreePath path) {
             while (path != null) {
                 if (Tree.Kind.BLOCK == path.getLeaf().getKind())
@@ -5223,12 +5223,12 @@ public class Reformatter implements ReformatTask {
                 path = path.getParentPath();
             }
             return false;
-        }        
+        }
 
         private boolean isEnumerator(VariableTree tree) {
             return (((JCModifiers)tree.getModifiers()).flags & Flags.ENUM) != 0;
         }
-        
+
         private boolean isSynthetic(CompilationUnitTree cut, Tree leaf) {
             JCTree tree = (JCTree) leaf;
             if (tree.pos == (-1))
@@ -5252,31 +5252,31 @@ public class Reformatter implements ReformatTask {
             }
             return false;
         }
-        
+
         private static class WrapAbort extends Error {
-            
+
             private int pos;
 
             public WrapAbort(int pos) {
                 this.pos = pos;
             }
-            
+
             @Override
             public synchronized Throwable fillInStackTrace() {
                 return null;
             }
         }
-    
+
         private static class FakeBlock extends JCBlock {
-            
+
             private StatementTree stat;
-            
+
             private FakeBlock(StatementTree stat) {
                 super(0L, com.sun.tools.javac.util.List.of((JCStatement)stat));
                 this.stat = stat;
             }
         }
-        
+
         private static class DanglingElseChecker extends SimpleTreeVisitor<Void, Void> {
 
             private boolean foundDanglingElse;
@@ -5355,7 +5355,7 @@ public class Reformatter implements ReformatTask {
         public int getStartOffset() {
             return start;
         }
-        
+
         public int getEndOffset() {
             return end;
         }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -54,8 +54,8 @@ import org.openide.util.SharedClassObject;
 import org.openide.util.Utilities;
 
 /**
- * Test different formating options
- * 
+ * Test different formatting options
+ *
  * @author Dusan Balek
  */
 public class FormatingTest extends NbTestCase {
@@ -3431,7 +3431,7 @@ public class FormatingTest extends NbTestCase {
         Preferences preferences = MimeLookup.getLookup(JavaTokenId.language().mimeType()).lookup(Preferences.class);
 
         preferences.putBoolean("enableBlockCommentFormatting", true);
-        
+
         String content =
                 "package hierbas.del.litoral;\n"
                 + "public class Test{\n"
@@ -3493,9 +3493,9 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
-        
+
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3521,11 +3521,11 @@ public class FormatingTest extends NbTestCase {
                 + "        /*  This is a block comment.*/\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("enableCommentFormatting", false);
         reformat(doc, content, golden);
         preferences.remove("enableCommentFormatting");
-        
+
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3554,11 +3554,11 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("wrapCommentText", false);
         reformat(doc, content, golden);
         preferences.remove("wrapCommentText");
-        
+
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3592,7 +3592,7 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("addLeadingStarInComment", false);
         reformat(doc, content, golden);
 
@@ -3630,7 +3630,7 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("preserveNewLinesInComments", true);
         reformat(doc, content, golden);
         preferences.remove("addLeadingStarInComment");
@@ -3669,7 +3669,7 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
         preferences.remove("preserveNewLinesInComments");
 
@@ -3706,7 +3706,7 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("generateParagraphTagOnBlankLines", false);
         reformat(doc, content, golden);
 
@@ -3743,12 +3743,12 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("addLeadingStarInComment", false);
         reformat(doc, content, golden);
         preferences.remove("addLeadingStarInComment");
         preferences.putBoolean("generateParagraphTagOnBlankLines", true);
-        
+
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3780,11 +3780,11 @@ public class FormatingTest extends NbTestCase {
                 + "        /* This is a block comment. */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("wrapOneLineComment", false);
         reformat(doc, content, golden);
         preferences.remove("wrapOneLineComment");
-        
+
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3817,11 +3817,11 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("blankLineAfterJavadocDescription", false);
         reformat(doc, content, golden);
         preferences.remove("blankLineAfterJavadocDescription");
-        
+
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3857,7 +3857,7 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("alignJavadocParameterDescriptions", true);
         preferences.putBoolean("alignJavadocReturnDescription", true);
         preferences.putBoolean("alignJavadocExceptionDescriptions", true);
@@ -3865,7 +3865,7 @@ public class FormatingTest extends NbTestCase {
         preferences.remove("alignJavadocExceptionDescriptions");
         preferences.remove("alignJavadocReturnDescription");
         preferences.remove("alignJavadocParameterDescriptions");
-        
+
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3901,13 +3901,13 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("blankLineAfterJavadocParameterDescriptions", true);
         preferences.putBoolean("blankLineAfterJavadocReturnTag", true);
         reformat(doc, content, golden);
         preferences.remove("blankLineAfterJavadocReturnTag");
         preferences.remove("blankLineAfterJavadocParameterDescriptions");
-        
+
         content =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3919,7 +3919,7 @@ public class FormatingTest extends NbTestCase {
                 + "         */\n"
                 + "    public void taragui() {\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3933,9 +3933,9 @@ public class FormatingTest extends NbTestCase {
                 + "     */\n"
                 + "    public void taragui() {\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
-        preferences.remove("generateParagraphTagOnBlankLines");        
+        preferences.remove("generateParagraphTagOnBlankLines");
 
         content =
                 "package hierbas.del.litoral;\n"
@@ -3944,7 +3944,7 @@ public class FormatingTest extends NbTestCase {
                 + " * Test JavaDoc \n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3952,7 +3952,7 @@ public class FormatingTest extends NbTestCase {
                 + " * Test JavaDoc\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
 
         content =
@@ -3962,7 +3962,7 @@ public class FormatingTest extends NbTestCase {
                 + " * @author XYZ\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3970,7 +3970,7 @@ public class FormatingTest extends NbTestCase {
                 + " * @author XYZ\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
 
         content =
@@ -3982,7 +3982,7 @@ public class FormatingTest extends NbTestCase {
                 + " * {@link #write(ByteBuffer,long,TimeUnit,Object,CompletionHandler) write} methods.\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -3994,7 +3994,7 @@ public class FormatingTest extends NbTestCase {
                 + " * methods.\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
 
         content =
@@ -4008,7 +4008,7 @@ public class FormatingTest extends NbTestCase {
                 + " * @author XYZ\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4020,9 +4020,9 @@ public class FormatingTest extends NbTestCase {
                 + " * @author XYZ\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
-        
+
         content =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4032,7 +4032,7 @@ public class FormatingTest extends NbTestCase {
                 + " * </pre>\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4042,9 +4042,9 @@ public class FormatingTest extends NbTestCase {
                 + " * </pre>\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
-        
+
         content =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4054,7 +4054,7 @@ public class FormatingTest extends NbTestCase {
                 + " * @author XYZ\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4064,9 +4064,9 @@ public class FormatingTest extends NbTestCase {
                 + " * @author XYZ\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
-        
+
         content =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4076,7 +4076,7 @@ public class FormatingTest extends NbTestCase {
                 + " * @author XYZ\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4086,9 +4086,9 @@ public class FormatingTest extends NbTestCase {
                 + " * @author XYZ\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
-        
+
         content =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4098,7 +4098,7 @@ public class FormatingTest extends NbTestCase {
                 + " * @author XYZ\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4109,9 +4109,9 @@ public class FormatingTest extends NbTestCase {
                 + " * @author XYZ\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
-        
+
         content =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4122,7 +4122,7 @@ public class FormatingTest extends NbTestCase {
                 + " * @Deprecated\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4133,14 +4133,14 @@ public class FormatingTest extends NbTestCase {
                 + " @Deprecated\n"
                 + " */\n"
                 + "public class Test {\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("addLeadingStarInComment", false);
         preferences.putBoolean("wrapCommentText", false);
         preferences.putBoolean("blankLineAfterJavadocDescription", false);
         reformat(doc, content, golden);
-        preferences.remove("blankLineAfterJavadocDescription");        
-        preferences.remove("wrapCommentText");        
-        preferences.remove("addLeadingStarInComment");        
+        preferences.remove("blankLineAfterJavadocDescription");
+        preferences.remove("wrapCommentText");
+        preferences.remove("addLeadingStarInComment");
 
         content =
                 "package hierbas.del.litoral;\n"
@@ -4158,7 +4158,7 @@ public class FormatingTest extends NbTestCase {
                 + "    public <S> S get(S in, Object o, String... vararg) {\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4177,10 +4177,10 @@ public class FormatingTest extends NbTestCase {
                 + "    public <S> S get(S in, Object o, String... vararg) {\n"
                 + "        return null;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("alignJavadocParameterDescriptions", true);
         reformat(doc, content, golden);
-        preferences.remove("alignJavadocParameterDescriptions");        
+        preferences.remove("alignJavadocParameterDescriptions");
 
         content =
                 "package hierbas.del.litoral;\n"
@@ -4194,7 +4194,7 @@ public class FormatingTest extends NbTestCase {
                 + "    public void get(Object o) {\n"
                 + "        return o;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4207,7 +4207,7 @@ public class FormatingTest extends NbTestCase {
                 + "    public void get(Object o) {\n"
                 + "        return o;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         preferences.putBoolean("alignJavadocParameterDescriptions", true);
         reformat(doc, content, golden);
 
@@ -4224,7 +4224,7 @@ public class FormatingTest extends NbTestCase {
                 + "    public Object get(Object o) {\n"
                 + "        return o;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4238,7 +4238,7 @@ public class FormatingTest extends NbTestCase {
                 + "    public Object get(Object o) {\n"
                 + "        return o;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
 
         content =
@@ -4254,7 +4254,7 @@ public class FormatingTest extends NbTestCase {
                 + "    public Object get(Object o, String str) {\n"
                 + "        return o;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         golden =
                 "package hierbas.del.litoral;\n"
                 + "\n"
@@ -4268,9 +4268,9 @@ public class FormatingTest extends NbTestCase {
                 + "    public Object get(Object o, String str) {\n"
                 + "        return o;\n"
                 + "    }\n"
-                + "}\n";        
+                + "}\n";
         reformat(doc, content, golden);
-        preferences.remove("alignJavadocParameterDescriptions");        
+        preferences.remove("alignJavadocParameterDescriptions");
 
         preferences.remove("text-limit-width");
     }
@@ -4279,7 +4279,7 @@ public class FormatingTest extends NbTestCase {
      * Do not put spaces to parenthesis when method declaration has no
      * parameters. The same rule should be applied to method invocation.
      * Regression test.
-     * 
+     *
      * http://www.netbeans.org/issues/show_bug.cgi?id=116225
      */
     public void test116225() throws Exception {
@@ -4894,6 +4894,161 @@ public class FormatingTest extends NbTestCase {
                 + "}\n";
         reformat(doc, content, golden);
         JavaSourceTest.SourceLevelQueryImpl.sourceLevel = oldLevel;
+    }
+
+    public void testTryBlockAfterIf() throws Exception {
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie)testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        String content =
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        if (2 == 2) try {\n"
+                + "            int x = 3;\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+
+        String golden =  // no change
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        if (2 == 2) try {\n"
+                + "            int x = 3;\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+        reformat(doc, content, golden);
+    }
+
+    public void testTryBlockAfterElse() throws Exception {
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie)testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        String content =
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        if (2 == 2) {\n"
+                + "            int x = 3;\n"
+                + "        } else try {\n"
+                + "            int x = 6;\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+
+        String golden = // no change
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        if (2 == 2) {\n"
+                + "            int x = 3;\n"
+                + "        } else try {\n"
+                + "            int x = 6;\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+        reformat(doc, content, golden);
+    }
+
+    public void testTryBlockAfterWhile() throws Exception {
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie)testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        String content =
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        while (2 == 2) try {\n"
+                + "            int x = 3;\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+
+        String golden = // no change
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        while (2 == 2) try {\n"
+                + "            int x = 3;\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+        reformat(doc, content, golden);
+    }
+
+    public void testTryBlockAfterFor() throws Exception {
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie)testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        String content =
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        for (int y : Arrays.asList(1, 2, 3)) try {\n"
+                + "            int x = 3;\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+
+        String golden = // no change
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        for (int y : Arrays.asList(1, 2, 3)) try {\n"
+                + "            int x = 3;\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+        reformat(doc, content, golden);
+    }
+
+
+    public void testSynchronizedBlockAfterFor() throws Exception {
+        testFile = new File(getWorkDir(), "Test.java");
+        TestUtilities.copyStringToFile(testFile, "");
+        FileObject testSourceFO = FileUtil.toFileObject(testFile);
+        DataObject testSourceDO = DataObject.find(testSourceFO);
+        EditorCookie ec = (EditorCookie)testSourceDO.getCookie(EditorCookie.class);
+        final Document doc = ec.openDocument();
+        doc.putProperty(Language.class, JavaTokenId.language());
+        String content =
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        for (int y : Arrays.asList(1, 2, 3)) synchronized(Test.class) {\n"
+                + "            int x = 3;\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+
+        String golden = // no change
+                "package hierbas.del.litoral;\n\n"
+                + "public class Test {\n\n"
+                + "    public static void main(String[] args) {\n"
+                + "        for (int y : Arrays.asList(1, 2, 3)) synchronized(Test.class) {\n"
+                + "            int x = 3;\n"
+                + "        }\n"
+                + "    }\n"
+                + "}\n";
+        reformat(doc, content, golden);
     }
 
     private void reformat(Document doc, String content, String golden) throws Exception {


### PR DESCRIPTION
Extraneous braces will also be removed according to user preference

See previous PR which I was unable to update for context:

https://github.com/apache/netbeans/pull/173