### PR TITLE
[NETBEANS-2149] Space-Formatting of == and === in PHP does not match "Binary Operators"

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -2058,7 +2058,8 @@ public class FormatVisitor extends DefaultVisitor {
                     tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_AROUND_DECLARE_EQUAL, ts.offset() + ts.token().length()));
                     break;
                 }
-                if (TokenUtilities.endsWith(txt2, "=")) { // NOI18N
+                if (!TokenUtilities.startsWith(txt2, "==") // NOI18N NETBEANS-2149
+                        && TokenUtilities.endsWith(txt2, "=")) { // NOI18N
                     tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_BEFORE_ASSIGN_OP, ts.offset()));
                     tokens.add(new FormatToken(FormatToken.Kind.TEXT, ts.offset(), ts.token().text().toString()));
                     tokens.add(new FormatToken(FormatToken.Kind.WHITESPACE_AFTER_ASSIGN_OP, ts.offset() + ts.token().length()));

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_01.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$a=$b==$c;
+$a=$b===$c;

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_01.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_01.php.formatted
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$a=$b == $c;
+$a=$b === $c;

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_02.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$a=$b==$c;
+$a=$b===$c;

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_02.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_02.php.formatted
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$a = $b==$c;
+$a = $b===$c;

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_03.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_03.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$a=$b==$c;
+$a=$b===$c;

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_03.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_03.php.formatted
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$a = $b == $c;
+$a = $b === $c;

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_04.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_04.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$a=$b==$c;
+$a=$b===$c;

--- a/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_04.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/spaces/netbeans2149_04.php.formatted
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+$a=$b==$c;
+$a=$b===$c;

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterSpacesTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterSpacesTest.java
@@ -1426,4 +1426,34 @@ public class PHPFormatterSpacesTest extends PHPFormatterTestBase {
         options.put(FmtOptions.SPACE_AROUND_UNARY_OPS, true);
         reformatFileContents("testfiles/formatting/spaces/netbeans2994_02.php", options);
     }
+
+    // NETBEANS-2149
+    public void testSpacesAroundBinaryOperatorsOnly() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_AROUND_BINARY_OPS, true);
+        options.put(FmtOptions.SPACE_AROUND_ASSIGN_OPS, false);
+        reformatFileContents("testfiles/formatting/spaces/netbeans2149_01.php", options);
+    }
+
+    public void testSpacesAroundAssignmentOperatorsOnly() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_AROUND_BINARY_OPS, false);
+        options.put(FmtOptions.SPACE_AROUND_ASSIGN_OPS, true);
+        reformatFileContents("testfiles/formatting/spaces/netbeans2149_02.php", options);
+    }
+
+    public void testSpacesAroundAssignmentAndBinaryOperators() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_AROUND_BINARY_OPS, true);
+        options.put(FmtOptions.SPACE_AROUND_ASSIGN_OPS, true);
+        reformatFileContents("testfiles/formatting/spaces/netbeans2149_03.php", options);
+    }
+
+    public void testSpacesWithoutAroundAssignmentAndBinaryOperators() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        options.put(FmtOptions.SPACE_AROUND_BINARY_OPS, false);
+        options.put(FmtOptions.SPACE_AROUND_ASSIGN_OPS, false);
+        reformatFileContents("testfiles/formatting/spaces/netbeans2149_04.php", options);
+    }
+
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-2149
- Don't add `WHITESPACE_[BEFORE|AFTER]_ASSIGN_OP` to `==` and `===`

Example:
```php
$a=$b==$c;
$a=$b===$c;
```

Before:
```php
$a=$b== $c;
$a=$b=== $c;
```

After:
```php
$a=$b == $c;
$a=$b === $c;
```