### PR TITLE
[NETBEANS-1855] Autocomplete for property and method without $this->

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/ModelUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/ModelUtils.java
@@ -237,6 +237,16 @@ public final class ModelUtils {
     }
 
     @NonNull
+    public static Collection<? extends TypeScope> resolveType(Model model, int offset) {
+        VariableScope variableScope = model.getVariableScope(offset);
+        TypeScope typeScope = getTypeScope(variableScope);
+        if (typeScope != null) {
+            return Collections.singletonList(typeScope);
+        }
+        return Collections.emptyList();
+    }
+
+    @NonNull
     public static Collection<? extends TypeScope> resolveTypeAfterReferenceToken(Model model, TokenSequence<PHPTokenId> tokenSequence,
             int offset, boolean specialVariable) {
         tokenSequence.move(offset);

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue153707.php.testIssue153707_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/_base/issue153707.php.testIssue153707_01.completion
@@ -4,7 +4,11 @@ echo "class property: |$this->name\n";
 PACKAGE    ANS                             [PUBLIC]   null
 PACKAGE    CNS                             [PUBLIC]   null
 CLASS      Book                            [PUBLIC]   issue153707.php
+METHOD     getName()                       [PUBLIC]   Book
+METHOD     setName($name)                  [PUBLIC]   Book
 VARIABLE   ? $name                         [PUBLIC]   issue153707.php
+VARIABLE   ? name                          [PUBLIC]   Book
+CONSTANT   TEST 'Simon'                    [PUBLIC]   Book
 KEYWORD    Book $this->                               null
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class ParentClass {
+
+    public const PUBLIC_PARENT_CONSTANT = "pubic constant";
+    protected const PROTECTED_PARENT_CONSTANT = "protected constatnt";
+    private const PRIVATE_PARENT_CONSTANT = "private constant";
+
+    public $publicParentProperty;
+    protected $protectedParentProperty;
+    private $privateParentProperty;
+    public static $publicStaticParentProperty;
+    protected static $protectedParentStaticProperty;
+    private static $privateParentStaticProperty;
+
+    public function publicParentMethod($param) {
+        
+    }
+
+    protected function protectedParentMethod($param) {
+        
+    }
+
+    private function privateParentMethod($param) {
+        
+    }
+
+    public static function publicParentStaticMethod($param, $param2) {
+        
+    }
+
+    protected static function protectedParentStaticMethod($param, $param2) {
+        
+    }
+
+    private static function privateParentStaticMethod($param, $param2) {
+        
+    }
+
+}
+
+trait Trait1855 {
+
+    public $publicTraitProperty;
+    protected $protectedTraitProperty;
+    private $privateTraitProperty;
+    public static $publicStaticTraitProperty;
+    protected static $protectedTraitStaticProperty;
+    private static $privateTraitStaticProperty;
+
+    public function publicTraitMethod($param) {
+          // trait 1
+        $p; // trait 2
+        protectedTraitMethod($param); // trait 3
+    }
+
+    protected function protectedTraitMethod($param) {
+        
+    }
+
+    private function privateTraitMethod($param) {
+        
+    }
+
+    public static function publicTraitStaticMethod($param, $param2) {
+        
+    }
+
+    protected static function protectedTraitStaticMethod($param, $param2) {
+        
+    }
+
+    private static function privateTraitStaticMethod($param, $param2) {
+        
+    }
+
+}
+
+class Class1855 extends ParentClass {
+
+    public const PUBLIC_CONSTANT = "pubic constant";
+    protected const PROTECTED_CONSTANT = "protected constatnt";
+    private const PRIVATE_CONSTANT = "private constant";
+    public const TEST1 = ;
+    public const TEST2 = pri;
+
+    public $publicProperty;
+    protected $protectedProperty;
+    private $privateProperty;
+    public static $publicStaticProperty;
+    protected static $protectedStaticProperty;
+    private static $privateStaticProperty;
+
+    use Trait1855;
+
+    public function test() {
+          // test1
+        $ // test2
+        pri // test3
+    }
+
+    public function publicMethod($param) {
+        
+    }
+
+    protected function protectedMethod($param) {
+        
+    }
+
+    private function privateMethod($param) {
+        
+    }
+
+    public static function publicStaticMethod($param, $param2) {
+        
+    }
+
+    protected static function protectedStaticMethod($param, $param2) {
+        
+    }
+
+    private static function privateStaticMethod($param, $param2) {
+        
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInClassConst_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInClassConst_01.completion
@@ -1,0 +1,15 @@
+Code completion result for source line:
+public const TEST1 = |;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      Class1855                       [PUBLIC]   nb1855.php
+CLASS      ParentClass                     [PUBLIC]   nb1855.php
+CONSTANT   PRIVATE_CONSTANT "private cons  [PRIVATE]  Class1855
+CONSTANT   PROTECTED_CONSTANT "protected   [PROTECTE  Class1855
+CONSTANT   PROTECTED_PARENT_CONSTANT "pro  [PROTECTE  ParentClass
+CONSTANT   PUBLIC_CONSTANT "pubic constan  [PUBLIC]   Class1855
+CONSTANT   PUBLIC_PARENT_CONSTANT "pubic   [PUBLIC]   ParentClass
+CONSTANT   TEST2 ?                         [PUBLIC]   Class1855
+KEYWORD    parent::                                   null
+KEYWORD    self::                                     null
+------------------------------------
+KEYWORD    array                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInClassConst_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInClassConst_02.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+public const TEST2 = pri|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   PRIVATE_CONSTANT "private cons  [PRIVATE]  Class1855

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInTrait_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInTrait_01.completion
@@ -1,14 +1,22 @@
 Code completion result for source line:
-$af = static fn() => |isset($this); // static
+| // trait 1
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-CLASS      ArrowFunctions                  [PUBLIC]   arrowFunctions.php
-METHOD     getNumber()                     [PUBLIC]   ArrowFunctions
-METHOD     new()                           [STATIC]   ArrowFunctions
-METHOD     test()                          [PUBLIC]   ArrowFunctions
-VARIABLE   ? $af                           [PUBLIC]   arrowFunctions.php
-VARIABLE   int $test                       [PUBLIC]   arrowFunctions.php
-CONSTANT   CONSTANT_INT 1000               [PUBLIC]   arrowFunctions.php
-KEYWORD    ArrowFunctions $this->                     null
+CLASS      Class1855                       [PUBLIC]   nb1855.php
+CLASS      ParentClass                     [PUBLIC]   nb1855.php
+METHOD     privateTraitMethod($param)      [PRIVATE]  Trait1855
+METHOD     privateTraitStaticMethod($para  [PRIVATE,  Trait1855
+METHOD     protectedTraitMethod($param)    [PROTECTE  Trait1855
+METHOD     protectedTraitStaticMethod($pa  [PROTECTE  Trait1855
+METHOD     publicTraitMethod($param)       [PUBLIC]   Trait1855
+METHOD     publicTraitStaticMethod($param  [STATIC]   Trait1855
+VARIABLE   ? $param                        [PUBLIC]   nb1855.php
+VARIABLE   ? $privateTraitStaticProperty   [PRIVATE,  Trait1855
+VARIABLE   ? $protectedTraitStaticPropert  [PROTECTE  Trait1855
+VARIABLE   ? $publicStaticTraitProperty    [STATIC]   Trait1855
+VARIABLE   ? privateTraitProperty          [PRIVATE]  Trait1855
+VARIABLE   ? protectedTraitProperty        [PROTECTE  Trait1855
+VARIABLE   ? publicTraitProperty           [PUBLIC]   Trait1855
+KEYWORD    Trait1855 $this->                          null
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null
 KEYWORD    static::                                   null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInTrait_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInTrait_02.completion
@@ -1,9 +1,14 @@
 Code completion result for source line:
-echo "class property: $|this->name\n";
+$|p; // trait 2
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-VARIABLE   ? $name                         [PUBLIC]   issue153707.php
-VARIABLE   ? name                          [PUBLIC]   Book
-KEYWORD    Book $this->                               null
+VARIABLE   ? $param                        [PUBLIC]   nb1855.php
+VARIABLE   ? $privateTraitStaticProperty   [PRIVATE,  Trait1855
+VARIABLE   ? $protectedTraitStaticPropert  [PROTECTE  Trait1855
+VARIABLE   ? $publicStaticTraitProperty    [STATIC]   Trait1855
+VARIABLE   ? privateTraitProperty          [PRIVATE]  Trait1855
+VARIABLE   ? protectedTraitProperty        [PROTECTE  Trait1855
+VARIABLE   ? publicTraitProperty           [PUBLIC]   Trait1855
+KEYWORD    Trait1855 $this->                          null
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform
 VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInTrait_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefixInTrait_03.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+protected|TraitMethod($param); // trait 3
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     protectedTraitMethod($param)    [PROTECTE  Trait1855
+METHOD     protectedTraitStaticMethod($pa  [PROTECTE  Trait1855
+VARIABLE   ? $protectedTraitStaticPropert  [PROTECTE  Trait1855
+VARIABLE   ? protectedTraitProperty        [PROTECTE  Trait1855
+------------------------------------
+KEYWORD    protected                                  null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefix_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefix_01.completion
@@ -1,14 +1,48 @@
 Code completion result for source line:
-$af = static fn() => |isset($this); // static
+| // test1
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-CLASS      ArrowFunctions                  [PUBLIC]   arrowFunctions.php
-METHOD     getNumber()                     [PUBLIC]   ArrowFunctions
-METHOD     new()                           [STATIC]   ArrowFunctions
-METHOD     test()                          [PUBLIC]   ArrowFunctions
-VARIABLE   ? $af                           [PUBLIC]   arrowFunctions.php
-VARIABLE   int $test                       [PUBLIC]   arrowFunctions.php
-CONSTANT   CONSTANT_INT 1000               [PUBLIC]   arrowFunctions.php
-KEYWORD    ArrowFunctions $this->                     null
+CLASS      Class1855                       [PUBLIC]   nb1855.php
+CLASS      ParentClass                     [PUBLIC]   nb1855.php
+METHOD     privateMethod($param)           [PRIVATE]  Class1855
+METHOD     privateStaticMethod($param, $p  [PRIVATE,  Class1855
+METHOD     privateTraitMethod($param)      [PRIVATE]  Trait1855
+METHOD     privateTraitStaticMethod($para  [PRIVATE,  Trait1855
+METHOD     protectedMethod($param)         [PROTECTE  Class1855
+METHOD     protectedParentMethod($param)   [PROTECTE  ParentClass
+METHOD     protectedParentStaticMethod($p  [PROTECTE  ParentClass
+METHOD     protectedStaticMethod($param,   [PROTECTE  Class1855
+METHOD     protectedTraitMethod($param)    [PROTECTE  Trait1855
+METHOD     protectedTraitStaticMethod($pa  [PROTECTE  Trait1855
+METHOD     publicMethod($param)            [PUBLIC]   Class1855
+METHOD     publicParentMethod($param)      [PUBLIC]   ParentClass
+METHOD     publicParentStaticMethod($para  [STATIC]   ParentClass
+METHOD     publicStaticMethod($param, $pa  [STATIC]   Class1855
+METHOD     publicTraitMethod($param)       [PUBLIC]   Trait1855
+METHOD     publicTraitStaticMethod($param  [STATIC]   Trait1855
+METHOD     test()                          [PUBLIC]   Class1855
+VARIABLE   ? $privateStaticProperty        [PRIVATE,  Class1855
+VARIABLE   ? $privateTraitStaticProperty   [PRIVATE,  Trait1855
+VARIABLE   ? $protectedParentStaticProper  [PROTECTE  ParentClass
+VARIABLE   ? $protectedStaticProperty      [PROTECTE  Class1855
+VARIABLE   ? $protectedTraitStaticPropert  [PROTECTE  Trait1855
+VARIABLE   ? $publicStaticParentProperty   [STATIC]   ParentClass
+VARIABLE   ? $publicStaticProperty         [STATIC]   Class1855
+VARIABLE   ? $publicStaticTraitProperty    [STATIC]   Trait1855
+VARIABLE   ? privateProperty               [PRIVATE]  Class1855
+VARIABLE   ? privateTraitProperty          [PRIVATE]  Trait1855
+VARIABLE   ? protectedParentProperty       [PROTECTE  ParentClass
+VARIABLE   ? protectedProperty             [PROTECTE  Class1855
+VARIABLE   ? protectedTraitProperty        [PROTECTE  Trait1855
+VARIABLE   ? publicParentProperty          [PUBLIC]   ParentClass
+VARIABLE   ? publicProperty                [PUBLIC]   Class1855
+VARIABLE   ? publicTraitProperty           [PUBLIC]   Trait1855
+CONSTANT   PRIVATE_CONSTANT "private cons  [PRIVATE]  Class1855
+CONSTANT   PROTECTED_CONSTANT "protected   [PROTECTE  Class1855
+CONSTANT   PROTECTED_PARENT_CONSTANT "pro  [PROTECTE  ParentClass
+CONSTANT   PUBLIC_CONSTANT "pubic constan  [PUBLIC]   Class1855
+CONSTANT   PUBLIC_PARENT_CONSTANT "pubic   [PUBLIC]   ParentClass
+CONSTANT   TEST2 ?                         [PUBLIC]   Class1855
+KEYWORD    Class1855 $this->                          null
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null
 KEYWORD    static::                                   null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefix_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefix_02.completion
@@ -1,0 +1,35 @@
+Code completion result for source line:
+$| // test2
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+VARIABLE   ? $privateStaticProperty        [PRIVATE,  Class1855
+VARIABLE   ? $privateTraitStaticProperty   [PRIVATE,  Trait1855
+VARIABLE   ? $protectedParentStaticProper  [PROTECTE  ParentClass
+VARIABLE   ? $protectedStaticProperty      [PROTECTE  Class1855
+VARIABLE   ? $protectedTraitStaticPropert  [PROTECTE  Trait1855
+VARIABLE   ? $publicStaticParentProperty   [STATIC]   ParentClass
+VARIABLE   ? $publicStaticProperty         [STATIC]   Class1855
+VARIABLE   ? $publicStaticTraitProperty    [STATIC]   Trait1855
+VARIABLE   ? privateProperty               [PRIVATE]  Class1855
+VARIABLE   ? privateTraitProperty          [PRIVATE]  Trait1855
+VARIABLE   ? protectedParentProperty       [PROTECTE  ParentClass
+VARIABLE   ? protectedProperty             [PROTECTE  Class1855
+VARIABLE   ? protectedTraitProperty        [PROTECTE  Trait1855
+VARIABLE   ? publicParentProperty          [PUBLIC]   ParentClass
+VARIABLE   ? publicProperty                [PUBLIC]   Class1855
+VARIABLE   ? publicTraitProperty           [PUBLIC]   Trait1855
+KEYWORD    Class1855 $this->                          null
+------------------------------------
+VARIABLE   $GLOBALS                                   PHP Platform
+VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform
+VARIABLE   $_COOKIE                                   PHP Platform
+VARIABLE   $_ENV                                      PHP Platform
+VARIABLE   $_FILES                                    PHP Platform
+VARIABLE   $_GET                                      PHP Platform
+VARIABLE   $_POST                                     PHP Platform
+VARIABLE   $_REQUEST                                  PHP Platform
+VARIABLE   $_SERVER                                   PHP Platform
+VARIABLE   $_SESSION                                  PHP Platform
+VARIABLE   $argc                                      PHP Platform
+VARIABLE   $argv                                      PHP Platform
+VARIABLE   $http_response_header                      PHP Platform
+VARIABLE   $php_errormsg                              PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefix_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb1855/nb1855.php.testCompleteAccessPrefix_03.completion
@@ -1,0 +1,15 @@
+Code completion result for source line:
+pri| // test3
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     privateMethod($param)           [PRIVATE]  Class1855
+METHOD     privateStaticMethod($param, $p  [PRIVATE,  Class1855
+METHOD     privateTraitMethod($param)      [PRIVATE]  Trait1855
+METHOD     privateTraitStaticMethod($para  [PRIVATE,  Trait1855
+VARIABLE   ? $privateStaticProperty        [PRIVATE,  Class1855
+VARIABLE   ? $privateTraitStaticProperty   [PRIVATE,  Trait1855
+VARIABLE   ? privateProperty               [PRIVATE]  Class1855
+VARIABLE   ? privateTraitProperty          [PRIVATE]  Trait1855
+CONSTANT   PRIVATE_CONSTANT "private cons  [PRIVATE]  Class1855
+------------------------------------
+KEYWORD    print '';                                  Language Construct
+KEYWORD    private                                    null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass03.php.testAnonymousClass03a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/base/anonymousClass03.php.testAnonymousClass03a.completion
@@ -1,6 +1,8 @@
 Code completion result for source line:
 return new class($|this->prop) extends Outer {
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+VARIABLE   ? prop                          [PRIVATE]  \My\Outer
+VARIABLE   ? prop2                         [PROTECTE  \My\Outer
 KEYWORD    Outer $this->                              null
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_21b.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctions/arrowFunctions.php.testArrowFunctions_21b.completion
@@ -2,6 +2,9 @@ Code completion result for source line:
 $af = fn(): ?ArrowFunctions => |$this;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 CLASS      ArrowFunctions                  [PUBLIC]   arrowFunctions.php
+METHOD     getNumber()                     [PUBLIC]   ArrowFunctions
+METHOD     new()                           [STATIC]   ArrowFunctions
+METHOD     test()                          [PUBLIC]   ArrowFunctions
 VARIABLE   ? $af                           [PUBLIC]   arrowFunctions.php
 VARIABLE   int $test                       [PUBLIC]   arrowFunctions.php
 CONSTANT   CONSTANT_INT 1000               [PUBLIC]   arrowFunctions.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethod/arrowFunctionsInMethod.php.testArrowFunctionsInMethod_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethod/arrowFunctionsInMethod.php.testArrowFunctionsInMethod_01a.completion
@@ -2,6 +2,8 @@ Code completion result for source line:
 $fn = fn() => |$af->getNumber() + $number + $this->getNumber();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 CLASS      ArrowFunctions                  [PUBLIC]   arrowFunctionsInMethod.php
+METHOD     getNumber()                     [PUBLIC]   ArrowFunctions
+METHOD     test(ArrowFunctions $af, int $  [PUBLIC]   ArrowFunctions
 VARIABLE   ? $fn                           [PUBLIC]   arrowFunctionsInMethod.php
 VARIABLE   ArrowFunctions $af              [PUBLIC]   arrowFunctionsInMethod.php
 VARIABLE   int $number                     [PUBLIC]   arrowFunctionsInMethod.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethodWithError/arrowFunctionsInMethodWithError.php.testArrowFunctionsInMethodWithError_01a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethodWithError/arrowFunctionsInMethodWithError.php.testArrowFunctionsInMethodWithError_01a.completion
@@ -2,6 +2,8 @@ Code completion result for source line:
 $fn = fn(int $test) => $af->getNumber() + | + $this->getNumber();
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 CLASS      ArrowFunctions                  [PUBLIC]   arrowFunctionsInMethodWithError.php
+METHOD     getNumber()                     [PUBLIC]   ArrowFunctions
+METHOD     test(ArrowFunctions $af, int $  [PUBLIC]   ArrowFunctions
 VARIABLE   ? $fn                           [PUBLIC]   arrowFunctionsInMethodWithError.php
 VARIABLE   ArrowFunctions $af              [PUBLIC]   arrowFunctionsInMethodWithError.php
 VARIABLE   int $number                     [PUBLIC]   arrowFunctionsInMethodWithError.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethodWithError/arrowFunctionsInMethodWithError.php.testArrowFunctionsInMethodWithError_02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testArrowFunctionsInMethodWithError/arrowFunctionsInMethodWithError.php.testArrowFunctionsInMethodWithError_02a.completion
@@ -2,6 +2,8 @@ Code completion result for source line:
 $fn = fn(ArrowFunctions $object) => $af->getNumber() + |;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 CLASS      ArrowFunctions                  [PUBLIC]   arrowFunctionsInMethodWithError.php
+METHOD     getNumber()                     [PUBLIC]   ArrowFunctions
+METHOD     test(ArrowFunctions $af, int $  [PUBLIC]   ArrowFunctions
 VARIABLE   ? $fn                           [PUBLIC]   arrowFunctionsInMethodWithError.php
 VARIABLE   ArrowFunctions $af              [PUBLIC]   arrowFunctionsInMethodWithError.php
 VARIABLE   ArrowFunctions $object          [PUBLIC]   arrowFunctionsInMethodWithError.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_00.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_00.completion
@@ -6,6 +6,12 @@ PACKAGE    Foo                             [PUBLIC]   null
 CLASS      BarUnpackClass                  [PUBLIC]   Bar
 CLASS      UnpackChildClass                [PUBLIC]   Foo
 CLASS      UnpackClass                     [PUBLIC]   Foo
+CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
 CONSTANT   F_CONST "test"                  [PUBLIC]   Foo
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_01.completion
@@ -6,6 +6,12 @@ PACKAGE    Foo                             [PUBLIC]   null
 CLASS      BarUnpackClass                  [PUBLIC]   Bar
 CLASS      UnpackChildClass                [PUBLIC]   Foo
 CLASS      UnpackClass                     [PUBLIC]   Foo
+CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
 CONSTANT   F_CONST "test"                  [PUBLIC]   Foo
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_04.completion
@@ -6,6 +6,12 @@ PACKAGE    Foo                             [PUBLIC]   null
 CLASS      BarUnpackClass                  [PUBLIC]   Bar
 CLASS      UnpackChildClass                [PUBLIC]   Foo
 CLASS      UnpackClass                     [PUBLIC]   Foo
+CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
 CONSTANT   F_CONST "test"                  [PUBLIC]   Foo
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_07.completion
@@ -6,6 +6,13 @@ PACKAGE    Foo                             [PUBLIC]   null
 CLASS      BarUnpackClass                  [PUBLIC]   Bar
 CLASS      UnpackChildClass                [PUBLIC]   Foo
 CLASS      UnpackClass                     [PUBLIC]   Foo
+CONSTANT   CHILD_CONSTANT ?                [PUBLIC]   \Foo\UnpackChildClass
+CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
 CONSTANT   F_CONST "test"                  [PUBLIC]   Foo
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_11.completion
@@ -6,6 +6,10 @@ PACKAGE    Foo                             [PUBLIC]   null
 CLASS      BarUnpackClass                  [PUBLIC]   Bar
 CLASS      UnpackChildClass                [PUBLIC]   Foo
 CLASS      UnpackClass                     [PUBLIC]   Foo
+CONSTANT   CONST1 ?                        [PRIVATE]  \Bar\BarUnpackClass
+CONSTANT   CONST2 ?                        [PRIVATE]  \Bar\BarUnpackClass
+CONSTANT   CONST3 ?                        [PRIVATE]  \Bar\BarUnpackClass
+CONSTANT   CONST4 ?                        [PRIVATE]  \Bar\BarUnpackClass
 CONSTANT   F_CONST "test"                  [PUBLIC]   Foo
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests247082/issue247082.php.testForKeywords.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests247082/issue247082.php.testForKeywords.completion
@@ -3,7 +3,29 @@ echo |self::MY_CONST . PHP_EOL;
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 CLASS      A                               [PUBLIC]   issue247082.php
 CLASS      ParentA                         [PUBLIC]   issue247082.php
+METHOD     filter(array $values)           [PUBLIC]   A
+METHOD     myPrivateTestInstance()         [PRIVATE]  A
+METHOD     myPrivateTestStatic()           [PRIVATE,  A
+METHOD     myProtectedTestInstance()       [PROTECTE  A
+METHOD     myProtectedTestStatic()         [PROTECTE  A
+METHOD     myTestInstance()                [PUBLIC]   A
+METHOD     myTestStatic()                  [STATIC]   A
+METHOD     parentProtectedTestInstance()   [PROTECTE  ParentA
+METHOD     parentProtectedTestStatic()     [PROTECTE  ParentA
+METHOD     parentTestInstance()            [PUBLIC]   ParentA
+METHOD     parentTestStatic()              [STATIC]   ParentA
+METHOD     test()                          [PUBLIC]   A
+VARIABLE   ? $myFieldStatic                [STATIC]   A
+VARIABLE   ? $myPrivateFieldStatic         [PRIVATE,  A
+VARIABLE   ? $myProtectedFieldStatic       [PROTECTE  A
+VARIABLE   ? $parentFieldStatic            [STATIC]   ParentA
+VARIABLE   ? $parentProtectedFieldStatic   [PROTECTE  ParentA
 VARIABLE   ? $val                          [PUBLIC]   issue247082.php
+VARIABLE   ? myFieldInstance               [PUBLIC]   A
+VARIABLE   ? myPrivateFieldInstance        [PRIVATE]  A
+VARIABLE   ? myProtectedFieldInstance      [PROTECTE  A
+CONSTANT   MY_CONST 'MY_CONST'             [PUBLIC]   A
+CONSTANT   PARENT_CONST 'PARENT_CONST'     [PUBLIC]   ParentA
 KEYWORD    A $this->                                  null
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests257088/issue257088.php.testClassKeywords.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests257088/issue257088.php.testClassKeywords.completion
@@ -1,6 +1,7 @@
 Code completion result for source line:
 |;// HERE
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     publicMethod()                  [PUBLIC]   MyTrait
 KEYWORD    MyTrait $this->                            null
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb1855Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb1855Test.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+
+public class PHPCodeCompletionNb1855Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionNb1855Test(String testName) {
+        super(testName);
+    }
+
+    public void testCompleteAccessPrefix_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1855/nb1855.php", "         ^ // test1", false);
+    }
+
+    public void testCompleteAccessPrefix_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1855/nb1855.php", "        $^ // test2", false);
+    }
+
+    public void testCompleteAccessPrefix_03() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1855/nb1855.php", "        pri^ // test3", false);
+    }
+
+    public void testCompleteAccessPrefixInClassConst_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1855/nb1855.php", "    public const TEST1 = ^;", false);
+    }
+
+    public void testCompleteAccessPrefixInClassConst_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1855/nb1855.php", "    public const TEST2 = pri^;", false);
+    }
+
+    public void testCompleteAccessPrefixInTrait_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1855/nb1855.php", "         ^ // trait 1", false);
+    }
+
+    public void testCompleteAccessPrefixInTrait_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1855/nb1855.php", "        $^p; // trait 2", false);
+    }
+
+    public void testCompleteAccessPrefixInTrait_03() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb1855/nb1855.php", "        protected^TraitMethod($param); // trait 3", false);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/nb1855"))
+            })
+        );
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionTest.java
@@ -781,6 +781,7 @@ public class PHPCodeCompletionTest extends PHPCodeCompletionTestBase {
     }
 
     public void testIssue153707_01() throws Exception {
+        // FIXME: maybe, should add only variables and $this->
         checkCompletion("testfiles/completion/lib/_base/issue153707.php", "class property: ^", false);
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-1855

e.g.

```php
class MyClass {
    public test() {
        code// CC here : $this->codeCompletion() is added
    }

    private codeCompletion() {}

}

```
![netbeans-1855-prototype](https://user-images.githubusercontent.com/738383/68004383-a8558300-fcb4-11e9-80d6-b2caba28237b.gif)
