### PR TITLE
[NETBEANS-3276] Let GradleJavaEEProjectSettings be always registered.

### DIFF
--- a/groovy/gradle.javaee/src/org/netbeans/modules/gradle/javaee/web/WebProjectBrowserProvider.java
+++ b/groovy/gradle.javaee/src/org/netbeans/modules/gradle/javaee/web/WebProjectBrowserProvider.java
@@ -72,12 +72,8 @@ public final class WebProjectBrowserProvider implements ProjectBrowserProvider, 
 
     @Override
     public void setActiveBrowser(final WebBrowser browser) throws IllegalArgumentException, IOException {
-        ProjectManager.mutex().writeAccess(new Runnable() {
-
-            @Override
-            public void run() {
-                JavaEEProjectSettings.setBrowserID(project, browser.getId());
-            }
+        ProjectManager.mutex().writeAccess(() -> {
+            JavaEEProjectSettings.setBrowserID(project, browser.getId());
         });
         pcs.firePropertyChange(PROP_BROWSER_ACTIVE, null, null);
     }
@@ -116,12 +112,9 @@ public final class WebProjectBrowserProvider implements ProjectBrowserProvider, 
     }
     
     private Preferences getPreferences() {
-        Preferences prefs = project.getLookup().lookup(GradleJavaEEProjectSettings.class).getPreferences();
         if (preferences == null) {
-            preferences = prefs;
-        } else {
-            assert preferences == prefs : "Project JavaEE preferences has been changed on: " + project.getProjectDirectory();
+            preferences = project.getLookup().lookup(GradleJavaEEProjectSettings.class).getPreferences();
         }
-        return prefs;
+        return preferences;
     }
 }


### PR DESCRIPTION
Previously the GradleJavaEEProjectSettings has only been registered in the project lookup if that had the war plugin loaded. Loosing that plugin from the project could result that some listeners on the JavaEE project preferences would not be removed.
Adding the settings to all Gradle project probably won't really hurt as it is only used by the JavaEE functionality when installed.