### PR TITLE
[NETBEANS-2940] Invalidate cacheed ArchiveRootProviders on change

### DIFF
--- a/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/FileUtil.java
@@ -2326,7 +2326,7 @@ public final class FileUtil extends Object {
                 res = new ProxyLookup(
                     Lookups.singleton(new JarArchiveRootProvider()),
                     Lookup.getDefault()).lookupResult(ArchiveRootProvider.class);
-                if (!archiveRootProviders.compareAndSet(null, res)) {
+                if (archiveRootProviders.compareAndSet(null, res)) {
                     res = archiveRootProviders.get();
                     res.addLookupListener((ev) -> {
                         archiveRootProviderCache = null;
@@ -2338,6 +2338,6 @@ public final class FileUtil extends Object {
         return archiveRootProviderCache;
     }
 
-    private static Iterable<? extends ArchiveRootProvider> archiveRootProviderCache;
+    private static volatile Iterable<? extends ArchiveRootProvider> archiveRootProviderCache;
     private static final AtomicReference<Lookup.Result<ArchiveRootProvider>> archiveRootProviders = new AtomicReference<>();
 }


### PR DESCRIPTION
This is a followup to commit:

290420cfff1a "[NETBEANS-2940] Cache ArchiveRootProviders"

The issue is:

archiveRootProviders.compareAndSet(null, res)

returns true, when the set was successful. In this case, the 
LookupListener needs to registered, that invalidates the cache list of
ArchiveRootProviders. In the original commit, this logic was inverted,
so the LookupListener was not installed and the cache never invalidated.

In addition the archiveRootProviderCache was made volatile to prevent
wrong caching across threads.