### PR TITLE
Fix update centre links in master

### DIFF
--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
@@ -25,7 +25,15 @@ OpenIDE-Module-Short-Description=Declares NetBeans autoupdate centers.
 
 Services/AutoupdateType/distribution-update-provider.instance=NetBeans Distribution
 Services/AutoupdateType/pluginportal-update-provider.instance=NetBeans Plugin Portal
+Services/AutoupdateType/82pluginportal-update-provider.instance=NetBeans 8.2 Plugin Portal
+
 #NOI18N
-URL_Distribution=https://builds.apache.org/job/netbeans-linux/lastSuccessfulBuild/artifact/nbbuild/nbms/updates.xml.gz?{$netbeans.hash.code}
+URL_Distribution=https://netbeans.apache.org/nb/updates/dev/updates.xml.gz?{$netbeans.hash.code}
 #NOI18N
-URL_PluginPortal=http://netbeans-vm.apache.org/pluginportal/data/latest/catalog-experimental.xml.gz
+URL_PluginPortal=https://netbeans.apache.org/nb/plugins/dev/catalog.xml.gz
+#NOI18N
+URL_82PluginPortal=http://updates.netbeans.org/netbeans/updates/8.2/uc/final/distribution/catalog.xml.gz
+
+3rdparty=Third Party Libraries
+#NOI18N
+URL_3rdparty=nbresloc:/org/netbeans/modules/updatecenters/resources/3rdparty-catalog.xml

--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
@@ -45,6 +45,26 @@
          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
       </file>
       
+      <file name="82pluginportal-update-provider.instance">
+          <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/82pluginportal-update-provider.instance"/>
+          <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>
+          <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_82PluginPortal"/>
+          <attr name="category" stringvalue="STANDARD"/>
+          <attr name="enabled" boolvalue="false"/>
+          <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider"/>
+          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
+      </file>
+
+      <file name="3rdparty.instance">
+          <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#3rdparty"/>
+          <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>
+          <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_3rdparty"/>
+          <attr name="category" stringvalue="STANDARD"/>
+          <attr name="enabled" boolvalue="true"/>
+          <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider"/>
+          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
+      </file>
+
    </folder>
     
   </folder> <!-- Services -->


### PR DESCRIPTION
- Change master branch UC links to match standard format for server-side redirecting / release templating
- Re-add special nbres based 3rd-party UC (OpenJFX only?)
- Re-add 8.2 centre while still required in releases

As discussed in a wider PR that @ebarboni is working on, the idea is that these links will follow a standard form where `/dev/` is replaced by version (eg. `/11.1/`) automatically in the build process.

Actual targets are currently managed in the `.htaccess` at https://github.com/apache/netbeans-website/blob/master/netbeans.apache.org/src/content/.htaccess#L10

Redirects are set to match 11.1  for testing at present, although the redirect for `/nb/updates/dev/` should perhaps be `https://builds.apache.org/job/netbeans-linux/lastSuccessfulBuild/artifact/nbbuild/nbms/`?

We might want to consider adding `?{$netbeans.hash.code}` to the plugin centre link as well in future?