### PR TITLE
Cleanup redundant casts

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/IpComboBox.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/IpComboBox.java
@@ -307,8 +307,7 @@ public class IpComboBox extends JComboBox<IpComboBox.InetAddr> {
         for (i = 0; i < count; i++) {
             InetAddr element = dataModel.getElementAt(i);
             // Passed IP address has highest priority.
-            if (((InetAddress) ip).equals(
-                    element.getIp())) {
+            if (ip.equals(element.getIp())) {
                 super.setSelectedItem(element);
                 isSelectedSet = true;
                 break;

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/JavaSEPlatformPanel.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ui/JavaSEPlatformPanel.java
@@ -134,7 +134,7 @@ public class JavaSEPlatformPanel extends JPanel {
             Iterator<FileObject> platformIterator
                     = selectedPlatform.getInstallFolders().iterator();
             if (platformIterator.hasNext()) {
-                selectedJavaHome = (FileObject)platformIterator.next();
+                selectedJavaHome = platformIterator.next();
             }
         }
         if (selectedJavaHome != null && panel.updateProperties()) {

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/ResourceRegistrationHelper.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/ResourceRegistrationHelper.java
@@ -175,7 +175,7 @@ public class ResourceRegistrationHelper {
             if (key.indexOf("property.") != -1) { // NOI18N
                 props.add(key);
             }
-            String localValue = (String) localData.get(key);
+            String localValue = localData.get(key);
             if (localValue != null) {
                 if (remoteValue == null || !localValue.equals(remoteValue)) {
                     changedData.put(remoteDataKey, localValue);

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDVisualPanel.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDVisualPanel.java
@@ -54,7 +54,7 @@ public final class WebLogicDDVisualPanel extends JPanel {
         // figure out which ones exist already
         // 
         Lookup lookup = project.getLookup();
-        J2eeModuleProvider provider = (J2eeModuleProvider) lookup.lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider provider = lookup.lookup(J2eeModuleProvider.class);
         J2eeModule j2eeModule = provider.getJ2eeModule();
         sunDDFileName = getConfigFileName(j2eeModule,
                 org.netbeans.modules.glassfish.eecommon.api.Utils.getInstanceReleaseID(provider));

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/verifier/VerifierImpl.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/verifier/VerifierImpl.java
@@ -102,7 +102,7 @@ public  class VerifierImpl extends org.netbeans.modules.j2ee.deployment.plugins.
         J2eeModuleProvider modProvider = null;
         Project holdingProj = FileOwnerQuery.getOwner(target);
         if (holdingProj != null){
-            modProvider = (J2eeModuleProvider) holdingProj.getLookup().lookup(J2eeModuleProvider.class);
+            modProvider = holdingProj.getLookup().lookup(J2eeModuleProvider.class);
         }
         return modProvider;
     }

--- a/enterprise/j2ee.ejbrefactoring/src/org/netbeans/modules/j2ee/ejbrefactoring/EjbRefactoringPlugin.java
+++ b/enterprise/j2ee.ejbrefactoring/src/org/netbeans/modules/j2ee/ejbrefactoring/EjbRefactoringPlugin.java
@@ -233,8 +233,7 @@ public class EjbRefactoringPlugin implements RefactoringPlugin {
                     J2eeModuleProvider[] j2eeModules = j2eeApp.getChildModuleProviders();
 
                     if (j2eeModules != null) {
-                        J2eeModuleProvider affectedPrjProvider =
-                                (J2eeModuleProvider) affectedProject.getLookup().lookup(J2eeModuleProvider.class);
+                        J2eeModuleProvider affectedPrjProvider = affectedProject.getLookup().lookup(J2eeModuleProvider.class);
 
                         if (affectedPrjProvider != null) {
                             if (Arrays.asList(j2eeModules).contains(affectedPrjProvider)) {

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/logicalview/AbstractLogicalViewProvider.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/logicalview/AbstractLogicalViewProvider.java
@@ -175,11 +175,10 @@ public abstract class AbstractLogicalViewProvider implements LogicalViewProvider
             }
         };
         evaluator.addPropertyChangeListener(pcl);
-        j2eeModuleProvider.addInstanceListener((InstanceListener)WeakListeners.create(
-                    InstanceListener.class, il, j2eeModuleProvider));
+        j2eeModuleProvider.addInstanceListener(WeakListeners.create(InstanceListener.class, il, j2eeModuleProvider));
 //        j2eeModuleProvider.addConfigurationFilesListener((ConfigurationFilesListener)WeakListeners.create(
 //                    ConfigurationFilesListener.class, cfl, j2eeModuleProvider));
-        ConnectionManager.getDefault().addConnectionListener((ConnectionListener)WeakListeners.create(
+        ConnectionManager.getDefault().addConnectionListener(WeakListeners.create(
                 ConnectionListener.class, cl, ConnectionManager.getDefault()));
     }
 

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/logicalview/J2eePlatformNode.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/logicalview/J2eePlatformNode.java
@@ -100,9 +100,8 @@ class J2eePlatformNode extends AbstractNode implements PropertyChangeListener, I
         this.platformPropName = platformPropName;
         evaluator.addPropertyChangeListener(WeakListeners.propertyChange(this, evaluator));
         
-        J2eeModuleProvider moduleProvider = (J2eeModuleProvider)project.getLookup().lookup(J2eeModuleProvider.class);
-        moduleProvider.addInstanceListener(
-                (InstanceListener)WeakListeners.create(InstanceListener.class, this, moduleProvider));
+        J2eeModuleProvider moduleProvider = project.getLookup().lookup(J2eeModuleProvider.class);
+        moduleProvider.addInstanceListener(WeakListeners.create(InstanceListener.class, this, moduleProvider));
     }
     
     public static J2eePlatformNode create(Project project, PropertyEvaluator evaluator, String platformPropName, ClassPathSupport cs) {

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/logicalview/J2eePlatformTestNode.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/logicalview/J2eePlatformTestNode.java
@@ -95,9 +95,8 @@ class J2eePlatformTestNode extends AbstractNode implements PropertyChangeListene
         this.platformPropName = platformPropName;
         evaluator.addPropertyChangeListener(WeakListeners.propertyChange(this, evaluator));
         
-        J2eeModuleProvider moduleProvider = (J2eeModuleProvider)project.getLookup().lookup(J2eeModuleProvider.class);
-        moduleProvider.addInstanceListener(
-                (InstanceListener)WeakListeners.create(InstanceListener.class, this, moduleProvider));
+        J2eeModuleProvider moduleProvider = project.getLookup().lookup(J2eeModuleProvider.class);
+        moduleProvider.addInstanceListener(WeakListeners.create(InstanceListener.class, this, moduleProvider));
     }
     
     public static J2eePlatformTestNode create(Project project, PropertyEvaluator evaluator, String platformPropName, ClassPathSupport cs) {

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectImportLocationPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectImportLocationPanel.java
@@ -423,7 +423,7 @@ final class ProjectImportLocationPanel extends JPanel implements HelpCtx.Provide
         chooser.setMultiSelectionEnabled(false);
         chooser.setAcceptAllFileFilterUsed(false);
         chooser.setDialogTitle(NbBundle.getMessage(ProjectImportLocationPanel.class, "LBL_IW_BrowseProjectFolder"));
-        File lastUsed = (File) UserProjectSettings.getDefault().getLastChooserLocation();
+        File lastUsed = UserProjectSettings.getDefault().getLastChooserLocation();
         if (lastUsed != null) {
             chooser.setCurrentDirectory(lastUsed.getParentFile());
         } else {
@@ -456,7 +456,7 @@ final class ProjectImportLocationPanel extends JPanel implements HelpCtx.Provide
             if (currentDirectory != null) {
                 chooser.setCurrentDirectory(currentDirectory);
             } else {
-                File lastUsedImportLoc = (File) UserProjectSettings.getDefault().getLastUsedImportLocation();
+                File lastUsedImportLoc = UserProjectSettings.getDefault().getLastUsedImportLocation();
                 if (lastUsedImportLoc != null)
                     chooser.setCurrentDirectory(lastUsedImportLoc.getParentFile());
                 else                    

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectImportLocationWizardPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectImportLocationWizardPanel.java
@@ -105,7 +105,7 @@ public final class ProjectImportLocationWizardPanel implements WizardDescriptor.
     public void storeSettings (Object settings) {
         WizardDescriptor d = (WizardDescriptor) settings;
         panel.store(d);
-        ((WizardDescriptor) d).putProperty ("NewProjectWizard_Title", null); //NOI18N
+        d.putProperty("NewProjectWizard_Title", null); //NOI18N
     }
 
     public String getBuildFile() {

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectLocationWizardPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectLocationWizardPanel.java
@@ -97,6 +97,6 @@ public final class ProjectLocationWizardPanel implements WizardDescriptor.Panel,
     public void storeSettings(Object settings) {
         WizardDescriptor d = (WizardDescriptor) settings;
         component.store(d);
-        ((WizardDescriptor) d).putProperty("NewProjectWizard_Title", null); // NOI18N
+        d.putProperty("NewProjectWizard_Title", null); // NOI18N
     }
 }

--- a/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/findusages/FindUsagesPainter.java
+++ b/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/findusages/FindUsagesPainter.java
@@ -136,7 +136,7 @@ public class FindUsagesPainter {
         FontColorSettings settings = lookup.lookup(FontColorSettings.class);
         TokenSequence tok = tokenH.tokenSequence();
         while (tok.moveNext()) {
-            Token<GroovyTokenId> token = (Token) tok.token();
+            Token<GroovyTokenId> token = tok.token();
             String category = token.id().primaryCategory();
             if (category == null) {
                 category = "whitespace"; //NOI18N

--- a/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/findusages/impl/FindVariableUsages.java
+++ b/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/findusages/impl/FindVariableUsages.java
@@ -113,7 +113,7 @@ public class FindVariableUsages extends AbstractFindUsages {
 
         @Override
         public void visitVariableExpression(VariableExpression expression) {
-            final VariableExpression variableExpression = ((VariableExpression) expression);
+            final VariableExpression variableExpression = expression;
             final Variable variable = variableExpression.getAccessedVariable();
 
             if (variable != null) {

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/MainWindowOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/MainWindowOperator.java
@@ -454,14 +454,14 @@ public class MainWindowOperator extends JFrameOperator {
             synchronized (this) {
                 if(removeCompared) {
                     while(!statusTextHistory.isEmpty()) {
-                        String status = (String)statusTextHistory.remove(0);
+                        String status = statusTextHistory.remove(0);
                         if(comparator.equals(status, text)) {
                             return true;
                         }
                     }
                 } else {
                     for (int i = 0; i < statusTextHistory.size(); i ++) {
-                        if(comparator.equals((String)statusTextHistory.get(i), text)) {
+                        if(comparator.equals(statusTextHistory.get(i), text)) {
                             return true;
                         }
                     }

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/TopComponentOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/TopComponentOperator.java
@@ -548,7 +548,7 @@ public class TopComponentOperator extends JComponentOperator {
     public void pushMenuOnTab(String popupPath) {
         if (isOpened()) {
             this.makeComponentVisible();
-            TabbedContainer ta = (TabbedContainer) findTabbedAdapter();
+            TabbedContainer ta = findTabbedAdapter();
 
             int index = ta.indexOf((TopComponent) getSource());
 

--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryController.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryController.java
@@ -706,7 +706,7 @@ public class QueryController implements org.netbeans.modules.bugtracking.spi.Que
             public void run() {
                 handle.start();
                 try {
-                    openIssue((BugzillaIssue)repository.getIssue(id));
+                    openIssue(repository.getIssue(id));
                 } finally {
                     handle.finish();
                 }
@@ -828,7 +828,7 @@ public class QueryController implements org.netbeans.modules.bugtracking.spi.Que
             public void run() {
                 Collection<BugzillaIssue> issues = query.getIssues();
                 for (BugzillaIssue issue : issues) {
-                    ((BugzillaIssue) issue).setUpToDate(true);
+                    issue.setUpToDate(true);
                 }
             }
         });

--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/repository/BugzillaRepository.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/repository/BugzillaRepository.java
@@ -642,7 +642,7 @@ public class BugzillaRepository {
                 Collection<BugzillaQuery> qs = getQueries();
                 for (BugzillaQuery q : qs) {
                     Bugzilla.LOG.log(Level.FINER, "preparing to refresh query {0} - {1}", new Object[] {q.getDisplayName(), getDisplayName()}); // NOI18N
-                    QueryController qc = ((BugzillaQuery) q).getController();
+                    QueryController qc = q.getController();
                     qc.onRefresh();
                 }
             }

--- a/ide/db.dataview/src/org/netbeans/modules/db/dataview/util/EncodingHelper.java
+++ b/ide/db.dataview/src/org/netbeans/modules/db/dataview/util/EncodingHelper.java
@@ -48,7 +48,7 @@ public class EncodingHelper extends Object {
      * @return
      */
     public static String getIANA2JavaMapping(String ianaEncoding) {
-        String java = (String) encodingIANA2JavaMap.get (ianaEncoding.toUpperCase ());
+        String java = encodingIANA2JavaMap.get (ianaEncoding.toUpperCase ());
         return java == null ? ianaEncoding : java;
     }
     
@@ -59,7 +59,7 @@ public class EncodingHelper extends Object {
      * @return
      */
     public static String getJava2IANAMapping(String javaEncoding) {
-        String iana = (String) encodingJava2IANAMap.get (javaEncoding);
+        String iana = encodingJava2IANAMap.get (javaEncoding);
         return iana == null ? javaEncoding : iana;
     }
         

--- a/ide/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/MasterMatcher.java
+++ b/ide/editor.bracesmatching/src/org/netbeans/modules/editor/bracesmatching/MasterMatcher.java
@@ -337,7 +337,7 @@ public final class MasterMatcher {
             if (matchListeners.isEmpty()) {
                 return;
             }
-            ll = (MatchListener[]) matchListeners.toArray(new MatchListener[matchListeners.size()]);
+            ll = matchListeners.toArray(new MatchListener[matchListeners.size()]);
         }
         if (ll.length == 0) {
             return;
@@ -356,7 +356,7 @@ public final class MasterMatcher {
             if (matchListeners.isEmpty()) {
                 return;
             }
-            ll = (MatchListener[]) matchListeners.toArray(new MatchListener[matchListeners.size()]);
+            ll = matchListeners.toArray(new MatchListener[matchListeners.size()]);
         }
         MatchEvent evt = new MatchEvent(component, null, this);
         for (int i = 0; i < ll.length; i++) {

--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateParameterImpl.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateParameterImpl.java
@@ -339,7 +339,7 @@ public final class CodeTemplateParameterImpl {
         }
         
         // Determine default parameter's value
-        String defaultValue = (String)getHints().get(CodeTemplateParameter.DEFAULT_VALUE_HINT_NAME);
+        String defaultValue = getHints().get(CodeTemplateParameter.DEFAULT_VALUE_HINT_NAME);
         if (defaultValue == null) { // implicit value will be name of the parameter
             defaultValue = name;
         }
@@ -369,7 +369,7 @@ public final class CodeTemplateParameterImpl {
     }
     
     private boolean isHintValueFalse(String hintName) {
-        String hintValue = (String)getHints().get(hintName);
+        String hintValue = getHints().get(hintName);
         return (hintValue != null) && "false".equals(hintValue.toLowerCase()); // NOI18N
     }
     

--- a/ide/image/src/org/netbeans/modules/image/ImagePrintSupport.java
+++ b/ide/image/src/org/netbeans/modules/image/ImagePrintSupport.java
@@ -65,7 +65,7 @@ public class ImagePrintSupport implements PrintCookie, Printable, ImageObserver 
             AffineTransform af = new AffineTransform();
             if( pf.getOrientation() == pf.LANDSCAPE ){
             }else{
-                af.translate( (double)pf.getImageableX(), (double)pf.getImageableY() );
+                af.translate(pf.getImageableX(), pf.getImageableY());
             }
             
             /** notify if too big for page **/

--- a/ide/image/src/org/netbeans/modules/image/ImageViewer.java
+++ b/ide/image/src/org/netbeans/modules/image/ImageViewer.java
@@ -601,7 +601,7 @@ public class ImageViewer extends CloneableTopComponent {
     }
 
     protected boolean closeLast() {
-        ((ImageOpenSupport)storedObject.getCookie(ImageOpenSupport.class)).lastClosed();
+        (storedObject.getCookie(ImageOpenSupport.class)).lastClosed();
         return true;
     }
 
@@ -625,7 +625,7 @@ public class ImageViewer extends CloneableTopComponent {
         super.readExternal(in);
         storedObject = (ImageDataObject)in.readObject();
         // to reset the listener for FileObject changes
-        ((ImageOpenSupport)storedObject.getCookie(ImageOpenSupport.class)).prepareViewer();
+        (storedObject.getCookie(ImageOpenSupport.class)).prepareViewer();
         initialize(storedObject);
     }
     
@@ -639,7 +639,7 @@ public class ImageViewer extends CloneableTopComponent {
         SystemAction[] oldValue = super.getSystemActions();
         SystemAction fsa = null;
         try {
-            ClassLoader l = (ClassLoader) Lookup.getDefault().lookup(ClassLoader.class);
+            ClassLoader l = Lookup.getDefault().lookup(ClassLoader.class);
             if (l == null) {
                 l = getClass().getClassLoader();
             }
@@ -772,7 +772,7 @@ public class ImageViewer extends CloneableTopComponent {
         button.getAccessibleContext().setAccessibleDescription(NbBundle.getBundle(ImageViewer.class).getString("ACS_Zoom_BTN"));
         button.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent evt) {
-                CustomZoomAction sa = (CustomZoomAction) SystemAction.get(CustomZoomAction.class);
+                CustomZoomAction sa = SystemAction.get(CustomZoomAction.class);
                 sa.performAction ();
             }
         });

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogAction.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogAction.java
@@ -108,7 +108,7 @@ public class CatalogAction implements ActionListener {
             Iterator/*<Node>*/ it = nodes2open.iterator ();
             while (it.hasNext ()) {
                 Node n = (Node) it.next ();
-                ViewCookie vc = (ViewCookie) n.getLookup ().lookup (ViewCookie.class);
+                ViewCookie vc = n.getLookup().lookup(ViewCookie.class);
                 if (vc != null) {
                     vc.view();
                 } else {
@@ -127,7 +127,7 @@ public class CatalogAction implements ActionListener {
                     Node n = nodes [i];
 //                    EditCookie ec = (EditCookie) n.getLookup ().lookup (EditCookie.class);
 //                    OpenCookie oc = (OpenCookie) n.getLookup ().lookup (OpenCookie.class);
-                    ViewCookie vc = (ViewCookie) n.getLookup ().lookup (ViewCookie.class);
+                    ViewCookie vc = n.getLookup().lookup(ViewCookie.class);
                     res = vc != null; //ec != null || oc != null;
                     
                     i++;

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogRootNode.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogRootNode.java
@@ -297,7 +297,7 @@ public final class CatalogRootNode extends AbstractNode implements Node.Cookie {
         if (activatedNodes.length == 0) return;
         try {
             Node current = activatedNodes[0];
-            CatalogRootNode me = (CatalogRootNode) current.getCookie(CatalogRootNode.class);
+            CatalogRootNode me = current.getCookie(CatalogRootNode.class);
             CatalogMounter newType = me.new CatalogMounter();
             newType.create();
         } catch (IOException ex) {

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/RefreshAction.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/RefreshAction.java
@@ -40,7 +40,7 @@ final class RefreshAction extends CookieAction {
             for (int i = 0; i<nodes.length; i++) {
                 String msg = NbBundle.getMessage(RefreshAction.class, "MSG_refreshing", nodes[i].getDisplayName());
                 StatusDisplayer.getDefault().setStatusText(msg);
-                Refreshable cake = (Refreshable) nodes[i].getCookie(Refreshable.class);
+                Refreshable cake = nodes[i].getCookie(Refreshable.class);
                 cake.refresh();
             }
         } finally {

--- a/ide/xml.core/src/org/netbeans/modules/xml/api/EncodingUtil.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/api/EncodingUtil.java
@@ -119,7 +119,7 @@ public class EncodingUtil {
      * @return
      */
     public static String getIANA2JavaMapping(String ianaEncoding) {
-        String java = (String) encodingIANA2JavaMap.get (ianaEncoding.toUpperCase ());
+        String java = encodingIANA2JavaMap.get (ianaEncoding.toUpperCase ());
         return java == null ? ianaEncoding : java;
 }
     
@@ -130,7 +130,7 @@ public class EncodingUtil {
      * @return
      */
     public static String getJava2IANAMapping(String javaEncoding) {
-        String iana = (String) encodingJava2IANAMap.get (javaEncoding);
+        String iana = encodingJava2IANAMap.get (javaEncoding);
         return iana == null ? javaEncoding : iana;
     }
         

--- a/ide/xml.core/src/org/netbeans/modules/xml/core/lib/EncodingHelper.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/core/lib/EncodingHelper.java
@@ -46,7 +46,7 @@ public class EncodingHelper extends Object {
      * @return
      */
     public static String getIANA2JavaMapping(String ianaEncoding) {
-        String java = (String) encodingIANA2JavaMap.get (ianaEncoding.toUpperCase ());
+        String java = encodingIANA2JavaMap.get (ianaEncoding.toUpperCase ());
         return java == null ? ianaEncoding : java;
     }
     
@@ -57,7 +57,7 @@ public class EncodingHelper extends Object {
      * @return
      */
     public static String getJava2IANAMapping(String javaEncoding) {
-        String iana = (String) encodingJava2IANAMap.get (javaEncoding);
+        String iana = encodingJava2IANAMap.get (javaEncoding);
         return iana == null ? javaEncoding : iana;
     }
         

--- a/java/beans/src/org/netbeans/modules/beans/beaninfo/BiExcludeAllAction.java
+++ b/java/beans/src/org/netbeans/modules/beans/beaninfo/BiExcludeAllAction.java
@@ -68,7 +68,7 @@ public class BiExcludeAllAction extends NodeAction  {
             return false;
 
         for(int i = 0; i < activatedNodes.length; i++ ) {
-            BiNode.SubNode bis = ((BiNode.SubNode)activatedNodes[i].getCookie( BiNode.SubNode.class ));
+            BiNode.SubNode bis = activatedNodes[i].getCookie( BiNode.SubNode.class );
             if ( bis == null )
                 return false;
             Node[] nodes = bis.getChildren().getNodes();
@@ -102,7 +102,7 @@ public class BiExcludeAllAction extends NodeAction  {
 
         for(int i = 0; i < nodes.length; i++ ) {
             if( nodes[i].getCookie( BiNode.SubNode.class ) != null )
-                ((BiNode.SubNode)nodes[i].getCookie( BiNode.SubNode.class )).includeAll( false );
+                nodes[i].getCookie( BiNode.SubNode.class ).includeAll( false );
         }
 
     }

--- a/java/beans/src/org/netbeans/modules/beans/beaninfo/BiFeature.java
+++ b/java/beans/src/org/netbeans/modules/beans/beaninfo/BiFeature.java
@@ -940,7 +940,7 @@ public abstract class BiFeature implements IconBases, Node.Cookie, Comparable<Bi
                 int index;
                 
                 while( it.hasNext() ) {
-                    String statement = (String) it.next();
+                    String statement = it.next();
                     if ((index = statement.indexOf(creation)) > -1) {
                         this.varName = statement.substring(statement.indexOf("methods[METHOD_") + 15, index - 2); // NOI18N
                         break;

--- a/java/beans/src/org/netbeans/modules/beans/beaninfo/BiIncludeAllAction.java
+++ b/java/beans/src/org/netbeans/modules/beans/beaninfo/BiIncludeAllAction.java
@@ -68,7 +68,7 @@ public class BiIncludeAllAction extends NodeAction  {
             return false;
 
         for(int i = 0; i < activatedNodes.length; i++ ) {
-            BiNode.SubNode bis = ((BiNode.SubNode)activatedNodes[i].getCookie( BiNode.SubNode.class ));
+            BiNode.SubNode bis = activatedNodes[i].getCookie( BiNode.SubNode.class );
             if ( bis == null )
                 return false;
             Node[] nodes = bis.getChildren().getNodes();
@@ -102,7 +102,7 @@ public class BiIncludeAllAction extends NodeAction  {
 
         for(int i = 0; i < nodes.length; i++ ) {
             if( nodes[i].getCookie( BiNode.SubNode.class ) != null )
-                ((BiNode.SubNode)nodes[i].getCookie( BiNode.SubNode.class )).includeAll( true );
+                nodes[i].getCookie( BiNode.SubNode.class ).includeAll( true );
         }
 
     }

--- a/java/dbschema/src/org/netbeans/modules/dbschema/DBElement.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/DBElement.java
@@ -48,7 +48,7 @@ public abstract class DBElement implements Comparable, DBElementProperties {
      * @return implementation for the element
      */
     public final Impl getElementImpl() {
-        return (DBElement.Impl) impl;
+        return impl;
     }
 
    /** Sets the implementation factory of this database element.

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -247,7 +247,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
 
                         String tableTmp;
                         if (bridge != null)
-                            tableTmp = (String) bridge.getDriverSpecification().getRow().get(new Integer(3));
+                            tableTmp = bridge.getDriverSpecification().getRow().get(new Integer(3));
                         else
                             tableTmp = rs.getString("TABLE_NAME").trim(); //NOI18N
                         
@@ -276,7 +276,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                         }
 
                         if (bridge != null)
-                            viewsTmp.add((String) bridge.getDriverSpecification().getRow().get(new Integer(3)));
+                            viewsTmp.add(bridge.getDriverSpecification().getRow().get(new Integer(3)));
                         else
                             viewsTmp.add(rs.getString("TABLE_NAME").trim()); //NOI18N
                     }
@@ -545,7 +545,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
 
                             IndexElement[] indexes = new IndexElement[keys.length];
                             for (int k = 0; k < keys.length; k++)
-                                indexes[k] = ((UniqueKeyElement) keys[k]).getAssociatedIndex();
+                                indexes[k] = keys[k].getAssociatedIndex();
                             te.setIndexes(indexes);
                         }
 

--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -3036,7 +3036,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
                         final DeclaredType type = (DeclaredType) st;
                         final TypeElement element = (TypeElement) type.asElement();
                         if (element.getKind() == ANNOTATION_TYPE && (Utilities.isShowDeprecatedMembers() || !elements.isDeprecated(element))) {
-                            results.add(itemFactory.createAnnotationItem(env.getController(), element, (DeclaredType) type, anchorOffset, env.getReferencesCount(), elements.isDeprecated(element)));
+                            results.add(itemFactory.createAnnotationItem(env.getController(), element, type, anchorOffset, env.getReferencesCount(), elements.isDeprecated(element)));
                         }
                         if (JAVA_LANG_CLASS.contentEquals(element.getQualifiedName())) {
                             addTypeDotClassMembers(env, type);
@@ -3914,7 +3914,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
             }
         };
         for (TypeElement e : controller.getElementUtilities().getGlobalTypes(acceptor)) {
-            results.add(itemFactory.createTypeItem(env.getController(), (TypeElement) e, (DeclaredType) e.asType(), anchorOffset, null, elements.isDeprecated(e), env.isInsideNew(), env.isInsideNew() || env.isInsideClass(), false, false, false));
+            results.add(itemFactory.createTypeItem(env.getController(), e, (DeclaredType) e.asType(), anchorOffset, null, elements.isDeprecated(e), env.isInsideNew(), env.isInsideNew() || env.isInsideClass(), false, false, false));
         }
     }
 

--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
@@ -1060,7 +1060,7 @@ public class ElementJavadoc {
         final Elements elements = info.getElements();
         for (TypeMirror iface : type.getInterfaces()) {
             for (ExecutableElement method : ElementFilter.methodsIn(((DeclaredType)iface).asElement().getEnclosedElements())) {
-                if (elements.overrides((ExecutableElement)element, method, (TypeElement)element.getEnclosingElement())) {
+                if (elements.overrides(element, method, (TypeElement)element.getEnclosingElement())) {
                     T ret = funct.apply(method);
                     if (ret != null) {
                         return ret;
@@ -1077,7 +1077,7 @@ public class ElementJavadoc {
         TypeMirror superclass = type.getSuperclass();
         if (superclass.getKind() == TypeKind.DECLARED) {
             for (ExecutableElement method : ElementFilter.methodsIn(((DeclaredType)superclass).asElement().getEnclosedElements())) {
-                if (elements.overrides((ExecutableElement)element, method, (TypeElement)element.getEnclosingElement())) {
+                if (elements.overrides(element, method, (TypeElement)element.getEnclosingElement())) {
                     T ret = funct.apply(method);
                     if (ret != null) {
                         return ret;

--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBAttr.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBAttr.java
@@ -109,8 +109,8 @@ public class NBAttr extends Attr {
             fullyAttribute = true;
 
             Env<AttrContext> result = tree instanceof JCExpression ?
-                    attribExprToTree((JCExpression) tree, env, (JCTree) to) :
-                    attribStatToTree((JCTree) tree, env, (JCTree) to);
+                    attribExprToTree((JCExpression) tree, env, to) :
+                    attribStatToTree(tree, env, to);
 
             return fullyAttributeResult != null ? fullyAttributeResult : result;
         } finally {

--- a/java/spring.beans/src/org/netbeans/modules/spring/beans/completion/CompletionContext.java
+++ b/java/spring.beans/src/org/netbeans/modules/spring/beans/completion/CompletionContext.java
@@ -82,7 +82,7 @@ public class CompletionContext {
 
         Object sdp = bDoc.getProperty(Document.StreamDescriptionProperty);
         internalDoc.putProperty(Document.StreamDescriptionProperty, sdp);
-        this.support = (XMLSyntaxSupport)XMLSyntaxSupport.getSyntaxSupport(internalDoc);
+        this.support = XMLSyntaxSupport.getSyntaxSupport(internalDoc);
         this.documentContext = DocumentContext.create(internalDoc, caretOffset);
 
         // get last inserted character from the actual document
@@ -346,7 +346,7 @@ public class CompletionContext {
     public List<String> getExistingAttributes() {
         if (existingAttributes == null) {
             try {
-                existingAttributes = (List<String>)support.runWithSequence(
+                existingAttributes = support.runWithSequence(
                         documentContext.getCurrentTokenOffset(),
                         this::getExistingAttributesLocked
                 );

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/RestClientPojoCodeGenerator.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/RestClientPojoCodeGenerator.java
@@ -139,8 +139,8 @@ public class RestClientPojoCodeGenerator extends SaasClientCodeGenerator {
 
         if(getBean().getMethod().getSaas().getLibraryJars() == null) {
             WadlSaasEx ex = new WadlSaasEx(getBean().getMethod().getSaas());
-            ((WadlSaas)getBean().getMethod().getSaas()).setLibraryJars(ex.getLibraryJars());
-            ((WadlSaas)getBean().getMethod().getSaas()).setJaxbSourceJars(ex.getJaxbSourceJars());
+            getBean().getMethod().getSaas().setLibraryJars(ex.getLibraryJars());
+            getBean().getMethod().getSaas().setJaxbSourceJars(ex.getJaxbSourceJars());
         }
         if (getBean().getMethod().getSaas().getLibraryJars().size() > 0) {
             JavaUtil.addClientJars(getBean(), getProject(), null);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ParseGitBranch.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ParseGitBranch.java
@@ -61,11 +61,11 @@ public class ParseGitBranch extends Task {
         } catch (IOException ex) {
             throw new BuildException("Problem reading information for detached head");
         }
-        //if (secondLine != null) {
-        //    throw new BuildException("Problem parsing git information for detached head : too many line");
-        //}
-        if (secondLine != null || firstLine == null || firstLine.trim().isEmpty()) {
-            // Assume master if PR or detached HEAD on Travis, etc.
+        if (secondLine != null) {
+            throw new BuildException("Problem parsing git information for detached head : too many line");
+        }
+        if (firstLine == null || firstLine.trim().isEmpty()) {
+            // PullRequest assume master ?
             getProject().setProperty(propertyName, "master");
         } else {
             String[] splited = firstLine.trim().split(" ");

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ReleaseJsonProperties.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ReleaseJsonProperties.java
@@ -20,7 +20,6 @@ package org.netbeans.nbbuild;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -147,7 +146,7 @@ public class ReleaseJsonProperties extends Task {
         log("Writing releasinfo file " + propertiesFile);
         propertiesFile.getParentFile().mkdirs();
         try (OutputStream config = new FileOutputStream(propertiesFile)) {
-            String optionalversion = "";
+            String optionnalversion = "";
             boolean found = false;
             for (MileStone m : requiredbranchinfo.milestones) {
                 if (m.hash.equals(hash)) {
@@ -157,48 +156,40 @@ public class ReleaseJsonProperties extends Task {
                     if (m.vote != -1) {
                         // vote is set we want the full version
                     } else {
-                        optionalversion = "-" + m.version;
+                        optionnalversion = "-" + m.version;
                     }
 
                 }
             }
             if (!found && !branch.equals("master")) {
                 // hash no match we are building a dev version of specific branch
-                optionalversion = "-dev";
+                optionnalversion = "-dev";
             }
-            config.write(("metabuild.DistributionURL=" + requiredbranchinfo.updateurl + "\n").getBytes());
-            config.write(("metabuild.PluginPortalURL=" + requiredbranchinfo.pluginsurl + "\n").getBytes());
+            config.write(("metabuild.DistributionURL=" + requiredbranchinfo.updateurl.replace(requiredbranchinfo.version, requiredbranchinfo.version + optionnalversion) + "\n").getBytes());
+            config.write(("metabuild.PluginPortalURL=" + requiredbranchinfo.pluginsurl.replace(requiredbranchinfo.version, requiredbranchinfo.version + optionnalversion) + "\n").getBytes());
             // used for cache and user dir
-            config.write(("metabuild.RawVersion=" + requiredbranchinfo.version + optionalversion + "\n").getBytes());
+            config.write(("metabuild.RawVersion=" + requiredbranchinfo.version + optionnalversion + "\n").getBytes());
 
             if (branch.equals("master")) {
                 config.write(("metabuild.ComputedSplashVersion=DEV (Build {0})\n").getBytes());
                 config.write(("metabuild.ComputedTitleVersion=DEV {0}\n").getBytes());
                 config.write(("metabuild.logcli=-J-Dnetbeans.logger.console=true -J-ea\n").getBytes());
             } else {
-                config.write(("metabuild.ComputedSplashVersion=" + requiredbranchinfo.version + optionalversion + "\n").getBytes());
-                config.write(("metabuild.ComputedTitleVersion=" + requiredbranchinfo.version + optionalversion + "\n").getBytes());
+                config.write(("metabuild.ComputedSplashVersion=" + requiredbranchinfo.version + optionnalversion + "\n").getBytes());
+                config.write(("metabuild.ComputedTitleVersion=" + requiredbranchinfo.version + optionnalversion + "\n").getBytes());
                 config.write(("metabuild.logcli=\n").getBytes());
             }
         } catch (IOException ex) {
             throw new BuildException("Properties File for release cannot be created");
         }
 
-        log("Writing releasinfo file " + xmlFile );
+        log("Writing releasinfo file " + xmlFile);
 
         xmlFile.getParentFile().mkdirs();
         try (OutputStream config = new FileOutputStream(xmlFile)) {
             XMLUtil.write(doc, config);
         } catch (IOException ex) {
             throw new BuildException("XML File for release cannot be created");
-        }
-        String configline;
-        try (FileReader config = new FileReader(propertiesFile); BufferedReader configStream = new BufferedReader(config);) {
-            while ((configline = configStream.readLine()) != null) {
-                log("Branding computed info: " + configline);
-            }
-        } catch (IOException ex) {
-            throw new BuildException("propertiesFile for release cannot be read");
         }
     }
 

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -77,6 +77,7 @@
             <include name="nbbuild/external/binaries-list"/>
             <include name="platform/libs.junit4/external/binaries-list"/>
             <include name="platform/javahelp/external/binaries-list"/>
+            <include name="ide/libs.json_simple/external/binaries-list"/>
         </manifest>
     </downloadbinaries>
     <!--
@@ -94,7 +95,7 @@
         <!-- For JavaHelp indexing and link checking: -->
         <include name="platform/javahelp/external/jhall*.jar"/>
         <!-- For json parsing -->
-        <include name="nbbuild/external/json-simple*.jar"/>
+        <include name="ide/libs.json_simple/external/json-simple*.jar"/>
       </fileset>
     </path>
     <javac srcdir="antsrc" destdir="${build.ant.classes.dir}" deprecation="true" debug="${build.compiler.debug}" source="1.8" target="1.8">
@@ -138,7 +139,7 @@ metabuild.hash=f56623c16cc2cbc4a381508562545b13de91437e
     <taskdef name="releasejson" classname="org.netbeans.nbbuild.ReleaseJsonProperties" >
         <classpath>
             <pathelement location="${nbantext.jar}"/>
-            <fileset dir="${nb_all}/nbbuild/external">
+            <fileset dir="${nb_all}/ide/libs.json_simple/external">
                 <include name="json*.jar"/>
             </fileset>
         </classpath>

--- a/platform/masterfs.linux/src/org/netbeans/modules/masterfs/watcher/linux/LinuxNotifier.java
+++ b/platform/masterfs.linux/src/org/netbeans/modules/masterfs/watcher/linux/LinuxNotifier.java
@@ -80,7 +80,7 @@ public final class LinuxNotifier extends Notifier<LinuxNotifier.LKey> {
     private final Map<Integer, LKey> map = new HashMap<Integer, LKey>();
 
     public LinuxNotifier() {
-        IMPL = (InotifyImpl) Native.load("c", InotifyImpl.class);
+        IMPL = Native.load("c", InotifyImpl.class);
     }
 
     private String getString(int maxLen) {

--- a/platform/masterfs.ui/src/org/netbeans/modules/masterfs/providers/AnnotationProvider.java
+++ b/platform/masterfs.ui/src/org/netbeans/modules/masterfs/providers/AnnotationProvider.java
@@ -62,6 +62,6 @@ public abstract class AnnotationProvider extends BaseAnnotationProvider {
     @Override
     public Lookup findExtrasFor(Set<? extends FileObject> files) {
         Object[] arr = actions(files);
-        return arr == null ? null : Lookups.fixed((Object[]) arr);
+        return arr == null ? null : Lookups.fixed(arr);
     }
 }

--- a/platform/openide.options/src/org/openide/text/PrintSettings.java
+++ b/platform/openide.options/src/org/openide/text/PrintSettings.java
@@ -271,7 +271,7 @@ public final class PrintSettings extends ContextSystemOption {
             PageFormat npf = pj.pageDialog(pf);
 
             //setValue(npf);
-            ((PrintSettings)PrintSettings.findObject(PrintSettings.class)).setPageFormat((PageFormat) npf.clone());
+            (PrintSettings.findObject(PrintSettings.class)).setPageFormat((PageFormat) npf.clone());
             pj.cancel();
 
             return null;

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
@@ -280,7 +280,7 @@ public class Snapshot {
 
         List finalizables = new ArrayList();
         if (headFld != null) {
-            Instance head = (Instance) headFld.getInstance();
+            Instance head = headFld.getInstance();
             while (true) {
                 ObjectFieldValue referentFld = (ObjectFieldValue) head.getValueOfField("referent"); // NOI18N
                 ObjectFieldValue nextFld = (ObjectFieldValue) head.getValueOfField("next"); // NOI18N
@@ -288,7 +288,7 @@ public class Snapshot {
                 if (nextFld == null || nextFld.getInstance().equals(head)) {
                     break;
                 }
-                head = (Instance) nextFld.getInstance();
+                head = nextFld.getInstance();
                 finalizables.add(referentFld.getInstance());
             }
         }

--- a/webcommon/web.webkit.tooling/src/org/netbeans/modules/web/webkit/tooling/networkmonitor/ModelItem.java
+++ b/webcommon/web.webkit.tooling/src/org/netbeans/modules/web/webkit/tooling/networkmonitor/ModelItem.java
@@ -226,7 +226,7 @@ class ModelItem implements PropertyChangeListener {
     public JSONObject getRequestHeaders() {
         if (request != null) {
             JSONObject requestHeaders = (JSONObject)request.getRequest().get("headers");
-            JSONObject r = (JSONObject)request.getResponse();
+            JSONObject r = request.getResponse();
             if (r != null) {
                 r = (JSONObject)r.get("requestHeaders");
                 if (r != null) {
@@ -238,7 +238,7 @@ class ModelItem implements PropertyChangeListener {
             }
             return requestHeaders;
         } else {
-            JSONObject r = (JSONObject)wsRequest.getHandshakeRequest();
+            JSONObject r = wsRequest.getHandshakeRequest();
             if (r == null) {
                 return null;
             }
@@ -248,13 +248,13 @@ class ModelItem implements PropertyChangeListener {
 
     public JSONObject getResponseHeaders() {
         if (request != null) {
-            JSONObject r = (JSONObject)request.getResponse();
+            JSONObject r = request.getResponse();
             if (r == null) {
                 return null;
             }
             return (JSONObject)r.get("headers");
         } else {
-            JSONObject r = (JSONObject)wsRequest.getHandshakeResponse();
+            JSONObject r = wsRequest.getHandshakeResponse();
             if (r == null) {
                 return null;
             }


### PR DESCRIPTION
The compiler is warning us we have many redundant casts.

They look like this.
```
[repeat] /home/bwalker/src/netbeans/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/NamingFactory.java:253: warning: [cast] redundant cast to FileNaming
 [repeat] FileNaming cachedElement = (ref != null) ? (FileNaming) ref.get() : null;
 [repeat] 
```

So just simply clean it up..