### PR TITLE
Use .exe suffix when looking for jmod on Windows

### DIFF
--- a/nbbuild/jdk.xml
+++ b/nbbuild/jdk.xml
@@ -98,7 +98,7 @@
                 <available file="${nbjdk.javadoc}" type="file"/>
                 <or>
                     <available classname="java.lang.Object" classpath="${nbjdk.bootclasspath}" ignoresystemclasses="true"/>
-                    <available file="${nbjdk.home}/bin/jmod"/>
+                    <available file="${nbjdk.home}/bin/jmod${.exe}"/>
                 </or>
             </and>
         </condition>
@@ -107,7 +107,7 @@
         <available property="have-jdk-1.6" classname="java.util.ServiceLoader" classpath="${nbjdk.bootclasspath}" ignoresystemclasses="true"/>
         <available property="have-jdk-1.7" classname="java.lang.ReflectiveOperationException" classpath="${nbjdk.bootclasspath}" ignoresystemclasses="true"/>
         <available property="have-jdk-1.8" classname="java.lang.FunctionalInterface" classpath="${nbjdk.bootclasspath}" ignoresystemclasses="true"/>
-        <available property="have-jdk-1.9" file="${nbjdk.home}/bin/jmod"/>
+        <available property="have-jdk-1.9" file="${nbjdk.home}/bin/jmod${.exe}"/>
         <echo level="verbose">nbjdk.active=${nbjdk.active} nbjdk.home=${nbjdk.home} nbjdk.java=${nbjdk.java} nbjdk.javac=${nbjdk.javac} nbjdk.javadoc=${nbjdk.javadoc} nbjdk.bootclasspath=${nbjdk.bootclasspath} nbjdk.valid=${nbjdk.valid} have-jdk-1.4=${have-jdk-1.4} have-jdk-1.5=${have-jdk-1.5} have-jdk-1.6=${have-jdk-1.6} have-jdk-1.7=${have-jdk-1.7} have-jdk-1.8=${have-jdk-1.8} have-jdk-1.9=${have-jdk-1.9}</echo>
     </target>
 


### PR DESCRIPTION
I was seeing "Warning: nbjdk.active=... or nbjdk.home=... is an invalid Java platform" warnings when building NB on Windows. The reason was that the build script was not finding the `jmod` executable in the JDK. This simple patch makes sure to look for it using the .exe suffix, using the same mechanism as it currently uses for `javac` et al.