### PR TITLE
[NETBEANS-2974] PHPStan - make level optional

### DIFF
--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/analyzer/PHPStanCustomizerPanel.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/analyzer/PHPStanCustomizerPanel.java
@@ -79,6 +79,9 @@ public class PHPStanCustomizerPanel extends JPanel {
     private void setLevelComboBox() {
         assert EventQueue.isDispatchThread();
         phpStanLevelComboBox.removeAllItems();
+        // NETBEANS-2974
+        // allow empty level option to use a level of a configuration file
+        phpStanLevelComboBox.addItem(""); // NOI18N
         for (int i = AnalysisOptions.PHPSTAN_MIN_LEVEL; i <= AnalysisOptions.PHPSTAN_MAX_LEVEL; i++) {
             phpStanLevelComboBox.addItem(String.valueOf(i));
         }

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/options/PHPStanOptionsPanel.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/options/PHPStanOptionsPanel.java
@@ -64,6 +64,9 @@ public class PHPStanOptionsPanel extends AnalysisCategoryPanel {
     private void init() {
         phpStanHintLabel.setText(Bundle.PHPStanOptionsPanel_hint(PHPStan.NAME, PHPStan.LONG_NAME));
         phpStanLevelComboBox.removeAllItems();
+        // NETBEANS-2974
+        // allow empty level option to use a level of a configuration file
+        phpStanLevelComboBox.addItem(""); // NOI18N
         for (int i = AnalysisOptions.PHPSTAN_MIN_LEVEL; i <= AnalysisOptions.PHPSTAN_MAX_LEVEL; i++) {
             phpStanLevelComboBox.addItem(String.valueOf(i));
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-2974

- Allow empty level option to use a level of a configuration file

If the level is empty, it is not added to parameters.
https://github.com/apache/netbeans/blob/16aad9d2d289c748084b89959b3aef6c312b8133/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/PHPStan.java#L175-L183

