### PR TITLE
Fix tests for ide/editor.structure module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,7 @@ matrix:
              ide/editor.search
              ide/editor.settings
              ide/editor.settings.storage
+             ide/editor.structure
              ide/editor.tools.storage
              ide/editor.util
              ide/extbrowser

--- a/ide/editor.structure/nbproject/project.xml
+++ b/ide/editor.structure/nbproject/project.xml
@@ -107,6 +107,10 @@
                 <test-type>
                     <name>unit</name>
                     <test-dependency>
+                        <code-name-base>org.netbeans.insane</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.libs.junit4</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
@@ -140,11 +144,11 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.openide.util.ui</code-name-base>
+                        <code-name-base>org.openide.util.lookup</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.openide.util.lookup</code-name-base>
+                        <code-name-base>org.openide.util.ui</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
                 </test-type>

--- a/ide/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModel.java
+++ b/ide/editor.structure/src/org/netbeans/modules/editor/structure/api/DocumentModel.java
@@ -27,9 +27,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.List;
 import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.WeakHashMap;
 import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
@@ -573,8 +571,6 @@ public final class DocumentModel {
                 if(debug) System.out.println("Warning: DocumentModel.getChildren(...) called for " + de + " which has already been removed!");
                 return Collections.emptyList();
             }
-
-            //assert elements.get(index) == de;
             
             //there is a problem with empty elements - if an element is removed its boundaries
             //are the some and the standart getParent/getChildren algorith fails.
@@ -846,8 +842,6 @@ public final class DocumentModel {
             
             //create a new DocumentElement instance
             DocumentElement de = createDocumentElement(name, type, attributes, startOffset, endOffset);
-
-            assert startOffset < endOffset;
 
             if(!elements.contains(de)) {
                 if(debug) System.out.println("# ADD " + de + " adding into transaction");

--- a/ide/editor.structure/test/unit/src/org/netbeans/modules/editor/structure/api/DocumentModelTest.java
+++ b/ide/editor.structure/test/unit/src/org/netbeans/modules/editor/structure/api/DocumentModelTest.java
@@ -262,7 +262,7 @@ public class DocumentModelTest extends NbTestCase {
      *
      * @author Marek Fukala
      */
-    private class FakeDocumentModelProvider implements DocumentModelProvider {
+    private static class FakeDocumentModelProvider implements DocumentModelProvider {
         
         @Override
         public void updateModel(DocumentModel.DocumentModelModificationTransaction dtm,
@@ -305,7 +305,7 @@ public class DocumentModelTest extends NbTestCase {
         
     }
     
-    private class DocumentModelListenerAdapter implements DocumentModelListener {
+    private static class DocumentModelListenerAdapter implements DocumentModelListener {
         @Override
         public void documentElementAdded(DocumentElement de) {
         }
@@ -320,7 +320,7 @@ public class DocumentModelTest extends NbTestCase {
         }
     }
     
-    private class DocumentElementListenerAdapter implements DocumentElementListener {
+    private static class DocumentElementListenerAdapter implements DocumentElementListener {
         @Override
         public void attributesChanged(DocumentElementEvent e) {
         }
@@ -338,7 +338,7 @@ public class DocumentModelTest extends NbTestCase {
         }
     }
     
-    private class DocumentModelStateListenerAdapter implements DocumentModelStateListener {
+    private static class DocumentModelStateListenerAdapter implements DocumentModelStateListener {
 
         @Override
         public void sourceChanged() {
@@ -358,7 +358,7 @@ public class DocumentModelTest extends NbTestCase {
         
     }
     
-    private class State {
+    private static class State {
         
         private int value;
 

--- a/ide/editor.structure/test/unit/src/org/netbeans/modules/editor/structure/api/DocumentModelTest.java
+++ b/ide/editor.structure/test/unit/src/org/netbeans/modules/editor/structure/api/DocumentModelTest.java
@@ -22,16 +22,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Vector;
+import java.util.concurrent.CopyOnWriteArrayList;
 import javax.swing.text.BadLocationException;
-import javax.swing.text.DefaultEditorKit;
 import javax.swing.text.Document;
+import static junit.framework.TestCase.assertEquals;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.editor.structure.api.DocumentModel.DocumentChange;
 import org.netbeans.modules.editor.structure.api.DocumentModel.DocumentModelTransactionCancelledException;
 import org.netbeans.modules.editor.structure.spi.DocumentModelProvider;
-import org.openide.util.Exceptions;
 
 
 /** DocumentModel unit tests
@@ -40,12 +39,13 @@ import org.openide.util.Exceptions;
  */
 public class DocumentModelTest extends NbTestCase {
     
-    DocumentModelProvider dmProvider = null;
+    private DocumentModelProvider dmProvider;
     
     public DocumentModelTest() {
         super("document-model-test");
     }
     
+    @Override
     public void setUp() throws BadLocationException {
         dmProvider = new FakeDocumentModelProvider();
     }
@@ -53,7 +53,7 @@ public class DocumentModelTest extends NbTestCase {
     //--------- test methods -----------
     public void testModelBasis() throws DocumentModelException, BadLocationException {
         //set the document content
-        Document doc = new BaseDocument(DefaultEditorKit.class, false);
+        Document doc = new BaseDocument(false, "text/plain");
         doc.insertString(0,"abcde|fgh|ij|k",null); //4 elements should be created
         
         DocumentModel model = new DocumentModel(doc, dmProvider);
@@ -88,27 +88,30 @@ public class DocumentModelTest extends NbTestCase {
     }
     
     public void testAddElementEvent() throws DocumentModelException, BadLocationException, InterruptedException {
-        Document doc = new BaseDocument(DefaultEditorKit.class, false);
+        Document doc = new BaseDocument(false, "text/plain");
         final DocumentModel model = new DocumentModel(doc, dmProvider);
         
         
         //listen to model
-        final Vector addedElements = new Vector();
+        final List<DocumentElement> addedElements = new CopyOnWriteArrayList<DocumentElement>();
         model.addDocumentModelListener(new DocumentModelListenerAdapter() {
+            @Override
             public void documentElementAdded(DocumentElement de) {
                 addedElements.add(de);
             }
         });
         
         //listen to element
-        final Vector addedElements2 = new Vector();
+        final List<DocumentElement> addedElements2 = new CopyOnWriteArrayList<DocumentElement>();
         model.getRootElement().addDocumentElementListener(new DocumentElementListenerAdapter() {
+            @Override
             public void elementAdded(DocumentElementEvent e) {
                 addedElements2.add(e.getChangedChild());
             }
         });
         
         model.addDocumentModelStateListener(new DocumentModelStateListenerAdapter() {
+            @Override
             public void updateFinished() {
                 assertEquals(4, addedElements.size());
                 assertEquals(4, addedElements2.size());
@@ -121,7 +124,7 @@ public class DocumentModelTest extends NbTestCase {
     }
     
      public void testMoreDocumentElementListeners() throws DocumentModelException, BadLocationException, InterruptedException {
-        Document doc = new BaseDocument(DefaultEditorKit.class, false);
+        Document doc = new BaseDocument(false, "text/plain");
         DocumentModel model = new DocumentModel(doc, dmProvider);
         
         DocumentElement root = model.getRootElement();
@@ -167,7 +170,7 @@ public class DocumentModelTest extends NbTestCase {
     }
     
     public void testRemoveElementEvent() throws DocumentModelException, BadLocationException, InterruptedException {
-        Document doc = new BaseDocument(DefaultEditorKit.class, false);
+        Document doc = new BaseDocument(false, "text/plain");
         doc.insertString(0,"abcde|fgh|ij|k",null); //4 elements should be created
         final DocumentModel model = new DocumentModel(doc, dmProvider);
         
@@ -175,22 +178,25 @@ public class DocumentModelTest extends NbTestCase {
         DocumentModelUtils.dumpElementStructure(model.getRootElement());
         
         //listen to model
-        final Vector removedElements = new Vector();
+        final List<DocumentElement> removedElements = new CopyOnWriteArrayList<DocumentElement>();
         model.addDocumentModelListener(new DocumentModelListenerAdapter() {
+            @Override
             public void documentElementRemoved(DocumentElement de) {
                 removedElements.add(de);
             }
         });
         
         //listen to element
-        final Vector removedElements2 = new Vector();
+        final List<DocumentElement> removedElements2 = new CopyOnWriteArrayList<DocumentElement>();
         model.getRootElement().addDocumentElementListener(new DocumentElementListenerAdapter() {
+            @Override
             public void elementRemoved(DocumentElementEvent e) {
                 removedElements2.add(e.getChangedChild());
             }
         });
         
         model.addDocumentModelStateListener(new DocumentModelStateListenerAdapter() {
+            @Override
             public void updateFinished() {
                 assertEquals(4,removedElements2.size());
                 assertEquals(4, removedElements.size());
@@ -203,27 +209,31 @@ public class DocumentModelTest extends NbTestCase {
     }
     
     public void testDocumentModelStateListener() throws DocumentModelException, BadLocationException {
-        Document doc = new BaseDocument(DefaultEditorKit.class, false);
+        Document doc = new BaseDocument(false, "text/plain");
         final DocumentModel model = new DocumentModel(doc, dmProvider);
         final State s = new State();
-        s.value = -1;
+        s.setValue(-1);
 
         model.addDocumentModelStateListener(new DocumentModelStateListener() {
+            @Override
             public void sourceChanged() {
-                assert s.value == -1;
-                s.value = 0;
+                assertEquals(-1, s.getValue());
+                s.setValue(0);
             }
+            @Override
             public void scanningStarted() {
-                assert s.value == 0;
-                s.value = 1;
+                assertEquals(0, s.getValue());
+                s.setValue(1);
             }
+            @Override
             public void updateStarted() {
-                assert s.value == 1;
-                s.value = 2;
+                assertEquals(1, s.getValue());
+                s.setValue(2);
             }
+            @Override
             public void updateFinished() {
-                assert s.value == 2;
-                s.value = 3;
+                assertEquals(2, s.getValue());
+                s.setValue(3);
                 synchronized (s) {
                     s.notifyAll();
                 }
@@ -241,8 +251,7 @@ public class DocumentModelTest extends NbTestCase {
             }
         }
         
-        assert s.value == 3;
-        
+        assertEquals(3, s.getValue());
     }
     
     /**
@@ -253,8 +262,9 @@ public class DocumentModelTest extends NbTestCase {
      *
      * @author Marek Fukala
      */
-    private static class FakeDocumentModelProvider implements DocumentModelProvider {
+    private class FakeDocumentModelProvider implements DocumentModelProvider {
         
+        @Override
         public void updateModel(DocumentModel.DocumentModelModificationTransaction dtm,
                 DocumentModel model, DocumentChange[] changes)
                 throws DocumentModelException, DocumentModelTransactionCancelledException {
@@ -268,7 +278,8 @@ public class DocumentModelTest extends NbTestCase {
                         //create element if doesn't exist
                         DocumentElement test = model.getDocumentElement(lastElementEnd, i);
                         if( test == null) {
-                            foundElements.add(dtm.addDocumentElement("element"+(elCount++), FAKE_ELEMENT_TYPE, Collections.EMPTY_MAP, lastElementEnd, i));
+                            foundElements.add(dtm.addDocumentElement("element" + elCount, FAKE_ELEMENT_TYPE, Collections.EMPTY_MAP, lastElementEnd, i));
+                            elCount++;
                         } else {
                             foundElements.add(test);
                         }
@@ -294,48 +305,70 @@ public class DocumentModelTest extends NbTestCase {
         
     }
     
-    private static class DocumentModelListenerAdapter implements DocumentModelListener {
+    private class DocumentModelListenerAdapter implements DocumentModelListener {
+        @Override
         public void documentElementAdded(DocumentElement de) {
         }
+        @Override
         public void documentElementAttributesChanged(DocumentElement de) {
         }
+        @Override
         public void documentElementChanged(DocumentElement de) {
         }
+        @Override
         public void documentElementRemoved(DocumentElement de) {
         }
     }
     
-    private static class DocumentElementListenerAdapter implements DocumentElementListener {
+    private class DocumentElementListenerAdapter implements DocumentElementListener {
+        @Override
         public void attributesChanged(DocumentElementEvent e) {
         }
+        @Override
         public void childrenReordered(DocumentElementEvent e) {
         }
+        @Override
         public void contentChanged(DocumentElementEvent e) {
         }
+        @Override
         public void elementAdded(DocumentElementEvent e) {
         }
+        @Override
         public void elementRemoved(DocumentElementEvent e) {
         }
     }
     
-    private static class DocumentModelStateListenerAdapter implements DocumentModelStateListener {
+    private class DocumentModelStateListenerAdapter implements DocumentModelStateListener {
 
+        @Override
         public void sourceChanged() {
         }
 
+        @Override
         public void scanningStarted() {
         }
 
+        @Override
         public void updateStarted() {
         }
 
+        @Override
         public void updateFinished() {
         }
         
     }
     
-    private static class State {
-        public int value;
+    private class State {
+        
+        private int value;
+
+        public int getValue() {
+            return value;
+        }
+
+        public void setValue(int value) {
+            this.value = value;
+        }
     }
     
 }


### PR DESCRIPTION
Fix tests for ide/editor.structure module
- Remove assert in `DocumentModel.java` that brokes the tests.
- Add insane module is a test dependency.
- Change deprecated code.