### PR TITLE
Fix Ant errors caused by ParseGitBranch task (Travis issue, etc.)

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/ParseGitBranch.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ParseGitBranch.java
@@ -61,11 +61,11 @@ public class ParseGitBranch extends Task {
         } catch (IOException ex) {
             throw new BuildException("Problem reading information for detached head");
         }
-        if (secondLine != null) {
-            throw new BuildException("Problem parsing git information for detached head : too many line");
-        }
-        if (firstLine == null || firstLine.trim().isEmpty()) {
-            // PullRequest assume master ?
+        //if (secondLine != null) {
+        //    throw new BuildException("Problem parsing git information for detached head : too many line");
+        //}
+        if (secondLine != null || firstLine == null || firstLine.trim().isEmpty()) {
+            // Assume master if PR or detached HEAD on Travis, etc.
             getProject().setProperty(propertyName, "master");
         } else {
             String[] splited = firstLine.trim().split(" ");


### PR DESCRIPTION
Update ParseGitBranch to assume master if more than one line of info returned from git branch. This happens in case of Travis CI tests, and is currently breaking them.  Commented out old code for now - should review again later.