### PR TITLE
Avoid accessing network by j2ee.dd build

### DIFF
--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_8.xsd
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/resources/javaee_8.xsd
@@ -73,7 +73,7 @@
   </xsd:annotation>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:include schemaLocation="javaee_web_services_client_1_4.xsd"/>
 


### PR DESCRIPTION
Finally I found out when the build of `enterprise/j2ee.dd` fails behind corporate proxy. It needlessly accesses network to download `xml.xsd` which is available locally. Here in presented change seems to fix the problem.