### PR TITLE
[NETBEANS-3085] Improving text block handling.

### DIFF
--- a/ide/editor.lib/src/org/netbeans/editor/BaseKit.java
+++ b/ide/editor.lib/src/org/netbeans/editor/BaseKit.java
@@ -1250,9 +1250,10 @@ public class BaseKit extends DefaultEditorKit {
                                         Object[] r = transaction.textTyped();
                                         String insertionText = r == null ? cmd : (String) r[0];
                                         int caretPosition = r == null ? -1 : (Integer) r[1];
+                                        boolean formatNewLines = r == null ? false : (Boolean) r[2];
 
                                         try {
-                                            performTextInsertion(target, insertionOffset.getOffset(), insertionText, caretPosition);
+                                            performTextInsertion(target, insertionOffset.getOffset(), insertionText, caretPosition, formatNewLines);
                                             result[0] = Boolean.TRUE;
                                             result[1] = insertionText;
                                         } catch (BadLocationException ble) {
@@ -1357,7 +1358,7 @@ public class BaseKit extends DefaultEditorKit {
         // Private implementation
         // --------------------------------------------------------------------
 
-        private void performTextInsertion(JTextComponent target, int insertionOffset, String insertionText, int caretPosition) throws BadLocationException {
+        private void performTextInsertion(JTextComponent target, int insertionOffset, String insertionText, int caretPosition, boolean formatNewLines) throws BadLocationException {
             final BaseDocument doc = (BaseDocument)target.getDocument();
             
             try {
@@ -1378,7 +1379,7 @@ public class BaseKit extends DefaultEditorKit {
                 int targetCaretOffset = caretPosition;
                 for (int i = 0; i < insertionText.length();) {
                     int end = insertionText.indexOf('\n', i);
-                    if (end == (-1)) end = insertionText.length();
+                    if (end == (-1) || !formatNewLines) end = insertionText.length();
                     String currentLine = insertionText.substring(i, end);
                     if (i == 0) {
                         if (Utilities.isSelectionShowing(caret)) { // valid selection

--- a/ide/editor.lib2/apichanges.xml
+++ b/ide/editor.lib2/apichanges.xml
@@ -83,6 +83,18 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="TypedTextInterceptorIndent">
+            <summary>Ability to indent text set to TypedTextInterceptor</summary>
+            <version major="2" minor="26"/>
+            <date day="15" month="9" year="2019"/>
+            <author login="jlahoda"/>
+            <compatibility binary="compatible" source="compatible" semantic="compatible" addition="yes" deprecation="no" deletion="no" modification="no" />
+            <description>
+                <p>Added TypedTextInterceptor.MutableContext.setText overload, which
+                   optionally re-indents the provided text.</p>
+            </description>
+            <class name="TypedTextInterceptor" package="org.netbeans.spi.editor.typinghooks"/>
+        </change>
         <change id="PrependedTextOpt">
             <summary>Prepended text for highlights</summary>
             <version major="2" minor="24"/>

--- a/ide/editor.lib2/nbproject/project.properties
+++ b/ide/editor.lib2/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 javac.source=1.7
 javac.compilerargs=-Xlint:unchecked
-spec.version.base=2.25.0
+spec.version.base=2.26.0
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/editor.lib2/src/org/netbeans/spi/editor/typinghooks/TypedTextInterceptor.java
+++ b/ide/editor.lib2/src/org/netbeans/spi/editor/typinghooks/TypedTextInterceptor.java
@@ -276,11 +276,37 @@ public interface TypedTextInterceptor {
          *   are <code>&lt;0, text.getLength()&gt;</code>.
          */
         public void setText(String text, int caretPosition) {
+            setText(text, caretPosition, false);
+        }
+
+        /**
+         * Sets the insertion text and adjusted caret position. This method can
+         * be used for modifying text typed by a user that would normally be
+         * inserted into a document.
+         *
+         * <p>There is no restriction on the new text
+         * set by this method, except that it must not be <code>null</code>. It can
+         * be of any length (including an empty string) and can even span  multiple lines.
+         *
+         * <p>It is important to remember that the adjusted caret position is
+         * relative to the new text. Therefore valid values for the <code>caretPosition</code>
+         * parameter are <code>&lt;0, text.getLength()&gt;</code>! The adjusted position
+         * is <b>not</b> a document offset.
+         * 
+         * @param text The new text that will be inserted to a document.
+         * @param caretPosition The adjusted caret position <b>inside</b> the new text.
+         *   This position is relative to the new text. Valid values for this parameter
+         *   are <code>&lt;0, text.getLength()&gt;</code>.
+         * @param formatNewLines true if new lines in the provided text should be indented.
+         * @since 2.26
+         */
+        public void setText(String text, int caretPosition, boolean formatNewLines) {
             assert text != null : "Invalid text, it must not be null."; //NOI18N
             assert caretPosition >= 0 && caretPosition <= text.length() : "Invalid caretPostion=" + caretPosition + ", text.length=" + text.length(); //NOI18N
 
             this.insertionText = text;
             this.caretPosition = caretPosition;
+            this.formatNewLines = formatNewLines;
         }
 
         /**
@@ -302,6 +328,7 @@ public interface TypedTextInterceptor {
         private String insertionText = null;
         private String replacedText = null;
         private int caretPosition = -1;
+        private boolean formatNewLines = false;
         
         private MutableContext(JTextComponent c, Position offset, String typedText, String replacedText) {
             super(c, offset, typedText);
@@ -318,7 +345,7 @@ public interface TypedTextInterceptor {
             @Override
             public Object[] getTtiContextData(MutableContext context) {
                 return context.insertionText != null ?
-                    new Object [] { context.insertionText, context.caretPosition } :
+                    new Object [] { context.insertionText, context.caretPosition, context.formatNewLines } :
                     null;
             }
 
@@ -326,6 +353,7 @@ public interface TypedTextInterceptor {
             public void resetTtiContextData(MutableContext context) {
                 context.insertionText = null;
                 context.caretPosition = -1;
+                context.formatNewLines = false;
             }
 
             @Override

--- a/java/java.editor/nbproject/project.xml
+++ b/java/java.editor/nbproject/project.xml
@@ -163,7 +163,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>2.6</specification-version>
+                        <specification-version>2.26</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java
@@ -25,10 +25,11 @@ import java.util.prefs.Preferences;
 import javax.lang.model.SourceVersion;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
+import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.settings.SimpleValueNames;
 import org.netbeans.api.java.lexer.JavaTokenId;
-import static org.netbeans.api.java.source.SourceUtils.isTextBlockSupported;
+import org.netbeans.api.java.queries.SourceLevelQuery;
 import org.netbeans.api.lexer.PartType;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenSequence;
@@ -40,6 +41,7 @@ import org.netbeans.spi.editor.typinghooks.TypedBreakInterceptor;
 import org.netbeans.spi.editor.typinghooks.TypedTextInterceptor;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
+import org.openide.modules.SpecificationVersion;
 
 /**
  * This static class groups the whole aspect of bracket completion. It is
@@ -73,7 +75,8 @@ class TypingCompletion {
         char removedChar = context.getText().charAt(0);
         int caretOffset = context.isBackwardDelete() ? context.getOffset() - 1 : context.getOffset();
         if (removedChar == '\"') {
-            if (ts.token().id() == JavaTokenId.STRING_LITERAL && ts.offset() == caretOffset) {
+            if ((ts.token().id() == JavaTokenId.STRING_LITERAL && ts.offset() == caretOffset) ||
+                (ts.token().id() == JavaTokenId.MULTILINE_STRING_LITERAL && ts.offset() <= caretOffset - 2)) {
                 context.getDocument().remove(caretOffset, 1);
             }
         } else if (removedChar == '\'') {
@@ -142,7 +145,7 @@ class TypingCompletion {
             return;
         }
         
-        
+        //XXX:
         char chr = context.getDocument().getText(context.getOffset(), 1).charAt(0);
         if (chr == ')' || chr == ',' || chr == '\'' || chr == ' ' || chr == ']' || chr == '}' || chr == '\n' || chr == '\t' || chr == ';') {
             char insChr = context.getText().charAt(0);
@@ -258,8 +261,7 @@ class TypingCompletion {
             if (context.getText().equals("\"") && context.getOffset() >= 2 &&
                     context.getDocument().getText(context.getOffset() - 2, 2).equals("\"\"") &&
                     isTextBlockSupported(getFileObject((BaseDocument) context.getDocument()))) {
-                context.setText("\"\n\"\"\"", 2);  // NOI18N
-                Thread.dumpStack();
+                context.setText("\"\n\"\"\"", 2, true);  // NOI18N
             } else {
                 context.setText(context.getText() + context.getText(), 1);
             }
@@ -269,7 +271,7 @@ class TypingCompletion {
                 id = javaTS.token().id();
                 if ((id == JavaTokenId.STRING_LITERAL) && (javaTS.token().text().toString().equals("\"\""))) {
                     if (context.getDocument().getText(context.getOffset(), 2).equals("\"\"")) {
-                        context.setText("\"\"\"\n\"", 4);
+                        context.setText("\"\"\"\n\"", 4, true);
                     }
                 }
                 javaTS.movePrevious();
@@ -315,6 +317,20 @@ class TypingCompletion {
         return context.getDocument().getText(context.getOffset() - 1, 1).charAt(0) == '\\';
     }
     
+    private static boolean isTextBlockSupported(
+            @NullAllowed FileObject fileObject) {
+        SpecificationVersion supportedVer = new SpecificationVersion("13"); //NOI18N
+
+        if (fileObject != null) {
+            SpecificationVersion sourceVer = new SpecificationVersion(SourceLevelQuery.getSourceLevel(fileObject));
+            if (sourceVer.compareTo(supportedVer) < 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     /**
      * Resolve whether pairing right curly should be added automatically
      * at the caret position or not.
@@ -846,8 +862,7 @@ class TypingCompletion {
     }
 
     private static FileObject getFileObject(BaseDocument doc) {
-        DataObject dob = NbEditorUtilities.getDataObject(doc);
-        return dob.getPrimaryFile();
+        return doc != null ? NbEditorUtilities.getFileObject(doc) : null;
     }
 
     private static Set<JavaTokenId> STRING_AND_COMMENT_TOKENS = EnumSet.of(JavaTokenId.STRING_LITERAL, JavaTokenId.LINE_COMMENT, JavaTokenId.JAVADOC_COMMENT, JavaTokenId.BLOCK_COMMENT, JavaTokenId.CHAR_LITERAL, JavaTokenId.MULTILINE_STRING_LITERAL);

--- a/java/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java
@@ -145,18 +145,10 @@ class TypingCompletion {
             return;
         }
         
-        //XXX:
         char chr = context.getDocument().getText(context.getOffset(), 1).charAt(0);
-        if (chr == ')' || chr == ',' || chr == '\'' || chr == ' ' || chr == ']' || chr == '}' || chr == '\n' || chr == '\t' || chr == ';') {
+        if (chr == ')' || chr == ',' || chr == '\"' || chr == '\'' || chr == ' ' || chr == ']' || chr == '}' || chr == '\n' || chr == '\t' || chr == ';') {
             char insChr = context.getText().charAt(0);
             context.setText("" + insChr + matching(insChr), 1);  // NOI18N
-        } else if (chr == '\"') {
-            if ((context.getOffset() > 2 && context.getDocument().getText(context.getOffset() - 2, 3).equals("\"\"\"")) &&
-                    isTextBlockSupported(getFileObject((BaseDocument) context.getDocument()))) {
-                context.setText("\"\n\"\"\"", 2);  // NOI18N
-            } else {
-                context.setText("\"\"", 1);  // NOI18N
-            }
         }
     }
 

--- a/java/java.editor/src/org/netbeans/modules/java/editor/imports/ClipboardHandler.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/imports/ClipboardHandler.java
@@ -89,7 +89,6 @@ import org.netbeans.api.java.source.GeneratorUtilities;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.java.source.ModificationResult;
 import org.netbeans.api.java.source.SourceUtils;
-import static org.netbeans.api.java.source.SourceUtils.isTextBlockSupported;
 import org.netbeans.api.java.source.Task;
 import org.netbeans.api.java.source.WorkingCopy;
 import org.netbeans.api.lexer.TokenHierarchy;
@@ -664,7 +663,7 @@ public class ClipboardHandler {
                             return data;
                         }
                     });
-                } else if ((isTextBlockSupported(NbEditorUtilities.getFileObject(((JTextComponent)comp).getDocument()))) && insideToken((JTextComponent) comp, JavaTokenId.MULTILINE_STRING_LITERAL)) {
+                } else if (insideToken((JTextComponent) comp, JavaTokenId.MULTILINE_STRING_LITERAL)) {
                     final Transferable t = support.getTransferable();
                     return delegate.importData(comp, new Transferable() {
                         @Override

--- a/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/TypingCompletionUnitTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/TypingCompletionUnitTest.java
@@ -1154,18 +1154,46 @@ public class TypingCompletionUnitTest extends NbTestCase {
         ctx.assertDocumentTextEquals("()|");
     }
     
-    public void testRemoveQuotesBackSpace() throws Exception {
+    public void testRemoveQuotesBackSpace1() throws Exception {
+        Context ctx = new Context(new JavaKit(),
+                "\"|\"");
+        ctx.typeChar('\b');
+        ctx.assertDocumentTextEquals("|");
+    }
+    
+    public void testRemoveQuotesBackSpace2() throws Exception {
         Context ctx = new Context(new JavaKit(),
                 "\"\"\"|\"");
         ctx.typeChar('\b');
         ctx.assertDocumentTextEquals("\"\"|");
     }
     
-    public void testRemoveQuotesDelete() throws Exception {
+    public void testRemoveQuotesBackSpace3() throws Exception {
+        Context ctx = new Context(new JavaKit(),
+                "\"\"\"|\";");
+        ctx.typeChar('\b');
+        ctx.assertDocumentTextEquals("\"\"|;");
+    }
+    
+    public void testRemoveQuotesDelete1() throws Exception {
+        Context ctx = new Context(new JavaKit(),
+                "|\"\"");
+        ctx.typeChar('\f');
+        ctx.assertDocumentTextEquals("|");
+    }
+    
+    public void testRemoveQuotesDelete2() throws Exception {
         Context ctx = new Context(new JavaKit(),
                 "\"\"|\"\"");
         ctx.typeChar('\f');
         ctx.assertDocumentTextEquals("\"\"|");
+    }
+    
+    public void testRemoveQuotesDelete3() throws Exception {
+        Context ctx = new Context(new JavaKit(),
+                "\"\"|\"\";");
+        ctx.typeChar('\f');
+        ctx.assertDocumentTextEquals("\"\"|;");
     }
     
     public void testRemoveQuotes2BackSpace() throws Exception {

--- a/java/java.lexer/apichanges.xml
+++ b/java/java.lexer/apichanges.xml
@@ -85,13 +85,13 @@ is the proper place.
     <changes>
         <change id="RawStringLiteral">
              <api name="general"/>
-             <summary>Added RAW_STRING_LITERAL JavaTokenKind</summary>
+             <summary>Added MULTILINE_STRING_LITERAL JavaTokenKind</summary>
              <version major="1" minor="41"/>
              <date day="22" month="4" year="2018"/>
              <author login="jlahoda"/>
             <compatibility addition="yes" binary="compatible" deletion="no" deprecation="no" modification="no" semantic="compatible" source="compatible"/>
              <description>
-                 Added JavaTokenId.RAW_STRING_LITERAL.
+                 Added JavaTokenId.MULTILINE_STRING_LITERAL.
              </description>
              <class package="org.netbeans.api.java.lexer" name="JavaTokenId"/>
         </change>

--- a/java/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerBatchTest.java
+++ b/java/java.lexer/test/unit/src/org/netbeans/lib/java/lexer/JavaLexerBatchTest.java
@@ -698,35 +698,71 @@ public class JavaLexerBatchTest extends TestCase {
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
     }
 
-    private void enableRawStringLiterals(InputAttributes attr) {
-        attr.setValue(JavaTokenId.language(), "version", (Supplier<String>) () -> {
-            return "13";
-        }, true);
-    }
-
     public void testMultilineLiteral() {
         String text = "\"\"\"\n2\"3\n4\\\"\"\"5\"\"\\\"6\n7\"\"\" \"\"\"wrong\"\"\" \"\"\"\nbla\n";
         InputAttributes attr = new InputAttributes();
-        enableRawStringLiterals(attr);
         TokenHierarchy<?> hi = TokenHierarchy.create(text, false, JavaTokenId.language(), EnumSet.noneOf(JavaTokenId.class), attr);
         TokenSequence<?> ts = hi.tokenSequence();
 
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.MULTILINE_STRING_LITERAL, "\"\"\"\n2\"3\n4\\\"\"\"5\"\"\\\"6\n7\"\"\"");
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
-        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.MULTILINE_STRING_LITERAL, "\"\"\"wrong\"\"\"");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.STRING_LITERAL, "\"\"");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.STRING_LITERAL, "\"wrong\"");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.STRING_LITERAL, "\"\"");
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.WHITESPACE, " ");
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.MULTILINE_STRING_LITERAL, "\"\"\"\nbla\n");
         assertFalse(ts.moveNext());
     }
 
-    public void testTrailing() {
+    public void testTrailing1() {
         String text = "\"\"";
         InputAttributes attr = new InputAttributes();
-        enableRawStringLiterals(attr);
         TokenHierarchy<?> hi = TokenHierarchy.create(text, false, JavaTokenId.language(), EnumSet.noneOf(JavaTokenId.class), attr);
         TokenSequence<?> ts = hi.tokenSequence();
 
         LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.STRING_LITERAL, "\"\"");
+        assertFalse(ts.moveNext());
+    }
+
+    public void testTrailing2() {
+        String text = "\"\"\"";
+        InputAttributes attr = new InputAttributes();
+        TokenHierarchy<?> hi = TokenHierarchy.create(text, false, JavaTokenId.language(), EnumSet.noneOf(JavaTokenId.class), attr);
+        TokenSequence<?> ts = hi.tokenSequence();
+
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.STRING_LITERAL, "\"\"");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.STRING_LITERAL, "\"");
+        assertFalse(ts.moveNext());
+    }
+
+    public void testTrailing3() {
+        String text = "\"\"\" ";
+        InputAttributes attr = new InputAttributes();
+        TokenHierarchy<?> hi = TokenHierarchy.create(text, false, JavaTokenId.language(), EnumSet.noneOf(JavaTokenId.class), attr);
+        TokenSequence<?> ts = hi.tokenSequence();
+
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.STRING_LITERAL, "\"\"");
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.STRING_LITERAL, "\" ");
+        assertFalse(ts.moveNext());
+    }
+
+    public void testTrailing4() {
+        String text = "\"\"\"\n";
+        InputAttributes attr = new InputAttributes();
+        TokenHierarchy<?> hi = TokenHierarchy.create(text, false, JavaTokenId.language(), EnumSet.noneOf(JavaTokenId.class), attr);
+        TokenSequence<?> ts = hi.tokenSequence();
+
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.MULTILINE_STRING_LITERAL, "\"\"\"\n");
+        assertFalse(ts.moveNext());
+    }
+
+    public void testTrailing5() {
+        String text = "\"\"\" \n";
+        InputAttributes attr = new InputAttributes();
+        TokenHierarchy<?> hi = TokenHierarchy.create(text, false, JavaTokenId.language(), EnumSet.noneOf(JavaTokenId.class), attr);
+        TokenSequence<?> ts = hi.tokenSequence();
+
+        LexerTestUtilities.assertNextTokenEquals(ts, JavaTokenId.MULTILINE_STRING_LITERAL, "\"\"\" \n");
         assertFalse(ts.moveNext());
     }
 

--- a/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -568,26 +568,6 @@ public class SourceUtils {
         return null;        
     }
 
-    /**
-     * @since 13.0
-     */
-    public static boolean isTextBlockSupported(
-            @NullAllowed FileObject fileObject) {
-        SpecificationVersion supportedVer = new SpecificationVersion("13"); //NOI18N
-
-        SpecificationVersion runtimeVer = new SpecificationVersion(System.getProperty("java.specification.version")); //NOI18N
-        if (runtimeVer.compareTo(supportedVer) >= 0) {
-            if (fileObject != null) {
-                SpecificationVersion sourceVer = new SpecificationVersion(SourceLevelQuery.getSourceLevel(fileObject));
-                if (sourceVer.compareTo(supportedVer) < 0) {
-                    return false;
-                }
-            }
-            return true;
-        }
-        return false;
-    }
-
     private static FileObject findSourceForBinary(FileObject binaryRoot, FileObject binary, String signature, String pkgName, String className, boolean isPkg) throws IOException {
         FileObject[] sourceRoots = SourceForBinaryQuery.findSourceRoots(binaryRoot.toURL()).getRoots();                        
         ClassPath sourcePath = ClassPathSupport.createClassPath(sourceRoots);

--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
@@ -103,7 +103,6 @@ import org.netbeans.api.java.source.CodeStyle;
 import org.netbeans.api.java.source.CodeStyle.*;
 import org.netbeans.api.java.source.Comment;
 import org.netbeans.api.java.source.Comment.Style;
-import static org.netbeans.api.java.source.SourceUtils.isTextBlockSupported;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenSequence;
 import org.netbeans.modules.java.source.TreeShims;
@@ -1895,7 +1894,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
 	   case CLASS:
              if (tree.value instanceof String) {
                  print("\"" + quote((String) tree.value, '\'') + "\"");
-             } else if (isTextBlockSupported(null) && tree.value instanceof String[]) {
+             } else if (tree.value instanceof String[]) {
                  int indent = out.col;
                  print("\"\"\"");
                  newline();


### PR DESCRIPTION
Avoiding SourceUtils.isTextBlockSupported API. Some features seem to make sense even if text blocks are not enabled - e.g. having a text block already in the code, then lexing it as a text block seems fine. Type-completing code in such a way that the text block would be created is (probably) not fine when text blocks are created.

Also, fixing a problem in PHP with indenting the typed text, by introducing a special API method that preforms the indent, and leaving the existing methods work as before.
