### PR TITLE
JEDDICT-322 org.netbeans.modules.j2ee.persistence convert friend to public packages

### DIFF
--- a/java/j2ee.persistence/nbproject/project.xml
+++ b/java/j2ee.persistence/nbproject/project.xml
@@ -617,22 +617,7 @@
                     </test-dependency>
                 </test-type>
             </test-dependencies>
-            <friend-packages>
-                <friend>org.netbeans.modules.form.j2ee</friend>
-                <friend>org.netbeans.modules.gradle.javaee</friend>
-                <friend>org.netbeans.modules.hibernate</friend>
-                <friend>org.netbeans.modules.j2ee.common</friend>
-                <friend>org.netbeans.modules.j2ee.ejbcore</friend>
-                <friend>org.netbeans.modules.j2ee.ejbjarproject</friend>
-                <friend>org.netbeans.modules.j2ee.jpa.refactoring</friend>
-                <friend>org.netbeans.modules.j2ee.jpa.verification</friend>
-                <friend>org.netbeans.modules.javaee.project</friend>
-                <friend>org.netbeans.modules.javaee.specs.support</friend>
-                <friend>org.netbeans.modules.maven.j2ee</friend>
-                <friend>org.netbeans.modules.profiler.j2ee</friend>
-                <friend>org.netbeans.modules.web.jsf</friend>
-                <friend>org.netbeans.modules.web.project</friend>
-                <friend>org.netbeans.modules.websvc.rest</friend>
+            <public-packages>
                 <package>org.netbeans.modules.j2ee.persistence.action</package>
                 <package>org.netbeans.modules.j2ee.persistence.api.entity.generator</package>
                 <package>org.netbeans.modules.j2ee.persistence.dd</package>
@@ -653,7 +638,7 @@
                 <package>org.netbeans.modules.j2ee.persistence.wizard.jpacontroller</package>
                 <package>org.netbeans.modules.j2ee.persistence.wizard.library</package>
                 <package>org.netbeans.modules.j2ee.persistence.wizard.unit</package>
-            </friend-packages>
+            </public-packages>
         </data>
     </configuration>
 </project>


### PR DESCRIPTION
Github issue: https://github.com/jeddict/jeddict/issues/322

Friend API of the Apache NetBeans Platform used by Jeddict modules:

| NetBeans Module name | NetBeans Module location | APIs | Used by Jeddict modules | Requirement |  Why access needed? |
| --- | --- | --- | --- | --- | --------- |
| org.netbeans.modules:org-netbeans-modules-j2ee-persistence | netbeans\java\j2ee.persistence | org.netbeans.modules.j2ee.persistence.dd, org.netbeans.modules.j2ee.persistence.dd.common, org.netbeans.modules.j2ee.persistence.unit, org.netbeans.modules.j2ee.persistence.entitygenerator, org.netbeans.modules.j2ee.persistence.jpqleditor, org.netbeans.modules.j2ee.persistence.jpqleditor.ui, org.netbeans.modules.j2ee.persistence.editor, org.netbeans.modules.j2ee.persistence.provider, org.netbeans.modules.j2ee.persistence.wizard, org.netbeans.modules.j2ee.persistence.wizard.jpacontroller, org.netbeans.modules.j2ee.persistence.wizard.fromdb, org.netbeans.modules.j2ee.persistence.wizard.library, org.netbeans.modules.j2ee.persistence.wizard.unit | io.github.jeddict.jcode.util, io.github.jeddict.jpa.modeler, io.github.jeddict.reveng, io.github.jeddict.orm.generator,  io.github.jeddict.runtime, io.github.jeddict.rest.generator, io.github.jeddict.mvc.generator, io.github.jeddict.infra | public-packages | JPQL Editor integration in JPA Modeler, persistence.xml updated during source generation |