### PR TITLE
[NETBEANS-3198] fallback to hard-coded build date in Options API

### DIFF
--- a/platform/options.api/src/org/netbeans/modules/options/export/OptionsExportModel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/export/OptionsExportModel.java
@@ -226,7 +226,8 @@ public final class OptionsExportModel {
             String time = (hours != null && minutes != null) ? hours.concat(minutes) : "2359";  // NOI18N
             return year.concat(month).concat(day).concat(time);
         }
-        return null;
+        // FIX NETBEANS-3198 : build number no longer contains a date
+        return "201910010000";
     }
 
     /**


### PR DESCRIPTION
Hard-code the date (201910010000) when we switched from build number with date to build number with git hash as quick fix for Options Import / Export