### PR TITLE
[NETBEANS-1047] Don't add whitespace to a wrong place when textual operators are used

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -1326,10 +1326,12 @@ public class FormatVisitor extends DefaultVisitor {
         }
 
         while (ts.moveNext() && ts.offset() < node.getRight().getStartOffset()
-                && ts.token().id() != PHPTokenId.PHP_TOKEN && ts.token().id() != PHPTokenId.PHP_OPERATOR
+                && ts.token().id() != PHPTokenId.PHP_TOKEN && !LexUtilities.isPHPOperator(ts.token().id())
                 && lastIndex < ts.index()) {
             addFormatToken(formatTokens);
         }
+        // don't add to AND, OR, and XOR (PHPTokenId.PHP_TEXTUAL_OPERATOR)
+        // see https://netbeans.org/bugzilla/show_bug.cgi?id=240274
         if (ts.token().id() == PHPTokenId.PHP_TOKEN || ts.token().id() == PHPTokenId.PHP_OPERATOR) {
             formatTokens.add(new FormatToken(whitespaceBefore, ts.offset()));
             addFormatToken(formatTokens);
@@ -2558,4 +2560,5 @@ public class FormatVisitor extends DefaultVisitor {
     private static boolean isAnonymousClass(ASTNode astNode) {
         return astNode instanceof ClassInstanceCreation && ((ClassInstanceCreation) astNode).isAnonymous();
     }
+
 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/lexer/LexUtilities.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/lexer/LexUtilities.java
@@ -634,4 +634,16 @@ public final class LexUtilities {
 
         return start;
     }
+
+    /**
+     * Check whether the token id is an operator(PHP_OPERATOR or
+     * PHP_TEXTUAL_OPERATOR). PHP_TEXTUAL_OPERATOR is "AND", "OR", or "XOR".
+     *
+     * @param id the token id
+     * @return {@code true} the token id is an operator, otherwise {@code false}
+     */
+    public static boolean isPHPOperator(PHPTokenId id) {
+        return id == PHPTokenId.PHP_OPERATOR || id == PHPTokenId.PHP_TEXTUAL_OPERATOR;
+    }
+
 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/lexer/PHPTokenId.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/lexer/PHPTokenId.java
@@ -156,8 +156,8 @@ public enum PHPTokenId implements TokenId {
     PHP__LINE__(null, "constant"), //NOI18N
     PHP__DIR__(null, "constant"), //NOI18N
     PHP__NAMESPACE__(null, "constant"), //NOI18N
-    PHP_OPERATOR(null, "operator"), //NOI18N
-    PHP_TEXTUAL_OPERATOR(null, "operator"), //NOI18N
+    PHP_OPERATOR(null, "operator"), //NOI18N e.g. ||, &&
+    PHP_TEXTUAL_OPERATOR(null, "operator"), //NOI18N e.g. OR, AND
     PHP_PARENT(null, "keyword"), //NOI18N
     PHP__CLASS__(null, "constant"), //NOI18N
     PHP__TRAIT__(null, "constant"), //NOI18N

--- a/php/php.editor/test/unit/data/testfiles/formatting/netbeans1047.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/netbeans1047.php
@@ -1,0 +1,27 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$test = false;
+if ($test OR (!$test)) {
+}
+if ($test AND (!$test)) {
+}
+if ($test XOR (!$test)) {
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/netbeans1047.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/netbeans1047.php.formatted
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$test = false;
+if ($test OR (!$test)) {
+    
+}
+if ($test AND (!$test)) {
+    
+}
+if ($test XOR (!$test)) {
+    
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
@@ -824,4 +824,8 @@ public class PHPFormatterTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/arrowFunctions02.php", options);
     }
 
+    public void testNetBeans1047() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        reformatFileContents("testfiles/formatting/netbeans1047.php", options);
+    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-1047

Related to https://netbeans.org/bugzilla/show_bug.cgi?id=240274