### PR TITLE
Fixed typo in gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,7 +24,7 @@
 *.svg             text eol=lf
 *.txt             text eol=lf
 *.xml             text eol=lf
-*.xsd             test eol=lf
+*.xsd             text eol=lf
 
 .gitattributes    text eol=lf
 .gitignore        text eol=lf


### PR DESCRIPTION
`text` was misspelled as `test`. The impact has been that git hasn't enforced any particular line-ending style for files of type .xsd. It will do so now, similar to other text type files.