### PR TITLE
JEDDICT-322 Export public-packages & friend-packages to Jeddict modules

### DIFF
--- a/enterprise/j2ee.common/nbproject/project.xml
+++ b/enterprise/j2ee.common/nbproject/project.xml
@@ -542,6 +542,7 @@
                 <friend>org.netbeans.modules.websvc.core</friend>
                 <friend>org.netbeans.modules.websvc.jaxrpc</friend>
                 <friend>org.netbeans.modules.websvc.restapi</friend>
+                <friend>io.github.jeddict.jcode.util</friend>
                 <package>org.netbeans.modules.j2ee.common</package>
                 <package>org.netbeans.modules.j2ee.common.dd</package>
                 <package>org.netbeans.modules.j2ee.common.ui</package>

--- a/ide/db.core/nbproject/project.xml
+++ b/ide/db.core/nbproject/project.xml
@@ -233,6 +233,7 @@
                 <friend>org.netbeans.modules.db.sql.editor</friend>
                 <friend>org.netbeans.modules.edm.editor</friend>
                 <friend>org.netbeans.modules.etl.editor</friend>
+                <friend>io.github.jeddict.jpa.modeler</friend>
                 <package>org.netbeans.modules.db.api.sql.execute</package>
             </friend-packages>
         </data>

--- a/ide/db.metadata.model/nbproject/project.xml
+++ b/ide/db.metadata.model/nbproject/project.xml
@@ -68,6 +68,8 @@
                 <friend>org.netbeans.modules.db</friend>
                 <friend>org.netbeans.modules.db.sql.editor</friend>
                 <friend>org.netbeans.modules.dbapi</friend>
+                <friend>io.github.jeddict.jpa.modeler</friend>
+                <friend>io.github.jeddict.db.modeler</friend>
                 <package>org.netbeans.modules.db.metadata.model.api</package>
                 <package>org.netbeans.modules.db.metadata.model.spi</package>
             </friend-packages>

--- a/ide/db/nbproject/project.xml
+++ b/ide/db/nbproject/project.xml
@@ -222,6 +222,13 @@
                 <package>org.netbeans.api.db.explorer.support</package>
                 <package>org.netbeans.api.db.sql.support</package>
                 <package>org.netbeans.spi.db.explorer</package>
+                <package>org.netbeans.modules.db.explorer</package>
+                <package>org.netbeans.modules.db.explorer.action</package>
+                <package>org.netbeans.modules.db.explorer.node</package>
+                <package>org.netbeans.modules.db.explorer.sql.editor</package>
+                <package>org.netbeans.lib.ddl</package>
+                <package>org.netbeans.lib.ddl.impl</package>
+                <package>org.netbeans.lib.ddl.util</package>
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>ext/ddl.jar</runtime-relative-path>

--- a/ide/utilities/nbproject/project.xml
+++ b/ide/utilities/nbproject/project.xml
@@ -178,6 +178,7 @@
                 <friend>org.netbeans.modules.dlight.remote.impl</friend>
                 <friend>org.netbeans.modules.utilities.project</friend>
                 <friend>org.netbeans.modules.visualweb.gravy</friend>
+                <friend>io.github.jeddict.jpa.modeler</friend>
                 <package>org.netbeans.modules.openfile</package>
                 <package>org.netbeans.modules.search</package>
             </friend-packages>

--- a/java/dbschema/nbproject/project.xml
+++ b/java/dbschema/nbproject/project.xml
@@ -223,6 +223,7 @@
                 <friend>org.netbeans.modules.j2ee.persistence</friend>
                 <friend>org.netbeans.modules.j2ee.sun.appsrv</friend>
                 <friend>org.netbeans.modules.j2ee.sun.ddui</friend>
+                <friend>io.github.jeddict.reveng</friend>
                 <package>org.netbeans.modules.dbschema</package>
                 <package>org.netbeans.modules.dbschema.jdbcimpl</package>
                 <package>org.netbeans.modules.dbschema.jdbcimpl.wizard</package>

--- a/java/j2ee.persistence/nbproject/project.xml
+++ b/java/j2ee.persistence/nbproject/project.xml
@@ -633,6 +633,14 @@
                 <friend>org.netbeans.modules.web.jsf</friend>
                 <friend>org.netbeans.modules.web.project</friend>
                 <friend>org.netbeans.modules.websvc.rest</friend>
+                <friend>io.github.jeddict.jcode.util</friend>
+                <friend>io.github.jeddict.jpa.modeler</friend>
+                <friend>io.github.jeddict.reveng</friend>
+                <friend>io.github.jeddict.orm.generator</friend>
+                <friend>io.github.jeddict.runtime</friend>
+                <friend>io.github.jeddict.rest.generator</friend>
+                <friend>io.github.jeddict.mvc.generator</friend>
+                <friend>io.github.jeddict.infra</friend>
                 <package>org.netbeans.modules.j2ee.persistence.action</package>
                 <package>org.netbeans.modules.j2ee.persistence.api.entity.generator</package>
                 <package>org.netbeans.modules.j2ee.persistence.dd</package>

--- a/java/j2ee.persistence/nbproject/project.xml
+++ b/java/j2ee.persistence/nbproject/project.xml
@@ -645,7 +645,15 @@
                 <package>org.netbeans.modules.j2ee.persistence.api.entity.generator</package>
                 <package>org.netbeans.modules.j2ee.persistence.dd</package>
                 <package>org.netbeans.modules.j2ee.persistence.dd.common</package>
+                <package>org.netbeans.modules.j2ee.persistence.dd.persistence.model_1_0</package>
+                <package>org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_0</package>
+                <package>org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_1</package>
+                <package>org.netbeans.modules.j2ee.persistence.editor</package>
+                <package>org.netbeans.modules.j2ee.persistence.editor.completion</package>
                 <package>org.netbeans.modules.j2ee.persistence.entitygenerator</package>
+                <package>org.netbeans.modules.j2ee.persistence.jpqleditor</package>
+                <package>org.netbeans.modules.j2ee.persistence.jpqleditor.lexer</package>
+                <package>org.netbeans.modules.j2ee.persistence.jpqleditor.ui</package>
                 <package>org.netbeans.modules.j2ee.persistence.provider</package>
                 <package>org.netbeans.modules.j2ee.persistence.spi.datasource</package>
                 <package>org.netbeans.modules.j2ee.persistence.spi.entitymanagergenerator</package>

--- a/java/j2ee.persistenceapi/nbproject/project.xml
+++ b/java/j2ee.persistenceapi/nbproject/project.xml
@@ -213,6 +213,9 @@
                 <friend>org.netbeans.modules.websvc.core</friend>
                 <friend>org.netbeans.modules.websvc.rest</friend>
                 <friend>org.netbeans.modules.websvc.restapi</friend>
+                <friend>io.github.jeddict.jcode.util</friend>
+                <friend>io.github.jeddict.jpa.modeler</friend>
+                <friend>io.github.jeddict.reveng</friend>
                 <package>org.netbeans.modules.j2ee.persistence.api</package>
                 <package>org.netbeans.modules.j2ee.persistence.api.metadata.orm</package>
                 <package>org.netbeans.modules.j2ee.persistence.spi</package>

--- a/java/maven.embedder/nbproject/project.xml
+++ b/java/maven.embedder/nbproject/project.xml
@@ -173,6 +173,9 @@
                 <!-- NetBeans support for Google App Engine -->
                 <friend>org.netbeans.modules.j2ee.appengine</friend>
                 <friend>org.netbeans.modules.maven.util</friend>
+                <friend>io.github.jeddict.jcode.util</friend>
+                <friend>io.github.jeddict.runtime</friend>
+                <friend>io.github.jeddict.rest.generator</friend>
                 <!-- XXX <subpackages> not permitted by schema -->
                 <package>javax.inject</package>
                 <package>com.google.inject</package>

--- a/java/maven.model/nbproject/project.xml
+++ b/java/maven.model/nbproject/project.xml
@@ -235,6 +235,9 @@
                 <!-- NetBeans support for Google App Engine -->
                 <friend>org.netbeans.modules.j2ee.appengine</friend>
                 <friend>org.netbeans.modules.maven.util</friend>
+                <friend>io.github.jeddict.jcode.util</friend>
+                <friend>io.github.jeddict.runtime</friend>
+                <friend>io.github.jeddict.rest.generator</friend>
                 <package>org.netbeans.modules.maven.model</package>
                 <package>org.netbeans.modules.maven.model.pom</package>
                 <package>org.netbeans.modules.maven.model.settings</package>

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -628,6 +628,7 @@
                 <friend>org.netbeans.modules.maven.util</friend>
                 <!-- JShel support -->
                 <friend>org.netbeans.modules.jshell.support</friend>
+                <friend>io.github.jeddict.jcode.util</friend>
                 <package>org.netbeans.modules.maven.api</package>
                 <package>org.netbeans.modules.maven.api.archetype</package>
                 <package>org.netbeans.modules.maven.api.classpath</package>

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -637,6 +637,7 @@
                 <package>org.netbeans.modules.maven.api.execute</package>
                 <package>org.netbeans.modules.maven.api.output</package>
                 <package>org.netbeans.modules.maven.api.problem</package>
+                <package>org.netbeans.modules.maven.configurations</package>
                 <package>org.netbeans.modules.maven.execute</package>
                 <package>org.netbeans.modules.maven.execute.model</package>
                 <package>org.netbeans.modules.maven.execute.model.io.jdom</package>


### PR DESCRIPTION
Github issue: https://github.com/jeddict/jeddict/issues/322

Internal API of the Apache NetBeans Platform used by Jeddict modules:

| Netbeans Module name | Netbeans Module location | APIs | Used by Jeddict modules | Requirement |  Why access needed? |
| --- | --- | --- | --- | --- | --------- |
| org.netbeans.modules:org-netbeans-modules-j2ee-persistenceapi | netbeans\java\j2ee.persistenceapi |  org.netbeans.modules.j2ee.persistence.api, org.netbeans.modules.j2ee.persistence.spi | io.github.jeddict.jcode.util, io.github.jeddict.jpa.modeler, io.github.jeddict.reveng | friend-packages | Java persistence is core feature of Jeddict modeler so persistence.api module is needed to find persistence.xml location in project, to identify persistence descriptor properties, to list available Java Entity classes in project during Java Classes reverse engineering, etc. |
| org.netbeans.modules:org-netbeans-modules-j2ee-persistence | netbeans\java\j2ee.persistence | org.netbeans.modules.j2ee.persistence.dd, org.netbeans.modules.j2ee.persistence.dd.common, org.netbeans.modules.j2ee.persistence.unit, org.netbeans.modules.j2ee.persistence.entitygenerator, org.netbeans.modules.j2ee.persistence.jpqleditor, org.netbeans.modules.j2ee.persistence.jpqleditor.ui, org.netbeans.modules.j2ee.persistence.editor, org.netbeans.modules.j2ee.persistence.provider, org.netbeans.modules.j2ee.persistence.wizard, org.netbeans.modules.j2ee.persistence.wizard.jpacontroller, org.netbeans.modules.j2ee.persistence.wizard.fromdb, org.netbeans.modules.j2ee.persistence.wizard.library, org.netbeans.modules.j2ee.persistence.wizard.unit | io.github.jeddict.jcode.util, io.github.jeddict.jpa.modeler, io.github.jeddict.reveng, io.github.jeddict.orm.generator,  io.github.jeddict.runtime, io.github.jeddict.rest.generator, io.github.jeddict.mvc.generator, io.github.jeddict.infra | friend-packages | JPQL Editor integration in JPA Modeler, persistence.xml updated during source generation |
| org.netbeans.modules:org-netbeans-modules-j2ee-persistence | netbeans\java\j2ee.persistence | org.netbeans.modules.j2ee.persistence.jpqleditor, org.netbeans.modules.j2ee.persistence.jpqleditor.lexer, org.netbeans.modules.j2ee.persistence.jpqleditor.ui, org.netbeans.modules.j2ee.persistence.editor, org.netbeans.modules.j2ee.persistence.editor.completion, org.netbeans.modules.j2ee.persistence.dd.persistence.model_1_0, org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_0, org.netbeans.modules.j2ee.persistence.dd.persistence.model_2_1 | io.github.jeddict.jpa.modeler | export new friend package | JPQL Editor integration in JPA Modeler, To create new persistence.xml |
| org.netbeans.modules:org-netbeans-modules-j2ee-common | netbeans\enterprise\j2ee.common | org.netbeans.modules.j2ee.common, org.netbeans.modules.j2ee.common.dd | io.github.jeddict.jcode.util | friend-packages | Helper utilities classes are used to create web.xml and to identify Java EE features & spec/component version for given project |
| org.netbeans.modules:org-netbeans-modules-db-metadata-model | netbeans\ide\db.metadata.model | org.netbeans.modules.db.metadata.model.api |  io.github.jeddict.jpa.modeler, io.github.jeddict.db.modeler | friend-packages | To visualize Tree-Structured tables from Services > Database in Jeddict modeler |
| org.netbeans.modules:org-netbeans-modules-dbschema | netbeans\java\dbschema | org.netbeans.modules.dbschema | io.github.jeddict.reveng | friend-packages | To create modeler diagram from database connection via reverse engineering |
| org.netbeans.api:org-netbeans-modules-db | netbeans\ide\db | org.netbeans.modules.db.explorer, org.netbeans.modules.db.explorer.node, org.netbeans.modules.db.explorer.sql.editor, org.netbeans.modules.db.explorer.action, org.netbeans.lib.ddl, org.netbeans.lib.ddl.impl, org.netbeans.lib.ddl.util | io.github.jeddict.jpa.modeler, io.github.jeddict.db.modeler, io.github.jeddict.relation.mapper | public-packages | To import Tables from Service > Database in modeler db diagram via drag n drop, To execute db command from db diagram  |
| org.netbeans.modules:org-netbeans-modules-db-core | netbeans\ide\db.core | org.netbeans.modules.db.api.sql.execute | io.github.jeddict.jpa.modeler | friend-packages |  SQL Editor integration in JPA Modeler |
| org.netbeans.modules:org-netbeans-modules-utilities | netbeans\ide\utilities | org.netbeans.modules.openfile | io.github.jeddict.jpa.modeler | friend-packages | To open the generated Java source files directly from modeler |
| org.netbeans.modules:org-netbeans-modules-maven | netbeans\java\maven |org.netbeans.modules.maven.api, org.netbeans.modules.maven.api.customizer, org.netbeans.modules.maven.configurations, org.netbeans.modules.maven.execute.model | io.github.jeddict.jcode.util | friend-packages | To parse or update the project pom during source code generation |
| org.netbeans.modules:org-netbeans-modules-maven | netbeans\java\maven | org.netbeans.modules.maven.configurations | io.github.jeddict.jcode.util | export new friend package | To fetch or update the active maven configuration from nbactions.xml |
| org.netbeans.modules:org-netbeans-modules-maven-model | netbeans\java\maven.model | org.netbeans.modules.maven.model.pom | io.github.jeddict.jcode.util, io.github.jeddict.runtime, io.github.jeddict.rest.generator | friend-packages | To parse or update the project pom during source code generation |
| org.netbeans.modules:org-netbeans-modules-maven-embedder | netbeans\java\maven.embedder | org.codehaus.plexus.util.xml | io.github.jeddict.jcode.util, io.github.jeddict.runtime, io.github.jeddict.rest.generator | friend-packages | To update the project pom during source code generation |

The main features of Jeddict are ORM/DB modeler and source generator (currently only for maven project) hence API access required for the persistence, db, and maven modules.
