### PR TITLE
[NETBEANS-2971] Missing spaces in anonymous function declaration

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -1945,6 +1945,9 @@ public class FormatVisitor extends DefaultVisitor {
                         tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_BEFORE_METHOD_DEC_PAREN, ts.offset()));
                         tokens.add(new FormatToken(FormatToken.Kind.TEXT, ts.offset(), ts.token().text().toString()));
                         tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_WITHIN_METHOD_DECL_PARENS, ts.offset() + ts.token().length()));
+                    } else if (parent instanceof LambdaFunctionDeclaration) {
+                        tokens.add(new FormatToken(FormatToken.Kind.TEXT, ts.offset(), ts.token().text().toString()));
+                        tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_WITHIN_METHOD_DECL_PARENS, ts.offset() + ts.token().length()));
                     } else if (parent instanceof FunctionInvocation || parent instanceof MethodInvocation || parent instanceof ClassInstanceCreation) {
                         tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_BEFORE_METHOD_CALL_PAREN, ts.offset()));
                         tokens.add(new FormatToken(FormatToken.Kind.TEXT, ts.offset(), ts.token().text().toString()));
@@ -1980,7 +1983,8 @@ public class FormatVisitor extends DefaultVisitor {
                     if (isAnonymousClass(parent)) {
                         tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_WITHIN_ANONYMOUS_CLASS_PARENS, ts.offset()));
                         tokens.add(new FormatToken(FormatToken.Kind.TEXT, ts.offset(), ts.token().text().toString()));
-                    } else if (parent instanceof FunctionDeclaration || parent instanceof MethodDeclaration || parent instanceof ArrowFunctionDeclaration) {
+                    } else if (parent instanceof FunctionDeclaration || parent instanceof MethodDeclaration
+                            || parent instanceof LambdaFunctionDeclaration || parent instanceof ArrowFunctionDeclaration) {
                         tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_WITHIN_METHOD_DECL_PARENS, ts.offset()));
                         tokens.add(new FormatToken(FormatToken.Kind.TEXT, ts.offset(), ts.token().text().toString()));
                     } else if (parent instanceof FunctionInvocation || parent instanceof MethodInvocation || parent instanceof ClassInstanceCreation) {

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2971_01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2971_01.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$anon1 = function ($test) use ($lexicalVar) {
+    return $test . $lexicalVar;
+};
+
+$anon2 = function (int $test) use ($lexicalVar) {
+    return $test . $lexicalVar;
+};
+
+$anon3 = function (?int $test) use ($lexicalVar): string {
+    return $test . $lexicalVar;
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2971_01.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2971_01.php.formatted
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$anon1 = function ( $test ) use ( $lexicalVar ) {
+    return $test . $lexicalVar;
+};
+
+$anon2 = function ( int $test ) use ( $lexicalVar ) {
+    return $test . $lexicalVar;
+};
+
+$anon3 = function ( ?int $test ) use ( $lexicalVar ): string {
+    return $test . $lexicalVar;
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2971_02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2971_02.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$anon1 = function ( $test ) use ( $lexicalVar ) {
+    return $test . $lexicalVar;
+};
+
+$anon2 = function ( int $test ) use ( $lexicalVar ) {
+    return $test . $lexicalVar;
+};
+
+$anon3 = function ( ?int $test ) use ( $lexicalVar ): string {
+    return $test . $lexicalVar;
+};

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2971_02.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2971_02.php.formatted
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$anon1 = function ($test) use ($lexicalVar) {
+    return $test . $lexicalVar;
+};
+
+$anon2 = function (int $test) use ($lexicalVar) {
+    return $test . $lexicalVar;
+};
+
+$anon3 = function (?int $test) use ($lexicalVar): string {
+    return $test . $lexicalVar;
+};

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterSpacesTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterSpacesTest.java
@@ -1400,4 +1400,17 @@ public class PHPFormatterSpacesTest extends PHPFormatterTestBase {
         options.put(FmtOptions.SPACE_BEFORE_METHOD_DECL_PAREN, true);
         reformatFileContents("testfiles/formatting/spaces/spaceBeforeArrowFunctionParen01.php", options);
     }
+
+    // NETBEANS-2971
+    public void testSpacesWithinLambdaFunctionDeclParen01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_WITHIN_METHOD_DECL_PARENS, true);
+        reformatFileContents("testfiles/formatting/spaces/netbeans2971_01.php", options);
+    }
+
+    public void testSpacesWithinLambdaFunctionDeclParen02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_WITHIN_METHOD_DECL_PARENS, false);
+        reformatFileContents("testfiles/formatting/spaces/netbeans2971_02.php", options);
+    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-2971

When Within Parentheses - Method / Function Declaration is checked:
```php
$annon = function ($test) use ($lexicalVar) {
    return $test . $lexicalVar;
}
```
before
```php
$annon = function ($test) use ($lexicalVar) {
    return $test . $lexicalVar;
}
```
after
```php
$annon = function ( $test ) use ( $lexicalVar ) {
    return $test . $lexicalVar;
}
```

