### PR TITLE
NETBEANS-3185 use last maven-nbm-plugin

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
@@ -107,7 +107,7 @@ public class MavenNbModuleImpl implements NbModuleProvider {
     public static final String GROUPID_MOJO = "org.codehaus.mojo";
     public static final String GROUPID_APACHE = "org.apache.netbeans.utilities";
     public static final String NBM_PLUGIN = "nbm-maven-plugin";
-    public static final String LATEST_NBM_PLUGIN_VERSION = "4.2";
+    public static final String LATEST_NBM_PLUGIN_VERSION = "4.3";
     
     public static final String NETBEANSAPI_GROUPID = "org.netbeans.api";  
     


### PR DESCRIPTION
This is last part of fix for NETBEANS-3185.  It's to use the 4.3 version of plugin
As vote is in progress it's not yet available.