### PR TITLE
[NETBEANS-3209] Add JAVA_HOME and ANT_HOME note

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ Apache NetBeans is an open source development environment, tooling platform, and
   * JDK 9 or above (to run NetBeans)
   * MinGW (optional), to build Windows Launchers
 
-**Note:** NetBeans also runs with JDK 8, although then it will not include tools for the JDK 9 Shell.
+#### Notes:
 
-**Note:** NetBeans license violation checks are managed via the [rat-exclusions.txt](https://github.com/apache/netbeans/blob/master/nbbuild/rat-exclusions.txt) file.
+* NetBeans also runs with JDK 8, although then it will not include tools for the JDK 9 Shell.
+* NetBeans license violation checks are managed via the [rat-exclusions.txt](https://github.com/apache/netbeans/blob/master/nbbuild/rat-exclusions.txt) file.
+* Set JAVA_HOME and ANT_HOME appropriately or leave them undefined.
 
 ### Building NetBeans
 


### PR DESCRIPTION
Add a brief note about the JAVA_HOME and ANT_HOME environment variables
to the build instructions on the Web site and the GitHub repository. See
the following message on the mailing list for details:

Re: Building NetBeans 11.1 from source fails with compile errors
https://mail-archives.apache.org/mod_mbox/netbeans-dev/201910.mbox/%3C26c1f141-b021-4473-059f-41ec0b5e3613%40status6.com%3E

Fixes #3209
