### PR TITLE
    [NETBEANS-3345] - cleanup fallthrough warnings..

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/java/hints/errors/SearchModuleDependency.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/java/hints/errors/SearchModuleDependency.java
@@ -113,6 +113,7 @@ public class SearchModuleDependency implements org.netbeans.modules.java.hints.s
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     public List<Fix> run(final CompilationInfo info, String diagnosticKey,
             final int offset, TreePath treePath, Data<Void> data) {
         cancel.set(false);

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/ProcessIOParser.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/ProcessIOParser.java
@@ -200,6 +200,7 @@ public class ProcessIOParser {
          * @return Next state transition based on current state
          *         and character class.
          */
+        @SuppressWarnings("fallthrough")
         protected State action(final char c) {
             Input cl = Input.value(c, content.getCurrentPrompt(), promptBuff);
             switch (state) {

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/ProcessIOParser.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/ProcessIOParser.java
@@ -200,6 +200,7 @@ public class ProcessIOParser {
          * @return Next state transition based on current state
          *         and character class.
          */
+        @SuppressWarnings("fallthrough")
         protected State action(final char c) {
             Input cl = Input.value(c, content.getCurrentPrompt(), promptBuff);
             switch (state) {

--- a/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/RefactoringTask.java
+++ b/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/RefactoringTask.java
@@ -135,6 +135,7 @@ public abstract class RefactoringTask extends UserTask implements Runnable {
             }
         }
 
+        @SuppressWarnings("fallthrough")
         private RefactoringElement createRefactoringElement(AstPath path, ASTNode currentNode, ElementKind kind) {
             switch (kind) {
                 case CLASS:

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/csl/CssCompletion.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/csl/CssCompletion.java
@@ -707,6 +707,7 @@ public class CssCompletion implements CodeCompletionHandler {
         return ParameterInfo.NONE;
     }
 
+    @SuppressWarnings("fallthrough")
     private CodeCompletionResult handleLexicalBasedCompletion(FileObject file, TokenSequence<CssTokenId> ts, Snapshot snapshot, int caretOffset) {
         //position the token sequence on the caret position, not the recomputed offset with substracted prefix length
         int tokenDiff = ts.move(snapshot.getEmbeddedOffset(caretOffset));
@@ -793,6 +794,7 @@ public class CssCompletion implements CodeCompletionHandler {
         return null;
     }
 
+    @SuppressWarnings("fallthrough")
     private void completeClassSelectors(CompletionContext context, List<CompletionProposal> completionProposals, boolean unmappableClassOrId) {
         Node node = context.getActiveNode();
         FileObject file = context.getSnapshot().getSource().getFileObject();
@@ -816,11 +818,11 @@ public class CssCompletion implements CodeCompletionHandler {
                             break;
                         case IDENT:
                             if (tokenSequence.movePrevious()) {
-                            if (tokenSequence.token().id() == CssTokenId.DOT) {
-                                //.sg| case
-                                break;
+                                if (tokenSequence.token().id() == CssTokenId.DOT) {
+                                    //.sg| case
+                                    break;
+                                }
                             }
-                        }
                         default:
                             return;
                     }
@@ -998,6 +1000,7 @@ public class CssCompletion implements CodeCompletionHandler {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     private void completeHtmlSelectors(CompletionContext completionContext, List<CompletionProposal> completionProposals, TokenId tokenNodeTokenId) {
         String prefix = completionContext.getPrefix();
         int caretOffset = completionContext.getCaretOffset();
@@ -1007,9 +1010,9 @@ public class CssCompletion implements CodeCompletionHandler {
             case media:
                 //check if we are in the mediaQuery section and not in the media body
                 if (null == LexerUtils.followsToken(completionContext.getTokenSequence(), CssTokenId.LBRACE, true, true, CssTokenId.WS, CssTokenId.NL, CssTokenId.COMMENT)) {
-                //@media | { div {} }
-                break;
-            }
+                    //@media | { div {} }
+                    break;
+                }
             //@media xxx { | }
             //=>fallback to the mediaQuery 
             case mediaBody:
@@ -1056,14 +1059,14 @@ public class CssCompletion implements CodeCompletionHandler {
                 }
                 break;
             case declarations:
-                if(completionContext.isCssPreprocessorSource()) {
+                if (completionContext.isCssPreprocessorSource()) {
                     completionProposals.addAll(completeHtmlSelectors(completionContext, prefix, caretOffset));
                     break;
                 }
                 //@mixin mymixin() { div {} | }
                 if (NodeUtil.getAncestorByType(node, NodeType.cp_mixin_block) == null) {
-                break; //do not complete
-            }
+                    break; //do not complete
+                }
             //fallback to cp_mixin_block
 
             case cp_mixin_block:
@@ -1117,6 +1120,7 @@ public class CssCompletion implements CodeCompletionHandler {
      * @param completionProposals
      * @param tokenFound
      */
+    @SuppressWarnings("fallthrough")
     private void completeKeywords(CompletionContext completionContext, List<CompletionProposal> completionProposals, boolean tokenFound) {
         if (!tokenFound) {
             return;
@@ -1157,11 +1161,11 @@ public class CssCompletion implements CodeCompletionHandler {
             case simpleSelectorSequence:
                 //@| -- parsed as simpleSelectorSequence due to the possible less_selector_interpolation -- @{...} in selectorsGroup
                 switch (completionContext.getTokenSequence().token().id()) {
-                case AT_SIGN:
-                    Collection<String> possibleValues = filterStrings(AT_RULES, completionContext.getPrefix());
-                    completionProposals.addAll(Utilities.createRAWCompletionProposals(possibleValues, ElementKind.FIELD, completionContext.getSnapshot().getOriginalOffset(completionContext.getActiveNode().from())));
-                    break;
-            }
+                    case AT_SIGN:
+                        Collection<String> possibleValues = filterStrings(AT_RULES, completionContext.getPrefix());
+                        completionProposals.addAll(Utilities.createRAWCompletionProposals(possibleValues, ElementKind.FIELD, completionContext.getSnapshot().getOriginalOffset(completionContext.getActiveNode().from())));
+                        break;
+                }
             case styleSheet:
                 //@| in empty file
                 switch (completionContext.getTokenSequence().token().id()) {
@@ -1173,6 +1177,7 @@ public class CssCompletion implements CodeCompletionHandler {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     private void completePropertyName(CompletionContext cc, List<CompletionProposal> completionProposals) {
 //        Node activeNode = cc.getActiveNode();
 
@@ -1308,6 +1313,7 @@ public class CssCompletion implements CodeCompletionHandler {
 
     }
 
+    @SuppressWarnings("fallthrough")
     private void completePropertyValue(
             CompletionContext context,
             List<CompletionProposal> completionProposals,
@@ -1319,7 +1325,6 @@ public class CssCompletion implements CodeCompletionHandler {
         NodeType nodeType = node.type();
 
         switch (nodeType) {
-
             case declarations:
                 //In following case the caret offset falls into the declarations node
                 //which contains the whitespace after the propertyDescription.
@@ -1328,10 +1333,10 @@ public class CssCompletion implements CodeCompletionHandler {
                 //div { color: red | }
                 if (context.getActiveTokenId() == CssTokenId.SEMI
                         || LexerUtils.followsToken(context.getTokenSequence(), CssTokenId.SEMI, true, true, CssTokenId.WS, CssTokenId.NL, CssTokenId.COMMENT) != null) {
-                //semicolon found when searching backward - we are not going to
-                //complete property values
-                break;
-            }
+                    //semicolon found when searching backward - we are not going to
+                    //complete property values
+                    break;
+                }
                 //find the latest declaration backward
                 Node[] declarations = NodeUtil.getChildrenByType(node, NodeType.declaration);
                 if (declarations.length > 0) {

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/MediaQueriesModule.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/MediaQueriesModule.java
@@ -99,6 +99,7 @@ public class MediaQueriesModule extends CssEditorModule {
     static ElementKind NAMESPACE_ELEMENT_KIND = ElementKind.GLOBAL; //XXX fix CSL
 
     @Override
+    @SuppressWarnings("fallthrough")
     public List<CompletionProposal> getCompletionProposals(final CompletionContext context) {
         final List<CompletionProposal> proposals = new ArrayList<>();
         Node node = context.getActiveNode();

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/NamespacesModule.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/NamespacesModule.java
@@ -60,6 +60,7 @@ public class NamespacesModule extends CssEditorModule {
     static ElementKind NAMESPACE_ELEMENT_KIND = ElementKind.GLOBAL; //XXX fix CSL
 
     @Override
+    @SuppressWarnings("fallthrough")
     public List<CompletionProposal> getCompletionProposals(final CompletionContext context) {
         final List<CompletionProposal> proposals = new ArrayList<>();
         Node activeNode = context.getActiveNode();

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/SelectorsModule.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/SelectorsModule.java
@@ -97,6 +97,7 @@ public class SelectorsModule extends CssEditorModule {
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     public List<CompletionProposal> getCompletionProposals(CompletionContext context) {
         List<CompletionProposal> proposals = new ArrayList<>();
         Node activeNode = context.getActiveNode();
@@ -112,33 +113,33 @@ public class SelectorsModule extends CssEditorModule {
         switch (activeNode.type()) {
             case declaration:
                 if (errorNode != null) {
-                //div { &:| } completion
-                //SASS/LESS - referencing parent selector
-                switch (context.getActiveTokenId()) {
-                    case IDENT:
-                        //div { &:hov| }
-                        if (LexerUtils.followsToken(context.getTokenSequence(),
-                                Arrays.asList(CssTokenId.COLON, CssTokenId.DCOLON),
-                                true, false /* do NOT reposition back! */) == null) {
-                            break;
-                        } //else fallback!
+                    //div { &:| } completion
+                    //SASS/LESS - referencing parent selector
+                    switch (context.getActiveTokenId()) {
+                        case IDENT:
+                            //div { &:hov| }
+                            if (LexerUtils.followsToken(context.getTokenSequence(),
+                                    Arrays.asList(CssTokenId.COLON, CssTokenId.DCOLON),
+                                    true, false /* do NOT reposition back! */) == null) {
+                                break;
+                            } //else fallback!
 
-                    case COLON:
-                    case DCOLON:
-                        if (LexerUtils.followsToken(context.getTokenSequence(), CssTokenId.LESS_AND, true, true, CssTokenId.WS, CssTokenId.NL) != null) {
-                        //& before colon or double colon
-                        switch (context.getActiveTokenId()) {
-                            case COLON:
-                                proposals.addAll(getPseudoClasses(context));
-                                break;
-                            case DCOLON:
-                                proposals.addAll(getPseudoElements(context));
-                                break;
-                        }
+                        case COLON:
+                        case DCOLON:
+                            if (LexerUtils.followsToken(context.getTokenSequence(), CssTokenId.LESS_AND, true, true, CssTokenId.WS, CssTokenId.NL) != null) {
+                                //& before colon or double colon
+                                switch (context.getActiveTokenId()) {
+                                    case COLON:
+                                        proposals.addAll(getPseudoClasses(context));
+                                        break;
+                                    case DCOLON:
+                                        proposals.addAll(getPseudoElements(context));
+                                        break;
+                                }
+                            }
+                            break;
                     }
-                        break;
                 }
-            }
                 break;
 
             case simpleSelectorSequence:

--- a/ide/css.lib/src/org/netbeans/modules/css/lib/properties/GrammarParser.java
+++ b/ide/css.lib/src/org/netbeans/modules/css/lib/properties/GrammarParser.java
@@ -71,7 +71,8 @@ public class GrammarParser {
         }
         return root;
     }
-    
+
+    @SuppressWarnings("fallthrough")
     private void parseElements(ParserInput input, GroupGrammarElement parent, boolean ignoreInherits,
             AtomicInteger group_index, int openedParenthesis) {
         GrammarElement last = null;

--- a/ide/css.prep/src/org/netbeans/modules/css/prep/editor/CPCssEditorModule.java
+++ b/ide/css.prep/src/org/netbeans/modules/css/prep/editor/CPCssEditorModule.java
@@ -106,6 +106,7 @@ public class CPCssEditorModule extends CssEditorModule {
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     public List<CompletionProposal> getCompletionProposals(final CompletionContext context) {
         final List<CompletionProposal> proposals = new ArrayList<>();
 

--- a/ide/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPWhereUsedQueryPlugin.java
+++ b/ide/css.prep/src/org/netbeans/modules/css/prep/editor/refactoring/CPWhereUsedQueryPlugin.java
@@ -93,7 +93,8 @@ public class CPWhereUsedQueryPlugin implements RefactoringPlugin {
             elements.add(refactoring, WhereUsedElement.create(re.getFile(), re.getName(), re.getRange(), ElementKind.VARIABLE));
         }
     }
-    
+
+    @SuppressWarnings("fallthrough") 
     public static Collection<RefactoringElement> findVariables(RefactoringElementContext context) throws IOException, ParseException {
         Collection<RefactoringElement> elements = new ArrayList<>();
         String varName = context.getElementName();

--- a/ide/docker.editor/src/org/netbeans/modules/docker/editor/lexer/DockerfileLexer.java
+++ b/ide/docker.editor/src/org/netbeans/modules/docker/editor/lexer/DockerfileLexer.java
@@ -79,6 +79,7 @@ final class DockerfileLexer implements Lexer<DockerfileTokenId> {
 
     @Override
     @CheckForNull
+    @SuppressWarnings("fallthrough")
     public Token<DockerfileTokenId> nextToken() {
         if (state == null) {
             state = STATE_NEW_LINE;

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ClusteredIndexables.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/ClusteredIndexables.java
@@ -616,6 +616,7 @@ public final class ClusteredIndexables {
             }
 
             @Override
+            @SuppressWarnings("fallthrough")
             public boolean hasNext() {
                 if (current != null) {
                     return true;

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileObjectCrawler.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/FileObjectCrawler.java
@@ -87,6 +87,7 @@ final class FileObjectCrawler extends Crawler {
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     protected boolean collectResources(Collection<Indexable> resources, Collection<Indexable> allResources) {
         boolean finished = true;
         final long tm1 = System.currentTimeMillis();

--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -1522,6 +1522,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     private void insideMemberSelect(Env env) throws IOException {
         int offset = env.getOffset();
         String prefix = env.getPrefix();
@@ -2678,6 +2679,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     private void insideExpressionStatement(Env env) throws IOException {
         TreePath path = env.getPath();
         ExpressionStatementTree est = (ExpressionStatementTree) path.getLeaf();
@@ -3241,6 +3243,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     private Iterable<? extends Element> getLocalMembersAndVars(final Env env) throws IOException {
         final String prefix = env.getPrefix();
         final CompilationController controller = env.getController();
@@ -3345,6 +3348,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     private void addChainedMembers(final Env env, final Iterable<? extends Element> locals) throws IOException {
         final Set<? extends TypeMirror> smartTypes = getSmartTypes(env);
         if (smartTypes != null && !smartTypes.isEmpty()) {
@@ -3441,6 +3445,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     private void addMemberConstantsAndTypes(final Env env, final TypeMirror type, final Element elem) throws IOException {
         Set<? extends TypeMirror> smartTypes = options.contains(Options.ALL_COMPLETION) ? null : getSmartTypes(env);
         final CompilationController controller = env.getController();
@@ -4112,6 +4117,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         return subtypes;
     }
 
+    @SuppressWarnings("fallthrough")
     private void addMethodArguments(Env env, MethodInvocationTree mit) throws IOException {
         final CompilationController controller = env.getController();
         TreePath path = env.getPath();
@@ -4446,6 +4452,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     private void addKeywordsForStatement(Env env) {
         String prefix = env.getPrefix();
         for (String kw : STATEMENT_KEYWORDS) {
@@ -4840,6 +4847,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         return null;
     }
 
+    @SuppressWarnings("fallthrough")
     private VariableElement getFieldOrVar(Env env, final String simpleName) throws IOException {
         if (simpleName == null || simpleName.length() == 0) {
             return null;
@@ -5034,6 +5042,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         return smartTypes;
     }
 
+    @SuppressWarnings("fallthrough")
     private Set<? extends TypeMirror> getSmartTypesImpl(Env env) throws IOException {
         int offset = env.getOffset();
         final CompilationController controller = env.getController();

--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/fold/JavaElementFoldVisitor.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/fold/JavaElementFoldVisitor.java
@@ -221,6 +221,7 @@ public final class JavaElementFoldVisitor<T> extends CancellableTreePathScanner<
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     public Object visitCompilationUnit(CompilationUnitTree node, Object p) {
         int importsStart = Integer.MAX_VALUE;
         int importsEnd   = -1;

--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/javadoc/JavadocCompletionUtils.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/javadoc/JavadocCompletionUtils.java
@@ -169,6 +169,7 @@ public final class JavadocCompletionUtils {
      * @param e element for which the tokens are queried
      * @return javadoc token sequence or null.
      */
+    @SuppressWarnings("fallthrough")
     public static TokenSequence<JavadocTokenId> findJavadocTokenSequence(CompilationInfo javac, Tree tree, Element e) {
         if (e == null || javac.getElementUtilities().isSynthetic(e))
             return null;

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/FastTypeProvider.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/FastTypeProvider.java
@@ -98,6 +98,7 @@ public final class FastTypeProvider implements TypeProvider {
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     public void computeTypeNames(Context context, Result result) {
         StringBuilder pattern = new StringBuilder();
         boolean sensitive = true;

--- a/java/junit.ant/src/org/netbeans/modules/junit/ant/JUnitOutputReader.java
+++ b/java/junit.ant/src/org/netbeans/modules/junit/ant/JUnitOutputReader.java
@@ -288,6 +288,7 @@ final class JUnitOutputReader {
         }
     }
 
+    @SuppressWarnings("fallthrough")
     synchronized void messageLogged(final AntEvent event) {
         final String msg = event.getMessage();
         if (msg == null) {

--- a/java/spi.java.hints/src/org/netbeans/spi/java/hints/ErrorDescriptionFactory.java
+++ b/java/spi.java.hints/src/org/netbeans/spi/java/hints/ErrorDescriptionFactory.java
@@ -168,6 +168,7 @@ public class ErrorDescriptionFactory {
         return null;
     }
 
+    @SuppressWarnings("fallthrough")
     private static int[] computeNameSpan(Tree tree, HintContext context) {
         switch (tree.getKind()) {
             case LABELED_STATEMENT:

--- a/java/spring.beans/src/org/netbeans/modules/spring/beans/completion/SpringXMLConfigCompletionItem.java
+++ b/java/spring.beans/src/org/netbeans/modules/spring/beans/completion/SpringXMLConfigCompletionItem.java
@@ -1180,6 +1180,7 @@ public abstract class SpringXMLConfigCompletionItem implements CompletionItem {
             }
         }
 
+        @SuppressWarnings("fallthrough")
         private void resolveDocumentation(CompilationController controller, Element el) throws IOException {
             switch (el.getKind()) {
             case ANNOTATION_TYPE:

--- a/php/languages.neon/src/org/netbeans/modules/languages/neon/lexer/NeonColoringLexer.java
+++ b/php/languages.neon/src/org/netbeans/modules/languages/neon/lexer/NeonColoringLexer.java
@@ -749,6 +749,7 @@ public class NeonColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public NeonTokenId nextToken() throws java.io.IOException {
     int zzInput;
     int zzAction;

--- a/php/php.latte/src/org/netbeans/modules/php/latte/lexer/LatteMarkupColoringLexer.java
+++ b/php/php.latte/src/org/netbeans/modules/php/latte/lexer/LatteMarkupColoringLexer.java
@@ -721,6 +721,7 @@ public class LatteMarkupColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public LatteMarkupTokenId findNextToken() throws java.io.IOException {
     int zzInput;
     int zzAction;
@@ -859,21 +860,19 @@ public class LatteMarkupColoringLexer {
           }
         case 36: break;
         default:
-          if (zzInput == YYEOF)
-            //zzAtEOF = true;
-              {         if(input.readLength() > 0) {
-            // backup eof
-            input.backup(1);
-            //and return the text as error token
-            return LatteMarkupTokenId.T_ERROR;
-        } else {
-            return null;
-        }
- }
-
-          else {
-            zzScanError(ZZ_NO_MATCH);
-          }
+            if (zzInput == YYEOF) //zzAtEOF = true;
+            {
+                if (input.readLength() > 0) {
+                    // backup eof
+                    input.backup(1);
+                    //and return the text as error token
+                    return LatteMarkupTokenId.T_ERROR;
+                } else {
+                    return null;
+                }
+            } else {
+                zzScanError(ZZ_NO_MATCH);
+            }
       }
     }
   }

--- a/php/php.latte/src/org/netbeans/modules/php/latte/lexer/LatteTopColoringLexer.java
+++ b/php/php.latte/src/org/netbeans/modules/php/latte/lexer/LatteTopColoringLexer.java
@@ -781,6 +781,7 @@ public class LatteTopColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public LatteTopTokenId findNextToken() throws java.io.IOException {
     int zzInput;
     int zzAction;

--- a/php/php.twig/src/org/netbeans/modules/php/twig/editor/lexer/TwigBlockColoringLexer.java
+++ b/php/php.twig/src/org/netbeans/modules/php/twig/editor/lexer/TwigBlockColoringLexer.java
@@ -719,6 +719,7 @@ public class TwigBlockColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public TwigBlockTokenId findNextToken() throws java.io.IOException {
     int zzInput;
     int zzAction;

--- a/php/php.twig/src/org/netbeans/modules/php/twig/editor/lexer/TwigTopColoringLexer.java
+++ b/php/php.twig/src/org/netbeans/modules/php/twig/editor/lexer/TwigTopColoringLexer.java
@@ -597,6 +597,7 @@ public class TwigTopColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public TwigTopTokenId findNextToken() throws java.io.IOException {
     int zzInput;
     int zzAction;

--- a/php/php.twig/src/org/netbeans/modules/php/twig/editor/lexer/TwigVariableColoringLexer.java
+++ b/php/php.twig/src/org/netbeans/modules/php/twig/editor/lexer/TwigVariableColoringLexer.java
@@ -551,6 +551,7 @@ public class TwigVariableColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public TwigVariableTokenId findNextToken() throws java.io.IOException {
     int zzInput;
     int zzAction;

--- a/platform/core.network/src/org/netbeans/core/network/proxy/NetworkProxyReloader.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/NetworkProxyReloader.java
@@ -62,6 +62,7 @@ public class NetworkProxyReloader extends ProxySettings.Reloader {
      * The first it tries to retrieve proxy settings directly from system,
      * if it is unsuccessful it tries fallback (from environment property http_proxy etc.).
      */
+    @SuppressWarnings("fallthrough")
     public static void reloadNetworkProxy() {        
         LOGGER.log(Level.FINE, "System network proxy reloading started."); //NOI18N
         NetworkProxySettings networkProxySettings = NETWORK_PROXY_RESOLVER.getNetworkProxySettings();
@@ -140,6 +141,7 @@ public class NetworkProxyReloader extends ProxySettings.Reloader {
                 break;
             case DIRECT:
                 LOGGER.log(Level.INFO, "System network proxy - mode: direct"); //NOI18N
+
             default:
                 LOGGER.log(Level.INFO, "System network proxy: fell to default (correct if direct mode went before)"); //NOI18N
                 getPreferences().remove(ProxySettings.SYSTEM_PROXY_HTTP_HOST);

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/model/AngularWhenInterceptor.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/model/AngularWhenInterceptor.java
@@ -102,6 +102,7 @@ public class AngularWhenInterceptor implements FunctionInterceptor {
         INIT, INSTRING, INVALUE, END
     }
 
+    @SuppressWarnings("fallthrough")
     private String getStringValueAt(String content, int offset) {
         String value = "";
         STATE state = STATE.INIT;

--- a/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/KODataBindLanguageHierarchy.java
+++ b/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/KODataBindLanguageHierarchy.java
@@ -53,6 +53,7 @@ public class KODataBindLanguageHierarchy extends LanguageHierarchy<KODataBindTok
     }
 
     @Override
+    @SuppressWarnings("fallthrough")
     protected LanguageEmbedding embedding(
             Token<KODataBindTokenId> token, LanguagePath languagePath, InputAttributes inputAttributes) {
         switch (token.id()) {

--- a/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/KOTemplateContext.java
+++ b/webcommon/html.knockout/src/org/netbeans/modules/html/knockout/KOTemplateContext.java
@@ -40,6 +40,7 @@ public class KOTemplateContext {
 
     private boolean isId;
 
+    @SuppressWarnings("fallthrough")
     public Pair<Boolean, String> process(@NonNull Token<HTMLTokenId> token) {
         switch (token.id()) {
             case TAG_OPEN:

--- a/webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/JadeCodeCompletion.java
+++ b/webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/JadeCodeCompletion.java
@@ -74,6 +74,7 @@ public class JadeCodeCompletion implements CodeCompletionHandler2 {
     protected final static String CSS_CLASS_PREFIX = ".";
     
     @Override
+    @SuppressWarnings("fallthrough")
     public CodeCompletionResult complete(CodeCompletionContext context) {
         ParserResult info = context.getParserResult();
         int carretOffset = context.getParserResult().getSnapshot().getEmbeddedOffset(context.getCaretOffset());

--- a/webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/lexer/JadeColoringLexer.java
+++ b/webcommon/javascript2.jade/src/org/netbeans/modules/javascript2/jade/editor/lexer/JadeColoringLexer.java
@@ -1148,6 +1148,7 @@ public final class JadeColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public JadeTokenId yylex() throws java.io.IOException {
     int zzInput;
     int zzAction;

--- a/webcommon/javascript2.jquery/src/org/netbeans/modules/javascript2/jquery/editor/JQueryCodeCompletion.java
+++ b/webcommon/javascript2.jquery/src/org/netbeans/modules/javascript2/jquery/editor/JQueryCodeCompletion.java
@@ -68,7 +68,8 @@ public class JQueryCodeCompletion implements CompletionProvider {
     private static Collection<HtmlTagAttribute> allAttributes;
 
     private int lastTsOffset = 0;
-    
+
+    @SuppressWarnings("fallthrough")
     public List<CompletionProposal> complete(CodeCompletionContext ccContext, CompletionContext jsCompletionContext, String prefix) {
         long start = System.currentTimeMillis();
         List<CompletionProposal> result = new ArrayList<CompletionProposal>();

--- a/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsColoringLexer.java
+++ b/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsColoringLexer.java
@@ -1249,6 +1249,7 @@ public final class JsColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public JsTokenId yylex() throws java.io.IOException {
     int zzInput;
     int zzAction;

--- a/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsDocumentationColoringLexer.java
+++ b/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsDocumentationColoringLexer.java
@@ -651,6 +651,7 @@ public final class JsDocumentationColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public JsDocumentationTokenId yylex() throws java.io.IOException {
     int zzInput;
     int zzAction;

--- a/webcommon/languages.apacheconf/src/org/netbeans/modules/languages/apacheconf/lexer/ApacheConfColoringLexer.java
+++ b/webcommon/languages.apacheconf/src/org/netbeans/modules/languages/apacheconf/lexer/ApacheConfColoringLexer.java
@@ -624,6 +624,7 @@ public class ApacheConfColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public ApacheConfTokenId nextToken() throws java.io.IOException {
     int zzInput;
     int zzAction;

--- a/webcommon/languages.ini/src/org/netbeans/modules/languages/ini/lexer/IniColoringLexer.java
+++ b/webcommon/languages.ini/src/org/netbeans/modules/languages/ini/lexer/IniColoringLexer.java
@@ -530,6 +530,7 @@ public class IniColoringLexer {
    * @return      the next token
    * @exception   java.io.IOException  if any I/O-Error occurs
    */
+  @SuppressWarnings("fallthrough")
   public IniTokenId nextToken() throws java.io.IOException {
     int zzInput;
     int zzAction;


### PR DESCRIPTION
 [NETBEANS-3345] - cleanup fallthrough warnings..
    
    There are numerous places in the code where the following warning is issued.
    
```
       [repeat] /home/bwalker/src/netbeans/ide/css.editor/src/org/netbeans/modules/css/editor/csl/CssCompletion.java:718: warning: [fallthrough] possible fall-through into case
       [repeat]                 case WS: //@import |
       [repeat]                 ^
       [repeat] /home/bwalker/src/netbeans/ide/css.editor/src/org/netbeans/modules/css/editor/csl/CssCompletion.java:824: warning: [fallthrough] possible fall-through into case
       [repeat]                         default:
       [repeat]                         ^
       [repeat] /home/bwalker/src/netbeans/ide/css.editor/src/org/netbeans/modules/css/editor/csl/CssCompletion.java:1015: warning: [fallthrough] possible fall-through into case
       [repeat]             case mediaBody:
       [repeat]             ^
    
```
I've looked over each and every place where this warning is emitted. The vast majority of these
warnings are due to lexer spaghetti. Which happens often when dealing w/ look-ahead parsers..
    
The simple fix is to add a "@SuppressWarnings("fallthrough")" to the method. as the code looks
like the designer intended this behavior.
    
There is one place where I did find a bug..
    
_platform/core.network/src/org/netbeans/core/network/proxy/NetworkProxyReloader.java_
    
It's missing a break statement in this file.
