### PR TITLE
Update netbeans bundled JNA library to 5.4.0

### DIFF
--- a/contrib/libs.svnClientAdapter.svnkit/manifest.mf
+++ b/contrib/libs.svnClientAdapter.svnkit/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.libs.svnClientAdapter.svnkit/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/svnclientadapter/svnkit/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.25
+OpenIDE-Module-Specification-Version: 1.26
 

--- a/contrib/libs.svnClientAdapter.svnkit/nbproject/project.xml
+++ b/contrib/libs.svnClientAdapter.svnkit/nbproject/project.xml
@@ -38,8 +38,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.11</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/dlight.nativeexecution/nbproject/project.xml
+++ b/ide/dlight.nativeexecution/nbproject/project.xml
@@ -64,8 +64,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.4</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/LocalNativeProcess.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/LocalNativeProcess.java
@@ -187,7 +187,7 @@ public final class LocalNativeProcess extends AbstractNativeProcess {
                 f.setAccessible(true);
                 long phandle = f.getLong(process);
 
-                Win32APISupport kernel = Win32APISupport.instance;
+                Win32APISupport kernel = Win32APISupport.INSTANCE;
                 Win32APISupport.HANDLE handle = new Win32APISupport.HANDLE();
                 handle.setPointer(Pointer.createConstant(phandle));
                 newPid = kernel.GetProcessId(handle);

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Win32APISupport.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Win32APISupport.java
@@ -23,24 +23,13 @@ import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
 import com.sun.jna.win32.StdCallLibrary;
-import com.sun.jna.win32.W32APIFunctionMapper;
-import com.sun.jna.win32.W32APITypeMapper;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import com.sun.jna.win32.W32APIOptions;
 /* https://jna.dev.java.net/ */
 /* http://golesny.de/wiki/code:javahowtogetpid */
 
 public interface Win32APISupport extends StdCallLibrary {
 
-    final Map<String, Object> DEFAULT_OPTIONS = Collections.unmodifiableMap(new HashMap<String, Object>() {
-
-        {
-            put(OPTION_TYPE_MAPPER, W32APITypeMapper.UNICODE);
-            put(OPTION_FUNCTION_MAPPER, W32APIFunctionMapper.UNICODE);
-        }
-    });
-    final Win32APISupport instance = (Win32APISupport) Native.loadLibrary("kernel32", Win32APISupport.class, DEFAULT_OPTIONS); // NOI18N
+    final Win32APISupport INSTANCE = (Win32APISupport) Native.load("kernel32", Win32APISupport.class, W32APIOptions.UNICODE_OPTIONS); // NOI18N
 
     /* http://msdn.microsoft.com/en-us/library/ms683179(VS.85).aspx */
     HANDLE GetCurrentProcess();
@@ -53,13 +42,13 @@ public interface Win32APISupport extends StdCallLibrary {
         @Override
         public Object fromNative(Object nativeValue, FromNativeContext context) {
             Object o = super.fromNative(nativeValue, context);
-            if (InvalidHandle.equals(o)) {
-                return InvalidHandle;
+            if (INVALID_HANDLE.equals(o)) {
+                return INVALID_HANDLE;
             }
             return o;
         }
     }
-    public final static HANDLE InvalidHandle = new HANDLE() {
+    public final static HANDLE INVALID_HANDLE = new HANDLE() {
 
         {
             super.setPointer(Pointer.createConstant(-1));

--- a/ide/extexecution.process/nbproject/project.xml
+++ b/ide/extexecution.process/nbproject/project.xml
@@ -36,8 +36,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.23</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/libs.jsch.agentproxy/nbproject/project.xml
+++ b/ide/libs.jsch.agentproxy/nbproject/project.xml
@@ -28,15 +28,15 @@
                 <dependency>
                     <code-name-base>org.netbeans.libs.jna</code-name-base>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.37</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
                     <code-name-base>org.netbeans.libs.jna.platform</code-name-base>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.7</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/platform/core.nativeaccess/nbproject/project.xml
+++ b/platform/core.nativeaccess/nbproject/project.xml
@@ -39,8 +39,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.0</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -48,16 +48,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.0</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.openide.util.ui</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>9.3</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -74,6 +66,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>8.0</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.3</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/platform/core.network/nbproject/project.xml
+++ b/platform/core.network/nbproject/project.xml
@@ -56,8 +56,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.32</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -65,8 +65,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.16</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/core.network/src/org/netbeans/core/network/proxy/mac/MacCoreFoundationLibrary.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/mac/MacCoreFoundationLibrary.java
@@ -21,14 +21,13 @@ package org.netbeans.core.network.proxy.mac;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
-import com.sun.jna.Structure;
 
 /**
  *
  * @author lfischme
  */
 public interface MacCoreFoundationLibrary extends Library {
-    MacCoreFoundationLibrary LIBRARY = Native.loadLibrary("CoreFoundation", MacCoreFoundationLibrary.class);
+    MacCoreFoundationLibrary LIBRARY = Native.load("CoreFoundation", MacCoreFoundationLibrary.class);
 
     public boolean CFDictionaryGetValueIfPresent(Pointer dictionary, Pointer key, Pointer[] returnValue);
 
@@ -47,8 +46,8 @@ public interface MacCoreFoundationLibrary extends Library {
     public boolean CFNumberGetValue(Pointer cfNumberRef, Pointer cfNumberType, Pointer value);
 
     public long CFNumberGetByteSize(Pointer cfNumberRef);
-    
+
     public long CFArrayGetCount(Pointer cfArrayRef);
-    
+
     public Pointer CFArrayGetValueAtIndex(Pointer cfArrayRef, Pointer cfIndex);
 }

--- a/platform/core.network/src/org/netbeans/core/network/proxy/mac/MacNetworkProxy.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/mac/MacNetworkProxy.java
@@ -59,7 +59,7 @@ public class MacNetworkProxy implements NetworkProxyResolver {
         boolean resolved = false;
         
         LOGGER.log(Level.FINE, "Mac system proxy resolver started."); //NOI18N
-        Pointer settingsDictionary = cfNetworkLibrary.CFNetworkCopySystemProxySettings(); 
+        Pointer settingsDictionary = cfNetworkLibrary.CFNetworkCopySystemProxySettings();
 
         Pointer autoDiscoveryEnable = cfLibrary.CFDictionaryGetValue(settingsDictionary, getKeyCFStringRef(KEY_AUTO_DISCOVERY_ENABLE));
         if (getIntFromCFNumberRef(autoDiscoveryEnable) != 0) {

--- a/platform/core.network/src/org/netbeans/core/network/proxy/mac/MacNetworkProxyLibrary.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/mac/MacNetworkProxyLibrary.java
@@ -27,7 +27,7 @@ import com.sun.jna.Pointer;
  * @author lfischme
  */
 public interface MacNetworkProxyLibrary extends Library {
-    MacNetworkProxyLibrary LIBRARY = Native.loadLibrary("CoreServices", MacNetworkProxyLibrary.class);
+    MacNetworkProxyLibrary LIBRARY = Native.load("CoreServices", MacNetworkProxyLibrary.class);
 
     public Pointer CFNetworkCopySystemProxySettings();
 }

--- a/platform/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxy.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxy.java
@@ -57,7 +57,7 @@ public class WindowsNetworkProxy implements NetworkProxyResolver {
 
             Pointer pacFilePointer = prxCnf.pacFile;
             if (pacFilePointer != null) {
-                String pacFileUrl = pacFilePointer.getString(0L, true);
+                String pacFileUrl = pacFilePointer.getWideString(0);
                 
                 LOGGER.log(Level.INFO, "Windows system proxy resolver: auto - PAC ({0})", pacFileUrl); //NOI18N                
                 return new NetworkProxySettings(pacFileUrl);
@@ -66,7 +66,7 @@ public class WindowsNetworkProxy implements NetworkProxyResolver {
             Pointer proxyPointer = prxCnf.proxy;
             Pointer proxyBypassPointer = prxCnf.proxyBypass;
             if (proxyPointer != null) {
-                String proxyString = proxyPointer.getString(0L, true);
+                String proxyString = proxyPointer.getWideString(0);
                 
                 LOGGER.log(Level.INFO, "Windows system proxy resolver: manual ({0})", proxyString); //NOI18N
                 
@@ -107,7 +107,7 @@ public class WindowsNetworkProxy implements NetworkProxyResolver {
                 }
 
                 if (proxyBypassPointer != null) {
-                    String proxyBypass = proxyBypassPointer.getString(0L, true);
+                    String proxyBypass = proxyBypassPointer.getWideString(0);
                     
                     LOGGER.log(Level.INFO, "Windows system proxy resolver: manual - no proxy hosts ({0})", proxyBypass); //NOI18N
                     

--- a/platform/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxyLibrary.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxyLibrary.java
@@ -22,39 +22,27 @@ import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
-import java.util.Arrays;
-import java.util.List;
+import com.sun.jna.Structure.FieldOrder;
 
 /**
  *
  * @author lfischme
  */
 public interface WindowsNetworkProxyLibrary extends Library {
-    WindowsNetworkProxyLibrary LIBRARY = Native.loadLibrary("winhttp.dll", WindowsNetworkProxyLibrary.class);
+    WindowsNetworkProxyLibrary LIBRARY = Native.load("winhttp.dll", WindowsNetworkProxyLibrary.class);
 
+    @SuppressWarnings("PublicField")
+    @FieldOrder({"autoDetect", "pacFile", "proxy", "proxyBypass"})
     public class ProxyConfig extends Structure {
-
-        @Override
-        protected List getFieldOrder() {
-            return Arrays.asList( new String[] {
-                "autoDetect",
-                "pacFile",
-                "proxy",
-                "proxyBypass"
-            } );
-        }
-
         public static class ByReference extends ProxyConfig implements Structure.ByReference { }
-        
+
         public boolean autoDetect;
         public Pointer pacFile;
         public Pointer proxy;
-        public Pointer proxyBypass;        
+        public Pointer proxyBypass;
+    }
 
-
-    } 
-    
     public boolean WinHttpGetIEProxyConfigForCurrentUser(
-            ProxyConfig proxyConfig
-            );
+        ProxyConfig proxyConfig
+    );
 }

--- a/platform/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxyLibrary.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/windows/WindowsNetworkProxyLibrary.java
@@ -31,7 +31,7 @@ import java.util.List;
  */
 public interface WindowsNetworkProxyLibrary extends Library {
     WindowsNetworkProxyLibrary LIBRARY = Native.loadLibrary("winhttp.dll", WindowsNetworkProxyLibrary.class);
-    
+
     public class ProxyConfig extends Structure {
 
         @Override

--- a/platform/core.network/src/org/netbeans/core/network/utils/hname/unix/CLib.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/hname/unix/CLib.java
@@ -26,7 +26,7 @@ import com.sun.jna.Native;
  */
 interface CLib extends Library {
 
-    CLib INSTANCE = (CLib) Native.loadLibrary("c", CLib.class);
+    CLib INSTANCE = (CLib) Native.load("c", CLib.class);
 
     public int gethostname(byte[] hostname, int bufferSize);
 }

--- a/platform/core.network/src/org/netbeans/core/network/utils/hname/win/Winsock2Lib.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/hname/win/Winsock2Lib.java
@@ -26,7 +26,7 @@ import com.sun.jna.Native;
  */
 public interface Winsock2Lib extends Library {
 
-    Winsock2Lib INSTANCE = (Winsock2Lib) Native.loadLibrary("ws2_32", Winsock2Lib.class);
+    Winsock2Lib INSTANCE = Native.load("ws2_32", Winsock2Lib.class);
 
     public int gethostname(byte[] name, int namelen);
 }

--- a/platform/keyring.impl/nbproject/project.xml
+++ b/platform/keyring.impl/nbproject/project.xml
@@ -39,8 +39,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.32</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -76,14 +76,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.openide.util.ui</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>9.3</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.openide.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -97,6 +89,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>8.3</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.3</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/platform/keyring.impl/src/org/netbeans/modules/keyring/gnome/GnomeKeyringLibrary.java
+++ b/platform/keyring.impl/src/org/netbeans/modules/keyring/gnome/GnomeKeyringLibrary.java
@@ -85,7 +85,7 @@ public interface GnomeKeyringLibrary extends Library {
     /*GnomeKeyringItemType*/int GNOME_KEYRING_ITEM_GENERIC_SECRET = 0;
 
     // GnomeKeyringAttributeList gnome_keyring_attribute_list_new() = g_array_new(FALSE, FALSE, sizeof(GnomeKeyringAttribute))
-    int GnomeKeyringAttribute_SIZE = Pointer.SIZE * 3; // conservatively: 2 pointers + 1 enum
+    int GnomeKeyringAttribute_SIZE = Native.POINTER_SIZE * 3; // conservatively: 2 pointers + 1 enum
 
     void gnome_keyring_attribute_list_append_string(
             /*GnomeKeyringAttributeList*/Pointer attributes,

--- a/platform/keyring.impl/src/org/netbeans/modules/keyring/gnome/GnomeKeyringLibrary.java
+++ b/platform/keyring.impl/src/org/netbeans/modules/keyring/gnome/GnomeKeyringLibrary.java
@@ -25,12 +25,11 @@ import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.ToNativeContext;
 import com.sun.jna.TypeConverter;
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import org.netbeans.api.annotations.common.SuppressWarnings;
 
@@ -46,15 +45,15 @@ public interface GnomeKeyringLibrary extends Library {
         // http://packages.ubuntu.com/search?suite=precise&arch=any&mode=exactfilename&searchon=contents&keywords=libgnome-keyring.so.0
         private static final String EXPLICIT_ONEIRIC = "/usr/lib/libgnome-keyring.so.0";
         @SuppressWarnings("DMI_HARDCODED_ABSOLUTE_FILENAME")
-        private static Object load(Map<String,?> options) {
+        private static GnomeKeyringLibrary load(Map<String,?> options) {
             try {
-                return Native.loadLibrary(GENERIC, GnomeKeyringLibrary.class, options);
+                return Native.load(GENERIC, GnomeKeyringLibrary.class, options);
             } catch (UnsatisfiedLinkError x) {
                 // #203735: on Oneiric, may have trouble finding right lib.
                 // Precise is using multiarch (#211401) which should work automatically using JNA 3.4+ (#211403).
                 // Unclear if this workaround is still needed for Oneiric with 3.4, but seems harmless to leave it in for now.
                 if (new File(EXPLICIT_ONEIRIC).isFile()) {
-                    return Native.loadLibrary(EXPLICIT_ONEIRIC, GnomeKeyringLibrary.class, options);
+                    return Native.load(EXPLICIT_ONEIRIC, GnomeKeyringLibrary.class, options);
                 } else {
                     throw x;
                 }
@@ -63,14 +62,14 @@ public interface GnomeKeyringLibrary extends Library {
         private LibFinder() {}
     }
 
-    GnomeKeyringLibrary LIBRARY = (GnomeKeyringLibrary) LibFinder.load(Collections.singletonMap(OPTION_TYPE_MAPPER, new DefaultTypeMapper() {
+    GnomeKeyringLibrary LIBRARY = LibFinder.load(Collections.singletonMap(OPTION_TYPE_MAPPER, new DefaultTypeMapper() {
         {
             addTypeConverter(Boolean.TYPE, new TypeConverter() { // #198921
                 @Override public Object toNative(Object value, ToNativeContext context) {
                     return Boolean.TRUE.equals(value) ? 1 : 0;
                 }
                 @Override public Object fromNative(Object value, FromNativeContext context) {
-                    return ((Integer) value).intValue() != 0;
+                    return ((Integer) value) != 0;
                 }
                 @Override public Class<?> nativeType() {
                     // gint is 32-bit int
@@ -116,21 +115,13 @@ public interface GnomeKeyringLibrary extends Library {
     void gnome_keyring_found_list_free(
             /*GList<GnomeKeyringFound>*/Pointer found_list);
 
+    @java.lang.SuppressWarnings("PublicField")
+    @FieldOrder({"keyring", "item_id", "attributes", "secret"})
     class GnomeKeyringFound extends Structure {
         public String keyring;
         public int item_id;
         public /*GnomeKeyringAttributeList*/Pointer attributes;
         public String secret;
-
-        @Override
-        protected List getFieldOrder() {
-            return Arrays.asList( new String[] {
-                "keyring",
-                "item_id",
-                "attributes",
-                "secret",
-            } );
-        }
     }
 
     /** http://library.gnome.org/devel/glib/2.6/glib-Miscellaneous-Utility-Functions.html#g-set-application-name */

--- a/platform/keyring.impl/src/org/netbeans/modules/keyring/mac/SecurityLibrary.java
+++ b/platform/keyring.impl/src/org/netbeans/modules/keyring/mac/SecurityLibrary.java
@@ -28,7 +28,7 @@ import com.sun.jna.Pointer;
  */
 public interface SecurityLibrary extends Library {
 
-    SecurityLibrary LIBRARY = Native.loadLibrary("Security", SecurityLibrary.class);
+    SecurityLibrary LIBRARY = Native.load("Security", SecurityLibrary.class);
 
     int SecKeychainAddGenericPassword(
             Pointer keychain,

--- a/platform/keyring.impl/src/org/netbeans/modules/keyring/win32/Win32Protect.java
+++ b/platform/keyring.impl/src/org/netbeans/modules/keyring/win32/Win32Protect.java
@@ -23,10 +23,10 @@ import com.sun.jna.Memory;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.WString;
 import com.sun.jna.win32.StdCallLibrary;
 import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -44,7 +44,7 @@ import org.openide.util.lookup.ServiceProvider;
 public class Win32Protect implements EncryptionProvider {
 
     private static final Logger LOG = Logger.getLogger(Win32Protect.class.getName());
-    
+
     public @Override boolean enabled() {
         if (!Utilities.isWindows()) {
             LOG.fine("not running on Windows");
@@ -110,7 +110,7 @@ public class Win32Protect implements EncryptionProvider {
     public @Override void freshKeyring(boolean fresh) {}
 
     public interface CryptLib extends StdCallLibrary {
-        CryptLib INSTANCE = Native.loadLibrary("Crypt32", CryptLib.class); // NOI18N
+        CryptLib INSTANCE = Native.load("Crypt32", CryptLib.class); // NOI18N
         /** @see <a href="http://msdn.microsoft.com/en-us/library/aa380261(VS.85,printer).aspx">Reference</a> */
         boolean CryptProtectData(
                 CryptIntegerBlob pDataIn,
@@ -132,7 +132,9 @@ public class Win32Protect implements EncryptionProvider {
                 CryptIntegerBlob pDataOut
         )/* throws LastErrorException*/;
     }
-    
+
+    @SuppressWarnings("PublicField")
+    @FieldOrder({"cbData", "pbData"})
     public static class CryptIntegerBlob extends Structure {
         public int cbData;
         public /*byte[]*/Pointer pbData;
@@ -147,14 +149,6 @@ public class Win32Protect implements EncryptionProvider {
         }
         void zero() {
             ((Memory) pbData).clear();
-        }
-
-        @Override
-        protected List getFieldOrder() {
-            return Arrays.asList( new String[] {
-                "cbData",
-                "pbData",
-            } );
         }
     }
 

--- a/platform/libs.jna.platform/external/binaries-list
+++ b/platform/libs.jna.platform/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-F396B0CEB7ABABB8B4A5EA25E6742CED81E3D86F net.java.dev.jna:jna-platform:4.4.0
+A8267193887C38418AF986ADAE090EE5D2593F48 net.java.dev.jna:jna-platform:5.4.0

--- a/platform/libs.jna.platform/external/jna-platform-5.4.0-license.txt
+++ b/platform/libs.jna.platform/external/jna-platform-5.4.0-license.txt
@@ -1,5 +1,5 @@
 Name: Java Native Access
-Version: 4.4.0
+Version: 5.4.0
 License: Apache-2.0
 Description: Dynamically access native libraries from Java without JNI.
 Origin: Java Native Access

--- a/platform/libs.jna.platform/manifest.mf
+++ b/platform/libs.jna.platform/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
-OpenIDE-Module: org.netbeans.libs.jna.platform/1
+OpenIDE-Module: org.netbeans.libs.jna.platform/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/jna/platform/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.21
+OpenIDE-Module-Specification-Version: 2.1

--- a/platform/libs.jna.platform/nbproject/project.properties
+++ b/platform/libs.jna.platform/nbproject/project.properties
@@ -17,5 +17,5 @@
 
 is.autoload=true
 javac.source=1.6
-release.external/jna-platform-4.4.0.jar=modules/ext/jna-platform-4.4.0.jar
+release.external/jna-platform-5.4.0.jar=modules/ext/jna-platform-5.4.0.jar
 sigtest.gen.fail.on.error=false

--- a/platform/libs.jna.platform/nbproject/project.xml
+++ b/platform/libs.jna.platform/nbproject/project.xml
@@ -28,8 +28,8 @@
                 <dependency>
                     <code-name-base>org.netbeans.libs.jna</code-name-base>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.29</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>
@@ -45,8 +45,8 @@
                 <package>com.sun.jna.platform.wince</package>
             </friend-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/jna-platform-4.4.0.jar</runtime-relative-path>
-                <binary-origin>external/jna-platform-4.4.0.jar</binary-origin>
+                <runtime-relative-path>ext/jna-platform-5.4.0.jar</runtime-relative-path>
+                <binary-origin>external/jna-platform-5.4.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/libs.jna.platform/nbproject/project.xml
+++ b/platform/libs.jna.platform/nbproject/project.xml
@@ -33,17 +33,19 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
-            <friend-packages>
-                <friend>org.netbeans.core.nativeaccess</friend>
-                <friend>org.netbeans.core.network</friend>
-                <friend>org.netbeans.libs.jsch.agentproxy</friend>
+            <public-packages>
                 <package>com.sun.jna.platform</package>
                 <package>com.sun.jna.platform.dnd</package>
+                <package>com.sun.jna.platform.linux</package>
                 <package>com.sun.jna.platform.mac</package>
                 <package>com.sun.jna.platform.unix</package>
+                <package>com.sun.jna.platform.unix.solaris</package>
                 <package>com.sun.jna.platform.win32</package>
+                <package>com.sun.jna.platform.win32.COM</package>
+                <package>com.sun.jna.platform.win32.COM.util</package>
+                <package>com.sun.jna.platform.win32.COM.util.annotation</package>
                 <package>com.sun.jna.platform.wince</package>
-            </friend-packages>
+            </public-packages>
             <class-path-extension>
                 <runtime-relative-path>ext/jna-platform-5.4.0.jar</runtime-relative-path>
                 <binary-origin>external/jna-platform-5.4.0.jar</binary-origin>

--- a/platform/libs.jna/external/binaries-list
+++ b/platform/libs.jna/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-CB208278274BF12EBDB56C61BD7407E6F774D65A net.java.dev.jna:jna:4.4.0
+3E25BC70DD7750A3F0FEA5BD1467708280BEA04E net.java.dev.jna:jna:5.4.0

--- a/platform/libs.jna/external/jna-5.4.0-license.txt
+++ b/platform/libs.jna/external/jna-5.4.0-license.txt
@@ -1,5 +1,5 @@
 Name: Java Native Access
-Version: 4.4.0
+Version: 5.4.0
 License: Apache-2.0
 Description: Dynamically access native libraries from Java without JNI.
 Origin: Java Native Access

--- a/platform/libs.jna/manifest.mf
+++ b/platform/libs.jna/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module: org.netbeans.libs.jna/1
+OpenIDE-Module: org.netbeans.libs.jna/2
 OpenIDE-Module-Install: org/netbeans/libs/jna/Installer.class
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/jna/Bundle.properties
 AutoUpdate-Essential-Module: true
-OpenIDE-Module-Specification-Version: 1.53
+OpenIDE-Module-Specification-Version: 2.1

--- a/platform/libs.jna/nbproject/project.properties
+++ b/platform/libs.jna/nbproject/project.properties
@@ -16,17 +16,17 @@
 # under the License.
 
 javac.source=1.6
-release.external/jna-4.4.0.jar=modules/ext/jna-4.4.0.jar
+release.external/jna-5.4.0.jar=modules/ext/jna-5.4.0.jar
 # Do not forget to rename native libs being extracted from the JAR when upgrading the JNA library, and patch org.netbeans.libs.jna.Installer as well.
-release.external/jna-4.4.0.jar!/com/sun/jna/darwin/libjnidispatch.jnilib=modules/lib/libjnidispatch-440.jnilib
-release.external/jna-4.4.0.jar!/com/sun/jna/linux-x86-64/libjnidispatch.so=modules/lib/amd64/linux/libjnidispatch-440.so
-release.external/jna-4.4.0.jar!/com/sun/jna/linux-x86/libjnidispatch.so=modules/lib/i386/linux/libjnidispatch-440.so
-release.external/jna-4.4.0.jar!/com/sun/jna/win32-x86-64/jnidispatch.dll=modules/lib/amd64/jnidispatch-440.dll
-release.external/jna-4.4.0.jar!/com/sun/jna/win32-x86/jnidispatch.dll=modules/lib/x86/jnidispatch-440.dll
+release.external/jna-5.4.0.jar!/com/sun/jna/darwin/libjnidispatch.jnilib=modules/lib/libjnidispatch-nb.jnilib
+release.external/jna-5.4.0.jar!/com/sun/jna/linux-x86-64/libjnidispatch.so=modules/lib/amd64/linux/libjnidispatch-nb.so
+release.external/jna-5.4.0.jar!/com/sun/jna/linux-x86/libjnidispatch.so=modules/lib/i386/linux/libjnidispatch-nb.so
+release.external/jna-5.4.0.jar!/com/sun/jna/win32-x86-64/jnidispatch.dll=modules/lib/amd64/jnidispatch-nb.dll
+release.external/jna-5.4.0.jar!/com/sun/jna/win32-x86/jnidispatch.dll=modules/lib/x86/jnidispatch-nb.dll
 jnlp.verify.excludes=\
-    modules/lib/amd64/jnidispatch-440.dll,\
-    modules/lib/amd64/linux/libjnidispatch-440.so,\
-    modules/lib/i386/linux/libjnidispatch-440.so,\
-    modules/lib/x86/jnidispatch-440.dll,\
-    modules/lib/libjnidispatch-440.jnilib
+    modules/lib/amd64/jnidispatch-nb.dll,\
+    modules/lib/amd64/linux/libjnidispatch-nb.so,\
+    modules/lib/i386/linux/libjnidispatch-nb.so,\
+    modules/lib/x86/jnidispatch-nb.dll,\
+    modules/lib/libjnidispatch-nb.jnilib
 sigtest.gen.fail.on.error=false

--- a/platform/libs.jna/nbproject/project.xml
+++ b/platform/libs.jna/nbproject/project.xml
@@ -41,14 +41,6 @@
                         <specification-version>9.3</specification-version>
                     </run-dependency>
                 </dependency>
-                <dependency>
-                    <code-name-base>org.openide.util</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>9.3</specification-version>
-                    </run-dependency>
-                </dependency>
             </module-dependencies>
             <friend-packages>
                 <friend>com.sun.tools.swdev.sunstudio</friend>

--- a/platform/libs.jna/nbproject/project.xml
+++ b/platform/libs.jna/nbproject/project.xml
@@ -69,8 +69,8 @@
                 <package>com.sun.jna.win32</package>
             </friend-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/jna-4.4.0.jar</runtime-relative-path>
-                <binary-origin>external/jna-4.4.0.jar</binary-origin>
+                <runtime-relative-path>ext/jna-5.4.0.jar</runtime-relative-path>
+                <binary-origin>external/jna-5.4.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/libs.jna/nbproject/project.xml
+++ b/platform/libs.jna/nbproject/project.xml
@@ -42,32 +42,11 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
-            <friend-packages>
-                <friend>com.sun.tools.swdev.sunstudio</friend>
-                <friend>org.jruby</friend>
-                <friend>org.netbeans.core.browser.xulrunner</friend>
-                <friend>org.netbeans.core.nativeaccess</friend>
-                <friend>org.netbeans.core.network</friend>
-                <friend>org.netbeans.libs.djnsswt.gtklinuxx64</friend>
-                <friend>org.netbeans.libs.djnsswt.gtklinuxx86</friend>
-                <friend>org.netbeans.libs.djnsswt.win32x64</friend>
-                <friend>org.netbeans.libs.djnsswt.win32x86</friend>
-                <friend>org.netbeans.libs.jsch.agentproxy</friend>
-                <friend>org.netbeans.libs.jna.platform</friend>
-                <friend>org.netbeans.libs.svnClientAdapter.svnkit</friend>
-                <friend>org.netbeans.modules.dlight.nativeexecution</friend>
-                <friend>org.netbeans.modules.extbrowser.chrome</friend>
-                <friend>org.netbeans.modules.extexecution.process</friend>
-                <friend>org.netbeans.modules.keyring.impl</friend>
-                <friend>org.netbeans.modules.libs.djnsswt</friend>
-                <friend>org.netbeans.modules.masterfs.linux</friend>
-                <friend>org.netbeans.modules.masterfs.macosx</friend>
-                <friend>org.netbeans.modules.masterfs.windows</friend>
-                <friend>org.netbeans.modules.python.qshell</friend>
+            <public-packages>
                 <package>com.sun.jna</package>
                 <package>com.sun.jna.ptr</package>
                 <package>com.sun.jna.win32</package>
-            </friend-packages>
+            </public-packages>
             <class-path-extension>
                 <runtime-relative-path>ext/jna-5.4.0.jar</runtime-relative-path>
                 <binary-origin>external/jna-5.4.0.jar</binary-origin>

--- a/platform/libs.jna/src/org/netbeans/libs/jna/Installer.java
+++ b/platform/libs.jna/src/org/netbeans/libs/jna/Installer.java
@@ -19,7 +19,6 @@
 package org.netbeans.libs.jna;
 
 import org.openide.modules.ModuleInstall;
-import org.openide.util.Utilities;
 
 public class Installer extends ModuleInstall {
 

--- a/platform/libs.jna/src/org/netbeans/libs/jna/Installer.java
+++ b/platform/libs.jna/src/org/netbeans/libs/jna/Installer.java
@@ -26,6 +26,6 @@ public class Installer extends ModuleInstall {
     public void validate() {
         super.validate();
         //#211655
-        System.setProperty( "jna.boot.library.name", "jnidispatch-440" ); //NOI18N
+        System.setProperty( "jna.boot.library.name", "jnidispatch-nb" ); //NOI18N
     }
 }

--- a/platform/masterfs.linux/nbproject/project.xml
+++ b/platform/masterfs.linux/nbproject/project.xml
@@ -30,8 +30,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.18</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/masterfs.linux/src/org/netbeans/modules/masterfs/watcher/linux/LinuxNotifier.java
+++ b/platform/masterfs.linux/src/org/netbeans/modules/masterfs/watcher/linux/LinuxNotifier.java
@@ -45,7 +45,7 @@ public final class LinuxNotifier extends Notifier<LinuxNotifier.LKey> {
 	public int inotify_init();
 	public int inotify_init1(int flags);
 	public int close(int fd);
-    public int read(int fd, ByteBuffer buff, int count);
+        public int read(int fd, ByteBuffer buff, int count);
 	public int inotify_add_watch(int fd, String pathname, int mask);
 	public int inotify_rm_watch(int fd, int wd);
 
@@ -73,23 +73,21 @@ public final class LinuxNotifier extends Notifier<LinuxNotifier.LKey> {
     }
 
     final InotifyImpl IMPL;
-    int fd;
-    private ByteBuffer buff = ByteBuffer.allocateDirect(4096);
+    private int fd;
+    private final ByteBuffer buff = ByteBuffer.allocateDirect(4096);
 
     // An array would serve nearly as well
-    private Map<Integer, LKey> map = new HashMap<Integer, LKey>();
+    private final Map<Integer, LKey> map = new HashMap<Integer, LKey>();
 
     public LinuxNotifier() {
-        IMPL = (InotifyImpl) Native.loadLibrary("c", InotifyImpl.class);
+        IMPL = (InotifyImpl) Native.load("c", InotifyImpl.class);
     }
 
     private String getString(int maxLen) {
         if (maxLen < 1) return null; // no name field
-        int stop = maxLen - 1;
         byte[] temp = new byte[maxLen];
         buff.get(temp);
-        while (temp[stop] == 0) stop--;
-        return new String(temp, 0, stop+1);
+        return Native.toString(temp);
     }
 
     @Override public String nextEvent() throws IOException {
@@ -149,7 +147,6 @@ public final class LinuxNotifier extends Notifier<LinuxNotifier.LKey> {
         
         return key.path;
     }
-
 
     static class LKey {
         int id;

--- a/platform/masterfs.macosx/nbproject/project.xml
+++ b/platform/masterfs.macosx/nbproject/project.xml
@@ -30,8 +30,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.18</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/masterfs.macosx/src/org/netbeans/modules/masterfs/watcher/macosx/OSXNotifier.java
+++ b/platform/masterfs.macosx/src/org/netbeans/modules/masterfs/watcher/macosx/OSXNotifier.java
@@ -66,8 +66,8 @@ public final class OSXNotifier extends Notifier<Void> {
     private static final String ALL_CHANGE = "ALL-CHANGE";  //xxx - shouldn't be global in Notifier rather than using null?
 
     public OSXNotifier() {
-        cf = Native.loadLibrary("CoreFoundation",CoreFoundation.class);    //NOI18N
-        cs = Native.loadLibrary("CoreServices",CoreServices.class);          //NOI18N
+        cf = Native.load("CoreFoundation",CoreFoundation.class);    //NOI18N
+        cs = Native.load("CoreServices",CoreServices.class);        //NOI18N
         callback = new EventCallbackImpl();
         events = new LinkedBlockingQueue<String>();
     }
@@ -83,9 +83,10 @@ public final class OSXNotifier extends Notifier<Void> {
 
     public @Override String nextEvent() throws IOException, InterruptedException {
         final String event = events.take();
-        return event == ALL_CHANGE ? null : event;
+        return ALL_CHANGE.equals(event) ? null : event;
     }
 
+    @Override
     public synchronized void start() throws IOException {
         if (worker != null) {
             throw new IllegalStateException("FileSystemWatcher already started.");  //NOI18N

--- a/platform/masterfs.windows/nbproject/project.xml
+++ b/platform/masterfs.windows/nbproject/project.xml
@@ -30,8 +30,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.38</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/masterfs.windows/src/org/netbeans/modules/masterfs/watcher/windows/WindowsNotifier.java
+++ b/platform/masterfs.windows/src/org/netbeans/modules/masterfs/watcher/windows/WindowsNotifier.java
@@ -90,7 +90,7 @@ public final class WindowsNotifier extends Notifier<Void> {
         }
 
         public ULONG_PTR(long value) {
-                super(Pointer.SIZE, value);
+                super(Native.POINTER_SIZE, value);
         }
     }
 
@@ -114,7 +114,7 @@ public final class WindowsNotifier extends Notifier<Void> {
     }
 
     public static HANDLE INVALID_HANDLE_VALUE = new HANDLE(Pointer.createConstant(
-    		Pointer.SIZE == 8 ? -1 : 0xFFFFFFFFL));
+    		Native.POINTER_SIZE == 8 ? -1 : 0xFFFFFFFFL));
 
 
 
@@ -125,7 +125,7 @@ public final class WindowsNotifier extends Notifier<Void> {
         }
 
         public HANDLEByReference(HANDLE h) {
-            super(Pointer.SIZE);
+            super(Native.POINTER_SIZE);
             setValue(h);
         }
 

--- a/platform/masterfs.windows/src/org/netbeans/modules/masterfs/watcher/windows/WindowsNotifier.java
+++ b/platform/masterfs.windows/src/org/netbeans/modules/masterfs/watcher/windows/WindowsNotifier.java
@@ -22,11 +22,11 @@ package org.netbeans.modules.masterfs.watcher.windows;
 import org.netbeans.modules.masterfs.providers.Notifier;
 import com.sun.jna.FromNativeContext;
 import com.sun.jna.IntegerType;
-import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
 import com.sun.jna.Structure;
+import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.ptr.ByReference;
 import java.io.File;
 import java.io.IOException;
@@ -36,11 +36,8 @@ import java.util.Map;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.PointerByReference;
 import com.sun.jna.win32.StdCallLibrary;
-import com.sun.jna.win32.W32APIFunctionMapper;
-import com.sun.jna.win32.W32APITypeMapper;
+import com.sun.jna.win32.W32APIOptions;
 import java.io.InterruptedIOException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
@@ -94,29 +91,18 @@ public final class WindowsNotifier extends Notifier<Void> {
         }
     }
 
+    @SuppressWarnings("PublicField")
+    @FieldOrder({"Internal", "InternalHigh", "Offset", "OffsetHigh", "hEvent"})
     public static class OVERLAPPED extends Structure {
         public ULONG_PTR Internal;
         public ULONG_PTR InternalHigh;
         public int Offset;
         public int OffsetHigh;
         public HANDLE hEvent;
-
-        @Override
-        protected List getFieldOrder() {
-            return Arrays.asList( new String[] {
-                "Internal",
-                "InternalHigh",
-                "Offset",
-                "OffsetHigh",
-                "hEvent",
-            } );
-        }
     }
 
     public static HANDLE INVALID_HANDLE_VALUE = new HANDLE(Pointer.createConstant(
     		Native.POINTER_SIZE == 8 ? -1 : 0xFFFFFFFFL));
-
-
 
     public static class HANDLEByReference extends ByReference {
 
@@ -145,6 +131,8 @@ public final class WindowsNotifier extends Notifier<Void> {
         }
     }
 
+    @SuppressWarnings("PublicField")
+    @FieldOrder({"NextEntryOffset", "Action", "FileNameLength", "FileName"})
     public static class FILE_NOTIFY_INFORMATION extends Structure {
         public int NextEntryOffset;
         public int Action;
@@ -160,16 +148,6 @@ public final class WindowsNotifier extends Notifier<Void> {
                                + size() + ", requested " + size);
             }
             allocateMemory(size);
-        }
-
-        @Override
-        protected List getFieldOrder() {
-            return Arrays.asList( new String[] {
-                "NextEntryOffset",
-                "Action",
-                "FileNameLength",
-                "FileName",
-            } );
         }
 
         /** WARNING: this filename may be either the short or long form of the filename. */
@@ -195,19 +173,12 @@ public final class WindowsNotifier extends Notifier<Void> {
         }
     }
 
+    @SuppressWarnings("PublicField")
+    @FieldOrder({"nLength", "lpSecurityDescriptor", "bInheritHandle"})
     public static class SECURITY_ATTRIBUTES extends Structure {
         public final int nLength = size();
         public Pointer lpSecurityDescriptor;
         public boolean bInheritHandle;
-
-        @Override
-        protected List getFieldOrder() {
-            return Arrays.asList( new String[] {
-                "nLength",
-                "lpSecurityDescriptor",
-                "bInheritHandle",
-            } );
-        }
     }
 
     interface Kernel32 extends StdCallLibrary {
@@ -244,13 +215,7 @@ public final class WindowsNotifier extends Notifier<Void> {
 
     }
 
-    final static Kernel32 KERNEL32 = Native.loadLibrary("kernel32", Kernel32.class,
-            new HashMap() {{
-                put(Library.OPTION_TYPE_MAPPER, W32APITypeMapper.UNICODE);
-                put(Library.OPTION_FUNCTION_MAPPER, W32APIFunctionMapper.UNICODE);
-            }});
-
-
+    final static Kernel32 KERNEL32 = Native.load("kernel32", Kernel32.class, W32APIOptions.UNICODE_OPTIONS);
 
     public WindowsNotifier() { // prepare port, start thread?
     }

--- a/webcommon/extbrowser.chrome/nbproject/project.xml
+++ b/webcommon/extbrowser.chrome/nbproject/project.xml
@@ -26,15 +26,6 @@
             <code-name-base>org.netbeans.modules.extbrowser.chrome</code-name-base>
             <module-dependencies>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.extbrowser</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.39</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.api.debugger</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -44,12 +35,30 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.libs.jna</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>2.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.libs.json_simple</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
                         <specification-version>0.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.extbrowser</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.39</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -126,14 +135,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.openide.util.ui</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>9.3</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.openide.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -150,12 +151,11 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.libs.jna</code-name-base>
+                    <code-name-base>org.openide.util.ui</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.30</specification-version>
+                        <specification-version>9.3</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/Utils.java
+++ b/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/Utils.java
@@ -23,25 +23,20 @@ import com.sun.jna.Native;
 import com.sun.jna.NativeMapped;
 import com.sun.jna.Platform;
 import com.sun.jna.PointerType;
-import com.sun.jna.TypeMapper;
-import com.sun.jna.win32.W32APIFunctionMapper;
-import com.sun.jna.win32.W32APITypeMapper;
+import com.sun.jna.win32.W32APIOptions;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -329,7 +324,7 @@ public final class Utils {
     }
     
     public static List<Integer> getVersionParts(String version) {
-        List<Integer> result = new ArrayList<Integer>();
+        List<Integer> result = new ArrayList<>();
         
         StringTokenizer tokens = new StringTokenizer(version, ".");
         while (tokens.hasMoreTokens()) {
@@ -425,8 +420,7 @@ public final class Utils {
             char[] pszPath = new char[Shell32.MAX_PATH];
             try {
                 if (Shell32_INSTANCE == null) {
-                    Shell32_INSTANCE = (Shell32) Native.loadLibrary("shell32",
-                            Shell32.class, OPTIONS);
+                    Shell32_INSTANCE = (Shell32) Native.load("shell32", Shell32.class, W32APIOptions.UNICODE_OPTIONS);
                 }
                 int hResult = Shell32_INSTANCE.SHGetFolderPath(null, Shell32.CSIDL_LOCAL_APPDATA,
                         null, Shell32.SHGFP_TYPE_CURRENT, pszPath);
@@ -444,13 +438,6 @@ public final class Utils {
     }
 
     private static Shell32 Shell32_INSTANCE;
-    
-    private static Map<String, Object> OPTIONS = new HashMap<String, Object>();
-    static {
-        OPTIONS.put(Library.OPTION_TYPE_MAPPER, W32APITypeMapper.UNICODE);
-        OPTIONS.put(Library.OPTION_FUNCTION_MAPPER,
-                W32APIFunctionMapper.UNICODE);
-    }
 
     static class HANDLE extends PointerType implements NativeMapped {
     }


### PR DESCRIPTION
The JNA release cycles not only added featured, but also improved stability
and deadlock resilience. This PR updates the JNA version bundled with JNA
and updates it to the current version.