### PR TITLE
Fix derby database tests in ide/db.metadata.model module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,7 @@ matrix:
              ide/css.lib
              ide/css.model
              ide/db.dataview
+             ide/db.metadata.model
              ide/db.sql.editor
              ide/docker.api
              ide/docker.ui

--- a/ide/db.metadata.model/nbproject/project.properties
+++ b/ide/db.metadata.model/nbproject/project.properties
@@ -19,7 +19,7 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.unit.cp.extra=\
-    ${nb_all}/db/external/derby-10.2.2.0.jar:\
+    ${nb_all}/ide/db/external/derby-10.2.2.0.jar:\
     ${nb_all}/db.drivers/external/mysql-connector-java-5.1.23-bin.jar
 
 test.config.stableBTD.includes=**/*Test.class


### PR DESCRIPTION
Fix MetadataElementHandleTest and JDBCMetadataDerbyTest tests in ide/db.metadata.model module.

Commands for run the tests:
```bash
ant -f ide/db.metadata.model -Dtest.type=unit -Dtest.includes=org/netbeans/modules/db/metadata/model/api/MetadataElementHandleTest.java test-single
```
```bash
ant -f ide/db.metadata.model -Dtest.type=unit -Dtest.includes=org/netbeans/modules/db/metadata/model/jdbc/JDBCMetadataDerbyTest.java test-single
```