### PR TITLE
[NETBEANS-3076] Try to create unit-test with Gradle Projects

### DIFF
--- a/apisupport/apisupport.project/nbproject/project.properties
+++ b/apisupport/apisupport.project/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/groovy/gradle.java/nbproject/project.properties
+++ b/groovy/gradle.java/nbproject/project.properties
@@ -20,6 +20,9 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 nbm.module.author=Laszlo Kishalmi
 
+test-unit-sys-prop.test.netbeans.dest.dir=${netbeans.dest.dir}
+test-unit-sys-prop.java.awt.headless=true
+
 release.external/org.jacoco.core-0.8.3.jar=modules/gradle/org.jacoco.core.jar
 release.external/asm-7.0.jar=modules/gradle/asm.jar
 release.external/asm-commons-7.0.jar=modules/gradle/asm-commons.jar

--- a/groovy/gradle.java/nbproject/project.xml
+++ b/groovy/gradle.java/nbproject/project.xml
@@ -313,12 +313,40 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
+                        <code-name-base>org.netbeans.modules.apisupport.project</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.gradle</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
                         <recursive/>
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.gradle</code-name-base>
+                        <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.projectui</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.openide.filesystems</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.openide.util.lookup</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.openide.util.ui</code-name-base>
                         <compile-dependency/>
                         <test/>
                     </test-dependency>

--- a/groovy/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImplTest.java
+++ b/groovy/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImplTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.classpath;
+
+import java.io.File;
+import static junit.framework.TestCase.assertNotNull;
+import org.netbeans.api.java.project.JavaProjectConstants;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.api.project.SourceGroup;
+import org.netbeans.api.project.Sources;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.apisupport.project.InstalledFileLocatorImpl;
+import org.netbeans.modules.project.uiapi.ProjectOpenedTrampoline;
+import org.netbeans.spi.project.ui.ProjectOpenedHook;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.test.TestFileUtils;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class GradleSourcesImplTest extends NbTestCase {
+
+    public GradleSourcesImplTest(String name) {
+        super(name);
+    }
+
+    private FileObject d;
+    /** Represents destination directory with NetBeans (always available). */
+    protected File destDirF;
+    
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        clearWorkDir();
+        d = FileUtil.toFileObject(getWorkDir());
+        destDirF = getTestNBDestDir();
+    }
+
+    public void testGeneratedSources() throws Exception { // #187595
+        InstalledFileLocatorImpl.registerDestDir(destDirF);
+
+        TestFileUtils.writeFile(d,
+                "build.gradle",
+                "apply plugin: 'java'\n" +
+                "sourceSets { main { java { srcDirs = [ 'src', 'build/gen-src' ] }}}");
+        FileObject src = FileUtil.createFolder(d, "src/");
+        FileObject gsrc = FileUtil.createFolder(d, "build/gen-src");
+        FileObject source = src.createData("Whatever.java");
+        FileObject generated = gsrc.createData("WhateverGen.java");
+        Project prj = ProjectManager.getDefault().findProject(d);
+        assertNotNull(prj);
+        ProjectOpenedTrampoline.DEFAULT.projectOpened(prj.getLookup().lookup(ProjectOpenedHook.class));
+        Sources srcs = ProjectUtils.getSources(prj);
+        SourceGroup[] groups = srcs.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA);
+        assertEquals(2, groups.length);
+        assertTrue(groups[0].contains(source));
+        assertFalse(groups[0].contains(generated));
+        assertTrue(groups[1].contains(generated));
+        assertFalse(groups[1].contains(source));
+    }
+
+    private static File getTestNBDestDir() {
+        String destDir = System.getProperty("test.netbeans.dest.dir");
+        // set in project.properties as test-unit-sys-prop.test.netbeans.dest.dir
+        assertNotNull("test.netbeans.dest.dir property has to be set when running within binary distribution", destDir);
+        return new File(destDir);
+    }
+
+}

--- a/platform/openide.util.ui/nbproject/project.properties
+++ b/platform/openide.util.ui/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial -Xlint:-processing
-javac.source=1.6
-javac.target=1.7
+javac.source=1.8
+javac.target=1.8
 module.jar.dir=lib
 
 

--- a/platform/openide.util/nbproject/project.properties
+++ b/platform/openide.util/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 module.jar.dir=lib


### PR DESCRIPTION
This is actually a unittest for NETBEANS-2925. Separated as it affects other modules with javac.source upgrade 1.6 -> 1.8
Also it needs to interact with Gradle which might fail, and is so requires more plumbing.