### PR TITLE
[NETBEANS-3075] - reduce number of warning w/ raw type iterator

### DIFF
--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerNode.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/LayerNode.java
@@ -184,9 +184,7 @@ public final class LayerNode extends FilterNode implements Node.Cookie {
                     if (highlighted != null) {
                         // Boldface resources which do come from this project.
                         boolean local = false;
-                        Iterator it = files.iterator();
-                        while (it.hasNext()) {
-                            FileObject f = (FileObject) it.next();
+                        for (FileObject f : files) {
                             if (!f.isRoot() && highlighted.findResource(f.getPath()) != null) {
                                 local = true;
                                 break;

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyVirtualSourceProvider.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyVirtualSourceProvider.java
@@ -254,10 +254,9 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
             if (!isEnum) {
                 getConstructors(classNode, out);
             }
-            List methods = classNode.getMethods();
+            List<MethodNode> methods = classNode.getMethods();
             if (methods != null) {
-                for (Iterator it = methods.iterator(); it.hasNext();) {
-                    MethodNode methodNode = (MethodNode) it.next();
+                for (MethodNode methodNode : methods) {
                     if (isEnum && methodNode.isSynthetic()) {
                         // skip values() method and valueOf(String)
                         String name = methodNode.getName();
@@ -274,10 +273,10 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
                     genMethod(classNode, methodNode, out);
                 }
             }
+
             // <netbeans>
-            List properties = classNode.getProperties();
-            for (Object object : properties) {
-                PropertyNode propertyNode = (PropertyNode) object;
+            List<PropertyNode> properties = classNode.getProperties();
+            for (PropertyNode propertyNode : properties) {
                 if (!propertyNode.isSynthetic()) {
                     String name = propertyNode.getName();
                     name = Character.toUpperCase(name.charAt(0)) + name.substring(1);
@@ -299,24 +298,23 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
         }
 
         private void getConstructors(ClassNode classNode, PrintWriter out) {
-            List constrs = classNode.getDeclaredConstructors();
+            List<ConstructorNode> constrs = classNode.getDeclaredConstructors();
             if (constrs != null) {
-                for (Iterator it = constrs.iterator(); it.hasNext();) {
-                    ConstructorNode constrNode = (ConstructorNode) it.next();
+                for (ConstructorNode constrNode : constrs) {
                     genConstructor(classNode, constrNode, out);
                 }
             }
         }
 
         private void genFields(ClassNode classNode, PrintWriter out, boolean isEnum) {
-            List fields = classNode.getFields();
+            List<FieldNode> fields = classNode.getFields();
             if (fields == null) {
                 return;
             }
             ArrayList<FieldNode> enumFields   = new ArrayList<FieldNode>(fields.size());
             ArrayList<FieldNode> normalFields = new ArrayList<FieldNode>(fields.size());
-            for (Iterator it = fields.iterator(); it.hasNext();) {
-                FieldNode fieldNode = (FieldNode) it.next();
+            
+            for (FieldNode fieldNode : fields) {
                 boolean isEnumField = (fieldNode.getModifiers() & Opcodes.ACC_ENUM) != 0;
                 boolean isSynthetic = (fieldNode.getModifiers() & Opcodes.ACC_SYNTHETIC) != 0;
                 if (isEnumField) {
@@ -326,17 +324,15 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
                 }
             }
             genEnumFields(enumFields, out);
-            for (Iterator iterator = normalFields.iterator(); iterator.hasNext();) {
-                FieldNode fieldNode = (FieldNode) iterator.next();
+            for (FieldNode fieldNode : normalFields) {
                 genField(fieldNode, out);
             }
         }
 
         private void genProps(ClassNode classNode, PrintWriter out) {
-            List props = classNode.getProperties();
+            List<PropertyNode> props = classNode.getProperties();
             if (props != null) {
-                for (Iterator it = props.iterator(); it.hasNext();) {
-                    PropertyNode propNode = (PropertyNode) it.next();
+                for (PropertyNode propNode : props) {
                     genProp(propNode, out);
                 }
             }
@@ -348,10 +344,9 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
             String getterName = "get" + name;
 
             boolean skipGetter = false;
-            List getterCandidates = propNode.getField().getOwner().getMethods(getterName);
+            List<MethodNode> getterCandidates = propNode.getField().getOwner().getMethods(getterName);
             if (getterCandidates != null) {
-                for (Iterator it = getterCandidates.iterator(); it.hasNext();) {
-                    MethodNode method = (MethodNode) it.next();
+                for (MethodNode method : getterCandidates) {
                     if (method.getParameters().length == 0) {
                         skipGetter = true;
                     }
@@ -373,10 +368,9 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
             String setterName = "set" + name;
 
             boolean skipSetter = false;
-            List setterCandidates = propNode.getField().getOwner().getMethods(setterName);
+            List<MethodNode> setterCandidates = propNode.getField().getOwner().getMethods(setterName);
             if (setterCandidates != null) {
-                for (Iterator it = setterCandidates.iterator(); it.hasNext();) {
-                    MethodNode method = (MethodNode) it.next();
+                for (MethodNode method : setterCandidates) {
                     if (method.getParameters().length == 1) {
                         skipSetter = true;
                     }
@@ -397,6 +391,7 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
                 return;
             }
             boolean first = true;
+            
             for (Iterator iterator = fields.iterator(); iterator.hasNext();) {
                 FieldNode fieldNode = (FieldNode) iterator.next();
                 if (!first) {
@@ -434,7 +429,7 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
                 return null;
             }
             BlockStatement block = (BlockStatement) code;
-            List stats = block.getStatements();
+            List<Statement> stats = block.getStatements();
             if (stats == null || stats.isEmpty()) {
                 return null;
             }
@@ -480,9 +475,7 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
             ClassNode superType = type.getSuperClass();
 
             boolean hadPrivateConstructor = false;
-            for (Iterator iter = superType.getDeclaredConstructors().iterator(); iter.hasNext();) {
-                ConstructorNode c = (ConstructorNode) iter.next();
-
+            for (ConstructorNode c : superType.getDeclaredConstructors()) {
                 // Only look at things we can actually call
                 if (c.isPublic() || c.isProtected()) {
                     return c.getParameters();
@@ -528,11 +521,9 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
             // Else try to render some arguments
             if (arguments instanceof ArgumentListExpression) {
                 ArgumentListExpression argumentListExpression = (ArgumentListExpression) arguments;
-                List args = argumentListExpression.getExpressions();
+                List<Expression> args = argumentListExpression.getExpressions();
 
-                for (Iterator it = args.iterator(); it.hasNext();) {
-                    Expression arg = (Expression) it.next();
-
+                for (Expression arg : args) {
                     if (arg instanceof ConstantExpression) {
                         ConstantExpression expression = (ConstantExpression) arg;
                         Object o = expression.getValue();
@@ -750,7 +741,7 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
         }
 
         private void genImports(ClassNode classNode, PrintWriter out) {
-            Set imports = new HashSet();
+            Set<String> imports = new HashSet<>();
 
             //
             // HACK: Add the default imports... since things like Closure and GroovyObject seem to parse out w/o fully qualified classnames.
@@ -766,8 +757,7 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
                 }
             }
 
-            for (Iterator it = moduleNode.getImports().iterator(); it.hasNext();) {
-                ImportNode imp = (ImportNode) it.next();
+            for (ImportNode imp : moduleNode.getImports()) {
                 String name = imp.getType().getName();
                 int lastDot = name.lastIndexOf('.');
                 if (lastDot != -1) {
@@ -775,8 +765,7 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
                 }
             }
 
-            for (Iterator it = imports.iterator(); it.hasNext();) {
-                String imp = (String) it.next();
+            for (String imp : imports) {
                 out.print("import ");
                 out.print(imp);
                 out.println("*;");

--- a/ide/db.mysql/src/org/netbeans/modules/db/mysql/impl/InstallationManager.java
+++ b/ide/db.mysql/src/org/netbeans/modules/db/mysql/impl/InstallationManager.java
@@ -103,9 +103,8 @@ public class InstallationManager {
         installationCopy.addAll(InstallationManager.getInstallations(loadedInstallations));
         List<Installation> validInstallations =
                 new ArrayList<Installation>(3);
-        for ( Iterator it = installationCopy.iterator() ; it.hasNext() ; ) {
-            Installation installation = (Installation)it.next();
-            
+        
+        for (Installation installation : installationCopy) {            
             LOGGER.log(Level.FINE, "Looking for MySQL installation " + 
                     installation.getStartCommand()[0] + 
                     installation.getStartCommand()[1]);

--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
@@ -67,9 +67,7 @@ final class CodeTemplatesModel {
         columns.add(loc("Expanded_Text_Title")); //NOI18N
         columns.add(loc("Description_Title")); //NOI18N
 
-        Set mimeTypes = EditorSettings.getDefault().getAllMimeTypes();
-        for(Iterator i = mimeTypes.iterator(); i.hasNext(); ) {
-            String mimeType = (String) i.next();
+        for (String mimeType : EditorSettings.getDefault().getAllMimeTypes()) {
             
             // Load the code templates
             MimePath mimePath = MimePath.parse(mimeType);

--- a/ide/image/src/org/netbeans/modules/image/ImageViewer.java
+++ b/ide/image/src/org/netbeans/modules/image/ImageViewer.java
@@ -380,9 +380,9 @@ public class ImageViewer extends CloneableTopComponent {
     private void setToolbarButtonsEnabled(final boolean enabled) {
         assert toolbarButtons != null;
         
-        final Iterator/*<JButton>*/ it = toolbarButtons.iterator();
+        final Iterator<JButton> it = toolbarButtons.iterator();
         while (it.hasNext()) {
-            ((JButton) it.next()).setEnabled(enabled);
+            it.next().setEnabled(enabled);
         }
     }
     
@@ -556,8 +556,8 @@ public class ImageViewer extends CloneableTopComponent {
             toolBar.add(new JLabel(NbBundle.getMessage(ImageViewer.class, label, formatter.format(size))));
         }
 
-        for (Iterator it = toolbarButtons.iterator(); it.hasNext(); ) {
-            ((JButton) it.next()).setFocusable(false);
+        for (JButton jb : toolbarButtons) {
+            jb.setFocusable(false);
         }
 
         return toolBar;

--- a/ide/xml/src/org/netbeans/modules/xml/sync/DataObjectSyncSupport.java
+++ b/ide/xml/src/org/netbeans/modules/xml/sync/DataObjectSyncSupport.java
@@ -149,8 +149,7 @@ public class DataObjectSyncSupport extends SyncSupport implements Synchronizator
             // check whether tree representation is loaded
             
             synchronized (reps) {
-                for (Iterator it = reps.iterator(); it.hasNext();) {
-                    Representation next = (Representation) it.next();
+                for (Representation next : reps) {
                     if (next.level() > 1) {
                         modelLoaded = true;
                     }                               

--- a/ide/xml/src/org/netbeans/modules/xml/sync/DataObjectSyncSupport.java
+++ b/ide/xml/src/org/netbeans/modules/xml/sync/DataObjectSyncSupport.java
@@ -115,10 +115,9 @@ public class DataObjectSyncSupport extends SyncSupport implements Synchronizator
 
         if (rep.represents(Document.class)) {
             synchronized (reps) {
-                for (Iterator it = reps.iterator(); it.hasNext();) {
-                    Representation next = (Representation) it.next();
+                for (Representation next : reps) {
                     if (next.represents(FileObject.class)) {
-                        it.remove();
+                        reps.remove(next);
                     }                               
                 }
             }
@@ -152,7 +151,7 @@ public class DataObjectSyncSupport extends SyncSupport implements Synchronizator
                 for (Representation next : reps) {
                     if (next.level() > 1) {
                         modelLoaded = true;
-                    }                               
+                    }
                 }
 
                 if (modelLoaded == false) {

--- a/java/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupport.java
+++ b/java/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupport.java
@@ -213,9 +213,7 @@ public final class MethodModelSupport {
                     annotationTree = genUtils.createAnnotation(annotation.getType());
                 } else {
                     List<ExpressionTree> annotationArgs = new ArrayList<ExpressionTree>();
-                    Iterator it = annotation.getArguments().entrySet().iterator();
-                    while (it.hasNext()) {
-                        Map.Entry pairs = (Map.Entry)it.next();
+                    for (Map.Entry pairs : annotation.getArguments().entrySet()) {
                         annotationArgs.add(genUtils.createAnnotationArgument((String) pairs.getKey(),pairs.getValue()));
                     }
                     annotationTree = genUtils.createAnnotation(annotation.getType(), annotationArgs);

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/Classpaths.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/Classpaths.java
@@ -172,9 +172,7 @@ final class Classpaths implements ClassPathProvider, AntProjectListener, Propert
             classpaths.put(type, classpathsByType);
         }
         // Check for cached value.
-        Iterator it = classpathsByType.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry entry = (Map.Entry)it.next();
+        for (Map.Entry entry : classpathsByType.entrySet()) {
             FileObject root = (FileObject)entry.getKey();
             if (root == file || FileUtil.isParentOf(root, file)) {
                 // Already have it.
@@ -187,20 +185,16 @@ final class Classpaths implements ClassPathProvider, AntProjectListener, Propert
             return null;
         }
         List<Element> compilationUnits = XMLUtil.findSubElements(java);
-        it = compilationUnits.iterator();
-        while (it.hasNext()) {
-            Element compilationUnitEl = (Element)it.next();
+
+        for (Element compilationUnitEl : compilationUnits) {
             assert compilationUnitEl.getLocalName().equals("compilation-unit") : compilationUnitEl;
             List<FileObject> packageRoots = findPackageRoots(helper, evaluator, compilationUnitEl);
-            Iterator it2 = packageRoots.iterator();
-            while (it2.hasNext()) {
-                FileObject root = (FileObject)it2.next();
+            for (FileObject root : packageRoots) {
                 if (root == file || FileUtil.isParentOf(root, file)) {
                     // Got it. Compute classpath and cache it (for each root).
                     ClassPath cp = getPath(compilationUnitEl, packageRoots, type);
-                    it2 = packageRoots.iterator();
-                    while (it2.hasNext()) {
-                        FileObject root2 = (FileObject)it2.next();
+
+                    for (FileObject root2 : packageRoots) {
                         classpathsByType.put(root2, cp);
                     }
                     return cp;
@@ -330,9 +324,7 @@ final class Classpaths implements ClassPathProvider, AntProjectListener, Propert
     
     static List<String> findPackageRootNames(Element compilationUnitEl) {
         List<String> names = new ArrayList<String>();
-        Iterator it = XMLUtil.findSubElements(compilationUnitEl).iterator();
-        while (it.hasNext()) {
-            Element e = (Element) it.next();
+        for (Element e : XMLUtil.findSubElements(compilationUnitEl)) {
             if (!e.getLocalName().equals("package-root")) { // NOI18N
                 continue;
             }
@@ -344,9 +336,7 @@ final class Classpaths implements ClassPathProvider, AntProjectListener, Propert
     
     static Map<String,FileObject> findPackageRootsByName(AntProjectHelper helper, PropertyEvaluator evaluator, List<String> packageRootNames) {
         Map<String,FileObject> roots = new LinkedHashMap<String,FileObject>();
-        Iterator it = packageRootNames.iterator();
-        while (it.hasNext()) {
-            String location = (String) it.next();
+        for (String location : packageRootNames) {
             String locationEval = evaluator.evaluate(location);
             if (locationEval != null) {
                 File locationFile = helper.resolveFile(locationEval);
@@ -563,9 +553,7 @@ final class Classpaths implements ClassPathProvider, AntProjectListener, Propert
                 return null;
             }
             List<Element> compilationUnits = XMLUtil.findSubElements(java);
-            Iterator it = compilationUnits.iterator();
-            while (it.hasNext()) {
-                Element compilationUnitEl = (Element)it.next();
+            for (Element compilationUnitEl : compilationUnits) {
                 assert compilationUnitEl.getLocalName().equals("compilation-unit") : compilationUnitEl;
                 if (packageRootNames.equals(findPackageRootNames(compilationUnitEl))) {
                     // Found a matching compilation unit.

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/JavaActions.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/JavaActions.java
@@ -296,8 +296,7 @@ final class JavaActions implements ActionProvider {
             List<ProjectModel.CompilationUnitKey> cuKeys = pm.createCompilationUnitKeys();
             assert cuKeys != null;
             boolean hasOutputs = false;
-            for (Iterator it = cuKeys.iterator(); it.hasNext();) {
-                ProjectModel.CompilationUnitKey ck = (ProjectModel.CompilationUnitKey) it.next();
+            for (ProjectModel.CompilationUnitKey ck : cuKeys) {
                 JavaProjectGenerator.JavaCompilationUnit cu = pm.getCompilationUnit(ck,false);
                 if (cu.output != null && cu.output.size()>0) {
                     hasOutputs = true;
@@ -454,8 +453,7 @@ final class JavaActions implements ActionProvider {
             List<ProjectModel.CompilationUnitKey> cuKeys = pm.createCompilationUnitKeys();
             assert cuKeys != null;
             boolean hasOutputs = false;
-            for (Iterator it = cuKeys.iterator(); it.hasNext();) {
-                ProjectModel.CompilationUnitKey ck = (ProjectModel.CompilationUnitKey) it.next();
+            for (ProjectModel.CompilationUnitKey ck : cuKeys) {
                 JavaProjectGenerator.JavaCompilationUnit cu = pm.getCompilationUnit(ck,false);
                 if (cu.output != null && cu.output.size()>0) {
                     hasOutputs = true;

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/JavaFreeformFileBuiltQuery.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/JavaFreeformFileBuiltQuery.java
@@ -78,9 +78,7 @@ final class JavaFreeformFileBuiltQuery implements FileBuiltQueryImplementation, 
         
         if (java != null) {
             List<Element> compilationUnits = XMLUtil.findSubElements(java);
-            Iterator it = compilationUnits.iterator();
-            while (it.hasNext()) {
-                Element compilationUnitEl = (Element)it.next();
+            for (Element compilationUnitEl : compilationUnits) {
                 assert compilationUnitEl.getLocalName().equals("compilation-unit") : compilationUnitEl;
                 List<String> rootNames = Classpaths.findPackageRootNames(compilationUnitEl);
                 List<String> builtToNames = findBuiltToNames(compilationUnitEl);

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/JavaProjectGenerator.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/JavaProjectGenerator.java
@@ -298,9 +298,7 @@ public class JavaProjectGenerator {
             XMLUtil.appendChildElement(viewEl, itemsEl, viewElementsOrder);
         }
         List<Element> sourceViews = XMLUtil.findSubElements(itemsEl);
-        Iterator it = sourceViews.iterator();
-        while (it.hasNext()) {
-            Element sourceViewEl = (Element)it.next();
+        for (Element sourceViewEl : sourceViews) {
             if (!sourceViewEl.getLocalName().equals("source-folder")) { // NOI18N
                 continue;
             }
@@ -309,9 +307,8 @@ public class JavaProjectGenerator {
                 itemsEl.removeChild(sourceViewEl);
             }
         }
-        Iterator it2 = sources.iterator();
-        while (it2.hasNext()) {
-            SourceFolder sf = (SourceFolder)it2.next();
+        
+        for (SourceFolder sf : sources) {
             if (sf.style == null || sf.style.length() == 0) {
                 // perhaps this is principal source folder?
                 continue;
@@ -511,9 +508,7 @@ public class JavaProjectGenerator {
                 }
             }
             if (cu.output != null) {
-                Iterator it3 = cu.output.iterator();
-                while (it3.hasNext()) {
-                    String output = (String)it3.next();
+                for (String output : cu.output) {
                     el = doc.createElementNS(data.getNamespaceURI(), "built-to"); // NOI18N
                     el.appendChild(doc.createTextNode(output));
                     cuEl.appendChild(el);
@@ -694,17 +689,15 @@ public class JavaProjectGenerator {
         ArrayList list = new ArrayList();
         Element data = Util.getPrimaryConfigurationData(helper);
         Document doc = data.getOwnerDocument();
-        Iterator it = XMLUtil.findSubElements(data).iterator();
-        while (it.hasNext()) {
-            Element exportEl = (Element)it.next();
+        
+        for (Element exportEl : XMLUtil.findSubElements(data)) {
             if (!exportEl.getLocalName().equals("export")) { // NOI18N
                 continue;
             }
             data.removeChild(exportEl);
         }
-        Iterator it2 = exports.iterator();
-        while (it2.hasNext()) {
-            Export export = (Export)it2.next();
+        
+        for (Export export : exports) {
             Element exportEl = doc.createElementNS(Util.NAMESPACE, "export"); // NOI18N
             Element el;
             el = doc.createElementNS(Util.NAMESPACE, "type"); // NOI18N
@@ -780,10 +773,8 @@ public class JavaProjectGenerator {
         }
         subproject = doc.createElementNS(Util.NAMESPACE, "subprojects"); // NOI18N
         XMLUtil.appendChildElement(data, subproject, rootElementsOrder);
-        
-        Iterator it = subprojects.iterator();
-        while (it.hasNext()) {
-            String proj = (String)it.next();
+
+        for (String proj : subprojects) {
             Element projEl = doc.createElementNS(Util.NAMESPACE, "project"); // NOI18N
             projEl.appendChild(doc.createTextNode(proj));
             subproject.appendChild(projEl);
@@ -863,18 +854,15 @@ public class JavaProjectGenerator {
             XMLUtil.appendChildElement(data, foldersEl, rootElementsOrder);
         } else {
             List<Element> folders = XMLUtil.findSubElements(foldersEl);
-            Iterator it = folders.iterator();
-            while (it.hasNext()) {
-                Element buildFolderEl = (Element)it.next();
+            for (Element buildFolderEl  : folders) {
                 if (!buildFolderEl.getLocalName().equals(elemName)) { // NOI18N
                     continue;
                 }
                 foldersEl.removeChild(buildFolderEl);
             }
         }
-        Iterator it = buildFolders.iterator();
-        while (it.hasNext()) {
-            String location = (String)it.next();
+
+        for (String location : buildFolders) {
             Element buildFolderEl = doc.createElementNS(Util.NAMESPACE, elemName); // NOI18N
             Element locationEl = doc.createElementNS(Util.NAMESPACE, "location"); // NOI18N
             locationEl.appendChild(doc.createTextNode(location));

--- a/platform/core.startup/src/org/netbeans/core/startup/layers/BinaryCacheManager.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/layers/BinaryCacheManager.java
@@ -108,8 +108,8 @@ final class BinaryCacheManager extends ParsingLayerCacheManager {
         
         if (folder.attrs != null) {
             bw.writeInt(folder.attrs.size()); // attr count
-            for (Iterator it = folder.attrs.iterator(); it.hasNext(); ) {
-                writeAttribute(bw, (MemAttr)it.next()); // write attrs
+            for (MemAttr attr : folder.attrs) {
+                writeAttribute(bw, attr); // write attrs
             }
         } else {
             bw.writeInt(0); // no attrs
@@ -119,15 +119,13 @@ final class BinaryCacheManager extends ParsingLayerCacheManager {
             bw.writeInt(folder.children.size()); // file count
             // compute len of all FileRefs
             int baseOffset = bw.getPosition();
-            for (Iterator it = folder.children.iterator(); it.hasNext(); ) {
-                MemFileOrFolder item = (MemFileOrFolder)it.next(); 
+            for (MemFileOrFolder item : folder.children) {
                 baseOffset += computeHeaderSize(item, null);
             }
             // baseOffset now contains the offset of the first file content
 
             // write file headers
-            for (Iterator it = folder.children.iterator(); it.hasNext(); ) {
-                MemFileOrFolder item = (MemFileOrFolder)it.next(); 
+            for (MemFileOrFolder item : folder.children) {
                 bw.writeString(item.name); //    String name
                 bw.writeByte((item instanceof MemFile) ? (byte)0 : (byte)1); //boolean isFolder
                 bw.writeInt(baseOffset); //  int contentRef
@@ -137,8 +135,7 @@ final class BinaryCacheManager extends ParsingLayerCacheManager {
             }
 
             // write file/folder contents
-            for (Iterator it = folder.children.iterator(); it.hasNext(); ) {
-                MemFileOrFolder item = (MemFileOrFolder)it.next(); 
+            for (MemFileOrFolder item : folder.children) {
                 // TODO: can check the correctenss of the offsets now
                 if (item instanceof MemFile) {
                     writeFile(bw, (MemFile)item);
@@ -171,8 +168,8 @@ final class BinaryCacheManager extends ParsingLayerCacheManager {
 
         if (file.attrs != null) {
             bw.writeInt(file.attrs.size()); // attr count
-            for (Iterator it = file.attrs.iterator(); it.hasNext(); ) {
-                writeAttribute(bw, (MemAttr)it.next()); // write attrs
+            for (MemAttr attr : file.attrs) {
+                writeAttribute(bw, attr); // write attrs
             }
         } else {
             bw.writeInt(0); // no attrs
@@ -235,8 +232,8 @@ final class BinaryCacheManager extends ParsingLayerCacheManager {
 
         size += 4; // int attrCount
         if (mf.attrs != null) {
-            for (Iterator it = mf.attrs.iterator(); it.hasNext(); ) {
-                size += computeSize((MemAttr)it.next(), text); // Attribute[attrCount] attrs
+            for (MemAttr attr : mf.attrs) {
+                size += computeSize(attr, text); // Attribute[attrCount] attrs
             }
         }
 
@@ -393,9 +390,8 @@ final class BinaryCacheManager extends ParsingLayerCacheManager {
                 }
             }
             if (f instanceof MemFolder && ((MemFolder)f).children != null) {
-                Iterator it = ((MemFolder)f).children.iterator ();
-                while (it.hasNext ()) {
-                    collectBaseUrls ((MemFileOrFolder)it.next (), map, counter);
+                for (MemFileOrFolder item : ((MemFolder)f).children) {
+                    collectBaseUrls (item, map, counter);
                 }
             }
         }

--- a/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
@@ -41,7 +41,6 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -1047,11 +1046,7 @@ public final class FileUtil extends Object {
         //
         // apply all extended attributes
         //
-        Iterator it = attributes.entrySet().iterator();
-
-        while (it.hasNext()) {
-            Map.Entry entry = (Map.Entry) it.next();
-
+        for (Map.Entry entry : attributes.entrySet()) {
             String fileName = (String) entry.getKey();
             int last = fileName.lastIndexOf('/');
             String dirName;
@@ -1065,6 +1060,7 @@ public final class FileUtil extends Object {
             String prefix = fo.isRoot() ? dirName : (fo.getPath() + '/' + dirName);
 
             DefaultAttributes.Table t = (DefaultAttributes.Table) entry.getValue();
+            
             Iterator files = t.keySet().iterator();
 
             while (files.hasNext()) {
@@ -2324,24 +2320,17 @@ public final class FileUtil extends Object {
     }
 
     private static Iterable<? extends ArchiveRootProvider> getArchiveRootProviders() {
-        if (archiveRootProviderCache == null) {
-            Lookup.Result<ArchiveRootProvider> res = archiveRootProviders.get();
-            if (res == null) {
-                res = new ProxyLookup(
-                    Lookups.singleton(new JarArchiveRootProvider()),
-                    Lookup.getDefault()).lookupResult(ArchiveRootProvider.class);
-                if (!archiveRootProviders.compareAndSet(null, res)) {
-                    res = archiveRootProviders.get();
-                    res.addLookupListener((ev) -> {
-                        archiveRootProviderCache = null;
-                    });
-                }
+        Lookup.Result<ArchiveRootProvider> res = archiveRootProviders.get();
+        if (res == null) {
+            res = new ProxyLookup(
+                Lookups.singleton(new JarArchiveRootProvider()),
+                Lookup.getDefault()).lookupResult(ArchiveRootProvider.class);
+            if (!archiveRootProviders.compareAndSet(null, res)) {
+                res = archiveRootProviders.get();
             }
-            archiveRootProviderCache = new LinkedList<>(res.allInstances());
         }
-        return archiveRootProviderCache;
+        return res.allInstances();
     }
 
-    private static Iterable<? extends ArchiveRootProvider> archiveRootProviderCache;
     private static final AtomicReference<Lookup.Result<ArchiveRootProvider>> archiveRootProviders = new AtomicReference<>();
 }

--- a/platform/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/JarFileSystem.java
@@ -1298,8 +1298,8 @@ public class JarFileSystem extends AbstractFileSystem {
             names = newNames;
 
             // strip all the indices arrays:
-            for (Iterator it = folders.values().iterator(); it.hasNext();) {
-                ((Folder) it.next()).trunc();
+            for (Folder folder : folders.values()) {
+                folder.trunc();
             }
         }
 

--- a/platform/openide.filesystems/src/org/openide/filesystems/MemoryFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/MemoryFileSystem.java
@@ -187,11 +187,7 @@ final class MemoryFileSystem extends AbstractFileSystem implements AbstractFileS
 
         //System.out.println("Folder: " + f);
         synchronized(entries) {
-            Iterator it = entries.keySet().iterator();
-
-            while (it.hasNext()) {
-                String name = (String) it.next();
-
+            for (String name : entries.keySet()) {
                 if (name.startsWith(f) || (f.trim().length() == 0)) {
                     int i = name.indexOf('/', f.length());
                     String child = null;

--- a/platform/openide.filesystems/src/org/openide/filesystems/Repository.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/Repository.java
@@ -705,11 +705,7 @@ public class Repository implements Serializable {
     @Deprecated
     public final synchronized void writeExternal(ObjectOutput oos)
     throws IOException {
-        Iterator iter = fileSystems.iterator();
-
-        while (iter.hasNext()) {
-            FileSystem fs = (FileSystem) iter.next();
-
+        for (FileSystem fs : fileSystems) {
             if (!fs.isDefault()) {
                 oos.writeObject(new NbMarshalledObject(fs));
             }
@@ -777,8 +773,9 @@ public class Repository implements Serializable {
         init();
 
         // all is successfuly read
-        for (Iterator iter = temp.iterator(); iter.hasNext();)
-            addFileSystem((FileSystem) iter.next());
+        for (FileSystem fileSystem : temp) {
+            addFileSystem(fileSystem);
+        }
     }
 
     /** Finds file when its name is provided. It scans in the list of

--- a/platform/openide.loaders/src/org/openide/loaders/DataNode.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataNode.java
@@ -1026,9 +1026,8 @@ public class DataNode extends AbstractNode {
                 }
             } else {
                 thisChanged = false;
-                Iterator it = obj.files().iterator();
-                while (it.hasNext()) {
-                    FileObject fo = (FileObject)it.next();
+                
+                for (FileObject fo : obj.files()) {
                     if (ev.hasChanged(fo)) {
                         thisChanged = true;
                         break;

--- a/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlMethodNode.java
+++ b/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlMethodNode.java
@@ -80,9 +80,10 @@ public class WsdlMethodNode extends AbstractNode {
         String signature;
         if (javaMethod != null) {
             signature = javaMethod.getReturnType().getFormalName() + " " + javaMethod.getName() + "(";
-            Iterator parameterIterator = javaMethod.getParametersList().iterator();
+            
+            Iterator<JavaParameter> parameterIterator = javaMethod.getParametersList().iterator();
             while (parameterIterator.hasNext()) {
-                JavaParameter currentParam = (JavaParameter) parameterIterator.next();
+                JavaParameter currentParam = parameterIterator.next();
                 String parameterType = TypeUtil.getParameterType(currentParam);
                 signature += parameterType + " " + currentParam.getName();
                 if (parameterIterator.hasNext()) {
@@ -178,9 +179,9 @@ public class WsdlMethodNode extends AbstractNode {
             String signature = javaMethod.getReturnType().getRealName() + " " +
                     javaMethod.getName() + "(";
 
-            Iterator tempIterator = javaMethod.getParametersList().iterator();
+            Iterator<JavaParameter> tempIterator = javaMethod.getParametersList().iterator();
             while (tempIterator.hasNext()) {
-                JavaParameter currentparam = (JavaParameter) tempIterator.next();
+                JavaParameter currentparam = tempIterator.next();
                 signature += currentparam.getType().getRealName() + " " + currentparam.getName();
                 if (tempIterator.hasNext()) {
                     signature += ", ";
@@ -223,7 +224,9 @@ public class WsdlMethodNode extends AbstractNode {
                 paramSet.setShortDescription(NbBundle.getMessage(WsdlMethodNode.class, "METHOD_PARAMDIVIDER")); // NOI18N
                 sheet.put(paramSet);
             }
-            Iterator paramIterator = javaMethod.getParametersList().iterator();
+            
+            
+            Iterator<JavaParameter> paramIterator = javaMethod.getParametersList().iterator();
             if (paramIterator.hasNext()) {
                 p = new Reflection(NbBundle.getMessage(WsdlMethodNode.class, "METHOD_PARAMTYPE"), // NOI18N
                         String.class,
@@ -232,7 +235,7 @@ public class WsdlMethodNode extends AbstractNode {
                 p.setName("paramdivider2"); // NOI18N
 
                 for (int ii = 0; paramIterator.hasNext(); ii++) {
-                    JavaParameter currentParameter = (JavaParameter) paramIterator.next();
+                    JavaParameter currentParameter = paramIterator.next();
                     if (currentParameter.getType().isHolder()) {
                         p = new Reflection(TypeUtil.getParameterType(currentParameter), String.class, "toString", null); // NOI18N
                     } else {


### PR DESCRIPTION
I've tried to reduce the amount of iterator raw type warnings that are emitted from
code that looks like this..

```
   [repeat] /home/bwalker/netbeans/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceGroup.java:102: warning: [rawtypes] found raw type: Iterator
   [repeat]             Iterator iter = listeners.iterator();
   [repeat]             ^
   [repeat]   missing type arguments for generic class Iterator<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in interface Iterator
```