### PR TITLE
[NETBEANS-3393] - cleanup ArrayList uncheck conversion

### DIFF
--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
@@ -414,7 +414,7 @@ public class InternationalizationResourceBundleBrandingPanel extends AbstractBra
         }
 
         private void refreshList() {
-            List<BundleNode> keys = new ArrayList();
+            List<BundleNode> keys = new ArrayList<>();
             for (BundleNode node : resourceBundleNodes) {
                 keys.add(node);
             }

--- a/harness/jellytools.platform/nbproject/project.properties
+++ b/harness/jellytools.platform/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stable.includes=\

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/JellyTestCase.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/JellyTestCase.java
@@ -368,9 +368,9 @@ public class JellyTestCase extends NbTestCase {
             Object openProjectsInstance = getDefaultOpenProjectsMethod.invoke(null);
             Method getOpenProjectsMethod = openProjectsClass.getMethod("getOpenProjects");
             if (openedProjects == null) {
-                openedProjects = new ArrayList();
+                openedProjects = new ArrayList<>();
             }
-            List<Object> newProjects = new ArrayList<Object>();
+            List<Object> newProjects = new ArrayList<>();
             Object pr;
             for (String p : projects) {
                 Method getDefaultMethod = projectManagerClass.getMethod("getDefault");

--- a/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
@@ -991,7 +991,7 @@ public final class DebuggerManager implements ContextProvider {
             try {
                 initDebuggerManagerListeners ();
 
-                createdBreakpoints = new ArrayList();
+                createdBreakpoints = new ArrayList<>();
                 originatingListeners = new HashMap();
 
                 Vector l = (Vector) listeners.clone ();

--- a/ide/api.debugger/src/org/netbeans/api/debugger/Properties.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/Properties.java
@@ -573,12 +573,12 @@ public abstract class Properties {
                     props = new HashMap(properties);
                 }
                 Set s = props.keySet ();
-                ArrayList l = new ArrayList (s);
+                List<String> l = new ArrayList<>(s);
                 Collections.sort (l);
                 int i, k = l.size ();
                 for (i = 0; i < k; i++) {
-                    String key = (String) l.get (i);
-                    Object value = props.get (key);
+                    String key = l.get(i);
+                    Object value = props.get(key);
                     if (value != null) {
                         // Do not write null values
                         value = translateMultiLineStringToSingleLine(value.toString());

--- a/ide/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationViewDataImpl.java
+++ b/ide/editor.errorstripe/src/org/netbeans/modules/editor/errorstripe/AnnotationViewDataImpl.java
@@ -80,8 +80,8 @@ final class AnnotationViewDataImpl implements PropertyChangeListener, Annotation
     private List<MarkProvider> markProviders = new ArrayList<MarkProvider>();
     private List<UpToDateStatusProvider> statusProviders = new ArrayList<UpToDateStatusProvider>();
 
-    private List<PropertyChangeListener> markProvidersWeakLs = new ArrayList();
-    private List<PropertyChangeListener> statusProvidersWeakLs = new ArrayList();
+    private List<PropertyChangeListener> markProvidersWeakLs = new ArrayList<>();
+    private List<PropertyChangeListener> statusProvidersWeakLs = new ArrayList<>();
     
     private Collection<Mark> currentMarks = null;
     private SortedMap<Integer, List<Mark>> marksMap = null;

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/CaretUndoEdit.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/CaretUndoEdit.java
@@ -294,7 +294,7 @@ class CaretUndoEdit extends AbstractUndoableEdit {
             } else { // one or more complex positions markOffsetAndBias contains the marker value
                 int splitOffset = extraOffsets[0];
                 int i = 1;
-                dotAndMarkPosPairs = new ArrayList((extraOffsets.length + 1) >> 1);
+                dotAndMarkPosPairs = new ArrayList<>((extraOffsets.length + 1) >> 1);
                 Position pos = dotPos;
                 while (true) {
                     pos = ComplexPositions.create(pos, splitOffset);

--- a/ide/git/src/org/netbeans/modules/git/ui/clone/CloneWizard.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/clone/CloneWizard.java
@@ -51,7 +51,7 @@ class CloneWizard  implements ChangeListener {
     private WizardDescriptor wizardDescriptor;
     private final String forPath;
     private final PasswordAuthentication pa;
-    static final List<String> ALL_BRANCHES = new ArrayList(0);
+    static final List<String> ALL_BRANCHES = new ArrayList<>();
 
     public CloneWizard (PasswordAuthentication pa, String forPath) { 
         this.forPath = forPath;

--- a/ide/options.editor/nbproject/project.properties
+++ b/ide/options.editor/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 test.unit.run.cp.extra=${java/javacore.dir}/modules/org-netbeans-modules-javacore.jar:${java/javamodel.dir}/modules/org-netbeans-jmi-javamodel.jar:${java/javamodel.dir}/modules/ext/jmi.jar

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/keymap/EditorBridge.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/keymap/EditorBridge.java
@@ -177,7 +177,7 @@ public final class EditorBridge extends KeymapManager {
                 }
                 List<MultiKeyBinding> bindings = actionToMkb.get(an);
                 if (bindings == null) {
-                    bindings = new ArrayList(2);
+                    bindings = new ArrayList<>(2);
                     actionToMkb.put(an, bindings);
                 }
                 bindings.add(mkb);

--- a/ide/projectapi/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementation.java
+++ b/ide/projectapi/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementation.java
@@ -104,7 +104,7 @@ public class SimpleFileOwnerQueryImplementation implements FileOwnerQueryImpleme
     
     
     public Project getOwner(FileObject f) {
-        List<FileObject> folders = new ArrayList();
+        List<FileObject> folders = new ArrayList<>();
         
         deserialize();
         while (f != null) {

--- a/ide/selenium2/nbproject/project.properties
+++ b/ide/selenium2/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/selenium2/src/org/netbeans/modules/selenium2/api/Selenium2Support.java
+++ b/ide/selenium2/src/org/netbeans/modules/selenium2/api/Selenium2Support.java
@@ -141,7 +141,7 @@ public final class Selenium2Support {
     
     public static ArrayList<FileObject> createTests(TestCreatorProvider.Context context) {
         FileObject[] activatedFOs = context.getActivatedFOs();
-        ArrayList<FileObject> createdFiles = new ArrayList();
+        ArrayList<FileObject> createdFiles = new ArrayList<>();
         if (activatedFOs[0] != null && activatedFOs.length != 0 && activatedFOs[0].isValid()) {
             Project p = FileOwnerQuery.getOwner(activatedFOs[0]);
             Selenium2SupportImpl selenium2Support = Selenium2Support.findSelenium2Support(p);
@@ -154,7 +154,7 @@ public final class Selenium2Support {
                         createdFiles.add(seleniumTestFile);
                     }
                 } else {
-                    ArrayList<FileObject> activatedFOs2 = new ArrayList();
+                    ArrayList<FileObject> activatedFOs2 = new ArrayList<>();
                     for (FileObject fo : activatedFOs) {
                         if (fo.isData()) {
                             if (!activatedFOs2.contains(fo)) {

--- a/ide/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskList.java
+++ b/ide/tasklist.ui/src/org/netbeans/modules/tasklist/impl/TaskList.java
@@ -100,7 +100,7 @@ public class TaskList {
         if( null != removed && !removed.isEmpty() )
             fireTasksRemoved( removed );
         if( null != tasksToAdd && !tasksToAdd.isEmpty() )
-            fireTasksAdded(new ArrayList(tasksToAdd));
+            fireTasksAdded(new ArrayList<Task>(tasksToAdd));
     }
     
     void clear( PushTaskScanner scanner ) {

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/history/AbstractSummaryView.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/history/AbstractSummaryView.java
@@ -121,7 +121,7 @@ public abstract class AbstractSummaryView implements MouseListener, MouseMotionL
     }
 
     private List<Item> expandResults (List<? extends LogEntry> results) {
-        ArrayList<Item> newResults = new ArrayList(results.size() * 6);
+        List<Item> newResults = new ArrayList<>(results.size() * 6);
         for (LogEntry le : results) {
             le.removePropertyChangeListener(LogEntry.PROP_EVENTS_CHANGED, list);
             le.addPropertyChangeListener(LogEntry.PROP_EVENTS_CHANGED, list);

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/DeadlockDetectorImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/DeadlockDetectorImpl.java
@@ -161,7 +161,7 @@ public class DeadlockDetectorImpl extends DeadlockDetector implements PropertyCh
             result = new HashSet<Deadlock>();
             Set<Node> nodesSet = new HashSet<Node>(monitorToNode.values());
             while (!nodesSet.isEmpty()) {
-                Collection<JPDAThread> deadlockedThreads = new ArrayList(nodesSet.size());
+                Collection<JPDAThread> deadlockedThreads = new ArrayList<>(nodesSet.size());
                 Node node = nodesSet.iterator().next();
                 nodesSet.remove(node);
                 do {

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
@@ -321,7 +321,7 @@ public class ThreadsCache implements Executor {
     
     private List<ThreadGroupReference> addGroups(ThreadGroupReference group) throws ObjectCollectedExceptionWrapper {
         if (threadMap != null && !threadMap.containsKey(group)) {
-            List<ThreadReference> threads = new ArrayList();
+            List<ThreadReference> threads = new ArrayList<>();
             threadMap.put(group, threads);
         }
         if (groupMap == null) {

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
@@ -415,7 +415,7 @@ public class InspectAndRefactorPanel extends javax.swing.JPanel implements Popup
 
             customScope = org.netbeans.modules.refactoring.api.Scope.create(todo, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
         } else if (selectedItem == currentProject) {
-            ArrayList<FileObject> roots = new ArrayList();
+            List<FileObject> roots = new ArrayList<>();
             for (SourceGroup gr:ProjectUtils.getSources(project).getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA)) {
                 roots.add(gr.getRootFolder());
             }

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/J2SEModularPersistenceProvider.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/J2SEModularPersistenceProvider.java
@@ -182,7 +182,7 @@ public class J2SEModularPersistenceProvider implements PersistenceLocationProvid
         if (root != null) {
             return Collections.singletonList(root);                    
         }
-        final ArrayList<FileObject> roots = new ArrayList();
+        final ArrayList<FileObject> roots = new ArrayList<>();
         if (fo != null) {
             for (URL url : project.getSourceRoots().getRootURLs()) {
                 final FileObject r = URLMapper.findFileObject(url);

--- a/java/junit.ant/src/org/netbeans/modules/junit/ant/JUnitOutputReader.java
+++ b/java/junit.ant/src/org/netbeans/modules/junit/ant/JUnitOutputReader.java
@@ -614,7 +614,7 @@ final class JUnitOutputReader {
                         lastSuiteTime = reportSuite.getElapsedTime();
                         for(Testcase tc: currentSuite.getTestcases()){
                             if (!tc.getOutput().isEmpty()){
-                                List<String> output = new ArrayList();
+                                List<String> output = new ArrayList<>();
                                 for(OutputLine l: tc.getOutput()){
                                     output.add(l.getLine());
                                 }

--- a/java/testng/src/org/netbeans/modules/testng/AbstractTestGenerator.java
+++ b/java/testng/src/org/netbeans/modules/testng/AbstractTestGenerator.java
@@ -475,7 +475,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
                                                    workingCopy));
             }
         } else {
-            members = new ArrayList(membersCount);
+            members = new ArrayList<>(membersCount);
             if (constructor != null) {
                 members.add(constructor);
             }
@@ -550,7 +550,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
         final TreeMaker maker = workingCopy.getTreeMaker();
 
         List<? extends VariableElement> defaultCtorParams
-                = new ArrayList(superCtorParams);
+                = new ArrayList<>(superCtorParams);
 
         List<ExpressionTree> throwsList =
                 (superConstructor != null)
@@ -590,7 +590,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
             return Collections.emptyList();
         }
 
-        List<ExpressionTree> result = new ArrayList(params.size());
+        List<ExpressionTree> result = new ArrayList<>(params.size());
         for (VariableElement param : params) {
             result.add(getDefaultValue(maker, param.asType()));
         }
@@ -696,7 +696,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
             return Collections.singletonList(makeCopy(typeParams.get(0), maker));
         }
 
-        List<TypeParameterTree> result = new ArrayList(size);
+        List<TypeParameterTree> result = new ArrayList<>(size);
         for (TypeParameterElement typeParam : typeParams) {
             result.add(makeCopy(typeParam, maker));
         }
@@ -715,7 +715,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
             return Collections.singletonList(makeCopy(params.get(0), maker));
         }
 
-        List<VariableTree> result = new ArrayList(size);
+        List<VariableTree> result = new ArrayList<>(size);
         for (VariableElement param : params) {
             result.add(makeCopy(param, maker));
         }
@@ -753,7 +753,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
                    ? Collections.<ExpressionTree>emptyList()
                    : Collections.singletonList((ExpressionTree) maker.Type(bound));
         } else {
-            List<ExpressionTree> result = new ArrayList(size);
+            List<ExpressionTree> result = new ArrayList<>(size);
             for (DeclaredType type : typeList) {
                 result.add((ExpressionTree) maker.Type(type));
             }
@@ -814,7 +814,7 @@ abstract class AbstractTestGenerator implements CancellableTask<WorkingCopy>{
             Set<Modifier> modifiers = method.getModifiers();
             if (modifiers.contains(ABSTRACT) && !modifiers.contains(STATIC)) {
                 if (result == null) {
-                    result = new ArrayList(remainingCount);
+                    result = new ArrayList<>(remainingCount);
                 }
                 result.add(method);
             }

--- a/java/websvc.saas.codegen.java/nbproject/project.properties
+++ b/java/websvc.saas.codegen.java/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 requires.nb.javac=true

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
@@ -184,9 +184,9 @@ public class SourceGroupSupport {
     private static List<SourceGroup> getTestTargets(SourceGroup sourceGroup, Map foldersToSourceGroupsMap) {
         final URL[] rootURLs = UnitTestForSourceQuery.findUnitTests(sourceGroup.getRootFolder());
         if (rootURLs.length == 0) {
-            return new ArrayList();
+            return new ArrayList<>();
         }
-        List<SourceGroup> result = new ArrayList<SourceGroup>();
+        List<SourceGroup> result = new ArrayList<>();
         List<FileObject> sourceRoots = getFileObjects(rootURLs, true);
         for (int i = 0; i < sourceRoots.size(); i++) {
             FileObject sourceRoot = sourceRoots.get(i);

--- a/java/whitelist/nbproject/project.properties
+++ b/java/whitelist/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/java/whitelist/src/org/netbeans/modules/whitelist/project/WhiteListCategoryPanel.java
+++ b/java/whitelist/src/org/netbeans/modules/whitelist/project/WhiteListCategoryPanel.java
@@ -175,7 +175,7 @@ public class WhiteListCategoryPanel extends javax.swing.JPanel implements Action
 
         public WhiteListsModel(List<Desc> whitelists) {
             assert whitelists.size() > 0;
-            this.whitelists = new ArrayList(whitelists);
+            this.whitelists = new ArrayList<>(whitelists);
         }
         
         @Override

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
@@ -115,7 +115,7 @@ public class Utilities {
         if (c == null || c.isEmpty ()) {
             return Collections.emptyList ();
         }
-        List<KeyStore> kss = new ArrayList ();
+        List<KeyStore> kss = new ArrayList<>();
         
         for (KeyStoreProvider provider : c) {
             KeyStore ks = provider.getKeyStore ();

--- a/platform/core.multitabs/nbproject/project.properties
+++ b/platform/core.multitabs/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 nbm.needs.restart=true

--- a/platform/core.windows/src/org/netbeans/core/windows/PersistenceHandler.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/PersistenceHandler.java
@@ -131,7 +131,7 @@ final public class PersistenceHandler implements PersistenceObserver {
             wm.setRecentViewList(wmc.tcIdViewList);
         } else {
             //No recent view list is saved, fill it by opened TopComponents
-            List<String> idList = new ArrayList();
+            List<String> idList = new ArrayList<>();
             for (int i = 0; i < wmc.modes.length; i++) {
                 ModeConfig mc = wmc.modes[i];
                 for (int j = 0; j < mc.tcRefConfigs.length; j++) {

--- a/platform/core.windows/src/org/netbeans/core/windows/RecentViewList.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/RecentViewList.java
@@ -43,7 +43,7 @@ final class RecentViewList implements PropertyChangeListener {
 
     /** List of TopComponent IDs. First is most recently
      * activated. */
-    private List<String> tcIdList = new ArrayList(20);
+    private List<String> tcIdList = new ArrayList<>(20);
     private Map<String, Reference<TopComponent>> tcCache = new HashMap<String, Reference<TopComponent>>(20);
 
     public RecentViewList (WindowManager wm) {

--- a/profiler/profiler.attach/nbproject/project.properties
+++ b/profiler/profiler.attach/nbproject/project.properties
@@ -16,4 +16,4 @@
 # under the License.
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8

--- a/profiler/profiler.attach/src/org/netbeans/modules/profiler/attach/dialog/AttachDialog.java
+++ b/profiler/profiler.attach/src/org/netbeans/modules/profiler/attach/dialog/AttachDialog.java
@@ -143,7 +143,7 @@ public class AttachDialog extends AttachWizard {
             RunningVM[] vms = JpsProxy.getRunningVMs();
             if (vms == null || vms.length == 0) return false; // no locally running processes for dynamic attach
             
-            List<RunningVM> targets = new ArrayList();
+            List<RunningVM> targets = new ArrayList<>();
             for (RunningVM vm : vms)
                 if (getProcessName(vm.getMainClass()).equals(name))
                     targets.add(vm); // all processes with the preferred process name ready for profiling

--- a/profiler/profiler.oql/nbproject/project.properties
+++ b/profiler/profiler.oql/nbproject/project.properties
@@ -19,7 +19,7 @@ auxiliary.org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width=
 auxiliary.org-netbeans-modules-editor-indent.CodeStyle.usedProfile=default
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=**/OQLEngineTest.class

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/repository/api/OQLQueryRepository.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/repository/api/OQLQueryRepository.java
@@ -143,7 +143,7 @@ final public class OQLQueryRepository {
     }
 
     private static List<FileObject> sortedFOs(Enumeration<? extends FileObject> fos) {
-        List<FileObject> list = new ArrayList();
+        List<FileObject> list = new ArrayList<>();
         while(fos.hasMoreElements()) list.add(fos.nextElement());
         return FileUtil.getOrder(list, false);
     }

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsArrayImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsArrayImpl.java
@@ -86,7 +86,7 @@ public class JsArrayImpl extends JsObjectImpl implements JsArray {
     public void resolveTypes(JsDocumentationHolder jsDocHolder) {
         super.resolveTypes(jsDocHolder); 
         HashSet<String> nameTypesInArray = new HashSet<String>();
-        Collection<TypeUsage> resolved = new ArrayList();
+        Collection<TypeUsage> resolved = new ArrayList<>();
         Collection<? extends TypeUsage> typesIA = getTypesInArray();
         for (TypeUsage type : typesIA) {
             if (!(type.getType().equals(Type.UNRESOLVED) && typesIA.size() > 1)) {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsFunctionImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsFunctionImpl.java
@@ -246,7 +246,7 @@ public class JsFunctionImpl extends DeclarationScopeImpl implements JsFunction {
         super.resolveTypes(docHolder);
         if (!(returnTypes.size() == 1 && Type.UNDEFINED.equals(returnTypes.iterator().next().getType()))) {
             HashSet<String> nameReturnTypes = new HashSet<String>();
-            Collection<TypeUsage> resolved = new ArrayList();
+            Collection<TypeUsage> resolved = new ArrayList<>();
             for (TypeUsage type : returnTypes) {
                 if (!(type.getType().equals(Type.UNRESOLVED) && returnTypes.size() > 1)) {
                     if (!type.isResolved()) {
@@ -341,7 +341,7 @@ public class JsFunctionImpl extends DeclarationScopeImpl implements JsFunction {
                     }
                 }
             }
-            List<JsObject> paramProperties = new ArrayList(param.getProperties().values());
+            List<JsObject> paramProperties = new ArrayList<>(param.getProperties().values());
             for(JsObject paramProperty: paramProperties) {
                ((JsObjectImpl)paramProperty).resolveTypes(docHolder);
             }

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
@@ -283,7 +283,7 @@ public class JsObjectImpl extends JsElementImpl implements JsObject {
 
     @Override
     public Collection<? extends TypeUsage> getAssignmentForOffset(int offset) {
-        List<? extends TypeUsage> result = new ArrayList();
+        List<? extends TypeUsage> result = new ArrayList<>();
         Map.Entry<Integer, Collection<TypeUsage>> found = assignments.floorEntry(offset);
         int tmpOffset = offset;
         while (found != null) {
@@ -438,7 +438,7 @@ public class JsObjectImpl extends JsElementImpl implements JsObject {
                 || (parent != null && parent.getOffset() == getOffset() && ModelUtils.ARGUMENTS.equals(getName())) ) {
             return;
         }
-        Collection<TypeUsage> resolved = new ArrayList();
+        Collection<TypeUsage> resolved = new ArrayList<>();
         for (Collection<TypeUsage> unresolved : assignments.values()) {
             resolved.clear();
             JsObject global = ModelUtils.getGlobalObject(parent);

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelElementFactory.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelElementFactory.java
@@ -73,7 +73,7 @@ class ModelElementFactory {
             end = start + 1;  
             assert false: "The end offset of a function is before the start offset: [" + start + ", " + end + "] in file: " + parserResult.getSnapshot().getSource().getFileObject().getPath(); //NOI18N
         }
-        List<Identifier> parameters = new ArrayList(functionNode.getParameters().size());
+        List<Identifier> parameters = new ArrayList<>(functionNode.getParameters().size());
         for(IdentNode node: functionNode.getParameters()) {
             Identifier param = create(parserResult, node);
             if (param != null) {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -170,7 +170,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
                             }
                             List<TypeUsage> types = functionCalls.get(call.getCallOffset());
                             if (types == null) {
-                                types = new ArrayList();
+                                types = new ArrayList<>();
                                 functionCalls.put(new Integer(call.getCallOffset()), types);
                             }
                             for (TypeUsage type: returnTypes) {

--- a/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/model/NodeJsRequireFunctionInterceptor.java
+++ b/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/model/NodeJsRequireFunctionInterceptor.java
@@ -104,7 +104,7 @@ public class NodeJsRequireFunctionInterceptor implements FunctionInterceptor {
                                 JsObject jsObject = ((JsObject)scope).getProperty(objectName);
                                 if (jsObject != null) {
                                     int assignmentOffset =  ts.offset() + token.length();
-                                    List<TypeUsage> modelTypes = new ArrayList();
+                                    List<TypeUsage> modelTypes = new ArrayList<>();
                                     StringBuilder sb = new StringBuilder();
                                     sb.append(NodeJsUtils.FAKE_OBJECT_NAME_PREFIX).append(NodeJsUtils.getModuleName(module)).append('.');
                                     modelTypes.add(factory.newType(sb.toString() + NodeJsUtils.EXPORTS, assignmentOffset, true));

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/FSCompletionUtils.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/FSCompletionUtils.java
@@ -232,7 +232,7 @@ public class FSCompletionUtils {
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
             }
-            Collection<String> basePaths = new ArrayList();
+            Collection<String> basePaths = new ArrayList<>();
             Map<String, String> configPaths = new HashMap();
 
             if (rIndex != null) {

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/index/RequireJsIndex.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/index/RequireJsIndex.java
@@ -154,7 +154,7 @@ public class RequireJsIndex {
             Exceptions.printStackTrace(ex);
         }
         if (result != null && !result.isEmpty()) {
-            List<String> paths = new ArrayList();
+            List<String> paths = new ArrayList<>();
             for (IndexResult indexResult : result) {
                 paths.addAll(Arrays.asList(indexResult.getValues(RequireJsIndexer.FIELD_BASE_PATH)));
             }


### PR DESCRIPTION
There are many places in the code where an unchecked conversion warning is printed by the compiler..

   [repeat] /home/bwalker/src/netbeans/profiler/profiler.attach/src/org/netbeans/modules/profiler/attach/dialog/AttachDialog.java:146: warning: [unchecked] unchecked conversion
   [repeat]             List<RunningVM> targets = new ArrayList();
   [repeat]                                       ^
   [repeat]   required: List<RunningVM>
   [repeat]   found:    ArrayList

I've tried to remove these but there are several places where it still exists. This is because
it would require work other than being simple to fix. I'll try to fix those later.