### PR TITLE
[NETBEANS-3335] Enhance robustness of HTML Lexer

### DIFF
--- a/ide/html.lexer/src/org/netbeans/lib/html/lexer/HtmlLexer.java
+++ b/ide/html.lexer/src/org/netbeans/lib/html/lexer/HtmlLexer.java
@@ -1552,8 +1552,12 @@ public final class HtmlLexer implements Lexer<HTMLTokenId> {
 
     /** @param optimized - first sequence is lowercase, one call to Character.toLowerCase() */
     private static boolean equals(CharSequence text1, CharSequence text2, boolean ignoreCase, boolean optimized) {
-        assert text1 != null : "text1 arg is null";
-        assert text2 != null : "text2 arg is null";
+        if (text1 == text2) {
+            return true;
+        }
+        if (text1 == null || text2 == null) {
+            return false;
+        }
         if (text1.length() != text2.length()) {
             return false;
         } else {

--- a/php/php.smarty/test/unit/data/testfiles/parserErrors/testParserNETBEANS3335_01.tpl
+++ b/php/php.smarty/test/unit/data/testfiles/parserErrors/testParserNETBEANS3335_01.tpl
@@ -1,0 +1,1 @@
+<a {if $smarty.server.REQUEST_URI|strstr:"/new"}class="underline"{/if} href="{url('new')}">

--- a/php/php.smarty/test/unit/data/testfiles/parserErrors/testParserNETBEANS3335_01.tpl.errors
+++ b/php/php.smarty/test/unit/data/testfiles/parserErrors/testParserNETBEANS3335_01.tpl.errors
@@ -1,0 +1,1 @@
+Detected parser errors in the file:

--- a/php/php.smarty/test/unit/data/testfiles/parserErrors/testParserNETBEANS3335_02.tpl
+++ b/php/php.smarty/test/unit/data/testfiles/parserErrors/testParserNETBEANS3335_02.tpl
@@ -1,0 +1,1 @@
+<div class="{if $test eq ""}toto{/if}" {if $test}id="titi"{/if}></div>

--- a/php/php.smarty/test/unit/data/testfiles/parserErrors/testParserNETBEANS3335_02.tpl.errors
+++ b/php/php.smarty/test/unit/data/testfiles/parserErrors/testParserNETBEANS3335_02.tpl.errors
@@ -1,0 +1,1 @@
+Detected parser errors in the file:

--- a/php/php.smarty/test/unit/src/org/netbeans/modules/php/smarty/editor/parser/TplParserErrorsTest.java
+++ b/php/php.smarty/test/unit/src/org/netbeans/modules/php/smarty/editor/parser/TplParserErrorsTest.java
@@ -118,6 +118,15 @@ public class TplParserErrorsTest extends TplTestBase {
         assertParserErrors();
     }
 
+    // no errors
+    public void testParserNETBEANS3335_01() throws Exception {
+        assertParserErrors();
+    }
+
+    public void testParserNETBEANS3335_02() throws Exception {
+        assertParserErrors();
+    }
+
     private String getTestFileRelPath() {
         return "testfiles/parserErrors/" + getName() + ".tpl";
     }


### PR DESCRIPTION
After the update of the HTML lexer to support HTML5 style attributes,
new states in the lexer can be reached. Instead of bailing out with a
NullPointerException in HtmlLexer#equals, report comparisons with NULL
as false.