### PR TITLE
[NETBEANS-3095] avoid null pointer exception in SplashPainter

### DIFF
--- a/platform/core.startup/src/org/netbeans/core/startup/Splash.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Splash.java
@@ -439,7 +439,8 @@ public final class Splash implements Stamps.Updater {
 
         final void init() throws MissingResourceException, NumberFormatException {
             assert SwingUtilities.isEventDispatchThread();
-            if (maxSteps > 0) {
+            // check if init has already been called
+            if (statusBox != null) {
                 return;
             }
             // 100 is allocated for module system that will adjust this when number
@@ -520,7 +521,7 @@ public final class Splash implements Stamps.Updater {
                         return;
                     }
 
-                    if (statusBox == null || statusBox.fm == null) {
+                    if (statusBox.fm == null) {
                         return;
                     }
 
@@ -547,7 +548,7 @@ public final class Splash implements Stamps.Updater {
                 return ;
             }
 
-            if (statusBox == null || statusBox.fm == null) {           
+            if (statusBox.fm == null) {           
                 return;
             }
             

--- a/platform/core.startup/src/org/netbeans/core/startup/Splash.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Splash.java
@@ -518,7 +518,7 @@ public final class Splash implements Stamps.Updater {
                         return;
                     }
 
-                    if (statusBox.fm == null) {
+                    if (statusBox == null || statusBox.fm == null) {
                         return;
                     }
 
@@ -544,7 +544,7 @@ public final class Splash implements Stamps.Updater {
             if (text == null)
                 return ;
 
-            if (statusBox.fm == null)
+            if (statusBox == null ||statusBox.fm == null)
                 return;
             
             int width = statusBox.fm.stringWidth(text);

--- a/platform/core.startup/src/org/netbeans/core/startup/Splash.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Splash.java
@@ -244,10 +244,12 @@ public final class Splash implements Stamps.Updater {
         if (about) {
             ret = ImageUtilities.loadImage("org/netbeans/core/startup/about.png", true);
         }
-        if (ret == null)
+        if (ret == null) {
             ret = ImageUtilities.loadImage("org/netbeans/core/startup/splash.gif", true);
-        if (ret == null)
+        }
+        if (ret == null) {
             return null;
+        }
         return new ScaledBitmapIcon(ret,
                 Integer.parseInt(NbBundle.getMessage(Splash.class, "SPLASH_WIDTH")),
                 Integer.parseInt(NbBundle.getMessage(Splash.class, "SPLASH_HEIGHT")));
@@ -541,11 +543,13 @@ public final class Splash implements Stamps.Updater {
             String newText = null;
             String newString;
             
-            if (text == null)
+            if (text == null) {
                 return ;
+            }
 
-            if (statusBox == null ||statusBox.fm == null)
+            if (statusBox == null || statusBox.fm == null) {           
                 return;
+            }
             
             int width = statusBox.fm.stringWidth(text);
             

--- a/platform/core.startup/src/org/netbeans/core/startup/Splash.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Splash.java
@@ -637,7 +637,10 @@ public final class Splash implements Stamps.Updater {
         }
 	
         void paint() {
-            image.paintIcon(comp, graphics, 0, 0);
+            // loadContentIcon may return a null image
+            if (image != null) {
+                image.paintIcon(comp, graphics, 0, 0);
+            }
             // turn anti-aliasing on for the splash text
             graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
                     RenderingHints.VALUE_TEXT_ANTIALIAS_ON);


### PR DESCRIPTION
Avoids random null pointer exception.

`
java.lang.NullPointerExceptionjava.lang.NullPointerException at org.netbeans.core.startup.Splash$SplashPainter$1.run(Splash.java:521) at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311) at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758) at java.awt.EventQueue.access$500(EventQueue.java:97) at java.awt.EventQueue$3.run(EventQueue.java:709) at java.awt.EventQueue$3.run(EventQueue.java:703) at java.security.AccessController.doPrivileged(Native Method) at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74) at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)[catch] at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205) at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116) at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105) at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101) at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93) at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
`