### PR TITLE
[NETBEANS-2788] The link provided for downloading Groovy is obsolete

### DIFF
--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/Bundle.properties
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/Bundle.properties
@@ -36,7 +36,7 @@ OpenIDE-Module-Display-Category=Tools
 OpenIDE-Module-Short-Description=Enables editing and running of scripts written in Groovy language.
 OpenIDE-Module-Long-Description=The Groovy Support module enables editing and running of \
 user application files written in Groovy language. This module requires groovy installation \
-on the computer. Groovy home page: http://groovy.codehaus.org/
+on the computer. Groovy home page: https://groovy.apache.org/download.html
 
 #MakeGroovyWebApp
 CTL_MakeGroovyWebAppAction=Make WebApp Groovy Compliant

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/options/Bundle.properties
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/options/Bundle.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 # Followed by a URL where Groovy can be downloaded
-SupportPanel.jLabel2.text=Get Groovy at: http://groovy.codehaus.org
+SupportPanel.jLabel2.text=Get Groovy at: https://groovy.apache.org/download.html
 
 OptionsCategory_Name_Groovy=Groovy
 OptionsCategory_Title_Groovy=Groovy

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/options/SupportPanel.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/options/SupportPanel.java
@@ -196,7 +196,7 @@ private void chooseDocButtonActionPerformed(java.awt.event.ActionEvent evt) {//G
 
     private void jLabel2MousePressed(java.awt.event.MouseEvent evt) {//GEN-FIRST:event_jLabel2MousePressed
         try {
-            HtmlBrowser.URLDisplayer.getDefault().showURL(new URL("http://groovy.codehaus.org")); // NOI18N
+            HtmlBrowser.URLDisplayer.getDefault().showURL(new URL("https://groovy.apache.org/download.html")); // NOI18N
         } catch (MalformedURLException murle) {
             Exceptions.printStackTrace(murle);
         }


### PR DESCRIPTION
Changed the old URL to a new one:  https://groovy.apache.org/download.html
Jira Ticket: https://issues.apache.org/jira/projects/NETBEANS/issues/NETBEANS-2788