### PR TITLE
JarClassLoader needs to catch NoSuchFileException in addition to FileNotFoundException

### DIFF
--- a/platform/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
@@ -38,6 +38,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.nio.file.NoSuchFileException;
 import java.security.CodeSource;
 import java.security.PermissionCollection;
 import java.security.Policy;
@@ -519,7 +520,7 @@ public class JarClassLoader extends ProxyClassLoader {
                                         JarFile ret;
                                         try {
                                             ret = new JarFile(file, false);
-                                        } catch (FileNotFoundException ex) {
+                                        } catch (FileNotFoundException | NoSuchFileException ex) {
                                             throw (ZipException)new ZipException(ex.getMessage()).initCause(ex);
                                         }
                                         long took = System.currentTimeMillis() - now;


### PR DESCRIPTION
It seems that JarFile was moved to NIO. A missing file is thus not reported as a
`java.io.FileNotFoundException`, but a `java.nio.file.NoSuchFileException`. By catching
both, we are independent of this implementation detail (assuming people stop
reinventing the wheel).

The stacktrace for the error:

```
WARNUNG: problems with /home/matthias/src/netbeans/platform/o.n.bootstrap/build/test/unit/work/o.n.A/wcpe/install/platform/modules/ext/non-existent.jar
java.nio.file.NoSuchFileException: /home/matthias/src/netbeans/platform/o.n.bootstrap/build/test/unit/work/o.n.A/wcpe/install/platform/modules/ext/non-existent.jar
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
	at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:149)
	at java.base/sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
	at java.base/java.nio.file.Files.readAttributes(Files.java:1763)
	at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1225)
	at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:727)
	at java.base/java.util.zip.ZipFile$CleanableResource.get(ZipFile.java:844)
	at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:247)
	at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:177)
	at java.base/java.util.jar.JarFile.<init>(JarFile.java:346)
	at java.base/java.util.jar.JarFile.<init>(JarFile.java:317)
	at java.base/java.util.jar.JarFile.<init>(JarFile.java:297)
	at org.netbeans.JarClassLoader$JarSource$1.call(JarClassLoader.java:521)
	at org.netbeans.JarClassLoader$JarSource$1.call(JarClassLoader.java:512)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at org.netbeans.JarClassLoader$JarSource.getJarFile(JarClassLoader.java:547)
	at org.netbeans.JarClassLoader$JarSource.listCoveredPackages(JarClassLoader.java:626)
	at org.netbeans.JarClassLoader.getCoveredPackages(JarClassLoader.java:958)
	at org.netbeans.JarClassLoader.<init>(JarClassLoader.java:151)
	at org.netbeans.StandardModule$OneModuleClassLoader.<init>(StandardModule.java:609)
	at org.netbeans.StandardModule.createNewClassLoader(StandardModule.java:545)
	at org.netbeans.StandardModule.classLoaderUp(StandardModule.java:533)
	at org.netbeans.ModuleManager.enable(ModuleManager.java:1322)
	at org.netbeans.ModuleManager.enable(ModuleManager.java:1229)
	at org.netbeans.ModuleManager.enable(ModuleManager.java:1225)
	at org.netbeans.ArchiveTest.setUp(ArchiveTest.java:74)
	at org.netbeans.junit.NbTestCase.runBare(NbTestCase.java:452)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
```

This error was made known by the proposed PR #1597 (https://travis-ci.org/apache/netbeans/jobs/605913015#L31410). Before the PR is merged, we should fix the error.