### PR TITLE
Must ensure javac is initialized before attempting any lookups.

### DIFF
--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/AsyncJavaSymbolDescriptor.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/AsyncJavaSymbolDescriptor.java
@@ -214,6 +214,7 @@ final class AsyncJavaSymbolDescriptor extends JavaSymbolDescriptorBase implement
             final Symtab syms = Symtab.instance(jt.getContext());
             final Set<?> pkgs = new HashSet<>(getPackages(syms).keySet());
             final Set<?> clzs = new HashSet<>(getClasses(syms).keySet());
+            jt.getElements().getTypeElement("java.lang.Object"); // Ensure proper javac initialization
             final TypeElement te = (TypeElement) ElementUtils.getTypeElementByBinaryName(jt,
                     ElementHandleAccessor.getInstance().getJVMSignature(getOwner())[0]);
             if (te != null) {


### PR DESCRIPTION
tzezula reported that the Navigate/Go to Symbol feature does not work properly for Java:
-the entries in the list are missing the icon
-pressing Enter does not jump to the actual entry

I believe the reason is that ElementUtils.getTypeElementByBinaryName is called on an javac instance, that is not sufficiently initialized (since JDK 9, javac must be initialized a little bit more that before to work). This is particularly problem since this feature uses the javac internal directly. The proposed patch is to force the proper initialization. There are multiple ways to do that, but JavacTask.getElements().getTypeElement("java.lang.Object") feels like the cleanest. (Alternative would be "jt.ensureEntered()", but that is yet another call to an javac internal method, while getTypeElement is public.)
