### PR TITLE
[NETBEANS-3377] - cleanup unchecked conversions

### DIFF
--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
@@ -410,7 +410,7 @@ public class InternationalizationResourceBundleBrandingPanel extends AbstractBra
 
         @Override
         protected void removeNotify() {
-            setKeys(Collections.EMPTY_SET);
+            setKeys(Collections.emptySet());
         }
 
         private void refreshList() {

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2LibraryProvider.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2LibraryProvider.java
@@ -95,7 +95,7 @@ public class Hk2LibraryProvider /*implements JaxRsStackSupportImplementation*/ {
     /** Internal {@see GlassFishServer} to {@see Hk2LibraryProvider}
      *  mapping. */
     private static final Map <GlassFishServer, Hk2LibraryProvider> providers
-            = new HashMap();
+            = new HashMap<>();
 
     ////////////////////////////////////////////////////////////////////////////
     // Static methods                                                         //

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2MessageDestinationManager.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2MessageDestinationManager.java
@@ -75,7 +75,7 @@ public class Hk2MessageDestinationManager implements  MessageDestinationDeployme
             // TODO : need to account for a remote domain here?
             return readMessageDestinations(domainXml, "/domain/", null);
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/db/Hk2DatasourceManager.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/db/Hk2DatasourceManager.java
@@ -149,7 +149,7 @@ public class Hk2DatasourceManager implements DatasourceManager {
             return readDatasources(
                     domainXml, "/domain/", null, server.getVersion(), false);
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/enterprise/j2ee.ejbrefactoring/src/org/netbeans/modules/j2ee/ejbrefactoring/EjbRefactoringPlugin.java
+++ b/enterprise/j2ee.ejbrefactoring/src/org/netbeans/modules/j2ee/ejbrefactoring/EjbRefactoringPlugin.java
@@ -224,7 +224,7 @@ public class EjbRefactoringPlugin implements RefactoringPlugin {
             if (emod != null) {
                 projects.add(affectedProject);
             } else {
-                return Collections.EMPTY_SET;
+                return Collections.emptySet();
             }
             for (Project project : OpenProjects.getDefault().getOpenProjects()) {
                 Object isJ2eeApp = project.getLookup().lookup(J2eeApplicationProvider.class);

--- a/enterprise/javaee.beanvalidation/nbproject/project.properties
+++ b/enterprise/javaee.beanvalidation/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2LibraryProvider.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2LibraryProvider.java
@@ -110,7 +110,7 @@ public class Hk2LibraryProvider /*implements JaxRsStackSupportImplementation*/ {
     /** Internal {@see PayaraServer} to {@see Hk2LibraryProvider}
      *  mapping. */
     private static final Map <PayaraServer, Hk2LibraryProvider> providers
-            = new HashMap();
+            = new HashMap<>();
 
     ////////////////////////////////////////////////////////////////////////////
     // Static methods                                                         //

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2MessageDestinationManager.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2MessageDestinationManager.java
@@ -75,7 +75,7 @@ public class Hk2MessageDestinationManager implements  MessageDestinationDeployme
             // TODO : need to account for a remote domain here?
             return readMessageDestinations(domainXml, "/domain/", null);
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/db/Hk2DatasourceManager.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/db/Hk2DatasourceManager.java
@@ -149,7 +149,7 @@ public class Hk2DatasourceManager implements DatasourceManager {
             return readDatasources(
                     domainXml, "/domain/", null, server.getVersion(), false);
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/plugin/POMManager.java
+++ b/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/plugin/POMManager.java
@@ -449,7 +449,7 @@ public class POMManager {
                                 .stream()
                                 .map(Repository::getId)
                                 .collect(toSet()) 
-                        : Collections.EMPTY_SET;
+                        : Collections.emptySet();
                 for (org.apache.maven.model.Repository repository : sourceModel.getRepositories()) {
                     if (!existingRepositories.contains(repository.getId())) {
                         Repository repo = pomModel.getFactory().createRepository();

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/WebProject.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/WebProject.java
@@ -1526,7 +1526,7 @@ public final class WebProject implements Project {
             if (isArchive) {
                 return TYPES_ARCHIVE;
             } else if (projectCap.isEjb31LiteSupported()) {
-                Set<String> set = new HashSet(Arrays.asList(TYPES));
+                Set<String> set = new HashSet<>(Arrays.asList(TYPES));
                 if (projectCap.isEjb31Supported() || serverSupportsEJB31) {
                     set.addAll(Arrays.asList(TYPES_EJB31));
                 }

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/client/wizard/WebServiceClientWizardIterator.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/client/wizard/WebServiceClientWizardIterator.java
@@ -46,7 +46,7 @@ import org.openide.loaders.TemplateWizard;
 public class WebServiceClientWizardIterator implements TemplateWizard.Iterator {
 
     private int index = 0;
-    private WizardDescriptor.Panel [] panels;
+    private WizardDescriptor.Panel<WizardDescriptor>[] panels;
 
     private TemplateWizard wiz;
     // !PW FIXME How to handle freeform???

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/NewWebServiceFromWSDLWizardIterator.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/NewWebServiceFromWSDLWizardIterator.java
@@ -92,7 +92,7 @@ public class NewWebServiceFromWSDLWizardIterator implements TemplateWizard.Itera
     }
     
     private transient int index;
-    private transient WizardDescriptor.Panel[] panels;
+    private transient WizardDescriptor.Panel<WizardDescriptor>[] panels;
     private transient TemplateWizard wiz;
     private transient WizardDescriptor.Panel<WizardDescriptor> bottomPanel;
 

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/NewWebServiceWizardIterator.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/dev/wizard/NewWebServiceWizardIterator.java
@@ -88,7 +88,7 @@ public class NewWebServiceWizardIterator implements TemplateWizard.Iterator /*, 
     }
     
     private transient int index;
-    private transient WizardDescriptor.Panel[] panels;
+    private transient WizardDescriptor.Panel<WizardDescriptor>[] panels;
     private transient TemplateWizard wiz;
     private transient WizardDescriptor.Panel<WizardDescriptor> bottomPanel;
 

--- a/ide/db/src/org/netbeans/modules/db/explorer/node/NodeDataLookup.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/node/NodeDataLookup.java
@@ -36,7 +36,7 @@ import org.openide.util.lookup.InstanceContent;
 public class NodeDataLookup extends AbstractLookup {
 
     /** the data instances held in the lookup */
-    private final Set dataInstances = Collections.synchronizedSet(new HashSet());
+    private final Set<Object> dataInstances = Collections.synchronizedSet(new HashSet<Object>());
 
     /** the content of the underlying AbstractLookup */
     private final InstanceContent content;

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/NbReaderProvider.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/NbReaderProvider.java
@@ -96,7 +96,7 @@ public class NbReaderProvider implements ReaderProvider {
     }
 
     private Map<String, String> parseCatalog(Reader catalogReader) {
-        HashMap hashmap = new HashMap();
+        HashMap<String, String> hashmap = new HashMap<>();
         LineNumberReader reader = new LineNumberReader(catalogReader);
 
         for (;;) {

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/api/Utils.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/api/Utils.java
@@ -90,7 +90,7 @@ public class Utils {
         }
 
         do {
-            Token t = ts.token();
+            Token<HTMLTokenId> t = ts.token();
             TokenId id = t.id();
             if( id == HTMLTokenId.TAG_OPEN) {
                 return t;

--- a/ide/localhistory/src/org/netbeans/modules/localhistory/LocalHistory.java
+++ b/ide/localhistory/src/org/netbeans/modules/localhistory/LocalHistory.java
@@ -110,7 +110,7 @@ public class LocalHistory {
         
         String rootPaths = System.getProperty("netbeans.localhistory.historypath");
         if(rootPaths == null || rootPaths.trim().equals("")) {            
-            userDefinedRoots = Collections.EMPTY_SET;               
+            userDefinedRoots = Collections.emptySet();
         } else {
             String[] paths = rootPaths.split(";");
             userDefinedRoots = new HashSet<String>(paths.length);

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
@@ -673,7 +673,7 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
             final Set<Component> initiallyOpenedMinimized;
             if (componentsInitiallyOpened.isEmpty()) {
                 initiallyOpened = Collections.emptyList();
-                initiallyOpenedMinimized = Collections.EMPTY_SET;
+                initiallyOpenedMinimized = Collections.emptySet();
             } else {
                 initiallyOpened = new ArrayList<Component>();
                 initiallyOpenedMinimized = new HashSet<>();

--- a/ide/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskList.java
+++ b/ide/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskList.java
@@ -150,7 +150,7 @@ public class TaskList {
                 groupTasks.removeAll( toRemove );
             }
         }
-        return toRemove == null ? null : new LinkedList(toRemove);
+        return toRemove == null ? null : new LinkedList<Task>(toRemove);
     }
     
     void update( FileTaskScanner scanner, FileObject resource, List<Task> newTasks, TaskFilter filter ) {
@@ -294,7 +294,7 @@ public class TaskList {
                 groupTasks.removeAll( toRemove );
             }
         }
-        return toRemove == null ? null : new LinkedList(toRemove);
+        return toRemove == null ? null : new LinkedList<Task>(toRemove);
     }
     
     void clear( FileObject resource ) {

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogAction.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogAction.java
@@ -103,7 +103,7 @@ public class CatalogAction implements ActionListener {
         public void actionPerformed (ActionEvent ev) {
             Node [] nodes = (Node []) cp.getExplorerManager ().getSelectedNodes ();
             assert nodes != null && nodes.length > 0 : "Selected templates cannot be null or empty.";
-            Set nodes2open = getNodes2Open (nodes);
+            Set<Node> nodes2open = getNodes2Open (nodes);
             assert ! nodes2open.isEmpty () : "Selected templates to open cannot by empty for nodes " + Arrays.asList (nodes);
             Iterator<Node> it = nodes2open.iterator();
             while (it.hasNext ()) {

--- a/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/SyntaxElement.java
+++ b/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/SyntaxElement.java
@@ -81,7 +81,7 @@ public abstract class SyntaxElement implements org.netbeans.modules.xml.text.api
         if(cached_first == null) {
             try {
                 TokenItem new_first = support.getTokenChain(offset, offset + 1); //it is a first token offset, so we shouldn't overlap the document length
-                first = new WeakReference(new_first);
+                first = new WeakReference<>(new_first);
                 return new_first;
             }catch(BadLocationException e) {
                 return null;
@@ -101,11 +101,11 @@ public abstract class SyntaxElement implements org.netbeans.modules.xml.text.api
     }
     
     void setNext(SyntaxElement se) {
-        next = new WeakReference(se);
+        next = new WeakReference<>(se);
     }
     
     void setPrevious(SyntaxElement se) {
-        previous = new WeakReference(se);
+        previous = new WeakReference<>(se);
     }
 
     /**

--- a/ide/xml/nbproject/project.properties
+++ b/ide/xml/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 is.autoload=true
 
 javadoc.packages=\

--- a/java/ant.debugger/nbproject/project.properties
+++ b/java/ant.debugger/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 spec.version.base=1.44.0
 test.unit.run.cp.extra=${tools.jar}
 # Make the debugger find it, even if it is not on the startup debug classpath:

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AdvancedActionPanel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AdvancedActionPanel.java
@@ -95,7 +95,7 @@ final class AdvancedActionPanel extends javax.swing.JPanel {
         FileObject script = project.getFileObject();
         assert script != null : "No file found for " + project;
         String initialTargets = (String) script.getAttribute(ATTR_TARGETS);
-        SortedSet<String> relevantTargets = new TreeSet(Collator.getInstance());
+        SortedSet<String> relevantTargets = new TreeSet<>(Collator.getInstance());
         Iterator it = allTargets.iterator();
         while (it.hasNext()) {
             TargetLister.Target target = (TargetLister.Target) it.next();

--- a/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/ObservableSet.java
+++ b/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/ObservableSet.java
@@ -40,7 +40,7 @@ public class ObservableSet<E> implements Set<E> {
     
     private final PropertyChangeSupport pchs = new PropertyChangeSupport(this);
     
-    private Set<E> set = Collections.EMPTY_SET;
+    private Set<E> set = Collections.emptySet();
     
     @Override
     public int size() {

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ActionsPanel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ActionsPanel.java
@@ -327,7 +327,7 @@ private void cbSuspendActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIR
     
     private static Set<Breakpoint> createBreakpointsSet(Object selectedGroup) {
         if (selectedGroup == null || selectedGroup == NONE_BREAKPOINT_GROUP) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         } else {
             TestGroupProperties tgp = createTestProperties(selectedGroup);
             if (tgp != null) {
@@ -338,7 +338,7 @@ private void cbSuspendActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIR
                 if (!customGroup.isEmpty()) {
                     return new BreakpointsFromGroup(customGroup);
                 } else {
-                    return Collections.EMPTY_SET;
+                    return Collections.emptySet();
                 }
             }
         }

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/formatters/VariablesFormatter.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/formatters/VariablesFormatter.java
@@ -327,7 +327,7 @@ public final class VariablesFormatter implements Cloneable {
         mapEntry.setClassTypes("java.util.Map$Entry");
         mapEntry.setIncludeSubTypes(true);
         mapEntry.setUseChildrenVariables(true);
-        Map childrenMap = new LinkedHashMap();
+        Map<String, String> childrenMap = new LinkedHashMap<>();
         childrenMap.put("key", "getKey()");
         childrenMap.put("value", "getValue()");
         mapEntry.setChildrenVariables(childrenMap);

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
@@ -221,7 +221,7 @@ public class ThreadsCache implements Executor {
     }
 
     public synchronized List<ThreadReference> getAllThreads() {
-        return Collections.unmodifiableList(new ArrayList(allThreads));
+        return Collections.<List<ThreadReference>>unmodifiableList(new ArrayList(allThreads));
     }
     
     public synchronized List<ThreadGroupReference> getTopLevelThreadGroups() {
@@ -245,7 +245,7 @@ public class ThreadsCache implements Executor {
                 }
             }
         }
-        return Collections.unmodifiableList(new ArrayList(topGroups));
+        return Collections.<List<ThreadReference>>unmodifiableList(new ArrayList(topGroups));
     }
     
     public synchronized List<ThreadReference> getThreads(ThreadGroupReference group) {
@@ -262,7 +262,7 @@ public class ThreadsCache implements Executor {
         if (threads == null) {
             threads = Collections.emptyList();
         } else {
-            threads = Collections.unmodifiableList(new ArrayList(threads));
+            threads = Collections.<List<ThreadReference>>unmodifiableList(new ArrayList(threads));
         }
         return threads;
     }
@@ -285,7 +285,7 @@ public class ThreadsCache implements Executor {
         if (groups == null) {
             groups = Collections.emptyList();
         } else {
-            groups = Collections.unmodifiableList(new ArrayList(groups));
+            groups = Collections.<List<ThreadReference>>unmodifiableList(new ArrayList(groups));
         }
         return groups;
     }

--- a/php/php.nette2/src/org/netbeans/modules/php/nette2/annotations/Nette2AnnotationsProvider.java
+++ b/php/php.nette2/src/org/netbeans/modules/php/nette2/annotations/Nette2AnnotationsProvider.java
@@ -41,12 +41,12 @@ public class Nette2AnnotationsProvider extends AnnotationCompletionTagProvider {
 
     @Override
     public List<AnnotationCompletionTag> getFunctionAnnotations() {
-        return Collections.emptyList();
+        return Collections.<AnnotationCompletionTag>emptyList();
     }
 
     @Override
     public List<AnnotationCompletionTag> getTypeAnnotations() {
-        return Collections.emptyList();
+        return Collections.<AnnotationCompletionTag>emptyList();
     }
 
     @Override
@@ -58,7 +58,7 @@ public class Nette2AnnotationsProvider extends AnnotationCompletionTagProvider {
 
     @Override
     public List<AnnotationCompletionTag> getMethodAnnotations() {
-        return Collections.emptyList();
+        return Collections.<AnnotationCompletionTag>emptyList();
     }
 
 }

--- a/php/selenium2.php/src/org/netbeans/modules/selenium2/php/Selenium2PhpSupportImpl.java
+++ b/php/selenium2.php/src/org/netbeans/modules/selenium2/php/Selenium2PhpSupportImpl.java
@@ -113,17 +113,17 @@ public class Selenium2PhpSupportImpl extends Selenium2SupportImpl {
         configureProject(refFileObject);
         Project p = FileOwnerQuery.getOwner(refFileObject);
         if (p == null) {
-            return Collections.emptyList();
+            return Collections.<Object>emptyList();
         }
         PhpSeleniumProvider seleniumProvider = getSeleniumProvider(p);
         if(seleniumProvider == null) {
-            return Collections.emptyList();
+            return Collections.<Object>emptyList();
         }
         // selenium test dir was not set by user during configureProject()
         // user probably pressed Cancel. Do not bother him with extra
         // configuration dialogs.
         if(getSeleniumDir(p, false) == null) {
-            return Collections.emptyList();
+            return Collections.<Object>emptyList();
         }
         return seleniumProvider.getTestSourceRoots(createdSourceRoots, refFileObject);
     }

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OQLController.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OQLController.java
@@ -256,7 +256,7 @@ public class OQLController extends AbstractTopLevelController
                 rc = rc.getNext();
             }
         } else if (o instanceof Map) {
-            Set<Map.Entry> entries = ((Map)o).entrySet();
+            Set<Map.Entry> entries = ((Map)o).<Map.Entry>entrySet();
             sb.append("<span><b>{</b><br/>"); // NOI18N
             boolean first = true;
             for(Map.Entry entry : entries) {

--- a/profiler/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/AbstractProjectLookupProvider.java
+++ b/profiler/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/AbstractProjectLookupProvider.java
@@ -50,7 +50,7 @@ public abstract class AbstractProjectLookupProvider implements LookupProvider {
                 }
 
                 public List<FileObject> getDataFiles() {
-                    return Collections.emptyList();
+                    return Collections.<FileObject>emptyList();
                 }
             };
     }

--- a/webcommon/javascript2.extjs/src/org/netbeans/modules/javascript2/extjs/ExtJsCodeCompletion.java
+++ b/webcommon/javascript2.extjs/src/org/netbeans/modules/javascript2/extjs/ExtJsCodeCompletion.java
@@ -66,24 +66,24 @@ public class ExtJsCodeCompletion implements CompletionProvider {
     @Override
     public List<CompletionProposal> complete(CodeCompletionContext ccContext, CompletionContext jsCompletionContext, String prefix) {
         if (jsCompletionContext != CompletionContext.OBJECT_PROPERTY_NAME) {
-            return Collections.emptyList();
+            return Collections.<CompletionProposal>emptyList();
         }
         // find the object that can be configured
         TokenHierarchy<?> th = ccContext.getParserResult().getSnapshot().getTokenHierarchy();
         if (th == null) {
-            return Collections.emptyList();
+            return Collections.<CompletionProposal>emptyList();
         }
         int carretOffset  = ccContext.getCaretOffset();
         int eOffset = ccContext.getParserResult().getSnapshot().getEmbeddedOffset(carretOffset);
         TokenSequence<? extends JsTokenId> ts = LexUtilities.getJsTokenSequence(th, eOffset);
         if (ts == null) {
-            return Collections.emptyList();
+            return Collections.<CompletionProposal>emptyList();
         }
         
         ts.move(eOffset);
         
         if (!ts.moveNext() && !ts.movePrevious()){
-            return Collections.emptyList();
+            return Collections.<CompletionProposal>emptyList();
         }
         
         Token<? extends JsTokenId> token = null;
@@ -100,7 +100,7 @@ public class ExtJsCodeCompletion implements CompletionProvider {
             }
         }
         if (token == null || balance != 0) {
-            return Collections.emptyList();
+            return Collections.<CompletionProposal>emptyList();
         }
         
         // now we should be at the beginning of the object literal. 
@@ -129,7 +129,7 @@ public class ExtJsCodeCompletion implements CompletionProvider {
             }
             return result;
         }
-        return Collections.emptyList();
+        return Collections.<CompletionProposal>emptyList();
     }
 
     @Override

--- a/webcommon/selenium2.webclient.protractor/src/org/netbeans/modules/selenium2/webclient/protractor/ProtractorRunner.java
+++ b/webcommon/selenium2.webclient.protractor/src/org/netbeans/modules/selenium2/webclient/protractor/ProtractorRunner.java
@@ -355,7 +355,7 @@ class ProtractorRunner {
             }
             String output2display = testRunnerReporter.processLine(line);
             if(output2display == null) {
-                return Collections.emptyList();
+                return Collections.<ConvertedLine>emptyList();
             }
             TestRunnerReporter.CallStackCallback callStackCallback = new TestRunnerReporter.CallStackCallback(runInfo.getProject());
             Pair<File, int[]> parsedLocation = callStackCallback.parseLocation(line, false);

--- a/websvccommon/websvc.saas.codegen/nbproject/project.properties
+++ b/websvccommon/websvc.saas.codegen/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 
 # masterfs needed for the usual reasons; tools.jar needed for Ant's <javac> to work
 test.unit.run.cp.extra=${tools.jar}

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/GenericResourceBean.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/GenericResourceBean.java
@@ -153,7 +153,7 @@ public class GenericResourceBean {
     }
 
     public void setMethodTypes(HttpMethodType[] types) {
-        methodTypes = new HashSet(Arrays.asList(types));
+        methodTypes = new HashSet<>(Arrays.asList(types));
     }
     
     private String[] uriParams = null;

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SaasBean.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SaasBean.java
@@ -482,7 +482,7 @@ public abstract class SaasBean extends GenericResourceBean {
     }
     
     private Map<String, Map<String, String>> getArtifactTemplates(SaasMethod m) throws IOException {
-        Map<String, Map<String, String>> targetMaps = new HashMap();
+        Map<String, Map<String, String>> targetMaps = new HashMap<>();
         CodeGen codegen = m.getSaas().getSaasMetadata().getCodeGen();
         if(codegen != null) {
             List<Artifacts> artifactsList = codegen.getArtifacts();


### PR DESCRIPTION
There are a lot of places in the code where unchecked conversions are taking place..

   [repeat] /home/bwalker/src/netbeans/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OQLController.java:259: warning: [unchecked] unchecked conversion
   [repeat]             Set<Map.Entry> entries = ((Map)o).entrySet();
   [repeat]                                                       ^
   [repeat]   required: Set<Entry>
   [repeat]   found:    Set

Cleanup these warning messages..