### PR TITLE
Fix unittest ProxyClassLoaderNB11PackageAnnotationsTest

### DIFF
--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassLoaderNB11PackageAnnotationsTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassLoaderNB11PackageAnnotationsTest.java
@@ -45,6 +45,7 @@ public class ProxyClassLoaderNB11PackageAnnotationsTest extends NbTestCase {
             PackageClassLoader() {
                 super(new ClassLoader[0], false);
                 addCoveredPackages(Collections.singleton(TEST_PACKAGE));
+                definePackage(TEST_PACKAGE, null, null, null, null, null, null, null);
             }
 
             @Override
@@ -77,7 +78,7 @@ public class ProxyClassLoaderNB11PackageAnnotationsTest extends NbTestCase {
             }
 
         }
-        
+
         final ProxyClassLoader cl = new PackageClassLoader();
         final Class<? extends Annotation> annotClz = (Class<? extends Annotation>) cl.loadClass(TEST_PACKAGE + ".NB11PackageTestAnnotation");
         final Package pkg = annotClz.getPackage();


### PR DESCRIPTION
@borisheithecker please have a look at this - the new Unittest ProxyClassLoaderNB11PackageAnnotationsTest fails on JDK 8 (found by #1597). I update the unittest and with this change I get:

JDK8 without Fix: Test passes
JDK11 without Fix: Test fails
JDK8 with Fix: Test passes
JDK11 with Fix: Test passes

This is IMHO the expected outcome. Does that look sane to you?