### PR TITLE
Make newer snapcraft happy adding parse-info tag.

### DIFF
--- a/nbbuild/packaging/netbeans_snap/snap/snapcraft.yaml
+++ b/nbbuild/packaging/netbeans_snap/snap/snapcraft.yaml
@@ -40,6 +40,7 @@ parts:
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version "${VERSION}"
+    parse-info: []
       
   build:
     build-attributes: [ no-patchelf ]


### PR DESCRIPTION
This is just make the release buildable with recent snapcraft.