### PR TITLE
[NETBEANS-2983] Gradre returns CompileCP instead of RuntimeCP on non-modular projects

### DIFF
--- a/groovy/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
+++ b/groovy/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
@@ -231,7 +231,7 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
                                     getJava8RuntimeClassPath(),
                                     null)
                         ),
-                        getJava8CompileClassPath()
+                        getJava8RuntimeClassPath()
                 );
             }
             return runTime;

--- a/groovy/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/AbstractGradleJavaTestCase.java
+++ b/groovy/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/AbstractGradleJavaTestCase.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java;
+
+import java.io.File;
+import java.io.IOException;
+import static junit.framework.TestCase.assertNotNull;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.apisupport.project.InstalledFileLocatorImpl;
+import org.netbeans.modules.project.uiapi.ProjectOpenedTrampoline;
+import org.netbeans.spi.project.ui.ProjectOpenedHook;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.test.TestFileUtils;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class AbstractGradleJavaTestCase extends NbTestCase {
+
+    public AbstractGradleJavaTestCase(String name) {
+        super(name);
+    }
+
+    /** Represents destination directory with NetBeans (always available). */
+    protected File destDirF;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        clearWorkDir();
+        destDirF = getTestNBDestDir();
+        InstalledFileLocatorImpl.registerDestDir(destDirF);
+    }
+
+    protected FileObject createGradleProject(String buildScript) throws IOException {
+        return getGradleProject(buildScript, null);
+    }
+
+    protected Project openProject(FileObject projectDir) throws IOException {
+        Project prj = ProjectManager.getDefault().findProject(projectDir);
+        assertNotNull(prj);
+        ProjectOpenedTrampoline.DEFAULT.projectOpened(prj.getLookup().lookup(ProjectOpenedHook.class));
+        return prj;
+    }
+
+    protected FileObject getGradleProject(String buildScript, String settingsScript) throws IOException {
+        FileObject ret = FileUtil.toFileObject(getWorkDir());
+        TestFileUtils.writeFile(ret, "build.gradle", buildScript);
+        if (settingsScript != null) {
+            TestFileUtils.writeFile(ret, "settings.gradle", settingsScript);
+        }
+        return ret;
+    }
+
+    private static File getTestNBDestDir() {
+        String destDir = System.getProperty("test.netbeans.dest.dir");
+        // set in project.properties as test-unit-sys-prop.test.netbeans.dest.dir
+        assertNotNull("test.netbeans.dest.dir property has to be set when running within binary distribution", destDir);
+        return new File(destDir);
+    }
+}

--- a/groovy/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImplTest.java
+++ b/groovy/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImplTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.classpath;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.java.AbstractGradleJavaTestCase;
+import org.netbeans.modules.gradle.java.api.GradleJavaProject;
+import org.netbeans.spi.java.classpath.ClassPathProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class ClassPathProviderImplTest extends AbstractGradleJavaTestCase {
+
+    public ClassPathProviderImplTest(String name) {
+        super(name);
+    }
+
+    @Test
+    public void testRuntimeClassPath() throws Exception {
+        System.out.println("find runtime ClassPath");
+        FileObject fo = createGradleProject("apply plugin: 'java'");
+        FileObject src = FileUtil.createFolder(fo, "src/main/java");
+        FileObject java = src.createData("Whatever.java");
+        Project prj = openProject(fo);
+        ClassPathProvider cpp = prj.getLookup().lookup(ClassPathProvider.class);
+        assertNotNull(cpp);
+        GradleJavaProject gjp = GradleJavaProject.get(prj);
+
+
+        Set<FileObject> outputs = new HashSet<>();
+        outputs.add(FileUtil.createFolder(gjp.getMainSourceSet().getOutputResources()));
+        for (File dir : gjp.getMainSourceSet().getOutputClassDirs()) {
+            outputs.add(FileUtil.createFolder(dir));
+        }
+
+        ClassPath rt = cpp.findClassPath(java, ClassPath.EXECUTE);
+        for (FileObject output : outputs) {
+            assertTrue(rt.contains(output));
+        }
+    }
+
+}

--- a/groovy/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImplTest.java
+++ b/groovy/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImplTest.java
@@ -18,58 +18,34 @@
  */
 package org.netbeans.modules.gradle.java.classpath;
 
-import java.io.File;
-import static junit.framework.TestCase.assertNotNull;
 import org.netbeans.api.java.project.JavaProjectConstants;
 import org.netbeans.api.project.Project;
-import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.Sources;
-import org.netbeans.junit.NbTestCase;
-import org.netbeans.modules.apisupport.project.InstalledFileLocatorImpl;
-import org.netbeans.modules.project.uiapi.ProjectOpenedTrampoline;
-import org.netbeans.spi.project.ui.ProjectOpenedHook;
+import org.netbeans.modules.gradle.java.AbstractGradleJavaTestCase;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
-import org.openide.filesystems.test.TestFileUtils;
 
 /**
  *
  * @author lkishalmi
  */
-public class GradleSourcesImplTest extends NbTestCase {
+public class GradleSourcesImplTest extends AbstractGradleJavaTestCase {
 
     public GradleSourcesImplTest(String name) {
         super(name);
     }
 
-    private FileObject d;
-    /** Represents destination directory with NetBeans (always available). */
-    protected File destDirF;
-    
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        clearWorkDir();
-        d = FileUtil.toFileObject(getWorkDir());
-        destDirF = getTestNBDestDir();
-    }
-
     public void testGeneratedSources() throws Exception { // #187595
-        InstalledFileLocatorImpl.registerDestDir(destDirF);
-
-        TestFileUtils.writeFile(d,
-                "build.gradle",
+        FileObject d = createGradleProject(
                 "apply plugin: 'java'\n" +
                 "sourceSets { main { java { srcDirs = [ 'src', 'build/gen-src' ] }}}");
         FileObject src = FileUtil.createFolder(d, "src/");
         FileObject gsrc = FileUtil.createFolder(d, "build/gen-src");
         FileObject source = src.createData("Whatever.java");
         FileObject generated = gsrc.createData("WhateverGen.java");
-        Project prj = ProjectManager.getDefault().findProject(d);
-        assertNotNull(prj);
-        ProjectOpenedTrampoline.DEFAULT.projectOpened(prj.getLookup().lookup(ProjectOpenedHook.class));
+        Project prj = openProject(d);
         Sources srcs = ProjectUtils.getSources(prj);
         SourceGroup[] groups = srcs.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA);
         assertEquals(2, groups.length);
@@ -77,13 +53,6 @@ public class GradleSourcesImplTest extends NbTestCase {
         assertFalse(groups[0].contains(generated));
         assertTrue(groups[1].contains(generated));
         assertFalse(groups[1].contains(source));
-    }
-
-    private static File getTestNBDestDir() {
-        String destDir = System.getProperty("test.netbeans.dest.dir");
-        // set in project.properties as test-unit-sys-prop.test.netbeans.dest.dir
-        assertNotNull("test.netbeans.dest.dir property has to be set when running within binary distribution", destDir);
-        return new File(destDir);
     }
 
 }


### PR DESCRIPTION
Fixing a copy and paste bug introduced in the Java modular classpath rewrite in 11.1