### PR TITLE
[NETBEANS-3103] Formatting is broken with class constant code completion(self::)

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -914,6 +914,19 @@ public class FormatVisitor extends DefaultVisitor {
 
             }
             scan(node.getInitializers());
+            if (ts.token().id() == PHPTokenId.PHP_SELF || ts.token().id() == PHPTokenId.PHP_PARENT) {
+                // NETBEANS-3103 check whether the token behind self|parent is "::"
+                // e.g. const CONSTANT = self::;
+                int originalOffset = ts.offset();
+                if (ts.moveNext()) {
+                    if (ts.token().id() == PHPTokenId.PHP_PAAMAYIM_NEKUDOTAYIM) { // ::
+                        addFormatToken(formatTokens);
+                    } else {
+                        ts.move(originalOffset);
+                        ts.moveNext();
+                    }
+                }
+            }
             formatTokens.add(new FormatToken.IndentToken(node.getStartOffset(), options.continualIndentSize * -1));
             if (index == statements.size() - 1
                     || ((index < statements.size() - 1) && !(statements.get(index + 1) instanceof ConstantDeclaration))) {

--- a/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_parent_01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_parent_01.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class ClassName {
+
+    private const CONSTANT = /*FORMAT_START*/parent::/*FORMAT_END*/;
+
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_parent_01.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_parent_01.php.formatted
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class ClassName {
+
+    private const CONSTANT = parent::;
+
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_parent_02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_parent_02.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class ClassName {
+
+    private const CONSTANT = /*FORMAT_START*/parent::/*FORMAT_END*/
+
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_parent_02.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_parent_02.php.formatted
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class ClassName {
+
+    private const CONSTANT = parent::
+
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_self_01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_self_01.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class ClassName {
+
+    private const CONSTANT = /*FORMAT_START*/self::/*FORMAT_END*/;
+
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_self_01.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_self_01.php.formatted
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class ClassName {
+
+    private const CONSTANT = self::;
+
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_self_02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_self_02.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class ClassName {
+
+    private const CONSTANT = /*FORMAT_START*/self::/*FORMAT_END*/
+
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_self_02.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/broken/netbeans3103_self_02.php.formatted
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class ClassName {
+
+    private const CONSTANT = self::
+
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterBrokenTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterBrokenTest.java
@@ -53,4 +53,24 @@ public class PHPFormatterBrokenTest extends PHPFormatterTestBase {
         options.put(FmtOptions.CONTINUATION_INDENT_SIZE, 4);
         reformatFileContents("testfiles/formatting/broken/issue197074_04.php", options);
     }
+
+    public void testNetBeans3103SelectedSelf_01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        reformatFileContents("testfiles/formatting/broken/netbeans3103_self_01.php", options);
+    }
+
+    public void testNetBeans3103SelectedSelf_02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        reformatFileContents("testfiles/formatting/broken/netbeans3103_self_02.php", options);
+    }
+
+    public void testNetBeans3103SelectedParent_01() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        reformatFileContents("testfiles/formatting/broken/netbeans3103_parent_01.php", options);
+    }
+
+    public void testNetBeans3103SelectedParent_02() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        reformatFileContents("testfiles/formatting/broken/netbeans3103_parent_02.php", options);
+    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-3103

This issue is related to #1314 .

- The parser ignores "::" because example code is incorrect syntax
- Check whether the token behind self or parent is "::" in the FormatVisitor

Example code:
```php
<?php
class ClassName {

    // ^ is the caret position
    // select "self::" or "parent::" in CC list
    // i.e. private const CONSTANT = self::;
    private const CONSTANT = ^;

}
```

Before:
```php
<?php
class ClassName {

    private const CONSTANT = self

    ::;

}
```

After:
```php
<?php
class ClassName {

    private const CONSTANT = self::;

}
```