### PR TITLE
[NETBEANS-2863]: change javac to 1.8 in libs.nbi.ant to allow RCP installers to be bui…

### DIFF
--- a/harness/libs.nbi.ant/stub/ext/components/products/helloworld/nbproject/project.properties
+++ b/harness/libs.nbi.ant/stub/ext/components/products/helloworld/nbproject/project.properties
@@ -42,8 +42,8 @@ javac.classpath=\
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
-javac.source=1.5
-javac.target=1.5
+javac.source=1.8
+javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}:\

--- a/harness/libs.nbi.ant/stub/ext/engine/nbproject/project.properties
+++ b/harness/libs.nbi.ant/stub/ext/engine/nbproject/project.properties
@@ -43,8 +43,8 @@ javac.classpath=\
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
-javac.source=1.5
-javac.target=1.5
+javac.source=1.8
+javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\
     ${build.classes.dir}:\


### PR DESCRIPTION
The javac version needs to be updated in the engine and helloworld stub projects to allow installers  to be build with JDK11.

This fixes ant projects and will fix maven projects when a new org-netbeans-libs-nbi-ant.nbm artifact is published with these changes.

