### PR TITLE
[NETBEANS-2940] Cache ArchiveRootProviders

### DIFF
--- a/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
@@ -41,6 +41,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -2323,17 +2324,24 @@ public final class FileUtil extends Object {
     }
 
     private static Iterable<? extends ArchiveRootProvider> getArchiveRootProviders() {
-        Lookup.Result<ArchiveRootProvider> res = archiveRootProviders.get();
-        if (res == null) {
-            res = new ProxyLookup(
-                Lookups.singleton(new JarArchiveRootProvider()),
-                Lookup.getDefault()).lookupResult(ArchiveRootProvider.class);
-            if (!archiveRootProviders.compareAndSet(null, res)) {
-                res = archiveRootProviders.get();
+        if (archiveRootProviderCache == null) {
+            Lookup.Result<ArchiveRootProvider> res = archiveRootProviders.get();
+            if (res == null) {
+                res = new ProxyLookup(
+                    Lookups.singleton(new JarArchiveRootProvider()),
+                    Lookup.getDefault()).lookupResult(ArchiveRootProvider.class);
+                if (!archiveRootProviders.compareAndSet(null, res)) {
+                    res = archiveRootProviders.get();
+                    res.addLookupListener((ev) -> {
+                        archiveRootProviderCache = null;
+                    });
+                }
             }
+            archiveRootProviderCache = new LinkedList<>(res.allInstances());
         }
-        return res.allInstances();
+        return archiveRootProviderCache;
     }
 
+    private static Iterable<? extends ArchiveRootProvider> archiveRootProviderCache;
     private static final AtomicReference<Lookup.Result<ArchiveRootProvider>> archiveRootProviders = new AtomicReference<>();
 }


### PR DESCRIPTION
My intention was to improve the 40s search for ArchiveRootProviders shown at [NETBEANS-2940](https://issues.apache.org/jira/browse/NETBEANS-2940?focusedCommentId=16905420&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16905420)

I'm not sure if this change good/safe enough. I'd ask the reporter to try this out first.
As far as I've checked it worked.