### PR TITLE
[NETBEANS-2994] PHP - formatting of unary operators adds extra space

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -2083,10 +2083,14 @@ public class FormatVisitor extends DefaultVisitor {
                     tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_AROUND_KEY_VALUE_OP, ts.offset() + ts.token().length()));
                 } else if (TokenUtilities.textEquals(txt2, "++") // NOI18N
                         || TokenUtilities.textEquals(txt2, "--")) { // NOI18N
-                    if (ts.movePrevious()) {
-                        if (ts.token().id() == PHPTokenId.PHP_VARIABLE || ts.token().id() == PHPTokenId.PHP_STRING) {
+                    Token<? extends PHPTokenId> previousToken = LexUtilities.findPrevious(ts, Arrays.asList(PHPTokenId.PHP_OPERATOR, PHPTokenId.WHITESPACE));
+                    if (previousToken != null) {
+                        if (previousToken.id() == PHPTokenId.PHP_VARIABLE
+                                || previousToken.id() == PHPTokenId.PHP_STRING
+                                || (previousToken.id() == PHPTokenId.PHP_TOKEN && TokenUtilities.equals(previousToken.text(), "]"))) { // NOI18N
                             tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_AROUND_UNARY_OP, ts.offset() + ts.token().length()));
-                        } else if (ts.token().id() != PHPTokenId.WHITESPACE) {
+                        } else if (previousToken.id() == PHPTokenId.PHP_TOKEN && TokenUtilities.equals(previousToken.text(), ".")) { // NOI18N
+                            // see PHPFormatterBrokenTest.testIssue197074_02
                             tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE, ts.offset() + ts.token().length()));
                         }
                         ts.move(origOffset);

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2994_01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2994_01.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function test() {
+    return [1, 2, 3];
+}
+
+$test++;
+$test   ++;
+$testArray[1]++;
+$testArray[1]   ++;
+test()[2]++;
+test()[2]  ++;
+
+++$test;
+++   $test;
+++  $testArray[1];
+++test()[2];
+++   test()[2];

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2994_01.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2994_01.php.formatted
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function test() {
+    return [1, 2, 3];
+}
+
+$test++;
+$test++;
+$testArray[1]++;
+$testArray[1]++;
+test()[2]++;
+test()[2]++;
+
+++$test;
+++$test;
+++$testArray[1];
+++test()[2];
+++test()[2];

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2994_02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2994_02.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function test() {
+    return [1, 2, 3];
+}
+
+$test--;
+$test   --;
+$testArray[1]--;
+$testArray[1]   --;
+test()[2]--;
+test()[2]  --;
+
+--$test;
+--   $test;
+--  $testArray[1];
+--test()[2];
+--   test()[2];

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2994_02.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2994_02.php.formatted
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function test() {
+    return [1, 2, 3];
+}
+
+$test --;
+$test --;
+$testArray[1] --;
+$testArray[1] --;
+test()[2] --;
+test()[2] --;
+
+-- $test;
+-- $test;
+-- $testArray[1];
+-- test()[2];
+-- test()[2];

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterSpacesTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterSpacesTest.java
@@ -1413,4 +1413,17 @@ public class PHPFormatterSpacesTest extends PHPFormatterTestBase {
         options.put(FmtOptions.SPACE_WITHIN_METHOD_DECL_PARENS, false);
         reformatFileContents("testfiles/formatting/spaces/netbeans2971_02.php", options);
     }
+
+    // NETBEANS-2994
+    public void testSpacesAroundUnaryOperator_01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_AROUND_UNARY_OPS, false);
+        reformatFileContents("testfiles/formatting/spaces/netbeans2994_01.php", options);
+    }
+
+    public void testSpacesAroundUnaryOperator_02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_AROUND_UNARY_OPS, true);
+        reformatFileContents("testfiles/formatting/spaces/netbeans2994_02.php", options);
+    }
 }


### PR DESCRIPTION
- Didn't fix curly brace array access cases (e.g. `++$test{0}`) because it is hardly used and it is deprecated since PHP 7.4
- If we fix the above case, we have to consider the following case:
```php
function test() {
    // something
}
++$test{0};
```

Example:
```php
$test++;
$test   ++;
$testArray[1]++;
$testArray[1]   ++;
test()[2]++;
test()[2]  ++;

++$test;
++   $test;
++  $testArray[1];
++test()[2];
++   test()[2];
```

Before:

```php
$test++;
$test ++;
$testArray[1] ++;
$testArray[1] ++;
test()[2] ++;
test()[2] ++;

++$test;
++$test;
++$testArray[1];
++test()[2];
++test()[2];
```

After:
```php
$test++;
$test++;
$testArray[1]++;
$testArray[1]++;
test()[2]++;
test()[2]++;

++$test;
++$test;
++$testArray[1];
++test()[2];
++test()[2];
```