### PR TITLE
[NETBEANS-1861] Recognize @method static for documenting static methods

### DIFF
--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -20,7 +20,7 @@ build.compiler=extJavac
 nbjavac.ignore.missing.enclosing=**/CUP$ASTPHP5Parser$actions.class
 javac.compilerargs=-J-Xmx512m
 nbm.needs.restart=true
-spec.version.base=1.83.0
+spec.version.base=1.84.0
 release.external/predefined_vars-1.0.zip=docs/predefined_vars.zip
 sigtest.gen.fail.on.error=false
 

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/OccurenceBuilder.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/OccurenceBuilder.java
@@ -72,6 +72,7 @@ import org.netbeans.modules.php.editor.model.VariableName;
 import org.netbeans.modules.php.editor.model.VariableScope;
 import org.netbeans.modules.php.editor.model.nodes.ASTNodeInfo;
 import org.netbeans.modules.php.editor.model.nodes.ASTNodeInfo.Kind;
+import org.netbeans.modules.php.editor.model.nodes.ASTNodeInfoUtils;
 import org.netbeans.modules.php.editor.model.nodes.ClassConstantDeclarationInfo;
 import org.netbeans.modules.php.editor.model.nodes.ClassDeclarationInfo;
 import org.netbeans.modules.php.editor.model.nodes.ConstantDeclarationInfo;
@@ -100,6 +101,7 @@ import org.netbeans.modules.php.editor.parser.astnodes.InterfaceDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.MethodDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.MethodInvocation;
 import org.netbeans.modules.php.editor.parser.astnodes.NamespaceName;
+import org.netbeans.modules.php.editor.parser.astnodes.PHPDocMethodTag;
 import org.netbeans.modules.php.editor.parser.astnodes.PHPDocTypeTag;
 import org.netbeans.modules.php.editor.parser.astnodes.Scalar;
 import org.netbeans.modules.php.editor.parser.astnodes.SingleFieldDeclaration;
@@ -460,7 +462,7 @@ class OccurenceBuilder {
 
     void prepare(final MagicMethodDeclarationInfo node, MethodScope scope) {
         if (canBePrepared(node.getOriginalNode(), scope)) {
-            if (node.getKind().equals(Kind.METHOD)) {
+            if (ASTNodeInfoUtils.isMethod(node.getKind())) {
                 magicMethodDeclarations.put(node, scope);
             }
         }
@@ -998,6 +1000,7 @@ class OccurenceBuilder {
                     buildMethodInvocations(elementInfo, fileScope, Accuracy.UNIQUE, occurences);
                 }
                 buildMethodDeclarations(elementInfo, fileScope, occurences);
+                buildMagicMethodDeclarations(elementInfo, fileScope, cachedOccurences);
             }
         }
     }
@@ -2461,7 +2464,8 @@ class OccurenceBuilder {
                 } else {
                     if (getScope().getInScope() instanceof TypeScope) {
                         if (originalNode instanceof MethodDeclaration
-                                || originalNode instanceof SingleFieldDeclaration) {
+                                || originalNode instanceof SingleFieldDeclaration
+                                || originalNode instanceof PHPDocMethodTag) { // NETBEANS-1861
                             return ((TypeScope) getScope().getInScope()).getFullyQualifiedName();
                         }
                     }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/nodes/ASTNodeInfoUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/nodes/ASTNodeInfoUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.model.nodes;
+
+import org.netbeans.modules.php.editor.model.nodes.ASTNodeInfo.Kind;
+import static org.netbeans.modules.php.editor.model.nodes.ASTNodeInfo.Kind.METHOD;
+import static org.netbeans.modules.php.editor.model.nodes.ASTNodeInfo.Kind.STATIC_METHOD;
+
+public final class ASTNodeInfoUtils {
+
+    private ASTNodeInfoUtils() {
+    }
+
+    /**
+     * Check whether the kind is METHOD or STATIC_METHOD.
+     *
+     * @param kind the kind
+     * @return {@code true} if this is METHOD or STATIC_METHOD, {@code false}
+     * otherwise
+     */
+    public static boolean isMethod(Kind kind) {
+        return kind == METHOD || kind == STATIC_METHOD;
+    }
+}

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/PHPDocMethodTag.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/PHPDocMethodTag.java
@@ -29,13 +29,44 @@ public class PHPDocMethodTag extends PHPDocTypeTag {
 
     private final List<PHPDocVarTypeTag> params;
     private final PHPDocNode name;
+    private final boolean isStatic;
 
     public PHPDocMethodTag(int start, int end, AnnotationParsedLine kind,
             List<PHPDocTypeNode> returnTypes, PHPDocNode methodName,
             List<PHPDocVarTypeTag> parameters, String documentation) {
+        this(start, end, kind, returnTypes, methodName, parameters, documentation, false);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param start start offset
+     * @param end end offset
+     * @param kind parsed annotation line
+     * @param returnTypes return types
+     * @param methodName method name
+     * @param parameters parameters
+     * @param documentation documentation
+     * @param isStatic static flag
+     * @since 1.84.0
+     */
+    public PHPDocMethodTag(int start, int end, AnnotationParsedLine kind,
+            List<PHPDocTypeNode> returnTypes, PHPDocNode methodName,
+            List<PHPDocVarTypeTag> parameters, String documentation, boolean isStatic) {
         super(start, end, kind, documentation, returnTypes);
         this.params = parameters;
         this.name = methodName;
+        this.isStatic = isStatic;
+    }
+
+    /**
+     * Check whethere the method is static.
+     *
+     * @return {@code true} if the method is static, {@code false} otherwise
+     * @since 1.84.0
+     */
+    public boolean isStatic() {
+        return isStatic;
     }
 
     public PHPDocNode getMethodName() {

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/csl/NavigatorTest/structure/magicMethods.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/csl/NavigatorTest/structure/magicMethods.pass
@@ -1,0 +1,9 @@
+|-Example [1215, 1317] : ESCAPED{Example}
+|--testVoid [852, 860] : ESCAPED{testVoid}ESCAPED{(}<font color="#999999">ESCAPED{Test}ESCAPED{ }</font>ESCAPED{$test}ESCAPED{)}<font color="#999999">:ESCAPED{void}</font>
+|--testType [902, 910] : ESCAPED{testType}ESCAPED{(}<font color="#999999">ESCAPED{Test}ESCAPED{ }</font>ESCAPED{$test}ESCAPED{)}<font color="#999999">:ESCAPED{int}</font>
+|--staticTestVoid [955, 969] : ESCAPED{staticTestVoid}ESCAPED{(}<font color="#999999">ESCAPED{Test}ESCAPED{ }</font>ESCAPED{$test}ESCAPED{)}<font color="#999999">:ESCAPED{void}</font>
+|--staticTestType [1017, 1031] : ESCAPED{staticTestType}ESCAPED{(}<font color="#999999">ESCAPED{Test}ESCAPED{ }</font>ESCAPED{$param1}ESCAPED{, }ESCAPED{$param2}ESCAPED{)}<font color="#999999">:ESCAPED{int}</font>
+|--staticTestNullable [1092, 1110] : ESCAPED{staticTestNullable}ESCAPED{(}<font color="#999999">ESCAPED{?}ESCAPED{string}ESCAPED{ }</font>ESCAPED{$param}ESCAPED{, }<font color="#999999">ESCAPED{int}ESCAPED{ }</font>ESCAPED{$param2}ESCAPED{)}<font color="#999999">:ESCAPED{?}ESCAPED{int}</font>
+|--getDefault [1180, 1190] : ESCAPED{getDefault}ESCAPED{(}ESCAPED{)}<font color="#999999">:ESCAPED{?}ESCAPED{\Example}</font>
+|--test [1246, 1260] : ESCAPED{test}ESCAPED{(}ESCAPED{)}
+|--staticTest [1289, 1314] : ESCAPED{staticTest}ESCAPED{(}ESCAPED{)}<font color="#999999">:ESCAPED{int}</font>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod01.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod01.pass
@@ -23,7 +23,7 @@
         <Comments>
             <PHPDocBlock start='10' end='31'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='27' kind='method'>
+                    <PHPDocMethodTag start='14' end='27' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>
@@ -37,7 +37,7 @@
             </PHPDocBlock>
             <PHPDocBlock start='10' end='31'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='27' kind='method'>
+                    <PHPDocMethodTag start='14' end='27' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod02.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod02.pass
@@ -23,7 +23,7 @@
         <Comments>
             <PHPDocBlock start='10' end='33'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='29' kind='method'>
+                    <PHPDocMethodTag start='14' end='29' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>
@@ -37,7 +37,7 @@
             </PHPDocBlock>
             <PHPDocBlock start='10' end='33'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='29' kind='method'>
+                    <PHPDocMethodTag start='14' end='29' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod03.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod03.pass
@@ -23,7 +23,7 @@
         <Comments>
             <PHPDocBlock start='10' end='50'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='46' kind='method'>
+                    <PHPDocMethodTag start='14' end='46' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>
@@ -37,7 +37,7 @@
             </PHPDocBlock>
             <PHPDocBlock start='10' end='50'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='46' kind='method'>
+                    <PHPDocMethodTag start='14' end='46' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod05.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod05.pass
@@ -23,7 +23,7 @@
         <Comments>
             <PHPDocBlock start='10' end='64'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='60' kind='method'>
+                    <PHPDocMethodTag start='14' end='60' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>
@@ -45,7 +45,7 @@
             </PHPDocBlock>
             <PHPDocBlock start='10' end='64'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='60' kind='method'>
+                    <PHPDocMethodTag start='14' end='60' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod06.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod06.pass
@@ -23,7 +23,7 @@
         <Comments>
             <PHPDocBlock start='10' end='66'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='62' kind='method'>
+                    <PHPDocMethodTag start='14' end='62' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>
@@ -46,7 +46,7 @@
             </PHPDocBlock>
             <PHPDocBlock start='10' end='66'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='62' kind='method'>
+                    <PHPDocMethodTag start='14' end='62' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod07.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethod07.pass
@@ -23,7 +23,7 @@
         <Comments>
             <PHPDocBlock start='10' end='78'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='74' kind='method'>
+                    <PHPDocMethodTag start='14' end='74' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>
@@ -54,7 +54,7 @@
             </PHPDocBlock>
             <PHPDocBlock start='10' end='78'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='74' kind='method'>
+                    <PHPDocMethodTag start='14' end='74' kind='method' isStatic='false'>
                         <Name>
                             <PHPDocNode start='24' end='26' value='m1'/>
                         </Name>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic01.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic01.pass
@@ -1,0 +1,66 @@
+<testresult testFile='magicMethodStatic01.php'>
+    <scanner>
+        <token id='T_CLASS' start='847' end='852'>
+            <text>class</text>
+        </token>
+        <token id='T_STRING' start='853' end='854'>
+            <text>A</text>
+        </token>
+        <token id='T_CURLY_OPEN' start='855' end='856'>
+            <text>{</text>
+        </token>
+        <token id='T_CURLY_CLOSE' start='862' end='863'>
+            <text>}</text>
+        </token>
+        <token id='EOF' start='864' end='864'>
+            <text></text>
+        </token>
+    </scanner>
+    <Program start='0' end='864'>
+        <Comments>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='846'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='842' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='846'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='842' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+        </Comments>
+        <Statements>
+            <ClassDeclaration start='847' end='863' modifier='NONE'>
+                <ClassName>
+                    <Identifier start='853' end='854' name='A'/>
+                </ClassName>
+                <SuperClassName>
+                </SuperClassName>
+                <Interfaces>
+                </Interfaces>
+                <Block start='855' end='863' isCurly='true'>
+                </Block>
+            </ClassDeclaration>
+        </Statements>
+    </Program>
+</testresult>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic02.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic02.pass
@@ -1,0 +1,66 @@
+<testresult testFile='magicMethodStatic02.php'>
+    <scanner>
+        <token id='T_CLASS' start='849' end='854'>
+            <text>class</text>
+        </token>
+        <token id='T_STRING' start='855' end='856'>
+            <text>A</text>
+        </token>
+        <token id='T_CURLY_OPEN' start='857' end='858'>
+            <text>{</text>
+        </token>
+        <token id='T_CURLY_CLOSE' start='864' end='865'>
+            <text>}</text>
+        </token>
+        <token id='EOF' start='866' end='866'>
+            <text></text>
+        </token>
+    </scanner>
+    <Program start='0' end='866'>
+        <Comments>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='848'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='844' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='848'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='844' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+        </Comments>
+        <Statements>
+            <ClassDeclaration start='849' end='865' modifier='NONE'>
+                <ClassName>
+                    <Identifier start='855' end='856' name='A'/>
+                </ClassName>
+                <SuperClassName>
+                </SuperClassName>
+                <Interfaces>
+                </Interfaces>
+                <Block start='857' end='865' isCurly='true'>
+                </Block>
+            </ClassDeclaration>
+        </Statements>
+    </Program>
+</testresult>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic03.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic03.pass
@@ -1,0 +1,66 @@
+<testresult testFile='magicMethodStatic03.php'>
+    <scanner>
+        <token id='T_CLASS' start='866' end='871'>
+            <text>class</text>
+        </token>
+        <token id='T_STRING' start='872' end='873'>
+            <text>A</text>
+        </token>
+        <token id='T_CURLY_OPEN' start='874' end='875'>
+            <text>{</text>
+        </token>
+        <token id='T_CURLY_CLOSE' start='881' end='882'>
+            <text>}</text>
+        </token>
+        <token id='EOF' start='883' end='883'>
+            <text></text>
+        </token>
+    </scanner>
+    <Program start='0' end='883'>
+        <Comments>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='865'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='861' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='865'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='861' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+        </Comments>
+        <Statements>
+            <ClassDeclaration start='866' end='882' modifier='NONE'>
+                <ClassName>
+                    <Identifier start='872' end='873' name='A'/>
+                </ClassName>
+                <SuperClassName>
+                </SuperClassName>
+                <Interfaces>
+                </Interfaces>
+                <Block start='874' end='882' isCurly='true'>
+                </Block>
+            </ClassDeclaration>
+        </Statements>
+    </Program>
+</testresult>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic04.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic04.pass
@@ -1,39 +1,37 @@
-<testresult testFile='magicMethod04.php'>
+<testresult testFile='magicMethodStatic04.php'>
     <scanner>
-        <token id='T_CLASS' start='58' end='63'>
+        <token id='T_CLASS' start='873' end='878'>
             <text>class</text>
         </token>
-        <token id='T_STRING' start='64' end='65'>
+        <token id='T_STRING' start='879' end='880'>
             <text>A</text>
         </token>
-        <token id='T_CURLY_OPEN' start='66' end='67'>
+        <token id='T_CURLY_OPEN' start='881' end='882'>
             <text>{</text>
         </token>
-        <token id='T_CURLY_CLOSE' start='73' end='74'>
+        <token id='T_CURLY_CLOSE' start='888' end='889'>
             <text>}</text>
         </token>
-        <token id='T_SEMICOLON' start='75' end='78'>
-            <text>?&gt;\n</text>
-        </token>
-        <token id='EOF' start='78' end='78'>
+        <token id='EOF' start='890' end='890'>
             <text></text>
         </token>
     </scanner>
-    <Program start='0' end='77'>
+    <Program start='0' end='890'>
         <Comments>
-            <PHPDocBlock start='10' end='57'>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='872'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='53' kind='method' isStatic='false'>
+                    <PHPDocMethodTag start='822' end='868' kind='method' isStatic='true'>
                         <Name>
-                            <PHPDocNode start='24' end='26' value='m1'/>
+                            <PHPDocNode start='839' end='841' value='m1'/>
                         </Name>
                         <Return Types>
-                            <PHPDocTypeNode start='22' end='23' value='A' isArray='false'/>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
                         </Return Types>
                         <Parameters>
-                            <PHPDocVarTypeTag start='27' end='34' kind='param'>
+                            <PHPDocVarTypeTag start='842' end='849' kind='param'>
                                 <Variable>
-                                    <PHPDocNode start='27' end='34' value='$param1'/>
+                                    <PHPDocNode start='842' end='849' value='$param1'/>
                                 </Variable>
                                 <Types>
                                 </Types>
@@ -42,19 +40,20 @@
                     </PHPDocMethodTag>
                 </Tags>
             </PHPDocBlock>
-            <PHPDocBlock start='10' end='57'>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='872'>
                 <Tags>
-                    <PHPDocMethodTag start='14' end='53' kind='method' isStatic='false'>
+                    <PHPDocMethodTag start='822' end='868' kind='method' isStatic='true'>
                         <Name>
-                            <PHPDocNode start='24' end='26' value='m1'/>
+                            <PHPDocNode start='839' end='841' value='m1'/>
                         </Name>
                         <Return Types>
-                            <PHPDocTypeNode start='22' end='23' value='A' isArray='false'/>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
                         </Return Types>
                         <Parameters>
-                            <PHPDocVarTypeTag start='27' end='34' kind='param'>
+                            <PHPDocVarTypeTag start='842' end='849' kind='param'>
                                 <Variable>
-                                    <PHPDocNode start='27' end='34' value='$param1'/>
+                                    <PHPDocNode start='842' end='849' value='$param1'/>
                                 </Variable>
                                 <Types>
                                 </Types>
@@ -65,18 +64,17 @@
             </PHPDocBlock>
         </Comments>
         <Statements>
-            <ClassDeclaration start='58' end='74' modifier='NONE'>
+            <ClassDeclaration start='873' end='889' modifier='NONE'>
                 <ClassName>
-                    <Identifier start='64' end='65' name='A'/>
+                    <Identifier start='879' end='880' name='A'/>
                 </ClassName>
                 <SuperClassName>
                 </SuperClassName>
                 <Interfaces>
                 </Interfaces>
-                <Block start='66' end='74' isCurly='true'>
+                <Block start='881' end='889' isCurly='true'>
                 </Block>
             </ClassDeclaration>
-            <EmptyStatement start='75' end='77'/>
         </Statements>
     </Program>
 </testresult>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic05.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic05.pass
@@ -1,0 +1,82 @@
+<testresult testFile='magicMethodStatic05.php'>
+    <scanner>
+        <token id='T_CLASS' start='880' end='885'>
+            <text>class</text>
+        </token>
+        <token id='T_STRING' start='886' end='887'>
+            <text>A</text>
+        </token>
+        <token id='T_CURLY_OPEN' start='888' end='889'>
+            <text>{</text>
+        </token>
+        <token id='T_CURLY_CLOSE' start='895' end='896'>
+            <text>}</text>
+        </token>
+        <token id='EOF' start='897' end='897'>
+            <text></text>
+        </token>
+    </scanner>
+    <Program start='0' end='897'>
+        <Comments>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='879'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='875' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                            <PHPDocVarTypeTag start='842' end='856' kind='param'>
+                                <Variable>
+                                    <PHPDocNode start='849' end='856' value='$param1'/>
+                                </Variable>
+                                <Types>
+                                    <PHPDocTypeNode start='842' end='848' value='string' isArray='false'/>
+                                </Types>
+                            </PHPDocVarTypeTag>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='879'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='875' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                            <PHPDocVarTypeTag start='842' end='856' kind='param'>
+                                <Variable>
+                                    <PHPDocNode start='849' end='856' value='$param1'/>
+                                </Variable>
+                                <Types>
+                                    <PHPDocTypeNode start='842' end='848' value='string' isArray='false'/>
+                                </Types>
+                            </PHPDocVarTypeTag>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+        </Comments>
+        <Statements>
+            <ClassDeclaration start='880' end='896' modifier='NONE'>
+                <ClassName>
+                    <Identifier start='886' end='887' name='A'/>
+                </ClassName>
+                <SuperClassName>
+                </SuperClassName>
+                <Interfaces>
+                </Interfaces>
+                <Block start='888' end='896' isCurly='true'>
+                </Block>
+            </ClassDeclaration>
+        </Statements>
+    </Program>
+</testresult>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic06.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic06.pass
@@ -1,0 +1,84 @@
+<testresult testFile='magicMethodStatic06.php'>
+    <scanner>
+        <token id='T_CLASS' start='882' end='887'>
+            <text>class</text>
+        </token>
+        <token id='T_STRING' start='888' end='889'>
+            <text>A</text>
+        </token>
+        <token id='T_CURLY_OPEN' start='890' end='891'>
+            <text>{</text>
+        </token>
+        <token id='T_CURLY_CLOSE' start='897' end='898'>
+            <text>}</text>
+        </token>
+        <token id='EOF' start='899' end='899'>
+            <text></text>
+        </token>
+    </scanner>
+    <Program start='0' end='899'>
+        <Comments>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='881'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='877' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                            <PHPDocVarTypeTag start='842' end='858' kind='param'>
+                                <Variable>
+                                    <PHPDocNode start='851' end='858' value='$param1'/>
+                                </Variable>
+                                <Types>
+                                    <PHPDocTypeNode start='842' end='848' value='string' isArray='false'/>
+                                    <PHPDocTypeNode start='849' end='850' value='A' isArray='false'/>
+                                </Types>
+                            </PHPDocVarTypeTag>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='881'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='877' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                            <PHPDocVarTypeTag start='842' end='858' kind='param'>
+                                <Variable>
+                                    <PHPDocNode start='851' end='858' value='$param1'/>
+                                </Variable>
+                                <Types>
+                                    <PHPDocTypeNode start='842' end='848' value='string' isArray='false'/>
+                                    <PHPDocTypeNode start='849' end='850' value='A' isArray='false'/>
+                                </Types>
+                            </PHPDocVarTypeTag>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+        </Comments>
+        <Statements>
+            <ClassDeclaration start='882' end='898' modifier='NONE'>
+                <ClassName>
+                    <Identifier start='888' end='889' name='A'/>
+                </ClassName>
+                <SuperClassName>
+                </SuperClassName>
+                <Interfaces>
+                </Interfaces>
+                <Block start='890' end='898' isCurly='true'>
+                </Block>
+            </ClassDeclaration>
+        </Statements>
+    </Program>
+</testresult>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic07.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest/parser/magicMethodStatic07.pass
@@ -1,0 +1,100 @@
+<testresult testFile='magicMethodStatic07.php'>
+    <scanner>
+        <token id='T_CLASS' start='894' end='899'>
+            <text>class</text>
+        </token>
+        <token id='T_STRING' start='900' end='901'>
+            <text>A</text>
+        </token>
+        <token id='T_CURLY_OPEN' start='902' end='903'>
+            <text>{</text>
+        </token>
+        <token id='T_CURLY_CLOSE' start='909' end='910'>
+            <text>}</text>
+        </token>
+        <token id='EOF' start='911' end='911'>
+            <text></text>
+        </token>
+    </scanner>
+    <Program start='0' end='911'>
+        <Comments>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='893'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='889' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                            <PHPDocVarTypeTag start='847' end='863' kind='param'>
+                                <Variable>
+                                    <PHPDocNode start='856' end='863' value='$param1'/>
+                                </Variable>
+                                <Types>
+                                    <PHPDocTypeNode start='847' end='853' value='string' isArray='false'/>
+                                    <PHPDocTypeNode start='854' end='855' value='A' isArray='false'/>
+                                </Types>
+                            </PHPDocVarTypeTag>
+                            <PHPDocVarTypeTag start='864' end='870' kind='param'>
+                                <Variable>
+                                    <PHPDocNode start='867' end='870' value='$p2'/>
+                                </Variable>
+                                <Types>
+                                    <PHPDocTypeNode start='865' end='866' value='A' isArray='false'/>
+                                </Types>
+                            </PHPDocVarTypeTag>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+            <Comment start='6' end='813' commentType='multiLine'/>
+            <PHPDocBlock start='818' end='893'>
+                <Tags>
+                    <PHPDocMethodTag start='822' end='889' kind='method' isStatic='true'>
+                        <Name>
+                            <PHPDocNode start='839' end='841' value='m1'/>
+                        </Name>
+                        <Return Types>
+                            <PHPDocTypeNode start='837' end='838' value='A' isArray='false'/>
+                        </Return Types>
+                        <Parameters>
+                            <PHPDocVarTypeTag start='847' end='863' kind='param'>
+                                <Variable>
+                                    <PHPDocNode start='856' end='863' value='$param1'/>
+                                </Variable>
+                                <Types>
+                                    <PHPDocTypeNode start='847' end='853' value='string' isArray='false'/>
+                                    <PHPDocTypeNode start='854' end='855' value='A' isArray='false'/>
+                                </Types>
+                            </PHPDocVarTypeTag>
+                            <PHPDocVarTypeTag start='864' end='870' kind='param'>
+                                <Variable>
+                                    <PHPDocNode start='867' end='870' value='$p2'/>
+                                </Variable>
+                                <Types>
+                                    <PHPDocTypeNode start='865' end='866' value='A' isArray='false'/>
+                                </Types>
+                            </PHPDocVarTypeTag>
+                        </Parameters>
+                    </PHPDocMethodTag>
+                </Tags>
+            </PHPDocBlock>
+        </Comments>
+        <Statements>
+            <ClassDeclaration start='894' end='910' modifier='NONE'>
+                <ClassName>
+                    <Identifier start='900' end='901' name='A'/>
+                </ClassName>
+                <SuperClassName>
+                </SuperClassName>
+                <Interfaces>
+                </Interfaces>
+                <Block start='902' end='910' isCurly='true'>
+                </Block>
+            </ClassDeclaration>
+        </Statements>
+    </Program>
+</testresult>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/Method01.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/Method01.pass
@@ -1,0 +1,22 @@
+<PHPDocBlock start='3' end='42'>
+    <Tags>
+        <PHPDocMethodTag start='3' end='45' kind='method' isStatic='false'>
+            <Name>
+                <PHPDocNode start='18' end='21' value='get'/>
+            </Name>
+            <Return Types>
+                <PHPDocTypeNode start='14' end='17' value='int' isArray='false'/>
+            </Return Types>
+            <Parameters>
+                <PHPDocVarTypeTag start='22' end='28' kind='param'>
+                    <Variable>
+                        <PHPDocNode start='26' end='28' value='$i'/>
+                    </Variable>
+                    <Types>
+                        <PHPDocTypeNode start='22' end='25' value='int' isArray='false'/>
+                    </Types>
+                </PHPDocVarTypeTag>
+            </Parameters>
+        </PHPDocMethodTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/Method02.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/Method02.pass
@@ -1,0 +1,21 @@
+<PHPDocBlock start='3' end='38'>
+    <Tags>
+        <PHPDocMethodTag start='3' end='41' kind='method' isStatic='false'>
+            <Name>
+                <PHPDocNode start='14' end='17' value='get'/>
+            </Name>
+            <Return Types>
+            </Return Types>
+            <Parameters>
+                <PHPDocVarTypeTag start='18' end='24' kind='param'>
+                    <Variable>
+                        <PHPDocNode start='22' end='24' value='$i'/>
+                    </Variable>
+                    <Types>
+                        <PHPDocTypeNode start='18' end='21' value='int' isArray='false'/>
+                    </Types>
+                </PHPDocVarTypeTag>
+            </Parameters>
+        </PHPDocMethodTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/Method03.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/Method03.pass
@@ -1,0 +1,22 @@
+<PHPDocBlock start='3' end='44'>
+    <Tags>
+        <PHPDocMethodTag start='3' end='47' kind='method' isStatic='false'>
+            <Name>
+                <PHPDocNode start='19' end='22' value='get'/>
+            </Name>
+            <Return Types>
+                <PHPDocTypeNode start='14' end='18' value='?int' isArray='false'/>
+            </Return Types>
+            <Parameters>
+                <PHPDocVarTypeTag start='23' end='30' kind='param'>
+                    <Variable>
+                        <PHPDocNode start='28' end='30' value='$i'/>
+                    </Variable>
+                    <Types>
+                        <PHPDocTypeNode start='23' end='27' value='?int' isArray='false'/>
+                    </Types>
+                </PHPDocVarTypeTag>
+            </Parameters>
+        </PHPDocMethodTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/MethodStatic01.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/MethodStatic01.pass
@@ -1,0 +1,22 @@
+<PHPDocBlock start='3' end='49'>
+    <Tags>
+        <PHPDocMethodTag start='3' end='52' kind='method' isStatic='true'>
+            <Name>
+                <PHPDocNode start='25' end='28' value='get'/>
+            </Name>
+            <Return Types>
+                <PHPDocTypeNode start='21' end='24' value='int' isArray='false'/>
+            </Return Types>
+            <Parameters>
+                <PHPDocVarTypeTag start='29' end='35' kind='param'>
+                    <Variable>
+                        <PHPDocNode start='33' end='35' value='$i'/>
+                    </Variable>
+                    <Types>
+                        <PHPDocTypeNode start='29' end='32' value='int' isArray='false'/>
+                    </Types>
+                </PHPDocVarTypeTag>
+            </Parameters>
+        </PHPDocMethodTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/MethodStatic02.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/MethodStatic02.pass
@@ -1,0 +1,21 @@
+<PHPDocBlock start='3' end='45'>
+    <Tags>
+        <PHPDocMethodTag start='3' end='48' kind='method' isStatic='true'>
+            <Name>
+                <PHPDocNode start='21' end='24' value='get'/>
+            </Name>
+            <Return Types>
+            </Return Types>
+            <Parameters>
+                <PHPDocVarTypeTag start='25' end='31' kind='param'>
+                    <Variable>
+                        <PHPDocNode start='29' end='31' value='$i'/>
+                    </Variable>
+                    <Types>
+                        <PHPDocTypeNode start='25' end='28' value='int' isArray='false'/>
+                    </Types>
+                </PHPDocVarTypeTag>
+            </Parameters>
+        </PHPDocMethodTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/MethodStatic03.pass
+++ b/php/php.editor/test/unit/data/goldenfiles/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest/MethodStatic03.pass
@@ -1,0 +1,22 @@
+<PHPDocBlock start='3' end='51'>
+    <Tags>
+        <PHPDocMethodTag start='3' end='54' kind='method' isStatic='true'>
+            <Name>
+                <PHPDocNode start='26' end='29' value='get'/>
+            </Name>
+            <Return Types>
+                <PHPDocTypeNode start='21' end='25' value='?int' isArray='false'/>
+            </Return Types>
+            <Parameters>
+                <PHPDocVarTypeTag start='30' end='37' kind='param'>
+                    <Variable>
+                        <PHPDocNode start='35' end='37' value='$i'/>
+                    </Variable>
+                    <Types>
+                        <PHPDocTypeNode start='30' end='34' value='?int' isArray='false'/>
+                    </Types>
+                </PHPDocVarTypeTag>
+            </Parameters>
+        </PHPDocMethodTag>
+    </Tags>
+</PHPDocBlock>

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_01.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Example class.
+ *
+ * @method testVoid(Test $test)  test comment
+ * @method int testType(Test $test)  test comment
+ * @method static staticTestVoid(Test $test) test comment
+ * @method static int staticTestType(Test $param1, $param2)  test comment
+ * @method static ?int staticTestNullable(?string $param, int $param2) test comment
+ */
+class Example {
+
+    public function test() {
+        self::
+    }
+
+    public static function staticTest(): int {
+    }
+
+}
+
+Example::

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_01.php.testMagicMethodStatic_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_01.php.testMagicMethodStatic_01a.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+self::|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticTest()                    [STATIC]   Example
+METHOD     staticTestNullable(?string $pa  [STATIC]   Example
+METHOD     staticTestType(Test $param1, $  [STATIC]   Example
+METHOD     staticTestVoid(Test $test)      [STATIC]   Example
+CONSTANT   class \Example                  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_01.php.testMagicMethodStatic_01b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_01.php.testMagicMethodStatic_01b.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+Example::|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticTest()                    [STATIC]   Example
+METHOD     staticTestNullable(?string $pa  [STATIC]   Example
+METHOD     staticTestType(Test $param1, $  [STATIC]   Example
+METHOD     staticTestVoid(Test $test)      [STATIC]   Example
+CONSTANT   class \Example                  [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_02.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Example class.
+ *
+ * @method testVoid(Test $test)  test comment
+ * @method int testType(Test $test)  test comment
+ * @method static ?Example getDefault() Description
+ */
+class Example {
+
+    public function test() {
+        self::getDefault()->
+    }
+
+    public static function staticTest(): int {
+    }
+
+}
+
+Example::getDefault()->

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_02.php.testMagicMethodStatic_02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_02.php.testMagicMethodStatic_02a.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+self::getDefault()->|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     getDefault()                    [STATIC]   Example
+METHOD     staticTest()                    [STATIC]   Example
+METHOD     test()                          [PUBLIC]   Example
+METHOD     testType(Test $test)            [PUBLIC]   Example
+METHOD     testVoid(Test $test)            [PUBLIC]   Example

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_02.php.testMagicMethodStatic_02b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1861/nb1861_02.php.testMagicMethodStatic_02b.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+Example::getDefault()->|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     getDefault()                    [STATIC]   Example
+METHOD     staticTest()                    [STATIC]   Example
+METHOD     test()                          [PUBLIC]   Example
+METHOD     testType(Test $test)            [PUBLIC]   Example
+METHOD     testVoid(Test $test)            [PUBLIC]   Example

--- a/php/php.editor/test/unit/data/testfiles/gotodeclaration/testNb1861/testNb1861.php
+++ b/php/php.editor/test/unit/data/testfiles/gotodeclaration/testNb1861/testNb1861.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Example class.
+ *
+ * @method testVoid(Test $test)  test comment
+ * @method int testType(Test $test)  test comment
+ * @method static staticTestVoid(Test $test) test comment
+ * @method static int staticTestType(Test $param1, $param2)  test comment
+ * @method static ?int staticTestNullable(?string $param, int $param2) test comment
+ * @method static ?Example getDefault() Description
+ */
+class Example {
+
+    public function test() {
+        self::staticTestVoid($test);
+        self::staticTestType($param1, $param2);
+        self::staticTestNullable($param1, $param2);
+        self::getDefault();
+    }
+
+    public static function staticTest(): int {
+    }
+
+}
+
+Example::staticTestVoid($test);
+Example::staticTestType($param1, $param2);
+Example::staticTestNullable($param1, $param2);
+Example::getDefault();

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/testNb1861/testNb1861.php
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/testNb1861/testNb1861.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Example class.
+ *
+ * @method testVoid(Test $test)  test comment
+ * @method int testType(Test $test)  test comment
+ * @method static staticTestVoid(Test $test) test comment
+ * @method static int staticTestType(Test $param1, $param2)  test comment
+ * @method static ?int staticTestNullable(?string $param, int $param2) test comment
+ * @method static ?Example getDefault() Description
+ */
+class Example {
+
+    public function test() {
+        self::staticTestVoid($test);
+        self::staticTestType($param1, $param2);
+        self::staticTestNullable($param1, $param2);
+        self::getDefault();
+    }
+
+    public static function staticTest(): int {
+    }
+
+}
+
+Example::staticTestVoid($test);
+Example::staticTestType($param1, $param2);
+Example::staticTestNullable($param1, $param2);
+Example::getDefault();

--- a/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic01.php
+++ b/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic01.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @method static A m1 
+ */
+class A {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic02.php
+++ b/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic02.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @method static A m1() 
+ */
+class A {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic03.php
+++ b/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic03.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @method static A m1() small description
+ */
+class A {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic04.php
+++ b/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic04.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @method static A m1($param1) small description
+ */
+class A {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic05.php
+++ b/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic05.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @method static A m1(string $param1) small description
+ */
+class A {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic06.php
+++ b/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic06.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @method static A m1(string|A $param1) small description
+ */
+class A {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic07.php
+++ b/php/php.editor/test/unit/data/testfiles/parser/magicMethodStatic07.php
@@ -1,0 +1,26 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * @method static A m1() m1(string|A $param1, A $p2) small description
+ */
+class A {
+    
+}

--- a/php/php.editor/test/unit/data/testfiles/structure/magicMethods.php
+++ b/php/php.editor/test/unit/data/testfiles/structure/magicMethods.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Example class.
+ *
+ * @method testVoid(Test $test)  test comment
+ * @method int testType(Test $test)  test comment
+ * @method static staticTestVoid(Test $test) test comment
+ * @method static int staticTestType(Test $param1, $param2)  test comment
+ * @method static ?int staticTestNullable(?string $param, int $param2) test comment
+ * @method static ?Example getDefault() Description
+ */
+class Example {
+
+    public function test() {
+    }
+
+    public static function staticTest(): int {
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_01a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_01a.occurrences
@@ -1,0 +1,3 @@
+ * @method static ^|>MARK_OCCURRENCES:staticTestVoid<|(Test $test) test comment
+        self::|>MARK_OCCURRENCES:staticTestVoid<|($test);
+Example::|>MARK_OCCURRENCES:staticTestVoid<|($test);

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_01b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_01b.occurrences
@@ -1,0 +1,3 @@
+ * @method static |>MARK_OCCURRENCES:staticTestVoid<|(Test $test) test comment
+        self::|>MARK_OCCURRENCES:staticTes^tVoid<|($test);
+Example::|>MARK_OCCURRENCES:staticTestVoid<|($test);

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_01c.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_01c.occurrences
@@ -1,0 +1,3 @@
+ * @method static |>MARK_OCCURRENCES:staticTestVoid<|(Test $test) test comment
+        self::|>MARK_OCCURRENCES:staticTestVoid<|($test);
+Example::|>MARK_OCCURRENCES:staticTestVoi^d<|($test);

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_02a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_02a.occurrences
@@ -1,0 +1,3 @@
+ * @method static int |>MARK_OCCURRENCES:staticTestT^ype<|(Test $param1, $param2)  test comment
+        self::|>MARK_OCCURRENCES:staticTestType<|($param1, $param2);
+Example::|>MARK_OCCURRENCES:staticTestType<|($param1, $param2);

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_02b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_02b.occurrences
@@ -1,0 +1,3 @@
+ * @method static int |>MARK_OCCURRENCES:staticTestType<|(Test $param1, $param2)  test comment
+        self::|>MARK_OCCURRENCES:staticT^estType<|($param1, $param2);
+Example::|>MARK_OCCURRENCES:staticTestType<|($param1, $param2);

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_02c.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_02c.occurrences
@@ -1,0 +1,3 @@
+ * @method static int |>MARK_OCCURRENCES:staticTestType<|(Test $param1, $param2)  test comment
+        self::|>MARK_OCCURRENCES:staticTestType<|($param1, $param2);
+Example::|>MARK_OCCURRENCES:staticTe^stType<|($param1, $param2);

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_03a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_03a.occurrences
@@ -1,0 +1,3 @@
+ * @method static ?int |>MARK_OCCURRENCES:stat^icTestNullable<|(?string $param, int $param2) test comment
+        self::|>MARK_OCCURRENCES:staticTestNullable<|($param1, $param2);
+Example::|>MARK_OCCURRENCES:staticTestNullable<|($param1, $param2);

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_03b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_03b.occurrences
@@ -1,0 +1,3 @@
+ * @method static ?int |>MARK_OCCURRENCES:staticTestNullable<|(?string $param, int $param2) test comment
+        self::|>MARK_OCCURRENCES:staticTestNu^llable<|($param1, $param2);
+Example::|>MARK_OCCURRENCES:staticTestNullable<|($param1, $param2);

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_03c.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_03c.occurrences
@@ -1,0 +1,3 @@
+ * @method static ?int |>MARK_OCCURRENCES:staticTestNullable<|(?string $param, int $param2) test comment
+        self::|>MARK_OCCURRENCES:staticTestNullable<|($param1, $param2);
+Example::|>MARK_OCCURRENCES:staticTe^stNullable<|($param1, $param2);

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_04a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_04a.occurrences
@@ -1,0 +1,3 @@
+ * @method static ?Example |>MARK_OCCURRENCES:g^etDefault<|() Description
+        self::|>MARK_OCCURRENCES:getDefault<|();
+Example::|>MARK_OCCURRENCES:getDefault<|();

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_04b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_04b.occurrences
@@ -1,0 +1,3 @@
+ * @method static ?Example |>MARK_OCCURRENCES:getDefault<|() Description
+        self::|>MARK_OCCURRENCES:get^Default<|();
+Example::|>MARK_OCCURRENCES:getDefault<|();

--- a/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_04c.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb1861.php.testNb1861_04c.occurrences
@@ -1,0 +1,3 @@
+ * @method static ?Example |>MARK_OCCURRENCES:getDefault<|() Description
+        self::|>MARK_OCCURRENCES:getDefault<|();
+Example::^|>MARK_OCCURRENCES:getDefault<|();

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb1861Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb1861Test.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+
+public class PHPCodeCompletionNb1861Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionNb1861Test(String testName) {
+        super(testName);
+    }
+
+    public void testMagicMethodStatic_01a() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1861/nb1861_01.php", "self::^", false);
+    }
+
+    public void testMagicMethodStatic_01b() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1861/nb1861_01.php", "Example::^", false);
+    }
+
+    public void testMagicMethodStatic_02a() throws Exception {
+        // return type
+        checkCompletion("testfiles/completion/lib/nb1861/nb1861_02.php", "self::getDefault()->^", false);
+    }
+
+    public void testMagicMethodStatic_02b() throws Exception {
+        // return type
+        checkCompletion("testfiles/completion/lib/nb1861/nb1861_02.php", "Example::getDefault()->^", false);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/nb1861"))
+            })
+        );
+    }
+
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationNb1861Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationNb1861Test.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.csl;
+
+
+public class GotoDeclarationNb1861Test extends GotoDeclarationTestBase {
+
+    public GotoDeclarationNb1861Test(String testName) {
+        super(testName);
+    }
+
+    // Magic methods (@method)
+    public void testNb1861_01a() throws Exception {
+        checkDeclaration(getTestPath(), "        self::staticTestV^oid($test);", " * @method static ^staticTestVoid(Test $test) test comment");
+    }
+
+    public void testNb1861_01b() throws Exception {
+        checkDeclaration(getTestPath(), "Example::static^TestVoid($test);", " * @method static ^staticTestVoid(Test $test) test comment");
+    }
+
+    public void testNb1861_02a() throws Exception {
+        checkDeclaration(getTestPath(), "        self::staticTestTy^pe($param1, $param2);", " * @method static int ^staticTestType(Test $param1, $param2)  test comment");
+    }
+
+    public void testNb1861_02b() throws Exception {
+        checkDeclaration(getTestPath(), "Example::^staticTestType($param1, $param2);", " * @method static int ^staticTestType(Test $param1, $param2)  test comment");
+    }
+
+    public void testNb1861_03a() throws Exception {
+        checkDeclaration(getTestPath(), "        self::st^aticTestNullable($param1, $param2);", " * @method static ?int ^staticTestNullable(?string $param, int $param2) test comment");
+    }
+
+    public void testNb1861_03b() throws Exception {
+        checkDeclaration(getTestPath(), "Example::staticTe^stNullable($param1, $param2);", " * @method static ?int ^staticTestNullable(?string $param, int $param2) test comment");
+    }
+
+    public void testNb1861_04a() throws Exception {
+        checkDeclaration(getTestPath(), "        self::ge^tDefault();", " * @method static ?Example ^getDefault() Description");
+    }
+
+    public void testNb1861_04b() throws Exception {
+        checkDeclaration(getTestPath(), "Example::getDe^fault();", " * @method static ?Example ^getDefault() Description");
+    }
+
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/NavigatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/NavigatorTest.java
@@ -105,4 +105,8 @@ public class NavigatorTest extends PhpNavigatorTestBase{
         performTest("structure/nullableTypes_02");
     }
 
+    public void testMagicMethods_01() throws Exception {
+        performTest("structure/magicMethods");
+    }
+
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplNb1861Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplNb1861Test.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.csl;
+
+
+public class OccurrencesFinderImplNb1861Test extends OccurrencesFinderImplTestBase {
+
+    public OccurrencesFinderImplNb1861Test(String testName) {
+        super(testName);
+    }
+
+    public void testNb1861_01a() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static ^staticTestVoid(Test $test) test comment", true);
+    }
+
+    public void testNb1861_01b() throws Exception {
+        checkOccurrences(getTestPath(), "        self::staticTes^tVoid($test);", true);
+    }
+
+    public void testNb1861_01c() throws Exception {
+        checkOccurrences(getTestPath(), "Example::staticTestVoi^d($test);", true);
+    }
+
+    public void testNb1861_02a() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static int staticTestT^ype(Test $param1, $param2)  test comment", true);
+    }
+
+    public void testNb1861_02b() throws Exception {
+        checkOccurrences(getTestPath(), "        self::staticT^estType($param1, $param2);", true);
+    }
+
+    public void testNb1861_02c() throws Exception {
+        checkOccurrences(getTestPath(), "Example::staticTe^stType($param1, $param2);", true);
+    }
+
+    public void testNb1861_03a() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static ?int stat^icTestNullable(?string $param, int $param2) test comment", true);
+    }
+
+    public void testNb1861_03b() throws Exception {
+        checkOccurrences(getTestPath(), "        self::staticTestNu^llable($param1, $param2);", true);
+    }
+
+    public void testNb1861_03c() throws Exception {
+        checkOccurrences(getTestPath(), "Example::staticTe^stNullable($param1, $param2);", true);
+    }
+
+    public void testNb1861_04a() throws Exception {
+        checkOccurrences(getTestPath(), " * @method static ?Example g^etDefault() Description", true);
+    }
+
+    public void testNb1861_04b() throws Exception {
+        checkOccurrences(getTestPath(), "        self::get^Default();", true);
+    }
+
+    public void testNb1861_04c() throws Exception {
+        checkOccurrences(getTestPath(), "Example::^getDefault();", true);
+    }
+
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/ASTPHP5ParserTest.java
@@ -310,6 +310,35 @@ public class ASTPHP5ParserTest extends ParserTestBase {
         performTest("parser/magicMethod07");
     }
 
+    // NETBEANS-1861
+    public void testMagicMethodStatic01() throws Exception {
+        performTest("parser/magicMethodStatic01");
+    }
+
+    public void testMagicMethodStatic02() throws Exception {
+        performTest("parser/magicMethodStatic02");
+    }
+
+    public void testMagicMethodStatic03() throws Exception {
+        performTest("parser/magicMethodStatic03");
+    }
+
+    public void testMagicMethodStatic04() throws Exception {
+        performTest("parser/magicMethodStatic04");
+    }
+
+    public void testMagicMethodStatic05() throws Exception {
+        performTest("parser/magicMethodStatic05");
+    }
+
+    public void testMagicMethodStatic06() throws Exception {
+        performTest("parser/magicMethodStatic06");
+    }
+
+    public void testMagicMethodStatic07() throws Exception {
+        performTest("parser/magicMethodStatic07");
+    }
+
     public void testTraits_01() throws Exception {
         performTest("parser/traits_01");
     }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/PHPDocCommentParserTest.java
@@ -355,6 +355,36 @@ public class PHPDocCommentParserTest extends PHPTestBase {
         perform(comment, "testIssue257953");
     }
 
+    public void testMethod01() throws Exception {
+        String comment = " * @method int get(int $i) message foo bar";
+        perform(comment, "Method01");
+    }
+
+    public void testMethod02() throws Exception {
+        String comment = " * @method get(int $i) message foo bar";
+        perform(comment, "Method02");
+    }
+
+    public void testMethod03() throws Exception {
+        String comment = " * @method ?int get(?int $i) message foo bar";
+        perform(comment, "Method03");
+    }
+
+    public void testMethodStatic01() throws Exception {
+        String comment = " * @method static int get(int $i) message foo bar";
+        perform(comment, "MethodStatic01");
+    }
+
+    public void testMethodStatic02() throws Exception {
+        String comment = " * @method static get(int $i) message foo bar";
+        perform(comment, "MethodStatic02");
+    }
+
+    public void testMethodStatic03() throws Exception {
+        String comment = " * @method static ?int get(?int $i) message foo bar";
+        perform(comment, "MethodStatic03");
+    }
+
     public void perform(String comment, String filename) throws Exception {
         PHPDocCommentParser parser = new PHPDocCommentParser();
         PHPDocBlock block = parser.parse(0, comment.length(), comment);

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/PrintASTVisitor.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/PrintASTVisitor.java
@@ -876,7 +876,7 @@ public class PrintASTVisitor implements Visitor {
     @Override
     public void visit(PHPDocMethodTag node) {
         XMLPrintNode printNode = new XMLPrintNode(node, "PHPDocMethodTag",
-                new String[] {"kind", node.getKind().getName()});
+                new String[] {"kind", node.getKind().getName(), "isStatic", node.isStatic() ? "true" : "false"});
         printNode.addChild("Name", node.getMethodName());
         printNode.addChildrenGroup("Return Types", node.getTypes());
         printNode.addChildrenGroup("Parameters", node.getParameters());

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/astnodes/CommentExtractorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/astnodes/CommentExtractorTest.java
@@ -58,4 +58,28 @@ public class CommentExtractorTest extends PHPTestBase {
         assertEquals(description, documentation);
     }
 
+    // NETBEANS-1861
+    public void testStaticNoDescription() throws Exception {
+        PHPDocNode methodName = new PHPDocNode(1, 2, "where");
+        PHPDocMethodTag methodTag = new PHPDocMethodTag(1, 2, PHPDocTag.Type.METHOD, null, methodName, null, "@method static DibiConnection where($cond)");
+        String documentation = methodTag.getDocumentation();
+        assertEquals("", documentation);
+    }
+
+    public void testStaticExistingDescription() throws Exception {
+        PHPDocNode methodName = new PHPDocNode(1, 2, "where");
+        final String description = "My description.";
+        PHPDocMethodTag methodTag = new PHPDocMethodTag(1, 2, PHPDocTag.Type.METHOD, null, methodName, null, "@method static DibiConnection where($cond) " + description);
+        String documentation = methodTag.getDocumentation();
+        assertEquals(description, documentation);
+    }
+
+    public void testStaticExistingDescriptionWithMoreDeclarations() throws Exception {
+        PHPDocNode methodName = new PHPDocNode(1, 2, "where");
+        final String description = "My description.";
+        PHPDocMethodTag methodTag = new PHPDocMethodTag(1, 2, PHPDocTag.Type.METHOD, null, methodName, null, "@method static DibiConnection where() where($cond) " + description);
+        String documentation = methodTag.getDocumentation();
+        assertEquals(description, documentation);
+    }
+
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-1861

Example:
```php
/**
 * Example class.
 *
 * @method testVoid(Test $test)  test comment
 * @method int testType(Test $test)  test comment
 * @method static staticTestVoid(Test $test) test comment
 * @method static int staticTestType(Test $param1, $param2)  test comment
 * @method static ?int staticTestNullable(?string $param, int $param2) test comment
 * @method static ?Example getDefault() Description
 */
class Example {

    public function test() {
        self::staticTestVoid($test);
        self::staticTestType($param1, $param2);
        self::staticTestNullable($param1, $param2);
        self::getDefault();
    }

}
```

- Fix DeclarationFinderImpl and PHPDocCommentParser
- Fix MarkOccurences and GoToDeclaration features
- Add unit tests for CC, MarkOccurences, GoToDeclaration, Navigator, CommentExtractor, ASTPHP5Parser, and PHPDocCommentParser