### PR TITLE
Always prefer showing of errors in notifications window

### DIFF
--- a/platform/o.n.core/nbproject/project.properties
+++ b/platform/o.n.core/nbproject/project.properties
@@ -16,8 +16,8 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
-javac.target=1.7
+javac.source=1.8
+javac.target=1.8
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/o.n.core/src/org/netbeans/core/NotifyExcPanel.java
+++ b/platform/o.n.core/src/org/netbeans/core/NotifyExcPanel.java
@@ -601,9 +601,7 @@ public final class NotifyExcPanel extends JPanel implements ActionListener {
      */
     private static boolean shallNotify(Level level, boolean dialog) {
         int minAlert = Integer.getInteger("netbeans.exception.alert.min.level", 900); // NOI18N
-        boolean assertionsOn = false;
-        assert assertionsOn = true;
-        int defReport = assertionsOn ? 900 : 1001;
+        int defReport = 1001;
         int minReport = Integer.getInteger("netbeans.exception.report.min.level", defReport); // NOI18N
 
         if (dialog) {


### PR DESCRIPTION
There is a nice Notifications UI that can collect and help users process exceptions. Use it always, even in development builds. E.g. don't consider the assertion status when setting the minimal report level.