### PR TITLE
[NETBEANS-3107] - cleanup use of generics

### DIFF
--- a/ide/db/src/org/netbeans/modules/db/explorer/DbDriverManager.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/DbDriverManager.java
@@ -64,12 +64,12 @@ public class DbDriverManager {
     /**
      * Maps each connection to the driver used to create that connection.
      */
-    private Map/*<Connection, Driver>*/ conn2Driver = new WeakHashMap();
+    private Map<Connection, Driver> conn2Driver = new WeakHashMap<>();
     
     /**
      * Maps each driver to the class loader for that driver.
      */
-    private Map/*<JDBCDriver, ClassLoader>*/ driver2Loader = new WeakHashMap();
+    private Map<JDBCDriver, ClassLoader> driver2Loader = new WeakHashMap<>();
     
     private DbDriverManager() {
     }

--- a/ide/db/src/org/netbeans/modules/db/explorer/driver/JDBCDriverConvertor.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/driver/JDBCDriverConvertor.java
@@ -68,7 +68,7 @@ public class JDBCDriverConvertor implements Environment.Provider, InstanceCookie
     /**
      * The reference to the instance of Environment.Provider
      */
-    private static Reference/*<JDBCDriverConvertor>*/ providerRef;
+    private static Reference<JDBCDriverConvertor> providerRef;
     
     /**
      * The path where the drivers are registered in the SystemFileSystem.

--- a/ide/editor.lib/test/unit/src/org/netbeans/editor/UndoableEditWrapperTest.java
+++ b/ide/editor.lib/test/unit/src/org/netbeans/editor/UndoableEditWrapperTest.java
@@ -100,7 +100,7 @@ public class UndoableEditWrapperTest extends NbTestCase {
         /** if not null contains message why this document cannot be modified */
         private transient String cannotBeModified;
         private transient Date date = new Date ();
-        private transient List/*<PropertyChangeListener>*/ propL = new ArrayList ();
+        private transient List<PropertyChangeListener> propL = new ArrayList<>();
         private transient VetoableChangeListener vetoL;
 
         public CESEnv() {

--- a/ide/options.editor/src/org/netbeans/modules/options/colors/AnnotationsPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/AnnotationsPanel.java
@@ -465,7 +465,7 @@ public class AnnotationsPanel extends JPanel implements ActionListener,
     }
     
     private AttributeSet getDefaultColoring() {
-        Collection/*<AttributeSet>*/ defaults = colorModel.getCategories(currentScheme, ColorModel.ALL_LANGUAGES);
+        Collection<AttributeSet> defaults = colorModel.getCategories(currentScheme, ColorModel.ALL_LANGUAGES);
         
         for(Iterator i = defaults.iterator(); i.hasNext(); ) {
             AttributeSet as = (AttributeSet) i.next();

--- a/ide/options.editor/src/org/netbeans/modules/options/colors/HighlightingPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/HighlightingPanel.java
@@ -494,7 +494,7 @@ public class HighlightingPanel extends JPanel implements ActionListener, ItemLis
     }
     
     private AttributeSet getDefaultColoring() {
-        Collection/*<AttributeSet>*/ defaults = colorModel.getCategories(currentProfile, ColorModel.ALL_LANGUAGES);
+        Collection<AttributeSet> defaults = colorModel.getCategories(currentProfile, ColorModel.ALL_LANGUAGES);
         
         for(Iterator i = defaults.iterator(); i.hasNext(); ) {
             AttributeSet as = (AttributeSet) i.next();

--- a/ide/project.ant/src/org/netbeans/spi/project/support/ant/ReferenceHelper.java
+++ b/ide/project.ant/src/org/netbeans/spi/project/support/ant/ReferenceHelper.java
@@ -1643,7 +1643,7 @@ public final class ReferenceHelper {
             this.props = props;
         }
         
-        private static final List/*<String>*/ SUB_ELEMENT_NAMES = Arrays.asList(new String[] {
+        private static final List<String> SUB_ELEMENT_NAMES = Arrays.asList(new String[] {
             "foreign-project", // NOI18N
             "artifact-type", // NOI18N
             "script", // NOI18N
@@ -1762,7 +1762,7 @@ public final class ReferenceHelper {
                 artifactID,
             };
             for (int i = 0; i < 6; i++) {
-                Element subel = ownerDocument.createElementNS(namespace, (String)SUB_ELEMENT_NAMES.get(i));
+                Element subel = ownerDocument.createElementNS(namespace, SUB_ELEMENT_NAMES.get(i));
                 subel.appendChild(ownerDocument.createTextNode(values[i]));
                 el.appendChild(subel);
             }

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogAction.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogAction.java
@@ -105,7 +105,7 @@ public class CatalogAction implements ActionListener {
             assert nodes != null && nodes.length > 0 : "Selected templates cannot be null or empty.";
             Set nodes2open = getNodes2Open (nodes);
             assert ! nodes2open.isEmpty () : "Selected templates to open cannot by empty for nodes " + Arrays.asList (nodes);
-            Iterator/*<Node>*/ it = nodes2open.iterator ();
+            Iterator<Node> it = nodes2open.iterator();
             while (it.hasNext ()) {
                 Node n = (Node) it.next ();
                 ViewCookie vc = (ViewCookie) n.getLookup ().lookup (ViewCookie.class);

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AdvancedActionPanel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AdvancedActionPanel.java
@@ -67,7 +67,7 @@ final class AdvancedActionPanel extends javax.swing.JPanel {
     };
     
     private final AntProjectCookie project;
-    private final Set/*<TargetLister.Target>*/ allTargets;
+    private final Set<TargetLister.Target> allTargets;
     private String defaultTarget = null;
     
     public AdvancedActionPanel(AntProjectCookie project, Set/*<TargetLister.Target>*/ allTargets) {
@@ -95,7 +95,7 @@ final class AdvancedActionPanel extends javax.swing.JPanel {
         FileObject script = project.getFileObject();
         assert script != null : "No file found for " + project;
         String initialTargets = (String) script.getAttribute(ATTR_TARGETS);
-        SortedSet/*<String>*/ relevantTargets = new TreeSet(Collator.getInstance());
+        SortedSet<String> relevantTargets = new TreeSet(Collator.getInstance());
         Iterator it = allTargets.iterator();
         while (it.hasNext()) {
             TargetLister.Target target = (TargetLister.Target) it.next();

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetsAction.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetsAction.java
@@ -255,7 +255,7 @@ public final class RunTargetsAction extends AbstractAction implements ContextAwa
     private static final class AdvancedAction extends AbstractAction {
         
         private final AntProjectCookie project;
-        private final Set/*<TargetLister.Target>*/ allTargets;
+        private final Set<TargetLister.Target> allTargets;
         
         public AdvancedAction(AntProjectCookie project, Set/*<TargetLister.Target>*/ allTargets) {
             super(NbBundle.getMessage(RunTargetsAction.class, "LBL_run_advanced"));

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTablesPanel.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/DBSchemaTablesPanel.java
@@ -304,7 +304,7 @@ public class DBSchemaTablesPanel extends JPanel implements ListDataListener {
         return params.getResult();
     }
 
-    private void invokeHandlers(final List/*<Handler>*/ handlers, final Parameters params) {
+    private void invokeHandlers(final List<Handler> handlers, final Parameters params) {
         final ProgressPanel progressPanel = new ProgressPanel();
         
         ProgressHandle progressHandle = ProgressHandleFactory.createHandle(null);
@@ -339,7 +339,7 @@ public class DBSchemaTablesPanel extends JPanel implements ListDataListener {
         }
     }
     
-    private int invokeHandlers(List/*<Handler>*/ handlers, int start, Parameters params, final ProgressPanel progressPanel) {
+    private int invokeHandlers(List<Handler> handlers, int start, Parameters params, final ProgressPanel progressPanel) {
         boolean isEDT = SwingUtilities.isEventDispatchThread();
         int i;
         

--- a/java/javadoc/src/org/netbeans/modules/javadoc/JavadocModule.java
+++ b/java/javadoc/src/org/netbeans/modules/javadoc/JavadocModule.java
@@ -33,11 +33,11 @@ import org.openide.windows.TopComponent;
  */
 public final class JavadocModule extends ModuleInstall {
 
-    private static Collection/*<TopComponent>*/ floatingTopComponents;
+    private static Collection<TopComponent> floatingTopComponents;
 
     public synchronized static void registerTopComponent(TopComponent tc) {
         if (floatingTopComponents == null)
-            floatingTopComponents = new LinkedList();
+            floatingTopComponents = new LinkedList<>();
         floatingTopComponents.add(tc);
     }
     

--- a/platform/core.startup/src/org/netbeans/core/startup/ModuleList.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/ModuleList.java
@@ -1472,9 +1472,11 @@ final class ModuleList implements Stamps.Updater {
                 }
             }
         }
-        private void stepCheckSer(Map/*<String,FileObject>*/ xmlfiles, Map/*<String,Map<String,Object>>*/ dirtyprops) {
+
+        private void stepCheckSer(Map<String,FileObject> xmlfiles, Map<String,Map<String,Object>> dirtyprops) {
             // There is NO step 7!
         }
+
         private void stepUpdateProps(Map<String,Map<String,Object>> dirtyprops) {
             LOG.fine("ModuleList: stepUpdateProps");
             for (Map.Entry<String,Map<String,Object>> entry: dirtyprops.entrySet()) {

--- a/platform/core.windows/src/org/netbeans/core/windows/services/ActionPasteType.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/services/ActionPasteType.java
@@ -111,11 +111,11 @@ final class ActionPasteType {
 
     private final static class PasteTypeImpl extends PasteType {
         final private DataFolder targetFolder;
-        final private Collection/*<DataObject>*/  sourceDataObjects;
+        final private Collection<DataObject>  sourceDataObjects;
         final private int pasteOperation;
 
     
-        private PasteTypeImpl(final Collection/*<DataObject>*/ sourceDataObjects, final DataFolder targetFolder, final int pasteOperation) {
+        private PasteTypeImpl(final Collection<DataObject> sourceDataObjects, final DataFolder targetFolder, final int pasteOperation) {
             this.targetFolder = targetFolder;
             this.sourceDataObjects = sourceDataObjects;
             this.pasteOperation = pasteOperation;

--- a/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
+++ b/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
@@ -242,7 +242,7 @@ public class WizardDescriptor extends DialogDescriptor {
     private final JButton cancelButton = new JButton();
     private final JButton previousButton = new JButton();
     private FinishAction finishOption;
-    private Set /*<Object>*/ newObjects = Collections.EMPTY_SET;
+    private Set<Object> newObjects = Collections.EMPTY_SET;
 
     /** a component with wait cursor */
     private Component waitingComponent;

--- a/platform/templates/src/org/netbeans/modules/templates/actions/TemplatesAction.java
+++ b/platform/templates/src/org/netbeans/modules/templates/actions/TemplatesAction.java
@@ -127,7 +127,7 @@ public class TemplatesAction extends AbstractAction { // XXX could be ActionList
             assert nodes != null && nodes.length > 0 : "Selected templates cannot be null or empty.";
             Set nodes2open = getNodes2Open (nodes);
             assert ! nodes2open.isEmpty () : "Selected templates to open cannot by empty for nodes " + Arrays.asList (nodes);
-            Iterator/*<Node>*/ it = nodes2open.iterator ();
+            Iterator<Node> it = nodes2open.iterator();
             while (it.hasNext ()) {
                 Node n = (Node) it.next ();
                 EditCookie ec = n.getLookup ().lookup (EditCookie.class);

--- a/profiler/lib.profiler.ui/nbproject/project.properties
+++ b/profiler/lib.profiler.ui/nbproject/project.properties
@@ -16,4 +16,4 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.6
+javac.source=1.8

--- a/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/statistics/StatisticalModuleContainer.java
+++ b/profiler/lib.profiler.ui/src/org/netbeans/lib/profiler/ui/cpu/statistics/StatisticalModuleContainer.java
@@ -38,7 +38,7 @@ import org.openide.util.lookup.ServiceProvider;
 public class StatisticalModuleContainer implements CPUCCTProvider.Listener {
     //~ Instance fields ----------------------------------------------------------------------------------------------------------
 
-    private final Set /*<StatisticalModule>*/ modules = new HashSet();
+    private final Set<StatisticalModule> modules = new HashSet<>();
 
     //~ Constructors -------------------------------------------------------------------------------------------------------------
 

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDumpSegment.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDumpSegment.java
@@ -60,7 +60,7 @@ class ClassDumpSegment extends TagBounds {
     ClassDump java_lang_Class;
     boolean newSize;
     Map /*<JavaClass,List<Field>>*/ fieldsCache;
-    private List /*<JavaClass>*/ classes;
+    private List<JavaClass> classes;
     private Map /*<Byte,JavaClass>*/ primitiveArrayMap;
 
     //~ Constructors -------------------------------------------------------------------------------------------------------------
@@ -319,7 +319,7 @@ class ClassDumpSegment extends TagBounds {
         this(heap, start, end);
         int classesSize = dis.readInt();
         if (classesSize != 0) {
-            List cls = new ArrayList /*<JavaClass>*/(classesSize);
+            List<JavaClass> cls = new ArrayList<>(classesSize);
             arrayMap = new HashMap(classesSize / 15);
             
             for (int i=0; i<classesSize; i++) {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/Instrumentor.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/instrumentation/Instrumentor.java
@@ -140,7 +140,7 @@ public class Instrumentor implements CommonConstants {
 
     // --------------------------------------- Public interface ----------------------------------------------------------
     public String[] getRootClassNames() {
-        List /*<String>*/ rootClassNames = rootMethods.getRootClassNames();
+        List<String> rootClassNames = rootMethods.getRootClassNames();
         RuntimeProfilingPoint[] pps = settings.getRuntimeProfilingPoints();
 
         if ((rootClassNames == null) && (pps.length > 0)) {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/BaseCallGraphBuilder.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/BaseCallGraphBuilder.java
@@ -42,7 +42,7 @@ public abstract class BaseCallGraphBuilder implements ProfilingResultListener, C
 
     //~ Instance fields ----------------------------------------------------------------------------------------------------------
 
-    protected List /*<Runnable>*/ afterBatchCommands = new ArrayList /*<Runnable>*/();
+    protected List <Runnable> afterBatchCommands = new ArrayList<>();
     protected ProfilingSessionStatus status;
     protected final Set cctListeners = new CopyOnWriteArraySet();
     protected WeakReference clientRef;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/BaseCallGraphBuilder.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/BaseCallGraphBuilder.java
@@ -42,7 +42,7 @@ public abstract class BaseCallGraphBuilder implements ProfilingResultListener, C
 
     //~ Instance fields ----------------------------------------------------------------------------------------------------------
 
-    protected List <Runnable> afterBatchCommands = new ArrayList<>();
+    protected List/*<Runnable>*/ afterBatchCommands = new ArrayList<>();
     protected ProfilingSessionStatus status;
     protected final Set cctListeners = new CopyOnWriteArraySet();
     protected WeakReference clientRef;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/CCTResultsFilter.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/CCTResultsFilter.java
@@ -46,7 +46,7 @@ public final class CCTResultsFilter extends RuntimeCCTNodeProcessor.PluginAdapte
     }
     
     public static interface EvaluatorProvider {
-        Set/*<Evaluator>*/ getEvaluators();
+        Set<Evaluator> getEvaluators();
     }
 
     //~ Static fields/initializers -----------------------------------------------------------------------------------------------

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/CCTResultsFilter.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/CCTResultsFilter.java
@@ -46,7 +46,7 @@ public final class CCTResultsFilter extends RuntimeCCTNodeProcessor.PluginAdapte
     }
     
     public static interface EvaluatorProvider {
-        Set<Evaluator> getEvaluators();
+        Set/*<Evaluator>*/ getEvaluators();
     }
 
     //~ Static fields/initializers -----------------------------------------------------------------------------------------------

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/CCTResultsFilter.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/cct/CCTResultsFilter.java
@@ -46,7 +46,7 @@ public final class CCTResultsFilter extends RuntimeCCTNodeProcessor.PluginAdapte
     }
     
     public static interface EvaluatorProvider {
-        Set/*<Evaluator>*/ getEvaluators();
+        Set<Evaluator> getEvaluators();
     }
 
     //~ Static fields/initializers -----------------------------------------------------------------------------------------------
@@ -55,7 +55,7 @@ public final class CCTResultsFilter extends RuntimeCCTNodeProcessor.PluginAdapte
 
     //~ Instance fields ----------------------------------------------------------------------------------------------------------
 
-    private Set /*<Evaluator>*/ evaluators = null;
+    private Set<Evaluator> evaluators = null;
     private Set evaluatorProviders = new HashSet();
 
     private Stack passFlagStack;
@@ -65,7 +65,7 @@ public final class CCTResultsFilter extends RuntimeCCTNodeProcessor.PluginAdapte
 
     /** Creates a new instance of CategoryFilter */
     public CCTResultsFilter() {
-        evaluators = new HashSet /*<Evaluator>*/();
+        evaluators = new HashSet<>();
         passFlagStack = new Stack();
         doReset();
     }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ClassLoaderManager.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/server/ClassLoaderManager.java
@@ -51,8 +51,8 @@ class ClassLoaderManager implements CommonConstants {
     // TODO [release]: change value to TRUE to remove the print code below entirely by compiler
     private static final boolean DEBUG = System.getProperty("org.netbeans.lib.profiler.server.ClassLoaderManager") != null; // NOI18N
     private static ProfilerServer profilerServer;
-    private static WeakHashMap /*<ClassLoader, ClassLoaderManager>*/ manMap;
-    private static Vector /*<ClassLoaderManager>*/ manVec;
+    private static WeakHashMap<ClassLoader, ClassLoaderManager> manMap;
+    private static Vector<ClassLoaderManager> manVec;
     private static ReferenceQueue rq;
     private static boolean notifyToolAboutUnloadedClasses;
     private static Method findLoadedClassMethod;

--- a/profiler/profiler/nbproject/project.properties
+++ b/profiler/profiler/nbproject/project.properties
@@ -19,7 +19,7 @@ is.autoload=true
 
 cp.extra=${tools.jar}
 
-javac.source=1.6
+javac.source=1.8
 test-qa-functional-sys-prop.BrokenReferencesSupport.suppressBrokenRefAlert=true
 test.config.uicommit.includes=\
     org/netbeans/test/profiler/ProfilerValidationTest.class


### PR DESCRIPTION
I'm trying to clean up the use of generics when there is a private method or variable.

For example, we see a lot of the follow code in the source tree:

`private Map/*<Connection, Driver>*/ conn2Driver = new WeakHashMap();`

Change this to

`private Map<Connection, Driver> conn2Driver = new WeakHashMap<>();`

Java really wants us to use Generics and this looks like it was a work in progress. So I'm simply
trying to complete some of it.