### PR TITLE
Default JDK for Maven projects

### DIFF
--- a/java/java.platform.ui/src/org/netbeans/api/java/platform/PlatformsCustomizer.java
+++ b/java/java.platform.ui/src/org/netbeans/api/java/platform/PlatformsCustomizer.java
@@ -34,7 +34,7 @@ public final class PlatformsCustomizer {
 
     /**
      * Shows platforms customizer
-     * @param  platform which should be seelcted, may be null
+     * @param  platform which should be selected, may be null
      * @return boolean for future extension, currently always true
      */
     public static boolean showCustomizer (JavaPlatform platform) {

--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -77,6 +77,7 @@ import org.netbeans.modules.maven.cos.CopyResourcesOnSave;
 import org.netbeans.modules.maven.embedder.EmbedderFactory;
 import org.netbeans.modules.maven.embedder.MavenEmbedder;
 import org.netbeans.modules.maven.modelcache.MavenProjectCache;
+import org.netbeans.modules.maven.options.MavenSettings;
 import org.netbeans.modules.maven.problems.ProblemReporterImpl;
 import org.netbeans.modules.maven.queries.PomCompilerOptionsQueryImpl;
 import org.netbeans.modules.maven.queries.UnitTestsCompilerOptionsQueryImpl;
@@ -260,6 +261,14 @@ public final class NbMavenProjectImpl implements Project {
 
     public ProblemReporterImpl getProblemReporter() {
         return problemReporter;
+    }
+
+    public String getHintJavaPlatform() {
+        String hint = getAuxProps().get(Constants.HINT_JDK_PLATFORM, true);
+        if (hint == null) {
+            hint = MavenSettings.getDefault().getDefaultJdk();
+        }
+        return hint == null || hint.isEmpty() ? null : hint;
     }
 
     /**

--- a/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.maven.api;
 
+import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
@@ -122,7 +123,7 @@ public final class NbMavenProject {
 
 
     
-    private class FCHSL implements FileChangeListener {
+    private class FCHSL implements FileChangeListener, PropertyChangeListener {
 
 
         @Override
@@ -153,7 +154,11 @@ public final class NbMavenProject {
         @Override
         public void fileAttributeChanged(FileAttributeEvent fe) {
         }
-        
+
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            doFireReload();
+        }
     }
     
     
@@ -163,6 +168,7 @@ public final class NbMavenProject {
         //TODO oh well, the sources is the actual project instance not the watcher.. a problem?
         support = new PropertyChangeSupport(proj);
         task = createBinaryDownloadTask(BINARYRP);
+        MavenSettings.getDefault().addWeakPropertyChangeListener(listener);
     }
     
     /**

--- a/java/maven/src/org/netbeans/modules/maven/classpath/AbstractBootPathImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/AbstractBootPathImpl.java
@@ -33,6 +33,7 @@ import org.netbeans.modules.java.api.common.util.CommonProjectUtils;
 import org.netbeans.modules.maven.NbMavenProjectImpl;
 import org.netbeans.modules.maven.api.Constants;
 import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.modules.maven.options.MavenSettings;
 import org.netbeans.spi.java.classpath.ClassPathImplementation;
 import org.netbeans.spi.java.classpath.PathResourceImplementation;
 import org.openide.util.WeakListeners;
@@ -107,7 +108,7 @@ public abstract class AbstractBootPathImpl implements ClassPathImplementation, P
 
     @Override 
     public void propertyChange(PropertyChangeEvent evt) {
-        String newVal = project.getAuxProps().get(Constants.HINT_JDK_PLATFORM, true);
+        String newVal = project.getHintJavaPlatform();
         if (evt.getSource() == platformManager && 
                 JavaPlatformManager.PROP_INSTALLED_PLATFORMS.equals(evt.getPropertyName()) 
                 && lastHintValue != null) {
@@ -150,7 +151,7 @@ public abstract class AbstractBootPathImpl implements ClassPathImplementation, P
             }
             //TODO ideally we would handle this by toolchains in future.
             //only use the default auximpl otherwise we get recursive calls problems.
-            String val = project.getAuxProps().get(Constants.HINT_JDK_PLATFORM, true);
+            String val = project.getHintJavaPlatform();
             JavaPlatform plat = getActivePlatform(val);
             if (plat == null) {
                 //TODO report how?

--- a/java/maven/src/org/netbeans/modules/maven/classpath/BootClassPathImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/BootClassPathImpl.java
@@ -57,7 +57,7 @@ public final class BootClassPathImpl extends AbstractBootPathImpl {
                 boolean[] includeJDK = { true };
                 boolean[] includeFX = { false };
                 result.addAll(ecpImpl.getResources(includeJDK, includeFX));
-                lastHintValue = project.getAuxProps().get(Constants.HINT_JDK_PLATFORM, true);
+                lastHintValue = project.getHintJavaPlatform();
                 if (includeJDK[0]) {
                     JavaPlatform pat = findActivePlatform();
                     boolean hasFx = false;
@@ -80,7 +80,7 @@ public final class BootClassPathImpl extends AbstractBootPathImpl {
 
     public @Override void propertyChange(PropertyChangeEvent evt) {
         super.propertyChange(evt);
-        String newVal = project.getAuxProps().get(Constants.HINT_JDK_PLATFORM, true);
+        String newVal = project.getHintJavaPlatform();
         if (evt.getSource() == project && evt.getPropertyName().equals(NbMavenProject.PROP_PROJECT)) {
             if (ecpImpl.resetCache()) {
                 resetCache();

--- a/java/maven/src/org/netbeans/modules/maven/options/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/options/Bundle.properties
@@ -87,3 +87,4 @@ SettingsPanel.lblCustom.text=Custom...
 SettingsPanel.cbShowInfoLevel.text=&Print Maven output logging level
 SettingsPanel.cbShowInfoLevel.toolTipText=Will print Maven output logging level into the Output view
 SettingsPanel.jLabel5.text=(NOT recommended, many features will be limited as a result)
+SettingsPanel.lblJdkHome.text=Default &JDK

--- a/java/maven/src/org/netbeans/modules/maven/options/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/options/Bundle.properties
@@ -88,3 +88,4 @@ SettingsPanel.cbShowInfoLevel.text=&Print Maven output logging level
 SettingsPanel.cbShowInfoLevel.toolTipText=Will print Maven output logging level into the Output view
 SettingsPanel.jLabel5.text=(NOT recommended, many features will be limited as a result)
 SettingsPanel.lblJdkHome.text=Default &JDK
+SettingsPanel.comManageJdks.text=Mana&ge Java Platforms

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -19,6 +19,8 @@
 
 package org.netbeans.modules.maven.options;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -28,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
@@ -35,11 +38,13 @@ import java.util.prefs.Preferences;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.modules.maven.embedder.EmbedderFactory;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.NbPreferences;
+import org.openide.util.WeakSet;
 
 /**
  * a netbeans settings for global options that cannot be put into the settings file.
@@ -66,6 +71,7 @@ public final class MavenSettings  {
     private static final String PROP_EXPERIMENTAL_USE_ALTERNATE_LOCATION = "useBestMavenAltLocation";
     private static final String PROP_EXPERIMENTAL_ALTERNATE_LOCATION = "bestMavenAltLocation";
     private static final String PROP_VM_OPTIONS_WRAP = "vmOptionsWrap";
+    private static final String PROP_DEFAULT_JDK = "defaultJdk";
 
     //these are from former versions (6.5) and are here only for conversion
     private static final String PROP_DEBUG = "showDebug"; // NOI18N
@@ -77,6 +83,8 @@ public final class MavenSettings  {
       
     private static final MavenSettings INSTANCE = new MavenSettings();
     
+    private final Set<PropertyChangeListener> listeners = new WeakSet<>();
+
     public static MavenSettings getDefault() {
         return INSTANCE;
     }
@@ -230,6 +238,21 @@ public final class MavenSettings  {
         getPreferences().putBoolean(PROP_VM_OPTIONS_WRAP, b);
     }
 
+    public String getDefaultJdk() {
+        return getPreferences().get(PROP_DEFAULT_JDK, "");
+    }
+
+    public void setDefaultJdk(String jdk) {
+        getPreferences().put(PROP_DEFAULT_JDK, jdk);
+        PropertyChangeListener[] arr;
+        synchronized (listeners) {
+            arr = listeners.toArray(new PropertyChangeListener[0]);
+        }
+        for (PropertyChangeListener l : arr) {
+            l.propertyChange(new PropertyChangeEvent(this, PROP_DEFAULT_JDK, null, jdk));
+        }
+    }
+
     public String getLastArchetypeGroupId() {
         return getPreferences().get(PROP_LAST_ARCHETYPE_GROUPID, Boolean.getBoolean("netbeans.full.hack") ? "test" : "com.mycompany"); //NOI18N
     }
@@ -349,6 +372,12 @@ public final class MavenSettings  {
             getPreferences().put(PROP_OUTPUT_TAB_NAME, ds.name());
         } else {
             getPreferences().remove(PROP_OUTPUT_TAB_NAME);
+        }
+    }
+
+    public void addWeakPropertyChangeListener(PropertyChangeListener l) {
+        synchronized (listeners) {
+            listeners.add(l);
         }
     }
 

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.form
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.form
@@ -216,7 +216,7 @@
                       </Group>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="jLabel3" min="-2" pref="44" max="-2" attributes="0"/>
-                      <EmptySpace pref="15" max="32767" attributes="0"/>
+                      <EmptySpace pref="218" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -322,7 +322,7 @@
                       <Component id="cbDisableIndex" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="jLabel5" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace pref="12" max="32767" attributes="0"/>
+                      <EmptySpace pref="290" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -422,7 +422,7 @@
                           <Component id="txtDirectory" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="btnDirectory" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace pref="30" max="32767" attributes="0"/>
+                      <EmptySpace pref="180" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -485,15 +485,16 @@
                       <EmptySpace min="-2" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Group type="102" attributes="0">
-                              <Component id="lblCommandLine" min="-2" max="-2" attributes="0"/>
-                              <EmptySpace min="-2" max="-2" attributes="0"/>
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="lblExternalVersion" max="32767" attributes="0"/>
-                                  <Group type="102" attributes="0">
-                                      <Component id="comMavenHome" max="32767" attributes="0"/>
-                                      <EmptySpace max="-2" attributes="0"/>
-                                  </Group>
+                                  <Component id="lblCommandLine" min="-2" max="-2" attributes="0"/>
+                                  <Component id="lblJdkHome" min="-2" max="-2" attributes="0"/>
                               </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Component id="comMavenHome" max="32767" attributes="0"/>
+                                  <Component id="comJdkHome" max="32767" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
                           </Group>
                           <Group type="102" attributes="0">
                               <Group type="103" groupAlignment="1" attributes="0">
@@ -533,6 +534,10 @@
                           </Group>
                       </Group>
                   </Group>
+                  <Group type="102" alignment="0" attributes="0">
+                      <EmptySpace min="-2" pref="119" max="-2" attributes="0"/>
+                      <Component id="lblExternalVersion" max="32767" attributes="0"/>
+                  </Group>
               </Group>
             </DimensionLayout>
             <DimensionLayout dim="1">
@@ -545,7 +550,12 @@
                       </Group>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="lblExternalVersion" min="-2" pref="14" max="-2" attributes="0"/>
-                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="3" attributes="0">
+                          <Component id="lblJdkHome" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="comJdkHome" alignment="3" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                      <EmptySpace min="-2" pref="32" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="3" attributes="0">
                           <Component id="lblOptions" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="txtOptions" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -698,6 +708,23 @@
                 </Property>
                 <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                   <ResourceString bundle="org/netbeans/modules/maven/options/Bundle.properties" key="SettingsPanel.cbShowInfoLevel.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+            </Component>
+            <Component class="javax.swing.JLabel" name="lblJdkHome">
+              <Properties>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/netbeans/modules/maven/options/Bundle.properties" key="SettingsPanel.lblJdkHome.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+              <AuxValues>
+                <AuxValue name="JavaCodeGenerator_InitCodePre" type="java.lang.String" value="lblCommandLine.setLabelFor(comMavenHome);"/>
+              </AuxValues>
+            </Component>
+            <Component class="javax.swing.JComboBox" name="comJdkHome">
+              <Properties>
+                <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
+                  <StringArray count="0"/>
                 </Property>
               </Properties>
             </Component>

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.form
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.form
@@ -485,18 +485,6 @@
                       <EmptySpace min="-2" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Group type="102" attributes="0">
-                              <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="lblCommandLine" min="-2" max="-2" attributes="0"/>
-                                  <Component id="lblJdkHome" min="-2" max="-2" attributes="0"/>
-                              </Group>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Group type="103" groupAlignment="0" attributes="0">
-                                  <Component id="comMavenHome" max="32767" attributes="0"/>
-                                  <Component id="comJdkHome" max="32767" attributes="0"/>
-                              </Group>
-                              <EmptySpace max="-2" attributes="0"/>
-                          </Group>
-                          <Group type="102" attributes="0">
                               <Group type="103" groupAlignment="1" attributes="0">
                                   <Group type="102" attributes="0">
                                       <Group type="103" groupAlignment="0" attributes="0">
@@ -524,12 +512,31 @@
                               </Group>
                               <EmptySpace min="0" pref="45" max="32767" attributes="0"/>
                           </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="lblOptions" min="-2" max="-2" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Component id="txtOptions" max="32767" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Component id="btnOptions" min="-2" max="-2" attributes="0"/>
+                          <Group type="102" attributes="0">
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Group type="102" attributes="0">
+                                      <Group type="103" groupAlignment="0" attributes="0">
+                                          <Component id="lblCommandLine" min="-2" max="-2" attributes="0"/>
+                                          <Component id="lblJdkHome" min="-2" max="-2" attributes="0"/>
+                                      </Group>
+                                      <EmptySpace max="-2" attributes="0"/>
+                                      <Group type="103" groupAlignment="0" attributes="0">
+                                          <Component id="comMavenHome" max="32767" attributes="0"/>
+                                          <Group type="102" attributes="0">
+                                              <Component id="comJdkHome" max="32767" attributes="0"/>
+                                              <EmptySpace max="-2" attributes="0"/>
+                                              <Component id="comManageJdks" min="-2" max="-2" attributes="0"/>
+                                          </Group>
+                                      </Group>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="lblOptions" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="-2" attributes="0"/>
+                                      <Component id="txtOptions" max="32767" attributes="0"/>
+                                      <EmptySpace max="-2" attributes="0"/>
+                                      <Component id="btnOptions" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                              </Group>
                               <EmptySpace max="-2" attributes="0"/>
                           </Group>
                       </Group>
@@ -554,8 +561,9 @@
                       <Group type="103" groupAlignment="3" attributes="0">
                           <Component id="lblJdkHome" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="comJdkHome" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="comManageJdks" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace min="-2" pref="32" max="-2" attributes="0"/>
+                      <EmptySpace min="-2" pref="31" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="3" attributes="0">
                           <Component id="lblOptions" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="txtOptions" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -727,6 +735,16 @@
                   <StringArray count="0"/>
                 </Property>
               </Properties>
+            </Component>
+            <Component class="javax.swing.JButton" name="comManageJdks">
+              <Properties>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/netbeans/modules/maven/options/Bundle.properties" key="SettingsPanel.comManageJdks.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+              <Events>
+                <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="comManageJdksActionPerformed"/>
+              </Events>
             </Component>
           </SubComponents>
         </Container>

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
@@ -43,6 +43,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.api.java.platform.JavaPlatformManager;
+import org.netbeans.api.java.platform.PlatformsCustomizer;
 import org.netbeans.modules.maven.TextValueCompleter;
 import org.netbeans.modules.maven.configurations.M2Configuration;
 import org.netbeans.modules.maven.customizer.ActionMappings;
@@ -390,6 +391,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         cbShowInfoLevel = new javax.swing.JCheckBox();
         lblJdkHome = new javax.swing.JLabel();
         comJdkHome = new javax.swing.JComboBox();
+        comManageJdks = new javax.swing.JButton();
         jScrollPane1 = new javax.swing.JScrollPane();
         lstCategory = new javax.swing.JList();
         lblCategory = new javax.swing.JLabel();
@@ -674,6 +676,13 @@ public class SettingsPanel extends javax.swing.JPanel {
         lblCommandLine.setLabelFor(comMavenHome);
         org.openide.awt.Mnemonics.setLocalizedText(lblJdkHome, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.lblJdkHome.text")); // NOI18N
 
+        org.openide.awt.Mnemonics.setLocalizedText(comManageJdks, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.comManageJdks.text")); // NOI18N
+        comManageJdks.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                comManageJdksActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout pnlExecutionLayout = new javax.swing.GroupLayout(pnlExecution);
         pnlExecution.setLayout(pnlExecutionLayout);
         pnlExecutionLayout.setHorizontalGroup(
@@ -681,15 +690,6 @@ public class SettingsPanel extends javax.swing.JPanel {
             .addGroup(pnlExecutionLayout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(pnlExecutionLayout.createSequentialGroup()
-                        .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(lblCommandLine)
-                            .addComponent(lblJdkHome))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(comMavenHome, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addComponent(comJdkHome, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                        .addContainerGap())
                     .addGroup(pnlExecutionLayout.createSequentialGroup()
                         .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                             .addGroup(pnlExecutionLayout.createSequentialGroup()
@@ -712,11 +712,24 @@ public class SettingsPanel extends javax.swing.JPanel {
                             .addComponent(cbSkipTests, javax.swing.GroupLayout.Alignment.LEADING))
                         .addGap(0, 45, Short.MAX_VALUE))
                     .addGroup(pnlExecutionLayout.createSequentialGroup()
-                        .addComponent(lblOptions)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(txtOptions)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(btnOptions)
+                        .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(pnlExecutionLayout.createSequentialGroup()
+                                .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addComponent(lblCommandLine)
+                                    .addComponent(lblJdkHome))
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addComponent(comMavenHome, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                    .addGroup(pnlExecutionLayout.createSequentialGroup()
+                                        .addComponent(comJdkHome, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                        .addComponent(comManageJdks))))
+                            .addGroup(pnlExecutionLayout.createSequentialGroup()
+                                .addComponent(lblOptions)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(txtOptions)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(btnOptions)))
                         .addContainerGap())))
             .addGroup(pnlExecutionLayout.createSequentialGroup()
                 .addGap(119, 119, 119)
@@ -734,8 +747,9 @@ public class SettingsPanel extends javax.swing.JPanel {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(lblJdkHome)
-                    .addComponent(comJdkHome, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addGap(32, 32, 32)
+                    .addComponent(comJdkHome, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(comManageJdks))
+                .addGap(31, 31, 31)
                 .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(lblOptions)
                     .addComponent(txtOptions, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -893,6 +907,10 @@ public class SettingsPanel extends javax.swing.JPanel {
         }
     
     }//GEN-LAST:event_btnDirectoryActionPerformed
+
+    private void comManageJdksActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_comManageJdksActionPerformed
+        PlatformsCustomizer.showCustomizer(findSelectedJdk(new String[1]));
+    }//GEN-LAST:event_comManageJdksActionPerformed
     
     
     // Variables declaration - do not modify//GEN-BEGIN:variables
@@ -915,6 +933,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     private javax.swing.JComboBox comIndex;
     private javax.swing.JComboBox comJavadoc;
     private javax.swing.JComboBox comJdkHome;
+    private javax.swing.JButton comManageJdks;
     private javax.swing.JComboBox comMavenHome;
     private javax.swing.JComboBox comSource;
     private javax.swing.JLabel jLabel1;
@@ -1252,22 +1271,33 @@ public class SettingsPanel extends javax.swing.JPanel {
     }
 
     final String findSelectedJdkName() {
+        String[] name = { null };
+        findSelectedJdk(name);
+        return name[0];
+    }
+
+    private final JavaPlatform findSelectedJdk(String[] name) {
         if (jdkHomeDataModel == null) {
-            return "";
+            name[0] = "";
+            return null;
         }
         String jdk = (String) jdkHomeDataModel.getSelectedItem();
-        if (jdk == null || jdk.equals(JavaPlatformManager.getDefault().getDefaultPlatform().getDisplayName())) {
-            return "";
+        final JavaPlatform def = JavaPlatformManager.getDefault().getDefaultPlatform();
+        if (jdk == null || jdk.equals(def.getDisplayName())) {
+            name[0] = "";
+            return def;
         }
         for (JavaPlatform p : JavaPlatformManager.getDefault().getInstalledPlatforms()) {
             if (jdk.equals(p.getDisplayName())) {
                 String antName = p.getProperties().get("platform.ant.name");
                 if (antName != null) {
-                    return antName;
+                    name[0] = antName;
+                    return p;
                 }
             }
         }
-        return jdk;
+        name[0] = jdk;
+        return null;
     }
     
     private class ActionListenerImpl implements ActionListener {

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
@@ -41,6 +41,8 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import org.netbeans.api.java.platform.JavaPlatform;
+import org.netbeans.api.java.platform.JavaPlatformManager;
 import org.netbeans.modules.maven.TextValueCompleter;
 import org.netbeans.modules.maven.configurations.M2Configuration;
 import org.netbeans.modules.maven.customizer.ActionMappings;
@@ -85,6 +87,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     private final List<String>       userDefinedMavenRuntimesStored = new ArrayList<String>();
     private final List<String>       predefinedRuntimes = new ArrayList<String>();
     private final DefaultComboBoxModel mavenHomeDataModel = new DefaultComboBoxModel();
+    private final DefaultComboBoxModel jdkHomeDataModel = new DefaultComboBoxModel();
     private String             mavenRuntimeHome = null;
     private int                lastSelected = -1;
     private final static RequestProcessor RP = new RequestProcessor(SettingsPanel.class);
@@ -124,6 +127,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         comJavadoc.setModel(new DefaultComboBoxModel(downloads));
         comSource.setModel(new DefaultComboBoxModel(downloads));
         comMavenHome.setModel(mavenHomeDataModel);
+        comJdkHome.setModel(jdkHomeDataModel);
 
         ListCellRenderer rend = new DefaultListCellRenderer() {
             @Override
@@ -384,6 +388,8 @@ public class SettingsPanel extends javax.swing.JPanel {
         rbOutputTabId = new javax.swing.JRadioButton();
         cbOutputTabShowConfig = new javax.swing.JCheckBox();
         cbShowInfoLevel = new javax.swing.JCheckBox();
+        lblJdkHome = new javax.swing.JLabel();
+        comJdkHome = new javax.swing.JComboBox();
         jScrollPane1 = new javax.swing.JScrollPane();
         lstCategory = new javax.swing.JList();
         lblCategory = new javax.swing.JLabel();
@@ -503,7 +509,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                     .addComponent(comSource, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jLabel3, javax.swing.GroupLayout.PREFERRED_SIZE, 44, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(15, Short.MAX_VALUE))
+                .addContainerGap(218, Short.MAX_VALUE))
         );
 
         pnlCards.add(pnlDependencies, "dependencies");
@@ -563,7 +569,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                 .addComponent(cbDisableIndex)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jLabel5)
-                .addContainerGap(12, Short.MAX_VALUE))
+                .addContainerGap(290, Short.MAX_VALUE))
         );
 
         pnlCards.add(pnlIndex, "index");
@@ -619,7 +625,7 @@ public class SettingsPanel extends javax.swing.JPanel {
                     .addComponent(lblDirectory)
                     .addComponent(txtDirectory, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(btnDirectory))
-                .addContainerGap(30, Short.MAX_VALUE))
+                .addContainerGap(180, Short.MAX_VALUE))
         );
 
         pnlCards.add(plnExperimental, "experimental");
@@ -665,6 +671,9 @@ public class SettingsPanel extends javax.swing.JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(cbShowInfoLevel, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.cbShowInfoLevel.text")); // NOI18N
         cbShowInfoLevel.setToolTipText(org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.cbShowInfoLevel.toolTipText")); // NOI18N
 
+        lblCommandLine.setLabelFor(comMavenHome);
+        org.openide.awt.Mnemonics.setLocalizedText(lblJdkHome, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.lblJdkHome.text")); // NOI18N
+
         javax.swing.GroupLayout pnlExecutionLayout = new javax.swing.GroupLayout(pnlExecution);
         pnlExecution.setLayout(pnlExecutionLayout);
         pnlExecutionLayout.setHorizontalGroup(
@@ -673,13 +682,14 @@ public class SettingsPanel extends javax.swing.JPanel {
                 .addContainerGap()
                 .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(pnlExecutionLayout.createSequentialGroup()
-                        .addComponent(lblCommandLine)
+                        .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(lblCommandLine)
+                            .addComponent(lblJdkHome))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(lblExternalVersion, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addGroup(pnlExecutionLayout.createSequentialGroup()
-                                .addComponent(comMavenHome, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                .addContainerGap())))
+                            .addComponent(comMavenHome, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(comJdkHome, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                        .addContainerGap())
                     .addGroup(pnlExecutionLayout.createSequentialGroup()
                         .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                             .addGroup(pnlExecutionLayout.createSequentialGroup()
@@ -708,6 +718,9 @@ public class SettingsPanel extends javax.swing.JPanel {
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(btnOptions)
                         .addContainerGap())))
+            .addGroup(pnlExecutionLayout.createSequentialGroup()
+                .addGap(119, 119, 119)
+                .addComponent(lblExternalVersion, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         pnlExecutionLayout.setVerticalGroup(
             pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -718,7 +731,11 @@ public class SettingsPanel extends javax.swing.JPanel {
                     .addComponent(comMavenHome, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(lblExternalVersion, javax.swing.GroupLayout.PREFERRED_SIZE, 14, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(lblJdkHome)
+                    .addComponent(comJdkHome, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addGap(32, 32, 32)
                 .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(lblOptions)
                     .addComponent(txtOptions, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -897,6 +914,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     private javax.swing.JComboBox comBinaries;
     private javax.swing.JComboBox comIndex;
     private javax.swing.JComboBox comJavadoc;
+    private javax.swing.JComboBox comJdkHome;
     private javax.swing.JComboBox comMavenHome;
     private javax.swing.JComboBox comSource;
     private javax.swing.JLabel jLabel1;
@@ -913,6 +931,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     private javax.swing.JLabel lblHint;
     private javax.swing.JLabel lblIndex;
     private javax.swing.JLabel lblJavadoc;
+    private javax.swing.JLabel lblJdkHome;
     private javax.swing.JLabel lblOptions;
     private javax.swing.JLabel lblOutputTab;
     private javax.swing.JLabel lblSource;
@@ -1023,6 +1042,20 @@ public class SettingsPanel extends javax.swing.JPanel {
                             mavenHomeDataModel.addElement(desc);
                         }
 
+                        jdkHomeDataModel.removeAllElements();
+                        JavaPlatform def = JavaPlatformManager.getDefault().getDefaultPlatform();
+                        String defJdkName = MavenSettings.getDefault().getDefaultJdk();
+                        if (defJdkName.isEmpty()) {
+                            defJdkName = def.getDisplayName();
+                        }
+                        for (JavaPlatform p : JavaPlatformManager.getDefault().getInstalledPlatforms()) {
+                            jdkHomeDataModel.addElement(p.getDisplayName());
+                            String antName = p.getProperties().get("platform.ant.name"); // NOI18N
+                            if (defJdkName.equals(p.getDisplayName()) || defJdkName.equals(antName)) {
+                                jdkHomeDataModel.setSelectedItem(p.getDisplayName());
+                            }
+                        }
+
                         if (!userDefinedMavenRuntimes.isEmpty()) {
                             mavenHomeDataModel.addElement(SEPARATOR);
                             for (String runtime : userDefinedMavenRuntimes) {
@@ -1096,7 +1129,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     
     public void applyValues() {
         MavenSettings.getDefault().setDefaultOptions(txtOptions.getText().trim());
-        
+        MavenSettings.getDefault().setDefaultJdk(findSelectedJdkName());
         // remember only user-defined runtimes of RUNTIME_COUNT_LIMIT count at the most
         List<String> runtimes = new ArrayList<String>();
         for (int i = 0; i < userDefinedMavenRuntimes.size() && i < RUNTIME_COUNT_LIMIT; ++i) {
@@ -1177,6 +1210,7 @@ public class SettingsPanel extends javax.swing.JPanel {
             runtimes.add(0, predefinedRuntimes.get(1));
         }
         isChanged |= !userDefinedMavenRuntimesStored.equals(runtimes);
+        isChanged |= !findSelectedJdkName().equals(MavenSettings.getDefault().getDefaultJdk());
         String cl = mavenRuntimeHome;
         //MEVENIDE-553
         File command = (cl == null || cl.isEmpty()) ? null : new File(cl);
@@ -1215,6 +1249,25 @@ public class SettingsPanel extends javax.swing.JPanel {
             }
         }
         changed = isChanged;
+    }
+
+    final String findSelectedJdkName() {
+        if (jdkHomeDataModel == null) {
+            return "";
+        }
+        String jdk = (String) jdkHomeDataModel.getSelectedItem();
+        if (jdk == null || jdk.equals(JavaPlatformManager.getDefault().getDefaultPlatform().getDisplayName())) {
+            return "";
+        }
+        for (JavaPlatform p : JavaPlatformManager.getDefault().getInstalledPlatforms()) {
+            if (jdk.equals(p.getDisplayName())) {
+                String antName = p.getProperties().get("platform.ant.name");
+                if (antName != null) {
+                    return antName;
+                }
+            }
+        }
+        return jdk;
     }
     
     private class ActionListenerImpl implements ActionListener {


### PR DESCRIPTION
I am running NetBeans on JDK13 (to benefit from the great work Oracle guys put into `javac` in JDK13 and its co-operation with NetBeans).

However I don't want to develop my own code on such bleeding edge platform. I usually want my Maven projects to compile on JDK8, sometimes on JDK11. Never on JDK13.

There is a way to select non-default JDK per Maven project, but I'd like to do that for all projects at once. This PR solves it - it allows one to specify "Default JDK" in Maven settings and that one is then used for each Maven project without specifically selected JDK.