### PR TITLE
Always specify javac.target

### DIFF
--- a/ide/db/build.xml
+++ b/ide/db/build.xml
@@ -32,7 +32,7 @@
 
     <target name="compile-lib" depends="init,fake-jdbc-40">
         <mkdir dir="${build.dir}/lib-classes" />
-        <javac srcdir="libsrc" destdir="${build.dir}/lib-classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" source="1.6">
+        <javac target="${javac.target}" srcdir="libsrc" destdir="${build.dir}/lib-classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" source="1.6">
             <classpath>
                 <pathelement path="${lib.cp}"/>
             </classpath>
@@ -50,7 +50,7 @@
             public class RowIdLifetime {}
         </echo>
         <mkdir dir="${fake-jdbc-40.build}"/>
-        <javac srcdir="${fake-jdbc-40.src}" destdir="${fake-jdbc-40.build}"/>
+        <javac target="${javac.target}" source="1.7" srcdir="${fake-jdbc-40.src}" destdir="${fake-jdbc-40.build}"/>
     </target>
 
     <target name="jar-lib" depends="compile-lib">

--- a/ide/xml.tax/build.xml
+++ b/ide/xml.tax/build.xml
@@ -25,7 +25,7 @@
 
     <target name="lib-compile" depends="build-init">
         <mkdir dir="${build.dir}/libclasses"/>
-        <javac destdir="${build.dir}/libclasses" debug="${build.compiler.debug}" debuglevel="${build.compiler.debuglevel}" deprecation="${build.compiler.deprecation}" optimize="${build.compiler.optimize}" source="${javac.source}" includeantruntime="false">
+        <javac target="${javac.target}" destdir="${build.dir}/libclasses" debug="${build.compiler.debug}" debuglevel="${build.compiler.debuglevel}" deprecation="${build.compiler.deprecation}" optimize="${build.compiler.optimize}" source="${javac.source}" includeantruntime="false">
             <src path="lib/src"/>
             <classpath>
                 <pathelement location="${netbeans.dest.dir}/ide/modules/ext/xerces-2.8.0.jar"/>


### PR DESCRIPTION
Always specify javac.target to allow compilation on JDK11+ and execution on JDK8. Once I compiled NetBeans with JDK11:
```
nbbuild$ ant build -Dnbjdk.home=/jdk11
```
but then I wanted to compile again with JDK8
```
nbbuild$ ant build -Dnbjdk.home=/jdk8
```
it failed with "Incompatible class file error". In general we have to specify `target="${javac.target}"` to prevent JDK11+ to use too modern bytecode formats. This PR contains two places where the missing `target` was causing problems in my case.