### PR TITLE
[NETBEANS-1657] PHP visibility keywords via drop-down list

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/api/PhpModifiers.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/api/PhpModifiers.java
@@ -32,6 +32,12 @@ public final class PhpModifiers extends Modifier {
 
     private static final PhpModifiers EMPTY = new PhpModifiers(NO_FLAGS);
 
+    // visibility
+    public static final String VISIBILITY_VAR = "var"; // NOI18N
+    public static final String VISIBILITY_PUBLIC = "public"; // NOI18N
+    public static final String VISIBILITY_PRIVATE = "private"; // NOI18N
+    public static final String VISIBILITY_PROTECTED = "protected"; // NOI18N
+
     public static PhpModifiers noModifiers() {
         return fromBitMask(new int[]{});
     }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/resources/layer.xml
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/resources/layer.xml
@@ -394,6 +394,7 @@
                     <file name="org-netbeans-modules-php-editor-verification-ArrowFunctionSuggestion.instance"/>
                     <file name="org-netbeans-modules-php-editor-verification-AssignVariableSuggestion.instance"/>
                     <file name="org-netbeans-modules-php-editor-verification-CombinedAssignmentOperatorSuggestion.instance"/>
+                    <file name="org-netbeans-modules-php-editor-verification-ConvertVisibilitySuggestion.instance"/>
                     <file name="org-netbeans-modules-php-editor-verification-DeclareStrictTypesSuggestion.instance"/>
                     <file name="org-netbeans-modules-php-editor-verification-IdenticalComparisonSuggestion.instance"/>
                     <file name="org-netbeans-modules-php-editor-verification-InitializeFieldSuggestion.instance"/>

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/ConvertVisibilitySuggestion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/ConvertVisibilitySuggestion.java
@@ -1,0 +1,318 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.verification;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import org.netbeans.editor.BaseDocument;
+import org.netbeans.modules.csl.api.EditList;
+import org.netbeans.modules.csl.api.Hint;
+import org.netbeans.modules.csl.api.HintFix;
+import org.netbeans.modules.csl.api.OffsetRange;
+import org.netbeans.modules.csl.spi.support.CancelSupport;
+import org.netbeans.modules.php.editor.api.PhpModifiers;
+import org.netbeans.modules.php.editor.parser.PHPParseResult;
+import org.netbeans.modules.php.editor.parser.astnodes.ASTNode;
+import org.netbeans.modules.php.editor.parser.astnodes.BodyDeclaration;
+import org.netbeans.modules.php.editor.parser.astnodes.BodyDeclaration.Modifier;
+import org.netbeans.modules.php.editor.parser.astnodes.ConstantDeclaration;
+import org.netbeans.modules.php.editor.parser.astnodes.FieldsDeclaration;
+import org.netbeans.modules.php.editor.parser.astnodes.InterfaceDeclaration;
+import org.netbeans.modules.php.editor.parser.astnodes.MethodDeclaration;
+import org.netbeans.modules.php.editor.parser.astnodes.visitors.DefaultVisitor;
+import org.openide.filesystems.FileObject;
+import org.openide.util.NbBundle;
+import org.openide.util.Pair;
+
+/**
+ * Convert the visibility of a property, a method, or a constant.
+ */
+public class ConvertVisibilitySuggestion extends SuggestionRule {
+
+    private static final String HINT_ID = "Convert.Visibility.Suggestion"; // NOI18N
+    private static final Logger LOGGER = Logger.getLogger(ConvertVisibilitySuggestion.class.getName());
+
+    @Override
+    public String getId() {
+        return HINT_ID;
+    }
+
+    @Override
+    @NbBundle.Messages("ConvertVisibilitySuggestion.Description=Convert the visibility of a property, a method, or a constant. Please convert it carefully. (e.g. from public to private)")
+    public String getDescription() {
+        return Bundle.ConvertVisibilitySuggestion_Description();
+    }
+
+    @Override
+    @NbBundle.Messages("ConvertVisibilitySuggestion.DisplayName=Convert Visibility")
+    public String getDisplayName() {
+        return Bundle.ConvertVisibilitySuggestion_DisplayName();
+    }
+
+    @Override
+    public void invoke(PHPRuleContext context, List<Hint> result) {
+        PHPParseResult phpParseResult = (PHPParseResult) context.parserResult;
+        if (phpParseResult.getProgram() == null) {
+            return;
+        }
+        if (CancelSupport.getDefault().isCancelled()) {
+            return;
+        }
+        final BaseDocument doc = context.doc;
+        int caretOffset = getCaretOffset();
+        OffsetRange lineBounds = VerificationUtils.createLineBounds(caretOffset, doc);
+        if (lineBounds.containsInclusive(caretOffset)) {
+            FileObject fileObject = phpParseResult.getSnapshot().getSource().getFileObject();
+            if (fileObject != null) {
+                CheckVisitor checkVisitor = new CheckVisitor(fileObject, this, context.doc, lineBounds);
+                phpParseResult.getProgram().accept(checkVisitor);
+                if (CancelSupport.getDefault().isCancelled()) {
+                    return;
+                }
+                result.addAll(checkVisitor.getHints());
+            }
+        }
+    }
+
+    private static final class CheckVisitor extends DefaultVisitor {
+
+        private final FileObject fileObject;
+        private final ConvertVisibilitySuggestion suggestion;
+        private final BaseDocument document;
+        private final OffsetRange lineRange;
+        private final List<FixInfo> fixInfos = new ArrayList<>();
+        private boolean isInInterface;
+
+        public CheckVisitor(FileObject fileObject, ConvertVisibilitySuggestion suggestion, BaseDocument document, OffsetRange lineRange) {
+            this.fileObject = fileObject;
+            this.suggestion = suggestion;
+            this.document = document;
+            this.lineRange = lineRange;
+        }
+
+        @NbBundle.Messages("ConvertVisibilitySuggestion.Hint.Description=You can convert the visibility if needed")
+        public List<Hint> getHints() {
+            List<Hint> hints = new ArrayList<>();
+            for (FixInfo fixInfo : fixInfos) {
+                if (CancelSupport.getDefault().isCancelled()) {
+                    return Collections.emptyList();
+                }
+                List<HintFix> createFixes = createFixes(fixInfo);
+                if (!createFixes.isEmpty()) {
+                    hints.add(new Hint(suggestion, Bundle.ConvertVisibilitySuggestion_Hint_Description(), fileObject, lineRange, createFixes, 500));
+                }
+            }
+            return hints;
+        }
+
+        private List<HintFix> createFixes(FixInfo fixInfo) {
+            List<HintFix> hintFixes = new ArrayList<>();
+            hintFixes.addAll(fixInfo.createFixes(document));
+            return hintFixes;
+        }
+
+        @Override
+        public void scan(ASTNode node) {
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            if (node != null && (VerificationUtils.isBefore(node.getStartOffset(), lineRange.getEnd()))) {
+                super.scan(node);
+            }
+        }
+
+        @Override
+        public void visit(InterfaceDeclaration node) {
+            isInInterface = true;
+            super.visit(node);
+            isInInterface = false;
+        }
+
+        @Override
+        public void visit(FieldsDeclaration node) {
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            OffsetRange nodeRange = new OffsetRange(node.getStartOffset(), node.getEndOffset());
+            if (lineRange.overlaps(nodeRange)) {
+                processBodyDeclaration(node);
+            }
+        }
+
+        @Override
+        public void visit(ConstantDeclaration node) {
+            if (CancelSupport.getDefault().isCancelled()
+                    || node.isGlobal()) {
+                return;
+            }
+            OffsetRange nodeRange = new OffsetRange(node.getStartOffset(), node.getEndOffset());
+            if (lineRange.overlaps(nodeRange)) {
+                processBodyDeclaration(node);
+            }
+        }
+
+        @Override
+        public void visit(MethodDeclaration node) {
+            if (CancelSupport.getDefault().isCancelled()) {
+                return;
+            }
+            OffsetRange nodeRange = new OffsetRange(node.getStartOffset(), node.getEndOffset());
+            if (lineRange.overlaps(nodeRange)) {
+                processBodyDeclaration(node);
+            }
+        }
+
+        private void processBodyDeclaration(BodyDeclaration node) {
+            fixInfos.add(new FixInfo(node, isInInterface));
+            super.visit(node);
+        }
+    }
+
+    private static final class FixInfo {
+
+        private final BodyDeclaration bodyDeclaration;
+        private final boolean isInInterface;
+
+        public FixInfo(BodyDeclaration bodyDeclaration, boolean isInInterface) {
+            this.bodyDeclaration = bodyDeclaration;
+            this.isInInterface = isInInterface;
+        }
+
+        public Pair<String, OffsetRange> getVisibilityRange(Document document) {
+            String visibility = "implicit"; // NOI18N
+            int startOffset = bodyDeclaration.getStartOffset();
+            int endOffset = bodyDeclaration.getEndOffset();
+            try {
+                String text = document.getText(startOffset, endOffset - startOffset);
+                int indexOfVisibility = -1;
+                if (Modifier.isPublic(bodyDeclaration.getModifier())) {
+                    indexOfVisibility = text.indexOf(PhpModifiers.VISIBILITY_PUBLIC + " "); // NOI18N
+                    visibility = PhpModifiers.VISIBILITY_PUBLIC;
+                    if (indexOfVisibility == -1) {
+                        indexOfVisibility = text.indexOf(PhpModifiers.VISIBILITY_VAR + " "); // NOI18N
+                        visibility = PhpModifiers.VISIBILITY_VAR;
+                    }
+                    if (indexOfVisibility == -1) {
+                        visibility = "implicit"; // NOI18N
+                    }
+                } else if (Modifier.isPrivate(bodyDeclaration.getModifier())) {
+                    indexOfVisibility = text.indexOf(PhpModifiers.VISIBILITY_PRIVATE + " "); // NOI18N
+                    visibility = PhpModifiers.VISIBILITY_PRIVATE;
+                } else if (Modifier.isProtected(bodyDeclaration.getModifier())) {
+                    indexOfVisibility = text.indexOf(PhpModifiers.VISIBILITY_PROTECTED + " "); // NOI18N
+                    visibility = PhpModifiers.VISIBILITY_PROTECTED;
+                }
+                int visibilityStart = startOffset;
+                int visibilityEnd = startOffset;
+                if (indexOfVisibility != -1) {
+                    visibilityStart += indexOfVisibility;
+                    visibilityEnd = visibilityStart + visibility.length();
+                }
+                return Pair.of(visibility, new OffsetRange(visibilityStart, visibilityEnd));
+            } catch (BadLocationException ex) {
+                LOGGER.log(Level.WARNING, "Incorrect offset: {0}", ex.offsetRequested()); // NOI18N
+            }
+            return Pair.of(visibility, OffsetRange.NONE);
+        }
+
+        public List<HintFix> createFixes(BaseDocument document) {
+            ArrayList<HintFix> fixes = new ArrayList<>();
+            Pair<String, OffsetRange> visibilityRange = getVisibilityRange(document);
+            String visibility = visibilityRange.first();
+            OffsetRange range = visibilityRange.second();
+            switch (visibility) {
+                case "implicit": // NOI18N
+                    fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PUBLIC + " ", document)); // NOI18N
+                    if (!isInInterface) {
+                        fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PRIVATE + " ", document)); // NOI18N
+                        fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PROTECTED + " ", document)); // NOI18N
+                    }
+                    break;
+                case PhpModifiers.VISIBILITY_VAR:
+                    fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PUBLIC, document));
+                    fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PRIVATE, document));
+                    fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PROTECTED, document));
+                    break;
+                case PhpModifiers.VISIBILITY_PUBLIC:
+                    if (!isInInterface) {
+                        fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PRIVATE, document));
+                        fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PROTECTED, document));
+                    }
+                    break;
+                case PhpModifiers.VISIBILITY_PRIVATE:
+                    fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PUBLIC, document));
+                    fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PROTECTED, document));
+                    break;
+                case PhpModifiers.VISIBILITY_PROTECTED:
+                    fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PUBLIC, document));
+                    fixes.add(new Fix(range, PhpModifiers.VISIBILITY_PRIVATE, document));
+                    break;
+                default:
+                    break;
+            }
+            return fixes;
+        }
+
+    }
+
+    private static final class Fix implements HintFix {
+
+        private final OffsetRange visibilityRange;
+        private final String newVisibility;
+        private final BaseDocument document;
+
+        private Fix(OffsetRange visibilityRange, String newVisibility, BaseDocument document) {
+            this.visibilityRange = visibilityRange;
+            this.newVisibility = newVisibility;
+            this.document = document;
+        }
+
+        @Override
+        @NbBundle.Messages({
+            "# {0} - visibility",
+            "ConvertVisibilitySuggestion.Fix.Description=Convert Visibility to \"{0}\""
+        })
+        public String getDescription() {
+            return Bundle.ConvertVisibilitySuggestion_Fix_Description(newVisibility.trim());
+        }
+
+        @Override
+        public void implement() throws Exception {
+            EditList edits = new EditList(document);
+            edits.replace(visibilityRange.getStart(), visibilityRange.getLength(), newVisibility, true, 0);
+            edits.apply();
+        }
+
+        @Override
+        public boolean isSafe() {
+            return true;
+        }
+
+        @Override
+        public boolean isInteractive() {
+            return false;
+        }
+
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php
@@ -63,6 +63,18 @@ class Visibility {
 
 }
 
+abstract class AbstarctClass {
+
+    abstract function abstractImplicitPublic();
+    abstract public function abstractPublic();
+    abstract protected function abstractProtected();
+    // can't be declared private
+    // abstract private function abstractPrivate();
+    abstract static function abstractImplicitPublicStatic();
+    abstract public static function abstractPublicStatic();
+    abstract protected static function abstractProtectedStatic();
+}
+
 interface InterfaceName {
 
     const INTERFACE_IMPLICIT_CONST = "implicit";

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const CONSTANT = "global";
+
+class Visibility {
+
+    var $var = "public";
+    public $public = "public";
+    public $public1 = "public", $public2 = "public";
+    private $private = "private";
+    protected $protected = "protected";
+    public static $publicStatic = "public";
+    public static $publicStatic1 = "public", $publicStatic2 = "public";
+    private static $privateStatic = "private";
+    protected static $protectedStatic = "protected";
+
+    const IMPLICIT_CONST = "implicit";
+    public const PUBLIC_CONST = "public";
+    private const PRIVATE_CONST = "private";
+    protected const PROTECTED_CONST = "protected";
+
+    function implicitMethod($param) {
+    }
+
+    public function publicMethod($param) {
+    }
+
+    private function privateMethod($param) {
+    }
+
+    protected function protectedMethod($param) {
+    }
+
+    static function implicitStaticMethod($param) {
+    }
+
+    public static function publicStaticMethod($param) {
+    }
+
+    private static function privateStaticMethod($param) {
+    }
+
+    protected static function protectedStaticMethod($param) {
+    }
+
+}
+
+interface InterfaceName {
+
+    const INTERFACE_IMPLICIT_CONST = "implicit";
+    public const INTERFACE_PUBLIC_CONST = "implicit";
+
+    function interfaceImplicitMethod($param);
+
+    public function interfacePublicMethod($param);
+
+    static function interfaceImplicitStaticMethod();
+
+    public static function interfaceImplicitPublicStaticMethod();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_01.hints
@@ -1,0 +1,5 @@
+    abstract function abstractImplici^tPublic();
+-----------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_02.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_02.hints
@@ -1,0 +1,4 @@
+    abstract public function abstractP^ublic();
+----------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_03.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_03.hints
@@ -1,0 +1,4 @@
+    abstract protected ^function abstractProtected();
+----------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_04.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_04.hints
@@ -1,0 +1,5 @@
+    abstract static function abstractImplicitPu^blicStatic();
+------------------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_05.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_05.hints
@@ -1,0 +1,4 @@
+    abstract ^public static function abstractPublicStatic();
+-----------------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_06.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionAbstractMethod_06.hints
@@ -1,0 +1,4 @@
+    abstract protected static function abstractProtectedStat^ic();
+-----------------------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionConst_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionConst_01.hints
@@ -1,0 +1,6 @@
+    const IMPLICIT_CO^NST = "implicit";
+--------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionConst_02.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionConst_02.hints
@@ -1,0 +1,5 @@
+    public const PUBLIC_CONST = "pub^lic";
+-----------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionConst_03.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionConst_03.hints
@@ -1,0 +1,5 @@
+    private const PRIVATE_CONST = "priva^te";
+--------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionConst_04.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionConst_04.hints
@@ -1,0 +1,5 @@
+    protected const ^PROTECTED_CONST = "protected";
+--------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "private"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionInterfaceConst_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionInterfaceConst_01.hints
@@ -1,0 +1,4 @@
+    const INTERFACE_IMPLICIT_CONST = "implici^t";
+------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionInterfaceMethod_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionInterfaceMethod_01.hints
@@ -1,0 +1,4 @@
+    function interfaceImplicitMethod($para^m);
+---------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionInterfaceMethod_03.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionInterfaceMethod_03.hints
@@ -1,0 +1,4 @@
+    static function interfaceImplicitStaticMeth^od();
+----------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_01.hints
@@ -1,0 +1,6 @@
+    function implicitMethod($param)^ {
+-------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_02.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_02.hints
@@ -1,0 +1,5 @@
+    public function publicMethod($para^m) {
+------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_03.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_03.hints
@@ -1,0 +1,5 @@
+    private function privateMethod($param) {^
+--------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_04.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_04.hints
@@ -1,0 +1,5 @@
+    protected ^function protectedMethod($param) {
+------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "private"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_05.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_05.hints
@@ -1,0 +1,6 @@
+    static function implicitStaticMethod($pa^ram) {
+--------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_06.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_06.hints
@@ -1,0 +1,5 @@
+    public static function publicStaticMe^thod($param) {
+-------------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_07.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_07.hints
@@ -1,0 +1,5 @@
+    private static ^function privateStaticMethod($param) {
+---------------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_08.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionMethod_08.hints
@@ -1,0 +1,5 @@
+    prote^cted static function protectedStaticMethod($param) {
+-------------------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "private"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_01.hints
@@ -1,0 +1,5 @@
+    public $public = ^"public";
+------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_02.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_02.hints
@@ -1,0 +1,5 @@
+    public $public1 = "public", ^$public2 = "public";
+----------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_03.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_03.hints
@@ -1,0 +1,5 @@
+    private $privat^e = "private";
+---------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_04.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_04.hints
@@ -1,0 +1,5 @@
+    protected $prote^cted = "protected";
+---------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "private"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_05.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_05.hints
@@ -1,0 +1,5 @@
+    public static $^publicStatic = "public";
+-------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_06.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_06.hints
@@ -1,0 +1,5 @@
+    public static ^$publicStatic1 = "public", $publicStatic2 = "public";
+-----------------------------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_07.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_07.hints
@@ -1,0 +1,5 @@
+    private static $privateStatic = "privat^e";
+----------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_08.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_08.hints
@@ -1,0 +1,5 @@
+    protected static $protectedStatic = "protect^ed";
+----------------------------------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "private"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_09.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php.testConvertVisibilitySuggestionProperty_09.hints
@@ -1,0 +1,6 @@
+    var $var ^= "public";
+------------------------
+HINT:You can convert the visibility if needed
+FIX:Convert Visibility to "public"
+FIX:Convert Visibility to "private"
+FIX:Convert Visibility to "protected"

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php
@@ -1,0 +1,13 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+abstract class AbstarctClass {
+
+    abstract function abstractImplicitPublic();
+    abstract public function abstractPublic();
+    abstract protected function abstractProtected();
+    // can't be declared private
+    // abstract private function abstractPrivate();
+    abstract static function abstractImplicitPublicStatic();
+    abstract public static function abstractPublicStatic();
+    abstract protected static function abstractProtectedStatic();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_01.fixed
@@ -1,0 +1,13 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+abstract class AbstarctClass {
+
+    abstract public function abstractImplicitPublic();
+    abstract public function abstractPublic();
+    abstract protected function abstractProtected();
+    // can't be declared private
+    // abstract private function abstractPrivate();
+    abstract static function abstractImplicitPublicStatic();
+    abstract public static function abstractPublicStatic();
+    abstract protected static function abstractProtectedStatic();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_02.fixed
@@ -1,0 +1,13 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+abstract class AbstarctClass {
+
+    abstract function abstractImplicitPublic();
+    abstract protected function abstractPublic();
+    abstract protected function abstractProtected();
+    // can't be declared private
+    // abstract private function abstractPrivate();
+    abstract static function abstractImplicitPublicStatic();
+    abstract public static function abstractPublicStatic();
+    abstract protected static function abstractProtectedStatic();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_03.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_03.fixed
@@ -1,0 +1,13 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+abstract class AbstarctClass {
+
+    abstract function abstractImplicitPublic();
+    abstract public function abstractPublic();
+    abstract public function abstractProtected();
+    // can't be declared private
+    // abstract private function abstractPrivate();
+    abstract static function abstractImplicitPublicStatic();
+    abstract public static function abstractPublicStatic();
+    abstract protected static function abstractProtectedStatic();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_04.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_04.fixed
@@ -1,0 +1,13 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+abstract class AbstarctClass {
+
+    abstract function abstractImplicitPublic();
+    abstract public function abstractPublic();
+    abstract protected function abstractProtected();
+    // can't be declared private
+    // abstract private function abstractPrivate();
+    abstract protected static function abstractImplicitPublicStatic();
+    abstract public static function abstractPublicStatic();
+    abstract protected static function abstractProtectedStatic();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_05.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_05.fixed
@@ -1,0 +1,13 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+abstract class AbstarctClass {
+
+    abstract function abstractImplicitPublic();
+    abstract public function abstractPublic();
+    abstract protected function abstractProtected();
+    // can't be declared private
+    // abstract private function abstractPrivate();
+    abstract static function abstractImplicitPublicStatic();
+    abstract protected static function abstractPublicStatic();
+    abstract protected static function abstractProtectedStatic();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_06.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_06.fixed
@@ -1,0 +1,13 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+abstract class AbstarctClass {
+
+    abstract function abstractImplicitPublic();
+    abstract public function abstractPublic();
+    abstract protected function abstractProtected();
+    // can't be declared private
+    // abstract private function abstractPrivate();
+    abstract static function abstractImplicitPublicStatic();
+    abstract public static function abstractPublicStatic();
+    abstract public static function abstractProtectedStatic();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityConst.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityConst.php
@@ -1,0 +1,10 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    const IMPLICIT_CONST = "implicit";
+    public const PUBLIC_CONST = "public";
+    private const PRIVATE_CONST = "private";
+    protected const PROTECTED_CONST = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityConst.php.testConvertVisibilitySuggestionConstFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityConst.php.testConvertVisibilitySuggestionConstFix_01.fixed
@@ -1,0 +1,10 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    public const IMPLICIT_CONST = "implicit";
+    public const PUBLIC_CONST = "public";
+    private const PRIVATE_CONST = "private";
+    protected const PROTECTED_CONST = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityConst.php.testConvertVisibilitySuggestionConstFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityConst.php.testConvertVisibilitySuggestionConstFix_02.fixed
@@ -1,0 +1,10 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    const IMPLICIT_CONST = "implicit";
+    private const PUBLIC_CONST = "public";
+    private const PRIVATE_CONST = "private";
+    protected const PROTECTED_CONST = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityConst.php.testConvertVisibilitySuggestionConstFix_03.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityConst.php.testConvertVisibilitySuggestionConstFix_03.fixed
@@ -1,0 +1,10 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    const IMPLICIT_CONST = "implicit";
+    public const PUBLIC_CONST = "public";
+    protected const PRIVATE_CONST = "private";
+    protected const PROTECTED_CONST = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityConst.php.testConvertVisibilitySuggestionConstFix_04.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityConst.php.testConvertVisibilitySuggestionConstFix_04.fixed
@@ -1,0 +1,10 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    const IMPLICIT_CONST = "implicit";
+    public const PUBLIC_CONST = "public";
+    private const PRIVATE_CONST = "private";
+    public const PROTECTED_CONST = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php
@@ -1,0 +1,16 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+interface InterfaceName {
+
+    const INTERFACE_IMPLICIT_CONST = "implicit";
+    public const INTERFACE_PUBLIC_CONST = "implicit";
+
+    function interfaceImplicitMethod($param);
+
+    public function interfacePublicMethod($param);
+
+    static function interfaceImplicitStaticMethod();
+
+    public static function interfaceImplicitPublicStaticMethod();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_01.fixed
@@ -1,0 +1,16 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+interface InterfaceName {
+
+    public const INTERFACE_IMPLICIT_CONST = "implicit";
+    public const INTERFACE_PUBLIC_CONST = "implicit";
+
+    function interfaceImplicitMethod($param);
+
+    public function interfacePublicMethod($param);
+
+    static function interfaceImplicitStaticMethod();
+
+    public static function interfaceImplicitPublicStaticMethod();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_02.fixed
@@ -1,0 +1,16 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+interface InterfaceName {
+
+    const INTERFACE_IMPLICIT_CONST = "implicit";
+    public const INTERFACE_PUBLIC_CONST = "implicit";
+
+    public function interfaceImplicitMethod($param);
+
+    public function interfacePublicMethod($param);
+
+    static function interfaceImplicitStaticMethod();
+
+    public static function interfaceImplicitPublicStaticMethod();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_03.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_03.fixed
@@ -1,0 +1,16 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+interface InterfaceName {
+
+    const INTERFACE_IMPLICIT_CONST = "implicit";
+    public const INTERFACE_PUBLIC_CONST = "implicit";
+
+    function interfaceImplicitMethod($param);
+
+    public function interfacePublicMethod($param);
+
+    public static function interfaceImplicitStaticMethod();
+
+    public static function interfaceImplicitPublicStaticMethod();
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php
@@ -1,0 +1,30 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+class Visibility {
+
+    function implicitMethod($param) {
+    }
+
+    public function publicMethod($param) {
+    }
+
+    private function privateMethod($param) {
+    }
+
+    protected function protectedMethod($param) {
+    }
+
+    static function implicitStaticMethod($param) {
+    }
+
+    public static function publicStaticMethod($param) {
+    }
+
+    private static function privateStaticMethod($param) {
+    }
+
+    protected static function protectedStaticMethod($param) {
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_01.fixed
@@ -1,0 +1,30 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+class Visibility {
+
+    public function implicitMethod($param) {
+    }
+
+    public function publicMethod($param) {
+    }
+
+    private function privateMethod($param) {
+    }
+
+    protected function protectedMethod($param) {
+    }
+
+    static function implicitStaticMethod($param) {
+    }
+
+    public static function publicStaticMethod($param) {
+    }
+
+    private static function privateStaticMethod($param) {
+    }
+
+    protected static function protectedStaticMethod($param) {
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_02.fixed
@@ -1,0 +1,30 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+class Visibility {
+
+    function implicitMethod($param) {
+    }
+
+    private function publicMethod($param) {
+    }
+
+    private function privateMethod($param) {
+    }
+
+    protected function protectedMethod($param) {
+    }
+
+    static function implicitStaticMethod($param) {
+    }
+
+    public static function publicStaticMethod($param) {
+    }
+
+    private static function privateStaticMethod($param) {
+    }
+
+    protected static function protectedStaticMethod($param) {
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_03.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_03.fixed
@@ -1,0 +1,30 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+class Visibility {
+
+    function implicitMethod($param) {
+    }
+
+    public function publicMethod($param) {
+    }
+
+    protected function privateMethod($param) {
+    }
+
+    protected function protectedMethod($param) {
+    }
+
+    static function implicitStaticMethod($param) {
+    }
+
+    public static function publicStaticMethod($param) {
+    }
+
+    private static function privateStaticMethod($param) {
+    }
+
+    protected static function protectedStaticMethod($param) {
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_04.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_04.fixed
@@ -1,0 +1,30 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+class Visibility {
+
+    function implicitMethod($param) {
+    }
+
+    public function publicMethod($param) {
+    }
+
+    private function privateMethod($param) {
+    }
+
+    public function protectedMethod($param) {
+    }
+
+    static function implicitStaticMethod($param) {
+    }
+
+    public static function publicStaticMethod($param) {
+    }
+
+    private static function privateStaticMethod($param) {
+    }
+
+    protected static function protectedStaticMethod($param) {
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_05.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_05.fixed
@@ -1,0 +1,30 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+class Visibility {
+
+    function implicitMethod($param) {
+    }
+
+    public function publicMethod($param) {
+    }
+
+    private function privateMethod($param) {
+    }
+
+    protected function protectedMethod($param) {
+    }
+
+    public static function implicitStaticMethod($param) {
+    }
+
+    public static function publicStaticMethod($param) {
+    }
+
+    private static function privateStaticMethod($param) {
+    }
+
+    protected static function protectedStaticMethod($param) {
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_06.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_06.fixed
@@ -1,0 +1,30 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+class Visibility {
+
+    function implicitMethod($param) {
+    }
+
+    public function publicMethod($param) {
+    }
+
+    private function privateMethod($param) {
+    }
+
+    protected function protectedMethod($param) {
+    }
+
+    static function implicitStaticMethod($param) {
+    }
+
+    private static function publicStaticMethod($param) {
+    }
+
+    private static function privateStaticMethod($param) {
+    }
+
+    protected static function protectedStaticMethod($param) {
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_07.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_07.fixed
@@ -1,0 +1,30 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+class Visibility {
+
+    function implicitMethod($param) {
+    }
+
+    public function publicMethod($param) {
+    }
+
+    private function privateMethod($param) {
+    }
+
+    protected function protectedMethod($param) {
+    }
+
+    static function implicitStaticMethod($param) {
+    }
+
+    public static function publicStaticMethod($param) {
+    }
+
+    public static function privateStaticMethod($param) {
+    }
+
+    protected static function protectedStaticMethod($param) {
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_08.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityMethod.php.testConvertVisibilitySuggestionMethodFix_08.fixed
@@ -1,0 +1,30 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+class Visibility {
+
+    function implicitMethod($param) {
+    }
+
+    public function publicMethod($param) {
+    }
+
+    private function privateMethod($param) {
+    }
+
+    protected function protectedMethod($param) {
+    }
+
+    static function implicitStaticMethod($param) {
+    }
+
+    public static function publicStaticMethod($param) {
+    }
+
+    private static function privateStaticMethod($param) {
+    }
+
+    public static function protectedStaticMethod($param) {
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php
@@ -1,0 +1,15 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    var $var = "public";
+    public $public = "public";
+    public $public1 = "public", $public2 = "public";
+    private $private = "private";
+    protected $protected = "protected";
+    public static $publicStatic = "public";
+    public static $publicStatic1 = "public", $publicStatic2 = "public";
+    private static $privateStatic = "private";
+    protected static $protectedStatic = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_01.fixed
@@ -1,0 +1,15 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    public $var = "public";
+    public $public = "public";
+    public $public1 = "public", $public2 = "public";
+    private $private = "private";
+    protected $protected = "protected";
+    public static $publicStatic = "public";
+    public static $publicStatic1 = "public", $publicStatic2 = "public";
+    private static $privateStatic = "private";
+    protected static $protectedStatic = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_02.fixed
@@ -1,0 +1,15 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    var $var = "public";
+    private $public = "public";
+    public $public1 = "public", $public2 = "public";
+    private $private = "private";
+    protected $protected = "protected";
+    public static $publicStatic = "public";
+    public static $publicStatic1 = "public", $publicStatic2 = "public";
+    private static $privateStatic = "private";
+    protected static $protectedStatic = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_03.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_03.fixed
@@ -1,0 +1,15 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    var $var = "public";
+    public $public = "public";
+    private $public1 = "public", $public2 = "public";
+    private $private = "private";
+    protected $protected = "protected";
+    public static $publicStatic = "public";
+    public static $publicStatic1 = "public", $publicStatic2 = "public";
+    private static $privateStatic = "private";
+    protected static $protectedStatic = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_04.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_04.fixed
@@ -1,0 +1,15 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    var $var = "public";
+    public $public = "public";
+    public $public1 = "public", $public2 = "public";
+    public $private = "private";
+    protected $protected = "protected";
+    public static $publicStatic = "public";
+    public static $publicStatic1 = "public", $publicStatic2 = "public";
+    private static $privateStatic = "private";
+    protected static $protectedStatic = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_05.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_05.fixed
@@ -1,0 +1,15 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    var $var = "public";
+    public $public = "public";
+    public $public1 = "public", $public2 = "public";
+    private $private = "private";
+    public $protected = "protected";
+    public static $publicStatic = "public";
+    public static $publicStatic1 = "public", $publicStatic2 = "public";
+    private static $privateStatic = "private";
+    protected static $protectedStatic = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_06.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_06.fixed
@@ -1,0 +1,15 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    var $var = "public";
+    public $public = "public";
+    public $public1 = "public", $public2 = "public";
+    private $private = "private";
+    protected $protected = "protected";
+    protected static $publicStatic = "public";
+    public static $publicStatic1 = "public", $publicStatic2 = "public";
+    private static $privateStatic = "private";
+    protected static $protectedStatic = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_07.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_07.fixed
@@ -1,0 +1,15 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    var $var = "public";
+    public $public = "public";
+    public $public1 = "public", $public2 = "public";
+    private $private = "private";
+    protected $protected = "protected";
+    public static $publicStatic = "public";
+    private static $publicStatic1 = "public", $publicStatic2 = "public";
+    private static $privateStatic = "private";
+    protected static $protectedStatic = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_08.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_08.fixed
@@ -1,0 +1,15 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    var $var = "public";
+    public $public = "public";
+    public $public1 = "public", $public2 = "public";
+    private $private = "private";
+    protected $protected = "protected";
+    public static $publicStatic = "public";
+    public static $publicStatic1 = "public", $publicStatic2 = "public";
+    public static $privateStatic = "private";
+    protected static $protectedStatic = "protected";
+
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_09.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityProperty.php.testConvertVisibilitySuggestionPropertyFix_09.fixed
@@ -1,0 +1,15 @@
+<?php
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+class Visibility {
+
+    var $var = "public";
+    public $public = "public";
+    public $public1 = "public", $public2 = "public";
+    private $private = "private";
+    protected $protected = "protected";
+    public static $publicStatic = "public";
+    public static $publicStatic1 = "public", $publicStatic2 = "public";
+    private static $privateStatic = "private";
+    private static $protectedStatic = "protected";
+
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ConvertVisibilitySuggestionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ConvertVisibilitySuggestionTest.java
@@ -141,6 +141,30 @@ public class ConvertVisibilitySuggestionTest extends PHPHintsTestBase {
         checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "const CON^STANT = \"global\";");
     }
 
+    public void testConvertVisibilitySuggestionAbstractMethod_01() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    abstract function abstractImplici^tPublic();");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractMethod_02() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    abstract public function abstractP^ublic();");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractMethod_03() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    abstract protected ^function abstractProtected();");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractMethod_04() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    abstract static function abstractImplicitPu^blicStatic();");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractMethod_05() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    abstract ^public static function abstractPublicStatic();");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractMethod_06() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    abstract protected static function abstractProtectedStat^ic();");
+    }
+
     // Fix
     public void testConvertVisibilitySuggestionPropertyFix_01() throws Exception {
         applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityProperty.php", "    var ^$var = \"public\";", "Convert Visibility");
@@ -236,6 +260,30 @@ public class ConvertVisibilitySuggestionTest extends PHPHintsTestBase {
 
     public void testConvertVisibilitySuggestionInterfaceFix_03() throws Exception {
         applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityInterface.php", "    static function interfaceImplicitStaticMetho^d();", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractClassFix_01() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityAbstractClass.php", "    abstract function abst^ractImplicitPublic();", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractClassFix_02() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityAbstractClass.php", "    abstract public ^function abstractPublic();", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractClassFix_03() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityAbstractClass.php", "    abstract protected function ^abstractProtected();", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractClassFix_04() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityAbstractClass.php", "    abstract ^static function abstractImplicitPublicStatic();", "protected");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractClassFix_05() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityAbstractClass.php", "    abstract public s^tatic function abstractPublicStatic();", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionAbstractClassFix_06() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityAbstractClass.php", "    abstract protected static function abs^tractProtectedStatic();", "Convert Visibility");
     }
 
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ConvertVisibilitySuggestionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ConvertVisibilitySuggestionTest.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.verification;
+
+public class ConvertVisibilitySuggestionTest extends PHPHintsTestBase {
+
+    public ConvertVisibilitySuggestionTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected String getTestDirectory() {
+        return TEST_DIRECTORY + "ConvertVisibilitySuggestion/";
+    }
+
+    public void testConvertVisibilitySuggestionProperty_01() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    public $public = ^\"public\";");
+    }
+
+    public void testConvertVisibilitySuggestionProperty_02() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    public $public1 = \"public\", ^$public2 = \"public\";");
+    }
+
+    public void testConvertVisibilitySuggestionProperty_03() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    private $privat^e = \"private\";");
+    }
+
+    public void testConvertVisibilitySuggestionProperty_04() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    protected $prote^cted = \"protected\";");
+    }
+
+    public void testConvertVisibilitySuggestionProperty_05() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    public static $^publicStatic = \"public\";");
+    }
+
+    public void testConvertVisibilitySuggestionProperty_06() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    public static ^$publicStatic1 = \"public\", $publicStatic2 = \"public\";");
+    }
+
+    public void testConvertVisibilitySuggestionProperty_07() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    private static $privateStatic = \"privat^e\";");
+    }
+
+    public void testConvertVisibilitySuggestionProperty_08() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    protected static $protectedStatic = \"protect^ed\";");
+    }
+
+    public void testConvertVisibilitySuggestionProperty_09() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    var $var ^= \"public\";");
+    }
+
+    public void testConvertVisibilitySuggestionConst_01() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    const IMPLICIT_CO^NST = \"implicit\";");
+    }
+
+    public void testConvertVisibilitySuggestionConst_02() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    public const PUBLIC_CONST = \"pub^lic\";");
+    }
+
+    public void testConvertVisibilitySuggestionConst_03() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    private const PRIVATE_CONST = \"priva^te\";");
+    }
+
+    public void testConvertVisibilitySuggestionConst_04() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    protected const ^PROTECTED_CONST = \"protected\";");
+    }
+
+    public void testConvertVisibilitySuggestionMethod_01() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    function implicitMethod($param)^ {");
+    }
+
+    public void testConvertVisibilitySuggestionMethod_02() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    public function publicMethod($para^m) {");
+    }
+
+    public void testConvertVisibilitySuggestionMethod_03() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    private function privateMethod($param) {^");
+    }
+
+    public void testConvertVisibilitySuggestionMethod_04() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    protected ^function protectedMethod($param) {");
+    }
+
+    public void testConvertVisibilitySuggestionMethod_05() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    static function implicitStaticMethod($pa^ram) {");
+    }
+
+    public void testConvertVisibilitySuggestionMethod_06() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    public static function publicStaticMe^thod($param) {");
+    }
+
+    public void testConvertVisibilitySuggestionMethod_07() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    private static ^function privateStaticMethod($param) {");
+    }
+
+    public void testConvertVisibilitySuggestionMethod_08() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    prote^cted static function protectedStaticMethod($param) {");
+    }
+
+    public void testConvertVisibilitySuggestionInterfaceConst_01() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    const INTERFACE_IMPLICIT_CONST = \"implici^t\";");
+    }
+
+    public void testConvertVisibilitySuggestionInterfaceConst_02() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    public const INTERFACE_P^UBLIC_CONST = \"implicit\";");
+    }
+
+    public void testConvertVisibilitySuggestionInterfaceMethod_01() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    function interfaceImplicitMethod($para^m);");
+    }
+
+    public void testConvertVisibilitySuggestionInterfaceMethod_02() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    public ^function interfacePublicMethod($param);");
+    }
+
+    public void testConvertVisibilitySuggestionInterfaceMethod_03() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    static function interfaceImplicitStaticMeth^od();");
+    }
+
+    public void testConvertVisibilitySuggestionInterfaceMethod_04() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "    public ^static function interfaceImplicitPublicStaticMethod();");
+    }
+
+    public void testConvertVisibilitySuggestionGlobalConst_01() throws Exception {
+        checkHints(new ConvertVisibilitySuggestion(), "testConvertVisibility.php", "const CON^STANT = \"global\";");
+    }
+
+    // Fix
+    public void testConvertVisibilitySuggestionPropertyFix_01() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityProperty.php", "    var ^$var = \"public\";", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionPropertyFix_02() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityProperty.php", "    public ^$public = \"public\";", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionPropertyFix_03() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityProperty.php", "    public $public1 = \"public\", $public2^ = \"public\";", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionPropertyFix_04() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityProperty.php", "    private ^$private = \"private\";", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionPropertyFix_05() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityProperty.php", "    protected $protected = \"pr^otected\";", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionPropertyFix_06() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityProperty.php", "    public static $publicStat^ic = \"public\";", "protected");
+    }
+
+    public void testConvertVisibilitySuggestionPropertyFix_07() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityProperty.php", "    public static $publicStatic1 = \"public\", $publicStatic2 ^= \"public\";", "private");
+    }
+
+    public void testConvertVisibilitySuggestionPropertyFix_08() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityProperty.php", "    private static $privateStatic = \"priva^te\";", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionPropertyFix_09() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityProperty.php", "    protected ^static $protectedStatic = \"protected\";", "private");
+    }
+
+    public void testConvertVisibilitySuggestionConstFix_01() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityConst.php", "    const IMPLICIT_CO^NST = \"implicit\";", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionConstFix_02() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityConst.php", "    public const PUBLIC_CONST = ^\"public\";", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionConstFix_03() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityConst.php", "    private const PRIVATE_CONST^ = \"private\";", "protected");
+    }
+
+    public void testConvertVisibilitySuggestionConstFix_04() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityConst.php", "    protected const PROTECTED_^CONST = \"protected\";", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionMethodFix_01() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityMethod.php", "    function implicitMeth^od($param) {", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionMethodFix_02() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityMethod.php", "    public function publicMethod($^param) {", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionMethodFix_03() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityMethod.php", "    private function privat^eMethod($param) {", "protected");
+    }
+
+    public void testConvertVisibilitySuggestionMethodFix_04() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityMethod.php", "    protected fu^nction protectedMethod($param) {", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionMethodFix_05() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityMethod.php", "    static function implicitStaticMethod($para^m) {", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionMethodFix_06() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityMethod.php", "    public static fun^ction publicStaticMethod($param) {", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionMethodFix_07() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityMethod.php", "    private static function privateStat^icMethod($param) {", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionMethodFix_08() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityMethod.php", "    protected static function protecte^dStaticMethod($param) {", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionInterfaceFix_01() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityInterface.php", "    const INTERFACE_IMPLICIT_CONST = \"impli^cit\";", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionInterfaceFix_02() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityInterface.php", "    function interfaceImp^licitMethod($param);", "Convert Visibility");
+    }
+
+    public void testConvertVisibilitySuggestionInterfaceFix_03() throws Exception {
+        applyHint(new ConvertVisibilitySuggestion(), "testConvertVisibilityInterface.php", "    static function interfaceImplicitStaticMetho^d();", "Convert Visibility");
+    }
+
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-1657
- Add ConvertVisibilitySuggestion
- Note: Just convert the visibility keyword, i.e. don't check whether there is a problem (e.g. "public" -> "private")
- In the case of interface, it is available if the visibility is implicit public ("" -> "public")

e.g.
Before:
```php
interface MyInterface {
    const IMPLICIT_CONST = "implicit";
    function implicitPublicMethod($param);
}
```
After:
```php
interface MyInterface {
    public const IMPLICIT_CONST = "implicit";
    public function implicitPublicMethod($param);
}
```