### PR TITLE
Fixing injection of com.sun.tools.javac.code.Scope and adding injecti…

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
@@ -48,7 +48,7 @@ public class NoJavacHelper {
             res = false;
         }
         hasWorkingJavac.compareAndSet(null, res);
-        return res;
+        return hasWorkingJavac.get();
     }
 
     public static boolean hasNbJavac() {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
@@ -18,20 +18,15 @@
  */
 package org.netbeans.modules.java.source;
 
-import com.sun.source.tree.BreakTree;
-import com.sun.source.tree.ExpressionTree;
-import java.io.IOException;
-import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Opcodes;
 import org.openide.modules.OnStart;
-import sun.misc.Unsafe;
 
 /**
  *
@@ -39,14 +34,21 @@ import sun.misc.Unsafe;
  */
 public class NoJavacHelper {
 
+    private static final AtomicReference<Boolean> hasWorkingJavac = new AtomicReference<>();
     public static boolean hasWorkingJavac() {
+        Boolean res = hasWorkingJavac.get();
+        if (res != null) {
+            return res;
+        }
         try {
             Class.forName("javax.lang.model.element.ModuleElement");
-            return true;
+            res = true;
         } catch (ClassNotFoundException ex) {
             //OK
-            return false;
+            res = false;
         }
+        hasWorkingJavac.compareAndSet(null, res);
+        return res;
     }
 
     public static boolean hasNbJavac() {
@@ -65,41 +67,49 @@ public class NoJavacHelper {
         @Override
         public void run() {
             if (!hasWorkingJavac()) {
-                ClassWriter w = new ClassWriter(0);
-                w.visit(Opcodes.V1_8, Opcodes.ACC_ABSTRACT | Opcodes.ACC_PUBLIC, "com/sun/tools/javac/code/Scope$WriteableScope", null, "com/sun/tools/javac/code/Scope", null);
-                byte[] classData = w.toByteArray();
-
                 String JavaVersion = System.getProperty("java.specification.version"); //NOI18N
                 boolean isJdkVer8OrBelow = true;
                 if (!JavaVersion.startsWith("1.")) {   //NOI18N
                     isJdkVer8OrBelow = false;
                 }
                 if (isJdkVer8OrBelow) {
-                    try {
-                        Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe"); //NOI18N
-                        theUnsafe.setAccessible(true);
-                        Unsafe unsafe = (Unsafe) theUnsafe.get(null);
+                    {
+                        ClassWriter w = new ClassWriter(0);
+                        w.visit(Opcodes.V1_8, Opcodes.ACC_ABSTRACT | Opcodes.ACC_PUBLIC, "com/sun/tools/javac/code/Scope$WriteableScope", null, "com/sun/tools/javac/code/Scope", null);
+                        byte[] classData = w.toByteArray();
 
-                        Class scopeClass = Class.forName("com.sun.tools.javac.code.Scope");  //NOI18N
-
-                        Method defineClass = Unsafe.class.getDeclaredMethod("defineClass", String.class, Byte[].class, Integer.class, Integer.class, ClassLoader.class, ProtectionDomain.class);  //NOI18N
-                        defineClass.invoke(unsafe, "com.sun.tools.javac.code.Scope$WriteableScope", classData, 0, classData.length, scopeClass.getClassLoader(), scopeClass.getProtectionDomain());  //NOI18N 
-                    } catch (Throwable t) {
-                        //ignore...
-                        Logger.getLogger(NoJavacHelper.class.getName()).log(Level.FINE, null, t);
+                        defineClass("com.sun.tools.javac.code.Scope$WriteableScope",
+                                    "com.sun.tools.javac.code.Scope",
+                                    classData);
                     }
-                } else {
-                    try {
-                        Method defineClass = MethodHandles.Lookup.class.getDeclaredMethod("defineClass", Byte[].class); //NOI18N
-                        defineClass.invoke(MethodHandles.lookup(), classData);
-                    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ex) {
-                        Logger.getLogger(NoJavacHelper.class.getName()).log(Level.FINE, null, ex);
+                    {
+                        ClassWriter w = new ClassWriter(0);
+                        w.visit(Opcodes.V1_8, Opcodes.ACC_ABSTRACT | Opcodes.ACC_INTERFACE | Opcodes.ACC_PUBLIC, "javax/lang/model/element/ModuleElement", null, "java/lang/Object", new String[] {"javax/lang/model/element/Element"});
+                        byte[] classData = w.toByteArray();
 
+                        defineClass("javax.lang.model.element.ModuleElement",
+                                    "com.sun.tools.javac.code.Scope",
+                                    classData);
                     }
                 }
-
             }
         }
 
+        private void defineClass(String fqn, String injectToClass, byte[] classData) {
+            try {
+                Class<?> unsafeClass = Class.forName("sun.misc.Unsafe");
+                Field theUnsafe = unsafeClass.getDeclaredField("theUnsafe"); //NOI18N
+                theUnsafe.setAccessible(true);
+                Object unsafe = theUnsafe.get(null);
+
+                Class targetClass = Class.forName(injectToClass);  //NOI18N
+
+                Method defineClass = unsafeClass.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class, ClassLoader.class, ProtectionDomain.class);  //NOI18N
+                defineClass.invoke(unsafe, fqn, classData, 0, classData.length, targetClass.getClassLoader(), targetClass.getProtectionDomain());  //NOI18N 
+            } catch (Throwable t) {
+                //ignore...
+                Logger.getLogger(NoJavacHelper.class.getName()).log(Level.WARNING, null, t);
+            }
+        }
     }
 }


### PR DESCRIPTION
…on of javax.lang.model.element.ModuleElement, when the available javac is not new enough.

These are to avoid exceptions while running on JDK 8 without nb-javac. (javac based features don't work, of course, but at least some exceptions that would happen anyway are avoided.)