### PR TITLE
[NETBEANS-3346] - Upgrade asm-all-5.0.1 version to asm-7.2

### DIFF
--- a/contrib/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentFactory.java
+++ b/contrib/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentFactory.java
@@ -153,7 +153,7 @@ public class WildflyDeploymentFactory implements DeploymentFactory {
                                 return super.getCommonSuperClass(string, string1);
                             }
                         };
-                        ClassNode node = new ClassNode();
+                        ClassNode node = new ClassNode(Opcodes.ASM7);
                         cr.accept(node, 0);
 
                         for (MethodNode m : (Collection<MethodNode>) node.methods) {

--- a/harness/apisupport.harness/build.xml
+++ b/harness/apisupport.harness/build.xml
@@ -39,13 +39,13 @@
                 <pathelement location="${cluster}/tasks.jar"></pathelement>
             </classpath>
         </taskdef>
-        <echo file="build/binaries-list">2F7553F50B0D14ED811B849C282DA8C1FFC32AAE org.ow2.asm:asm-all:5.0.1</echo>
+        <echo file="build/binaries-list">FA637EB67EB7628C915D73762B681AE7FF0B9731 org.ow2.asm:asm:7.2</echo>
         <TestDownload>
             <manifest dir="build">
                 <include name="binaries-list"/>
             </manifest>
         </TestDownload>
-        <delete file="build/asm-all-5.0.1.jar"/>
+        <delete file="build/asm-7.2.jar"/>
     </target>
 
     <target name="compile-jnlp-launcher" depends="init,compile">

--- a/java/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/NbJShellAgent.java
+++ b/java/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/NbJShellAgent.java
@@ -377,7 +377,7 @@ public class NbJShellAgent implements Runnable, ClassFileTransformer {
      */
     private void insertClassInit(String className, ClassNode target) {
         // method void static clinit()
-        MethodNode clinit = new MethodNode(Opcodes.ASM5,
+        MethodNode clinit = new MethodNode(Opcodes.ASM7,
             Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
             CLASS_INIT_NAME,
             CLASS_INIT_DESC,
@@ -400,7 +400,7 @@ public class NbJShellAgent implements Runnable, ClassFileTransformer {
             istm = new ByteArrayInputStream(classfileBuffer);
             ClassReader reader = new ClassReader(istm);
             ClassWriter wr = new ClassWriter(reader, 0);
-            ClassNode clazz = new ClassNode();
+            ClassNode clazz = new ClassNode(Opcodes.ASM7);
             reader.accept(clazz, 0);
             
             boolean found = false;

--- a/java/lib.jshell.agent/nbproject/project.properties
+++ b/java/lib.jshell.agent/nbproject/project.properties
@@ -21,5 +21,5 @@ javac.compilerargs=-Xlint -Xlint:-serial
 extra.module.files=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 jnlp.indirect.jars=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 
-agentsrc.asm.cp=${libs.asm.dir}/core/asm-all-5.0.1.jar
+agentsrc.asm.cp=${libs.asm.dir}/core/asm-7.2.jar
 agentsrc.jshell.cp=${nb_all}/java/libs.jshell.compile/external/jshell-9.jar

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -78,10 +78,10 @@
         <tstamp>
             <format property="module.build.started.time" pattern="yyyy-MM-dd'T'HH:mm:ss.SSSZ"/>
         </tstamp>
-        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-all-5.0.1.jar">
-            <available file="${nbplatform.active.dir}/platform/core/asm-all-5.0.1.jar"/>
+        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-7.2.jar">
+            <available file="${nbplatform.active.dir}/platform/core/asm-7.2.jar"/>
         </condition>
-        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-all-5.0.1.jar"/>
+        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-7.2.jar"/>
     </target>
 
     <target name="-release.dir">

--- a/platform/libs.asm/external/asm-7.2-license.txt
+++ b/platform/libs.asm/external/asm-7.2-license.txt
@@ -1,8 +1,9 @@
 Name: OW2 ASM
-Version: 5.0.1
+Version: 7.2
+Files: asm-tree-7.2.jar asm-7.2.jar
 License: BSD-INRIA
 Origin: OW2 Consortium
-URL: http://forge.ow2.org/project/download.php?group_id=23&file_id=19789
+URL: https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/
 Description: Bytecode manipulation library
 
 *******************************************************************************
@@ -14,13 +15,13 @@ Description: Bytecode manipulation library
 * modification, are permitted provided that the following conditions
 * are met:
 * 1. Redistributions of source code must retain the above copyright
-*    notice, this list of conditions and the following disclaimer.
+*   notice, this list of conditions and the following disclaimer.
 * 2. Redistributions in binary form must reproduce the above copyright
-*    notice, this list of conditions and the following disclaimer in the
-*    documentation and/or other materials provided with the distribution.
+*   notice, this list of conditions and the following disclaimer in the
+*   documentation and/or other materials provided with the distribution.
 * 3. Neither the name of the copyright holders nor the names of its
-*    contributors may be used to endorse or promote products derived from
-*    this software without specific prior written permission.
+*   contributors may be used to endorse or promote products derived from
+*   this software without specific prior written permission.
 *
 * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -34,4 +35,3 @@ Description: Bytecode manipulation library
 * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 * THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************
-

--- a/platform/libs.asm/external/binaries-list
+++ b/platform/libs.asm/external/binaries-list
@@ -14,4 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-2F7553F50B0D14ED811B849C282DA8C1FFC32AAE org.ow2.asm:asm-all:5.0.1
+FA637EB67EB7628C915D73762B681AE7FF0B9731 org.ow2.asm:asm:7.2
+3A23CC36EDAF8FC5A89CB100182758CCB5991487 org.ow2.asm:asm-tree:7.2

--- a/platform/libs.asm/nbproject/project.properties
+++ b/platform/libs.asm/nbproject/project.properties
@@ -16,8 +16,9 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 module.jar.dir=core
 
-release.external/asm-all-5.0.1.jar=core/asm-all-5.0.1.jar
-license.file=../external/asm-all-5.0.1-license.txt
+release.external/asm-7.2.jar=core/asm-7.2.jar
+release.external/asm-tree-7.2.jar=core/asm-tree-7.2.jar
+license.file=../external/asm-7.2-license.txt

--- a/platform/libs.asm/nbproject/project.xml
+++ b/platform/libs.asm/nbproject/project.xml
@@ -29,21 +29,13 @@
                 <subpackages>org</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>asm-all-5.0.1.jar</runtime-relative-path>
-                <binary-origin>external/asm-all-5.0.1.jar</binary-origin>
-            </class-path-extension>
-<!--            <class-path-extension>
-                <runtime-relative-path>ext/asm-5.0.1/asm-5.0.1.jar</runtime-relative-path>
-                <binary-origin>external/asm-5.0.1.jar</binary-origin>
+                <runtime-relative-path>asm-7.2.jar</runtime-relative-path>
+                <binary-origin>external/asm-7.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/asm-5.0.1/asm-commons-5.0.1.jar</runtime-relative-path>
-                <binary-origin>external/asm-commons-5.0.1.jar</binary-origin>
+                <runtime-relative-path>asm-tree-7.2.jar</runtime-relative-path>
+                <binary-origin>external/asm-tree-7.2.jar</binary-origin>
             </class-path-extension>
-            <class-path-extension>
-                <runtime-relative-path>ext/asm-5.0.1/asm-util-5.0.1.jar</runtime-relative-path>
-                <binary-origin>external/asm-util-5.0.1.jar</binary-origin>
-            </class-path-extension>-->
         </data>
     </configuration>
 </project>


### PR DESCRIPTION
-Upgrade asm-all-5.0.1 version to asm-7.2

-Add constructor parameter to use ASMv7 API

`ClassNode theClass = new ClassNode(Opcodes.ASM7);`
If you don't set the ASM version API it will use the default version from the jar:

- asm-all-5.0.1.jar = Opcodes.ASM5
- asm-6.1.jar = Opcodes.ASM6
- asm-7.2.jar = Opcodes.ASM7

-Visit @ConstructorDelegate parameters as array. (by sdedic)
