### PR TITLE
Fix unit tests for ConvertVisibilitySuggestion

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibility.php
@@ -63,7 +63,7 @@ class Visibility {
 
 }
 
-abstract class AbstarctClass {
+abstract class AbstractVisibilityClass {
 
     abstract function abstractImplicitPublic();
     abstract public function abstractPublic();
@@ -75,7 +75,7 @@ abstract class AbstarctClass {
     abstract protected static function abstractProtectedStatic();
 }
 
-interface InterfaceName {
+interface VisibilityInterface {
 
     const INTERFACE_IMPLICIT_CONST = "implicit";
     public const INTERFACE_PUBLIC_CONST = "implicit";

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php
@@ -1,6 +1,6 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
-abstract class AbstarctClass {
+abstract class AbstractVisibilityClass {
 
     abstract function abstractImplicitPublic();
     abstract public function abstractPublic();

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_01.fixed
@@ -1,6 +1,6 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
-abstract class AbstarctClass {
+abstract class AbstractVisibilityClass {
 
     abstract public function abstractImplicitPublic();
     abstract public function abstractPublic();

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_02.fixed
@@ -1,6 +1,6 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
-abstract class AbstarctClass {
+abstract class AbstractVisibilityClass {
 
     abstract function abstractImplicitPublic();
     abstract protected function abstractPublic();

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_03.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_03.fixed
@@ -1,6 +1,6 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
-abstract class AbstarctClass {
+abstract class AbstractVisibilityClass {
 
     abstract function abstractImplicitPublic();
     abstract public function abstractPublic();

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_04.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_04.fixed
@@ -1,6 +1,6 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
-abstract class AbstarctClass {
+abstract class AbstractVisibilityClass {
 
     abstract function abstractImplicitPublic();
     abstract public function abstractPublic();

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_05.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_05.fixed
@@ -1,6 +1,6 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
-abstract class AbstarctClass {
+abstract class AbstractVisibilityClass {
 
     abstract function abstractImplicitPublic();
     abstract public function abstractPublic();

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_06.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityAbstractClass.php.testConvertVisibilitySuggestionAbstractClassFix_06.fixed
@@ -1,6 +1,6 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
-abstract class AbstarctClass {
+abstract class AbstractVisibilityClass {
 
     abstract function abstractImplicitPublic();
     abstract public function abstractPublic();

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php
@@ -1,7 +1,7 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
 
-interface InterfaceName {
+interface VisibilityInterface {
 
     const INTERFACE_IMPLICIT_CONST = "implicit";
     public const INTERFACE_PUBLIC_CONST = "implicit";

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_01.fixed
@@ -1,7 +1,7 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
 
-interface InterfaceName {
+interface VisibilityInterface {
 
     public const INTERFACE_IMPLICIT_CONST = "implicit";
     public const INTERFACE_PUBLIC_CONST = "implicit";

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_02.fixed
@@ -1,7 +1,7 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
 
-interface InterfaceName {
+interface VisibilityInterface {
 
     const INTERFACE_IMPLICIT_CONST = "implicit";
     public const INTERFACE_PUBLIC_CONST = "implicit";

--- a/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_03.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ConvertVisibilitySuggestion/testConvertVisibilityInterface.php.testConvertVisibilitySuggestionInterfaceFix_03.fixed
@@ -1,7 +1,7 @@
 <?php
 // Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
 
-interface InterfaceName {
+interface VisibilityInterface {
 
     const INTERFACE_IMPLICIT_CONST = "implicit";
     public const INTERFACE_PUBLIC_CONST = "implicit";


### PR DESCRIPTION
- Fix typo of abstract class name
- Fix the interface name of test data because there is the same name in testImplementAbstractMethodsHint.php (from InterfaceName to VisibilityInterface)

So, two unit tests failed in `HintsTest`, sorry.

