### PR TITLE
[NETBEANS-3249] Chrome connector connection with NetBeans

### DIFF
--- a/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/ExternalBrowserPlugin.java
+++ b/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/ExternalBrowserPlugin.java
@@ -124,12 +124,19 @@ public final class ExternalBrowserPlugin {
     }
 
     private String urlToString(URL url) {
-        try {
+        String urlStr;
+        String badStart = "file:/private/var/";
+        String goodStart = "file:/var/";
+        try { 
             // try to 'normalize' the URL
-            return url.toURI().toASCIIString().toLowerCase();
-        } catch (URISyntaxException ex) {
-            return url.toExternalForm();
-        }
+            urlStr =  url.toURI().toASCIIString().toLowerCase();
+        } catch (URISyntaxException ex) { 
+            urlStr = url.toExternalForm();
+        }     
+        if (urlStr != null && urlStr.startsWith(badStart)) {
+            return goodStart + urlStr.substring(badStart.length());
+        }     
+        return urlStr;
     }
 
     /**
@@ -408,7 +415,9 @@ public final class ExternalBrowserPlugin {
                     LOG.log(Level.FINE, "awaiting URL: {0}", awaiting);  // NOI18N
                 }
             }
-            Pair pair = (u == null) ? null : awaitingBrowserResponse.remove(urlToString(u));
+            Pair pair = (u == null) ? null : awaitingBrowserResponse.remove(
+                
+                (u));
             ChromeBrowserImpl browserImpl = pair != null ? pair.impl : null;
 
             // XXX: workaround: when Web Project is run it is started as "http:/localhost/aa" but browser URL is


### PR DESCRIPTION
When NetBeans gets the handshake from Chrome, it attempts to find the session it stored, but because the name has had '/private' inserted, the lookup fails and NetBeans refuses to debug. This fixes that.