### PR TITLE
[NETBEANS-2775] Fix duplicate server entries by filtering using PlatformFactory

### DIFF
--- a/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/AmazonServerInstanceImplementation.java
+++ b/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/AmazonServerInstanceImplementation.java
@@ -19,6 +19,8 @@
 package org.netbeans.modules.cloud.amazon;
 
 import javax.swing.JComponent;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import org.netbeans.modules.cloud.amazon.ui.AmazonInstanceNode;
 import org.netbeans.modules.cloud.amazon.ui.AmazonWizardComponent;
 import org.netbeans.spi.server.ServerInstanceImplementation;
@@ -70,10 +72,5 @@ public class AmazonServerInstanceImplementation implements ServerInstanceImpleme
     public boolean isRemovable() {
         return true;
     }
-
-    @Override
-    public String getProperty(String key) {
-        return ai.getServerInstance().getProperty(key);
-    }
-
+    
 }

--- a/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/serverplugin/AmazonJ2EEServerInstanceImplementation.java
+++ b/enterprise/cloud.amazon/src/org/netbeans/modules/cloud/amazon/serverplugin/AmazonJ2EEServerInstanceImplementation.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.cloud.amazon.serverplugin;
 
 import javax.swing.JComponent;
+import javax.swing.JLabel;
 import org.netbeans.modules.cloud.amazon.ui.AmazonJ2EEInstanceNode;
 import org.netbeans.modules.cloud.amazon.ui.serverplugin.AmazonJ2EEServerWizardComponent;
 import org.netbeans.spi.server.ServerInstanceImplementation;
@@ -69,11 +70,6 @@ public class AmazonJ2EEServerInstanceImplementation implements ServerInstanceImp
     @Override
     public boolean isRemovable() {
         return false;
-    }
-
-    @Override
-    public String getProperty(String key) {
-        return aij.getInstance().getProperty(key);
     }
 
 }

--- a/enterprise/j2eeserver/nbproject/project.properties
+++ b/enterprise/j2eeserver/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 spec.version.base=1.117.0
 
 javadoc.arch=${basedir}/arch.xml

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/devmodules/api/ServerManager.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/devmodules/api/ServerManager.java
@@ -19,13 +19,16 @@
 package org.netbeans.modules.j2ee.deployment.devmodules.api;
 
 import java.awt.EventQueue;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import org.netbeans.api.server.CommonServerUIs;
 import org.netbeans.api.server.ServerInstance;
+import org.netbeans.modules.j2ee.deployment.impl.ServerRegistry;
+import org.netbeans.modules.j2ee.deployment.impl.bridge.BridgingServerInstanceProvider;
+import org.netbeans.modules.j2ee.deployment.impl.bridge.ServerInstanceProviderLookup;
+import org.netbeans.modules.j2ee.deployment.impl.ui.wizard.AddServerInstanceWizard;
 import org.netbeans.modules.j2ee.deployment.plugins.api.CommonServerBridge;
-import org.netbeans.modules.j2ee.deployment.plugins.api.InstanceProperties;
-import org.netbeans.modules.server.ui.wizard.AddServerInstanceWizard;
 
 /**
  * ServerManager class provides access to the Server Manager dialog.
@@ -88,8 +91,7 @@ public final class ServerManager {
      */
     public static String showAddServerInstanceWizard(Map<String, String> props) {
         checkDispatchThread();
-        ServerInstance instance = AddServerInstanceWizard.showAddServerInstanceWizard(props);
-        return instance.getProperty(InstanceProperties.URL_ATTR);
+        return AddServerInstanceWizard.showAddServerInstanceWizard(props);
     }
     
     private static void checkDispatchThread() {

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/bridge/BridgingServerInstance.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/bridge/BridgingServerInstance.java
@@ -118,11 +118,6 @@ public class BridgingServerInstance implements ServerInstanceImplementation, Loo
     }
 
     @Override
-    public String getProperty(String key) {
-        return instance.getInstanceProperties().getProperty(key);
-    }
-
-    @Override
     public Lookup getLookup() {
         // FIXME why is the platform written in such strange way ?
         J2eePlatform platform = Deployment.getDefault().getJ2eePlatform(instance.getUrl());

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ui/wizard/AddServerInstanceWizard.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ui/wizard/AddServerInstanceWizard.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.j2ee.deployment.impl.ui.wizard;
+
+import java.awt.Dialog;
+import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.logging.Logger;
+import javax.swing.JComponent;
+import javax.swing.event.ChangeListener;
+import org.netbeans.modules.j2ee.deployment.impl.Server;
+import org.netbeans.modules.j2ee.deployment.impl.ServerRegistry;
+import org.netbeans.modules.j2ee.deployment.plugins.api.InstanceProperties;
+import org.netbeans.modules.j2ee.deployment.plugins.spi.OptionalDeploymentManagerFactory;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
+import org.openide.WizardDescriptor;
+import org.openide.util.NbBundle;
+
+/**
+ *
+ * @author Andrei Badea
+ */
+public class AddServerInstanceWizard extends WizardDescriptor {
+    public final static String PROP_DISPLAY_NAME = "ServInstWizard_displayName"; // NOI18N
+    public final static String PROP_SERVER = "ServInstWizard_server"; // NOI18N
+
+    private final static String PROP_AUTO_WIZARD_STYLE = WizardDescriptor.PROP_AUTO_WIZARD_STYLE; // NOI18N
+    private final static String PROP_CONTENT_DISPLAYED = WizardDescriptor.PROP_CONTENT_DISPLAYED; // NOI18N
+    private final static String PROP_CONTENT_NUMBERED = WizardDescriptor.PROP_CONTENT_NUMBERED; // NOI18N
+    private final static String PROP_CONTENT_DATA = WizardDescriptor.PROP_CONTENT_DATA; // NOI18N
+    private final static String PROP_CONTENT_SELECTED_INDEX = WizardDescriptor.PROP_CONTENT_SELECTED_INDEX; // NOI18N
+    private final static String PROP_ERROR_MESSAGE = WizardDescriptor.PROP_ERROR_MESSAGE; // NOI18N
+
+    private AddServerInstanceWizardIterator iterator;
+    private ServerChooserPanel chooser;
+    
+    private static final Logger LOGGER = Logger.getLogger("org.netbeans.modules.j2ee.deployment"); // NOI18N
+
+    private AddServerInstanceWizard(Map<String, String> props) {
+        this(new AddServerInstanceWizardIterator());
+        
+        putProperty(PROP_AUTO_WIZARD_STYLE, Boolean.TRUE);
+        putProperty(PROP_CONTENT_DISPLAYED, Boolean.TRUE);
+        putProperty(PROP_CONTENT_NUMBERED, Boolean.TRUE);
+        for (Entry<String, String> entry : props.entrySet()) {
+            putProperty(entry.getKey(), entry.getValue());
+        }
+        
+        setTitle(NbBundle.getMessage(AddServerInstanceWizard.class, "LBL_ASIW_Title"));
+        setTitleFormat(new MessageFormat(NbBundle.getMessage(AddServerInstanceWizard.class, "LBL_ASIW_TitleFormat")));
+        
+        initialize();
+    }
+    
+    private AddServerInstanceWizard(AddServerInstanceWizardIterator iterator) {
+        super(iterator);
+        this.iterator = iterator;
+    }
+    
+    
+    public static String showAddServerInstanceWizard(Map<String, String> props) {
+        Collection<Server> allServers = ServerRegistry.getInstance().getServers();
+        for (java.util.Iterator<Server> it = allServers.iterator(); it.hasNext();) {
+            Server server = it.next();
+            OptionalDeploymentManagerFactory factory = server.getOptionalFactory();
+            if (factory == null || factory.getAddInstanceIterator() == null) {
+                it.remove();
+            }
+        }
+        if (allServers.isEmpty()) {
+            // display the warning dialog - no server plugins
+            String close = NbBundle.getMessage(AddServerInstanceWizard.class, "LBL_NoServerPlugins_Close");
+            DialogDescriptor descriptor = new DialogDescriptor(
+                    NbBundle.getMessage(AddServerInstanceWizard.class, "LBL_NoServerPlugins_Text"),
+                    NbBundle.getMessage(AddServerInstanceWizard.class, "LBL_NoServerPlugins_Title"),
+                    true,
+                    new Object[] {close},
+                    close,
+                    DialogDescriptor.DEFAULT_ALIGN,
+                    null,
+                    null);
+
+            // TODO invoke plugin manager once API to do that will be available
+            DialogDisplayer.getDefault().notify(descriptor);
+            return null;
+        }
+            
+        AddServerInstanceWizard wizard = new AddServerInstanceWizard(props);
+        Dialog dialog = DialogDisplayer.getDefault().createDialog(wizard);
+        try {
+            dialog.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(AddServerInstanceWizard.class, "ACSD_Add_Server_Instance"));
+            dialog.setVisible(true);
+        } finally {
+            dialog.dispose();
+        }
+        if (wizard.getValue() == WizardDescriptor.FINISH_OPTION) {
+            Set instantiatedObjects = wizard.getInstantiatedObjects();
+            if (instantiatedObjects != null && instantiatedObjects.size() > 0) {
+                Object result = instantiatedObjects.iterator().next();
+                if (result instanceof InstanceProperties) {
+                    return ((InstanceProperties) result).getProperty(InstanceProperties.URL_ATTR);
+                } else {
+                    LOGGER.warning(wizard.iterator.getSelectedServer() + "'s add server instance wizard iterator should return " + // NOI18N
+                            "a Set containing new server instance InstanceProperties object as a result of the " + // NOI18N
+                            "WizardDescriptor.InstantiatingIterator.instantiate() method."); // NOI18N
+                    // there is an error in the server plugin, cannot return the added instance
+                    return null;
+                }
+            }
+        }
+        // the wizard was cancelled
+        return null;
+    }
+    
+    public void setErrorMessage(String message) {
+        putProperty(PROP_ERROR_MESSAGE, message);
+    }
+    
+    protected void updateState() {
+        super.updateState();
+        
+        String[] contentData = getContentData();
+        if (contentData != null) {
+            putProperty(PROP_CONTENT_DATA, contentData);
+            putProperty(PROP_CONTENT_SELECTED_INDEX, Integer.valueOf(getContentSelectedIndex()));
+        }
+    }
+
+    private ServerChooserPanel getChooser() {
+        if (chooser == null)
+            chooser = new ServerChooserPanel();
+
+        return chooser;
+    }
+    
+    private String[] getContentData() {
+        JComponent first;
+        String[] firstContentData;
+        
+        first = (JComponent)getChooser().getComponent();
+        firstContentData = (String[])first.getClientProperty(PROP_CONTENT_DATA);
+        
+        if (iterator.current().equals(getChooser())) {
+            return firstContentData;
+        } else {
+            JComponent component = (JComponent)iterator.current().getComponent();
+            String[] componentContentData = (String[])component.getClientProperty(PROP_CONTENT_DATA);
+            if (componentContentData == null)
+                return firstContentData;
+            
+            String[] contentData = new String[componentContentData.length + 1];
+            contentData[0] = firstContentData[0];
+            System.arraycopy(componentContentData, 0, contentData, 1, componentContentData.length);
+            return contentData;
+        }
+    }
+
+    private int getContentSelectedIndex() {
+        if (iterator.current().equals(getChooser())) {
+            return 0;
+        } else {
+            JComponent component = (JComponent)iterator.current().getComponent();
+            Integer componentIndex = (Integer)component.getClientProperty(PROP_CONTENT_SELECTED_INDEX);
+            if (componentIndex != null)
+                return componentIndex.intValue() + 1;
+            else
+                return 1;
+        }
+    }
+    
+    private static class AddServerInstanceWizardIterator implements WizardDescriptor.AsynchronousInstantiatingIterator {
+        private AddServerInstanceWizard wd;
+        public boolean showingChooser;
+        private WizardDescriptor.InstantiatingIterator iterator;
+        private HashMap iterators;
+        
+        public AddServerInstanceWizardIterator() {
+            showingChooser = true;
+            iterators = new HashMap();
+        }
+        
+        public void addChangeListener(ChangeListener l) {
+        }
+        
+        public WizardDescriptor.Panel current() {
+            if (showingChooser)
+                return wd.getChooser();
+            else
+                if (iterator != null)
+                    return iterator.current();
+                else
+                    return null;
+        }
+        
+        public boolean hasNext() {
+            if (showingChooser)
+                return true;
+            else
+                if (iterator != null)
+                    return iterator.hasNext();
+                else
+                    return false;
+        }
+        
+        public boolean hasPrevious() {
+            if (showingChooser)
+                return false;
+            else
+                return true;
+        }
+        
+        public String name() {
+            return null;
+        }
+        
+        public void nextPanel() {
+            if (iterator == null)
+                iterator = getServerIterator();
+            else {
+                if (!showingChooser)
+                    iterator.nextPanel();
+            }
+            showingChooser = false;
+        }
+        
+        public void previousPanel() {
+            if (iterator.hasPrevious())
+                iterator.previousPanel();
+            else {
+                showingChooser = true;
+                iterator = null;
+            }
+        }
+        
+        public void removeChangeListener(ChangeListener l) {
+        }
+        
+        public void uninitialize(WizardDescriptor wizard) {
+        }
+
+        public void initialize(WizardDescriptor wizard) {
+            wd = (AddServerInstanceWizard)wizard;
+            
+            JComponent chooser = (JComponent)wd.getChooser().getComponent();
+            chooser.putClientProperty(PROP_CONTENT_DATA, new String[] { 
+                NbBundle.getMessage(AddServerInstanceWizard.class, "LBL_ASIW_ChooseServer"),
+                NbBundle.getMessage(AddServerInstanceWizard.class, "LBL_ASIW_Ellipsis")
+            });
+        }
+
+        public java.util.Set instantiate() throws java.io.IOException {
+            if (iterator != null) {
+                return iterator.instantiate();
+            }
+            else
+                return null;
+        }
+        
+        private WizardDescriptor.InstantiatingIterator getServerIterator() {
+            Server server = getSelectedServer();
+            if (server == null)
+                return null;
+            
+            WizardDescriptor.InstantiatingIterator iterator = (WizardDescriptor.InstantiatingIterator)iterators.get(server);
+            if (iterator != null)
+                return iterator;
+            
+            OptionalDeploymentManagerFactory factory = server.getOptionalFactory();
+            if (factory != null) {
+                iterator = factory.getAddInstanceIterator();
+                iterator.initialize(wd);
+                iterators.put(server, iterator);
+                return iterator;
+            }
+            else
+                return null;
+        }
+        
+        public Server getSelectedServer() {
+            return (Server)wd.getProperty(PROP_SERVER);
+        }
+    }  
+}

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+LBL_ASIW_Title=Add Server Instance
+LBL_ASIW_TitleFormat={0}
+
+LBL_ASIW_ChooseServer=Choose Server
+LBL_ASIW_Ellipsis=...
+
+LBL_SCV_Name=Choose Server
+
+LBL_SCV_Server=&Server\:
+
+LBL_SCV_DisplayName=&Name\:
+
+MSG_SCV_ChooseServer=Choose a server
+MSG_SCV_DisplayName=Enter the server instance name
+MSG_SCV_DisplayNameExists=A server instance with this name already exists
+
+A11Y_SCV_NAME=Server
+A11Y_SCV_DESC=Choose the server type
+
+A11Y_SCV_NAME_Server=Server
+A11Y_SCV_DESC_Server=Choose the server type you want to add
+
+A11Y_SCV_NAME_DisplayName=Display Name
+A11Y_SCV_DESC_DisplayName=Choose the name under which the new server will be displayed
+
+ACSD_Add_Server_Instance=Add server instance wizard
+
+LBL_NoServerPlugins_Title=Add Server
+LBL_NoServerPlugins_Text=<html><strong>No server plugins are installed in the IDE</strong><br>\
+The IDE needs a server plugin (e.g. GlassFish plugin) to enable registering<br>\
+and using a server. Use Plugins Manager to install server plugins.</html>
+LBL_NoServerPlugins_Close=Close

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ui/wizard/ServerChooserPanel.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ui/wizard/ServerChooserPanel.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.j2ee.deployment.impl.ui.wizard;
+
+import java.awt.Component;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import org.openide.WizardDescriptor;
+import org.openide.util.HelpCtx;
+
+/**
+ *
+ * @author Andrei Badea
+ */
+class ServerChooserPanel implements WizardDescriptor.Panel, ChangeListener {
+    private final List listeners = new ArrayList();
+    private ServerChooserVisual component;
+
+    public ServerChooserPanel() {
+    }
+
+    public Component getComponent() {
+        if (component == null) { 
+            component = new ServerChooserVisual();
+            component.addChangeListener(this);
+        }
+        return component;
+    }
+
+    public HelpCtx getHelp() {
+        return HelpCtx.DEFAULT_HELP;
+    }
+
+    public void readSettings(Object settings) {
+        getVisual().read((AddServerInstanceWizard)settings);
+    }
+
+    public void storeSettings(Object settings) {
+        getVisual().store((AddServerInstanceWizard)settings);
+    }
+
+    public boolean isValid() {
+        return getVisual().hasValidData();
+    }
+
+    public void addChangeListener(ChangeListener l) {
+        synchronized (listeners) {
+            listeners.add(l);
+        }
+    }
+
+    public void removeChangeListener(ChangeListener l) {
+        synchronized (listeners) {
+            listeners.remove(l);
+        }
+    }
+
+    public void stateChanged(ChangeEvent event) {
+        fireChange(event);
+    }
+
+    private void fireChange(ChangeEvent event) {
+        ArrayList tempList;
+
+        synchronized (listeners) {
+            tempList = new ArrayList(listeners);
+        }
+
+        Iterator iter = tempList.iterator();
+        while (iter.hasNext())
+            ((ChangeListener)iter.next()).stateChanged(event);
+    }
+
+    private ServerChooserVisual getVisual() {
+        return (ServerChooserVisual)getComponent();
+    }
+}

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ui/wizard/ServerChooserVisual.form
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ui/wizard/ServerChooserVisual.form
@@ -1,0 +1,152 @@
+<?xml version="1.1" encoding="UTF-8" ?>
+
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<Form version="1.3" maxVersion="1.3" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
+  <Properties>
+    <Property name="name" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+      <ResourceString bundle="org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties" key="LBL_SCV_Name" replaceFormat="org.openide.util.NbBundle.getBundle({sourceFileName}.class).getString(&quot;{key}&quot;)"/>
+    </Property>
+  </Properties>
+  <AccessibilityProperties>
+    <Property name="AccessibleContext.accessibleName" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+      <ResourceString bundle="org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties" key="A11Y_SCV_NAME" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+    </Property>
+    <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+      <ResourceString bundle="org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties" key="A11Y_SCV_DESC" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+    </Property>
+  </AccessibilityProperties>
+  <AuxValues>
+    <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
+    <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="1"/>
+    <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
+    <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
+  </AuxValues>
+
+  <Layout>
+    <DimensionLayout dim="0">
+      <Group type="103" groupAlignment="0" attributes="0">
+          <Group type="102" attributes="0">
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="displayNameEditField" pref="375" max="32767" attributes="0"/>
+                  <Component id="jScrollPane1" alignment="0" pref="375" max="32767" attributes="0"/>
+              </Group>
+          </Group>
+      </Group>
+    </DimensionLayout>
+    <DimensionLayout dim="1">
+      <Group type="103" groupAlignment="0" attributes="0">
+          <Group type="102" alignment="0" attributes="0">
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+                  <Component id="jScrollPane1" pref="202" max="32767" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="displayNameEditField" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+          </Group>
+      </Group>
+    </DimensionLayout>
+  </Layout>
+  <SubComponents>
+    <Component class="javax.swing.JLabel" name="jLabel1">
+      <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="serverListBox"/>
+        </Property>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties" key="LBL_SCV_Server" replaceFormat="org.openide.util.NbBundle.getBundle({sourceFileName}.class).getString(&quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+      </AuxValues>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel2">
+      <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="displayNameEditField"/>
+        </Property>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties" key="LBL_SCV_DisplayName" replaceFormat="org.openide.util.NbBundle.getBundle({sourceFileName}.class).getString(&quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+      </AuxValues>
+    </Component>
+    <Component class="javax.swing.JTextField" name="displayNameEditField">
+      <AccessibilityProperties>
+        <Property name="AccessibleContext.accessibleName" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties" key="A11Y_SCV_NAME_DisplayName" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+        <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties" key="A11Y_SCV_DESC_DisplayName" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </AccessibilityProperties>
+      <Events>
+        <EventHandler event="keyReleased" listener="java.awt.event.KeyListener" parameters="java.awt.event.KeyEvent" handler="displayNameEditFieldKeyReleased"/>
+      </Events>
+    </Component>
+    <Container class="javax.swing.JScrollPane" name="jScrollPane1">
+      <AuxValues>
+        <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
+      </AuxValues>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+      <SubComponents>
+        <Component class="javax.swing.JList" name="serverListBox">
+          <Properties>
+            <Property name="model" type="javax.swing.ListModel" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="new ServerModel()" type="code"/>
+            </Property>
+          </Properties>
+          <AccessibilityProperties>
+            <Property name="AccessibleContext.accessibleName" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties" key="A11Y_SCV_NAME_Server" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+            </Property>
+            <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="org/netbeans/modules/j2ee/deployment/impl/ui/wizard/Bundle.properties" key="A11Y_SCV_DESC_Server" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+            </Property>
+          </AccessibilityProperties>
+          <Events>
+            <EventHandler event="valueChanged" listener="javax.swing.event.ListSelectionListener" parameters="javax.swing.event.ListSelectionEvent" handler="serverListBoxValueChanged"/>
+          </Events>
+        </Component>
+      </SubComponents>
+    </Container>
+  </SubComponents>
+</Form>

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ui/wizard/ServerChooserVisual.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/ui/wizard/ServerChooserVisual.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.j2ee.deployment.impl.ui.wizard;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import javax.swing.ComboBoxModel;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import org.netbeans.modules.j2ee.deployment.impl.Server;
+import org.netbeans.modules.j2ee.deployment.impl.ServerInstance;
+import org.netbeans.modules.j2ee.deployment.impl.ServerRegistry;
+import org.netbeans.modules.j2ee.deployment.plugins.spi.OptionalDeploymentManagerFactory;
+import org.openide.util.NbBundle;
+
+/**
+ *
+ * @author  Andrei Badea
+ */
+public class ServerChooserVisual extends javax.swing.JPanel {
+    private final List listeners = new ArrayList();
+    private AddServerInstanceWizard wizard;
+    private HashMap displayNames;
+    private boolean updatingDisplayName = false;
+    
+    public ServerChooserVisual() {
+        displayNames = new HashMap();
+        initComponents();
+        
+        ServerAdapter selected = (ServerAdapter) ((ComboBoxModel)serverListBox.getModel()).getSelectedItem();
+        serverListBox.setSelectedValue(selected, true);
+        if (selected != null)
+            fillDisplayName(selected.getServer());
+        
+        displayNameEditField.getDocument().addDocumentListener(new DocumentListener() {
+            public void insertUpdate(DocumentEvent e) {
+                displayNameEditFieldUpdate();
+            }
+            
+            public void removeUpdate(DocumentEvent e) {
+                displayNameEditFieldUpdate();
+            }
+            
+            public void changedUpdate(DocumentEvent e) {
+                displayNameEditFieldUpdate();
+            }
+        });
+    }
+    
+    public void addChangeListener(ChangeListener l) {
+        synchronized (listeners) {
+            listeners.add(l);
+        }
+    }
+    
+    public void removeChangeListener(ChangeListener l) {
+        synchronized (listeners) {
+            listeners.remove(l);
+        }
+    }
+    
+    public void read(AddServerInstanceWizard wizard) {
+        if (this.wizard == null)
+            this.wizard = wizard;
+        
+        Object prop = wizard.getProperty(AddServerInstanceWizard.PROP_DISPLAY_NAME);
+        if (prop != null)
+            displayNameEditField.setText((String)prop);
+    }
+    
+    public void store(AddServerInstanceWizard wizard) {
+        wizard.putProperty(AddServerInstanceWizard.PROP_DISPLAY_NAME, displayNameEditField.getText());
+        Object selectedItem = serverListBox.getSelectedValue();
+        if (selectedItem != null) {
+            wizard.putProperty(AddServerInstanceWizard.PROP_SERVER, ((ServerAdapter)selectedItem).getServer());
+        }
+    }
+
+    public boolean hasValidData() {
+        boolean result = isServerValid() && isDisplayNameValid();
+        if (result) {
+            wizard.setErrorMessage(null);
+        }
+        return result;
+    }
+
+    private boolean isServerValid() {
+        boolean result = serverListBox.getSelectedValue() != null;
+        if (!result)
+            wizard.setErrorMessage(NbBundle.getMessage(ServerChooserVisual.class, "MSG_SCV_ChooseServer"));
+        return result;
+    }
+    
+    private boolean isDisplayNameValid() {
+        String trimmed = displayNameEditField.getText().trim();
+        boolean result;
+        
+        if (trimmed.length() <= 0) {
+            wizard.setErrorMessage(NbBundle.getMessage(ServerChooserVisual.class, "MSG_SCV_DisplayName"));
+            return false;
+        }
+        
+        if (getServerInstance(trimmed) != null) {
+            wizard.setErrorMessage(NbBundle.getMessage(ServerChooserVisual.class, "MSG_SCV_DisplayNameExists"));
+            return false;
+        }
+        
+        return true;
+    }
+    
+    private ServerInstance getServerInstance(String displayName) {
+        Iterator iter = ServerRegistry.getInstance().getInstances().iterator();
+        while (iter.hasNext()) {
+            ServerInstance instance = (ServerInstance)iter.next();
+            if (instance.getDisplayName() != null
+                    && instance.getDisplayName().equalsIgnoreCase(displayName)) {
+                return instance;
+            }
+        }
+        return null;
+    }
+    
+    private void displayNameEditFieldUpdate() {
+        if (!updatingDisplayName) {
+            fireChange();
+        }
+    }
+    
+    private void fireChange() {
+        ChangeEvent event = new ChangeEvent(this);
+        ArrayList tempList;
+
+        synchronized (listeners) {
+            tempList = new ArrayList(listeners);
+        }
+
+        Iterator iter = tempList.iterator();
+        while (iter.hasNext())
+            ((ChangeListener)iter.next()).stateChanged(event);
+    }   
+    
+    private String generateDisplayName(Server server) {
+        String name;
+        int count = 0;
+        
+        do {
+            name = server.getDisplayName();
+            if (count != 0)
+                name += " (" + String.valueOf(count) + ")";
+            
+            count++;
+        } while (getServerInstance(name) != null);
+        
+        return name;
+    }
+    
+    private void fillDisplayName(Server server) {
+        String name = (String)displayNames.get(server);
+        if (name == null)
+            name = generateDisplayName(server);
+        updatingDisplayName = true; //disable firing from setText
+        displayNameEditField.setText(name);
+        updatingDisplayName = false;
+        fireChange();
+    }
+    
+    /** This method is called from within the constructor to
+     * initialize the form.
+     * WARNING: Do NOT modify this code. The content of this method is
+     * always regenerated by the Form Editor.
+     */
+    // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
+    private void initComponents() {
+
+        jLabel1 = new javax.swing.JLabel();
+        jLabel2 = new javax.swing.JLabel();
+        displayNameEditField = new javax.swing.JTextField();
+        jScrollPane1 = new javax.swing.JScrollPane();
+        serverListBox = new javax.swing.JList();
+
+        setName(org.openide.util.NbBundle.getBundle(ServerChooserVisual.class).getString("LBL_SCV_Name")); // NOI18N
+
+        jLabel1.setLabelFor(serverListBox);
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getBundle(ServerChooserVisual.class).getString("LBL_SCV_Server")); // NOI18N
+
+        jLabel2.setLabelFor(displayNameEditField);
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel2, org.openide.util.NbBundle.getBundle(ServerChooserVisual.class).getString("LBL_SCV_DisplayName")); // NOI18N
+
+        displayNameEditField.addKeyListener(new java.awt.event.KeyAdapter() {
+            public void keyReleased(java.awt.event.KeyEvent evt) {
+                displayNameEditFieldKeyReleased(evt);
+            }
+        });
+
+        serverListBox.setModel(new ServerModel());
+        serverListBox.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
+            public void valueChanged(javax.swing.event.ListSelectionEvent evt) {
+                serverListBoxValueChanged(evt);
+            }
+        });
+        jScrollPane1.setViewportView(serverListBox);
+        serverListBox.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(ServerChooserVisual.class, "A11Y_SCV_NAME_Server")); // NOI18N
+        serverListBox.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(ServerChooserVisual.class, "A11Y_SCV_DESC_Server")); // NOI18N
+
+        javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
+        this.setLayout(layout);
+        layout.setHorizontalGroup(
+            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(layout.createSequentialGroup()
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jLabel1)
+                    .addComponent(jLabel2))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(displayNameEditField, javax.swing.GroupLayout.DEFAULT_SIZE, 375, Short.MAX_VALUE)
+                    .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 375, Short.MAX_VALUE)))
+        );
+        layout.setVerticalGroup(
+            layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+            .addGroup(layout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jLabel1)
+                    .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 202, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel2)
+                    .addComponent(displayNameEditField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addContainerGap())
+        );
+
+        displayNameEditField.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(ServerChooserVisual.class, "A11Y_SCV_NAME_DisplayName")); // NOI18N
+        displayNameEditField.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(ServerChooserVisual.class, "A11Y_SCV_DESC_DisplayName")); // NOI18N
+
+        getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(ServerChooserVisual.class, "A11Y_SCV_NAME")); // NOI18N
+        getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(ServerChooserVisual.class, "A11Y_SCV_DESC")); // NOI18N
+    }// </editor-fold>//GEN-END:initComponents
+
+private void serverListBoxValueChanged(javax.swing.event.ListSelectionEvent evt) {//GEN-FIRST:event_serverListBoxValueChanged
+       if (!evt.getValueIsAdjusting()) {
+           ServerAdapter adapter = (ServerAdapter) serverListBox.getSelectedValue();
+           if (adapter != null) {
+               Server server = adapter.getServer();
+               if (server != null) {
+                   fillDisplayName(server);
+               }
+           } else {
+               fireChange();
+           }
+       }
+}//GEN-LAST:event_serverListBoxValueChanged
+
+    private void displayNameEditFieldKeyReleased(java.awt.event.KeyEvent evt) {//GEN-FIRST:event_displayNameEditFieldKeyReleased
+        ServerAdapter serverAdapter = (ServerAdapter) serverListBox.getSelectedValue();
+        if (serverAdapter != null) {
+            displayNames.put(serverAdapter.getServer(), displayNameEditField.getText());
+        }
+    }//GEN-LAST:event_displayNameEditFieldKeyReleased
+    
+    
+    // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JTextField displayNameEditField;
+    private javax.swing.JLabel jLabel1;
+    private javax.swing.JLabel jLabel2;
+    private javax.swing.JScrollPane jScrollPane1;
+    private javax.swing.JList serverListBox;
+    // End of variables declaration//GEN-END:variables
+    
+    private static class ServerModel implements ComboBoxModel {
+        private List servers;
+        private ServerAdapter selected;
+                
+        public ServerModel() {
+            servers = new ArrayList();
+            Collection allServers = ServerRegistry.getInstance().getServers();
+            Iterator iter = allServers.iterator();
+            while (iter.hasNext()) {
+                Server server = (Server)iter.next();
+                OptionalDeploymentManagerFactory factory = server.getOptionalFactory();
+                if (factory != null && factory.getAddInstanceIterator() != null) {
+                    ServerAdapter serverAdapter = new ServerAdapter(server);
+                    servers.add(serverAdapter);
+                    String n = server.getShortName();
+                    if (null != n && n.startsWith("gfv3")) {
+                        selected = serverAdapter;
+                    }
+                    if (null == selected && "J2EE".equals(n)) { // NOI18N
+                        selected = serverAdapter;
+                    }
+                }
+            }
+            Collections.sort(servers);
+            if (selected == null) {
+                selected = (servers.size() > 0) ? (ServerAdapter)servers.get(0) : null;
+            }
+        }
+        
+        public Object getElementAt(int index) {
+            return servers.get(index);
+        }
+
+        public void removeListDataListener(javax.swing.event.ListDataListener l) {
+        }
+
+        public void addListDataListener(javax.swing.event.ListDataListener l) {
+        }
+
+        public int getSize() {
+            return servers.size();
+        }
+        
+        public Object getSelectedItem() {
+            return selected;
+        }
+        
+        public void setSelectedItem(Object anItem) {
+            selected = (ServerAdapter)anItem;
+        }
+    }
+    
+    private static class ServerAdapter implements Comparable {
+        private Server server;
+        
+        public ServerAdapter(Server server) {
+            this.server = server;
+        }
+        
+        public Server getServer() {
+            return server;
+        }
+        
+        public String toString() {
+            return server.getDisplayName();
+        }
+        
+        public int compareTo(Object o) {
+            return toString().compareTo(o.toString());
+        }
+    }
+}

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/Bundle.properties
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/Bundle.properties
@@ -133,6 +133,10 @@ MSG_RecommendationSetJdk7=<html>Note: JDK 7 will be used for Java EE 7 projects.
 MSG_RecommendationSetSourceLevel7=<html>Note: Source Level 7 will be set for Java EE 7 project.
 MSG_RecommendationJDK7=<html>Recommendation: JDK 7 should be used for Java EE 7 projects.
 
+MSG_RecommendationSetJdk8=<html>Note: JDK 8 will be used for Java EE 8 projects.
+MSG_RecommendationSetSourceLevel8=<html>Note: Source Level 8 will be set for Java EE 8 project.
+MSG_RecommendationJDK8=<html>Recommendation: JDK 8 should be used for Java EE 8 projects.
+
 #Import wizard - existing sources
 LBL_IW_ImportTitle=Add Existing Sources
 LBL_IW_LocationSrcDesc=<html>Select the folder that contains all the sources for your application.</html>

--- a/enterprise/payara.eecommon/nbproject/project.xml
+++ b/enterprise/payara.eecommon/nbproject/project.xml
@@ -150,6 +150,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.payara.micro</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>0-1</release-version>
+                        <specification-version>2.0</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.projectapi</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/enterprise/payara.micro/nbproject/project.xml
+++ b/enterprise/payara.micro/nbproject/project.xml
@@ -289,7 +289,9 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
-            <public-packages/>
+            <public-packages>
+                <package>org.netbeans.modules.fish.payara.micro.plugin</package>
+            </public-packages>
         </data>
     </configuration>
 </project>

--- a/ide/server/nbproject/project.xml
+++ b/ide/server/nbproject/project.xml
@@ -156,8 +156,6 @@
                 <package>org.netbeans.api.server</package>
                 <package>org.netbeans.api.server.properties</package>
                 <package>org.netbeans.spi.server</package>
-                <package>org.netbeans.modules.server</package>
-                <package>org.netbeans.modules.server.ui.wizard</package>
             </public-packages>
         </data>
     </configuration>

--- a/ide/server/src/org/netbeans/api/server/ServerInstance.java
+++ b/ide/server/src/org/netbeans/api/server/ServerInstance.java
@@ -133,17 +133,4 @@ public final class ServerInstance implements Lookup.Provider {
         }
         return Lookup.EMPTY;
     }
-
-    /**
-     * Returns property value to which the specified <code>key</code> is mapped,
-     * or <code>null</code> if this map contains no mapping for the
-     * <code>key</code>.
-     *
-     * @param key server property <code>key</code>.
-     * @return server property value or <code>null</code> if no value with given
-     * <code>key</code> is stored.
-     */
-    public String getProperty(String key) {
-        return delegate.getProperty(key);
-    }
 }

--- a/ide/server/src/org/netbeans/modules/server/ui/wizard/AddServerInstanceWizard.java
+++ b/ide/server/src/org/netbeans/modules/server/ui/wizard/AddServerInstanceWizard.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,19 +77,12 @@ public class AddServerInstanceWizard extends WizardDescriptor {
     private ServerRegistry registry;
 
     private AddServerInstanceWizard(ServerRegistry registry) {
-        this(registry, Collections.<String, String>emptyMap());
-    }
-
-    private AddServerInstanceWizard(ServerRegistry registry, Map<String, String> props) {
         this(new AddServerInstanceWizardIterator(registry));
         this.registry = registry;
-
+        
         putProperty(PROP_AUTO_WIZARD_STYLE, Boolean.TRUE);
         putProperty(PROP_CONTENT_DISPLAYED, Boolean.TRUE);
         putProperty(PROP_CONTENT_NUMBERED, Boolean.TRUE);
-        for (Map.Entry<String, String> entry : props.entrySet()) {
-            putProperty(entry.getKey(), entry.getValue());
-        }
 
         if (registry.isCloud()) {
             setTitle(NbBundle.getMessage(AddServerInstanceWizard.class, "LBL_ACIW_Title"));
@@ -113,23 +105,11 @@ public class AddServerInstanceWizard extends WizardDescriptor {
         return showAddServerInstanceWizard(ServerRegistry.getInstance());
     }
 
-    public static ServerInstance showAddServerInstanceWizard(Map<String, String> props) {
-        return showAddServerInstanceWizard(ServerRegistry.getInstance(), props);
-    }
-
     public static ServerInstance showAddCloudInstanceWizard() {
         return showAddServerInstanceWizard(ServerRegistry.getCloudInstance());
     }
 
-    public static ServerInstance showAddCloudInstanceWizard(Map<String, String> props) {
-        return showAddServerInstanceWizard(ServerRegistry.getCloudInstance(), props);
-    }
-
     private static ServerInstance showAddServerInstanceWizard(ServerRegistry registry) {
-        return showAddServerInstanceWizard(registry, Collections.<String, String>emptyMap());
-    }
-
-    private static ServerInstance showAddServerInstanceWizard(ServerRegistry registry, Map<String, String> props) {
         Collection<? extends ServerWizardProvider> providers = Lookups.forPath(
                 registry.getPath()).lookupAll(ServerWizardProvider.class);
         // this will almost never happen if this module will be autoload
@@ -196,7 +176,7 @@ public class AddServerInstanceWizard extends WizardDescriptor {
             }
         }
 
-        AddServerInstanceWizard wizard = new AddServerInstanceWizard(registry, props);
+        AddServerInstanceWizard wizard = new AddServerInstanceWizard(registry);
 
         Dialog dialog = DialogDisplayer.getDefault().createDialog(wizard);
         try {

--- a/ide/server/src/org/netbeans/spi/server/ServerInstanceImplementation.java
+++ b/ide/server/src/org/netbeans/spi/server/ServerInstanceImplementation.java
@@ -86,15 +86,4 @@ public interface ServerInstanceImplementation {
      */
     boolean isRemovable();
 
-    /**
-     * Returns property value to which the specified <code>key</code> is mapped,
-     * or <code>null</code> if this map contains no mapping for the
-     * <code>key</code>.
-     *
-     * @param key server property <code>key</code>.
-     * @return server property value or <code>null</code> if no value with given
-     * <code>key</code> is stored.
-     */
-    public String getProperty(String key);
-
 }

--- a/ide/server/test/unit/src/org/netbeans/modules/server/test/MockInstanceImplementation.java
+++ b/ide/server/test/unit/src/org/netbeans/modules/server/test/MockInstanceImplementation.java
@@ -116,10 +116,4 @@ public final class MockInstanceImplementation implements ServerInstanceImplement
     public ServerInstance getServerInstance() {
         return serverInstance;
     }
-
-    @Override
-    public String getProperty(String key) {
-        return serverInstance.getProperty(key);
-    }
-
 }


### PR DESCRIPTION
Reverted the previous PR https://github.com/apache/netbeans/pull/1347 which causes unavailability of `org.netbeans.modules.cloud.amazon.ui.serverplugin.AmazonJ2EEServerWizardComponent` during maven web application creation.

And filtered the server entries with different URI fragment based on unique J2eePlatformFactory e.g [gfv3ee6, gfv5ee8] & [pfv3ee6, pfv4ee7, pfvee8].