### PR TITLE
NETBEANS-3250: Fix warnings from annotation processors.

### DIFF
--- a/harness/nbjunit/src/org/netbeans/junit/internal/RandomlyFailsProcessor.java
+++ b/harness/nbjunit/src/org/netbeans/junit/internal/RandomlyFailsProcessor.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -39,11 +38,15 @@ import org.openide.util.lookup.ServiceProvider;
  * Just verifies usage.
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class RandomlyFailsProcessor extends AbstractProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {
         return Collections.singleton(RandomlyFails.class.getCanonicalName());
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
 
     @Override

--- a/ide/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
+++ b/ide/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
@@ -40,8 +40,6 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.MirroredTypeException;
-import javax.lang.model.type.MirroredTypesException;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
@@ -54,7 +52,6 @@ import org.netbeans.spi.debugger.DebuggerServiceRegistration;
 import org.netbeans.spi.debugger.DebuggerServiceRegistrations;
 import org.netbeans.spi.debugger.SessionProvider;
 import org.openide.filesystems.annotations.LayerBuilder;
-import org.openide.filesystems.annotations.LayerBuilder.File;
 import org.openide.filesystems.annotations.LayerGeneratingProcessor;
 import org.openide.filesystems.annotations.LayerGenerationException;
 import org.openide.util.lookup.ServiceProvider;
@@ -64,7 +61,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Martin Entlicher
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class DebuggerProcessor extends LayerGeneratingProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingRegistrationProcessor.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/BugtrackingRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.bugtracking.spi.BugtrackingConnector;
@@ -38,7 +36,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Tomas Stupka
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class BugtrackingRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/ide/core.ide/src/org/netbeans/core/ide/ServiceTabProcessor.java
+++ b/ide/core.ide/src/org/netbeans/core/ide/ServiceTabProcessor.java
@@ -23,8 +23,6 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.api.core.ide.ServicesTabNodeRegistration;
@@ -53,7 +51,6 @@ import org.openide.util.lookup.ServiceProvider;
     showInFileChooser={"#PlainResolver.FileChooserName", "#ResourceFiles"}
 )
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class ServiceTabProcessor extends LayerGeneratingProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/ide/csl.api/src/org/netbeans/modules/csl/core/LanguageRegistrationProcessor.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/core/LanguageRegistrationProcessor.java
@@ -26,8 +26,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -69,7 +67,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.csl.spi.LanguageRegistration") //NOI18N
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class LanguageRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorActionRegistrationProcessor.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorActionRegistrationProcessor.java
@@ -26,8 +26,6 @@ import org.netbeans.modules.editor.lib2.actions.EditorActionUtilities;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -49,7 +47,6 @@ import org.openide.util.lookup.ServiceProvider;
  * and {@link EditorActionRegistrations}.
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public final class EditorActionRegistrationProcessor extends LayerGeneratingProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/ide/extexecution/src/org/netbeans/modules/extexecution/startup/StartupExtenderRegistrationProcessor.java
+++ b/ide/extexecution/src/org/netbeans/modules/extexecution/startup/StartupExtenderRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.api.extexecution.startup.StartupExtender.StartMode;
@@ -39,7 +37,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @SupportedAnnotationTypes("org.netbeans.spi.extexecution.startup.StartupExtenderImplementation.Registration")
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class StartupExtenderRegistrationProcessor extends LayerGeneratingProcessor {
 
     public static final String PATH = "StartupExtender"; // NOI18N

--- a/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/CoreManagerProcessor.java
+++ b/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/CoreManagerProcessor.java
@@ -23,8 +23,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.gsf.testrunner.api.CoreManager;
@@ -39,7 +37,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.gsf.testrunner.api.CoreManager.Registration")
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 public class CoreManagerProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/TestCreatorProviderProcessor.java
+++ b/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/TestCreatorProviderProcessor.java
@@ -19,13 +19,9 @@
 package org.netbeans.modules.gsf.testrunner;
 
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.gsf.testrunner.api.TestCreatorProvider;
@@ -41,7 +37,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.gsf.testrunner.api.TestCreatorProvider.Registration")
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class TestCreatorProviderProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/ide/parsing.api/src/org/netbeans/modules/parsing/impl/EmbeddingProviderRegistrationProcessor.java
+++ b/ide/parsing.api/src/org/netbeans/modules/parsing/impl/EmbeddingProviderRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.parsing.spi.EmbeddingProvider;
@@ -37,7 +35,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Tomas Zezula
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class EmbeddingProviderRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerRegistrationProcessor.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
@@ -41,7 +39,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Tomas Zezula
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public final class IndexerRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRecognizerRegistrationProcessor.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/PathRecognizerRegistrationProcessor.java
@@ -23,8 +23,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.parsing.spi.indexing.PathRecognizer;
@@ -41,7 +39,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.parsing.spi.indexing.PathRecognizerRegistration") //NOI18N
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class PathRecognizerRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/ide/project.ant/src/org/netbeans/modules/project/ant/AntBasedProcessor.java
+++ b/ide/project.ant/src/org/netbeans/modules/project/ant/AntBasedProcessor.java
@@ -23,8 +23,6 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -32,7 +30,6 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.project.ant.AntBasedProjectFactorySingleton;
 import org.netbeans.spi.project.support.ant.AntBasedProjectRegistration;
 import org.netbeans.spi.project.support.ant.AntBasedProjectType;
 import org.netbeans.spi.project.support.ant.AntProjectHelper;
@@ -46,7 +43,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Jaroslav Tulach
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class AntBasedProcessor extends LayerGeneratingProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/ide/projectapi/src/org/netbeans/modules/projectapi/LookupProviderAnnotationProcessor.java
+++ b/ide/projectapi/src/org/netbeans/modules/projectapi/LookupProviderAnnotationProcessor.java
@@ -27,8 +27,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
@@ -57,7 +55,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author mkleint
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class LookupProviderAnnotationProcessor extends LayerGeneratingProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/ide/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/ProjectConvertorProcessor.java
+++ b/ide/projectuiapi.base/src/org/netbeans/modules/project/ui/convertor/ProjectConvertorProcessor.java
@@ -24,8 +24,6 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
@@ -41,7 +39,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Tomas Zezula
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class ProjectConvertorProcessor extends LayerGeneratingProcessor {
     @Override
     public Set<String> getSupportedAnnotationTypes() {

--- a/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/CompositeCategoryProviderAnnotationProcessor.java
+++ b/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/CompositeCategoryProviderAnnotationProcessor.java
@@ -24,8 +24,6 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -38,7 +36,6 @@ import org.openide.filesystems.annotations.LayerGenerationException;
 import org.openide.util.lookup.ServiceProvider;
 
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class CompositeCategoryProviderAnnotationProcessor extends LayerGeneratingProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/NodeFactoryAnnotationProcessor.java
+++ b/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/NodeFactoryAnnotationProcessor.java
@@ -23,8 +23,6 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.spi.project.ui.support.NodeFactory;
@@ -37,7 +35,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author mkleint
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class NodeFactoryAnnotationProcessor extends LayerGeneratingProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ScopeAnnotationProcessor.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/ScopeAnnotationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
@@ -41,7 +39,6 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @author Ralph Benjamin Ruijs <ralphbenjamin@netbeans.org>
  */
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 @SupportedAnnotationTypes({"org.netbeans.modules.refactoring.spi.ui.ScopeDescription",
 "org.netbeans.modules.refactoring.spi.ui.ScopeReference",
 "org.netbeans.modules.refactoring.spi.ui.ScopeReferences"})

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beansdev/Schema2BeansProcessor.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beansdev/Schema2BeansProcessor.java
@@ -34,7 +34,6 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.FilerException;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
@@ -42,20 +41,23 @@ import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
-import org.apache.tools.ant.util.FileUtils;
 import org.netbeans.modules.schema2beans.Schema2Beans;
 import org.netbeans.modules.schema2beans.Schema2Beans.Multiple;
 import org.netbeans.modules.schema2beansdev.GenBeans.Config;
 import org.openide.util.lookup.ServiceProvider;
 
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class Schema2BeansProcessor extends AbstractProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {
         return new HashSet<String>(Arrays.asList(
                 Schema2Beans.class.getCanonicalName(),
                 Multiple.class.getCanonicalName()));
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
 
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/DebuggerProcessor.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/registry/DebuggerProcessor.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -56,7 +54,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Martin Entlicher
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class DebuggerProcessor extends LayerGeneratingProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/ide/spi.navigator/src/org/netbeans/modules/navigator/NavigatorPanelRegistrationProcessor.java
+++ b/ide/spi.navigator/src/org/netbeans/modules/navigator/NavigatorPanelRegistrationProcessor.java
@@ -24,8 +24,6 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.spi.navigator.NavigatorPanel;
@@ -34,7 +32,6 @@ import org.openide.filesystems.annotations.LayerGenerationException;
 import org.openide.util.lookup.ServiceProvider;
 
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class NavigatorPanelRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override public Set<String> getSupportedAnnotationTypes() {

--- a/ide/spi.palette/src/org/netbeans/modules/palette/PaletteItemRegistrationProcessor.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/PaletteItemRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -42,7 +40,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Eric Barboni <skygo@netbeans.org>
  */
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 @SupportedAnnotationTypes({"org.netbeans.spi.palette.PaletteItemRegistration", "org.netbeans.spi.palette.PaletteItemRegistrations"})
 public final class PaletteItemRegistrationProcessor extends LayerGeneratingProcessor {
 

--- a/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/CreateRegistrationProcessor.java
+++ b/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/CreateRegistrationProcessor.java
@@ -31,8 +31,6 @@ import javax.annotation.processing.Completion;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
@@ -55,7 +53,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @SupportedAnnotationTypes({"org.netbeans.modules.textmate.lexer.api.GrammarRegistration", "org.netbeans.modules.textmate.lexer.api.GrammarRegistrations",
     "org.netbeans.modules.textmate.lexer.api.GrammarInjectionRegistration", "org.netbeans.modules.textmate.lexer.api.GrammarInjectionRegistrations"})
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @ServiceProvider(service = Processor.class)
 public class CreateRegistrationProcessor extends LayerGeneratingProcessor {
 

--- a/ide/versioning.core/src/org/netbeans/modules/versioning/core/VCSRegistrationProcessor.java
+++ b/ide/versioning.core/src/org/netbeans/modules/versioning/core/VCSRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.versioning.core.spi.VersioningSystem;
@@ -38,7 +36,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Tomas Stupka
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class VCSRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/ide/versioning/src/org/netbeans/modules/versioning/VCSRegistrationProcessor.java
+++ b/ide/versioning/src/org/netbeans/modules/versioning/VCSRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.versioning.spi.VersioningSystem;
@@ -38,7 +36,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Tomas Stupka
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class VCSRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/java/api.debugger.jpda/src/org/netbeans/modules/debugger/jpda/apiregistry/DebuggerProcessor.java
+++ b/java/api.debugger.jpda/src/org/netbeans/modules/debugger/jpda/apiregistry/DebuggerProcessor.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -54,7 +52,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Martin Entlicher
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class DebuggerProcessor extends LayerGeneratingProcessor {
 
     public static final String SERVICE_NAME = "serviceName"; // NOI18N

--- a/java/java.hints/nbproject/project.properties
+++ b/java/java.hints/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-spec.version.base=1.89.0
+spec.version.base=1.90.0
 
 javac.source=1.8
 

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/AnnotationProcessors.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/AnnotationProcessors.java
@@ -18,18 +18,42 @@
  */
 package org.netbeans.modules.java.hints.jdk;
 
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.BlockTree;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ModifiersTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
+import com.sun.source.util.TreePath;
+import java.util.Collections;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Types;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.TreeMaker;
+import org.netbeans.api.java.source.WorkingCopy;
+import org.netbeans.modules.java.hints.errors.Utilities;
 import org.netbeans.spi.editor.hints.ErrorDescription;
+import org.netbeans.spi.editor.hints.Fix;
+import org.netbeans.spi.java.hints.ConstraintVariableType;
 import org.netbeans.spi.java.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.java.hints.Hint;
 import org.netbeans.spi.java.hints.HintContext;
+import org.netbeans.spi.java.hints.JavaFix;
+import org.netbeans.spi.java.hints.JavaFixUtilities;
+import org.netbeans.spi.java.hints.TriggerPattern;
 import org.netbeans.spi.java.hints.TriggerTreeKind;
+import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
 
 /**
@@ -37,6 +61,8 @@ import org.openide.util.NbBundle.Messages;
  * @author lahvac
  */
 public class AnnotationProcessors {
+    private AnnotationProcessors() {
+    }
 
     @Hint(displayName="#DN_AnnotationProcessors.overridingGetSupportedAnnotations",
           description="#DESC_AnnotationProcessors.overridingGetSupportedAnnotations",
@@ -71,5 +97,409 @@ public class AnnotationProcessors {
         }
 
         return null;
+    }
+    
+    private static final String PROCESSOR_TYPE = Processor.class.getName();
+    private static final String ABSTRACT_PROCESSOR_TYPE = AbstractProcessor.class.getName();
+    private static final String SUPPORTED_SOURCE_TYPE = SupportedSourceVersion.class.getName();
+    private static final String SOURCE_VERSION_TYPE = SourceVersion.class.getName();
+
+    private static final String METHOD_SUPPORTED_SOURCE_VERSION = "getSupportedSourceVersion"; // NOI18N
+    
+    
+    /**
+     * Warns on incorrect @{@link SupportedSourceVersion} annotation. The hint triggers in
+     * following cases, if the class does <b>not</b> override {@link javax.annotation.processing.Processor#getSupportedSourceVersion()}.
+     * <ul>
+     * <li>Class derived from AbstractProcessor with no annotation at all: defaults to 1.6, which
+     * is almost certainly wrong.
+     * <li>Declares {@code @SupportedSourceVersion} earlier than the project's source level.
+     * </ul>
+     * Offers a hint to declare a {@code @SupportedSourceVersion} or to override the {@code getSupportedSourceVersion}
+     * to return {@link SourceVersion#latest()}.
+     * @param ctx
+     * @return 
+     */
+    @Hint(
+        category = "rules15",
+        displayName = "#DN_AnnoProcessor_ObsoleteSupportedSource",
+        description = "#DESC_AnnoProcessor_ObsoleteSupportedSource",
+        id = "obsoleteAnnotationSupportedSource",
+        suppressWarnings = "ObsoleteAnnotationSupportedSource"
+    )
+    @TriggerPattern(
+        value = "$modifiers$ class $name extends $superClass$ implements $superInterfaces$ { $body$; }", 
+            constraints = @ConstraintVariableType(
+                variable = "$superInterfaces",
+                type = "javax.annotation.processing.Processor"
+        )
+    )
+    @NbBundle.Messages({
+        "DN_AnnoProcessor_ObsoleteSupportedSource=Missing or obsolete @SupportedSourceVersion",
+        "HINT_AnnoProcessor_DeclaredSourceObsolete=Annoration declares older source version than the project source level.",
+        "HINT_AnnoProcessor_NoSupportedSource=No @SupportedSourceVersion is declared, the default (1.6) is older than project source level."
+    })
+    public static ErrorDescription annotatedByObsoleteSource(HintContext ctx) {
+        CompilationInfo info = ctx.getInfo();
+        ProcessorHintSupport helper = new ProcessorHintSupport(ctx.getInfo(), ctx.getPath());
+        if (!helper.initialize()) {
+            return null;
+        }
+        // not an AbstractProcessor; or overrides the getSupported method.
+        if (!helper.canOverrideAbstract(true)) {
+            return null;
+        }
+        SupportedSourceVersion ssv = helper.getProcessor().getAnnotation(SupportedSourceVersion.class);
+        SourceVersion current = info.getSourceVersion();
+        if (ssv != null) {
+            SourceVersion declared = ssv.value();
+            if (declared.compareTo(current) >= 0) {
+                // OK
+                return null;
+            }
+            TreePath rewriteAt = helper.findSupportedAnnotation();
+            if (rewriteAt == null) {
+                return null;
+            }
+            
+            return ErrorDescriptionFactory.forTree(ctx, rewriteAt, 
+                    Bundle.HINT_AnnoProcessor_DeclaredSourceObsolete(), 
+                    // suggest to generate latest()
+                    new OverrideReturnLatest(info, rewriteAt, false).toEditorFix(),
+                    new OverrideReturnLatest(info, rewriteAt, true).toEditorFix(),
+                    // suggest change to the current version
+                    changeToCurrentSource(ctx, helper, info.getSourceVersion())
+            );
+        } else {
+            TreePath path = helper.getProcessorPath();
+            return ErrorDescriptionFactory.forTree(ctx, path, 
+                    Bundle.HINT_AnnoProcessor_NoSupportedSource(), 
+                    new OverrideReturnLatest(info, path, false).toEditorFix(),
+                    new OverrideReturnLatest(info, path, true).toEditorFix(),
+                    new DeclareCurrentSourceFix(info, path, info.getSourceVersion()).toEditorFix()
+            );
+        }
+    }
+    
+    /**
+     * Code factored out from various hint branches.
+     */
+    public static class ProcessorHintSupport {
+        private final CompilationInfo info;
+        private final TreePath processorPath;
+        
+        private TypeElement baseProcessor;
+        private TypeMirror baseProcessorType;
+        private TypeElement abstractProcessor;
+        private TypeMirror abstractProcessorType;
+        private TypeElement supportedSource;
+        private TypeMirror supportedSourceType;
+
+        private TypeElement processor;
+        
+        private ExecutableElement abstractGetSupported;
+
+        private ExecutableElement overridenGetSupported;
+        
+        public ProcessorHintSupport(CompilationInfo info, TreePath path) {
+            this.info = info;
+            this.processorPath = path;
+        }
+        
+        public ExecutableElement findOverridenSupportedSource() {
+            Element e = info.getElementUtilities().getImplementationOf(abstractGetSupported, processor);
+            if (e == null || e.getEnclosingElement() == abstractProcessor || e.getKind() != ElementKind.METHOD) {
+                return null;
+            }
+            return (ExecutableElement)e;
+        }
+        
+        /**
+         * Checks if the annotation types are reachable, initializes
+         * types and elements for the API types.
+         * @return false if the code is not in good shape.
+         */
+        public boolean initialize() {
+            Element e = info.getTrees().getElement(processorPath);
+            if (e == null || e.getKind() != ElementKind.CLASS) {
+                return false;
+            }
+            processor = (TypeElement)e;
+            if (processorPath.getLeaf().getKind() != Tree.Kind.CLASS) {
+                return false;
+            }
+
+            abstractProcessor = info.getElements().getTypeElement(ABSTRACT_PROCESSOR_TYPE);
+            if (!Utilities.isValidElement(e)) {
+                return false;
+            }
+            abstractProcessorType = abstractProcessor.asType();
+            baseProcessor = info.getElements().getTypeElement(PROCESSOR_TYPE);
+            if (!Utilities.isValidElement(e)) {
+                return false;
+            }
+            baseProcessorType = baseProcessor.asType();
+            supportedSource = info.getElements().getTypeElement(SUPPORTED_SOURCE_TYPE);
+            if (!Utilities.isValidElement(supportedSource)) {
+                return false;
+            }
+            supportedSourceType = supportedSource.asType();
+            if (!Utilities.isValidType(supportedSourceType)) {
+                return false;
+            }
+            ExecutableElement ee = findGetSupported(abstractProcessor);
+            if (ee == null) {
+                return false;
+            }
+            abstractGetSupported = ee;
+            
+            return info.getTypes().isSubtype(processor.asType(), abstractProcessor.getSuperclass());
+        }
+        
+        public ExecutableElement findGetSupported(Element clazz) {
+            return ElementFilter.methodsIn(
+                    clazz.getEnclosedElements()).
+                    stream().filter(
+                            (ExecutableElement x)
+                            -> x.getSimpleName().contentEquals(METHOD_SUPPORTED_SOURCE_VERSION)
+                    ).
+                    findAny().
+                    orElse(null);
+        }
+        
+        public boolean canOverrideProcessor(boolean checkOverride) {
+            if (!info.getTypes().isSubtype(processor.asType(), baseProcessorType)) {
+                return false;
+            }
+            if (!checkOverride) {
+                return true;
+            }
+            ExecutableElement ee = findGetSupported(baseProcessor);
+            if (ee == null) {
+                return false;
+            }
+            Element e = info.getElementUtilities().getImplementationOf(ee, processor);
+            if (e == null) {
+                return true;
+            }
+            if (!Utilities.isValidElement(e) || e.getKind() != ElementKind.METHOD) {
+                return false;
+            }
+            overridenGetSupported = (ExecutableElement)e;
+            return e.getEnclosingElement() == baseProcessor || 
+                e.getEnclosingElement() == abstractProcessor;
+        }
+        
+        /**
+         * Determines if the class derives from AbstractProcessor.
+         * @param checkOverride checks that getSupported* method is overriden
+         * @return true if derived and method is NOT overriden
+         */
+        public boolean canOverrideAbstract(boolean checkOverride) {
+            if (!info.getTypes().isSubtype(processor.asType(), abstractProcessorType)) {
+                return false;
+            }
+            if (!checkOverride) {
+                return true;
+            }
+            Element e = info.getElementUtilities().getImplementationOf(abstractGetSupported, processor);
+            if (e == null) {
+                return true;
+            }
+            if (!Utilities.isValidElement(e) || e.getKind() != ElementKind.METHOD) {
+                return false;
+            }
+            overridenGetSupported = (ExecutableElement)e;
+            return e.getEnclosingElement() == abstractProcessor;
+        }
+
+        public TypeElement getProcessor() {
+            return processor;
+        }
+        
+        public TreePath findSupportedAnnotation() {
+            ClassTree ct = (ClassTree) processorPath.getLeaf();
+            TreePath modPath = new TreePath(processorPath, ct.getModifiers());
+            for (AnnotationTree at : ct.getModifiers().getAnnotations()) {
+                TreePath tp = new TreePath(modPath, at);
+                TypeMirror am = info.getTrees().getTypeMirror(tp);
+                if (info.getTypes().isSameType(am, supportedSourceType)) {
+                    return tp;
+                }
+            }
+            return null;
+        }
+
+        public ExecutableElement getOverridenGetSupported() {
+            return overridenGetSupported;
+        }
+
+        public TreePath getProcessorPath() {
+            return processorPath;
+        }
+        
+        public void makeGetSupportedOverride(WorkingCopy wc, SourceVersion projectSource) {
+            TreeMaker make = wc.getTreeMaker();
+            
+            BlockTree body = make.Block(Collections.singletonList(
+                    make.Return(
+                            projectSource != null ? 
+                                make.MemberSelect(
+                                        make.QualIdent(SOURCE_VERSION_TYPE),
+                                        projectSource.name()
+                                ) :
+                                make.MethodInvocation(Collections.emptyList(), 
+                                        make.MemberSelect(
+                                                make.QualIdent(SOURCE_VERSION_TYPE),
+                                                "latest" // NOI18N
+                                        ),
+                                        Collections.emptyList())
+                    )
+                ), false);
+            MethodTree overrideMethod = make.Method(
+                    make.Modifiers(Collections.singleton(Modifier.PUBLIC), 
+                            // @Override is since 1.5 as well as AnnotationProcessors.
+                            // we always implement in subclass; so @Override is desired.
+                            Collections.singletonList(
+                                    make.Annotation(make.Identifier("Override"), Collections.emptyList())
+                            )),
+                    METHOD_SUPPORTED_SOURCE_VERSION,
+                    make.QualIdent(SOURCE_VERSION_TYPE),
+                    Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), body, 
+                    null);
+        
+            ClassTree ct = (ClassTree)getProcessorPath().getLeaf();
+            ClassTree nct = make.addClassMember(ct, overrideMethod);
+            wc.rewrite(ct, nct);
+        }
+    }        
+    
+    /**
+     * Creates a fix that changes the annotation to the current project's source
+     * level.
+     * @param target the target source version
+     * @return 
+     */
+    @NbBundle.Messages({
+        "# {0} - project source level",
+        "FIX_AnnoProcessor_UseProjectSourceLevel=Use the project's source level ({0})",
+        "# {0} - the target level",
+        "FIX_AnnoProcessor_SpecificSourceLevel=Use the source level {0}"
+    })
+    static Fix changeToCurrentSource(HintContext ctx, ProcessorHintSupport support, SourceVersion target) {
+        TreePath rewriteAt = support.findSupportedAnnotation();
+        if (rewriteAt == null) {
+            return null;
+        }
+        String msg = ctx.getInfo().getSourceVersion().compareTo(target) == 0 ?
+                Bundle.FIX_AnnoProcessor_SpecificSourceLevel(levelToString(target)) :
+                Bundle.FIX_AnnoProcessor_UseProjectSourceLevel(levelToString(target));
+        return JavaFixUtilities.rewriteFix(ctx, msg, rewriteAt, 
+                "@javax.annotation.processing.SupportedSourceVersion(javax.lang.model.SourceVersion." + 
+                        target.name() + ")");
+    }
+    
+    public static String levelToString(SourceVersion l) {
+        String s = l.name();
+        switch (l) {
+            case RELEASE_0:
+                return "1";
+            case RELEASE_1:
+                return "1.1";
+            case RELEASE_2: case RELEASE_3: case RELEASE_4:
+                return "1." + s.charAt(s.length() - 1);
+            default:
+                int under = s.lastIndexOf('_');
+                return s.substring(under + 1);
+        }
+    }
+    
+    @NbBundle.Messages({
+            "# {0} - project's source level",
+            "FIX_AnnoProcessor_OverrideProjectSupported=Override getSupportedSourceVersion() and return project''s source level ({0})",
+            "FIX_AnnoProcessor_OverrideLatestSupported=Override getSupportedSourceVersion() and return SourceVersion.latest()"
+    })
+    public static class OverrideReturnLatest extends JavaFix {
+        private final SourceVersion projectSource;
+        
+        public OverrideReturnLatest(CompilationInfo info, TreePath tp, boolean project) {
+            super(info, tp, createSortedText(project));
+            if (project) {
+                projectSource = info.getSourceVersion();
+            } else {
+                projectSource = null;
+            }
+        }
+        
+        private static String createSortedText(boolean project) {
+            return project ?
+                    "010:FIX_AnnoProcessor_OverrideProjectSupported" :
+                    "000:FIX_AnnoProcessor_OverrideLatestSupported";
+        }
+        
+        @Override
+        protected String getText() {
+            return projectSource != null ?
+                    Bundle.FIX_AnnoProcessor_OverrideProjectSupported(levelToString(projectSource)):
+                    Bundle.FIX_AnnoProcessor_OverrideLatestSupported();
+        }
+
+        @Override
+        protected void performRewrite(TransformationContext ctx) throws Exception {
+            TreePath path = ctx.getPath();
+            if (path.getLeaf().getKind() != Tree.Kind.CLASS) {
+                return;
+            }
+            ProcessorHintSupport support = new ProcessorHintSupport(ctx.getWorkingCopy(), path);
+            support.makeGetSupportedOverride(ctx.getWorkingCopy(), projectSource);
+        }
+    }
+    
+    @NbBundle.Messages({
+        "# {0} - project source level",
+        "FIX_AnnoProcessor_AddProjectSourceLevel=Declare the project''s source level ({0})",
+        "# {0} - the target level",
+        "FIX_AnnoProcessor_AddSpecificSourceLevel=Declare the source level {0}"
+    })
+    private static class DeclareCurrentSourceFix extends JavaFix {
+        private final SourceVersion target;
+        private final boolean project;
+        
+        DeclareCurrentSourceFix(CompilationInfo info, TreePath tp, SourceVersion target) {
+            super(info, tp);
+            this.target = target;
+            this.project = target.compareTo(info.getSourceVersion()) == 0;
+        }
+        
+        @Override
+        protected String getText() {
+            return project ? 
+                    Bundle.FIX_AnnoProcessor_AddProjectSourceLevel(levelToString(target)) :
+                    Bundle.FIX_AnnoProcessor_AddSpecificSourceLevel(levelToString(target));
+        }
+
+        @Override
+        protected void performRewrite(TransformationContext ctx) throws Exception {
+            TreePath cpath = ctx.getPath();
+            if (cpath.getLeaf().getKind() != Tree.Kind.CLASS) {
+                return;
+            }
+            WorkingCopy wc = ctx.getWorkingCopy();
+            TreeMaker make = wc.getTreeMaker();
+            ClassTree ct = (ClassTree)cpath.getLeaf();
+            ModifiersTree mt = ct.getModifiers();
+            ModifiersTree nmt = make.Modifiers(mt, Collections.singletonList(
+                    make.Annotation(
+                            make.QualIdent(SUPPORTED_SOURCE_TYPE),
+                            Collections.singletonList(
+                                    make.MemberSelect(
+                                            make.QualIdent(SOURCE_VERSION_TYPE), 
+                                            wc.getSourceVersion().name()
+                                    )
+                            )
+                    )
+            ));
+            wc.rewrite(mt, nmt);
+        }
     }
 }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/Bundle.properties
@@ -104,3 +104,10 @@ DN_CanUseVarForExplicitType=Convert Explicit Type to Var
 DESC_CanUseVarForExplicitType=Converts explicit type of local variable to var.
 DN_ConvertVarToExplicitType=Convert Var to Explicit Type
 DESC_ConvertVarToExplicitType=Converts var type local variable to explicit type.
+
+DESC_AnnoProcessor_ObsoleteSupportedSource=If the project's source level is greater than the maximum supported by the Annotation Processor, compilation that uses the \
+    Processor always generates an useless compiler warning. If the processor does not declare <b>any @SupportedSourceVersion at all</b>. \
+    derives from <b>javax.annotation.processing.AbstractProcessor</b>,  the maximum supported version will <b>default to 1.6</b>, which will produce \
+    another useless warning during compilation. <p/>\
+    It is recommended to return at least the current project's source level. \
+    For future compatibility, consider to return <b>SourceVersion.latest()</b>; most Processors are not affected by future language changes.

--- a/java/java.hints/src/org/netbeans/modules/java/hints/ui/AnnoProcessorGenerator.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/ui/AnnoProcessorGenerator.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.hints.ui;
+
+import com.sun.source.util.TreePath;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.lang.model.element.TypeElement;
+import javax.swing.text.JTextComponent;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.java.source.CompilationController;
+import org.netbeans.api.java.source.ElementHandle;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.ModificationResult;
+import org.netbeans.api.java.source.Task;
+import org.netbeans.api.java.source.TreeUtilities;
+import org.netbeans.api.java.source.WorkingCopy;
+import org.netbeans.modules.java.editor.codegen.GeneratorUtils;
+import org.netbeans.modules.java.hints.errors.Utilities;
+import org.netbeans.modules.java.hints.jdk.AnnotationProcessors.ProcessorHintSupport;
+import org.netbeans.spi.editor.codegen.CodeGenerator;
+import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
+
+/**
+ *
+ * @author sdedic
+ */
+@MimeRegistration(mimeType = "text/x-java", service = CodeGenerator.Factory.class)
+public class AnnoProcessorGenerator implements CodeGenerator.Factory {
+    
+    @Override
+    public List<? extends CodeGenerator> create(Lookup context) {
+        ArrayList<CodeGenerator> ret = new ArrayList<>();
+        JTextComponent component = context.lookup(JTextComponent.class);
+        CompilationController controller = context.lookup(CompilationController.class);
+        if (component == null || controller == null) {
+            return ret;
+        }
+        TreePath path = context.lookup(TreePath.class);
+        path = controller.getTreeUtilities().getPathElementOfKind(TreeUtilities.CLASS_TREE_KINDS, path);
+        if (path == null) {
+            return ret;
+        }
+        try {
+            controller.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
+        } catch (IOException ioe) {
+            return ret;
+        }
+
+        ProcessorHintSupport supp = new ProcessorHintSupport(controller, path);
+        if (!supp.initialize()) {
+            return ret;
+        }
+        if (!supp.canOverrideProcessor(true)) {
+            return ret;
+        }
+        ret.add(new Gen(component, ElementHandle.create(supp.getProcessor())));
+        return ret;
+    }
+
+    private static class Gen implements CodeGenerator {
+        private final ElementHandle<TypeElement> handle;
+        private final JTextComponent component;
+        
+        public Gen(JTextComponent component, ElementHandle<TypeElement> handle) {
+            this.component = component;
+            this.handle = handle;
+        }
+
+        @NbBundle.Messages({
+                "GEN_AnnoProcessor_OverrideLatestSupported=Support SourceVersion.latest()"
+        })
+        @Override
+        public String getDisplayName() {
+            return Bundle.GEN_AnnoProcessor_OverrideLatestSupported();
+        }
+
+        @Override
+        public void invoke() {
+            JavaSource js = JavaSource.forDocument(component.getDocument());
+            if (js == null) {
+                return;
+            }
+            try {
+                ModificationResult mr = js.runModificationTask(new Mod(handle));
+                GeneratorUtils.guardedCommit(component, mr);
+                int span[] = mr.getSpan("methodBodyTag"); // NOI18N
+                if(span != null) {
+                    component.setSelectionStart(span[0]);
+                    component.setSelectionEnd(span[1]);
+                }
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+    }
+    private static class Mod implements Task<WorkingCopy> {
+        private final ElementHandle<TypeElement> handle;
+
+        public Mod(ElementHandle<TypeElement> handle) {
+            this.handle = handle;
+        }
+        
+        @Override
+        public void run(WorkingCopy parameter) throws Exception {
+            parameter.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
+            TypeElement resolved = handle.resolve(parameter);
+            if (!Utilities.isValidElement(resolved)) {
+                return;
+            }
+            TreePath path = parameter.getTrees().getPath(resolved);
+            if (path == null) {
+                return;
+            }
+            
+            ProcessorHintSupport supp = new ProcessorHintSupport(parameter, path);
+            if (!supp.initialize() || !supp.canOverrideProcessor(true)) {
+                return;
+            }
+            supp.makeGetSupportedOverride(parameter, null, true);
+        }
+    }
+}

--- a/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/NodeOpenerProcessor.java
+++ b/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/NodeOpenerProcessor.java
@@ -24,8 +24,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.openide.filesystems.annotations.LayerBuilder;
@@ -39,7 +37,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.java.testrunner.ui.api.NodeOpener.Registration")
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 public class NodeOpenerProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/java/spi.debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/apiregistry/DebuggerProcessor.java
+++ b/java/spi.debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/apiregistry/DebuggerProcessor.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -49,7 +47,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Martin Entlicher
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class DebuggerProcessor extends LayerGeneratingProcessor {
 
     public static final String SERVICE_NAME = "serviceName"; // NOI18N

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/processor/JavaHintsAnnotationProcessor.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/processor/JavaHintsAnnotationProcessor.java
@@ -22,15 +22,12 @@ package org.netbeans.modules.java.hints.spiimpl.processor;
 import java.lang.reflect.Array;
 import java.util.Map.Entry;
 import java.util.*;
-import java.util.AbstractMap.SimpleEntry;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
@@ -44,14 +41,12 @@ import org.openide.filesystems.annotations.LayerBuilder;
 import org.openide.filesystems.annotations.LayerBuilder.File;
 import org.openide.filesystems.annotations.LayerGeneratingProcessor;
 import org.openide.filesystems.annotations.LayerGenerationException;
-import org.openide.util.NbCollections;
 import org.openide.util.lookup.ServiceProvider;
 
 /**Inspired by https://sezpoz.dev.java.net/.
  *
  * @author lahvac
  */
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 @SupportedAnnotationTypes("org.netbeans.spi.java.hints.*")
 @ServiceProvider(service=Processor.class, position=100)
 public class JavaHintsAnnotationProcessor extends LayerGeneratingProcessor {

--- a/php/php.api.annotation/src/org/netbeans/modules/php/api/annotation/registration/AnnotationLineParserRegistrationProcessor.java
+++ b/php/php.api.annotation/src/org/netbeans/modules/php/api/annotation/registration/AnnotationLineParserRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.php.api.annotation.PhpAnnotations;
@@ -38,7 +36,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @SupportedAnnotationTypes("org.netbeans.modules.php.spi.annotation.AnnotationLineParser.Registration")
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class AnnotationLineParserRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/php/php.api.annotation/src/org/netbeans/modules/php/api/annotation/registration/PhpAnnotationsRegistrationProcessor.java
+++ b/php/php.api.annotation/src/org/netbeans/modules/php/api/annotation/registration/PhpAnnotationsRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.php.api.annotation.PhpAnnotations;
@@ -34,7 +32,6 @@ import org.openide.util.lookup.ServiceProvider;
 
 @SupportedAnnotationTypes("org.netbeans.modules.php.spi.annotation.AnnotationCompletionTagProvider.Registration")
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class PhpAnnotationsRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/php/php.api.documentation/src/org/netbeans/modules/php/api/documentation/registration/PhpDocumentationRegistrationProcessor.java
+++ b/php/php.api.documentation/src/org/netbeans/modules/php/api/documentation/registration/PhpDocumentationRegistrationProcessor.java
@@ -23,8 +23,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.php.api.documentation.PhpDocumentations;
@@ -38,7 +36,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @SupportedAnnotationTypes("org.netbeans.modules.php.spi.documentation.PhpDocumentationProvider.Registration")
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class PhpDocumentationRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/php/php.api.framework/src/org/netbeans/modules/php/api/framework/registration/PhpFrameworkRegistrationProcessor.java
+++ b/php/php.api.framework/src/org/netbeans/modules/php/api/framework/registration/PhpFrameworkRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.php.api.framework.PhpFrameworks;
@@ -34,7 +32,6 @@ import org.openide.util.lookup.ServiceProvider;
 
 @SupportedAnnotationTypes("org.netbeans.modules.php.spi.framework.PhpFrameworkProvider.Registration")
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class PhpFrameworkRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/php/php.api.phpmodule/src/org/netbeans/modules/php/api/ui/options/PhpOptionsPanelControllerProcessor.java
+++ b/php/php.api.phpmodule/src/org/netbeans/modules/php/api/ui/options/PhpOptionsPanelControllerProcessor.java
@@ -24,8 +24,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.php.api.util.UiUtils.PhpOptionsPanelRegistration;
@@ -40,7 +38,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author S. Aubrecht
  */
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 @SupportedAnnotationTypes("org.netbeans.modules.php.api.util.UiUtils.PhpOptionsPanelRegistration")
 public class PhpOptionsPanelControllerProcessor extends LayerGeneratingProcessor {
 

--- a/php/php.api.testing/src/org/netbeans/modules/php/api/testing/registration/PhpTestingRegistrationProcessor.java
+++ b/php/php.api.testing/src/org/netbeans/modules/php/api/testing/registration/PhpTestingRegistrationProcessor.java
@@ -23,8 +23,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.php.api.testing.PhpTesting;
@@ -38,7 +36,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @SupportedAnnotationTypes("org.netbeans.modules.php.spi.testing.PhpTestingProvider.Registration")
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class PhpTestingRegistrationProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/platform/api.annotations.common/src/org/netbeans/api/annotations/common/proc/StaticResourceProcessor.java
+++ b/platform/api.annotations.common/src/org/netbeans/api/annotations/common/proc/StaticResourceProcessor.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.PackageElement;
@@ -38,11 +37,15 @@ import javax.tools.JavaFileManager;
 import javax.tools.StandardLocation;
 import org.netbeans.api.annotations.common.StaticResource;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class StaticResourceProcessor extends AbstractProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {
         return Collections.singleton(StaticResource.class.getCanonicalName());
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
 
     @Override public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/platform/api.htmlui/src/org/netbeans/modules/htmlui/HTMLDialogProcessor.java
+++ b/platform/api.htmlui/src/org/netbeans/modules/htmlui/HTMLDialogProcessor.java
@@ -33,7 +33,6 @@ import java.util.TreeSet;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -58,7 +57,6 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @author Jaroslav Tulach
  */
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 @ServiceProvider(service = Processor.class)
 public class HTMLDialogProcessor extends AbstractProcessor
 implements Comparator<ExecutableElement> {
@@ -68,6 +66,11 @@ implements Comparator<ExecutableElement> {
         hash.add(HTMLDialog.class.getCanonicalName());
         hash.add(HTMLComponent.class.getCanonicalName());
         return hash;
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
     
     private Set<Element> annotatedWith(RoundEnvironment re, Class<? extends Annotation> type) {

--- a/platform/api.htmlui/src/org/netbeans/modules/htmlui/HTMLViewProcessor.java
+++ b/platform/api.htmlui/src/org/netbeans/modules/htmlui/HTMLViewProcessor.java
@@ -22,8 +22,6 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -41,7 +39,6 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @author jtulach
  */
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 @ServiceProvider(service = Processor.class)
 public class HTMLViewProcessor extends LayerGeneratingProcessor {
     @Override

--- a/platform/api.intent/src/org/netbeans/modules/intent/OpenUriHandlerProcessor.java
+++ b/platform/api.intent/src/org/netbeans/modules/intent/OpenUriHandlerProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -44,7 +42,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author jhavlin
  */
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 @SupportedAnnotationTypes("org.netbeans.spi.intent.IntentHandlerRegistration")
 public class OpenUriHandlerProcessor extends LayerGeneratingProcessor {
 

--- a/platform/api.templates/src/org/netbeans/modules/templates/TemplateProcessor.java
+++ b/platform/api.templates/src/org/netbeans/modules/templates/TemplateProcessor.java
@@ -27,8 +27,6 @@ import java.util.Set;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -44,7 +42,6 @@ import org.openide.filesystems.annotations.LayerGeneratingProcessor;
 import org.openide.util.lookup.ServiceProvider;
 
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class TemplateProcessor extends LayerGeneratingProcessor {
 
     @Override public Set<String> getSupportedAnnotationTypes() {

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewProcessor.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewProcessor.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -50,7 +48,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Jaroslav Tulach
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class MultiViewProcessor extends LayerGeneratingProcessor {
     public @Override Set<String> getSupportedAnnotationTypes() {
         return new HashSet<String>(Arrays.asList(

--- a/platform/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/CreateRegistrationProcessor.java
+++ b/platform/editor.mimelookup/src/org/netbeans/modules/editor/mimelookup/CreateRegistrationProcessor.java
@@ -30,8 +30,6 @@ import javax.annotation.processing.Completion;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
@@ -58,7 +56,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Jan Lahoda
  */
 @SupportedAnnotationTypes({"org.netbeans.api.editor.mimelookup.MimeRegistration", "org.netbeans.api.editor.mimelookup.MimeRegistrations", "org.netbeans.spi.editor.mimelookup.MimeLocation"})
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 @ServiceProvider(service=Processor.class)
 public class CreateRegistrationProcessor extends LayerGeneratingProcessor {
 

--- a/platform/javahelp/src/org/netbeans/modules/javahelp/HelpSetRegistrationProcessor.java
+++ b/platform/javahelp/src/org/netbeans/modules/javahelp/HelpSetRegistrationProcessor.java
@@ -38,8 +38,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic.Kind;
@@ -60,7 +58,6 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class HelpSetRegistrationProcessor extends LayerGeneratingProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/platform/openide.awt/src/org/netbeans/modules/openide/awt/ActionProcessor.java
+++ b/platform/openide.awt/src/org/netbeans/modules/openide/awt/ActionProcessor.java
@@ -30,8 +30,6 @@ import javax.annotation.processing.Completion;
 import javax.annotation.processing.Completions;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
@@ -74,7 +72,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Jaroslav Tulach <jtulach@netbeans.org>
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public final class ActionProcessor extends LayerGeneratingProcessor {
     private static final String IDENTIFIER = "(?:\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)"; // NOI18N
     private static final Pattern FQN = Pattern.compile(IDENTIFIER + "(?:[.]" + IDENTIFIER + ")*"); // NOI18N

--- a/platform/openide.filesystems/apichanges.xml
+++ b/platform/openide.filesystems/apichanges.xml
@@ -25,6 +25,30 @@
         <apidef name="filesystems">Filesystems API</apidef>
     </apidefs>
     <changes>
+        <change id="LayerProcessorSupportedSource">
+            <api name="filesystems"/>
+            <summary>Declare support for all source levels.</summary>
+            <version major="9" minor="17"/>
+            <date year="2019" month="10" day="18"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes" source="compatible" semantic="incompatible" binary="compatible"/>
+            <description>
+                <p>
+                    <a href="@TOP@/org/openide/filesystems/annotations/LayerGeneratingProcessor.html"><code>LayerGeneratingProcessor</code></a> subclasses declare some
+                    <a href="@JDK@/javax/lang/model/SourceVersion.html"><code>SourceVersion</code></a> support,
+                    but as new JDKs are released, the declaration becomes obsolete and produces spurious warnings. The processors
+                    are typically not affected by newer Java language features.
+                </p>
+                <p>
+                    This change changes the default behaviour if NO 
+                    <a href="@JDK@/javax/annotation/processing/SupportedSourceVersion.html"><code>@SupportedSourceVersion</code></a>
+                    annotation is present on subclass. From 8.40, the Processor will report 
+                    <a href="@JDK@/javax/lang/model/SourceVersion.html#latest--"><code>@SourceVersion.latest()</code></a>.
+                </p>
+            </description>
+            <class name="LayerGeneratingProcessor" package="org.openide.filesystems.annotations"/>
+            <issue number="NETBEANS-3250"/>
+        </change>
         <change id="ArchiveRootProvider">
             <api name="filesystems"/>
             <summary>Pluggable archive files support for FileUtil</summary>
@@ -41,6 +65,7 @@
             </description>
             <class name="FileUtil" package="org.openide.filesystems"/>
             <class name="ArchiveRootProvider" package="org.openide.filesystems.spi"/>
+            
         </change>
         <change id="repository.multiuser">
             <api name="filesystems"/>

--- a/platform/openide.filesystems/manifest.mf
+++ b/platform/openide.filesystems/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.openide.filesystems
 OpenIDE-Module-Localizing-Bundle: org/openide/filesystems/Bundle.properties
 OpenIDE-Module-Layer: org/openide/filesystems/resources/layer.xml
-OpenIDE-Module-Specification-Version: 9.16
+OpenIDE-Module-Specification-Version: 9.17
 
 

--- a/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java
+++ b/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java
@@ -27,8 +27,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -49,7 +47,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Jaroslav Tulach <jtulach@netbeans.org>
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class MIMEResolverProcessor extends LayerGeneratingProcessor {
 
     @Override

--- a/platform/openide.filesystems/src/org/openide/filesystems/annotations/LayerGeneratingProcessor.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/annotations/LayerGeneratingProcessor.java
@@ -37,6 +37,8 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic.Kind;
@@ -57,6 +59,9 @@ import org.xml.sax.SAXParseException;
 
 /**
  * Convenience base class for an annotation processor which creates XML layer entries.
+ * From version 9.17, it is not necessary (and is not recommended) to declare @{@link SupportedSourceVersion}
+ * on subclasses: the default implementation declares support for {@link SourceVersion#latest()}. Declare
+ * specific {@link SourceVersion} limits only when necessary.
  * @see XMLFileSystem
  * @since org.openide.filesystems 7.15
  */
@@ -233,4 +238,20 @@ public abstract class LayerGeneratingProcessor extends AbstractProcessor {
         return doc;
     }
 
+    /**
+     * If the subclass itself does not define SupportedSourceVersion, assume latest(). If it does
+     * (was recommended prior to 9.17), returns the subclass' value for compatibility.
+     * @return max supported source version.
+     * @since 9.17
+     */
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        SupportedSourceVersion ssv = this.getClass().getAnnotation(SupportedSourceVersion.class);
+        SourceVersion sv;
+        if (ssv == null) {
+            sv = SourceVersion.latest();
+        } else
+            sv = ssv.value();
+        return sv;
+    }
 }

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGeneratingProcessorTest.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGeneratingProcessorTest.java
@@ -29,8 +29,6 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.tools.JavaCompiler;
@@ -82,7 +80,6 @@ public class LayerGeneratingProcessorTest extends NbTestCase {
         assertGC("can collect ProcessingEnvironment", r);
     }
     public @interface A {}
-    @SupportedSourceVersion(SourceVersion.RELEASE_7)
     static class P extends LayerGeneratingProcessor {
         ProcessingEnvironment env;
         public @Override Set<String> getSupportedAnnotationTypes() {

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGenerationExceptionTest.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerGenerationExceptionTest.java
@@ -26,8 +26,6 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic.Kind;
@@ -79,7 +77,6 @@ public class LayerGenerationExceptionTest extends NbTestCase {
     }
 
     @ServiceProvider(service=Processor.class)
-    @SupportedSourceVersion(SourceVersion.RELEASE_7)
     public static class AP extends LayerGeneratingProcessor {
         public @Override Set<String> getSupportedAnnotationTypes() {
             return new HashSet<String>(Arrays.asList(A.class.getCanonicalName(), AS.class.getCanonicalName()));

--- a/platform/openide.loaders/src/org/netbeans/modules/openide/loaders/DataObjectFactoryProcessor.java
+++ b/platform/openide.loaders/src/org/netbeans/modules/openide/loaders/DataObjectFactoryProcessor.java
@@ -22,8 +22,6 @@ import java.util.*;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -44,7 +42,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Eric Barboni <skygo@netbeans.org>
  */
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 @SupportedAnnotationTypes({"org.openide.loaders.DataObject.Registration", "org.openide.loaders.DataObject.Registrations"})
 public class DataObjectFactoryProcessor extends LayerGeneratingProcessor {
 

--- a/platform/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesAnnotationProcessor.java
+++ b/platform/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesAnnotationProcessor.java
@@ -26,8 +26,6 @@ import java.util.Set;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
@@ -54,7 +52,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Jan Horvath <jhorvath@netbeans.org>
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class NodesAnnotationProcessor extends LayerGeneratingProcessor {
 
     public NodesAnnotationProcessor() {

--- a/platform/openide.util.lookup/apichanges.xml
+++ b/platform/openide.util.lookup/apichanges.xml
@@ -25,6 +25,30 @@
     <apidef name="lookup">Lookup API</apidef>
 </apidefs>
 <changes>
+    <change id="AbstractProcessorSupportedSource">
+        <api name="lookup"/>
+        <summary>Declare support for all source levels.</summary>
+        <version major="8" minor="40"/>
+        <date year="2019" month="10" day="18"/>
+        <author login="sdedic"/>
+        <compatibility addition="yes" source="compatible" semantic="incompatible" binary="compatible"/>
+        <description>
+            <p>
+                Typically <code>AbstractServiceProviderProcessor</code> subclasses declare some 
+                <a href="@JDK@/javax/lang/model/SourceVersion.html"><code>SourceVersion</code></a> support,
+                but as new JDKs are released, the declaration becomes obsolete and produces spurious warnings. The processors
+                are typically not affected by newer Java language features.
+            </p>
+            <p>
+                This change changes the default behaviour if NO 
+                <a href="@JDK@/javax/annotation/processing/SupportedSourceVersion.html"><code>@SupportedSourceVersion</code></a>
+                annotation is present on subclass. From 8.40, the Processor will report 
+                <a href="@JDK@/javax/lang/model/SourceVersion.html#latest--"><code>@SourceVersion.latest()</code></a>.
+            </p>
+        </description>
+        <class name="LayerGeneratingProcessor" package="org.openide.filesystems.annotations"/>
+        <issue number="NETBEANS-3250"/>
+    </change>
     <change id="lookups.execute">
         <api name="lookup"/>
         <summary>A way to control Lookup.getDefault</summary>

--- a/platform/openide.util.lookup/manifest.mf
+++ b/platform/openide.util.lookup/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.util.lookup
 OpenIDE-Module-Localizing-Bundle: org/openide/util/lookup/Bundle.properties
-OpenIDE-Module-Specification-Version: 8.39
+OpenIDE-Module-Specification-Version: 8.40
 

--- a/platform/openide.util.lookup/src/org/netbeans/modules/openide/util/NamedServiceProcessor.java
+++ b/platform/openide.util.lookup/src/org/netbeans/modules/openide/util/NamedServiceProcessor.java
@@ -36,8 +36,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -45,12 +43,10 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import org.openide.util.lookup.NamedServiceDefinition;
 import org.openide.util.lookup.implspi.AbstractServiceProviderProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public final class NamedServiceProcessor extends AbstractServiceProviderProcessor {
     private static final String PATH = "META-INF/namedservices.index"; // NOI18N
     private static Pattern reference = Pattern.compile("@([^/]+)\\(\\)"); // NOI18N

--- a/platform/openide.util.lookup/src/org/netbeans/modules/openide/util/ServiceProviderProcessor.java
+++ b/platform/openide.util.lookup/src/org/netbeans/modules/openide/util/ServiceProviderProcessor.java
@@ -29,8 +29,6 @@ import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.Completion;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -42,7 +40,6 @@ import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
 import org.openide.util.lookup.implspi.AbstractServiceProviderProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class ServiceProviderProcessor extends AbstractServiceProviderProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/implspi/AbstractServiceProviderProcessor.java
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/implspi/AbstractServiceProviderProcessor.java
@@ -39,6 +39,8 @@ import java.util.WeakHashMap;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
@@ -54,7 +56,12 @@ import javax.tools.StandardLocation;
 
 /**
  * Infrastructure for generating {@code META-INF/services/*} and
- * {@code META-INF/namedservices/*} registrations from annotations.
+ * {@code META-INF/namedservices/*} registrations from annotations. From version
+ * 8.40, it is not necessary (and is not recommended) to declare
+ * @{@link SupportedSourceVersion} on subclasses: the default implementation
+ * declares support for {@link SourceVersion#latest()}. Declare specific
+ * {@link SourceVersion} limits only when necessary.
+ *
  * @since 8.1
  */
 public abstract class AbstractServiceProviderProcessor extends AbstractProcessor {
@@ -315,4 +322,20 @@ public abstract class AbstractServiceProviderProcessor extends AbstractProcessor
         register((Element) el, annotation, type, path, position, supersedes);
     }
 
+    /**
+     * If the subclass itself does not define SupportedSourceVersion, assume latest(). If it does
+     * (was recommended prior to 8.40), returns the subclass' value.
+     * @return max supported source version.
+     * @since 8.40
+     */
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        SupportedSourceVersion ssv = this.getClass().getAnnotation(SupportedSourceVersion.class);
+        SourceVersion sv;
+        if (ssv == null) {
+            sv = SourceVersion.latest();
+        } else
+            sv = ssv.value();
+        return sv;
+    }
 }

--- a/platform/openide.util.lookup/test/unit/src/org/openide/util/test/AnnotationProcessorTestUtils.java
+++ b/platform/openide.util.lookup/test/unit/src/org/openide/util/test/AnnotationProcessorTestUtils.java
@@ -85,6 +85,21 @@ public class AnnotationProcessorTestUtils {
      * @return true if compilation succeeded, false if it failed
      */
     public static boolean runJavac(File src, String srcIncludes, File dest, File[] cp, OutputStream stderr) {
+        return runJavac(src, srcIncludes, dest, cp, stderr, null);
+    }
+    
+    /**
+     * Run the Java compiler.
+     * (A JSR 199 implementation must be available.)
+     * @param src a source root (runs javac on all *.java it finds matching {@code srcIncludes})
+     * @param srcIncludes a pattern of source files names without path to compile (useful for testing incremental compiles), or null for all
+     * @param dest a dest dir to compile classes to
+     * @param cp classpath entries; if null, use Java classpath of test
+     * @param source the source level option to the compiler
+     * @param stderr output stream to print messages to, or null for test console (i.e. do not capture)
+     * @return true if compilation succeeded, false if it failed
+     */
+    public static boolean runJavac(File src, String srcIncludes, File dest, File[] cp, OutputStream stderr, String source) {
         List<String> args = new ArrayList<String>();
         args.add("-classpath");
         StringBuilder b = new StringBuilder(dest.getAbsolutePath());
@@ -105,7 +120,11 @@ public class AnnotationProcessorTestUtils {
         File destG = new File(dest.getParentFile(), "generated-" + dest.getName());
         args.add(destG.getAbsolutePath());
         args.add("-source");
-        args.add("6");
+        if (source == null) {
+            args.add("6");
+        } else {
+            args.add(source);
+        }
         args.add("-Xlint:-options");
         dest.mkdirs();
         destG.mkdirs();

--- a/platform/openide.util/src/org/netbeans/modules/openide/util/NbBundleProcessor.java
+++ b/platform/openide.util/src/org/netbeans/modules/openide/util/NbBundleProcessor.java
@@ -39,7 +39,6 @@ import java.util.regex.Pattern;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -57,11 +56,15 @@ import org.openide.util.NbCollections;
 import org.openide.util.lookup.ServiceProvider;
 
 @ServiceProvider(service = Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_6)
 public class NbBundleProcessor extends AbstractProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {
         return Collections.singleton(NbBundle.Messages.class.getCanonicalName());
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
 
     public @Override boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {

--- a/platform/openide.windows/src/org/netbeans/modules/openide/windows/TopComponentProcessor.java
+++ b/platform/openide.windows/src/org/netbeans/modules/openide/windows/TopComponentProcessor.java
@@ -19,23 +19,16 @@
 
 package org.netbeans.modules.openide.windows;
 
-import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
 import org.openide.awt.ActionID;
-import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.annotations.LayerBuilder.File;
 import org.openide.filesystems.annotations.LayerGeneratingProcessor;
 import org.openide.filesystems.annotations.LayerGenerationException;
@@ -44,7 +37,6 @@ import org.openide.windows.TopComponent;
 import org.openide.windows.TopComponent.Description;
 import org.openide.windows.TopComponent.Registration;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 @ServiceProvider(service=Processor.class)
 public final class TopComponentProcessor extends LayerGeneratingProcessor {
     public TopComponentProcessor() {

--- a/platform/options.api/src/org/netbeans/modules/options/OptionsPanelControllerProcessor.java
+++ b/platform/options.api/src/org/netbeans/modules/options/OptionsPanelControllerProcessor.java
@@ -33,13 +33,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
-import javax.swing.JPanel;
 import org.netbeans.api.options.OptionsDisplayer;
 import org.netbeans.spi.options.AdvancedOption;
 import org.netbeans.spi.options.OptionsCategory;
@@ -57,7 +54,6 @@ import org.openide.util.NbBundle;
 import org.openide.util.lookup.ServiceProvider;
 
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class OptionsPanelControllerProcessor extends LayerGeneratingProcessor {
 
     private Element originatingElement;

--- a/platform/sendopts/src/org/netbeans/modules/sendopts/OptionAnnotationProcessor.java
+++ b/platform/sendopts/src/org/netbeans/modules/sendopts/OptionAnnotationProcessor.java
@@ -64,7 +64,7 @@ public final class OptionAnnotationProcessor implements Processor {
         if (delegate() != null) {
             return delegate().getSupportedSourceVersion();
         } else {
-            return SourceVersion.RELEASE_7;
+            return SourceVersion.latest();
         }
     }
 

--- a/platform/sendopts/src/org/netbeans/modules/sendopts/OptionAnnotationProcessorImpl.java
+++ b/platform/sendopts/src/org/netbeans/modules/sendopts/OptionAnnotationProcessorImpl.java
@@ -22,8 +22,6 @@ package org.netbeans.modules.sendopts;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.PrimitiveType;
@@ -41,7 +39,6 @@ import org.openide.filesystems.annotations.LayerGenerationException;
  *
  * @author Jaroslav Tulach <jtulach@netbeans.org>
  */
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 final class OptionAnnotationProcessorImpl extends LayerGeneratingProcessor {
 
     @Override

--- a/platform/settings/src/org/netbeans/modules/settings/convertors/ConvertorProcessor.java
+++ b/platform/settings/src/org/netbeans/modules/settings/convertors/ConvertorProcessor.java
@@ -25,8 +25,6 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -49,7 +47,6 @@ import org.openide.util.lookup.ServiceProvider;
  * @author Jaroslav Tulach <jtulach@netbeans.org>
  */
 @ServiceProvider(service=Processor.class)
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class ConvertorProcessor extends LayerGeneratingProcessor {
 
     public @Override Set<String> getSupportedAnnotationTypes() {

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/CompletionInterceptorRegistrationProcessor.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/CompletionInterceptorRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.javascript2.editor.spi.CompletionProvider;
@@ -37,7 +35,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.javascript2.editor.spi.CompletionProvider.Registration") //NOI18N
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class CompletionInterceptorRegistrationProcessor extends LayerGeneratingProcessor {
 
     public CompletionInterceptorRegistrationProcessor() {

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/DeclarationFinderInterceptorRegistrationProcessor.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/DeclarationFinderInterceptorRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.javascript2.editor.spi.DeclarationFinder;
@@ -37,7 +35,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.javascript2.editor.spi.DeclarationFinder.Registration") //NOI18N
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class DeclarationFinderInterceptorRegistrationProcessor extends LayerGeneratingProcessor {
 
     public DeclarationFinderInterceptorRegistrationProcessor() {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/FunctionInterceptorRegistrationProcessor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/FunctionInterceptorRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.javascript2.model.spi.FunctionInterceptor;
@@ -37,7 +35,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.javascript2.model.spi.FunctionInterceptor.Registration") //NOI18N
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class FunctionInterceptorRegistrationProcessor extends LayerGeneratingProcessor {
 
     public FunctionInterceptorRegistrationProcessor() {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelInterceptorRegistrationProcessor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelInterceptorRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.javascript2.model.spi.ModelInterceptor;
@@ -37,7 +35,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.javascript2.model.spi.ModelInterceptor.Registration") //NOI18N
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class ModelInterceptorRegistrationProcessor extends LayerGeneratingProcessor {
 
     public ModelInterceptorRegistrationProcessor() {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ObjectInterceptorRegistrationProcessor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ObjectInterceptorRegistrationProcessor.java
@@ -23,8 +23,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.netbeans.modules.javascript2.model.spi.ObjectInterceptor;
@@ -38,7 +36,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.javascript2.model.spi.ObjectInterceptor.Registration") //NOI18N
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class ObjectInterceptorRegistrationProcessor extends LayerGeneratingProcessor {
 
     public ObjectInterceptorRegistrationProcessor() {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/TypeNameConvertorRegistrationProcessor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/TypeNameConvertorRegistrationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import org.openide.filesystems.annotations.LayerGeneratingProcessor;
@@ -38,7 +36,6 @@ import org.netbeans.modules.javascript2.model.spi.TypeNameConvertor;
 
 @ServiceProvider(service=Processor.class)
 @SupportedAnnotationTypes("org.netbeans.modules.javascript2.model.spi.TypeNameConvertor.Registration") //NOI18N
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
 public class TypeNameConvertorRegistrationProcessor extends LayerGeneratingProcessor {
 
     public TypeNameConvertorRegistrationProcessor() {


### PR DESCRIPTION
See [NETBEANS-3250](https://issues.apache.org/jira/browse/NETBEANS-3250).
Most of annotation processors are not affected by features added to Java, and once they declare a specific `@SupportedSourceVersion`, they start to produce warnings during compilation with the next released JDK:
```
"warning: Supported source version 'RELEASE_7' from annotation processor 'org.netbeans.modules.openide.util.ServiceProviderProcessor' less than -source '1.8'"
```
So usually it's best to declare the processor to support `SourceVersion.latest()`, but that cannot be done using annotation. Most of annotation processors in NetBeans generate layers, and derive from `LayerGeneratingProcessor`, so I've decided to change that base class.

I've split the work into several commits, to make it cleaner for review:
* b2acf687 - changes to `org.openide.util.lookup` and `org.openide.filesystems` to the abstract processor impl, increased specification version
* 5d32a993 - adapted the rest of Util + Filesystems processors.
* 467f689b - updated the rest of the GIT repository
* 3126f706 - hint that looks for obsolete or missing `@SupportedSourceVersion`, and suggest solutions
* daf35838 - code generation support in Editor (hooked onto ALT-INSERT) that generates override of `getSupportedSourceVersion` + some fixes to the shared code.
