### PR TITLE
Pack200 is deprecated for removal, disabling it by default when creat…

### DIFF
--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -435,7 +435,7 @@
         <mkdir dir="${build.dir}"/>
         <property name="nbm.target.cluster" value=""/> <!-- fallback -->
         <property name="license.file.override" value="${license.file}"/>
-        <property name="use.pack200" value="true"/>
+        <property name="use.pack200" value="false"/>
         <property name="pack200.excludes" value=""/>
         <property name="nbm.locales" value="${locales}"/>
         <makenbm file="${build.dir}/${nbm}"


### PR DESCRIPTION
…ing an NBM.

As pack200 is deprecated for removal, I don't think we can count on it being present. So I propose to change the default, and produce non-pack200 NBMs.