### PR TITLE
[NETBEANS-3096]:Updation for external nb-javac jar in libs.javacapi a…

### DIFF
--- a/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask113FeaturesTest.java
+++ b/java/java.completion/test/unit/src/org/netbeans/modules/java/completion/JavaCompletionTask113FeaturesTest.java
@@ -20,12 +20,14 @@ package org.netbeans.modules.java.completion;
 
 import javax.lang.model.SourceVersion;
 import org.netbeans.junit.NbTestSuite;
-
+import org.netbeans.modules.java.source.parsing.JavacParser;
 /**
  *
  * @author arusinha
  */
 public class JavaCompletionTask113FeaturesTest extends CompletionTestBase {
+
+    private static String SOURCE_LEVEL = "1.13"; //NOI18N
 
     public JavaCompletionTask113FeaturesTest(String testName) {
         super(testName);
@@ -44,14 +46,17 @@ public class JavaCompletionTask113FeaturesTest extends CompletionTestBase {
     }
 
     public void testSwitchExprAutoCompleteYieldValue() throws Exception {
-        performTest("SwitchExprForYieldWithValue", 1019, "yi", "SwitchExprYieldAutoCompletion.pass");
+        performTest("SwitchExprForYieldWithValue", 1019, "yi", "SwitchExprYieldAutoCompletion.pass", SOURCE_LEVEL);
     }
 
     public void testSwitchExprAutoCompleteYieldValue2() throws Exception {
-        performTest("SwitchExprForYieldWithValue2", 1023, "yi", "SwitchExprYieldAutoCompletion.pass");
+        performTest("SwitchExprForYieldWithValue2", 1023, "yi", "SwitchExprYieldAutoCompletion.pass", SOURCE_LEVEL);
     }
 
     public void noop() {
     }
 
+    static {
+        JavacParser.DISABLE_SOURCE_LEVEL_DOWNGRADE = true;
+    }
 }

--- a/java/java.source.nbjavac/src/org/netbeans/modules/java/source/nbjavac/parsing/TreeLoader.java
+++ b/java/java.source.nbjavac/src/org/netbeans/modules/java/source/nbjavac/parsing/TreeLoader.java
@@ -101,7 +101,9 @@ public class TreeLoader extends LazyTreeLoader {
     private static final ThreadLocal<Boolean> isTreeLoading = new ThreadLocal<Boolean>();
 
     public static void preRegister(final Context context, final ClasspathInfo cpInfo, final boolean detached) {
-        context.put(lazyTreeLoaderKey, new TreeLoader(context, cpInfo, detached));
+        LazyTreeLoader instance = context.get(lazyTreeLoaderKey);
+        if (instance == null)
+            context.put(lazyTreeLoaderKey, new TreeLoader(context, cpInfo, detached));
     }
     
     public static TreeLoader instance (final Context ctx) {

--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-9FA2C56C15D013C391EF76E9AA07172F20447673 nb-javac-12-api.jar
+E6F49BAA176938C82F4EBAA148F8A8AB13556233 nb-javac-13-api.jar

--- a/java/libs.javacapi/external/nb-javac-13-api-license.txt
+++ b/java/libs.javacapi/external/nb-javac-13-api-license.txt
@@ -1,6 +1,6 @@
 Name: Javac Compiler API
 Description: Javac Compiler API
-Version: 12
+Version: 13
 License: GPL-2-CP
 Origin: OpenJDK (http://hg.openjdk.java.net/)
 Source: http://hg.netbeans.org/main/nb-java-x/

--- a/java/libs.javacapi/nbproject/org-netbeans-libs-javacapi.sig
+++ b/java/libs.javacapi/nbproject/org-netbeans-libs-javacapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 8.26.0
+#Version 8.26.1
 
 CLSS public abstract interface com.sun.source.doctree.AttributeTree
 innr public final static !enum ValueKind
@@ -308,7 +308,6 @@ meth public abstract java.util.List<? extends com.sun.source.tree.StatementTree>
 
 CLSS public abstract interface com.sun.source.tree.BreakTree
 intf com.sun.source.tree.StatementTree
-meth public abstract com.sun.source.tree.ExpressionTree getValue()
  anno 0 java.lang.Deprecated()
 meth public abstract javax.lang.model.element.Name getLabel()
 
@@ -795,6 +794,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitUses(com.sun.sourc
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitVariable(com.sun.source.tree.VariableTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitWhileLoop(com.sun.source.tree.WhileLoopTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitWildcard(com.sun.source.tree.WildcardTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitYield(com.sun.source.tree.YieldTree,{com.sun.source.tree.TreeVisitor%1})
 
 CLSS public abstract interface com.sun.source.tree.TryTree
 intf com.sun.source.tree.StatementTree
@@ -1112,6 +1112,7 @@ meth public {com.sun.source.util.SimpleTreeVisitor%0} visitUses(com.sun.source.t
 meth public {com.sun.source.util.SimpleTreeVisitor%0} visitVariable(com.sun.source.tree.VariableTree,{com.sun.source.util.SimpleTreeVisitor%1})
 meth public {com.sun.source.util.SimpleTreeVisitor%0} visitWhileLoop(com.sun.source.tree.WhileLoopTree,{com.sun.source.util.SimpleTreeVisitor%1})
 meth public {com.sun.source.util.SimpleTreeVisitor%0} visitWildcard(com.sun.source.tree.WildcardTree,{com.sun.source.util.SimpleTreeVisitor%1})
+meth public {com.sun.source.util.SimpleTreeVisitor%0} visitYield(com.sun.source.tree.YieldTree,{com.sun.source.util.SimpleTreeVisitor%1})
 supr java.lang.Object
 
 CLSS public abstract interface com.sun.source.util.SourcePositions
@@ -1238,6 +1239,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitUses(com.sun.source.tree.Us
 meth public {com.sun.source.util.TreeScanner%0} visitVariable(com.sun.source.tree.VariableTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitWhileLoop(com.sun.source.tree.WhileLoopTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitWildcard(com.sun.source.tree.WildcardTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitYield(com.sun.source.tree.YieldTree,{com.sun.source.util.TreeScanner%1})
 supr java.lang.Object
 
 CLSS public abstract com.sun.source.util.Trees

--- a/java/libs.javacapi/nbproject/project.xml
+++ b/java/libs.javacapi/nbproject/project.xml
@@ -40,7 +40,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-12-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-13-api.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.javacimpl/external/binaries-list
+++ b/java/libs.javacimpl/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-3B790BEAE746363CB8EC4C18B0A6187D683BC247 nb-javac-12-impl.jar
+58ECEA2987072A9AD96F2ECF82C18AB90CEF8CFD nb-javac-13-impl.jar

--- a/java/libs.javacimpl/external/nb-javac-13-impl-license.txt
+++ b/java/libs.javacimpl/external/nb-javac-13-impl-license.txt
@@ -1,6 +1,6 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: 12
+Version: 13
 License: GPL-2-CP
 Origin: OpenJDK (http://hg.openjdk.java.net/)
 Source: http://hg.netbeans.org/main/nb-java-x/

--- a/java/libs.javacimpl/nbproject/project.xml
+++ b/java/libs.javacimpl/nbproject/project.xml
@@ -37,7 +37,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-12-impl.jar</binary-origin>
+                <binary-origin>external/nb-javac-13-impl.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -177,7 +177,7 @@ If you are sure you want to build with JDK 9+ anyway, use: -Dpermit.jdk9.builds=
         <property name="locmakenbm.brands" value="${brandings}"/>
         <!-- When requires.nb.javac property is true, prepend javac-api and javac-impl on bootclasspath to allow override the default annotation
              processing API located in rt.jar. -->
-        <property name="bootclasspath.prepend.nb" value="${nb_all}/java/libs.javacapi/external/nb-javac-12-api.jar${path.separator}${nb_all}/java/libs.javacimpl/external/nb-javac-12-impl.jar" />
+        <property name="bootclasspath.prepend.nb" value="${nb_all}/java/libs.javacapi/external/nb-javac-13-api.jar${path.separator}${nb_all}/java/libs.javacimpl/external/nb-javac-13-impl.jar" />
         <property name="bootclasspath.prepend.vanilla" value="${nb_all}/nbbuild/external/vanilla-javac-api.jar${path.separator}${nb_all}/nbbuild/external/vanilla-javac-impl.jar" />
         <condition property="bootclasspath.prepend" value="${bootclasspath.prepend.nb}">
             <istrue value="${requires.nb.javac.impl}"/>


### PR DESCRIPTION
…nd libs.javaimpl modules with nb-javac jar for jdk-13
Changes:
1. Updation of external jars of libs.javacapi & libs.javacimp modules.
2. Correction of Test cases of JavaCompetion for JDK-13 
Find below the list of test-cases which are failing with nb-javac (for jdk-13) but the same scenario is working in editor when used with nb-javac plugin for jdk-13
https://issues.apache.org/jira/browse/NETBEANS-3099