### PR TITLE
[NETBEANS-2993] PHP 7.1: Add void return type to generated setter

### DIFF
--- a/php/php.api.phpmodule/manifest.mf
+++ b/php/php.api.phpmodule/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.api.phpmodule
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/api/phpmodule/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.67
+OpenIDE-Module-Specification-Version: 2.68

--- a/php/php.api.phpmodule/src/org/netbeans/modules/php/api/PhpVersion.java
+++ b/php/php.api.phpmodule/src/org/netbeans/modules/php/api/PhpVersion.java
@@ -159,6 +159,17 @@ public enum PhpVersion {
     }
 
     /**
+     * Check whether this version supports a void return type.
+     *
+     * @return {@code true} if this version supports a void return type,
+     * {@code false} otherwise
+     * @since 2.68
+     */
+    public boolean hasVoidReturnType() {
+        return this.compareTo(PhpVersion.PHP_71) >= 0;
+    }
+
+    /**
      * Check whether this version supports typed properties.
      *
      * @return {@code true} if this version supports typed properties,

--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -20,7 +20,7 @@ build.compiler=extJavac
 nbjavac.ignore.missing.enclosing=**/CUP$ASTPHP5Parser$actions.class
 javac.compilerargs=-J-Xmx512m
 nbm.needs.restart=true
-spec.version.base=1.82.0
+spec.version.base=1.83.0
 release.external/predefined_vars-1.0.zip=docs/predefined_vars.zip
 sigtest.gen.fail.on.error=false
 

--- a/php/php.editor/nbproject/project.xml
+++ b/php/php.editor/nbproject/project.xml
@@ -304,7 +304,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>2.67</specification-version>
+                        <specification-version>2.68</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/SinglePropertyMethodCreator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/SinglePropertyMethodCreator.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import org.netbeans.modules.php.api.PhpVersion;
 import org.netbeans.modules.php.editor.api.elements.BaseFunctionElement;
 import org.netbeans.modules.php.editor.api.elements.MethodElement;
-
 import static org.netbeans.modules.php.editor.codegen.CGSGenerator.NEW_LINE;
+import org.netbeans.modules.php.editor.model.impl.Type;
 
 /**
  *
@@ -129,8 +129,9 @@ public interface SinglePropertyMethodCreator<T extends Property> {
     final class SingleSetterCreator extends SinglePropertyMethodCreatorImpl {
         private static final String PARAM_TYPE = "${PARAM_TYPE}"; //NOI18N
         private static final String FLUENT_SETTER = "${FluentSetter}"; //NOI18N
+        private static final String RETURN_TYPE = "${ReturnType}"; // NOI18N
         private static final String SETTER_TEMPLATE
-            = CGSGenerator.ACCESS_MODIFIER + FUNCTION_MODIFIER + " function " + TEMPLATE_NAME + "(" + PARAM_TYPE + "$$" + CGSGenerator.PARAM_NAME + ") {"
+            = CGSGenerator.ACCESS_MODIFIER + FUNCTION_MODIFIER + " function " + TEMPLATE_NAME + "(" + PARAM_TYPE + "$$" + CGSGenerator.PARAM_NAME + ")" + RETURN_TYPE + "{"
             + CGSGenerator.ASSIGNMENT_TEMPLATE + CGSGenerator.NEW_LINE + FLUENT_SETTER + "}" + CGSGenerator.NEW_LINE; //NOI18N
 
         private final FluentSetterReturnPartCreator fluentSetterCreator;
@@ -155,12 +156,20 @@ public interface SinglePropertyMethodCreator<T extends Property> {
                     .replace(CGSGenerator.ACCESSOR, property.getAccessor())
                     .replace(CGSGenerator.PROPERTY, property.getAccessedName())
                     .replace(FLUENT_SETTER, fluentSetterCreator.create(property))
+                    .replace(RETURN_TYPE, getReturnType())
                     .replace(CGSGenerator.PARAM_NAME, paramName)
                     .replace(CGSGenerator.UP_FIRST_LETTER_PROPERTY, methodName)
                     .replace(CGSGenerator.UP_FIRST_LETTER_PROPERTY_WITHOUT_UNDERSCORE, methodName)
                     .replace(PARAM_TYPE, type.isEmpty() ? type : property.getTypeForTemplate()));
             setter.append(CGSGenerator.NEW_LINE);
             return setter.toString();
+        }
+
+        private String getReturnType() {
+            if (!cgsInfo.isFluentSetter() && cgsInfo.getPhpVersion().hasVoidReturnType()) {
+                return String.format(": %s ", Type.VOID); // NOI18N
+            }
+            return " "; // NOI18N
         }
 
         private static final class FluentSetterReturnPartCreator {

--- a/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP70Fluent.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP70Fluent.codegen
@@ -1,0 +1,90 @@
+public  function setInstanceArray(array $$instanceArray) {
+$$this->instanceArray = $instanceArray;
+return $$this;
+}
+
+public  function setInstanceInt(int $$instanceInt) {
+$$this->instanceInt = $instanceInt;
+return $$this;
+}
+
+public  function setInstanceString(string $$instanceString) {
+$$this->instanceString = $instanceString;
+return $$this;
+}
+
+public  function setInstanceBool(bool $$instanceBool) {
+$$this->instanceBool = $instanceBool;
+return $$this;
+}
+
+public  function setInstanceNull($$instanceNull) {
+$$this->instanceNull = $instanceNull;
+return $$this;
+}
+
+public  function setInstanceNullable(string $$instanceNullable) {
+$$this->instanceNullable = $instanceNullable;
+return $$this;
+}
+
+public  function setInstanceArrayNullable(array $$instanceArrayNullable) {
+$$this->instanceArrayNullable = $instanceArrayNullable;
+return $$this;
+}
+
+public  function setInstanceClass(Test53 $$instanceClass) {
+$$this->instanceClass = $instanceClass;
+return $$this;
+}
+
+public static function setStaticInt(int $$staticInt) {
+self::$$staticInt = $staticInt;
+return self;
+}
+
+public static function setStaticNullable(int $$staticNullable) {
+self::$$staticNullable = $staticNullable;
+return self;
+}
+
+public  function setInstanceInt74($$instanceInt74) {
+$$this->instanceInt74 = $instanceInt74;
+return $$this;
+}
+
+public  function setInstanceString74($$instanceString74) {
+$$this->instanceString74 = $instanceString74;
+return $$this;
+}
+
+public  function setInstanceBool74($$instanceBool74) {
+$$this->instanceBool74 = $instanceBool74;
+return $$this;
+}
+
+public  function setInstanceNullable74($$instanceNullable74) {
+$$this->instanceNullable74 = $instanceNullable74;
+return $$this;
+}
+
+public static function setStaticInt74($$staticInt74) {
+self::$$staticInt74 = $staticInt74;
+return self;
+}
+
+public static function setStaticString74($$staticString74) {
+self::$$staticString74 = $staticString74;
+return self;
+}
+
+public static function setStaticBool74($$staticBool74) {
+self::$$staticBool74 = $staticBool74;
+return self;
+}
+
+public static function setStaticNullable74($$staticNullable74) {
+self::$$staticNullable74 = $staticNullable74;
+return self;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP71.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP71.codegen
@@ -1,72 +1,72 @@
-public  function setInstanceArray(array $$instanceArray) {
+public  function setInstanceArray(array $$instanceArray): void {
 $$this->instanceArray = $instanceArray;
 }
 
-public  function setInstanceInt(int $$instanceInt) {
+public  function setInstanceInt(int $$instanceInt): void {
 $$this->instanceInt = $instanceInt;
 }
 
-public  function setInstanceString(string $$instanceString) {
+public  function setInstanceString(string $$instanceString): void {
 $$this->instanceString = $instanceString;
 }
 
-public  function setInstanceBool(bool $$instanceBool) {
+public  function setInstanceBool(bool $$instanceBool): void {
 $$this->instanceBool = $instanceBool;
 }
 
-public  function setInstanceNull($$instanceNull) {
+public  function setInstanceNull($$instanceNull): void {
 $$this->instanceNull = $instanceNull;
 }
 
-public  function setInstanceNullable(?string $$instanceNullable) {
+public  function setInstanceNullable(?string $$instanceNullable): void {
 $$this->instanceNullable = $instanceNullable;
 }
 
-public  function setInstanceArrayNullable(?array $$instanceArrayNullable) {
+public  function setInstanceArrayNullable(?array $$instanceArrayNullable): void {
 $$this->instanceArrayNullable = $instanceArrayNullable;
 }
 
-public  function setInstanceClass(Test53 $$instanceClass) {
+public  function setInstanceClass(Test53 $$instanceClass): void {
 $$this->instanceClass = $instanceClass;
 }
 
-public static function setStaticInt(int $$staticInt) {
+public static function setStaticInt(int $$staticInt): void {
 self::$$staticInt = $staticInt;
 }
 
-public static function setStaticNullable(?int $$staticNullable) {
+public static function setStaticNullable(?int $$staticNullable): void {
 self::$$staticNullable = $staticNullable;
 }
 
-public  function setInstanceInt74($$instanceInt74) {
+public  function setInstanceInt74($$instanceInt74): void {
 $$this->instanceInt74 = $instanceInt74;
 }
 
-public  function setInstanceString74($$instanceString74) {
+public  function setInstanceString74($$instanceString74): void {
 $$this->instanceString74 = $instanceString74;
 }
 
-public  function setInstanceBool74($$instanceBool74) {
+public  function setInstanceBool74($$instanceBool74): void {
 $$this->instanceBool74 = $instanceBool74;
 }
 
-public  function setInstanceNullable74($$instanceNullable74) {
+public  function setInstanceNullable74($$instanceNullable74): void {
 $$this->instanceNullable74 = $instanceNullable74;
 }
 
-public static function setStaticInt74($$staticInt74) {
+public static function setStaticInt74($$staticInt74): void {
 self::$$staticInt74 = $staticInt74;
 }
 
-public static function setStaticString74($$staticString74) {
+public static function setStaticString74($$staticString74): void {
 self::$$staticString74 = $staticString74;
 }
 
-public static function setStaticBool74($$staticBool74) {
+public static function setStaticBool74($$staticBool74): void {
 self::$$staticBool74 = $staticBool74;
 }
 
-public static function setStaticNullable74($$staticNullable74) {
+public static function setStaticNullable74($$staticNullable74): void {
 self::$$staticNullable74 = $staticNullable74;
 }
 

--- a/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP71Fluent.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP71Fluent.codegen
@@ -1,0 +1,90 @@
+public  function setInstanceArray(array $$instanceArray) {
+$$this->instanceArray = $instanceArray;
+return $$this;
+}
+
+public  function setInstanceInt(int $$instanceInt) {
+$$this->instanceInt = $instanceInt;
+return $$this;
+}
+
+public  function setInstanceString(string $$instanceString) {
+$$this->instanceString = $instanceString;
+return $$this;
+}
+
+public  function setInstanceBool(bool $$instanceBool) {
+$$this->instanceBool = $instanceBool;
+return $$this;
+}
+
+public  function setInstanceNull($$instanceNull) {
+$$this->instanceNull = $instanceNull;
+return $$this;
+}
+
+public  function setInstanceNullable(?string $$instanceNullable) {
+$$this->instanceNullable = $instanceNullable;
+return $$this;
+}
+
+public  function setInstanceArrayNullable(?array $$instanceArrayNullable) {
+$$this->instanceArrayNullable = $instanceArrayNullable;
+return $$this;
+}
+
+public  function setInstanceClass(Test53 $$instanceClass) {
+$$this->instanceClass = $instanceClass;
+return $$this;
+}
+
+public static function setStaticInt(int $$staticInt) {
+self::$$staticInt = $staticInt;
+return self;
+}
+
+public static function setStaticNullable(?int $$staticNullable) {
+self::$$staticNullable = $staticNullable;
+return self;
+}
+
+public  function setInstanceInt74($$instanceInt74) {
+$$this->instanceInt74 = $instanceInt74;
+return $$this;
+}
+
+public  function setInstanceString74($$instanceString74) {
+$$this->instanceString74 = $instanceString74;
+return $$this;
+}
+
+public  function setInstanceBool74($$instanceBool74) {
+$$this->instanceBool74 = $instanceBool74;
+return $$this;
+}
+
+public  function setInstanceNullable74($$instanceNullable74) {
+$$this->instanceNullable74 = $instanceNullable74;
+return $$this;
+}
+
+public static function setStaticInt74($$staticInt74) {
+self::$$staticInt74 = $staticInt74;
+return self;
+}
+
+public static function setStaticString74($$staticString74) {
+self::$$staticString74 = $staticString74;
+return self;
+}
+
+public static function setStaticBool74($$staticBool74) {
+self::$$staticBool74 = $staticBool74;
+return self;
+}
+
+public static function setStaticNullable74($$staticNullable74) {
+self::$$staticNullable74 = $staticNullable74;
+return self;
+}
+

--- a/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP74.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testTypedPropertiesSetter/testTypedPropertiesSetter.php.testTypedPropertiesSetter_PHP74.codegen
@@ -1,72 +1,72 @@
-public  function setInstanceArray(array $$instanceArray) {
+public  function setInstanceArray(array $$instanceArray): void {
 $$this->instanceArray = $instanceArray;
 }
 
-public  function setInstanceInt(int $$instanceInt) {
+public  function setInstanceInt(int $$instanceInt): void {
 $$this->instanceInt = $instanceInt;
 }
 
-public  function setInstanceString(string $$instanceString) {
+public  function setInstanceString(string $$instanceString): void {
 $$this->instanceString = $instanceString;
 }
 
-public  function setInstanceBool(bool $$instanceBool) {
+public  function setInstanceBool(bool $$instanceBool): void {
 $$this->instanceBool = $instanceBool;
 }
 
-public  function setInstanceNull($$instanceNull) {
+public  function setInstanceNull($$instanceNull): void {
 $$this->instanceNull = $instanceNull;
 }
 
-public  function setInstanceNullable(?string $$instanceNullable) {
+public  function setInstanceNullable(?string $$instanceNullable): void {
 $$this->instanceNullable = $instanceNullable;
 }
 
-public  function setInstanceArrayNullable(?array $$instanceArrayNullable) {
+public  function setInstanceArrayNullable(?array $$instanceArrayNullable): void {
 $$this->instanceArrayNullable = $instanceArrayNullable;
 }
 
-public  function setInstanceClass(Test53 $$instanceClass) {
+public  function setInstanceClass(Test53 $$instanceClass): void {
 $$this->instanceClass = $instanceClass;
 }
 
-public static function setStaticInt(int $$staticInt) {
+public static function setStaticInt(int $$staticInt): void {
 self::$$staticInt = $staticInt;
 }
 
-public static function setStaticNullable(?int $$staticNullable) {
+public static function setStaticNullable(?int $$staticNullable): void {
 self::$$staticNullable = $staticNullable;
 }
 
-public  function setInstanceInt74(int $$instanceInt74) {
+public  function setInstanceInt74(int $$instanceInt74): void {
 $$this->instanceInt74 = $instanceInt74;
 }
 
-public  function setInstanceString74(string $$instanceString74) {
+public  function setInstanceString74(string $$instanceString74): void {
 $$this->instanceString74 = $instanceString74;
 }
 
-public  function setInstanceBool74(bool $$instanceBool74) {
+public  function setInstanceBool74(bool $$instanceBool74): void {
 $$this->instanceBool74 = $instanceBool74;
 }
 
-public  function setInstanceNullable74(?string $$instanceNullable74) {
+public  function setInstanceNullable74(?string $$instanceNullable74): void {
 $$this->instanceNullable74 = $instanceNullable74;
 }
 
-public static function setStaticInt74(int $$staticInt74) {
+public static function setStaticInt74(int $$staticInt74): void {
 self::$$staticInt74 = $staticInt74;
 }
 
-public static function setStaticString74(string $$staticString74) {
+public static function setStaticString74(string $$staticString74): void {
 self::$$staticString74 = $staticString74;
 }
 
-public static function setStaticBool74(bool $$staticBool74) {
+public static function setStaticBool74(bool $$staticBool74): void {
 self::$$staticBool74 = $staticBool74;
 }
 
-public static function setStaticNullable74(?string $$staticNullable74) {
+public static function setStaticNullable74(?string $$staticNullable74): void {
 self::$$staticNullable74 = $staticNullable74;
 }
 

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
@@ -286,9 +286,23 @@ public class SelectedPropertyMethodsCreatorTest extends PHPTestBase {
         checkResult(new SelectedPropertyMethodsCreator().create(selectAllProperties(cgsInfo.getPossibleSetters()), new SinglePropertyMethodCreator.SingleSetterCreator(cgsInfo)));
     }
 
+    public void testTypedPropertiesSetter_PHP70Fluent() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_70);
+        cgsInfo.setPublicModifier(true);
+        cgsInfo.setFluentSetter(true);
+        checkResult(new SelectedPropertyMethodsCreator().create(selectAllProperties(cgsInfo.getPossibleSetters()), new SinglePropertyMethodCreator.SingleSetterCreator(cgsInfo)));
+    }
+
     public void testTypedPropertiesSetter_PHP71() throws Exception {
         CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_71);
         cgsInfo.setPublicModifier(true);
+        checkResult(new SelectedPropertyMethodsCreator().create(selectAllProperties(cgsInfo.getPossibleSetters()), new SinglePropertyMethodCreator.SingleSetterCreator(cgsInfo)));
+    }
+
+    public void testTypedPropertiesSetter_PHP71Fluent() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("^}", PhpVersion.PHP_71);
+        cgsInfo.setPublicModifier(true);
+        cgsInfo.setFluentSetter(true);
         checkResult(new SelectedPropertyMethodsCreator().create(selectAllProperties(cgsInfo.getPossibleSetters()), new SinglePropertyMethodCreator.SingleSetterCreator(cgsInfo)));
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-2993

- Add void return type when fluent is disabled

```php
public function setFoo(?string $foo): void {
        $this->foo = $foo;
}
```
