### PR TITLE
[NETBEANS-3078]:Provided Error Hint to turn on Preview Features in An…

### DIFF
--- a/java/ant.hints/build.xml
+++ b/java/ant.hints/build.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<project basedir="." default="build" name="java/ant.hints">
+    <description>Builds, tests, and runs the project org.netbeans.modules.ant.hints</description>
+    <import file="../../nbbuild/templates/projectized.xml"/>
+</project>

--- a/java/ant.hints/manifest.mf
+++ b/java/ant.hints/manifest.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.netbeans.modules.ant.hints/1
+OpenIDE-Module-Specification-Version: 1.0
+OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/ant/hints/Bundle.properties
+OpenIDE-Module-Layer: org/netbeans/modules/ant/hints/layer.xml
+AutoUpdate-Show-In-Client: false

--- a/java/ant.hints/nbproject/project.properties
+++ b/java/ant.hints/nbproject/project.properties
@@ -17,7 +17,3 @@
 
 is.eager=true
 javac.source=1.8
-#javac.compilerargs=-Xlint -Xlint:-serial
-
-test.config.stableBTD.includes=**/*Test.class
-requires.nb.javac=true

--- a/java/ant.hints/nbproject/project.properties
+++ b/java/ant.hints/nbproject/project.properties
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+is.eager=true
+javac.source=1.8
+#javac.compilerargs=-Xlint -Xlint:-serial
+
+test.config.stableBTD.includes=**/*Test.class
+requires.nb.javac=true

--- a/java/ant.hints/nbproject/project.xml
+++ b/java/ant.hints/nbproject/project.xml
@@ -35,6 +35,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.libs.javacapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>8.27</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.editor.mimelookup</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -128,32 +136,7 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
-            <test-dependencies>
-                <test-type>
-                    <name>unit</name>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.masterfs</code-name-base>
-                        <recursive/>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
-                        <recursive/>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.openide.filesystems</code-name-base>
-                        <compile-dependency/>
-                        <test/>
-                    </test-dependency>
-                </test-type>
-            </test-dependencies>
+            <test-dependencies/>
             <public-packages/>
         </data>
     </configuration>

--- a/java/ant.hints/nbproject/project.xml
+++ b/java/ant.hints/nbproject/project.xml
@@ -23,14 +23,33 @@
     <type>org.netbeans.modules.apisupport.project</type>
     <configuration>
         <data xmlns="http://www.netbeans.org/ns/nb-module-project/3">
-            <code-name-base>org.netbeans.modules.java.hints.legacy.spi</code-name-base>
+            <code-name-base>org.netbeans.modules.ant.hints</code-name-base>
             <module-dependencies>
                 <dependency>
-                    <code-name-base>org.netbeans.libs.javacapi</code-name-base>
+                    <code-name-base>org.netbeans.api.annotations.common</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.9</specification-version>
+                        <release-version>1</release-version>
+                        <specification-version>1.33</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.editor.mimelookup</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.20</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.java.hints.legacy.spi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -42,12 +61,21 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.parsing.api</code-name-base>
+                    <code-name-base>org.netbeans.modules.project.ant</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>9.0</specification-version>
+                        <specification-version>1.73</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.projectapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.73</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -55,16 +83,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>0-1</release-version>
-                        <specification-version>1.24</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.spi.java.hints</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <implementation-version/>
+                        <release-version>0</release-version>
+                        <specification-version>1.48</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -76,27 +96,27 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.openide.loaders</code-name-base>
+                    <code-name-base>org.openide.modules</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.61</specification-version>
+                        <specification-version>7.7</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.openide.nodes</code-name-base>
+                    <code-name-base>org.openide.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.26</specification-version>
+                        <specification-version>9.13</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.openide.text</code-name-base>
+                    <code-name-base>org.openide.util.lookup</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>6.44</specification-version>
+                        <specification-version>8.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -107,36 +127,34 @@
                         <specification-version>9.3</specification-version>
                     </run-dependency>
                 </dependency>
-                <dependency>
-                    <code-name-base>org.openide.util</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>9.3</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.openide.util.lookup</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>8.12</specification-version>
-                    </run-dependency>
-                </dependency>
             </module-dependencies>
-            <friend-packages>
-                <friend>org.netbeans.modules.apisupport.ant</friend>
-                <friend>org.netbeans.modules.ant.hints</friend>
-                <friend>org.netbeans.modules.javadoc</friend>
-                <friend>org.netbeans.modules.javahints</friend>
-                <friend>org.netbeans.modules.maven.hints</friend>
-                <friend>org.netbeans.modules.maven.j2ee</friend>
-                <friend>org.netbeans.modules.web.beans</friend>
-                <friend>org.netbeans.modules.jshell.support</friend>
-                <package>org.netbeans.modules.java.hints.spi</package>
-                <package>org.netbeans.modules.java.hints.spi.support</package>
-                <package>org.netbeans.modules.jshell.support</package>
-            </friend-packages>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.masterfs</code-name-base>
+                        <recursive/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.openide.filesystems</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
+            <public-packages/>
         </data>
     </configuration>
 </project>

--- a/java/ant.hints/src/org/netbeans/modules/ant/hints/Bundle.properties
+++ b/java/ant.hints/src/org/netbeans/modules/ant/hints/Bundle.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+OpenIDE-Module-Display-Category=Ant
+OpenIDE-Module-Name=Ant Hints
+OpenIDE-Module-Long-Description=Providing Ant Hints set for common mistakes and best practices
+org-netbeans-modules-java-hints/rules/hints/ant=Ant

--- a/java/ant.hints/src/org/netbeans/modules/ant/hints/errors/Bundle.properties
+++ b/java/ant.hints/src/org/netbeans/modules/ant/hints/errors/Bundle.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FIX_EnablePreviewFeature=Enable Preview Feature

--- a/java/ant.hints/src/org/netbeans/modules/ant/hints/errors/EnablePreviewAntProj.java
+++ b/java/ant.hints/src/org/netbeans/modules/ant/hints/errors/EnablePreviewAntProj.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.ant.hints.errors;
+
+import com.sun.source.util.TreePath;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.SourceVersion;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.modules.java.hints.spi.ErrorRule;
+import org.netbeans.spi.editor.hints.ChangeInfo;
+import org.netbeans.spi.editor.hints.Fix;
+import org.openide.filesystems.FileObject;
+import org.openide.util.NbBundle;
+import org.openide.util.Parameters;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.spi.project.support.ant.AntProjectHelper;
+import org.openide.util.EditableProperties;
+import org.openide.util.Mutex;
+import org.openide.util.MutexException;
+
+/**
+ * Handle error rule "compiler.err.preview.feature.disabled.plural" and provide
+ * the fix for Ant type project.
+ *
+ * @author arusinha
+ */
+public class EnablePreviewAntProj implements ErrorRule<Void> {
+
+    private static final Set<String> ERROR_CODES = new HashSet<String>(Arrays.asList(
+            "compiler.err.preview.feature.disabled.plural")); // NOI18N
+    private static final String ENABLE_PREVIEW_FLAG = "--enable-preview";   // NOI18N
+    private static final String JAVAC_COMPILER_ARGS = "javac.compilerargs"; // NOI18N
+    private static final String RUN_JVMARGS = "run.jvmargs"; // NOI18N
+
+    @Override
+    public Set<String> getCodes() {
+        return Collections.unmodifiableSet(ERROR_CODES);
+    }
+
+    @Override
+    @NonNull
+    public List<Fix> run(CompilationInfo compilationInfo, String diagnosticKey, int offset, TreePath treePath, Data<Void> data) {
+
+        if (SourceVersion.latest() != compilationInfo.getSourceVersion()) {
+            return Collections.<Fix>emptyList();
+        }
+
+        final FileObject file = compilationInfo.getFileObject();
+        Fix fix = null;
+        if (file != null) {
+            final Project prj = FileOwnerQuery.getOwner(file);
+
+            if (isAntProject(prj)) {
+                fix = new EnablePreviewAntProj.ResolveAntFix(prj);
+            } else {
+                fix = null;
+            }
+        }
+        return (fix != null) ? Collections.<Fix>singletonList(fix) : Collections.<Fix>emptyList();
+    }
+
+    @Override
+    public String getId() {
+        return EnablePreviewAntProj.class.getName();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return NbBundle.getMessage(EnablePreviewAntProj.class, "FIX_EnablePreviewFeature"); // NOI18N
+    }
+
+    public String getDescription() {
+        return NbBundle.getMessage(EnablePreviewAntProj.class, "FIX_EnablePreviewFeature"); // NOI18N
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    private static final class ResolveAntFix implements Fix {
+
+        private final Project prj;
+
+        ResolveAntFix(@NonNull final Project prj) {
+            Parameters.notNull("prj", prj); //NOI18N
+            this.prj = prj;
+        }
+
+        @Override
+        public String getText() {
+            return NbBundle.getMessage(EnablePreviewAntProj.class, "FIX_EnablePreviewFeature");  // NOI18N
+        }
+
+        @Override
+        public ChangeInfo implement() throws Exception {
+
+            EditableProperties ep = getEditableProperties(prj, AntProjectHelper.PROJECT_PROPERTIES_PATH);
+
+            String compilerArgs = ep.getProperty(JAVAC_COMPILER_ARGS);
+            compilerArgs = compilerArgs != null ? compilerArgs + " " + ENABLE_PREVIEW_FLAG : ENABLE_PREVIEW_FLAG;
+
+            String runJVMArgs = ep.getProperty(RUN_JVMARGS);
+            if (!runJVMArgs.contains(ENABLE_PREVIEW_FLAG)) {
+                runJVMArgs = runJVMArgs != null ? runJVMArgs + " " + ENABLE_PREVIEW_FLAG : ENABLE_PREVIEW_FLAG;
+            }
+
+            ep.setProperty(JAVAC_COMPILER_ARGS, compilerArgs);
+            ep.setProperty(RUN_JVMARGS, runJVMArgs);
+            storeEditableProperties(prj, AntProjectHelper.PROJECT_PROPERTIES_PATH, ep);
+            return null;
+        }
+
+    }
+
+    private static void storeEditableProperties(final Project prj, final String propertiesPath, final EditableProperties ep)
+            throws IOException {
+        try {
+            ProjectManager.mutex().writeAccess(new Mutex.ExceptionAction<Void>() {
+                @Override
+                public Void run() throws IOException {
+                    FileObject propertiesFo = prj.getProjectDirectory().getFileObject(propertiesPath);
+                    if (propertiesFo != null) {
+                        OutputStream os = null;
+                        try {
+                            os = propertiesFo.getOutputStream();
+                            ep.store(os);
+                        } finally {
+                            if (os != null) {
+                                os.close();
+                            }
+                        }
+                    }
+                    return null;
+                }
+            });
+        } catch (MutexException ex) {
+        }
+    }
+
+    private static EditableProperties getEditableProperties(final Project prj, final String propertiesPath)
+            throws IOException {
+        try {
+            return ProjectManager.mutex().readAccess(new Mutex.ExceptionAction<EditableProperties>() {
+                @Override
+                public EditableProperties run() throws IOException {
+                    FileObject propertiesFo = prj.getProjectDirectory().getFileObject(propertiesPath);
+                    EditableProperties ep = null;
+                    if (propertiesFo != null) {
+                        InputStream is = null;
+                        ep = new EditableProperties(false);
+                        try {
+                            is = propertiesFo.getInputStream();
+                            ep.load(is);
+                        } finally {
+                            if (is != null) {
+                                is.close();
+                            }
+                        }
+                    }
+                    return ep;
+                }
+            });
+        } catch (MutexException ex) {
+            return null;
+        }
+    }
+
+    private boolean isAntProject(Project prj) {
+        if (prj == null) {
+            return false;
+        }
+        FileObject prjDir = prj.getProjectDirectory();
+        if (prjDir == null) {
+            return false;
+        }
+        List<FileObject> antProjectFiles = new ArrayList();
+        antProjectFiles.add(prjDir.getFileObject("build.xml"));   // NOI18N
+        antProjectFiles.add(prjDir.getFileObject("nbproject/project.properties"));   // NOI18N
+        antProjectFiles.add(prjDir.getFileObject("nbproject/project.xml"));   // NOI18N
+        boolean isAntProject = true;
+        for (FileObject file : antProjectFiles) {
+            if (!(file != null && file.isValid())) {
+                isAntProject = false;
+                break;
+            }
+        }
+
+        return isAntProject;
+
+    }
+
+}

--- a/java/ant.hints/src/org/netbeans/modules/ant/hints/layer.xml
+++ b/java/ant.hints/src/org/netbeans/modules/ant/hints/layer.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.1//EN" "http://www.netbeans.org/dtds/filesystem-1_1.dtd">
+<filesystem>
+    <folder name="org-netbeans-modules-java-hints">
+        <folder name="rules">
+            <folder name="errors">
+                <file name="org-netbeans-modules-ant-hints-errors-EnablePreviewAntProj.instance"/>
+            </folder>
+        </folder>
+    </folder>
+
+</filesystem>

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/errors/EnablePreviewMavenProj.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/errors/EnablePreviewMavenProj.java
@@ -166,8 +166,15 @@ public class EnablePreviewMavenProj implements ErrorRule<Void> {
     }
 
     private boolean isMavenProject(Project prj) {
+        if (prj == null) {
+            return false;
+        }
+        FileObject prjDir = prj.getProjectDirectory();
+        if (prjDir == null) {
+            return false;
+        }
 
-        FileObject pom = prj.getProjectDirectory().getFileObject("pom.xml");
+        FileObject pom = prjDir.getFileObject("pom.xml");
         return (pom != null) && pom.isValid();
 
     }

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -565,6 +565,7 @@ nb.cluster.java=\
         ant.debugger,\
         ant.freeform,\
         ant.grammar,\
+        ant.hints,\
         ant.kit,\
         api.debugger.jpda,\
         api.java,\


### PR DESCRIPTION
…t Java projects


Jira Link: https://issues.apache.org/jira/browse/NETBEANS-3078

Suppose we had used switch-expression in Java application (JDK-12)
e.g.,
int a = switch (num)
{      case 1 ->1;     default->2; }
;
It will show the below error:

switch expressions are a preview feature and are disabled by default.
(use --enable-preview to enable switch expressions)

The proposed hint will add the needed JVM parameter in run/compiler properties