### PR TITLE
[NETBEANS-3191] ensuring ElementHandle works even for CompilationInfo…

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ElementHandle.java
@@ -114,9 +114,20 @@ public final class ElementHandle<T extends Element> {
     @SuppressWarnings ("unchecked")     // NOI18N
     public @CheckForNull T resolve (@NonNull final CompilationInfo compilationInfo) {
         Parameters.notNull("compilationInfo", compilationInfo); // NOI18N
-        ModuleElement module = compilationInfo.getFileObject() != null
-                ? ((JCTree.JCCompilationUnit)compilationInfo.getCompilationUnit()).modle
-                : null;
+        ModuleElement module;
+
+        if (compilationInfo.getFileObject() != null) {
+            JCTree.JCCompilationUnit cut = (JCTree.JCCompilationUnit)compilationInfo.getCompilationUnit();
+            if (cut != null) {
+                module = cut.modle;
+            } else if (compilationInfo.getTopLevelElements().iterator().hasNext()) {
+                module = ((Symbol) compilationInfo.getTopLevelElements().iterator().next()).packge().modle;
+            } else {
+                module = null;
+            }
+        } else {
+            module = null;
+        }
         T result = resolveImpl (module, compilationInfo.impl.getJavacTask());
         if (result == null) {
             if (log.isLoggable(Level.INFO))


### PR DESCRIPTION
…s that are based on classfiles (and hence don't have a CompilationUnitTree).

Basically prevents the NPE, while still determining a reasonable module to use when looking up the symbol.