### PR TITLE
[NETBEANS-2910] Suggest using brackets for accessing arrays instead of curly braces

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/ArrayAccess.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/ArrayAccess.java
@@ -19,12 +19,15 @@
 package org.netbeans.modules.php.editor.parser.astnodes;
 
 /**
- * Holds a variable and an index that point to array or hashtable
- * <pre>e.g. $a[],
+ * Holds a variable and an index that point to array or hashtable. e.g.
+ * <pre>
+ * $a[],
  * $a[1],
  * $a[$b],
- * $a{'name'}
+ * $a{'name'} // deprecate since PHP 7.4
  * </pre>
+ *
+ * @see https://wiki.php.net/rfc/deprecate_curly_braces_array_access
  */
 public class ArrayAccess extends Variable {
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/ArrayDimension.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/ArrayDimension.java
@@ -19,7 +19,20 @@
 package org.netbeans.modules.php.editor.parser.astnodes;
 
 /**
+ * Represents array dimension. e.g.
+ * <pre>
+ * [1],
+ * ["test"],
+ * {1},
+ * {'key'}
+ * </pre>
  *
+ * Used classes:
+ * {@link ArrayAccess}, {@link ExpressionArrayAccess}, {@link DereferencedArrayAccess}
+ *
+ * Curly brace syntax ({}) is deprecated since PHP 7.4.
+ *
+ * @see https://wiki.php.net/rfc/deprecate_curly_braces_array_access
  * @author Ondrej Brejla <obrejla@netbeans.org>
  */
 public class ArrayDimension extends Expression {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/resources/layer.xml
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/resources/layer.xml
@@ -335,6 +335,7 @@
                     <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.php.editor.verification.Bundle"/>
                     <file name="org-netbeans-modules-php-editor-verification-AccidentalAssignmentHint.instance"/>
                     <file name="org-netbeans-modules-php-editor-verification-AmbiguousComparisonHint.instance"/>
+                    <file name="org-netbeans-modules-php-editor-verification-ArrayDimensionSyntaxSuggestionHint.instance"/>
                     <folder name="braces">
                         <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.php.editor.verification.Bundle"/>
                         <file name="org-netbeans-modules-php-editor-verification-BracesHint$DoWhileBracesHint.instance"/>

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/ArrayDimensionSyntaxSuggestionHint.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/ArrayDimensionSyntaxSuggestionHint.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.verification;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.text.BadLocationException;
+import org.netbeans.api.editor.document.LineDocumentUtils;
+import org.netbeans.editor.BaseDocument;
+import org.netbeans.modules.csl.api.EditList;
+import org.netbeans.modules.csl.api.Hint;
+import org.netbeans.modules.csl.api.HintFix;
+import org.netbeans.modules.csl.api.OffsetRange;
+import org.netbeans.modules.csl.spi.support.CancelSupport;
+import org.netbeans.modules.php.editor.parser.PHPParseResult;
+import org.netbeans.modules.php.editor.parser.astnodes.ArrayAccess;
+import org.netbeans.modules.php.editor.parser.astnodes.ArrayDimension;
+import org.netbeans.modules.php.editor.parser.astnodes.DereferencedArrayAccess;
+import org.netbeans.modules.php.editor.parser.astnodes.ExpressionArrayAccess;
+import org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultVisitor;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.NbBundle;
+
+/**
+ * Suggest using brackets for accessing arrays instead of curly braces. {} (e.g.
+ * {@code $array{0}}) syntax is deprecated since PHP 7.4.
+ *
+ * @see https://wiki.php.net/rfc/deprecate_curly_braces_array_access
+ */
+public class ArrayDimensionSyntaxSuggestionHint extends HintRule {
+
+    private static final String HINT_ID = "Array.Dimension.Syntax.Suggestion.Hint"; // NOI18N
+    private static final Logger LOGGER = Logger.getLogger(ArrayDimensionSyntaxSuggestionHint.class.getName());
+
+    @Override
+    public String getId() {
+        return HINT_ID;
+    }
+
+    @Override
+    @NbBundle.Messages("ArrayDimensionSyntaxSuggestion.Description=Curly brace syntax(\"{}\") for accessing array elements is deprecated since PHP 7.4. Instead, suggest using bracket syntax(\"[]\").")
+    public String getDescription() {
+        return Bundle.ArrayDimensionSyntaxSuggestion_Description();
+    }
+
+    @Override
+    @NbBundle.Messages("ArrayDimensionSyntaxSuggestion.DisplayName=Array Dimension Syntax")
+    public String getDisplayName() {
+        return Bundle.ArrayDimensionSyntaxSuggestion_DisplayName();
+    }
+
+    @Override
+    public boolean getDefaultEnabled() {
+        return false;
+    }
+
+    @Override
+    public void invoke(PHPRuleContext context, List<Hint> result) {
+        PHPParseResult phpParseResult = (PHPParseResult) context.parserResult;
+        if (phpParseResult.getProgram() == null) {
+            return;
+        }
+        if (CancelSupport.getDefault().isCancelled()) {
+            return;
+        }
+        final BaseDocument doc = context.doc;
+        FileObject fileObject = phpParseResult.getSnapshot().getSource().getFileObject();
+        if (fileObject != null) {
+            CheckVisitor checkVisitor = new CheckVisitor(fileObject, this, doc);
+            phpParseResult.getProgram().accept(checkVisitor);
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            result.addAll(checkVisitor.getHints());
+        }
+    }
+
+    // for unit tests
+    boolean isFixAllEnabled() {
+        return true;
+    }
+
+    //~ Innser classes
+    private static final class CheckVisitor extends DefaultVisitor {
+
+        private final FileObject fileObject;
+        private final ArrayDimensionSyntaxSuggestionHint suggestion;
+        private final BaseDocument document;
+        private final List<FixInfo> fixInfos = new ArrayList<>();
+
+        public CheckVisitor(FileObject fileObject, ArrayDimensionSyntaxSuggestionHint suggestion, BaseDocument document) {
+            this.fileObject = fileObject;
+            this.suggestion = suggestion;
+            this.document = document;
+        }
+
+        @NbBundle.Messages("ArrayDimensionSyntaxSuggestion.Hint.Description=Curly brace syntax(\"{}\") is deprecated since PHP 7.4")
+        public List<Hint> getHints() {
+            List<Hint> hints = new ArrayList<>();
+            int originalLineIndex = 0;
+            for (FixInfo fixInfo : fixInfos) {
+                if (CancelSupport.getDefault().isCancelled()) {
+                    return Collections.emptyList();
+                }
+                if (document.getLength() > fixInfo.getOffsetRange().getStart()) {
+                    if (suggestion.isFixAllEnabled()) {
+                        try {
+                            // all
+                            int lineIndex = LineDocumentUtils.getLineIndex(document, fixInfo.getOffsetRange().getStart());
+                            if (originalLineIndex != lineIndex) {
+                                int lineStart = LineDocumentUtils.getLineStart(document, fixInfo.getOffsetRange().getStart());
+                                int lineEnd = LineDocumentUtils.getLineEnd(document, fixInfo.getOffsetRange().getStart());
+                                addHint(hints, new OffsetRange(lineStart, lineEnd), createAllFixes(fixInfos));
+                                originalLineIndex = lineIndex;
+                            }
+                        } catch (BadLocationException ex) {
+                            String filePath = fileObject == null ? "no file" : FileUtil.toFile(fileObject).getAbsolutePath(); // NOI18N
+                            LOGGER.log(Level.WARNING, "Invalid offset: {0} {1}", new Object[]{ex.offsetRequested(), filePath}); // NOI18N
+                        }
+                    }
+                    addHint(hints, fixInfo.getOffsetRange(), createFixes(fixInfo));
+                }
+            }
+            return hints;
+        }
+
+        private void addHint(List<Hint> hints, OffsetRange offsetRange, List<HintFix> fixes) {
+            hints.add(new Hint(
+                    suggestion,
+                    Bundle.ArrayDimensionSyntaxSuggestion_Hint_Description(),
+                    fileObject,
+                    offsetRange,
+                    fixes,
+                    500
+            ));
+        }
+
+        private List<HintFix> createFixes(FixInfo fixInfo) {
+            List<HintFix> hintFixes = new ArrayList<>();
+            hintFixes.add(fixInfo.createFix(document));
+            return hintFixes;
+        }
+
+        private List<HintFix> createAllFixes(List<FixInfo> fixInfos) {
+            List<HintFix> hintFixes = new ArrayList<>();
+            ArrayAccessingSyntaxSuggestionFix fix = new ArrayAccessingSyntaxSuggestionFix(fixInfos, document, true);
+            hintFixes.add(fix);
+            return hintFixes;
+        }
+
+        @Override
+        public void visit(ArrayAccess node) {
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            processArrayDimension(node.getDimension());
+            super.visit(node);
+        }
+
+        @Override
+        public void visit(DereferencedArrayAccess node) {
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            processArrayDimension(node.getDimension());
+            super.visit(node);
+        }
+
+        @Override
+        public void visit(ExpressionArrayAccess node) {
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            processArrayDimension(node.getDimension());
+            super.visit(node);
+        }
+
+        private void processArrayDimension(ArrayDimension arrayDimension) {
+            if (arrayDimension.getType() == ArrayDimension.Type.VARIABLE_HASHTABLE) {
+                int startOffset = arrayDimension.getStartOffset();
+                int endOffset = arrayDimension.getEndOffset();
+                OffsetRange headRange = new OffsetRange(startOffset, startOffset + 1);
+                OffsetRange tailRange = new OffsetRange(endOffset - 1, endOffset);
+                fixInfos.add(new FixInfo(headRange, tailRange, new OffsetRange(startOffset, endOffset)));
+            }
+        }
+
+    }
+
+    private static final class FixInfo {
+
+        private final OffsetRange headRange;
+        private final OffsetRange tailRange;
+        private final OffsetRange offsetRange;
+
+        public FixInfo(OffsetRange headRange, OffsetRange tailRange, OffsetRange offsetRange) {
+            this.headRange = headRange;
+            this.tailRange = tailRange;
+            this.offsetRange = offsetRange;
+        }
+
+        public OffsetRange getHeadRange() {
+            return headRange;
+        }
+
+        public OffsetRange getTailRange() {
+            return tailRange;
+        }
+
+        public OffsetRange getOffsetRange() {
+            return offsetRange;
+        }
+
+        private HintFix createFix(BaseDocument document) {
+            return new ArrayAccessingSyntaxSuggestionFix(Collections.singletonList(this), document);
+        }
+
+    }
+
+    private static final class ArrayAccessingSyntaxSuggestionFix implements HintFix {
+
+        private final List<FixInfo> fixInfos;
+        private final BaseDocument document;
+        private final boolean isAll;
+
+        private ArrayAccessingSyntaxSuggestionFix(List<FixInfo> fixInfos, BaseDocument document) {
+            this(fixInfos, document, false);
+        }
+
+        private ArrayAccessingSyntaxSuggestionFix(List<FixInfo> fixInfos, BaseDocument document, boolean isAll) {
+            this.fixInfos = fixInfos;
+            this.document = document;
+            this.isAll = isAll;
+        }
+
+        @Override
+        @NbBundle.Messages({
+            "# {0} - array dimension",
+            "ArrayDimensionSyntaxSuggestion.Fix.Description=Use Bracket Syntax ({0})",
+            "ArrayDimensionSyntaxSuggestion.Fix.All.Description=Use Bracket Syntax (All)"
+        })
+        public String getDescription() {
+            if (isAll) {
+                return Bundle.ArrayDimensionSyntaxSuggestion_Fix_All_Description();
+            }
+            assert !fixInfos.isEmpty();
+            FixInfo fixInfo = fixInfos.get(0);
+            String arrayDimension = ""; // NOI18N
+            if (document.getLength() >= fixInfo.getOffsetRange().getEnd()) {
+                try {
+                    arrayDimension = document.getText(fixInfo.getOffsetRange().getStart(), fixInfo.getOffsetRange().getLength());
+                } catch (BadLocationException ex) {
+                    LOGGER.log(Level.WARNING, "Invalid offset: {0}", ex.offsetRequested()); // NOI18N
+                }
+            }
+            assert !arrayDimension.isEmpty();
+            return Bundle.ArrayDimensionSyntaxSuggestion_Fix_Description(arrayDimension);
+        }
+
+        @Override
+        public void implement() throws Exception {
+            EditList edits = new EditList(document);
+            for (FixInfo fixInfo : fixInfos) {
+                // don't format because there is a problem in the following case
+                // whitespace is added behind "]"
+                // $array{1}{2}{$test}; -> $array{1}[2] {$test};
+                OffsetRange headRange = fixInfo.getHeadRange();
+                edits.replace(headRange.getStart(), headRange.getLength(), "[", false, 0); // NOI18N
+                OffsetRange tailRange = fixInfo.getTailRange();
+                edits.replace(tailRange.getStart(), tailRange.getLength(), "]", false, 0); // NOI18N
+            }
+            edits.apply();
+        }
+
+        @Override
+        public boolean isSafe() {
+            return true;
+        }
+
+        @Override
+        public boolean isInteractive() {
+            return false;
+        }
+
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array[1];
+$array{1};
+$array{1}[2];
+$array{1}[2]{3};
+$array{1}{2}{"test"};
+$array{1}{2}{$test};
+$array{getIndex()};
+
+myFunction(){"test"};
+
+[1,2,3]{0};
+"string"{0};
+CONSTANT{1}{2};
+MyClass::CONSTANT{0};
+((string) $variable->something){0};
+($a){"test"};
+
+$test = "${$foo}";
+$test = "{$test}";

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces.php.testDeprecatedCurlyBraces.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces.php.testDeprecatedCurlyBraces.hints
@@ -1,0 +1,90 @@
+$array{1};
+      ----
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({1})
+$array{1}[2];
+      -------
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({1})
+$array{1}[2]{3};
+            ----
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({1})
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({3})
+$array{1}{2}{"test"};
+            ---------
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({1})
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({2})
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({"test"})
+$array{1}{2}{$test};
+            --------
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({1})
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({2})
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({$test})
+$array{getIndex()};
+      -------------
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({getIndex()})
+myFunction(){"test"};
+            ---------
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({"test"})
+[1,2,3]{0};
+       ----
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({0})
+"string"{0};
+        ----
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({0})
+CONSTANT{1}{2};
+           ----
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({1})
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({2})
+MyClass::CONSTANT{0};
+                 ----
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({0})
+((string) $variable->something){0};
+                               ----
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({0})
+($a){"test"};
+    ---------
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax (All)
+HINT:Curly brace syntax("{}") is deprecated since PHP 7.4
+FIX:Use Bracket Syntax ({"test"})

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces.php.testDeprecatedCurlyBracesFixAll.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces.php.testDeprecatedCurlyBracesFixAll.fixed
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array[1];
+$array[1];
+$array[1][2];
+$array[1][2][3];
+$array[1][2]["test"];
+$array[1][2][$test];
+$array[getIndex()];
+
+myFunction()["test"];
+
+[1,2,3][0];
+"string"[0];
+CONSTANT[1][2];
+MyClass::CONSTANT[0];
+((string) $variable->something)[0];
+($a)["test"];
+
+$test = "${$foo}";
+$test = "{$test}";

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_01.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_01.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+$array{1};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_01.php.testDeprecatedCurlyBracesFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_01.php.testDeprecatedCurlyBracesFix_01.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+$array[1];

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_02.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_02.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+$array{1}{2}{"test"};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_02.php.testDeprecatedCurlyBracesFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_02.php.testDeprecatedCurlyBracesFix_02.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+$array{1}{2}["test"];

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_03.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_03.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+$array{1}{2}{$test};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_03.php.testDeprecatedCurlyBracesFix_03a.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_03.php.testDeprecatedCurlyBracesFix_03a.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+$array[1]{2}{$test};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_03.php.testDeprecatedCurlyBracesFix_03b.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_03.php.testDeprecatedCurlyBracesFix_03b.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+$array{1}[2]{$test};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_03.php.testDeprecatedCurlyBracesFix_03c.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_03.php.testDeprecatedCurlyBracesFix_03c.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+$array{1}{2}[$test];

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_04.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_04.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+$array{getIndex()};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_04.php.testDeprecatedCurlyBracesFix_04.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_04.php.testDeprecatedCurlyBracesFix_04.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+$array[getIndex()];

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_05.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_05.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+myFunction(){"test"};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_05.php.testDeprecatedCurlyBracesFix_05.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_05.php.testDeprecatedCurlyBracesFix_05.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+myFunction()["test"];

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_06.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_06.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+[1,2,3]{0};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_06.php.testDeprecatedCurlyBracesFix_06.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_06.php.testDeprecatedCurlyBracesFix_06.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+[1,2,3][0];

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_07.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_07.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+"string"{0};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_07.php.testDeprecatedCurlyBracesFix_07.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_07.php.testDeprecatedCurlyBracesFix_07.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+"string"[0];

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_08.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_08.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+CONSTANT{1}{2};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_08.php.testDeprecatedCurlyBracesFix_08.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_08.php.testDeprecatedCurlyBracesFix_08.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+CONSTANT{1}[2];

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_09.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_09.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+MyClass::CONSTANT{0};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_09.php.testDeprecatedCurlyBracesFix_09.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_09.php.testDeprecatedCurlyBracesFix_09.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+MyClass::CONSTANT[0];

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_10.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_10.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+((string) $variable->something){0};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_10.php.testDeprecatedCurlyBracesFix_10.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_10.php.testDeprecatedCurlyBracesFix_10.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+((string) $variable->something)[0];

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_11.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_11.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+($a){"test"};

--- a/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_11.php.testDeprecatedCurlyBracesFix_11.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ArrayDimensionSyntaxSuggestion/deprecatedCurlyBraces_11.php.testDeprecatedCurlyBracesFix_11.fixed
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$array{0};
+($a)["test"];

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ArrayDimensionSyntaxSuggestionHintTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ArrayDimensionSyntaxSuggestionHintTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.verification;
+
+public class ArrayDimensionSyntaxSuggestionHintTest extends PHPHintsTestBase {
+
+    public ArrayDimensionSyntaxSuggestionHintTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected String getTestDirectory() {
+        return TEST_DIRECTORY + "ArrayDimensionSyntaxSuggestion/";
+    }
+
+    public void testDeprecatedCurlyBraces() throws Exception {
+        checkHints(new ArrayDimensionSyntaxSuggestionHint(), "deprecatedCurlyBraces.php");
+    }
+
+    public void testDeprecatedCurlyBracesFixAll() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHint(), "deprecatedCurlyBraces.php", "$array^{1};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_01() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_01.php", "$array^{1};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_02() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_02.php", "$array{1}{2}{\"t^est\"};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_03a() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_03.php", "$array^{1}{2}{$test};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_03b() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_03.php", "$array{1}^{2}{$test};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_03c() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_03.php", "$array{1}{2}{^$test};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_04() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_04.php", "$array^{getIndex()};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_05() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_05.php", "myFunction(){\"t^est\"};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_06() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_06.php", "[1,2,3]^{0};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_07() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_07.php", "\"string\"{0^};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_08() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_08.php", "CONSTANT{1}{^2};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_09() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_09.php", "MyClass::CONSTANT{^0};", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_10() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_10.php", "((string) $variable->something){0}^;", "Use Bracket Syntax");
+    }
+
+    public void testDeprecatedCurlyBracesFix_11() throws Exception {
+        applyHint(new ArrayDimensionSyntaxSuggestionHintStub(false), "deprecatedCurlyBraces_11.php", "($a){\"tes^t\"};", "Use Bracket Syntax");
+    }
+
+    private static final class ArrayDimensionSyntaxSuggestionHintStub extends ArrayDimensionSyntaxSuggestionHint {
+
+        private final boolean isFixAllEnabled;
+
+        public ArrayDimensionSyntaxSuggestionHintStub(boolean isFixAllEnabled) {
+            this.isFixAllEnabled = isFixAllEnabled;
+        }
+
+        @Override
+        boolean isFixAllEnabled() {
+            return isFixAllEnabled;
+        }
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-2910

See: https://wiki.php.net/rfc/deprecate_curly_braces_array_access

This feature is **disabled** by default because I don't think that many people are using curly braces. 

![netbeans-2910-suggest-using-bracket-syntax](https://user-images.githubusercontent.com/738383/62666969-979cb600-b9c0-11e9-8c21-388ab63f89c9.gif)
