### PR TITLE
FIX: fire a table model event even if there are no children yet.

### DIFF
--- a/platform/o.n.swing.outline/src/org/netbeans/swing/outline/EventBroadcaster.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/outline/EventBroadcaster.java
@@ -673,10 +673,6 @@ final class EventBroadcaster implements TableModelListener, TreeModelListener, E
         //Start with the number of children of whatever was expanded/collapsed
         int count = getTreeModel().getChildCount(path.getLastPathComponent());
         
-        if (count == 0) {
-            return null;
-        }
-        
         //Iterate any of the expanded children, adding in their child counts
         for (int i=0; i < paths.length; i++) {
             count += getTreeModel().getChildCount(paths[i].getLastPathComponent());


### PR DESCRIPTION
   * The early return of null was added in version 8.2 of the component.
   * If we return early from this method, when a node is expanded in
     a sorted outline component, the children of the node appear in
     random positions underneath other folders.
   * Re-sorting the tree makes the problem go away, so the tree model
     is fine, but the table model had not updated properly on the tree
     node expansion.
   * Firing the event forces the table model to update properly on
     node expansion.

The reason this doesn't happen on node expansion in an unsorted tree
is that the nodes are always in the order of the table model, so
by luck they appear in the right positions in the view.  When an
outline is sorted, the positions in the view no longer match the
order of nodes in the table model, so they display incorrectly.

See: https://issues.apache.org/jira/browse/NETBEANS-3401 and https://github.com/digital-preservation/droid/issues/306 for more details of the bug and this fix.