### PR TITLE
[NETBEANS-3002] NullPointerExceptions during PHPStan inspection

### DIFF
--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/PHPStan.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/PHPStan.java
@@ -108,8 +108,8 @@ public final class PHPStan {
     public List<Result> analyze(PHPStanParams params, FileObject file) {
         assert file.isValid() : "Invalid file given: " + file;
         try {
-            File workDir = findWorkDir(file);
-            Integer result = getExecutable(Bundle.PHPStan_analyze(analyzeGroupCounter++), workDir)
+            FileObject workDir = findWorkDir(file);
+            Integer result = getExecutable(Bundle.PHPStan_analyze(analyzeGroupCounter++), workDir == null ? null : FileUtil.toFile(workDir))
                     .additionalParameters(getParameters(params, file))
                     .runAndWait(getDescriptor(), "Running phpstan..."); // NOI18N
             if (result == null) {
@@ -135,17 +135,22 @@ public final class PHPStan {
      * @return project directory or {@code null}
      */
     @CheckForNull
-    private File findWorkDir(FileObject file) {
+    private FileObject findWorkDir(FileObject file) {
         assert file != null;
         Project project = FileOwnerQuery.getOwner(file);
+        FileObject workDir = null;
         if (project != null) {
-            File projectDir = FileUtil.toFile(project.getProjectDirectory());
+            workDir = project.getProjectDirectory();
             if (LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.log(Level.FINE, "Project directory for {0} found in {1}", new Object[]{FileUtil.toFile(file), projectDir});
+                if (workDir != null) {
+                    LOGGER.log(Level.FINE, "Project directory for {0} is found in {1}", new Object[]{FileUtil.toFile(file), workDir}); // NOI18N
+                } else {
+                    // the file/directory may not be in a PHP project
+                    LOGGER.log(Level.FINE, "Project directory for {0} is not found", FileUtil.toFile(file)); // NOI18N
+                }
             }
-            return projectDir;
         }
-        return null;
+        return workDir;
     }
 
     private PhpExecutable getExecutable(String title, @NullAllowed File workDir) {

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/PHPStan.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/PHPStan.java
@@ -102,19 +102,21 @@ public final class PHPStan {
 
     @NbBundle.Messages({
         "# {0} - counter",
-        "PHPStan.analyze=PHPStan (analyze #{0})",})
+        "PHPStan.analyze=PHPStan (analyze #{0})"
+    })
     @CheckForNull
     public List<Result> analyze(PHPStanParams params, FileObject file) {
         assert file.isValid() : "Invalid file given: " + file;
         try {
-            Integer result = getExecutable(Bundle.PHPStan_analyze(analyzeGroupCounter++), findWorkDir(file))
+            File workDir = findWorkDir(file);
+            Integer result = getExecutable(Bundle.PHPStan_analyze(analyzeGroupCounter++), workDir)
                     .additionalParameters(getParameters(params, file))
                     .runAndWait(getDescriptor(), "Running phpstan..."); // NOI18N
             if (result == null) {
                 return null;
             }
 
-            return PHPStanReportParser.parse(XML_LOG, file);
+            return PHPStanReportParser.parse(XML_LOG, file, workDir);
         } catch (CancellationException ex) {
             // cancelled
             return Collections.emptyList();

--- a/php/php.code.analysis/test/unit/data/phpstan/PHPStanSupport/netbeans3022/Test1.php
+++ b/php/php.code.analysis/test/unit/data/phpstan/PHPStanSupport/netbeans3022/Test1.php
@@ -1,0 +1,3 @@
+<?php
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0. */
+// dummy file

--- a/php/php.code.analysis/test/unit/data/phpstan/PHPStanSupport/netbeans3022/Test2.php
+++ b/php/php.code.analysis/test/unit/data/phpstan/PHPStanSupport/netbeans3022/Test2.php
@@ -1,0 +1,3 @@
+<?php
+/* Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0. */
+// dummy file

--- a/php/php.code.analysis/test/unit/data/phpstan/phpstan-log-netbeans-3022-win.xml
+++ b/php/php.code.analysis/test/unit/data/phpstan/phpstan-log-netbeans-3022-win.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<checkstyle>
+<file name="netbeans3022\Test1.php">
+  <error line="13" column="1" severity="error" message="Binary operation &quot;+&quot; between string and 2 results in an error." />
+</file>
+<file name="netbeans3022\Test2.php">
+  <error line="9" column="1" severity="error" message="Anonymous function should return string but returns void." />
+  <error line="9" column="1" severity="error" message="Result of closure (void) is used." />
+</file>
+<file>
+  <error severity="error" message="Ignored error pattern #TEST# was not matched in reported errors." />
+</file>
+</checkstyle>

--- a/php/php.code.analysis/test/unit/data/phpstan/phpstan-log-netbeans-3022-without-workdir.xml
+++ b/php/php.code.analysis/test/unit/data/phpstan/phpstan-log-netbeans-3022-without-workdir.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<checkstyle>
+<file name="/home/junichi11/NetBeansProjects/PHPStan/app/Test1.php">
+  <error line="13" column="1" severity="error" message="Binary operation &quot;+&quot; between string and 2 results in an error." />
+</file>
+<file name="/home/junichi11/NetBeansProjects/PHPStan/app/Test2.php">
+  <error line="9" column="1" severity="error" message="Anonymous function should return string but returns void." />
+  <error line="9" column="1" severity="error" message="Result of closure (void) is used." />
+</file>
+</checkstyle>

--- a/php/php.code.analysis/test/unit/data/phpstan/phpstan-log-netbeans-3022.xml
+++ b/php/php.code.analysis/test/unit/data/phpstan/phpstan-log-netbeans-3022.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<checkstyle>
+<file name="netbeans3022/Test1.php">
+  <error line="13" column="1" severity="error" message="Binary operation &quot;+&quot; between string and 2 results in an error." />
+</file>
+<file name="netbeans3022/Test2.php">
+  <error line="9" column="1" severity="error" message="Anonymous function should return string but returns void." />
+  <error line="9" column="1" severity="error" message="Result of closure (void) is used." />
+</file>
+<file>
+  <error severity="error" message="Ignored error pattern #TEST# was not matched in reported errors." />
+</file>
+</checkstyle>

--- a/php/php.code.analysis/test/unit/src/org/netbeans/modules/php/analysis/parsers/PHPStanReportParserTest.java
+++ b/php/php.code.analysis/test/unit/src/org/netbeans/modules/php/analysis/parsers/PHPStanReportParserTest.java
@@ -35,8 +35,8 @@ public class PHPStanReportParserTest extends NbTestCase {
     }
 
     public void testParse() throws Exception {
-        FileObject root = getRoot("phpstan/PHPStanSupport");
-        File workDir = FileUtil.toFile(root);
+        FileObject root = getDataDir("phpstan/PHPStanSupport");
+        FileObject workDir = root;
         List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log.xml"), root, workDir);
         assertNotNull(results);
 
@@ -62,25 +62,33 @@ public class PHPStanReportParserTest extends NbTestCase {
     }
 
     public void testParseWithOtherOutput() throws Exception {
-        FileObject root = getRoot("phpstan/PHPStanSupport");
-        File workDir = FileUtil.toFile(root);
+        FileObject root = getDataDir("phpstan/PHPStanSupport");
+        FileObject workDir = root;
         List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log-with-other-output.xml"), root, workDir);
         assertNotNull(results);
         assertEquals(2, results.size());
     }
 
     public void testParseNetBeans3022() throws Exception {
-        FileObject root = getRoot("phpstan/PHPStanSupport/netbeans3022");
-        File workDir = getWorkDir("phpstan/PHPStanSupport");
+        FileObject root = getDataDir("phpstan/PHPStanSupport/netbeans3022");
+        FileObject workDir = getDataDir("phpstan/PHPStanSupport");
         List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log-netbeans-3022.xml"), root, workDir);
         assertNotNull(results);
         assertEquals(3, results.size());
     }
 
     public void testParseNetBeans3022Win() throws Exception {
-        FileObject root = getRoot("phpstan/PHPStanSupport/netbeans3022");
-        File workDir = getWorkDir("phpstan/PHPStanSupport");
+        FileObject root = getDataDir("phpstan/PHPStanSupport/netbeans3022");
+        FileObject workDir = getDataDir("phpstan/PHPStanSupport");
         List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log-netbeans-3022-win.xml"), root, workDir);
+        assertNotNull(results);
+        assertEquals(3, results.size());
+    }
+
+    public void testParseNetBeans3022WithoutWorkDir() throws Exception {
+        FileObject root = getDataDir("phpstan/PHPStanSupport/netbeans3022");
+        FileObject workDir = null;
+        List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log-netbeans-3022-without-workdir.xml"), root, workDir);
         assertNotNull(results);
         assertEquals(3, results.size());
     }
@@ -93,15 +101,10 @@ public class PHPStanReportParserTest extends NbTestCase {
         return xmlLog;
     }
 
-    private FileObject getRoot(String name) {
+    private FileObject getDataDir(String name) {
         assertNotNull(name);
         FileObject dataDir = FileUtil.toFileObject(getDataDir());
         return dataDir.getFileObject(name);
-    }
-
-    private File getWorkDir(String name) {
-        assertNotNull(name);
-        return new File(getDataDir(), name);
     }
 
 }

--- a/php/php.code.analysis/test/unit/src/org/netbeans/modules/php/analysis/parsers/PHPStanReportParserTest.java
+++ b/php/php.code.analysis/test/unit/src/org/netbeans/modules/php/analysis/parsers/PHPStanReportParserTest.java
@@ -36,7 +36,8 @@ public class PHPStanReportParserTest extends NbTestCase {
 
     public void testParse() throws Exception {
         FileObject root = getRoot("phpstan/PHPStanSupport");
-        List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log.xml"), root);
+        File workDir = FileUtil.toFile(root);
+        List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log.xml"), root, workDir);
         assertNotNull(results);
 
         assertEquals(4, results.size());
@@ -62,9 +63,26 @@ public class PHPStanReportParserTest extends NbTestCase {
 
     public void testParseWithOtherOutput() throws Exception {
         FileObject root = getRoot("phpstan/PHPStanSupport");
-        List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log-with-other-output.xml"), root);
+        File workDir = FileUtil.toFile(root);
+        List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log-with-other-output.xml"), root, workDir);
         assertNotNull(results);
         assertEquals(2, results.size());
+    }
+
+    public void testParseNetBeans3022() throws Exception {
+        FileObject root = getRoot("phpstan/PHPStanSupport/netbeans3022");
+        File workDir = getWorkDir("phpstan/PHPStanSupport");
+        List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log-netbeans-3022.xml"), root, workDir);
+        assertNotNull(results);
+        assertEquals(3, results.size());
+    }
+
+    public void testParseNetBeans3022Win() throws Exception {
+        FileObject root = getRoot("phpstan/PHPStanSupport/netbeans3022");
+        File workDir = getWorkDir("phpstan/PHPStanSupport");
+        List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log-netbeans-3022-win.xml"), root, workDir);
+        assertNotNull(results);
+        assertEquals(3, results.size());
     }
 
     private File getLogFile(String name) throws Exception {
@@ -79,6 +97,11 @@ public class PHPStanReportParserTest extends NbTestCase {
         assertNotNull(name);
         FileObject dataDir = FileUtil.toFileObject(getDataDir());
         return dataDir.getFileObject(name);
+    }
+
+    private File getWorkDir(String name) {
+        assertNotNull(name);
+        return new File(getDataDir(), name);
     }
 
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-3002

- The file name value can be null

e.g.
```xml
<file>
  <error severity="error" message="Ignored error pattern #TEST# was not matched in reported errors." />
</file>
```
So, in this case, just ignore the error.

- There is a difference in file name value between the old version and the new version

e.g. Inspect the following app directory (myproject is the working directory)
- myproject/app/Test1.php
- myproject/app/Test2.php

old version: the relative path from target directory
```xml
<file name="Test1.php">
  <error line="13" column="1" severity="error" message="Binary operation &quot;+&quot; between string and 2 results in an error." />
</file>
<file name="Test2.php">
  <error line="9" column="1" severity="error" message="Anonymous function should return string but returns void." />
  <error line="9" column="1" severity="error" message="Result of closure (void) is used." />
</file>
```

new verison: the relative path from working directory
```xml
<file name="app/Test1.php">
  <error line="13" column="1" severity="error" message="Binary operation &quot;+&quot; between string and 2 results in an error." />
</file>
<file name="app/Test2.php">
  <error line="9" column="1" severity="error" message="Anonymous function should return string but returns void." />
  <error line="9" column="1" severity="error" message="Result of closure (void) is used." />
</file>
```

So, check also the relative path from the working directory.