### PR TITLE
[NETBEANS-3285] - cleanup bootstrap class path

### DIFF
--- a/ide/api.debugger/nbproject/project.properties
+++ b/ide/api.debugger/nbproject/project.properties
@@ -17,6 +17,6 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/api.xml/nbproject/project.properties
+++ b/ide/api.xml/nbproject/project.properties
@@ -17,6 +17,8 @@
 
 is.autoload=true
 
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
 javadoc.overview=${basedir}/doc/overview.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/bugtracking.commons/nbproject/project.properties
+++ b/ide/bugtracking.commons/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/ide/bugzilla/nbproject/project.properties
+++ b/ide/bugzilla/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/code.analysis/nbproject/project.properties
+++ b/ide/code.analysis/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml

--- a/ide/csl.types/nbproject/project.properties
+++ b/ide/csl.types/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 javadoc.arch=${basedir}/arch.xml

--- a/ide/css.lib/nbproject/project.properties
+++ b/ide/css.lib/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 

--- a/ide/css.model/nbproject/project.properties
+++ b/ide/css.model/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/css.prep/nbproject/project.properties
+++ b/ide/css.prep/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 auxiliary.org-netbeans-modules-css-prep.less_2e_configured=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test-unit-sys-prop.netbeans.dirs=${netbeans.dest.dir}/${nb.cluster.ide.dir}

--- a/ide/css.visual/nbproject/project.properties
+++ b/ide/css.visual/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 cp.extra=
 javac.compilerargs=\ -Xlint:unchecked  -Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 
 test.config.stable.includes=\
 **/CSSTest.class

--- a/ide/db.core/nbproject/project.properties
+++ b/ide/db.core/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/ide/db.sql.editor/nbproject/project.properties
+++ b/ide/db.sql.editor/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 spec.version.base=1.42.0
 
 # org-netbeans-core: for /xml/lookups in the default fs

--- a/ide/db/nbproject/project.properties
+++ b/ide/db/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/derby/nbproject/project.properties
+++ b/ide/derby/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint:unchecked
 
 release.build/derbysampledb.zip=modules/ext/derbysampledb.zip

--- a/ide/diff/nbproject/project.properties
+++ b/ide/diff/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 
 spec.version.base=1.57.0
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/dlight.nativeexecution.nb/nbproject/project.properties
+++ b/ide/dlight.nativeexecution.nb/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/dlight.nativeexecution/nbproject/project.properties
+++ b/ide/dlight.nativeexecution/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 project.license=apache20-asf

--- a/ide/editor.bookmarks/nbproject/project.properties
+++ b/ide/editor.bookmarks/nbproject/project.properties
@@ -18,6 +18,6 @@
 #javadoc.arch=${basedir}/arch/arch-editor-bookmarks.xml
 #test.qa-functional.cp.extra=${editor/bookmarks.dir}/modules/org-netbeans-modules-editor-bookmarks.jar:${editor.dir}/modules/org-netbeans-modules-editor.jar:${editor.dir}/modules/org-netbeans-modules-editor-lib.jar:${nb_all}/editor/build/test/qa-functional/classes
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 # #178009
 disable.qa-functional.tests=true

--- a/ide/editor.bracesmatching/nbproject/project.properties
+++ b/ide/editor.bracesmatching/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/editor.breadcrumbs/nbproject/project.properties
+++ b/ide/editor.breadcrumbs/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/editor.codetemplates/nbproject/project.properties
+++ b/ide/editor.codetemplates/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 #javadoc.name=EditorCodeTemplates
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.document/nbproject/project.properties
+++ b/ide/editor.document/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.15.0
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.errorstripe.api/nbproject/project.properties
+++ b/ide/editor.errorstripe.api/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 spec.version.base=2.38.0
 is.autoload=true
 

--- a/ide/editor.errorstripe/nbproject/project.properties
+++ b/ide/editor.errorstripe/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 spec.version.base=2.40.0
 nbm.needs.restart=true
 

--- a/ide/editor.fold.nbui/nbproject/project.properties
+++ b/ide/editor.fold.nbui/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.18.0

--- a/ide/editor.fold/nbproject/project.properties
+++ b/ide/editor.fold/nbproject/project.properties
@@ -20,6 +20,6 @@ javadoc.apichanges=${basedir}/apichanges.xml
 #javadoc.base=../../../editor/fold
 #cp.extra=
 
-javac.source=1.7
+javac.source=1.8
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/editor.global.format/nbproject/project.properties
+++ b/ide/editor.global.format/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.21.0

--- a/ide/editor.guards/nbproject/project.properties
+++ b/ide/editor.guards/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 

--- a/ide/editor.indent.project/nbproject/project.properties
+++ b/ide/editor.indent.project/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.eager=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.indent/nbproject/project.properties
+++ b/ide/editor.indent/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint:unchecked
 
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.lib/nbproject/project.properties
+++ b/ide/editor.lib/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 spec.version.base=4.13.0
 is.autoload=true
 

--- a/ide/editor.lib2/nbproject/project.properties
+++ b/ide/editor.lib2/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint:unchecked
 spec.version.base=2.26.0
 

--- a/ide/editor.plain.lib/nbproject/project.properties
+++ b/ide/editor.plain.lib/nbproject/project.properties
@@ -16,3 +16,5 @@
 # under the License.
 
 #javadoc.arch=${basedir}/arch/arch-editor-plain-lib.xml
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8

--- a/ide/editor.search/nbproject/project.properties
+++ b/ide/editor.search/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.31.0

--- a/ide/editor.settings.lib/nbproject/project.properties
+++ b/ide/editor.settings.lib/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.57.0

--- a/ide/editor.settings.storage/nbproject/project.properties
+++ b/ide/editor.settings.storage/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.eager=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.57.0

--- a/ide/editor.settings/nbproject/project.properties
+++ b/ide/editor.settings/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 

--- a/ide/editor.tools.storage/nbproject/project.properties
+++ b/ide/editor.tools.storage/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.util/nbproject/project.properties
+++ b/ide/editor.util/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 javadoc.arch=${basedir}/arch.xml
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.title=Editor Utilities
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/editor/nbproject/project.properties
+++ b/ide/editor/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 spec.version.base=1.93.0
 is.autoload=true
 

--- a/ide/extbrowser/nbproject/project.properties
+++ b/ide/extbrowser/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 javadoc.arch=${basedir}/arch.xml
 # test.unit.cp.extra and/or test.unit.run.cp.extra
-javac.source=1.7
+javac.source=1.8
 release.external/extbrowser-dlls-18.03.15.zip!/extbrowser.dll=modules/lib/extbrowser.dll
 release.external/extbrowser-dlls-18.03.15.zip!/extbrowser64.dll=modules/lib/extbrowser64.dll
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/extexecution.process/nbproject/project.properties
+++ b/ide/extexecution.process/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 release.external/winp-1.26.jar=modules/ext/winp-1.26.jar
 release.external/libpam4j-1.1.jar=modules/ext/libpam4j-1.1.jar

--- a/ide/git/nbproject/project.properties
+++ b/ide/git/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 nbm.homepage=http://netbeans.org/projects/versioncontrol/pages/Git_main
 nbm.module.author=Ondrej Vrabec
 nbm.needs.restart=true

--- a/ide/gsf.codecoverage/nbproject/project.properties
+++ b/ide/gsf.codecoverage/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 ant.jar=${ant.core.lib}

--- a/ide/html.custom/nbproject/project.properties
+++ b/ide/html.custom/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/html.editor.lib/nbproject/project.properties
+++ b/ide/html.editor.lib/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 #javadoc.arch=${basedir}/arch/arch-html-editor-lib.xml
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/html.lexer/nbproject/project.properties
+++ b/ide/html.lexer/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 #javadoc.arch=${basedir}/arch.xml
 #javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.title=HTML Lexer API

--- a/ide/image/nbproject/project.properties
+++ b/ide/image/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8

--- a/ide/javascript2.debug.ui/nbproject/project.properties
+++ b/ide/javascript2.debug.ui/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 
 is.autoload=true

--- a/ide/javascript2.debug/nbproject/project.properties
+++ b/ide/javascript2.debug/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 
 is.autoload=true

--- a/ide/lib.terminalemulator/nbproject/project.properties
+++ b/ide/lib.terminalemulator/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 nbm.homepage=http://wiki.netbeans.org/TerminalEmulator

--- a/ide/libs.git/nbproject/project.properties
+++ b/ide/libs.git/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 
-javac.source=1.7
+javac.source=1.8
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/localtasks/nbproject/project.properties
+++ b/ide/localtasks/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/mercurial/nbproject/project.properties
+++ b/ide/mercurial/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 nbm.homepage=http://wiki.netbeans.org/wiki/view/MercurialVersionControl
 nbm.module.author=John Rice and Padraig O'Briain
 nbm.needs.restart=true

--- a/ide/parsing.api/nbproject/project.properties
+++ b/ide/parsing.api/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=9.13.0

--- a/ide/parsing.lucene/nbproject/project.properties
+++ b/ide/parsing.lucene/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javadoc.apichanges=${basedir}/apichanges.xml
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/ide/parsing.nb/nbproject/project.properties
+++ b/ide/parsing.nb/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.9.0
 #javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/parsing.ui/nbproject/project.properties
+++ b/ide/parsing.ui/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 is.eager=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 spec.version.base=1.20.0

--- a/ide/project.ant.ui/nbproject/project.properties
+++ b/ide/project.ant.ui/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/project.ant/nbproject/project.properties
+++ b/ide/project.ant/nbproject/project.properties
@@ -24,7 +24,7 @@ antsrc.cp=\
     ${openide.filesystems.dir}/core/org-openide-filesystems.jar
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/project.libraries/nbproject/project.properties
+++ b/ide/project.libraries/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/spi.editor.hints.projects/nbproject/project.properties
+++ b/ide/spi.editor.hints.projects/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/spi.editor.hints/nbproject/project.properties
+++ b/ide/spi.editor.hints/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 spec.version.base=1.48.0

--- a/ide/subversion/nbproject/project.properties
+++ b/ide/subversion/nbproject/project.properties
@@ -17,7 +17,7 @@
 spec.version.base=1.47.0
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 
 #qa-functional
 test.qa-functional.cp.extra=${openide.nodes.dir}/modules/org-openide-nodes.jar:\${openide.util.dir}/lib/org-openide-util.jar:${openide.util.ui.dir}/lib/org-openide-util-ui.jar

--- a/ide/terminal.nb/nbproject/project.properties
+++ b/ide/terminal.nb/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/versioning.util/nbproject/project.properties
+++ b/ide/versioning.util/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 
 javadoc.name=Versioning Support Utilities
 spec.version.base=1.76.0

--- a/ide/web.browser.api/nbproject/project.properties
+++ b/ide/web.browser.api/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 ant.jar=${ant.core.lib}

--- a/ide/web.webkit.debugging/nbproject/project.properties
+++ b/ide/web.webkit.debugging/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/xml.text.obsolete90/nbproject/project.properties
+++ b/ide/xml.text.obsolete90/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.6.0

--- a/platform/api.htmlui/nbproject/project.properties
+++ b/platform/api.htmlui/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/api.intent/nbproject/project.properties
+++ b/platform/api.intent/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml

--- a/platform/api.progress/nbproject/project.properties
+++ b/platform/api.progress/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/api.search/nbproject/project.properties
+++ b/platform/api.search/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/autoupdate.cli/nbproject/project.properties
+++ b/platform/autoupdate.cli/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 
 
 test.unit.cp.extra=${libs.asm.dir}/core/core.jar:\

--- a/platform/core.startup/nbproject/project.properties
+++ b/platform/core.startup/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 javadoc.arch=${basedir}/arch.xml
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.apichanges=${basedir}/apichanges.xml
 module.jar.dir=core
 module.jar.basename=core.jar

--- a/platform/core.ui/nbproject/project.properties
+++ b/platform/core.ui/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 
 test.config.stableBTD.includes=**/*Test.class

--- a/platform/core.windows/nbproject/project.properties
+++ b/platform/core.windows/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/editor.mimelookup.impl/nbproject/project.properties
+++ b/platform/editor.mimelookup.impl/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.eager=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 
 test.config.stableBTD.includes=**/*Test.class

--- a/platform/editor.mimelookup/nbproject/project.properties
+++ b/platform/editor.mimelookup/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/platform/libs.jsr223/nbproject/project.properties
+++ b/platform/libs.jsr223/nbproject/project.properties
@@ -16,3 +16,5 @@
 # under the License.
 
 is.autoload=true
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8

--- a/platform/o.n.bootstrap/nbproject/project.properties
+++ b/platform/o.n.bootstrap/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 module.jar.dir=lib
 module.jar.basename=boot.jar
 release.launcher/unix/nbexec=lib/nbexec

--- a/platform/o.n.swing.plaf/nbproject/project.properties
+++ b/platform/o.n.swing.plaf/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/openide.modules/nbproject/project.properties
+++ b/platform/openide.modules/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 module.jar.dir=lib
 javadoc.main.page=org/openide/modules/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml

--- a/platform/openide.options/nbproject/project.properties
+++ b/platform/openide.options/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.main.page=org/openide/options/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/openide.util.lookup/nbproject/project.properties
+++ b/platform/openide.util.lookup/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 module.jar.dir=lib
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 javadoc.arch=${basedir}/arch.xml

--- a/platform/openide.windows/nbproject/project.properties
+++ b/platform/openide.windows/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.main.page=org/openide/windows/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/options.keymap/nbproject/project.properties
+++ b/platform/options.keymap/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/platform/templates/nbproject/project.properties
+++ b/platform/templates/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/platform/templatesui/nbproject/project.properties
+++ b/platform/templatesui/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/platform/uihandler/nbproject/project.properties
+++ b/platform/uihandler/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 
 test.config.stableBTD.includes=**/*Test.class


### PR DESCRIPTION
There are a lot of places where we see the following warning..

```
...
up-to-date:
compile:
 [nb-javac] Compiling 31 source files to /home/bwalker/src/netbeans/platform/openide.util.lookup/build/classes
 [repeat] warning: [options] bootstrap class path not set in conjunction with -source 1.7
 [repeat] /home/bwalker/src/netbeans/platform/openide.util.lookup/src/org/openide/util/lookup/ProxyLookup.java:112: warning: [rawtypes] found raw type: R
 [repeat] Collection<Reference<R>> arr;
 [repeat] ^
...
```

The warning is telling us that we are compiling for Java 1.7 source. Yet, we are using a different **_rt.jar._**

This can be a problem going forward.

A really good Oracle blog, from a friend, about this is
https://blogs.oracle.com/darcy/new-javac-warning-for-setting-an-older-source-without-bootclasspath]