### PR TITLE
[NETBEANS-3341] - Upgrade asm-all.jar 5.0.1 to 5.1

### DIFF
--- a/contrib/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentFactory.java
+++ b/contrib/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentFactory.java
@@ -153,7 +153,7 @@ public class WildflyDeploymentFactory implements DeploymentFactory {
                                 return super.getCommonSuperClass(string, string1);
                             }
                         };
-                        ClassNode node = new ClassNode();
+                        ClassNode node = new ClassNode(Opcodes.ASM5);
                         cr.accept(node, 0);
 
                         for (MethodNode m : (Collection<MethodNode>) node.methods) {

--- a/harness/apisupport.harness/build.xml
+++ b/harness/apisupport.harness/build.xml
@@ -39,13 +39,13 @@
                 <pathelement location="${cluster}/tasks.jar"></pathelement>
             </classpath>
         </taskdef>
-        <echo file="build/binaries-list">2F7553F50B0D14ED811B849C282DA8C1FFC32AAE org.ow2.asm:asm-all:5.0.1</echo>
+        <echo file="build/binaries-list">AE8BE205E00013DCE1E31420AEE506A0333D21AD org.ow2.asm:asm-all:5.1</echo>
         <TestDownload>
             <manifest dir="build">
                 <include name="binaries-list"/>
             </manifest>
         </TestDownload>
-        <delete file="build/asm-all-5.0.1.jar"/>
+        <delete file="build/asm-all-5.1.jar"/>
     </target>
 
     <target name="compile-jnlp-launcher" depends="init,compile">

--- a/java/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/NbJShellAgent.java
+++ b/java/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/NbJShellAgent.java
@@ -400,7 +400,7 @@ public class NbJShellAgent implements Runnable, ClassFileTransformer {
             istm = new ByteArrayInputStream(classfileBuffer);
             ClassReader reader = new ClassReader(istm);
             ClassWriter wr = new ClassWriter(reader, 0);
-            ClassNode clazz = new ClassNode();
+            ClassNode clazz = new ClassNode(Opcodes.ASM5);
             reader.accept(clazz, 0);
             
             boolean found = false;

--- a/java/lib.jshell.agent/nbproject/project.properties
+++ b/java/lib.jshell.agent/nbproject/project.properties
@@ -21,5 +21,5 @@ javac.compilerargs=-Xlint -Xlint:-serial
 extra.module.files=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 jnlp.indirect.jars=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 
-agentsrc.asm.cp=${libs.asm.dir}/core/asm-all-5.0.1.jar
+agentsrc.asm.cp=${libs.asm.dir}/core/asm-all-5.1.jar
 agentsrc.jshell.cp=${nb_all}/java/libs.jshell.compile/external/jshell-9.jar

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -78,10 +78,10 @@
         <tstamp>
             <format property="module.build.started.time" pattern="yyyy-MM-dd'T'HH:mm:ss.SSSZ"/>
         </tstamp>
-        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-all-5.0.1.jar">
-            <available file="${nbplatform.active.dir}/platform/core/asm-all-5.0.1.jar"/>
+        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-all-5.1.jar">
+            <available file="${nbplatform.active.dir}/platform/core/asm-all-5.1.jar"/>
         </condition>
-        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-all-5.0.1.jar"/>
+        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-all-5.1.jar"/>
     </target>
 
     <target name="-release.dir">

--- a/platform/core.startup/src/org/netbeans/core/startup/Asm.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Asm.java
@@ -57,7 +57,7 @@ final class Asm {
         // must analyze the extender class, as some annotations there may trigger
         ClassReader clr = new ClassReader(data);
         ClassWriter wr = new ClassWriter(clr, 0);
-        ClassNode theClass = new ClassNode();
+        ClassNode theClass = new ClassNode(Opcodes.ASM5);
         
         clr.accept(theClass, 0);
         
@@ -74,7 +74,7 @@ final class Asm {
                 throw new IOException("Could not find classfile for extender class"); // NOI18N
             }
             ClassReader extenderReader = new ClassReader(istm);
-            ClassNode extenderClass = new ClassNode();
+            ClassNode extenderClass = new ClassNode(Opcodes.ASM5);
             extenderReader.accept(extenderClass, ClassReader.SKIP_FRAMES);
             
             // search for a no-arg ctor, replace all invokespecial calls in ctors
@@ -292,18 +292,27 @@ final class Asm {
     }
     
     private static class CtorDelVisitor extends AnnotationVisitor {
-        int[]   indices;
+        
+        int[] indices;
        
-        public CtorDelVisitor(int i) {
-            super(i);
+        /**
+         * Constructs a new {@link AnnotationVisitor}.
+         *
+         * @param api the ASM API version implemented by this visitor. Must be one of {@link
+         *     Opcodes#ASM4}, {@link Opcodes#ASM5}
+         */
+        public CtorDelVisitor(int api) {
+            super(api);
         }
 
         @Override
         public void visit(String string, Object o) {
+
             if ("delegateParams".equals(string)) {  // NOI18N
                 indices = (int[])o;
             }
             super.visit(string, o);
+
         }
     }
     

--- a/platform/libs.asm/external/asm-all-5.1-license.txt
+++ b/platform/libs.asm/external/asm-all-5.1-license.txt
@@ -1,8 +1,8 @@
 Name: OW2 ASM
-Version: 5.0.1
+Version: 5.1
 License: BSD-INRIA
 Origin: OW2 Consortium
-URL: http://forge.ow2.org/project/download.php?group_id=23&file_id=19789
+URL: https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/asm-all/5.1/
 Description: Bytecode manipulation library
 
 *******************************************************************************

--- a/platform/libs.asm/external/binaries-list
+++ b/platform/libs.asm/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-2F7553F50B0D14ED811B849C282DA8C1FFC32AAE org.ow2.asm:asm-all:5.0.1
+AE8BE205E00013DCE1E31420AEE506A0333D21AD org.ow2.asm:asm-all:5.1

--- a/platform/libs.asm/nbproject/project.properties
+++ b/platform/libs.asm/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 module.jar.dir=core
 
-release.external/asm-all-5.0.1.jar=core/asm-all-5.0.1.jar
-license.file=../external/asm-all-5.0.1-license.txt
+release.external/asm-all-5.1.jar=core/asm-all-5.1.jar
+license.file=../external/asm-all-5.1-license.txt

--- a/platform/libs.asm/nbproject/project.xml
+++ b/platform/libs.asm/nbproject/project.xml
@@ -29,8 +29,8 @@
                 <subpackages>org</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>asm-all-5.0.1.jar</runtime-relative-path>
-                <binary-origin>external/asm-all-5.0.1.jar</binary-origin>
+                <runtime-relative-path>asm-all-5.1.jar</runtime-relative-path>
+                <binary-origin>external/asm-all-5.1.jar</binary-origin>
             </class-path-extension>
 <!--            <class-path-extension>
                 <runtime-relative-path>ext/asm-5.0.1/asm-5.0.1.jar</runtime-relative-path>


### PR DESCRIPTION
1.-Upgrade asm-all-5.0.1 version to asm-all-5.1including it's license 

2.-Add constructor parameter to use ASMv5 API:
`ClassNode clazz = new ClassNode(Opcodes.ASM5);`

3.-Add documentation to one class that extends a class from asm.jar