### PR TITLE
[NETBEANS-2953] Fix for NPE after pressing 'DTDs and XML Schemas' men…

### DIFF
--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/layer.xml
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/layer.xml
@@ -237,14 +237,14 @@
         <folder name="XML">
             <folder name="UserCatalogs">
                 <file name="org-netbeans-modules-payara-jakartaee-RunTimeDDCatalog.instance">
-                    <attr name="instanceCreate" methodvalue="org.netbeans.modules.payara.jakartaee.RunTimeDDCatalog.getRunTimeDDCatalog"/>
+                    <attr name="instanceCreate" methodvalue="org.netbeans.modules.payara.jakartaee.RunTimeDDCatalog.getDefaultRunTimeDDCatalog"/>
                     <attr name="instanceOf" stringvalue="org.netbeans.modules.xml.catalog.spi.CatalogReader"/>
                 </file>
             </folder>
             <folder name="GrammarQueryManagers">
                 <file name="org-netbeans-modules-payara-jakartaee-RunTimeDDCatalog.instance">
                     <attr name="position" intvalue="350"/>
-                    <attr name="instanceCreate" methodvalue="org.netbeans.modules.payara.jakartaee.RunTimeDDCatalog.getRunTimeDDCatalog"/>
+                    <attr name="instanceCreate" methodvalue="org.netbeans.modules.payara.jakartaee.RunTimeDDCatalog.getDefaultRunTimeDDCatalog"/>
                 </file>
             </folder> <!-- GrammarQueryManagers -->
         </folder>


### PR DESCRIPTION
*What this pull request does*
Prevents Netbeans from crashing with a NPE when selecting Tools -> DTDs and XML Schemas

*Files Changed*
enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/layer.xml 
Changed so that the method used when registering is getDefaultRuntimeDDCatalog() instead of getRuntimeDDCatalog().  This now matches the equivilent method called when registering GlassFish DD catalog - getEE6RunTimeDDCatalog()

*Testing*
Navigate to Tools menu -> DTD and XML Schemas
Before this PR: NB will crash with a NPE
After this PR: The Enterprise Catalog dialog will open successfully
