### PR TITLE
[NETBEANS-3252] NodeListModel must clear VisualizerNode count cache b…

### DIFF
--- a/platform/openide.explorer/src/org/openide/explorer/view/NodeListModel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/NodeListModel.java
@@ -327,12 +327,10 @@ public class NodeListModel extends AbstractListModel implements ComboBoxModel {
 
     final void changeAll() {
         size = getSize();
-
-        if (size > 0) {
-            fireContentsChanged(this, 0, size - 1);
-        }
-
         clearChildrenCount();
+        if (size > 0) {
+            fireContentsChanged(this, 0, size);
+        }
     }
 
     final void added(VisualizerEvent.Added ev) {


### PR DESCRIPTION
…efore dispatching event.

Simply reorder the cache clear and event dispatch.