### PR TITLE
[TRAVIS] Fix Travis config when run tests for ide modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -232,7 +232,7 @@ matrix:
             - ant $OPTS -f ide/extbrowser test
             - ant $OPTS -f ide/extexecution.base test
             - ant $OPTS -f ide/gsf.testrunner.ui test
-            - ant $OPTS -f ide/html test
+            - travis_retry ant $OPTS -f ide/html test
             - ant $OPTS -f ide/html.custom test
             #- ant $OPTS -f ide/html.editor test
             #- ant $OPTS -f ide/html.lexer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -188,110 +188,109 @@ matrix:
             - hide-logs.sh ant $OPTS -f platform/templatesui test
             - hide-logs.sh ant $OPTS -f platform/uihandler test
           
-        - env: > 
-            SIGTEST=false 
-            COMPILETEST=false 
-            LICENSE=false 
-            CV=false 
-            RUN_TESTS_JDK9PLUS=false 
-            RUN_TESTS_JDK8=true 
-            OPTS="-Dcluster.config=minimal -quiet build -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true"
-            TEST_MODULES="ide/api.xml
-             ide/api.xml.ui
-             ide/bugtracking
-             ide/bugtracking.bridge
-             ide/bugtracking.commons
-             ide/bugzilla
-             ide/code.analysis
-             ide/core.ide
-             ide/csl.api
-             ide/csl.types
-             ide/css.editor
-             ide/css.lib
-             ide/css.model
-             ide/db
-             ide/db.dataview
-             ide/db.sql.editor
-             ide/docker.api
-             ide/docker.ui
-             ide/editor.bookmarks
-             ide/editor.bracesmatching
-             ide/editor.document
-             ide/editor.fold
-             ide/editor.fold.nbui
-             ide/editor.guards
-             ide/editor.indent
-             ide/editor.indent.project
-             ide/editor.macros
-             ide/editor.search
-             ide/editor.settings
-             ide/editor.settings.storage
-             ide/editor.structure
-             ide/editor.tools.storage
-             ide/editor.util
-             ide/extbrowser
-             ide/extexecution.base
-             ide/gsf.testrunner.ui
-             ide/html
-             ide/html.custom
-             ide/html.editor
-             ide/html.lexer
-             ide/html.parser
-             ide/html.validation
-             ide/hudson
-             ide/hudson.git
-             ide/hudson.mercurial
-             ide/hudson.subversion
-             ide/hudson.tasklist
-             ide/hudson.ui
-             ide/javascript2.debug
-             ide/languages.yaml
-             ide/lexer
-             ide/lib.terminalemulator
-             ide/libs.freemarker
-             ide/libs.git
-             ide/libs.graalsdk
-             ide/localhistory
-             ide/o.openidex.util
-             ide/parsing.api
-             ide/parsing.indexing
-             ide/parsing.lucene
-             ide/project.ant
-             ide/project.ant.compat8
-             ide/project.ant.ui
-             ide/project.libraries
-             ide/project.libraries.ui
-             ide/projectapi
-             ide/projectapi.nb
-             ide/projectuiapi.base
-             ide/refactoring.api
-             ide/schema2beans
-             ide/server
-             ide/spellchecker
-             ide/spi.editor.hints
-             ide/spi.palette
-             ide/spi.tasklist
-             ide/tasklist.ui
-             ide/team.commons
-             ide/terminal.nb
-             ide/utilities
-             ide/versioning.masterfs
-             ide/versioning.ui
-             ide/versioning.util
-             ide/web.common
-             ide/web.common.ui
-             ide/web.webkit.debugging
-             ide/xml
-             ide/xml.axi
-             ide/xml.core
-             ide/xml.lexer
-             ide/xml.multiview
-             ide/xml.text
-             ide/xml.text.obsolete90
-             ide/xml.xam
-             ide/xml.xdm
-             ide/xsl"
+        - name: Test ide modules
           jdk: openjdk8
+          env:
+            - OPTS="-quiet -Dcluster.config=minimal -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true"
+          before_script:
+            - ant $OPTS clean
+            - ant $OPTS build
+          script:
+            - ant $OPTS -f ide/api.xml test
+            - ant $OPTS -f ide/api.xml.ui test
+            - ant $OPTS -f ide/bugtracking test
+            #- ant $OPTS -f ide/bugtracking.bridge test
+            - ant $OPTS -f ide/bugtracking.commons test
+            #- ant $OPTS -f ide/bugzilla test
+            - ant $OPTS -f ide/code.analysis test
+            - ant $OPTS -f ide/core.ide test
+            - ant $OPTS -f ide/csl.api test
+            - ant $OPTS -f ide/csl.types test
+            - ant $OPTS -f ide/css.editor test
+            - ant $OPTS -f ide/css.lib test
+            - ant $OPTS -f ide/css.model test
+            - ant $OPTS -f ide/db test
+            - ant $OPTS -f ide/db.dataview test
+            - ant $OPTS -f ide/db.sql.editor test
+            - ant $OPTS -f ide/docker.api test
+            - ant $OPTS -f ide/docker.ui test
+            - ant $OPTS -f ide/editor.bookmarks test
+            #- ant $OPTS -f ide/editor.bracesmatching test
+            - ant $OPTS -f ide/editor.document test
+            - ant $OPTS -f ide/editor.fold test
+            - ant $OPTS -f ide/editor.fold.nbui test
+            - ant $OPTS -f ide/editor.guards test
+            - ant $OPTS -f ide/editor.indent test
+            - ant $OPTS -f ide/editor.indent.project test
+            - ant $OPTS -f ide/editor.macros test
+            - ant $OPTS -f ide/editor.search test
+            - ant $OPTS -f ide/editor.settings test
+            - ant $OPTS -f ide/editor.settings.storage test
+            - ant $OPTS -f ide/editor.structure test
+            - ant $OPTS -f ide/editor.tools.storage test
+            - ant $OPTS -f ide/editor.util test
+            - ant $OPTS -f ide/extbrowser test
+            - ant $OPTS -f ide/extexecution.base test
+            - ant $OPTS -f ide/gsf.testrunner.ui test
+            - ant $OPTS -f ide/html test
+            - ant $OPTS -f ide/html.custom test
+            #- ant $OPTS -f ide/html.editor test
+            #- ant $OPTS -f ide/html.lexer test
+            - ant $OPTS -f ide/html.parser test
+            - ant $OPTS -f ide/html.validation test
+            - ant $OPTS -f ide/hudson test
+            - ant $OPTS -f ide/hudson.git test
+            - ant $OPTS -f ide/hudson.mercurial test
+            - ant $OPTS -f ide/hudson.subversion test
+            - ant $OPTS -f ide/hudson.tasklist test
+            - ant $OPTS -f ide/hudson.ui test
+            - ant $OPTS -f ide/javascript2.debug test
+            - ant $OPTS -f ide/languages.yaml test
+            - ant $OPTS -f ide/lexer test
+            - ant $OPTS -f ide/lib.terminalemulator test
+            - ant $OPTS -f ide/libs.freemarker test
+            - ant $OPTS -f ide/libs.git test
+            - ant $OPTS -f ide/libs.graalsdk test
+            #- ant $OPTS -f ide/localhistory test
+            - ant $OPTS -f ide/o.openidex.util test
+            #- ant $OPTS -f ide/parsing.api test
+            #- ant $OPTS -f ide/parsing.indexing test
+            - ant $OPTS -f ide/parsing.lucene test
+            - ant $OPTS -f ide/project.ant test
+            - ant $OPTS -f ide/project.ant.compat8 test
+            - ant $OPTS -f ide/project.ant.ui test
+            - ant $OPTS -f ide/project.libraries test
+            - ant $OPTS -f ide/project.libraries.ui test
+            - ant $OPTS -f ide/projectapi test
+            - ant $OPTS -f ide/projectapi.nb test
+            - ant $OPTS -f ide/projectuiapi.base test
+            - ant $OPTS -f ide/refactoring.api test
+            - ant $OPTS -f ide/schema2beans test
+            - ant $OPTS -f ide/server test
+            - ant $OPTS -f ide/spellchecker test
+            - ant $OPTS -f ide/spi.editor.hints test
+            #- ant $OPTS -f ide/spi.palette test
+            - ant $OPTS -f ide/spi.tasklist test
+            - ant $OPTS -f ide/tasklist.ui test
+            - ant $OPTS -f ide/team.commons test
+            - ant $OPTS -f ide/terminal.nb test
+            - ant $OPTS -f ide/utilities test
+            - ant $OPTS -f ide/versioning.masterfs test
+            - ant $OPTS -f ide/versioning.ui test
+            - ant $OPTS -f ide/versioning.util test
+            - ant $OPTS -f ide/web.common test
+            - ant $OPTS -f ide/web.common.ui test
+            - ant $OPTS -f ide/web.webkit.debugging test
+            - ant $OPTS -f ide/xml test
+            - ant $OPTS -f ide/xml.axi test
+            - ant $OPTS -f ide/xml.core test
+            - ant $OPTS -f ide/xml.lexer test
+            - ant $OPTS -f ide/xml.multiview test
+            - ant $OPTS -f ide/xml.text test
+            - ant $OPTS -f ide/xml.text.obsolete90 test
+            - ant $OPTS -f ide/xml.xam test
+            - ant $OPTS -f ide/xml.xdm test
+            - ant $OPTS -f ide/xsl test
 
         - name: "Versioning modules (ide/versioning and ide/versioning.core) tests"
           jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -249,7 +249,7 @@ matrix:
             - ant $OPTS -f ide/lexer test
             - ant $OPTS -f ide/lib.terminalemulator test
             - ant $OPTS -f ide/libs.freemarker test
-            - ant $OPTS -f ide/libs.git test
+            #- ant $OPTS -f ide/libs.git test
             - ant $OPTS -f ide/libs.graalsdk test
             #- ant $OPTS -f ide/localhistory test
             - ant $OPTS -f ide/o.openidex.util test


### PR DESCRIPTION
Current Travis configuration doesn't run the tests for the ide modules only does a build of the source code.

It's the same problem that @matthiasblaesing found when he try to add tests in webcommon cluster: https://github.com/apache/netbeans/pull/1451