### PR TITLE
[NETBEANS-3257]: Fixed issue on refactoring rename of java method

### DIFF
--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-8250FAEF60A423DA3D5EFA0EE699FB69D906D86C nb-javac-13-api.jar
+FC7D04B1F1AE92A87F113096862112BE7E6970D4 nb-javac-13-api.jar

--- a/java/libs.javacimpl/external/binaries-list
+++ b/java/libs.javacimpl/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-344C8C2A8B421A52ABE725A677BF75659C17FEB6 nb-javac-13-impl.jar
+34E9F9C1BDC61FE7EFCCF305D70960B862DE7815 nb-javac-13-impl.jar

--- a/nb/updatecenters/extras/nbjavac.api/manifest.mf
+++ b/nb/updatecenters/extras/nbjavac.api/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.nbjavac.api
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/nbjavac/api/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.0
+OpenIDE-Module-Specification-Version: 2.1
 OpenIDE-Module-Hide-Classpath-Packages: com.sun.javadoc.**, com.sun.source.**, javax.annotation.processing.**, javax.lang.model.**, javax.tools.**, com.sun.tools.javac.**
 OpenIDE-Module-Fragment-Host: org.netbeans.libs.javacapi

--- a/nb/updatecenters/extras/nbjavac.api/release/modules/ext/nb-javac-13-api.jar.external
+++ b/nb/updatecenters/extras/nbjavac.api/release/modules/ext/nb-javac-13-api.jar.external
@@ -1,4 +1,4 @@
-CRC:262612438
-SIZE:195677
-URL:https://netbeans.osuosl.org/binaries/8250FAEF60A423DA3D5EFA0EE699FB69D906D86C-nb-javac-13-api.jar
-URL:https://hg.netbeans.org/binaries/8250FAEF60A423DA3D5EFA0EE699FB69D906D86C-nb-javac-13-api.jar
+CRC:520567768
+SIZE:230395
+URL:https://netbeans.osuosl.org/binaries/FC7D04B1F1AE92A87F113096862112BE7E6970D4-nb-javac-13-api.jar
+URL:https://hg.netbeans.org/binaries/FC7D04B1F1AE92A87F113096862112BE7E6970D4-nb-javac-13-api.jar

--- a/nb/updatecenters/extras/nbjavac.impl/manifest.mf
+++ b/nb/updatecenters/extras/nbjavac.impl/manifest.mf
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.nbjavac.impl
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/nbjavac/impl/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.0
+OpenIDE-Module-Specification-Version: 2.1
 OpenIDE-Module-Hide-Classpath-Packages: com.sun.tools.javac.**, com.sun.tools.javadoc.**, com.sun.tools.javap.**, com.sun.tools.classfile.**, com.sun.tools.doclint.**
 OpenIDE-Module-Fragment-Host: org.netbeans.libs.javacimpl
 OpenIDE-Module-Provides: org.netbeans.modules.nbjavac

--- a/nb/updatecenters/extras/nbjavac.impl/release/modules/ext/nb-javac-13-impl.jar.external
+++ b/nb/updatecenters/extras/nbjavac.impl/release/modules/ext/nb-javac-13-impl.jar.external
@@ -1,4 +1,4 @@
-CRC:3148453464
-SIZE:3411241
-URL:https://netbeans.osuosl.org/binaries/344C8C2A8B421A52ABE725A677BF75659C17FEB6-nb-javac-13-impl.jar
-URL:https://hg.netbeans.org/binaries/344C8C2A8B421A52ABE725A677BF75659C17FEB6-nb-javac-13-impl.jar
+CRC:3482904810
+SIZE:3595235
+URL:https://netbeans.osuosl.org/binaries/34E9F9C1BDC61FE7EFCCF305D70960B862DE7815-nb-javac-13-impl.jar
+URL:https://hg.netbeans.org/binaries/34E9F9C1BDC61FE7EFCCF305D70960B862DE7815-nb-javac-13-impl.jar


### PR DESCRIPTION
Changes fix for refactoring rename of java methods.
https://issues.apache.org/jira/browse/NETBEANS-3257

nb-javac jars are oracle signed now.

https://github.com/apache/netbeans/pull/1589
this PR got accidentally closed while renaming branch and there is no option to reopen it.