### PR TITLE
[NETBEANS-3040] Diff to feature does not work for Remote files in C/C++

### DIFF
--- a/ide/diff/src/org/netbeans/modules/diff/DiffAction.java
+++ b/ide/diff/src/org/netbeans/modules/diff/DiffAction.java
@@ -48,7 +48,6 @@ import org.netbeans.modules.diff.builtin.SingleDiffPanel;
 import org.netbeans.modules.diff.options.AccessibleJFileChooser;
 import org.openide.DialogDisplayer;
 import org.openide.ErrorManager;
-import org.openide.util.lookup.ProxyLookup;
 
 /**
  * Diff Action. It gets the default diff visualizer and diff provider if needed
@@ -183,6 +182,11 @@ public class DiffAction extends NodeAction {
         int result = fileChooser.showDialog(WindowManager.getDefault().getMainWindow(), NbBundle.getMessage(DiffAction.class, "DiffTo_BrowseFile_OK")); // NOI18N
         if (result != JFileChooser.APPROVE_OPTION) return null;
 
+        FileObject userSelectedFo = editorSelector.getSelectedEditorFile();
+        if (userSelectedFo != null) {
+            return userSelectedFo;
+        }
+        
         File f = fileChooser.getSelectedFile();
         if (f != null) {
             File file = f.getAbsoluteFile();


### PR DESCRIPTION
Diff file chooser converts editor FileObjects to java.io.File for selection.
In this process files with remote sources (rfs:/) become null.
This fix checks if selected file is not a disk file, providing alternate
means to retrieve the FileObject

This bug and fix is not related to C++ module; except that it manifests there.