### PR TITLE
[NETBEANS-3277] - cleanup the external binary cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Caching dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.hgexternalcache
+          path: ~/.netbeans/nb_external_cache
           key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
 
@@ -86,7 +86,7 @@ jobs:
       - name: Caching dependencies
         uses: actions/cache@v2
         with:
-          path: ~/.hgexternalcache
+          path: ~/.netbeans/nb_external_cache
           key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-
 
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: |
-            ~/.hgexternalcache
+            ~/.netbeans/nb_external_cache
             ~/Library/Caches/Homebrew
           key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
           restore-keys: ${{ runner.os }}-

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 
 cache:
   directories:
-  - $HOME/.hgexternalcache
+  - $HOME/.netbeans/nb_external_cache
 
 matrix:
     include:

--- a/ide/html.parser/external/htmlparser-howtoupgrade.txt
+++ b/ide/html.parser/external/htmlparser-howtoupgrade.txt
@@ -20,6 +20,6 @@ How to upgrade the htmlparser library:
 For local testing without uploading the new file:
 
 1) Get the SHA1 sum for the file: sha1sum target/htmlparser-1.4.<date>.jar | awk '{print toupper($1)}'
-2) Copy the file to ~/.hgexternalcache/<SHA1SUM>-htmlparser-1.4.<date>.jar
-   DATE=20190624; cp target/htmlparser-1.4.$DATE.jar ~/.hgexternalcache/`sha1sum target/htmlparser-1.4.$DATE.jar | awk '{print toupper($1)}'`-htmlparser-1.4.$DATE.jar
+2) Copy the file to ~/.netbeans/nb_external_cache/<SHA1SUM>-htmlparser-1.4.<date>.jar
+   DATE=20190624; cp target/htmlparser-1.4.$DATE.jar ~/.netbeans/nb_external_cache/`sha1sum target/htmlparser-1.4.$DATE.jar | awk '{print toupper($1)}'`-htmlparser-1.4.$DATE.jar
 3) Update the binaries list

--- a/nbbuild/default-properties.xml
+++ b/nbbuild/default-properties.xml
@@ -66,7 +66,7 @@
 
   <property name="test.dist.dir" location="${nb.build.dir}/testdist"/>
   
-  <property name="binaries.cache" location="${user.home}/.hgexternalcache"/>
+  <property name="binaries.cache" location="${user.home}/.netbeans/nb_external_cache"/>
   <property name="binaries.server" value="https://netbeans.osuosl.org/binaries/"/>
 
   <target name="-load-build-properties">


### PR DESCRIPTION
Historically,  NetBeans has cached external binaries in a directory called ~/.hgexternalcache.

This change changes the name to nb_external_cache.

It also moves it out of the users home directory and into the .netbeans directory. This puts it into a place where it should be since things like this need to live in the .netbeans directory.