### PR TITLE
Fix a few cases where rendering hints were handled incorrectly

### DIFF
--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ColorUtil.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ColorUtil.java
@@ -180,7 +180,7 @@ final class ColorUtil {
                             RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
                 }
             }
-            if (shouldAntialias()) {
+            if (shouldAntialias() && (hintsMap == null || !hintsMap.containsKey(RenderingHints.KEY_TEXT_ANTIALIASING))) {
                 hintsMap.put(RenderingHints.KEY_ANTIALIASING,
                          RenderingHints.VALUE_ANTIALIAS_ON);
             }

--- a/platform/openide.awt/src/org/openide/awt/HtmlLabelUI.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlLabelUI.java
@@ -561,7 +561,7 @@ class HtmlLabelUI extends LabelUI {
     public static final boolean gtkShouldAntialias() {
         if (gtkAA == null) {
             Object o = Toolkit.getDefaultToolkit().getDesktopProperty("gnome.Xft/Antialias"); //NOI18N
-            gtkAA = new Integer(1).equals(o) ? Boolean.TRUE : Boolean.FALSE;
+            gtkAA = Integer.valueOf(1).equals(o);
         }
 
         return gtkAA.booleanValue();

--- a/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
@@ -20,6 +20,7 @@
 package org.openide.awt;
 
 import java.awt.Color;
+import java.awt.EventQueue;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
@@ -27,20 +28,21 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.Shape;
+import java.awt.Toolkit;
 import java.awt.font.LineMetrics;
 import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Icon;
 import javax.swing.JLabel;
 import javax.swing.ListCellRenderer;
-import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.tree.TreeCellRenderer;
@@ -192,7 +194,7 @@ public final class HtmlRenderer {
 
     /** Stack object used during HTML rendering to hold previous colors in
      * the case of nested color entries. */
-    private static Stack<Color> colorStack = new Stack<Color>();
+    private static LinkedList<Color> colorStack = new LinkedList<Color>();
 
     /**
      * Constant used by {@link #renderString renderString}, {@link #renderPlainString renderPlainString},
@@ -518,6 +520,19 @@ public final class HtmlRenderer {
         return _renderHTML( s, pos, g, x, y, w, h, f, defaultColor, style, paint, background, false );
     }
 
+    private static void configureRenderingHints(Graphics graphics) {
+        Graphics2D g = (Graphics2D) graphics;
+        Object desktopHints
+                = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
+        if (desktopHints instanceof Map<?, ?>) {
+            System.out.println("add hints " + desktopHints);
+            g.addRenderingHints((Map<?, ?>) desktopHints);
+        } else if (HtmlLabelUI.antialias) {
+            g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        }
+
+    }
+
     /** Implementation of HTML rendering */
     static double _renderHTML(
         String s, int pos, Graphics g, int x, int y, int w, int h, Font f, Color defaultColor, int style, boolean paint,
@@ -540,13 +555,11 @@ public final class HtmlRenderer {
         }
 
         //Thread safety - avoid allocating memory for the common case
-        Stack<Color> _colorStack = SwingUtilities.isEventDispatchThread() ? HtmlRenderer.colorStack : new Stack<Color>();
+        LinkedList<Color> _colorStack = EventQueue.isDispatchThread() ? HtmlRenderer.colorStack : new LinkedList<Color>();
 
         g.setColor(defaultColor);
         g.setFont(f);
-        if (HtmlLabelUI.antialias && g instanceof Graphics2D) {
-            ((Graphics2D) g).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        }
+        configureRenderingHints(g);
 
         char[] chars = s.toCharArray();
         int origX = x;

--- a/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
@@ -525,7 +525,6 @@ public final class HtmlRenderer {
         Object desktopHints
                 = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
         if (desktopHints instanceof Map<?, ?>) {
-            System.out.println("add hints " + desktopHints);
             g.addRenderingHints((Map<?, ?>) desktopHints);
         } else if (HtmlLabelUI.antialias) {
             g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);


### PR DESCRIPTION
Having spent a bunch of time on antialiasing settings lately, I ran across a couple of cases where the code to set them up can result in grayscale antialiasing settings clobbering the ones set correctly either by the JDK from the OS, or via, e.g. `-J-Dawt.useSystemAAFontSettings=lcd_hrgb`