### PR TITLE
[NETBEANS-1859] PHP autocompletion does only get fully qualified returned objects

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/NamespaceScopeImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/NamespaceScopeImpl.java
@@ -44,6 +44,7 @@ import org.netbeans.modules.php.editor.model.nodes.FunctionDeclarationInfo;
 import org.netbeans.modules.php.editor.model.nodes.GroupUseStatementPartInfo;
 import org.netbeans.modules.php.editor.model.nodes.NamespaceDeclarationInfo;
 import org.netbeans.modules.php.editor.model.nodes.SingleUseStatementPartInfo;
+import org.netbeans.modules.php.editor.parser.astnodes.Expression;
 import org.netbeans.modules.php.editor.parser.astnodes.FunctionDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.Program;
 import org.netbeans.modules.php.editor.parser.astnodes.Scalar;
@@ -85,8 +86,14 @@ final class NamespaceScopeImpl extends ScopeImpl implements NamespaceScope, Vari
     }
 
     FunctionScopeImpl createElement(Program program, FunctionDeclaration node) {
+        // NETBEANS-1859 add qualified return type
+        Expression returnType = node.getReturnType();
+        String qualifiedReturnType = VariousUtils.getReturnType(program, node);
+        if (returnType != null) {
+            qualifiedReturnType = VariousUtils.qualifyTypeNames(VariousUtils.getReturnType(program, node), returnType.getStartOffset(), this);
+        }
         FunctionScopeImpl retval = new FunctionScopeImpl(this, FunctionDeclarationInfo.create(program, node),
-                VariousUtils.getReturnType(program, node), VariousUtils.isDeprecatedFromPHPDoc(program, node));
+                qualifiedReturnType, VariousUtils.isDeprecatedFromPHPDoc(program, node));
         return retval;
     }
 

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1859/nb1859_01.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1859/nb1859_01.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace TestNamespace;
+
+class TestClass {
+
+    public $test = "test";
+    public static $staticTest = "staticTest";
+
+    public function test() {
+    }
+
+    public static function staticTest() {
+    }
+}
+
+function newTestClass(): TestClass {
+    return new TestClass();
+}
+
+namespace TestNamespace2;
+
+class TestClass {
+
+    public $test2 = "test2";
+    public static $staticTest2 = "staticTest2";
+
+    public function test2() {
+    }
+
+    public static function staticTest2() {
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1859/nb1859_02.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1859/nb1859_02.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+echo \TestNamespace\newTestClass()->
+echo \TestNamespace\newTestClass()::

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1859/nb1859_02.php.testNamespaceFunction_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1859/nb1859_02.php.testNamespaceFunction_01.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+echo \TestNamespace\newTestClass()->|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     staticTest()                    [STATIC]   \TestNamespace\TestClass
+METHOD     test()                          [PUBLIC]   \TestNamespace\TestClass
+VARIABLE   ? test                          [PUBLIC]   \TestNamespace\TestClass

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1859/nb1859_02.php.testNamespaceFunction_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1859/nb1859_02.php.testNamespaceFunction_02.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+echo \TestNamespace\newTestClass()::|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     staticTest()                    [STATIC]   \TestNamespace\TestClass
+VARIABLE   ? $staticTest                   [STATIC]   \TestNamespace\TestClass

--- a/php/php.editor/test/unit/data/testfiles/index/testNullableTypesForFunctions/testNullableTypesForFunctions.php.indexed
+++ b/php/php.editor/test/unit/data/testfiles/index/testNullableTypesForFunctions/testNullableTypesForFunctions.php.indexed
@@ -3,7 +3,7 @@
 Document 0
 Searchable Keys:
   base : parametertype;parameterType;16;$msg:?string:1::1:0:0,$num:int:1::1:0:0;;;0;<TESTURL>/testNullableTypesForFunctions.php;
-  base : returntype;returnType;68;$str:string:1::1:0:0;?Foo;;0;<TESTURL>/testNullableTypesForFunctions.php;
+  base : returntype;returnType;68;$str:string:1::1:0:0;?\Foo;;0;<TESTURL>/testNullableTypesForFunctions.php;
   top : parametertype
   top : returntype
 

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb1859Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb1859Test.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+
+public class PHPCodeCompletionNb1859Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionNb1859Test(String testName) {
+        super(testName);
+    }
+
+    public void testNamespaceFunction_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1859/nb1859_02.php", "echo \\TestNamespace\\newTestClass()->^", false);
+    }
+
+    public void testNamespaceFunction_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1859/nb1859_02.php", "echo \\TestNamespace\\newTestClass()::^", false);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/nb1859"))
+            })
+        );
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/model/impl/ModelTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/model/impl/ModelTest.java
@@ -246,7 +246,7 @@ public class ModelTest extends ModelTestBase {
         assertNotNull(functionScope);
         Collection<? extends String> returnTypeNames = functionScope.getReturnTypeNames();
         assertEquals(1, returnTypeNames.size());
-        assertEquals("DateTime", ModelUtils.getFirst(returnTypeNames));
+        assertEquals("\\DateTime", ModelUtils.getFirst(returnTypeNames));
     }
 
     public void testReturnTypes02() throws Exception {
@@ -301,7 +301,7 @@ public class ModelTest extends ModelTestBase {
         assertNotNull(foo);
         Collection<? extends String> fooReturnTypeNames = foo.getReturnTypeNames();
         assertEquals(1, fooReturnTypeNames.size());
-        assertEquals("Iterator", ModelUtils.getFirst(fooReturnTypeNames));
+        assertEquals("\\Iterator", ModelUtils.getFirst(fooReturnTypeNames));
         FunctionScope bar = ModelUtils.getFirst(ModelUtils.filter(ModelUtils.getDeclaredFunctions(program), "bar"));
         assertNotNull(bar);
         Collection<? extends String> barReturnTypeNames = bar.getReturnTypeNames();

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGeneratorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/typinghooks/PhpCommentGeneratorTest.java
@@ -444,7 +444,7 @@ public class PhpCommentGeneratorTest extends PHPNavTestBase {
                 + "/**\n"
                 + " * \n"
                 + " * @param string|null $string\n"
-                + " * @return Foo|null^\n"
+                + " * @return \\Foo|null^\n"
                 + " */\n"
                 + "function test(?string $string): ?Foo {\n"
                 + "    \n"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-1859

- Get fully qualified types from return types of functions

#### Note

One of php.editor unit tests fails at the moment. Maybe, changes of editor modules relate to it. 
https://issues.apache.org/jira/browse/NETBEANS-3085