### PR TITLE
[NETBEANS-3168] New Plugin Portal 11.2 Update Center for Apache NetBeans IDE 11.2

### DIFF
--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
@@ -32,6 +32,8 @@ URL_Distribution=@@metabuild.DistributionURL@@
 #NOI18N
 URL_PluginPortal=@@metabuild.PluginPortalURL@@
 #NOI18N
+URL_PluginPortal112=http://plugins.netbeans.org/nbpluginportal/updates/11.2/catalog.xml.gz
+#NOI18N
 URL_82PluginPortal=http://updates.netbeans.org/netbeans/updates/8.2/uc/final/distribution/catalog.xml.gz
 
 3rdparty=Third Party Libraries

--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
@@ -45,6 +45,16 @@
          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
       </file>
       
+      <file name="pluginportal112-update-provider.instance">
+         <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/pluginportal-update-provider.instance"/>
+         <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>
+         <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_PluginPortal112"/>
+         <attr name="category" stringvalue="COMMUNITY"/>
+         <attr name="enabled" boolvalue="true"/>
+         <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider"/>
+         <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
+      </file>
+      
       <file name="82pluginportal-update-provider.instance">
           <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/82pluginportal-update-provider.instance"/>
           <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>


### PR DESCRIPTION
Adding new Plugin Portal Update Center specific for Apache NetBeans IDE 11.2 because of nb-javac plugin 1.72 which is incompatible with Apache NetBeans IDE 11.1.

Fixes #NETBEANS-3168