### PR TITLE
[NETBEANS-3416] - cleanup non-generic EMPTY_LIST usage

### DIFF
--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/saas/RestWrapperForSoapGenerator.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/saas/RestWrapperForSoapGenerator.java
@@ -159,7 +159,7 @@ public class RestWrapperForSoapGenerator {
         targetSource.runModificationTask(task).commit();
 
 
-        return new HashSet<FileObject>(Collections.EMPTY_LIST);
+        return new HashSet<FileObject>(Collections.<FileObject>emptyList());
     }
 
     private void addQNameImport(WorkingCopy copy) {

--- a/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/ApplicationSubclassGenerator.java
+++ b/enterprise/websvc.restapi/src/org/netbeans/modules/websvc/rest/ApplicationSubclassGenerator.java
@@ -110,7 +110,7 @@ public class ApplicationSubclassGenerator {
         RestApplicationModel restAppModel = restSupport.getRestApplicationsModel();
         RestServicesModel model = restSupport.getRestServicesModel();
         String clazz = null;
-        Collection<String> classNames = Collections.EMPTY_LIST;
+        Collection<String> classNames = Collections.emptyList();
         try {
             clazz = restAppModel.runReadAction(
                     new MetadataModelAction<RestApplications, String>() {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionHandler.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionHandler.java
@@ -124,7 +124,7 @@ public class CompletionHandler implements CodeCompletionHandler {
 
             // if we are above a package statement or inside a comment there's no completion at all.
             if (context.location == CaretLocation.ABOVE_PACKAGE || context.location == CaretLocation.INSIDE_COMMENT) {
-                return new DefaultCompletionResult(Collections.EMPTY_LIST, false);
+                return new DefaultCompletionResult(Collections.<CompletionProposal>emptyList(), false);
             }
             
             ProposalsCollector proposalsCollector = new ProposalsCollector(context);

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/ContextHelper.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/ContextHelper.java
@@ -65,7 +65,7 @@ public final class ContextHelper {
     public static List<ClassNode> getDeclaredClasses(CompletionContext request) {
         if (request.path == null) {
             LOG.log(Level.FINEST, "path == null"); // NOI18N
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         for (Iterator<ASTNode> it = request.path.iterator(); it.hasNext();) {
@@ -75,7 +75,7 @@ public final class ContextHelper {
                 return ((ModuleNode) current).getClasses();
             }
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     /**

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/MethodCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/MethodCompletion.java
@@ -443,7 +443,7 @@ public class MethodCompletion extends BaseCompletion {
      */
     private List<MethodParameter> getParameterListForMethod(Parameter[] parameters) {
         if (parameters.length == 0) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
 
         List<MethodParameter> paramDescriptors = new ArrayList<>();

--- a/ide/localhistory/src/org/netbeans/modules/localhistory/store/StoreEntry.java
+++ b/ide/localhistory/src/org/netbeans/modules/localhistory/store/StoreEntry.java
@@ -75,7 +75,7 @@ public abstract class StoreEntry {
         this.ts = ts;
         this.label = label;
         this.date = new Date(ts);
-        setSiblings(Collections.EMPTY_LIST);
+        setSiblings(Collections.<StoreEntry>emptyList());
     }    
     
     public File getStoreFile() {

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
@@ -672,7 +672,7 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
             final List<Component> initiallyOpened;
             final Set<Component> initiallyOpenedMinimized;
             if (componentsInitiallyOpened.isEmpty()) {
-                initiallyOpened = Collections.EMPTY_LIST;
+                initiallyOpened = Collections.emptyList();
                 initiallyOpenedMinimized = Collections.EMPTY_SET;
             } else {
                 initiallyOpened = new ArrayList<Component>();

--- a/ide/spi.viewmodel/src/org/netbeans/modules/viewmodel/OutlineTable.java
+++ b/ide/spi.viewmodel/src/org/netbeans/modules/viewmodel/OutlineTable.java
@@ -838,7 +838,7 @@ ExplorerManager.Provider, PropertyChangeListener {
         } catch (SecurityException ex) {
             Exceptions.printStackTrace(ex);
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     // Re-order the UI columns according to the defined order

--- a/ide/team.commons/src/org/netbeans/modules/team/spi/TeamAccessorUtils.java
+++ b/ide/team.commons/src/org/netbeans/modules/team/spi/TeamAccessorUtils.java
@@ -143,7 +143,7 @@ public final class TeamAccessorUtils {
                 Logger.getLogger(TeamAccessorUtils.class.getName()).log(Level.WARNING, null, ex);
             }
         }
-        return Collections.EMPTY_LIST;
+        return Collections.<RepositoryUser>emptyList();
     }    
     
     /**

--- a/ide/web.common/src/org/netbeans/modules/web/common/remote/RemoteFS.java
+++ b/ide/web.common/src/org/netbeans/modules/web/common/remote/RemoteFS.java
@@ -274,7 +274,7 @@ public class RemoteFS extends AbstractFileSystem {
             if (fo != null) {
                 return fo.getAttributes();
             } else {
-                return Collections.enumeration(Collections.EMPTY_LIST);
+                return Collections.enumeration(Collections.emptyList());
             }
         }
 

--- a/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/CSS.java
+++ b/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/CSS.java
@@ -377,7 +377,7 @@ public class CSS {
      * @return computed style for the specified node.
      */
     public List<ComputedStyleProperty> getComputedStyle(Node node) {
-        List<ComputedStyleProperty> list = Collections.EMPTY_LIST;
+        List<ComputedStyleProperty> list = Collections.emptyList();
         JSONObject params = new JSONObject();
         params.put("nodeId", node.getNodeId()); // NOI18N
         Response response = transport.sendBlockingCommand(new Command("CSS.getComputedStyleForNode", params)); // NOI18N

--- a/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/DOM.java
+++ b/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/DOM.java
@@ -264,7 +264,7 @@ public class DOM {
      * no matching node is found).
      */
     public List<Node> querySelectorAll(Node node, String selector) {
-        List<Node> list = Collections.EMPTY_LIST;
+        List<Node> list = Collections.emptyList();
         JSONObject params = new JSONObject();
         params.put("nodeId", node.getNodeId()); // NOI18N
         params.put("selector", selector); // NOI18N

--- a/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/Node.java
+++ b/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/dom/Node.java
@@ -262,7 +262,7 @@ public class Node {
      * @return shadow roots of this node.
      */
     public final synchronized List<Node> getShadowRoots() {
-        return (shadowRoots == null) ? Collections.EMPTY_LIST : shadowRoots;
+        return (shadowRoots == null) ? Collections.emptyList() : shadowRoots;
     }
 
     /**
@@ -343,7 +343,7 @@ public class Node {
      * an empty list is returned when there are no attributes).
      */
     public synchronized List<Attribute> getAttributes() {
-        return (attributes == null) ? Collections.EMPTY_LIST : attributes;
+        return (attributes == null) ? Collections.emptyList() : attributes;
     }
 
     /**

--- a/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/IntroduceClass.java
+++ b/java/debugger.jpda.projects/src/org/netbeans/modules/debugger/jpda/projects/IntroduceClass.java
@@ -236,7 +236,7 @@ class IntroduceClass {
                 if (Tree.Kind.EXPRESSION_STATEMENT.equals(first.getKind())) {
                     statements = Collections.singletonList((StatementTree) firstLeaf.getLeaf());
                 } else {
-                    statements = Collections.EMPTY_LIST;
+                    statements = Collections.emptyList();
                 }
         }
         int s = statements.size();

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/JavaComponentInfo.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/JavaComponentInfo.java
@@ -352,7 +352,7 @@ abstract public class JavaComponentInfo implements ComponentInfo {
             //Method getTextMethod = methodsByName.get("getText");    // NOI18N
             if (getTextMethod != null) {
                 try {
-                    Value theText = ObjectReferenceWrapper.invokeMethod(component, getThread().getThreadReference(), getTextMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                    Value theText = ObjectReferenceWrapper.invokeMethod(component, getThread().getThreadReference(), getTextMethod, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                     if (theText instanceof StringReference) {
                         setComponentText(StringReferenceWrapper.value((StringReference) theText));
                     }
@@ -583,7 +583,7 @@ abstract public class JavaComponentInfo implements ComponentInfo {
             Lock l = t.accessLock.writeLock();
             l.lock();
             try {
-                Value v = ObjectReferenceWrapper.invokeMethod(component, tawt, getter, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                Value v = ObjectReferenceWrapper.invokeMethod(component, tawt, getter, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                 if (v != null) {
                     typePtr[0] = ValueWrapper.type(v);
                 }
@@ -596,7 +596,7 @@ abstract public class JavaComponentInfo implements ComponentInfo {
                     Type t = ValueWrapper.type(v);
                     if (t instanceof ClassType) {
                         Method toStringMethod = ClassTypeWrapper.concreteMethodByName((ClassType) t, "toString", "()Ljava/lang/String;");
-                        v = ObjectReferenceWrapper.invokeMethod((ObjectReference) v, tawt, toStringMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                        v = ObjectReferenceWrapper.invokeMethod((ObjectReference) v, tawt, toStringMethod, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                         if (v instanceof StringReference) {
                             return StringReferenceWrapper.value((StringReference) v);
                         }

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteAWTScreenshot.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteAWTScreenshot.java
@@ -246,7 +246,7 @@ public class RemoteAWTScreenshot {
                     try {
                         if (FAST_SNAPSHOT_RETRIEVAL) {
                             final Method getGUISnapshots = ClassTypeWrapper.concreteMethodByName(serviceClass, "getGUISnapshots", "()[Lorg/netbeans/modules/debugger/jpda/visual/remote/RemoteAWTService$Snapshot;");
-                            ArrayReference snapshotsArray = (ArrayReference) ClassTypeWrapper.invokeMethod(serviceClass, tawt, getGUISnapshots, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                            ArrayReference snapshotsArray = (ArrayReference) ClassTypeWrapper.invokeMethod(serviceClass, tawt, getGUISnapshots, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                             List<Value> snapshots = ArrayReferenceWrapper.getValues(snapshotsArray);
                             for (Value snapshot : snapshots) {
                                 ObjectReference snapshotObj = (ObjectReference) snapshot;
@@ -288,7 +288,7 @@ public class RemoteAWTScreenshot {
                             String msg = NbBundle.getMessage(RemoteAWTScreenshot.class, "MSG_ScreenshotNotTaken_MissingMethod", "java.awt.Window.getWindows()");
                             throw new RetrievalException(msg);
                         }
-                        ArrayReference windowsArray = (ArrayReference) ((ClassType) windowClass).invokeMethod(tawt, getWindows, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                        ArrayReference windowsArray = (ArrayReference) ((ClassType) windowClass).invokeMethod(tawt, getWindows, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                         List<Value> windows = windowsArray.getValues();
                         logger.fine("Have "+windows.size()+" window(s).");
 
@@ -345,19 +345,19 @@ public class RemoteAWTScreenshot {
                             ObjectReference window = (ObjectReference) windowValue;
                             //dumpHierarchy(window);
 
-                            BooleanValue visible = (BooleanValue) window.invokeMethod(tawt, isVisible, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                            BooleanValue visible = (BooleanValue) window.invokeMethod(tawt, isVisible, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                             if (!visible.value()) {
                                 // Ignore windows that are not visible.
                                 // TODO: mark them as not visible.
                                 //continue;
                             }
-                            Object owner = window.invokeMethod(tawt, getOwner, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                            Object owner = window.invokeMethod(tawt, getOwner, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                             if (owner != null) {
                                 // An owned window
                                 //continue;
                             }
 
-                            ObjectReference sizeDimension = (ObjectReference) window.invokeMethod(tawt, getSize, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                            ObjectReference sizeDimension = (ObjectReference) window.invokeMethod(tawt, getSize, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                             Field field = dimensionClass.fieldByName("width");
                             IntegerValue widthValue = (IntegerValue) sizeDimension.getValue(field);
                             int width = widthValue.value();
@@ -368,7 +368,7 @@ public class RemoteAWTScreenshot {
 
                             List<? extends Value> args = Arrays.asList(widthValue, heightValue, vm.mirrorOf(BufferedImage.TYPE_INT_ARGB));
                             ObjectReference bufferedImage = bufferedImageClass.newInstance(tawt, bufferedImageConstructor, args, ObjectReference.INVOKE_SINGLE_THREADED);
-                            ObjectReference graphics = (ObjectReference) bufferedImage.invokeMethod(tawt, createGraphics, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                            ObjectReference graphics = (ObjectReference) bufferedImage.invokeMethod(tawt, createGraphics, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
 
 
                             Method paint = windowClass.concreteMethodByName("paint", "(Ljava/awt/Graphics;)V");
@@ -377,13 +377,13 @@ public class RemoteAWTScreenshot {
                             /*
                             // getPeer() - java.awt.peer.ComponentPeer, ComponentPeer.paint()
                             Method getPeer = windowClass.concreteMethodByName("getPeer", "()Ljava/awt/peer/ComponentPeer;");
-                            ObjectReference peer = (ObjectReference) window.invokeMethod(tawt, getPeer, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                            ObjectReference peer = (ObjectReference) window.invokeMethod(tawt, getPeer, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                             Method paint = ((ClassType) peer.referenceType()).concreteMethodByName("paint", "(Ljava/awt/Graphics;)V");
                             peer.invokeMethod(tawt, paint, Arrays.asList(graphics), ObjectReference.INVOKE_SINGLE_THREADED);
                             - paints nothing! */
 
                             Method getData = bufferedImageClass.concreteMethodByName("getData", "()Ljava/awt/image/Raster;");
-                            ObjectReference raster = (ObjectReference) bufferedImage.invokeMethod(tawt, getData, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                            ObjectReference raster = (ObjectReference) bufferedImage.invokeMethod(tawt, getData, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
 
                             Method getDataElements = ((ClassType) raster.referenceType()).concreteMethodByName("getDataElements", "(IIIILjava/lang/Object;)Ljava/lang/Object;");
                             IntegerValue zero = vm.mirrorOf(0);
@@ -400,14 +400,14 @@ public class RemoteAWTScreenshot {
 
                             String title = null;
                             if (frameClass != null && EvaluatorVisitor.instanceOf(window.referenceType(), frameClass)) {
-                                Value v = window.invokeMethod(tawt, getFrameTitle, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                                Value v = window.invokeMethod(tawt, getFrameTitle, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                                 if (v instanceof StringReference) {
                                     StringReference sr = (StringReference) v;
                                     title = sr.value();
                                 }
                             }
                             if (dialogClass != null && EvaluatorVisitor.instanceOf(window.referenceType(), dialogClass)) {
-                                Value v = window.invokeMethod(tawt, getDialogTitle, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                                Value v = window.invokeMethod(tawt, getDialogTitle, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                                 if (v instanceof StringReference) {
                                     StringReference sr = (StringReference) v;
                                     title = sr.value();
@@ -470,7 +470,7 @@ public class RemoteAWTScreenshot {
                                                   RetrievalException {
         
         ThreadReference tawt = t.getThreadReference();
-        ObjectReference rectangle = (ObjectReference) component.invokeMethod(tawt, getBounds, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        ObjectReference rectangle = (ObjectReference) component.invokeMethod(tawt, getBounds, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         ClassType rectangleClass;
         try {
             rectangleClass = RemoteServices.getClass(vm, "java.awt.Rectangle");
@@ -500,7 +500,7 @@ public class RemoteAWTScreenshot {
             ci.setWindowBounds(new Rectangle(shiftx, shifty, r.width, r.height));
         }
         Method getName = componentClass.concreteMethodByName("getName", "()Ljava/lang/String;");
-        StringReference name = (StringReference) component.invokeMethod(tawt, getName, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        StringReference name = (StringReference) component.invokeMethod(tawt, getName, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         if (name != null) {
             ci.setName(name.value());
         }
@@ -536,7 +536,7 @@ public class RemoteAWTScreenshot {
 //        });
         
         if (isInstanceOfClass((ClassType) component.referenceType(), containerClass)) {
-            ArrayReference componentsArray = (ArrayReference) component.invokeMethod(tawt, getComponents, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            ArrayReference componentsArray = (ArrayReference) component.invokeMethod(tawt, getComponents, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
             List<Value> components = componentsArray.getValues();
             logger.log(Level.FINE, "Have {0} component(s).", components.size());
             if (components.size() > 0) {
@@ -564,7 +564,7 @@ public class RemoteAWTScreenshot {
             logger.severe("No getComponents() method!");
             return new AWTComponentInfo[] {};
         }
-        ArrayReference componentsArray = (ArrayReference) window.invokeMethod(tawt, getComponents, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        ArrayReference componentsArray = (ArrayReference) window.invokeMethod(tawt, getComponents, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         List<Value> components = componentsArray.getValues();
         logger.severe("Have "+components.size()+" component(s).");
         
@@ -573,7 +573,7 @@ public class RemoteAWTScreenshot {
         for(Value cv : components) {
             cis[i] = new AWTComponentInfo();
             ObjectReference c = (ObjectReference) cv;
-            ObjectReference rectangle = (ObjectReference) c.invokeMethod(tawt, getBounds, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            ObjectReference rectangle = (ObjectReference) c.invokeMethod(tawt, getBounds, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
             ClassType rectangleClass = getClass(vm, "java.awt.Rectangle");
             Field fx = rectangleClass.fieldByName("x");
             Field fy = rectangleClass.fieldByName("y");

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteFXScreenshot.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteFXScreenshot.java
@@ -111,7 +111,7 @@ public class RemoteFXScreenshot {
         final Method fromFXImage = (utilsClass != null) ? utilsClass.concreteMethodByName("fromFXImage", "(Ljavafx/scene/image/Image;Ljava/awt/image/BufferedImage;)Ljava/awt/image/BufferedImage;") : null;
         final Method snapshot = sceneClass.concreteMethodByName("snapshot", "(Ljavafx/scene/image/WritableImage;)Ljavafx/scene/image/WritableImage;");
 
-        ObjectReference scene = (ObjectReference) window.invokeMethod(tr, getScene, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        ObjectReference scene = (ObjectReference) window.invokeMethod(tr, getScene, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
 
         FloatValue factor = vm.mirrorOf(1.0f);
         BooleanValue syncNeeded = vm.mirrorOf(false);
@@ -134,15 +134,15 @@ public class RemoteFXScreenshot {
         }
 
         Method getData = ((ClassType)bufImage.referenceType()).concreteMethodByName("getData", "()Ljava/awt/image/Raster;");
-        ObjectReference rasterRef = (ObjectReference) bufImage.invokeMethod(tr, getData, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        ObjectReference rasterRef = (ObjectReference) bufImage.invokeMethod(tr, getData, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
 
         ClassType rasterType = (ClassType)rasterRef.referenceType();
         Method getWidth = rasterType.concreteMethodByName("getWidth", "()I");
         Method getHeight = rasterType.concreteMethodByName("getHeight", "()I");
         Method getDataElements = rasterType.concreteMethodByName("getDataElements", "(IIIILjava/lang/Object;)Ljava/lang/Object;");
         IntegerValue zero = vm.mirrorOf(0);
-        IntegerValue width = (IntegerValue)rasterRef.invokeMethod(tr, getWidth, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
-        IntegerValue height = (IntegerValue)rasterRef.invokeMethod(tr, getHeight, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        IntegerValue width = (IntegerValue)rasterRef.invokeMethod(tr, getWidth, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
+        IntegerValue height = (IntegerValue)rasterRef.invokeMethod(tr, getHeight, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         ArrayReference data = (ArrayReference) rasterRef.invokeMethod(tr, getDataElements, Arrays.asList(zero, zero, width, height, null), ObjectReference.INVOKE_SINGLE_THREADED);
 
         logger.log(Level.FINE, "Image data length = {0}", data.length());
@@ -251,18 +251,18 @@ public class RemoteFXScreenshot {
             Method getWindows = windowClass.concreteMethodByName("impl_getWindows", "()Ljava/util/Iterator;");
             Method windowName = windowClass.concreteMethodByName("impl_getMXWindowType", "()Ljava/lang/String;");
 
-            ObjectReference iterator = (ObjectReference)windowClass.invokeMethod(tr, getWindows, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            ObjectReference iterator = (ObjectReference)windowClass.invokeMethod(tr, getWindows, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
             ClassType iteratorClass = (ClassType)iterator.referenceType();
             Method hasNext = iteratorClass.concreteMethodByName("hasNext", "()Z");
             Method next = iteratorClass.concreteMethodByName("next", "()Ljava/lang/Object;");
             
             boolean nextFlag = false;
             do {
-                BooleanValue bv = (BooleanValue)iterator.invokeMethod(tr, hasNext, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                BooleanValue bv = (BooleanValue)iterator.invokeMethod(tr, hasNext, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                 nextFlag = bv.booleanValue();
                 if (nextFlag) {
-                    ObjectReference window = (ObjectReference)iterator.invokeMethod(tr, next, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
-                    StringReference name = (StringReference)window.invokeMethod(tr, windowName, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                    ObjectReference window = (ObjectReference)iterator.invokeMethod(tr, next, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
+                    StringReference name = (StringReference)window.invokeMethod(tr, windowName, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                     SGComponentInfo windowInfo = new SGComponentInfo(t, window);
                     
                     screenshots.add(createRemoteFXScreenshot(engine, vm, tr, name.value(), window, windowInfo));
@@ -296,8 +296,8 @@ public class RemoteFXScreenshot {
         }
         
         try {
-            ObjectReference tk = (ObjectReference)toolkitClass.invokeMethod(tr, getDefaultTk, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
-            tk.invokeMethod(tr, pauseScenes, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            ObjectReference tk = (ObjectReference)toolkitClass.invokeMethod(tr, getDefaultTk, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
+            tk.invokeMethod(tr, pauseScenes, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
             
             pauseMedia(tr, vm);
             return true;
@@ -337,8 +337,8 @@ public class RemoteFXScreenshot {
         }
         
         try {
-            ObjectReference tk = (ObjectReference)toolkitClass.invokeMethod(tr, getDefaultTk, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
-            tk.invokeMethod(tr, resumeScenes, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            ObjectReference tk = (ObjectReference)toolkitClass.invokeMethod(tr, getDefaultTk, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
+            tk.invokeMethod(tr, resumeScenes, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
             
             resumeMedia(tr, vm);
             return true;
@@ -363,18 +363,18 @@ public class RemoteFXScreenshot {
         
         if (audioClipClass != null) {
             Method stopAllClips = audioClipClass.concreteMethodByName("stopAllClips", "()V");
-            audioClipClass.invokeMethod(tr, stopAllClips, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            audioClipClass.invokeMethod(tr, stopAllClips, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         }
         
         if (mediaManagerClass != null && mediaPlayerClass != null && playerStateEnum != null) {
             Method getAllPlayers = mediaManagerClass.concreteMethodByName("getAllMediaPlayers", "()Ljava/util/List;");
 
-            ObjectReference plList = (ObjectReference)mediaManagerClass.invokeMethod(tr, getAllPlayers, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            ObjectReference plList = (ObjectReference)mediaManagerClass.invokeMethod(tr, getAllPlayers, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
 
             if (plList != null) {
                 ClassType listType = (ClassType)plList.referenceType();
                 Method iterator = listType.concreteMethodByName("iterator", "()Ljava/util/Iterator;");
-                ObjectReference plIter = (ObjectReference)plList.invokeMethod(tr, iterator, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                ObjectReference plIter = (ObjectReference)plList.invokeMethod(tr, iterator, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
 
                 ClassType iterType = (ClassType)plIter.referenceType();
                 Method hasNext = iterType.concreteMethodByName("hasNext", "()Z");
@@ -387,13 +387,13 @@ public class RemoteFXScreenshot {
                 Method pausePlayer = mediaPlayerClass.methodsByName("pause", "()V").get(0);
                 boolean hasNextFlag = false;
                 do {
-                    BooleanValue v = (BooleanValue)plIter.invokeMethod(tr, hasNext, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                    BooleanValue v = (BooleanValue)plIter.invokeMethod(tr, hasNext, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                     hasNextFlag = v.booleanValue();
                     if (hasNextFlag) {
-                        ObjectReference player = (ObjectReference)plIter.invokeMethod(tr, next, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
-                        ObjectReference curState = (ObjectReference)player.invokeMethod(tr, getState, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                        ObjectReference player = (ObjectReference)plIter.invokeMethod(tr, next, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
+                        ObjectReference curState = (ObjectReference)player.invokeMethod(tr, getState, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                         if (playingState.equals(curState)) {
-                            player.invokeMethod(tr, pausePlayer, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                            player.invokeMethod(tr, pausePlayer, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                             pausedPlayers.add(player);
                         }
                     }
@@ -411,7 +411,7 @@ public class RemoteFXScreenshot {
             }
             Method p = play.iterator().next();
             for(ObjectReference pR : pausedPlayers) {
-                pR.invokeMethod(tr, p, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                pR.invokeMethod(tr, p, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
             }
         }
     }
@@ -493,20 +493,20 @@ public class RemoteFXScreenshot {
                     compClass.name().equals("javafx.stage.Stage")) {
                     Method getTitle = compClass.concreteMethodByName("getTitle", "()Ljava/lang/String;");
                     if (getTitle != null) {
-                        StringReference nameR = (StringReference)getComponent().invokeMethod(tr, getTitle, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                        StringReference nameR = (StringReference)getComponent().invokeMethod(tr, getTitle, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                         setName(nameR != null ? nameR.value() : "");
                     }
                     Method getScene = compClass.concreteMethodByName("getScene", "()Ljavafx/scene/Scene;");
-                    ObjectReference scene = (ObjectReference)getComponent().invokeMethod(tr, getScene, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                    ObjectReference scene = (ObjectReference)getComponent().invokeMethod(tr, getScene, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                     ClassType sceneClass = (ClassType)scene.referenceType();
                     Method getX = sceneClass.concreteMethodByName("getX", "()D");
                     Method getY = sceneClass.concreteMethodByName("getY", "()D");
                     Method getWidth = sceneClass.concreteMethodByName("getWidth", "()D");
                     Method getHeight = sceneClass.concreteMethodByName("getHeight", "()D");
-                    DoubleValue x = (DoubleValue) scene.invokeMethod(tr, getX, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
-                    DoubleValue y = (DoubleValue) scene.invokeMethod(tr, getY, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
-                    DoubleValue width = (DoubleValue) scene.invokeMethod(tr, getWidth, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
-                    DoubleValue height = (DoubleValue) scene.invokeMethod(tr, getHeight, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                    DoubleValue x = (DoubleValue) scene.invokeMethod(tr, getX, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
+                    DoubleValue y = (DoubleValue) scene.invokeMethod(tr, getY, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
+                    DoubleValue width = (DoubleValue) scene.invokeMethod(tr, getWidth, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
+                    DoubleValue height = (DoubleValue) scene.invokeMethod(tr, getHeight, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                     Rectangle b = new Rectangle(x.intValue(), y.intValue(), width.intValue(), height.intValue());
                     b.x = 0;
                     b.y = 0;
@@ -514,7 +514,7 @@ public class RemoteFXScreenshot {
                     setBounds(b);
                     
                     Method getRoot = sceneClass.concreteMethodByName("getRoot", "()Ljavafx/scene/Parent;");
-                    ObjectReference root = (ObjectReference)scene.invokeMethod(tr, getRoot, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                    ObjectReference root = (ObjectReference)scene.invokeMethod(tr, getRoot, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                     SGComponentInfo rootInfo = new SGComponentInfo(getThread(), root);
                     
                     setSubComponents(new JavaComponentInfo[]{
@@ -523,15 +523,15 @@ public class RemoteFXScreenshot {
                 } else {
                     Method getId = compClass.concreteMethodByName("getId", "()Ljava/lang/String;");
                     if (getId != null) {
-                        StringReference id = (StringReference)getComponent().invokeMethod(tr, getId, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                        StringReference id = (StringReference)getComponent().invokeMethod(tr, getId, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                         setName(id != null ? id.value() : ""); // NOI18N
                     }
 //                    Method getRelBounds = compClass.concreteMethodByName("getBoundsInParent", "()Ljavafx/geometry/Bounds;");
                     Method getLocalBounds = compClass.concreteMethodByName("getBoundsInLocal", "()Ljavafx/geometry/Bounds;");
                     Method local2scene = compClass.concreteMethodByName("localToScene", "(Ljavafx/geometry/Bounds;)Ljavafx/geometry/Bounds;");
                     Method local2parent = compClass.concreteMethodByName("localToParent", "(Ljavafx/geometry/Bounds;)Ljavafx/geometry/Bounds;");
-//                    ObjectReference relBounds = (ObjectReference)getComponent().invokeMethod(tr, getRelBounds, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
-                    ObjectReference locBounds = (ObjectReference)getComponent().invokeMethod(tr, getLocalBounds, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+//                    ObjectReference relBounds = (ObjectReference)getComponent().invokeMethod(tr, getRelBounds, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
+                    ObjectReference locBounds = (ObjectReference)getComponent().invokeMethod(tr, getLocalBounds, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                     ObjectReference relBounds = (ObjectReference)getComponent().invokeMethod(tr, local2parent, Arrays.asList(locBounds), ObjectReference.INVOKE_SINGLE_THREADED);
                     ObjectReference absBounds = (ObjectReference)getComponent().invokeMethod(tr, local2scene, Arrays.asList(locBounds), ObjectReference.INVOKE_SINGLE_THREADED);
                     
@@ -544,7 +544,7 @@ public class RemoteFXScreenshot {
                         ClassType listClass = (ClassType)childrenList.referenceType();
                         Method size = listClass.concreteMethodByName("size", "()I");
                         Method get = listClass.concreteMethodByName("get", "(I)Ljava/lang/Object;");
-                        int cnt = ((IntegerValue)childrenList.invokeMethod(tr, size, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED)).intValue();
+                        int cnt = ((IntegerValue)childrenList.invokeMethod(tr, size, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED)).intValue();
                         JavaComponentInfo[] cs = new JavaComponentInfo[cnt];
                         for(int i=0;i<cnt;i++) {
                             ObjectReference sub = (ObjectReference)childrenList.invokeMethod(tr, get, Arrays.asList(vm.mirrorOf(i)), ObjectReference.INVOKE_SINGLE_THREADED);

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteServices.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/RemoteServices.java
@@ -147,7 +147,7 @@ public class RemoteServices {
          */
         ClassType classLoaderClass = getClass(vm, ClassLoader.class.getName());
         Method getSystemClassLoader = ClassTypeWrapper.concreteMethodByName(classLoaderClass, "getSystemClassLoader", "()Ljava/lang/ClassLoader;");
-        ObjectReference cl = (ObjectReference) ClassTypeWrapper.invokeMethod(classLoaderClass, tawt, getSystemClassLoader, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        ObjectReference cl = (ObjectReference) ClassTypeWrapper.invokeMethod(classLoaderClass, tawt, getSystemClassLoader, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         Method getParent = ClassTypeWrapper.concreteMethodByName(classLoaderClass, "getParent", "()Ljava/lang/ClassLoader;");
         ObjectReference bcl;
         do {
@@ -155,7 +155,7 @@ public class RemoteServices {
             if ("sun.misc.Launcher$AppClassLoader".equals(cl.referenceType().name())) {     // NOI18N
                 break;
             }
-            cl = (ObjectReference) ObjectReferenceWrapper.invokeMethod(cl, tawt, getParent, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            cl = (ObjectReference) ObjectReferenceWrapper.invokeMethod(cl, tawt, getParent, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         } while (cl != null);
         return bcl;
     }
@@ -163,12 +163,12 @@ public class RemoteServices {
     private static ObjectReference getContextClassLoader(ThreadReference tawt, VirtualMachine vm) throws InvalidTypeException, ClassNotLoadedException, IncompatibleThreadStateException, InvocationException, IOException, PropertyVetoException, InternalExceptionWrapper, VMDisconnectedExceptionWrapper, ObjectCollectedExceptionWrapper, UnsupportedOperationExceptionWrapper, ClassNotPreparedExceptionWrapper {
         ReferenceType threadType = tawt.referenceType();
         Method getContextCl = ClassTypeWrapper.concreteMethodByName((ClassType) threadType, "getContextClassLoader", "()Ljava/lang/ClassLoader;");
-        ObjectReference cl = (ObjectReference) ObjectReferenceWrapper.invokeMethod(tawt, tawt, getContextCl, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        ObjectReference cl = (ObjectReference) ObjectReferenceWrapper.invokeMethod(tawt, tawt, getContextCl, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         ClassType classLoaderClass = null;
         if (cl == null) {
             classLoaderClass = getClass(vm, ClassLoader.class.getName());
             Method getSystemClassLoader = ClassTypeWrapper.concreteMethodByName(classLoaderClass, "getSystemClassLoader", "()Ljava/lang/ClassLoader;");
-            cl = (ObjectReference) ClassTypeWrapper.invokeMethod(classLoaderClass, tawt, getSystemClassLoader, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            cl = (ObjectReference) ClassTypeWrapper.invokeMethod(classLoaderClass, tawt, getSystemClassLoader, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         }
         return cl;
     }
@@ -273,7 +273,7 @@ public class RemoteServices {
                         ClassType theClass = getClass(vm, Class.class.getName());
                         // Call some method that will prepare the class:
                         Method aMethod = ClassTypeWrapper.concreteMethodByName(theClass, "getConstructors", "()[Ljava/lang/reflect/Constructor;");
-                        ObjectReferenceWrapper.invokeMethod(basicClass, tawt, aMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                        ObjectReferenceWrapper.invokeMethod(basicClass, tawt, aMethod, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                     }
                 }
             } finally {
@@ -576,7 +576,7 @@ public class RemoteServices {
                 }
                 Value result;
                 try {
-                    result = ObjectReferenceWrapper.invokeMethod(component, t, m, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                    result = ObjectReferenceWrapper.invokeMethod(component, t, m, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                 } catch (ClassNotLoadedException cnlex) {
                     continue;
                 } catch (InvocationException iex) {
@@ -639,7 +639,7 @@ public class RemoteServices {
                 }
                 Value result;
                 try {
-                    result = ObjectReferenceWrapper.invokeMethod(component, t, m, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                    result = ObjectReferenceWrapper.invokeMethod(component, t, m, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                     if (result == null) {
                         continue;
                     }
@@ -1066,7 +1066,7 @@ public class RemoteServices {
                             try {
                                 if (attach) {
                                     Method startHierarchyListenerMethod = ClassTypeWrapper.concreteMethodByName(serviceClass, "startHierarchyListener", "()Ljava/lang/String;");
-                                    Value res = ClassTypeWrapper.invokeMethod(serviceClass, tr, startHierarchyListenerMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                                    Value res = ClassTypeWrapper.invokeMethod(serviceClass, tr, startHierarchyListenerMethod, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                                     if (res instanceof StringReference) {
                                         String reason = ((StringReference) res).value();
                                         InputOutput io = ((JPDAThreadImpl) t).getDebugger().getConsoleIO().getIO();
@@ -1076,7 +1076,7 @@ public class RemoteServices {
                                     }
                                 } else {
                                     Method stopHierarchyListenerMethod = ClassTypeWrapper.concreteMethodByName(serviceClass, "stopHierarchyListener", "()V");
-                                    ClassTypeWrapper.invokeMethod(serviceClass, tr, stopHierarchyListenerMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                                    ClassTypeWrapper.invokeMethod(serviceClass, tr, stopHierarchyListenerMethod, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                                 }
                             } catch (VMDisconnectedExceptionWrapper vmd) {                
                             } catch (Exception ex) {

--- a/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/VisualDebuggerListener.java
+++ b/java/debugger.jpda.visual/src/org/netbeans/modules/debugger/jpda/visual/VisualDebuggerListener.java
@@ -279,7 +279,7 @@ public class VisualDebuggerListener extends DebuggerManagerAdapter {
             Method startMethod = ClassTypeWrapper.concreteMethodByName(serviceClass, "startAccessLoop", "()Z");
             try {
                 t.notifyMethodInvoking();
-                Value ret = ClassTypeWrapper.invokeMethod(serviceClass, tr, startMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                Value ret = ClassTypeWrapper.invokeMethod(serviceClass, tr, startMethod, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                 if (ret instanceof PrimitiveValue) {
                     boolean success = PrimitiveValueWrapper.booleanValue((PrimitiveValue) ret);
                     RemoteServices.setAccessLoopStarted(t.getDebugger(), success);
@@ -292,7 +292,7 @@ public class VisualDebuggerListener extends DebuggerManagerAdapter {
                 if (trackComponentChanges && RemoteAWTScreenshot.FAST_SNAPSHOT_RETRIEVAL) {
                     Method startHierarchyListenerMethod = ClassTypeWrapper.concreteMethodByName(serviceClass, "startHierarchyListener", "()Ljava/lang/String;");
                     if (startHierarchyListenerMethod != null) {
-                        Value res = ClassTypeWrapper.invokeMethod(serviceClass, tr, startHierarchyListenerMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                        Value res = ClassTypeWrapper.invokeMethod(serviceClass, tr, startHierarchyListenerMethod, Collections.emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                         if (res instanceof StringReference) {
                             String reason = ((StringReference) res).value();
                             InputOutput io = t.getDebugger().getConsoleIO().getIO();

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/LineBreakpointImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/LineBreakpointImpl.java
@@ -591,7 +591,7 @@ public class LineBreakpointImpl extends ClassBasedBreakpoint {
             // We should indicate somehow that the breakpoint is invalid...
             reason[0] = iex.getLocalizedMessage();
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
     
     private static List<Location> locationsOfLineInClass(

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAClassTypeImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAClassTypeImpl.java
@@ -166,7 +166,7 @@ public class JPDAClassTypeImpl implements JPDAClassType {
                 return Collections.unmodifiableList(subClasses);
             }
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override
@@ -199,7 +199,7 @@ public class JPDAClassTypeImpl implements JPDAClassType {
                 // Nothing to return
             }
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override
@@ -219,7 +219,7 @@ public class JPDAClassTypeImpl implements JPDAClassType {
                 // Nothing to return
             }
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     private List<JPDAClassType> getTypes(Collection<? extends ReferenceType> types) {
@@ -231,7 +231,7 @@ public class JPDAClassTypeImpl implements JPDAClassType {
             }
             return Collections.unmodifiableList(interfaces);
         } else {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
     }
 

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
@@ -235,7 +235,7 @@ public class ThreadsCache implements Executor {
         List<ThreadGroupReference> topGroups = groupMap.get(null);
         if (topGroups == null) {
             if (vm == null) {
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
             topGroups = new ArrayList<>(VirtualMachineWrapper.topLevelThreadGroups0(vm));
             groupMap.put(null, topGroups);

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
@@ -413,13 +413,13 @@ public class InspectAndRefactorPanel extends javax.swing.JPanel implements Popup
                 todo.addAll(Arrays.asList(source.getRoots()));
             }
 
-            customScope = org.netbeans.modules.refactoring.api.Scope.create(todo, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+            customScope = org.netbeans.modules.refactoring.api.Scope.create(todo, Collections.<NonRecursiveFolder>emptyList(), Collections.<FileObject>emptyList());
         } else if (selectedItem == currentProject) {
             ArrayList<FileObject> roots = new ArrayList();
             for (SourceGroup gr:ProjectUtils.getSources(project).getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA)) {
                 roots.add(gr.getRootFolder());
             }
-            customScope = org.netbeans.modules.refactoring.api.Scope.create(roots, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+            customScope = org.netbeans.modules.refactoring.api.Scope.create(roots, Collections.<NonRecursiveFolder>emptyList(), Collections.<FileObject>emptyList());
         } else if (selectedItem == currentPackage) {
             //current package
             if (fileObject != null) {
@@ -430,15 +430,15 @@ public class InspectAndRefactorPanel extends javax.swing.JPanel implements Popup
                         return fileObject.isFolder()?fileObject:fileObject.getParent();
                     }
                 });
-                customScope = org.netbeans.modules.refactoring.api.Scope.create(Collections.EMPTY_LIST, col, Collections.EMPTY_LIST);
+                customScope = org.netbeans.modules.refactoring.api.Scope.create(Collections.<FileObject>emptyList(), col, Collections.<FileObject>emptyList());
             }
         } else if (selectedItem == currentFile) {
-                customScope = org.netbeans.modules.refactoring.api.Scope.create(Collections.EMPTY_LIST, Collections.EMPTY_LIST, Collections.singleton(fileObject));
+                customScope = org.netbeans.modules.refactoring.api.Scope.create(Collections.<FileObject>emptyList(), Collections.<NonRecursiveFolder>emptyList(), Collections.singleton(fileObject));
         } else {
             //custom
             customScope = readScope();
             if (customScope==null)
-                customScope = org.netbeans.modules.refactoring.api.Scope.create(Collections.EMPTY_LIST, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+                customScope = org.netbeans.modules.refactoring.api.Scope.create(Collections.<FileObject>emptyList(), Collections.<NonRecursiveFolder>emptyList(), Collections.<FileObject>emptyList());
         }
         org.netbeans.modules.refactoring.api.Scope s = JavaScopeBuilder.open(NbBundle.getMessage(InspectAndRefactorPanel.class, "CTL_CustomScope"), customScope);
         if (s != null) {

--- a/java/javadoc/src/org/netbeans/modules/javadoc/hints/AddTagFix.java
+++ b/java/javadoc/src/org/netbeans/modules/javadoc/hints/AddTagFix.java
@@ -96,7 +96,7 @@ abstract class AddTagFix extends JavaFix {
         return new AddTagFix(dtph, isTypeParam? MISSING_TYPEPARAM_HINT("<" + name + ">"):MISSING_PARAM_HINT(name), index) {
             @Override
             protected DocTree getNewTag(TreeMaker make) {
-                return make.Param(isTypeParam, make.DocIdentifier(name), Collections.EMPTY_LIST);
+                return make.Param(isTypeParam, make.DocIdentifier(name), Collections.emptyList());
             }
         };
     }
@@ -105,7 +105,7 @@ abstract class AddTagFix extends JavaFix {
         return new AddTagFix(dtph, MISSING_RETURN_HINT(), -1) {
             @Override
             protected DocTree getNewTag(TreeMaker make) {
-                return make.DocReturn(Collections.EMPTY_LIST);
+                return make.DocReturn(Collections.emptyList());
             }
         };
     }
@@ -114,7 +114,7 @@ abstract class AddTagFix extends JavaFix {
         return new AddTagFix(dtph, MISSING_THROWS_HINT(fqn), throwIndex) {
             @Override
             protected DocTree getNewTag(TreeMaker make) {
-                return make.Throws(make.Reference(make.Identifier(fqn), null, null), Collections.EMPTY_LIST);
+                return make.Throws(make.Reference(make.Identifier(fqn), null, null), Collections.emptyList());
             }
         };
     }
@@ -123,7 +123,7 @@ abstract class AddTagFix extends JavaFix {
         return new AddTagFix(dtph, MISSING_DEPRECATED_HINT(), -1) {
             @Override
             protected DocTree getNewTag(TreeMaker make) {
-                return make.Deprecated(Collections.EMPTY_LIST);
+                return make.Deprecated(Collections.emptyList());
             }
         };
     }

--- a/java/javadoc/src/org/netbeans/modules/javadoc/hints/JavadocGenerator.java
+++ b/java/javadoc/src/org/netbeans/modules/javadoc/hints/JavadocGenerator.java
@@ -221,7 +221,7 @@ public final class JavadocGenerator {
 
                 if (SourceVersion.RELEASE_5.compareTo(srcVersion) <= 0) {
                     for (TypeParameterElement param : clazz.getTypeParameters()) {
-                        tags.add(make.Param(true, make.DocIdentifier(param.getSimpleName()), Collections.EMPTY_LIST));
+                        tags.add(make.Param(true, make.DocIdentifier(param.getSimpleName()), Collections.emptyList()));
                     }
                 }
                 break;
@@ -229,15 +229,15 @@ public final class JavadocGenerator {
             case METHOD:
                 ExecutableElement method = (ExecutableElement) elm;
                 for (TypeParameterElement param : method.getTypeParameters()) {
-                    tags.add(make.Param(true, make.DocIdentifier(param.getSimpleName()), Collections.EMPTY_LIST));
+                    tags.add(make.Param(true, make.DocIdentifier(param.getSimpleName()), Collections.emptyList()));
                 }
 
                 for (VariableElement param : method.getParameters()) {
-                    tags.add(make.Param(false, make.DocIdentifier(param.getSimpleName()), Collections.EMPTY_LIST));
+                    tags.add(make.Param(false, make.DocIdentifier(param.getSimpleName()), Collections.emptyList()));
                 }
 
                 if (method.getReturnType().getKind() != TypeKind.VOID) {
-                    tags.add(make.DocReturn(Collections.EMPTY_LIST));
+                    tags.add(make.DocReturn(Collections.emptyList()));
                 }
                 for (TypeMirror exceptionType : method.getThrownTypes()) {
                     Element exception;
@@ -250,7 +250,7 @@ public final class JavadocGenerator {
                         throw new IllegalStateException("Illegal kind: " + exceptionType.getKind()); // NOI18N
                     }
                     ExpressionTree ident = make.QualIdent(exception);
-                    tags.add(make.Throws(make.Reference(ident, null, null), Collections.EMPTY_LIST));
+                    tags.add(make.Throws(make.Reference(ident, null, null), Collections.emptyList()));
                 }
                 break;
             case FIELD:
@@ -262,7 +262,7 @@ public final class JavadocGenerator {
         }
         if (SourceVersion.RELEASE_5.compareTo(srcVersion) <= 0
                 && JavadocUtilities.isDeprecated(javac, elm)) {
-            tags.add(make.Deprecated(Collections.EMPTY_LIST));
+            tags.add(make.Deprecated(Collections.emptyList()));
         }
         return make.DocComment(firstSentence, body, tags);
     }

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/CustomClientPojoCodeGenerator.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/CustomClientPojoCodeGenerator.java
@@ -169,7 +169,7 @@ public class CustomClientPojoCodeGenerator extends SaasClientCodeGenerator {
         
         finishProgressReporting();
 
-        return new HashSet<FileObject>(Collections.EMPTY_LIST);
+        return new HashSet<FileObject>(Collections.<FileObject>emptyList());
     }
     
     private void setJaxbWrapper() {

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/RestClientPojoCodeGenerator.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/RestClientPojoCodeGenerator.java
@@ -174,7 +174,7 @@ public class RestClientPojoCodeGenerator extends SaasClientCodeGenerator {
 
         finishProgressReporting();
 
-        return new HashSet<FileObject>(Collections.EMPTY_LIST);
+        return new HashSet<FileObject>(Collections.<FileObject>emptyList());
     }
 
     private void setJaxbWrapper() {

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/SoapClientPojoCodeGenerator.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/SoapClientPojoCodeGenerator.java
@@ -140,7 +140,7 @@ public class SoapClientPojoCodeGenerator extends SaasClientCodeGenerator {
 
         finishProgressReporting();
 
-        return new HashSet<FileObject>(Collections.EMPTY_LIST);
+        return new HashSet<FileObject>(Collections.<FileObject>emptyList());
     }
 
     /**

--- a/nbi/engine/src/org/netbeans/installer/utils/UninstallUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/UninstallUtils.java
@@ -189,7 +189,7 @@ public class UninstallUtils {
             }
             return descendants;
         } else {
-            return Collections.EMPTY_LIST;
+            return Collections.<File>emptyList();
         }
     }
 

--- a/php/php.nette2/src/org/netbeans/modules/php/nette2/annotations/Nette2AnnotationsProvider.java
+++ b/php/php.nette2/src/org/netbeans/modules/php/nette2/annotations/Nette2AnnotationsProvider.java
@@ -41,12 +41,12 @@ public class Nette2AnnotationsProvider extends AnnotationCompletionTagProvider {
 
     @Override
     public List<AnnotationCompletionTag> getFunctionAnnotations() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override
     public List<AnnotationCompletionTag> getTypeAnnotations() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override
@@ -58,7 +58,7 @@ public class Nette2AnnotationsProvider extends AnnotationCompletionTagProvider {
 
     @Override
     public List<AnnotationCompletionTag> getMethodAnnotations() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
 }

--- a/php/php.twig/src/org/netbeans/modules/php/twig/editor/completion/TwigCompletionHandler.java
+++ b/php/php.twig/src/org/netbeans/modules/php/twig/editor/completion/TwigCompletionHandler.java
@@ -128,7 +128,7 @@ public class TwigCompletionHandler implements CodeCompletionHandler2 {
         FILTERS.add(TwigElement.Factory.create("escape", documentationFactory, Arrays.asList(new Parameter[] {new Parameter("'html'")}))); //NOI18N
         FILTERS.add(TwigElement.Factory.create("format", documentationFactory, Arrays.asList(new Parameter[] {new Parameter("var")}))); //NOI18N
         FILTERS.add(TwigElement.Factory.create("join", documentationFactory, Arrays.asList(new Parameter[] {new Parameter("'separator'")}))); //NOI18N
-        FILTERS.add(TwigElement.Factory.create("json_encode", documentationFactory, Collections.EMPTY_LIST)); //NOI18N
+        FILTERS.add(TwigElement.Factory.create("json_encode", documentationFactory, Collections.emptyList())); //NOI18N
         FILTERS.add(TwigElement.Factory.create("keys", documentationFactory)); //NOI18N
         FILTERS.add(TwigElement.Factory.create("length", documentationFactory)); //NOI18N
         FILTERS.add(TwigElement.Factory.create("lower", documentationFactory)); //NOI18N
@@ -136,7 +136,7 @@ public class TwigCompletionHandler implements CodeCompletionHandler2 {
         FILTERS.add(TwigElement.Factory.create("nl2br", documentationFactory)); //NOI18N
         FILTERS.add(TwigElement.Factory.create("number_format", documentationFactory)); //NOI18N
         FILTERS.add(TwigElement.Factory.create("raw", documentationFactory)); //NOI18N
-        FILTERS.add(TwigElement.Factory.create("replace", documentationFactory, Collections.EMPTY_LIST)); //NOI18N
+        FILTERS.add(TwigElement.Factory.create("replace", documentationFactory, Collections.emptyList())); //NOI18N
         FILTERS.add(TwigElement.Factory.create("reverse", documentationFactory)); //NOI18N
         FILTERS.add(TwigElement.Factory.create("slice", documentationFactory, Arrays.asList(new Parameter[] {new Parameter("start"), new Parameter("length")}))); //NOI18N
         FILTERS.add(TwigElement.Factory.create("sort", documentationFactory)); //NOI18N
@@ -144,7 +144,7 @@ public class TwigCompletionHandler implements CodeCompletionHandler2 {
         FILTERS.add(TwigElement.Factory.create("title", documentationFactory)); //NOI18N
         FILTERS.add(TwigElement.Factory.create("trim", documentationFactory)); //NOI18N
         FILTERS.add(TwigElement.Factory.create("upper", documentationFactory)); //NOI18N
-        FILTERS.add(TwigElement.Factory.create("url_encode", documentationFactory, Collections.EMPTY_LIST)); //NOI18N
+        FILTERS.add(TwigElement.Factory.create("url_encode", documentationFactory, Collections.emptyList())); //NOI18N
         FILTERS.add(TwigElement.Factory.create("trans", documentationFactory)); //NOI18N
         FILTERS.add(TwigElement.Factory.create("truncate", documentationFactory, Arrays.asList(new Parameter[] {new Parameter("int")}))); //NOI18N
         FILTERS.add(TwigElement.Factory.create(
@@ -168,7 +168,7 @@ public class TwigCompletionHandler implements CodeCompletionHandler2 {
                 documentationFactory,
                 Arrays.asList(new Parameter[] {new Parameter("'date'"), new Parameter("'timezone'", Parameter.Need.OPTIONAL)}))); //NOI18N
         FUNCTIONS.add(TwigElement.Factory.create("dump", documentationFactory, Arrays.asList(new Parameter[] {new Parameter("variable", Parameter.Need.OPTIONAL)}))); //NOI18N
-        FUNCTIONS.add(TwigElement.Factory.create("parent", documentationFactory, Collections.EMPTY_LIST)); //NOI18N
+        FUNCTIONS.add(TwigElement.Factory.create("parent", documentationFactory, Collections.emptyList())); //NOI18N
         FUNCTIONS.add(TwigElement.Factory.create("random", documentationFactory, Arrays.asList(new Parameter[] {new Parameter("'value'")}))); //NOI18N
         FUNCTIONS.add(TwigElement.Factory.create(
                 "range",

--- a/php/selenium2.php/src/org/netbeans/modules/selenium2/php/Selenium2PhpSupportImpl.java
+++ b/php/selenium2.php/src/org/netbeans/modules/selenium2/php/Selenium2PhpSupportImpl.java
@@ -113,17 +113,17 @@ public class Selenium2PhpSupportImpl extends Selenium2SupportImpl {
         configureProject(refFileObject);
         Project p = FileOwnerQuery.getOwner(refFileObject);
         if (p == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         PhpSeleniumProvider seleniumProvider = getSeleniumProvider(p);
         if(seleniumProvider == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         // selenium test dir was not set by user during configureProject()
         // user probably pressed Cancel. Do not bother him with extra
         // configuration dialogs.
         if(getSeleniumDir(p, false) == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         return seleniumProvider.getTestSourceRoots(createdSourceRoots, refFileObject);
     }

--- a/platform/core.multitabs/nbproject/project.properties
+++ b/platform/core.multitabs/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 nbm.needs.restart=true

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
@@ -594,7 +594,8 @@ public class ETable extends JTable {
                     }
                     hiddenColumnIndexes[hci] = index;
                 }
-                List<TableColumn> sortedColumns = (sortable) ? etcm.getSortedColumns() : Collections.EMPTY_LIST;
+                List<TableColumn> sortedColumns = (sortable) ? etcm.getSortedColumns() : Collections.<TableColumn>emptyList();
+
                 int ns = sortedColumns.size();
                 if (ns > 0) {
                     sortedColumnIndexes = new int[ns];

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/KeymapModel.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/KeymapModel.java
@@ -655,7 +655,7 @@ public class KeymapModel {
     static Collection<ShortcutAction> filterSameScope(Set<ShortcutAction> actions, ShortcutAction anchor) {
         KeymapManager mgr = findOriginator(anchor);
         if (mgr == null) {
-            return Collections.EMPTY_SET;
+            return Collections.emptyList();
         }
         Collection<ShortcutAction> sameActions = null;
         
@@ -668,7 +668,7 @@ public class KeymapModel {
                 sameActions.add(sa);
             }
         }
-        return sameActions == null ? Collections.EMPTY_LIST : sameActions;
+        return sameActions == null ? Collections.emptyList() : sameActions;
     }
 
     /**

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
@@ -199,7 +199,7 @@ public class Snapshot {
 
             @Override
             protected Iterator<JavaClass> getTraversingIterator(JavaClass popped) {
-                return includeSubclasses ? popped.getSubClasses().iterator() : Collections.EMPTY_LIST.iterator();
+                return includeSubclasses ? popped.getSubClasses().iterator() : Collections.emptyList().iterator();
             }
         };
     }

--- a/profiler/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/AbstractProjectLookupProvider.java
+++ b/profiler/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/AbstractProjectLookupProvider.java
@@ -50,7 +50,7 @@ public abstract class AbstractProjectLookupProvider implements LookupProvider {
                 }
 
                 public List<FileObject> getDataFiles() {
-                    return Collections.EMPTY_LIST;
+                    return Collections.emptyList();
                 }
             };
     }

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/index/AngularJsIndex.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/index/AngularJsIndex.java
@@ -136,7 +136,7 @@ public class AngularJsIndex {
             }
             return controllers;
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     public Collection<String> getComponents(final String name, final boolean exact) {

--- a/webcommon/javascript2.extjs/src/org/netbeans/modules/javascript2/extjs/ExtJsCodeCompletion.java
+++ b/webcommon/javascript2.extjs/src/org/netbeans/modules/javascript2/extjs/ExtJsCodeCompletion.java
@@ -66,24 +66,24 @@ public class ExtJsCodeCompletion implements CompletionProvider {
     @Override
     public List<CompletionProposal> complete(CodeCompletionContext ccContext, CompletionContext jsCompletionContext, String prefix) {
         if (jsCompletionContext != CompletionContext.OBJECT_PROPERTY_NAME) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         // find the object that can be configured
         TokenHierarchy<?> th = ccContext.getParserResult().getSnapshot().getTokenHierarchy();
         if (th == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         int carretOffset  = ccContext.getCaretOffset();
         int eOffset = ccContext.getParserResult().getSnapshot().getEmbeddedOffset(carretOffset);
         TokenSequence<? extends JsTokenId> ts = LexUtilities.getJsTokenSequence(th, eOffset);
         if (ts == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         
         ts.move(eOffset);
         
         if (!ts.moveNext() && !ts.movePrevious()){
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         
         Token<? extends JsTokenId> token = null;
@@ -100,7 +100,7 @@ public class ExtJsCodeCompletion implements CompletionProvider {
             }
         }
         if (token == null || balance != 0) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         
         // now we should be at the beginning of the object literal. 
@@ -129,7 +129,7 @@ public class ExtJsCodeCompletion implements CompletionProvider {
             }
             return result;
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsFunctionImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsFunctionImpl.java
@@ -80,7 +80,7 @@ public class JsFunctionImpl extends DeclarationScopeImpl implements JsFunction {
     }
 
     private JsFunctionImpl(FileObject file, Identifier name, String mimeType, String sourceLabel) {
-        this(null, null, name, Collections.EMPTY_LIST, name.getOffsetRange(), mimeType, sourceLabel);
+        this(null, null, name, Collections.emptyList(), name.getOffsetRange(), mimeType, sourceLabel);
         this.setFileObject(file);
     }
     
@@ -160,7 +160,7 @@ public class JsFunctionImpl extends DeclarationScopeImpl implements JsFunction {
     @Override
     public Collection<? extends TypeUsage> getReturnTypes() {
         if (areReturnTypesResolved) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         Collection<TypeUsage> returns = new HashSet();
         HashSet<String> nameReturnTypes = new HashSet<String>();

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
@@ -395,7 +395,7 @@ public class JsObjectImpl extends JsElementImpl implements JsObject {
             return result;
         }
         visited.add(fqn);
-        Collection<? extends TypeUsage> offsetAssignments = Collections.EMPTY_LIST;
+        Collection<? extends TypeUsage> offsetAssignments = Collections.emptyList();
         Map.Entry<Integer, Collection<TypeUsage>> found = ((JsObjectImpl) jsObject).assignments.floorEntry(offset);
         if (found != null) {
             offsetAssignments = found.getValue();

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsWithObjectImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsWithObjectImpl.java
@@ -73,7 +73,7 @@ public class JsWithObjectImpl extends JsObjectImpl implements JsWith {
     
     @Override
     public Collection<JsWith> getInnerWiths() {
-        Collection<JsWith> result = innerWith.isEmpty() ? Collections.EMPTY_LIST : new ArrayList<JsWith>(innerWith);
+        Collection<JsWith> result = innerWith.isEmpty() ? Collections.emptyList(): new ArrayList<JsWith>(innerWith);
         return result;
     }
     

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/OccurrenceBuilder.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/OccurrenceBuilder.java
@@ -173,7 +173,7 @@ public class OccurrenceBuilder {
                     item.leftSite, parserResult.getSnapshot().getMimeType(), null);
         } else {
             FileObject fo = parserResult.getSnapshot().getSource().getFileObject();
-            newObject = new JsFunctionImpl(fo, parent, nameIden, Collections.EMPTY_LIST,
+            newObject = new JsFunctionImpl(fo, parent, nameIden, Collections.emptyList(),
                     parserResult.getSnapshot().getMimeType(), null);
         }
         newObject.addOccurrence(nameIden.getOffsetRange());

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/Index.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/Index.java
@@ -349,7 +349,7 @@ public final class Index {
                         if(split.length == 2 && !alreadyUsed.contains(split[0])) {
                             alreadyUsed.add(split[0]);
                             IndexedElement element = new IndexedElement(fo, split[0], split[0], false, false, split[1].equals("F") ? JsElement.Kind.FUNCTION : JsElement.Kind.OBJECT, 
-                                OffsetRange.NONE, Collections.singleton(Modifier.PUBLIC), Collections.EMPTY_LIST, false);
+                                OffsetRange.NONE, Collections.singleton(Modifier.PUBLIC), Collections.emptyList(), false);
                             usages.add(element);
                         }
                     }
@@ -365,7 +365,7 @@ public final class Index {
     
     private Collection <IndexedElement> getProperties(String fqn, int deepLevel, Collection<String> resolvedTypes) { 
         if (deepLevel > MAX_FIND_PROPERTIES_RECURSION) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         Collection<IndexedElement> result = new ArrayList<IndexedElement>();
         if (!resolvedTypes.contains(fqn)) {

--- a/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsCodeCompletion.java
+++ b/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsCodeCompletion.java
@@ -53,20 +53,20 @@ public class NodeJsCodeCompletion implements CompletionProvider {
     public List<CompletionProposal> complete(CodeCompletionContext ccContext, CompletionContext jsCompletionContext, String prefix) {
         FileObject fo = ccContext.getParserResult().getSnapshot().getSource().getFileObject();
         if (fo == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         List<CompletionProposal> result = new ArrayList<CompletionProposal>();
         if (jsCompletionContext == CompletionContext.IN_STRING || jsCompletionContext == CompletionContext.EXPRESSION
                 || jsCompletionContext == CompletionContext.GLOBAL) {
             TokenHierarchy<?> th = ccContext.getParserResult().getSnapshot().getTokenHierarchy();
             if (th == null) {
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
             int carretOffset = ccContext.getCaretOffset();
             int eOffset = ccContext.getParserResult().getSnapshot().getEmbeddedOffset(carretOffset);
             TokenSequence<? extends JsTokenId> ts = LexUtilities.getJsTokenSequence(th, eOffset);
             if (ts == null) {
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
             ts.move(eOffset);
 
@@ -146,7 +146,7 @@ public class NodeJsCodeCompletion implements CompletionProvider {
             }
         }
 
-        return result.isEmpty() ? Collections.EMPTY_LIST : result;
+        return result.isEmpty() ? Collections.<CompletionProposal>emptyList(): result;
     }
 
     @Override

--- a/webcommon/selenium2.webclient.mocha/src/org/netbeans/modules/selenium2/webclient/mocha/MochaRunner.java
+++ b/webcommon/selenium2.webclient.mocha/src/org/netbeans/modules/selenium2/webclient/mocha/MochaRunner.java
@@ -257,7 +257,7 @@ public class MochaRunner {
         List<File> siteRoots = getRoots(project, WebClientProjectConstants.SOURCES_TYPE_HTML5_SITE_ROOT);
         List<File> testRoots = getRoots(project, isSelenium ? WebClientProjectConstants.SOURCES_TYPE_HTML5_TEST_SELENIUM : WebClientProjectConstants.SOURCES_TYPE_HTML5_TEST);
         List<String> localPaths = new ArrayList<>(sourceRoots.size());
-        List<String> localPathsExclusionFilter = Collections.EMPTY_LIST;
+        List<String> localPathsExclusionFilter = Collections.emptyList();
         sourceRoots.addAll(testRoots);
         for (File src : sourceRoots) {
             localPaths.add(src.getAbsolutePath());
@@ -270,7 +270,7 @@ public class MochaRunner {
                 }
             }
         }
-        return new Connector.Properties(host, port, localPaths, Collections.EMPTY_LIST, localPathsExclusionFilter);
+        return new Connector.Properties(host, port, localPaths, Collections.<String>emptyList(), localPathsExclusionFilter);
     }
     
     private static List<File> getRoots(Project project, String type) {
@@ -337,7 +337,7 @@ public class MochaRunner {
             }
             String output2display = testRunnerReporter.processLine(line);
             if(output2display == null) {
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
             TestRunnerReporter.CallStackCallback callStackCallback = new TestRunnerReporter.CallStackCallback(runInfo.getProject());
             Pair<File, int[]> parsedLocation = callStackCallback.parseLocation(line, false);

--- a/webcommon/selenium2.webclient.protractor/src/org/netbeans/modules/selenium2/webclient/protractor/ProtractorRunner.java
+++ b/webcommon/selenium2.webclient.protractor/src/org/netbeans/modules/selenium2/webclient/protractor/ProtractorRunner.java
@@ -268,7 +268,7 @@ class ProtractorRunner {
         List<File> siteRoots = getRoots(project, WebClientProjectConstants.SOURCES_TYPE_HTML5_SITE_ROOT);
         List<File> testRoots = getRoots(project, WebClientProjectConstants.SOURCES_TYPE_HTML5_TEST);
         List<String> localPaths = new ArrayList<>(sourceRoots.size());
-        List<String> localPathsExclusionFilter = Collections.EMPTY_LIST;
+        List<String> localPathsExclusionFilter = Collections.emptyList();
         for (File src : sourceRoots) {
             localPaths.add(src.getAbsolutePath());
             for (File site : siteRoots) {
@@ -288,7 +288,7 @@ class ProtractorRunner {
                 }
             }
         }
-        return new Connector.Properties(host, port, localPaths, Collections.EMPTY_LIST, localPathsExclusionFilter);
+        return new Connector.Properties(host, port, localPaths, Collections.<String>emptyList(), localPathsExclusionFilter);
     }
     
     private static List<File> getRoots(Project project, String type) {
@@ -355,7 +355,7 @@ class ProtractorRunner {
             }
             String output2display = testRunnerReporter.processLine(line);
             if(output2display == null) {
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
             TestRunnerReporter.CallStackCallback callStackCallback = new TestRunnerReporter.CallStackCallback(runInfo.getProject());
             Pair<File, int[]> parsedLocation = callStackCallback.parseLocation(line, false);

--- a/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/MiscEditorUtil.java
+++ b/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/MiscEditorUtil.java
@@ -283,7 +283,7 @@ public final class MiscEditorUtil {
      *         the list is empty when the script does not have a source map.
      */
     public static List<FileObject> registerScriptSourceMap(Project project, Debugger debugger, Script script) {
-        List<FileObject> mappedSourceFiles = Collections.EMPTY_LIST;
+        List<FileObject> mappedSourceFiles = Collections.emptyList();
         if (USE_SOURCE_MAPS) {
             String url = script.getURL();
             if (!url.isEmpty()) {

--- a/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/callstack/DebuggingViewSupportImpl.java
+++ b/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/callstack/DebuggingViewSupportImpl.java
@@ -94,7 +94,7 @@ public class DebuggingViewSupportImpl extends DebuggingView.DVSupport {
 
     @Override
     protected List<DebuggingView.DVFilter> getFilters() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
     
     private class ChangeListener implements Debugger.Listener {

--- a/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/callstack/JSThread.java
+++ b/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/callstack/JSThread.java
@@ -78,7 +78,7 @@ public class JSThread implements DebuggingView.DVThread {
 
     @Override
     public List<DebuggingView.DVThread> getLockerThreads() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override


### PR DESCRIPTION
There are several places where EMPTY_LIST is used in a generic context..

  [repeat] /home/bwalker/src/netbeans/platform/options.keymap/src/org/netbeans/modules/options/keymap/KeymapModel.java:658: warning: [unchecked] unchecked conversion
   [repeat]             return Collections.EMPTY_SET;
   [repeat]                               ^
   [repeat]   required: Collection<ShortcutAction>
   [repeat]   found:    Set

Convert this code to use the emptyList() method.. This will maintain type-safety and remove the warning..