### PR TITLE
[NETBEANS-3082]: Fixed formatting issue happening on use of Switch-Ex…

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -2647,7 +2647,6 @@ public class Reformatter implements ReformatTask {
                     break;
             }
             if (node.getKind().toString().equals(TreeShims.SWITCH_EXPRESSION)) {
-                old = indent;
                 indent = lastIndent + indentSize;
             }
             List<? extends CaseTree> caseTrees = TreeShims.getCases(node);

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -2104,7 +2104,8 @@ public class FormatingTest extends NbTestCase {
                 + "default:"
                 + "{System.out.println(\"DEFAULT\");"
                 + "yield 6;}"
-                + "}"
+                + "};"
+                + "System.out.println(i);"
                 + "}"
                 + "}\n";
 
@@ -2121,7 +2122,8 @@ public class FormatingTest extends NbTestCase {
                 + "                System.out.println(\"DEFAULT\");\n"
                 + "                yield 6;\n"
                 + "            }\n"
-                + "        }\n"
+                + "        };\n"
+                + "        System.out.println(i);\n"
                 + "    }\n"
                 + "}\n";
         preferences.putBoolean("spaceBeforeSwitchParen", true);
@@ -2143,7 +2145,8 @@ public class FormatingTest extends NbTestCase {
                 + "                System.out.println(\"DEFAULT\");\n"
                 + "                yield 6;\n"
                 + "            }\n"
-                + "        }\n"
+                + "        };\n"
+                + "        System.out.println(i);\n"
                 + "    }\n"
                 + "}\n";
 
@@ -2174,7 +2177,8 @@ public class FormatingTest extends NbTestCase {
                 + "                  System.out.println(\"DEFAULT\");\n"
                 + "                  yield 6;\n"
                 + "                }\n"
-                + "          }\n"
+                + "          };\n"
+                + "        System.out.println(i);\n"
                 + "    }\n"
                 + "}\n";
         preferences.putBoolean("spaceBeforeSwitchParen", true);
@@ -2199,7 +2203,8 @@ public class FormatingTest extends NbTestCase {
                 + "                    System.out.println(\"DEFAULT\");\n"
                 + "                    yield 6;\n"
                 + "                    }\n"
-                + "            }\n"
+                + "            };\n"
+                + "        System.out.println(i);\n"
                 + "    }\n"
                 + "}\n";
 


### PR DESCRIPTION
…pression

Jira Link: https://issues.apache.org/jira/browse/NETBEANS-3082
Suppose We have below  Code Snippet

int a = switch(1)
{ default : yield 1 }
;
System.out.println(a);

Expressions/Statements used after Switch-Expression are getting wrongly indented.
