### PR TITLE
[NETBEANS-3108] PHP: Some features(e.g. Go to declaration) do not work after "new"

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/ModelVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/ModelVisitor.java
@@ -575,7 +575,9 @@ public final class ModelVisitor extends DefaultTreePathVisitor {
             }
         } else {
             Expression name = node.getClassName().getName();
-            if (name instanceof Variable) {
+            if (name instanceof Variable
+                    || name instanceof StaticFieldAccess // NETBEANS-3108 e.g. new self::staticProperty[self::getIndex()];
+                    || name instanceof FieldAccess) { // NETBEANS-3108 e.g. new $this->property[$this->getIndex()];
                 scan(name);
             } else {
                 ScopeImpl currentScope = modelBuilder.getCurrentScope();

--- a/php/php.editor/test/unit/data/testfiles/gotodeclaration/testNb3108/testNb3108.php
+++ b/php/php.editor/test/unit/data/testfiles/gotodeclaration/testNb3108/testNb3108.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class Class3108 {
+
+    private $property = [
+        Class3108::class,
+    ];
+    private static $staticProperty = [
+        Class3108::class,
+    ];
+
+    private static function getIndex() {
+        return 0;
+    }
+
+    public static function test() {
+        $instance1 = new self::$staticProperty[self::getIndex()];
+        $instance2 = new $this->property[$this->getIndex()];
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/testNb3108/testNb3108.php
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/testNb3108/testNb3108.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class Class3108 {
+
+    private $property = [
+        Class3108::class,
+    ];
+    private static $staticProperty = [
+        Class3108::class,
+    ];
+
+    private static function getIndex() {
+        return 0;
+    }
+
+    public static function test() {
+        $instance1 = new self::$staticProperty[self::getIndex()];
+        $instance2 = new $this->property[$this->getIndex()];
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_01a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_01a.occurrences
@@ -1,0 +1,2 @@
+    private $|>MARK_OCCURRENCES:pro^perty<| = [
+        $instance2 = new $this->|>MARK_OCCURRENCES:property<|[$this->getIndex()];

--- a/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_01b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_01b.occurrences
@@ -1,0 +1,2 @@
+    private $|>MARK_OCCURRENCES:property<| = [
+        $instance2 = new $this->|>MARK_OCCURRENCES:pr^operty<|[$this->getIndex()];

--- a/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_02a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_02a.occurrences
@@ -1,0 +1,2 @@
+    private static $^|>MARK_OCCURRENCES:staticProperty<| = [
+        $instance1 = new self::$|>MARK_OCCURRENCES:staticProperty<|[self::getIndex()];

--- a/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_02b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_02b.occurrences
@@ -1,0 +1,2 @@
+    private static $|>MARK_OCCURRENCES:staticProperty<| = [
+        $instance1 = new self::$|>MARK_OCCURRENCES:stati^cProperty<|[self::getIndex()];

--- a/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_03a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_03a.occurrences
@@ -1,0 +1,3 @@
+    private static function |>MARK_OCCURRENCES:ge^tIndex<|() {
+        $instance1 = new self::$staticProperty[self::|>MARK_OCCURRENCES:getIndex<|()];
+        $instance2 = new $this->property[$this->|>MARK_OCCURRENCES:getIndex<|()];

--- a/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_03b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_03b.occurrences
@@ -1,0 +1,3 @@
+    private static function |>MARK_OCCURRENCES:getIndex<|() {
+        $instance1 = new self::$staticProperty[self::|>MARK_OCCURRENCES:get^Index<|()];
+        $instance2 = new $this->property[$this->|>MARK_OCCURRENCES:getIndex<|()];

--- a/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_03c.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb3108.php.testNb3108_03c.occurrences
@@ -1,0 +1,2 @@
+    private static function |>MARK_OCCURRENCES:getIndex<|() {
+        $instance2 = new $this->property[$this->|>MARK_OCCURRENCES:getI^ndex<|()];

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationNb3108Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationNb3108Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.csl;
+
+
+public class GotoDeclarationNb3108Test extends GotoDeclarationTestBase {
+
+    public GotoDeclarationNb3108Test(String testName) {
+        super(testName);
+    }
+
+    public void testNb3108_01() throws Exception {
+        checkDeclaration(getTestPath(), "        $instance1 = new self::$static^Property[self::getIndex()];", "    private static $^staticProperty = [");
+    }
+
+    public void testNb3108_02() throws Exception {
+        checkDeclaration(getTestPath(), "        $instance2 = new $this->pr^operty[$this->getIndex()];", "    private $^property = [");
+    }
+
+    public void testNb3108_03a() throws Exception {
+        checkDeclaration(getTestPath(), "        $instance1 = new self::$staticProperty[self::getIn^dex()];", "    private static function ^getIndex() {");
+    }
+
+    public void testNb3108_03b() throws Exception {
+        checkDeclaration(getTestPath(), "        $instance2 = new $this->property[$this->g^etIndex()];", "    private static function ^getIndex() {");
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplNb3108Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplNb3108Test.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.csl;
+
+
+public class OccurrencesFinderImplNb3108Test extends OccurrencesFinderImplTestBase {
+
+    public OccurrencesFinderImplNb3108Test(String testName) {
+        super(testName);
+    }
+
+    public void testNb3108_01a() throws Exception {
+        checkOccurrences(getTestPath(), "    private $pro^perty = [", true);
+    }
+
+    public void testNb3108_01b() throws Exception {
+        checkOccurrences(getTestPath(), "        $instance2 = new $this->pr^operty[$this->getIndex()];", true);
+    }
+
+    public void testNb3108_02a() throws Exception {
+        checkOccurrences(getTestPath(), "    private static $^staticProperty = [", true);
+    }
+
+    public void testNb3108_02b() throws Exception {
+        checkOccurrences(getTestPath(), "        $instance1 = new self::$stati^cProperty[self::getIndex()];", true);
+    }
+
+    public void testNb3108_03a() throws Exception {
+        checkOccurrences(getTestPath(), "    private static function ge^tIndex() {", true);
+    }
+
+    public void testNb3108_03b() throws Exception {
+        checkOccurrences(getTestPath(), "        $instance1 = new self::$staticProperty[self::get^Index()];", true);
+    }
+
+    public void testNb3108_03c() throws Exception {
+        checkOccurrences(getTestPath(), "        $instance2 = new $this->property[$this->getI^ndex()];", true);
+    }
+
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-3108

- Just check `StaticFieldAccess` and `FieldAccess` in the `ModelVisitor`