### PR TITLE
Fix org.osgi.framework.BundleException when run core/osgi/ActivatorTest

### DIFF
--- a/platform/core.osgi/nbproject/project.properties
+++ b/platform/core.osgi/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 cp.extra=\
     ${nb_all}/platform/libs.osgi/external/osgi.core-7.0.0.jar:\

--- a/platform/core.osgi/src/org/netbeans/core/osgi/OSGiClassLoader.java
+++ b/platform/core.osgi/src/org/netbeans/core/osgi/OSGiClassLoader.java
@@ -67,7 +67,7 @@ class OSGiClassLoader extends ClassLoader {
             // Sort framework last so since in Felix 4 its loadClass will search app classpath, causing test failures.
             // (Tried to disable this using various framework config properties without success.)
             return NbCollections.iterable(Enumerations.concat(Enumerations.filter(Enumerations.array(bundles), new Enumerations.Processor<Bundle,Bundle>() {
-                public @Override Bundle process(Bundle b, Collection<Bundle> _) {
+                public @Override Bundle process(Bundle b, Collection<Bundle> c) {
                     if (b.getBundleId() == 0) {
                         return null;
                     }

--- a/platform/core.osgi/test/unit/src/org/netbeans/core/osgi/ActivatorTest.java
+++ b/platform/core.osgi/test/unit/src/org/netbeans/core/osgi/ActivatorTest.java
@@ -237,7 +237,7 @@ public class ActivatorTest extends NbTestCase {
                 .manifest(
                     "OpenIDE-Module: custom",
                     "OpenIDE-Module-Install: custom.Install",
-                    "OpenIDE-Module-Module-Dependencies: org.openide.modules, org.netbeans.libs.jna/1")
+                    "OpenIDE-Module-Module-Dependencies: org.openide.modules, org.netbeans.libs.jna/2")
                 .done()
                 .module("org.netbeans.libs.jna")
                 .run(false);


### PR DESCRIPTION
Fix org.osgi.framework.BundleException when run `org.netbeans.core.osgi.ActivatorTest.testClassPathExtensions` test method.

```
Unable to resolve custom [8](R 8.0): missing requirement [custom [8](R 8.0)] osgi.wiring.bundle; (&(osgi.wiring.bundle=org.netbeans.libs.jna)(bundle-version>=100.0.0)(!(bundle-version>=200.0.0))) Unresolved requirements: [[custom [8](R 8.0)] osgi.wiring.bundle; (&(osgi.wiring.bundle=org.netbeans.libs.jna)(bundle-version>=100.0.0)(!(bundle-version>=200.0.0)))]
```