### PR TITLE
Removes old LBL_Ergonomics_Extra_Required message about Javascript parser

### DIFF
--- a/ergonomics/ide.ergonomics/enterprise.properties
+++ b/ergonomics/ide.ergonomics/enterprise.properties
@@ -23,4 +23,3 @@ project.xpath.src/main/webapp=
 
 mainModule=org.netbeans.modules.j2ee.kit
 
-LBL_Ergonomics_Extra_Required=Javascript Parser is required by HTML5 features.

--- a/ergonomics/ide.ergonomics/webcommon.properties
+++ b/ergonomics/ide.ergonomics/webcommon.properties
@@ -16,4 +16,3 @@
 # under the License.
 
 mainModule=org.netbeans.modules.web.client.kit
-LBL_Ergonomics_Extra_Required=Javascript Parser is required for Javascript + HTML support to work properly.


### PR DESCRIPTION
Minor edit.

Since NetBeans has a proper Javascript Parser, no need for the ergonomic messages about the old Oracle JSParser.