### PR TITLE
HtmlRenderer.createLabel() has been broken for years

### DIFF
--- a/platform/openide.awt/manifest.mf
+++ b/platform/openide.awt/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.openide.awt
 OpenIDE-Module-Localizing-Bundle: org/openide/awt/Bundle.properties
 AutoUpdate-Essential-Module: true
-OpenIDE-Module-Specification-Version: 7.74
+OpenIDE-Module-Specification-Version: 7.75
 

--- a/platform/openide.awt/src/org/openide/awt/HtmlLabelUI.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlLabelUI.java
@@ -98,31 +98,51 @@ class HtmlLabelUI extends LabelUI {
     private static int textWidth(String text, Graphics g, Font f, boolean html) {
         if (text != null) {
             if (html) {
-                return Math.round(
-                    Math.round(
-                        Math.ceil(
-                            HtmlRenderer.renderHTML(
+                return (int) Math.ceil(
+                        HtmlRenderer.renderHTML(
                                 text, g, 0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE, f, Color.BLACK,
                                 HtmlRenderer.STYLE_CLIP, false
-                            )
                         )
-                    )
                 );
             } else {
-                return Math.round(
-                    Math.round(
-                        Math.ceil(
-                            HtmlRenderer.renderPlainString(
+                return (int) Math.ceil(
+                        HtmlRenderer.renderPlainString(
                                 text, g, 0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE, f, Color.BLACK,
                                 HtmlRenderer.STYLE_CLIP, false
-                            )
                         )
-                    )
                 );
             }
         } else {
             return 0;
         }
+    }
+
+    private static Font font(HtmlRendererImpl c) {
+        Font result = c.getFont();
+        if (result == null) {
+            String key;
+            switch(c.type()) {
+                case LIST :
+                    key = "List.font";
+                    break;
+                case TABLE :
+                    key = "Table.font";
+                    break;
+                case TREE :
+                    key = "Tree.font";
+                    break;
+                default :
+                    key = "Label.font";
+            }
+            result = UIManager.getFont(key);
+        }
+        if (result == null) {
+            result = UIManager.getFont("controlFont");
+            if (result == null) {
+                result = new Font("SansSerif", Font.PLAIN, 12);
+            }
+        }
+        return result;
     }
 
     private Dimension calcPreferredSize(HtmlRendererImpl r) {
@@ -132,9 +152,9 @@ class HtmlLabelUI extends LabelUI {
 
         Graphics g = r.getGraphics();
         Icon icon = r.getIcon();
-
+        Font font = font(r);
         if (text != null) {
-            FontMetrics fm = g.getFontMetrics(r.getFont());
+            FontMetrics fm = g.getFontMetrics(font);
             prefSize.height += (fm.getMaxAscent() + fm.getMaxDescent());
         }
 
@@ -153,7 +173,7 @@ class HtmlLabelUI extends LabelUI {
         //than the space actually needed
         ((Graphics2D) g).addRenderingHints(getHints());
 
-        int textwidth = textWidth(text, g, r.getFont(), r.isHtml()) + 4;
+        int textwidth = textWidth(text, g, font, r.isHtml()) + 4;
 
         if (r.isCentered()) {
             prefSize.width = Math.max(prefSize.width, textwidth + ins.right + ins.left);
@@ -239,7 +259,7 @@ class HtmlLabelUI extends LabelUI {
 
     /** Actually paint the icon and text using our own html rendering engine. */
     private void paintIconAndText(Graphics g, HtmlRendererImpl r) {
-        Font f = r.getFont();
+        Font f = font(r);
         g.setFont(f);
 
         FontMetrics fm = g.getFontMetrics();
@@ -348,7 +368,7 @@ class HtmlLabelUI extends LabelUI {
 
         int txtH = r.getHeight() - txtY;
 
-        Font f = r.getFont();
+        Font f = font(r);
         g.setFont(f);
 
         FontMetrics fm = g.getFontMetrics(f);
@@ -363,7 +383,7 @@ class HtmlLabelUI extends LabelUI {
             );
         } else {
             HtmlRenderer.renderString(
-                r.getText(), g, txtX, txtY, txtW, txtH, r.getFont(), foreground, r.getRenderStyle(), true
+                r.getText(), g, txtX, txtY, txtW, txtH, f, foreground, r.getRenderStyle(), true
             );
         }
     }

--- a/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
@@ -266,7 +266,7 @@ public final class HtmlRenderer {
      * @return A cell renderer that can render HTML.
      */
     public static final Renderer createRenderer() {
-        return new HtmlRendererImpl();
+        return new HtmlRendererImpl(true);
     }
 
     /**
@@ -288,7 +288,7 @@ public final class HtmlRenderer {
      * @return a label which can render a subset of HTML very quickly
      */
     public static final JLabel createLabel() {
-        return new HtmlRendererImpl();
+        return new HtmlRendererImpl(false);
     }
 
     /**

--- a/platform/openide.awt/src/org/openide/awt/HtmlRendererImpl.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlRendererImpl.java
@@ -54,13 +54,13 @@ import javax.swing.event.AncestorListener;
 class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
     private static final Rectangle bounds = new Rectangle();
     private static final boolean swingRendering = Boolean.getBoolean("nb.useSwingHtmlRendering"); //NOI18N
-    private static final Insets EMPTY_INSETS = new Insets(0, 0, 0, 0);
+    private final Insets EMPTY_INSETS = new Insets(0, 0, 0, 0);
     enum Type {UNKNOWN, TREE, LIST, TABLE}
 
     //For experimentation - holding the graphics object may be the source of some
     //strange painting problems on Apple
     private static boolean noCacheGraphics = Boolean.getBoolean("nb.renderer.nocache"); //NOI18N
-    private static Reference<Graphics> scratchGraphics = null;
+    private static Reference<Graphics2D> scratchGraphics = null;
     private boolean centered = false;
     private boolean parentFocused = false;
     private Boolean html = null;
@@ -72,6 +72,15 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
     private Type type = Type.UNKNOWN;
     private int renderStyle = HtmlRenderer.STYLE_CLIP;
     private boolean enabled = true;
+    private final boolean cellRenderer;
+
+    HtmlRendererImpl(boolean cellRenderer) {
+        this.cellRenderer = cellRenderer;
+    }
+
+    Type type() {
+        return type;
+    }
 
     /** Restore the renderer to a pristine state */
     public void reset() {
@@ -166,10 +175,6 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
     /** Generic code to set properties appropriately from any of the renderer
      * fetching methods */
     private void configureFrom(Object value, JComponent target, boolean selected, boolean leadSelection) {
-        if (value == null) {
-            value = "";
-        }
-
         setText((value == null) ? "" : value.toString());
 
         setSelected(selected);
@@ -199,13 +204,13 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
     }
 
     public @Override void addNotify() {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addNotify();
         }
     }
 
     public @Override void removeNotify() {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.removeNotify();
         }
     }
@@ -244,6 +249,9 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
 
     public void setIndent(int pixels) {
         this.indent = pixels;
+        if (!cellRenderer || swingRendering) {
+            invalidate();
+        }
     }
 
     public void setHtml(boolean val) {
@@ -251,7 +259,7 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
         String txt = getText();
         html = val ? Boolean.TRUE : Boolean.FALSE;
 
-        if (swingRendering && (html != wasHtml)) {
+        if ((html != wasHtml) || (swingRendering || !cellRenderer)) {
             //Ensure label UI gets updated and builds its little document tree...
             firePropertyChange("text", txt, getText()); //NOI18N
         }
@@ -484,7 +492,7 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
     /** Overridden to do nothing under normal circumstances.  If the boolean flag to <strong>not</strong> use the
      * internal HTML renderer is in effect, this will fire changes normally */
     protected @Override final void firePropertyChange(String name, Object old, Object nue) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             if ("text".equals(name) && isHtml()) {
                 //Force in the HTML tags so the UI will set up swing HTML rendering appropriately
                 nue = getText();
@@ -497,7 +505,7 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
     public @Override Border getBorder() {
         Border result;
 
-        if ((indent != 0) && swingRendering) {
+        if ((indent != 0) && (swingRendering || !cellRenderer)) {
             result = BorderFactory.createEmptyBorder(0, indent, 0, 0);
         } else {
             result = border;
@@ -510,7 +518,7 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
         Border old = border;
         border = b;
 
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             firePropertyChange("border", old, b);
         }
     }
@@ -528,14 +536,15 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
         Border b = getBorder();
 
         if (b == null) {
-            result = EMPTY_INSETS;
+            // If being used externally, defensively return a new instance
+            result = cellRenderer ? EMPTY_INSETS : new Insets(0, 0, 0, 0);
         } else {
             //workaround for open jdk bug, see issue #192388
             try {
                 result = b.getBorderInsets(this);
             } catch( NullPointerException e ) {
                 Logger.getLogger(HtmlRendererImpl.class.getName()).log(Level.FINE, null, e);
-                result = EMPTY_INSETS;
+                result = cellRenderer ? EMPTY_INSETS : new Insets(0, 0, 0, 0);
             }
         }
         if( null != insets ) {
@@ -549,7 +558,7 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
         //OptimizeIt shows about 12Ms overhead calling back to Component.enable(), so avoid it if possible
         enabled = b;
 
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.setEnabled(b);
         }
     }
@@ -586,8 +595,8 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
 
     /** Fetch a scratch graphics object for calculating preferred sizes while
      * offscreen */
-    private static final Graphics scratchGraphics() {
-        Graphics result = null;
+    private static final Graphics2D scratchGraphics() {
+        Graphics2D result = null;
 
         if (scratchGraphics != null) {
             result = scratchGraphics.get();
@@ -599,10 +608,9 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
 
         if (result == null) {
             result = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration()
-                                        .createCompatibleImage(1, 1).getGraphics();
-
+                                        .createCompatibleImage(1, 1).createGraphics();
             if (!noCacheGraphics) {
-                scratchGraphics = new SoftReference<Graphics>(result);
+                scratchGraphics = new SoftReference<>(result);
             }
         }
 
@@ -610,18 +618,15 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
     }
 
     public @Override void setBounds(int x, int y, int w, int h) {
-        if (swingRendering) {
-            super.setBounds(x, y, w, h);
-        }
-
-        bounds.setBounds(x, y, w, h);
+        reshape(x, y, w, h);
     }
 
     @Deprecated
     public @Override void reshape(int x, int y, int w, int h) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.reshape(x, y, w, h);
         }
+        bounds.setBounds(x, y, w, h);
     }
 
     public @Override int getWidth() {
@@ -638,115 +643,132 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
 
     /** Overridden to do nothing for performance reasons */
     public @Override void validate() {
-        //do nothing
+        if (!cellRenderer) {
+            super.validate();
+        }
+    }
+
+    public @Override void setText(String text) {
+        if (!cellRenderer) {
+            prefSize = null;
+        }
+        super.setText(text);
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void repaint(long tm, int x, int y, int w, int h) {
-        //do nothing
+        if (!cellRenderer) {
+            super.repaint(tm, x, y, w, h);
+        }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void repaint() {
-        //do nothing
+        if (!cellRenderer) {
+            super.repaint();
+        }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void invalidate() {
-        //do nothing
+        if (!cellRenderer) {
+            super.invalidate();
+        }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void revalidate() {
-        //do nothing
+        if (!cellRenderer) {
+            super.revalidate();
+        }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addAncestorListener(AncestorListener l) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addAncestorListener(l);
         }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addComponentListener(ComponentListener l) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addComponentListener(l);
         }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addContainerListener(ContainerListener l) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addContainerListener(l);
         }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addHierarchyListener(HierarchyListener l) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addHierarchyListener(l);
         }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addHierarchyBoundsListener(HierarchyBoundsListener l) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addHierarchyBoundsListener(l);
         }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addInputMethodListener(InputMethodListener l) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addInputMethodListener(l);
         }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addFocusListener(FocusListener fl) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addFocusListener(fl);
         }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addMouseListener(MouseListener ml) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addMouseListener(ml);
         }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addMouseWheelListener(MouseWheelListener ml) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addMouseWheelListener(ml);
         }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addMouseMotionListener(MouseMotionListener ml) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addMouseMotionListener(ml);
         }
     }
 
     /** Overridden to do nothing for performance reasons */
     public @Override void addVetoableChangeListener(VetoableChangeListener vl) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addVetoableChangeListener(vl);
         }
     }
 
     /** Overridden to do nothing for performance reasons, unless using standard swing rendering */
     public @Override void addPropertyChangeListener(String s, PropertyChangeListener l) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addPropertyChangeListener(s, l);
         }
     }
 
     public @Override void addPropertyChangeListener(PropertyChangeListener l) {
-        if (swingRendering) {
+        if (swingRendering || !cellRenderer) {
             super.addPropertyChangeListener(l);
         }
     }

--- a/platform/openide.awt/test/unit/src/org/openide/awt/HtmlRendererTest.java
+++ b/platform/openide.awt/test/unit/src/org/openide/awt/HtmlRendererTest.java
@@ -16,14 +16,33 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.openide.awt;
 
 import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.EventQueue;
 import java.awt.Font;
 import java.awt.Graphics;
+import java.awt.GraphicsEnvironment;
+import java.awt.LayoutManager;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.swing.CellRendererPane;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.RepaintManager;
 import junit.framework.TestCase;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  *
@@ -32,6 +51,7 @@ import junit.framework.TestCase;
 public class HtmlRendererTest extends TestCase {
 
     private Graphics graphic;
+
     public HtmlRendererTest(String testName) {
         super(testName);
     }
@@ -39,9 +59,197 @@ public class HtmlRendererTest extends TestCase {
     protected void setUp() throws Exception {
         BufferedImage waitingForPaintDummyImage = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
         graphic = waitingForPaintDummyImage.getGraphics();
-        
+
     }
-    
+
+    public void testCreatedLabelBehavesLikeLabel() throws Throwable {
+        if (GraphicsEnvironment.isHeadless()) {
+            return;
+        }
+        Throwable[] thrown = new Throwable[1];
+        CountDownLatch latch = new CountDownLatch(1);
+        EventQueue.invokeLater(() -> {
+            Thread.currentThread().setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                @Override
+                public void uncaughtException(Thread t, Throwable e) {
+                    thrown[0] = e;
+                    latch.countDown();
+                }
+            });
+            try {
+                validationBehaviorTest();
+            } catch (Throwable t) {
+                thrown[0] = t;
+            } finally {
+                latch.countDown();
+            }
+        });
+        latch.await(10, TimeUnit.SECONDS);
+        if (thrown[0] != null) {
+            throw thrown[0];
+        }
+    }
+
+    private void validationBehaviorTest() throws Throwable {
+        assert EventQueue.isDispatchThread();
+
+        OffscreenRepaintManager mgr = new OffscreenRepaintManager();
+
+        CRP crp = new CRP();
+        RepaintManager.setCurrentManager(mgr);
+
+        Rectangle oldBounds = crp.lbl1.getBounds();
+        Rectangle oldBounds2 = crp.lbl2.getBounds();
+
+        crp.lbl1.setText("<html><i>This text is longer!");
+        crp.assertLabelFired("text");
+
+        mgr.assertInvalidated(crp.lbl1);
+        mgr.validateInvalidComponents();
+        // We can't fool Swing quite *this* well without a peer, so manually
+        // trigger layout
+        crp.layout();
+
+        Rectangle newBounds = crp.lbl1.getBounds();
+        Rectangle newBounds2 = crp.lbl2.getBounds();
+
+        assertNotEquals(oldBounds, newBounds);
+        assertNotEquals(oldBounds2, newBounds2);
+        assertTrue(newBounds.width > oldBounds.width);
+        assertTrue(newBounds2.width > oldBounds2.width);
+    }
+
+    static final class OffscreenRepaintManager extends RepaintManager {
+        Set<JComponent> toValidate = new HashSet<>();
+
+        void assertInvalidated(Object... o) {
+            assertTrue(toValidate.toString(), toValidate.containsAll(Arrays.asList(o)));
+        }
+
+        @Override
+        public void paintDirtyRegions() {
+            super.paintDirtyRegions(); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void validateInvalidComponents() {
+            super.validateInvalidComponents();
+            for (Iterator<JComponent> it=toValidate.iterator(); it.hasNext();) {
+                JComponent jc = it.next();
+                it.remove();
+                jc.validate();
+                jc.getParent().validate();
+            }
+        }
+
+        @Override
+        public void addDirtyRegion(JComponent c, int x, int y, int w, int h) {
+            super.addDirtyRegion(c, x, y, w, h); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public synchronized void addInvalidComponent(JComponent invalidComponent) {
+            super.addInvalidComponent(invalidComponent);
+            toValidate.add(invalidComponent);
+        }
+
+    }
+
+    private static final class CRP extends CellRendererPane implements LayoutManager, PropertyChangeListener {
+
+        final JLabel lbl1;
+        final JLabel lbl2;
+        int doLayoutCount;
+        int layoutCount;
+        private final Set<String> firedProperties = new HashSet<>();
+
+        CRP() {
+            setLayout(this);
+            lbl1 = HtmlRenderer.createLabel();
+            lbl2 = HtmlRenderer.createLabel();
+            lbl1.setText("<html><b>Bold</b> Timid");
+            lbl2.setText("<html><i>Italic</i> Espanic");
+            add(lbl1);
+            add(lbl2);
+            setSize(preferredLayoutSize(this));
+            doLayoutContainer(this);
+            lbl1.addPropertyChangeListener(this);
+        }
+
+        @Override
+        public void doLayout() {
+            doLayoutCount++;
+            super.doLayout();
+        }
+
+        @Override
+        public boolean isShowing() {
+            return true;
+        }
+
+        @Override
+        public boolean isDisplayable() {
+            return true;
+        }
+
+        @Override
+        public void addLayoutComponent(String name, Component comp) {
+            // do nothing
+        }
+
+        @Override
+        public void removeLayoutComponent(Component comp) {
+            // do nothing
+        }
+
+        @Override
+        public Dimension preferredLayoutSize(Container parent) {
+            Dimension d = new Dimension();
+            for (Component c : parent.getComponents()) {
+                Dimension ps = c.getPreferredSize();
+                if (ps == null) {
+                    throw new IllegalStateException("Null pref size from " + c);
+                }
+                d.width += ps.width;
+                d.height = Math.max(d.height, ps.height);
+            }
+            return d;
+        }
+
+        @Override
+        public Dimension minimumLayoutSize(Container parent) {
+            return preferredLayoutSize(parent);
+        }
+
+        @Override
+        public void layoutContainer(Container parent) {
+            layoutCount++;
+            doLayoutContainer(this);
+        }
+
+        private void doLayoutContainer(Container parent) {
+            int x = 0;
+            for (Component c : parent.getComponents()) {
+                Dimension ps = c.getPreferredSize();
+                c.setBounds(x, 0, ps.width, ps.height);
+                x += ps.width;
+            }
+        }
+
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            firedProperties.add(evt.getPropertyName());
+        }
+
+        void assertLabelFired(String... props) {
+            assert props.length > 0;
+            Set<String> copy = new HashSet<>(firedProperties);
+            firedProperties.clear();
+            assertTrue(copy.toString(), copy.containsAll(Arrays.asList(props)));
+        }
+
+    }
+
     /**
      * Test of renderHTML method, of class org.openide.awt.HtmlRenderer.
      */
@@ -61,12 +269,12 @@ public class HtmlRendererTest extends TestCase {
         doTestRender55310();
         doTestRender("<html><body>text</body>");
     }
-    
+
     private void doTestRender(String text) {
         HtmlRenderer.renderHTML(text, graphic, 0, 0, 1000, 1000,
                 Font.getFont("Dialog"), Color.RED, HtmlRenderer.STYLE_TRUNCATE, true);
     }
-    
+
     /**
      * Test issue #55310: AIOOBE from HtmlRenderer.
      *


### PR DESCRIPTION
I wrote it sometime around 2002; later, to improve performance in its primary use-case as a cell-renderer, no-op overrides of listener adding and layout methods were added - without considering `HtmlRenderer.createLabel()` which hands the caller a `JLabel` that uses the high-performance limited-subset HTML renderer of `org.openide.awt.HtmlRenderer`.

Recently I've had several situations in the Antlr plugins where an HTML label without the overhead of creating a DOM under the hood was exactly what I needed, and I wound up forking this class.

Since the current API does not work as advertised, a better long term solution is simply to fix it.  The attached patch does that, without breaking the performance optimizations of the cell renderer use-case.