### PR TITLE
Fix rawtypes warning for Iterator in platform cluster

### DIFF
--- a/harness/o.n.insane/src/org/netbeans/insane/impl/InsaneEngine.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/impl/InsaneEngine.java
@@ -64,9 +64,11 @@ public final class InsaneEngine {
     // to the known* structures and reported to the visitor
     private Queue<Object> queue = new Queue<Object>();
     
-    public void traverse(Collection roots) throws Exception {
+    public void traverse(Collection<?> roots) throws Exception {
         // process all given roots first - remember them and put them into queue
-        for (Iterator it = roots.iterator(); it.hasNext(); ) recognize(it.next());
+        for (Object root : roots) {
+            recognize(root);
+        }
         
         while (!queue.isEmpty()) {
             process(queue.get());

--- a/harness/o.n.insane/src/org/netbeans/insane/impl/LiveEngine.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/impl/LiveEngine.java
@@ -126,14 +126,14 @@ public class LiveEngine implements ObjectMap, Visitor {
         objects.put(to, entry);
     }
 
-    private Iterator/*<Object>*/ getIncomingRefs(Object to) {
+    private Collection<Object> getIncomingRefs(Object to) {
         Object oo = objects.get(to);
         if (oo instanceof Object[]) {
-            return Arrays.asList((Object[])oo).iterator();
+            return Arrays.asList((Object[])oo);
         } else if (oo == null) {
-            return Collections.emptyIterator();
+            return Collections.emptyList();
         } else {
-            return Collections.singleton(oo).iterator();
+            return Collections.singleton(oo);
         }
     }
         
@@ -181,8 +181,7 @@ public class LiveEngine implements ObjectMap, Visitor {
         int base = objExpected;
         int step = found > 0 ? objExpected/9/found : 0;
         
-        for (Iterator it = objs.iterator(); it.hasNext(); ) {
-            Object obj = it.next();
+        for (Object obj : objs) {
             if (rest.containsKey(obj)) continue; // not found
             Path toObj = findRoots(obj, s.keySet());
             if (toObj != null) result.put(obj, toObj);
@@ -212,9 +211,7 @@ public class LiveEngine implements ObjectMap, Visitor {
             }
 
             // follow incomming
-            Iterator it = getIncomingRefs(item);
-            while(it.hasNext()) {
-                Object o = it.next();
+            for (Object o : getIncomingRefs(item)) {
                 Path prev = Utils.createPath(o, act);
                 if (o instanceof Root) return prev;
 

--- a/harness/o.n.insane/src/org/netbeans/insane/model/InsaneConverter.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/model/InsaneConverter.java
@@ -351,7 +351,7 @@ final class InsaneConverter {
         objsOffset = currentOffset;
         
         // compute offsets of instances
-        for (Iterator it = instanceInfo.iterator(); it.hasNext(); ) {
+        for (Iterator<Object> it = instanceInfo.iterator(); it.hasNext(); ) {
             InstanceInfo info = (InstanceInfo)it.next();
             currentOffset = info.computeNextOffset(currentOffset);
         }

--- a/harness/o.n.insane/src/org/netbeans/insane/model/ObjectSet.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/model/ObjectSet.java
@@ -90,8 +90,8 @@ class ObjectSet {
         return get(key) != null;
     }
     
-    public Iterator iterator() {
-        return new Iterator() {
+    public Iterator<Object> iterator() {
+        return new Iterator<Object>() {
             int ptr = 0;
             Object next;
             public boolean hasNext() {

--- a/platform/autoupdate.services/libsrc/org/netbeans/updater/Localization.java
+++ b/platform/autoupdate.services/libsrc/org/netbeans/updater/Localization.java
@@ -152,15 +152,12 @@ class Localization {
             for( LocaleIterator li = new LocaleIterator( Locale.getDefault() ); li.hasNext(); ) {
                 String localeName = li.next().toString ();
                 // loop for clusters
-                Iterator it = UpdateTracking.clusters (true).iterator ();
-                while (it.hasNext ()) {
-                    File cluster = (File)it.next ();
-                    File locJar = new File( cluster.getPath () + FILE_SEPARATOR + LOCALE_DIR + FILE_SEPARATOR + UPDATER_JAR + localeName + UPDATER_JAR_EXT );
-                    if ( locJar.exists() ) {  // File exists
+                for (File cluster : UpdateTracking.clusters (true)) {
+                    File locJar = new File(cluster.getPath() + FILE_SEPARATOR + LOCALE_DIR + FILE_SEPARATOR + UPDATER_JAR + localeName + UPDATER_JAR_EXT);
+                    if (locJar.exists()) { // File exists
                         try {
-                            locJarURLs.add( locJar.toURI().toURL() ); // Convert to URL
-                        }
-                        catch ( MalformedURLException e ) {
+                            locJarURLs.add(locJar.toURI().toURL()); // Convert to URL
+                        } catch (MalformedURLException e) {
                             // dont use and ignore
                         }
                     }
@@ -232,7 +229,7 @@ class Localization {
      * Branding tokens with underscores are broken apart naturally: so e.g.
      * branding "f4j_ce" looks first for "f4j_ce" branding, then "f4j" branding, then none.
      */
-    private static class LocaleIterator extends Object implements Iterator {
+    private static class LocaleIterator extends Object implements Iterator<String> {
         /** this flag means, if default locale is in progress */
         private boolean defaultInProgress = false;
 
@@ -267,7 +264,8 @@ class Localization {
         /** @return next sufix.
         * @exception NoSuchElementException if there is no more locale sufix.
         */
-        public Object next () throws NoSuchElementException {
+        @Override
+        public String next () throws NoSuchElementException {
             if (current == null)
                 throw new NoSuchElementException();
 

--- a/platform/autoupdate.services/libsrc/org/netbeans/updater/UpdateTracking.java
+++ b/platform/autoupdate.services/libsrc/org/netbeans/updater/UpdateTracking.java
@@ -854,17 +854,15 @@ public final class UpdateTracking {
             config.getParentFile().mkdirs();
             Boolean isAutoload = null;
             Boolean isEager = null;
-            java.util.Iterator it = newVersion.getFiles().iterator();
             boolean needToWrite = false;
-            while (it.hasNext()) {
-                ModuleFile f = (ModuleFile) it.next ();
+            for (ModuleFile f : newVersion.getFiles()) {
                 String n = f.getName();
                 String parentDir;
                 {
                     File p = new File(f.getName()).getParentFile();
                     parentDir = p != null ? p.getName() : "";
                 }
-                needToWrite = needToWrite || n.indexOf(ModuleDeactivator.MODULES) >= 0 || osgi;
+                needToWrite = needToWrite || n.contains(ModuleDeactivator.MODULES) || osgi;
                 if (n.endsWith(".jar") && ! parentDir.equals("ext")) { // NOI18N
                     // ok, module candidate
                     candidate = f.getName();

--- a/platform/core.kit/test/unit/src/org/openide/explorer/windows/TopComponentGetLookupTest.java
+++ b/platform/core.kit/test/unit/src/org/openide/explorer/windows/TopComponentGetLookupTest.java
@@ -200,7 +200,7 @@ public class TopComponentGetLookupTest extends NbTestCase {
     }
    
     public void testNodesAreThereEvenIfTheyAreNotContainedInTheirOwnLookup () {
-        Lookup.Result res = lookup.lookup(new Lookup.Template(Node.class));
+        Lookup.Result<Node> res = lookup.lookup(new Lookup.Template(Node.class));
         
         AbstractNode n1 = new AbstractNode(Children.LEAF, Lookup.EMPTY);
         
@@ -227,7 +227,7 @@ public class TopComponentGetLookupTest extends NbTestCase {
         // then it contains only the one correct node..
         listener.check ("Node changed", 1);
         
-        Collection addedByTCLookup = res.allInstances();
+        Collection<? extends Node> addedByTCLookup = res.allInstances();
         assertEquals ("One item still", 1, addedByTCLookup.size ());
         
         content.add (n2);
@@ -247,9 +247,9 @@ public class TopComponentGetLookupTest extends NbTestCase {
         // this could be commented out if necessary:
         listener.check ("And nothing is fired", 0);
         // Change from former behavior (#36336): we don't *want* n1 in res.
-        Collection one = res.allInstances();
+        Collection<? extends Node> one = res.allInstances();
         assertEquals("Really just the activated node", 1, one.size());
-        Iterator it = one.iterator();
+        Iterator<? extends Node> it = one.iterator();
         assertEquals("It is the one added by the TC lookup", n2, it.next());
     }
     

--- a/platform/core.multiview/nbproject/project.properties
+++ b/platform/core.multiview/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewCloneableTopComponent.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewCloneableTopComponent.java
@@ -285,14 +285,11 @@ public final class MultiViewCloneableTopComponent extends CloneableTopComponent
         }
         // now try a best guess.. iterate the already created elements and check if any of
         // them is a Pane
-        Collection col = peer.model.getCreatedElements();
-        Iterator it = col.iterator();
-        while (it.hasNext()) {
-            el = (MultiViewElement)it.next();
-            if (el.getVisualRepresentation() instanceof CloneableEditorSupport.Pane) {
+        for (MultiViewElement el2 : peer.model.getCreatedElements()) {
+            if (el2.getVisualRepresentation() instanceof CloneableEditorSupport.Pane) {
                 // fingers crossed and hope for the best... could result in bad results once
                 // we have multiple editors in the multiview component.
-                return el;
+                return el2;
             }
         }
         

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewModel.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewModel.java
@@ -110,8 +110,8 @@ class MultiViewModel {
     /**
      * returns all elements that were so far created/instantiated.
      */
-    synchronized Collection getCreatedElements() {
-       Collection<MultiViewElement> col = new ArrayList<MultiViewElement>(nestedElements.size());
+    synchronized Collection<MultiViewElement> getCreatedElements() {
+       Collection<MultiViewElement> col = new ArrayList<>(nestedElements.size());
        for (Map.Entry<MultiViewDescription, MultiViewElement> entry : nestedElements.entrySet()) {
            if (entry.getValue() != null) {
                col.add(entry.getValue());

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
@@ -297,9 +297,7 @@ public final class MultiViewPeer implements PropertyChangeListener {
     }        
     
     void peerComponentClosed() {
-        Iterator it = model.getCreatedElements().iterator();
-        while (it.hasNext()) {
-            MultiViewElement el = (MultiViewElement)it.next();
+        for (MultiViewElement el : model.getCreatedElements()) {
             model.markAsHidden(el);
             el.componentClosed();
         }
@@ -801,11 +799,11 @@ public final class MultiViewPeer implements PropertyChangeListener {
      * Delegates to CloseOperationHandler.
      */
     boolean canClose() {
-        Collection col = model.getCreatedElements();
-        Iterator it = col.iterator();
-        Collection badOnes = new ArrayList();
+        Collection<MultiViewElement> col = model.getCreatedElements();
+        Iterator<MultiViewElement> it = col.iterator();
+        Collection<CloseOperationState> badOnes = new ArrayList<>();
         while (it.hasNext()) {
-           MultiViewElement el = (MultiViewElement)it.next();
+           MultiViewElement el = it.next();
            CloseOperationState state = el.canCloseElement();
            if (!state.canClose()) {
                badOnes.add(state);
@@ -820,7 +818,7 @@ public final class MultiViewPeer implements PropertyChangeListener {
                 col = model.getCreatedElements();
                 it = col.iterator();
                 while (it.hasNext()) {
-                   MultiViewElement el = (MultiViewElement)it.next();
+                   MultiViewElement el = it.next();
                    CloseOperationState state = el.canCloseElement();
                    if (!state.canClose()) {
                        res = false;
@@ -1067,7 +1065,7 @@ public final class MultiViewPeer implements PropertyChangeListener {
     
     private class DelegateUndoRedo implements UndoRedo {
         
-        private List listeners = new ArrayList();
+        private List<ChangeListener> listeners = new ArrayList<>();
         
         public boolean canUndo() {
             return privateGetUndoRedo().canUndo();
@@ -1104,9 +1102,7 @@ public final class MultiViewPeer implements PropertyChangeListener {
         }
         
         private void fireElementChange() {
-            Iterator it = new ArrayList(listeners).iterator();
-            while (it.hasNext()) {
-                ChangeListener elem = (ChangeListener) it.next();
+            for (ChangeListener elem : new ArrayList<>(listeners)) {
                 ChangeEvent event = new ChangeEvent(this);
                 elem.stateChanged(event);
             }
@@ -1114,9 +1110,7 @@ public final class MultiViewPeer implements PropertyChangeListener {
         }
         
         void updateListeners(MultiViewElement old, MultiViewElement fresh) {
-            Iterator it = listeners.iterator();
-            while (it.hasNext()) {
-                ChangeListener elem = (ChangeListener) it.next();
+            for (ChangeListener elem : listeners) {
                 if (old.getUndoRedo() != null) {
                     old.getUndoRedo().removeChangeListener(elem);
                 }

--- a/platform/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewFactory.java
+++ b/platform/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewFactory.java
@@ -309,9 +309,7 @@ public final class MultiViewFactory {
             }
             
             StringBuilder sb = new StringBuilder();
-            Iterator it = elems.values().iterator();
-            while (it.hasNext()) {
-                CloseOperationState state = (CloseOperationState)it.next();
+            for (CloseOperationState state : elems.values()) {
                 if (sb.length() > 0) {
                     sb.append(" ");
                 }

--- a/platform/core.startup.base/src/org/netbeans/core/startup/layers/LocalFileSystemEx.java
+++ b/platform/core.startup.base/src/org/netbeans/core/startup/layers/LocalFileSystemEx.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
-import java.util.Iterator;
 import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -98,12 +97,10 @@ public final class LocalFileSystemEx extends LocalFileSystem {
         }
     }
 
-    private static Set<String> getInvalid (Set names) {
+    private static Set<String> getInvalid(Set<String> names) {
         LOGGER.finest("133616 - checking invalid");
         HashSet<String> invalid = new HashSet<String>();
-        Iterator i = names.iterator ();
-        while (i.hasNext ()) {
-            String name = (String) i.next ();
+        for (String name : names) {
             FileObject fo = FileUtil.getConfigFile(name);
             if (null == fo || !fo.isLocked()) {
                 // file lock recorded in potentialLock has been used

--- a/platform/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/NbinstURLMapperTest.java
+++ b/platform/core.startup.base/test/unit/src/org/netbeans/core/startup/layers/NbinstURLMapperTest.java
@@ -30,7 +30,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.security.Permission;
 import java.util.StringTokenizer;
-import org.netbeans.core.startup.layers.NbinstURLMapper;
 import org.netbeans.junit.MockServices;
 import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.FileObject;
@@ -63,10 +62,9 @@ public class NbinstURLMapperTest extends NbTestCase {
         
         File f = this.getWorkDir();
         this.clearWorkDir();
-        Lookup.Result result = Lookup.getDefault().lookupResult(InstalledFileLocator.class);
+        Lookup.Result<InstalledFileLocator> result = Lookup.getDefault().lookupResult(InstalledFileLocator.class);
         boolean found = false;
-        for (java.util.Iterator it = result.allInstances().iterator(); it.hasNext();) {
-            Object locator = it.next();
+        for (InstalledFileLocator locator : result.allInstances()) {
             if (locator instanceof TestInstalledFileLocator) {
                 ((TestInstalledFileLocator)locator).setRoot(f);
                 found = true;

--- a/platform/core.startup/src/org/netbeans/core/startup/Asm.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Asm.java
@@ -127,8 +127,7 @@ final class Asm {
      * @param mn method to process
      */
     private static void replaceSuperCtorCalls(final ClassNode theClass, final ClassNode extenderClass, MethodNode mn) {
-        for (Iterator it = mn.instructions.iterator(); it.hasNext(); ) {
-            AbstractInsnNode aIns = (AbstractInsnNode)it.next();
+        for (AbstractInsnNode aIns : mn.instructions) {
             if (aIns.getOpcode() == Opcodes.INVOKESPECIAL) {
                 MethodInsnNode mins = (MethodInsnNode)aIns;
                 if (CONSTRUCTOR_NAME.equals(mins.name) && mins.owner.equals(extenderClass.superName)) {

--- a/platform/core.startup/test/unit/src/org/netbeans/core/startup/AutomaticDependenciesTest.java
+++ b/platform/core.startup/test/unit/src/org/netbeans/core/startup/AutomaticDependenciesTest.java
@@ -203,13 +203,12 @@ public class AutomaticDependenciesTest extends NbTestCase {
     }
     
     private static String normalMessages(AutomaticDependencies.Report rep) {
-        SortedSet<String> s = new TreeSet<String>(); // Set<String>
-        Iterator it = rep.getMessages().iterator();
-        while (it.hasNext()) {
-            s.add((String)it.next());
+        Set<String> s = new TreeSet<>();
+        for (String message : rep.getMessages()) {
+            s.add(message);
         }
         StringBuilder b = new StringBuilder();
-        it = s.iterator();
+        Iterator<String> it = s.iterator();
         while (it.hasNext()) {
             b.append(it.next());
             if (it.hasNext()) {

--- a/platform/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/CompoundFolderChildrenTest.java
+++ b/platform/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/CompoundFolderChildrenTest.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.editor.mimelookup.impl;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -64,7 +63,7 @@ public class CompoundFolderChildrenTest extends NbTestCase {
         TestUtilities.createFile(getWorkDir(), "Tmp/A/B/" + fileName2);
 
         CompoundFolderChildren cfch = new CompoundFolderChildren(new String [] { "Tmp/A/B/C/D", "Tmp/A/B" }, false);
-        List files = cfch.getChildren();
+        List<FileObject> files = cfch.getChildren();
         
         assertEquals("Wrong number of files", 2, files.size());
         assertNotNull("Files do not contain " + fileName1, findFileByName(files, fileName1));
@@ -258,9 +257,8 @@ public class CompoundFolderChildrenTest extends NbTestCase {
 
     // test events
 
-    private FileObject findFileByName(List files, String nameExt) {
-        for (Iterator i = files.iterator(); i.hasNext(); ) {
-            FileObject f = (FileObject) i.next();
+    private FileObject findFileByName(List<FileObject> files, String nameExt) {
+        for (FileObject f : files) {
             if (nameExt.equals(f.getNameExt())) {
                 return f;
             }

--- a/platform/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DefaultMimeDataProviderTest.java
+++ b/platform/editor.mimelookup.impl/test/unit/src/org/netbeans/modules/editor/mimelookup/impl/DefaultMimeDataProviderTest.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.editor.mimelookup.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.spi.editor.mimelookup.MimeDataProvider;
 import org.openide.util.Lookup;
@@ -38,14 +37,13 @@ public class DefaultMimeDataProviderTest extends NbTestCase {
     }
 
     public void testProviderRegistration() {
-        Collection providers = Lookup.getDefault().lookupAll(MimeDataProvider.class);
+        Collection<? extends MimeDataProvider> providers = Lookup.getDefault().lookupAll(MimeDataProvider.class);
         assertTrue("No providers registered", providers.size() > 0);
         
-        ArrayList defaultProviders = new ArrayList();
-        for (Iterator i = providers.iterator(); i.hasNext(); ) {
-            MimeDataProvider provider = (MimeDataProvider) i.next();
+        ArrayList<DefaultMimeDataProvider> defaultProviders = new ArrayList<>();
+        for (MimeDataProvider provider : providers) {
             if (provider instanceof DefaultMimeDataProvider) {
-                defaultProviders.add(provider);
+                defaultProviders.add((DefaultMimeDataProvider) provider);
             }
         }
         
@@ -53,8 +51,7 @@ public class DefaultMimeDataProviderTest extends NbTestCase {
         if (defaultProviders.size() > 1) {
             String msg = "Too many default providers registered:\n";
             
-            for (Iterator i = defaultProviders.iterator(); i.hasNext();) {
-                DefaultMimeDataProvider provider = (DefaultMimeDataProvider) i.next();
+            for (DefaultMimeDataProvider provider : defaultProviders) {
                 msg += provider + "\n";
             }
             

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/BaseFileObjectTestHid.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/BaseFileObjectTestHid.java
@@ -1362,11 +1362,9 @@ public class BaseFileObjectTestHid extends TestBaseHid{
     private class IgnoreDirFileSystem extends LocalFileSystem {
         org.openide.filesystems.StatusDecorator status = new org.openide.filesystems.StatusDecorator() {
             @Override
-            public String annotateName (String name, java.util.Set files) {
+            public String annotateName (String name, Set<? extends FileObject> files) {
                 StringBuilder sb = new StringBuilder (name);
-                Iterator it = files.iterator ();
-                while (it.hasNext()) {                    
-                    FileObject fo = (FileObject)it.next();
+                for (FileObject fo : files) {
                     try {
                         if (fo.getFileSystem() instanceof IgnoreDirFileSystem) {
                             sb.append(",").append (fo.getNameExt());//NOI18N
@@ -1380,7 +1378,7 @@ public class BaseFileObjectTestHid extends TestBaseHid{
             }
 
             @Override
-            public String annotateNameHtml(String name, Set files) {
+            public String annotateNameHtml(String name, Set<? extends FileObject> files) {
                 return annotateName (name, files);
             }            
             

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/children/ChildrenSupportTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/children/ChildrenSupportTest.java
@@ -288,7 +288,7 @@ public class ChildrenSupportTest extends NbTestCase {
         assertTrue(childrenSupport.isStatus(ChildrenSupport.ALL_CHILDREN_CACHED));
     }
 
-    private Map refresh(ChildrenSupport childrenSupport, FileNaming fromFile) {
+    private Map<FileNaming, Integer> refresh(ChildrenSupport childrenSupport, FileNaming fromFile) {
         Runnable[] task = new Runnable[1];
         Map<FileNaming, Integer> res = null;
         while (res == null) {
@@ -400,11 +400,9 @@ public class ChildrenSupportTest extends NbTestCase {
      * Test of getChildren method, of class org.netbeans.modules.masterfs.children.FolderPathItems.
      */
     public void testGetChildrenPathItems() throws Exception{
-        Set childItems = getChildren(folderItem, folderName, true);
-        List lst = Arrays.asList(testFile.listFiles());
-        Iterator it = childItems.iterator();
-        while (it.hasNext()) {
-            FileNaming pi = (FileNaming)it.next();
+        Set<FileNaming> childItems = getChildren(folderItem, folderName, true);
+        List<File> lst = Arrays.asList(testFile.listFiles());
+        for (FileNaming pi : childItems) {
             File f = pi.getFile();
             assertTrue (lst.contains(f));
         }
@@ -415,10 +413,8 @@ public class ChildrenSupportTest extends NbTestCase {
      */
     public void testGetChildItem() throws Exception{
         getChildren(folderItem, folderName, true);
-        List lst = Arrays.asList(testFile.listFiles());
-        Iterator it = lst.iterator();
-        while (it.hasNext()) {
-            File f = (File)it.next();
+        List<File> lst = Arrays.asList(testFile.listFiles());
+        for (File f : lst) {
             FileNaming item = folderItem.getChild(f.getName(), folderName,false);
             assertNotNull(item);
             assertTrue (item.getFile().equals(f));
@@ -434,15 +430,13 @@ public class ChildrenSupportTest extends NbTestCase {
         assertTrue (added1.mkdirs());
         assertTrue (added2.mkdirs());
 
-        List added = Arrays.asList(new String[] {"added1", "added2"});
-        List removed = Arrays.asList(new String[] {"removed1", "removed2"});
+        List<String> added = Arrays.asList(new String[] {"added1", "added2"});
+        List<String> removed = Arrays.asList(new String[] {"removed1", "removed2"});
 
-        Map changes = refresh(fpi, fpiName);
-        Iterator it = changes.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry entry = (Map.Entry) it.next();
-            FileNaming pItem = (FileNaming)entry.getKey();
-            Integer type = (Integer)entry.getValue();
+        Map<FileNaming, Integer> changes = refresh(fpi, fpiName);
+        for (Map.Entry<FileNaming, Integer> entry : changes.entrySet()) {
+            FileNaming pItem = entry.getKey();
+            Integer type = entry.getValue();
             if (type == ChildrenCache.ADDED_CHILD) {
                 assertTrue (added.contains(pItem.getName()));
             }
@@ -462,12 +456,10 @@ public class ChildrenSupportTest extends NbTestCase {
         assertTrue (added1.mkdirs());
         assertTrue (added2.mkdirs());
 
-        Map changes = refresh(fpi, fpiName);
-        Iterator it = changes.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry entry = (Map.Entry) it.next();
-            FileNaming pItem = (FileNaming)entry.getKey();
-            Integer type = (Integer)entry.getValue();
+        Map<FileNaming, Integer> changes = refresh(fpi, fpiName);
+        for (Map.Entry<FileNaming, Integer> entry : changes.entrySet()) {
+            FileNaming pItem = entry.getKey();
+            Integer type = entry.getValue();
             assertEquals("removed1", pItem.getName());
         }
         assertTrue (changes.size() == 1);

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/providers/InterceptionListenerTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/providers/InterceptionListenerTest.java
@@ -20,8 +20,6 @@
 package org.netbeans.modules.masterfs.providers;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.Set;
 import javax.swing.Action;
 import org.netbeans.junit.MockServices;
@@ -51,11 +49,9 @@ public class InterceptionListenerTest extends NbTestCase  {
     }
 
     private InterceptionListenerImpl lookupImpl() {
-        Lookup.Result result = Lookups.metaInfServices(Thread.currentThread().getContextClassLoader()).
+        Lookup.Result<BaseAnnotationProvider> result = Lookups.metaInfServices(Thread.currentThread().getContextClassLoader()).
                 lookup(new Lookup.Template(BaseAnnotationProvider.class));
-        Collection all = result.allInstances();
-        for (Iterator it = all.iterator(); it.hasNext();) {
-            BaseAnnotationProvider ap = (BaseAnnotationProvider) it.next();
+        for (BaseAnnotationProvider ap : result.allInstances()) {
             InterceptionListener iil = ap.getInterceptionListener();
             if (iil != null && !(iil instanceof ProvidedExtensions)) {
                 return (InterceptionListenerImpl)iil;
@@ -136,11 +132,10 @@ public class InterceptionListenerTest extends NbTestCase  {
         }
 
         private InterceptionListenerImpl impl = new InterceptionListenerImpl(this);
-        public String annotateName(String name, java.util.Set files) {
+        @Override
+        public String annotateName(String name, Set<? extends FileObject> files) {
             java.lang.StringBuffer sb = new StringBuffer(name);
-            Iterator it = files.iterator();
-            while (it.hasNext()) {
-                FileObject fo = (FileObject)it.next();
+            for (FileObject fo : files) {
                 try {
                     sb.append("," +fo.getNameExt());//NOI18N
                 } catch (Exception ex) {
@@ -155,7 +150,8 @@ public class InterceptionListenerTest extends NbTestCase  {
             return icon;
         }
         
-        public String annotateNameHtml(String name, Set files) {
+        @Override
+        public String annotateNameHtml(String name, Set<? extends FileObject> files) {
             return annotateName(name, files);
         }
         

--- a/platform/netbinox/test/unit/src/org/netbeans/SetupHid.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/SetupHid.java
@@ -28,7 +28,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -128,11 +127,9 @@ public abstract class SetupHid extends NbTestCase {
         OutputStream os = new FileOutputStream(jar);
         try {
             JarOutputStream jos = new JarOutputStream(os, m);
-            Iterator it = contents.entrySet().iterator();
-            while (it.hasNext()) {
-                Map.Entry entry = (Map.Entry) it.next();
-                String path = (String) entry.getKey();
-                byte[] data = ((String) entry.getValue()).getBytes("UTF-8");
+            for (Map.Entry<String, String> entry : contents.entrySet()) {
+                String path =  entry.getKey();
+                byte[] data = entry.getValue().getBytes("UTF-8");
                 JarEntry je = new JarEntry(path);
                 je.setSize(data.length);
                 CRC32 crc = new CRC32();

--- a/platform/o.n.bootstrap/src/org/netbeans/Util.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Util.java
@@ -454,9 +454,8 @@ public final class Util {
         /** Fire changes to all result listeners. */
         public void changed() {
             synchronized (results) {
-                Iterator it = results.iterator();
-                while (it.hasNext()) {
-                    ((ModuleResult)it.next()).changed();
+                for (ModuleResult mr : results) {
+                    mr.changed();
                 }
             }
         }

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
@@ -129,11 +129,11 @@ public abstract class SetupHid extends NbTestCase {
         OutputStream os = new FileOutputStream(jar);
         try {
             JarOutputStream jos = new JarOutputStream(os, m);
-            Iterator it = contents.entrySet().iterator();
+            Iterator<Map.Entry<String, String>> it = contents.entrySet().iterator();
             while (it.hasNext()) {
-                Map.Entry entry = (Map.Entry) it.next();
-                String path = (String) entry.getKey();
-                byte[] data = ((String) entry.getValue()).getBytes("UTF-8");
+                Map.Entry<String, String> entry = it.next();
+                String path = entry.getKey();
+                byte[] data = entry.getValue().getBytes("UTF-8");
                 JarEntry je = new JarEntry(path);
                 je.setSize(data.length);
                 CRC32 crc = new CRC32();

--- a/platform/o.n.swing.outline/nbproject/project.properties
+++ b/platform/o.n.swing.outline/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ColumnSelectionPanel.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ColumnSelectionPanel.java
@@ -226,10 +226,10 @@ class ColumnSelectionPanel extends JPanel {
         if (columnModel == null) {
             return;
         }
-        for (Iterator it = checkBoxes.keySet().iterator(); it.hasNext(); ) {
-            ETableColumn etc = (ETableColumn) it.next();
-            JCheckBox checkBox = checkBoxes.get (etc);
-            columnModel.setColumnHidden(etc,! checkBox.isSelected());
+        for (Map.Entry<ETableColumn, JCheckBox> entry : checkBoxes.entrySet()) {
+            ETableColumn etc = entry.getKey();
+            JCheckBox checkBox = entry.getValue();
+            columnModel.setColumnHidden(etc, !checkBox.isSelected());
         }
     }
     

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
@@ -2157,7 +2157,7 @@ public class ETable extends JTable {
             implements DocumentListener, FocusListener {
         
         /** The last search results */
-        private List results = new ArrayList();
+        private List<Integer> results = new ArrayList<>();
         /** The last selected index from the search results. */
         private int currentSelectionIndex;
         
@@ -2226,8 +2226,7 @@ public class ETable extends JTable {
                 int rows[] = getSelectedRows();
                 int selectedRowIndex = (rows == null || rows.length == 0) ? 0 : rows[0];
                 int r = 0;
-                for (Iterator it = results.iterator(); it.hasNext(); r++) {
-                    int curResult = ((Integer)it.next()).intValue();
+                for (int curResult : results) {
                     if (selectedRowIndex <= curResult) {
                         currentSelectionIndex = r;
                         break;
@@ -2246,7 +2245,7 @@ public class ETable extends JTable {
                 if (currentSelectionIndex >= sz) {
                     currentSelectionIndex = sz - 1;
                 }
-                int selRow = ((Integer)results.get(currentSelectionIndex)).intValue();
+                int selRow = results.get(currentSelectionIndex);
                 setRowSelectionInterval(selRow, selRow);
                 Rectangle rect = getCellRect(selRow, 0, true);
                 scrollRectToVisible(rect);

--- a/platform/openide.actions/src/org/openide/actions/NewAction.java
+++ b/platform/openide.actions/src/org/openide/actions/NewAction.java
@@ -156,14 +156,11 @@ public final class NewAction extends NodeAction {
 
         private NewType[] newTypes() {
             if (lookup != null) {
-                java.util.Collection c = lookup.lookupResult(Node.class).allItems();
+                java.util.Collection<? extends Lookup.Item<Node>> c = lookup.lookupResult(Node.class).allItems();
 
                 if (c.size() == 1) {
-                    java.util.Iterator it = c.iterator();
-
-                    while (it.hasNext()) {
-                        Lookup.Item item = (Lookup.Item) it.next();
-                        Node n = (Node) item.getInstance();
+                    for (Lookup.Item<Node> item : c) {
+                        Node n = item.getInstance();
 
                         if (n != null) {
                             if (n == prevNode && prevTypes != null) {

--- a/platform/openide.actions/src/org/openide/actions/ToolsAction.java
+++ b/platform/openide.actions/src/org/openide/actions/ToolsAction.java
@@ -362,10 +362,10 @@ public class ToolsAction extends SystemAction implements ContextAwareAction, Pre
 
                     removeAll();
 
-                    Iterator it = generate(toolsAction, false).iterator();
+                    Iterator<JMenuItem> it = generate(toolsAction, false).iterator();
 
                     while (it.hasNext()) {
-                        java.awt.Component item = (java.awt.Component) it.next();
+                        JMenuItem item = it.next();
 
                         if (item == null) {
                             addSeparator();

--- a/platform/openide.explorer/nbproject/project.properties
+++ b/platform/openide.explorer/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.main.page=org/openide/explorer/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EditableDisplayerTest.java
+++ b/platform/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EditableDisplayerTest.java
@@ -45,7 +45,7 @@ import java.beans.PropertyEditor;
 import java.beans.PropertyEditorSupport;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Hashtable;
-import java.util.Iterator;
+import java.util.Map;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -523,7 +523,7 @@ public class EditableDisplayerTest extends NbTestCase {
             System.err.println("Cannot run test in < 16 bit graphics environment");
         }
         Component[] c = jp.getComponents();
-        Hashtable map = new Hashtable();
+        Hashtable<EditablePropertyDisplayer, RendererPropertyDisplayer> map = new Hashtable<>();
         synchronized (jp.getTreeLock()) {
             for (int i=0; i < c.length; i++) {
                 System.err.println("  Checking " + c[i]);
@@ -547,11 +547,9 @@ public class EditableDisplayerTest extends NbTestCase {
         
         jp.repaint();
         
-        
-        Iterator i = map.keySet().iterator();
-        while (i.hasNext()) {
-            EditablePropertyDisplayer editable = (EditablePropertyDisplayer) i.next();
-            RendererPropertyDisplayer renderer = (RendererPropertyDisplayer) map.get(editable);
+        for (Map.Entry<EditablePropertyDisplayer, RendererPropertyDisplayer> entry : map.entrySet()) {
+            EditablePropertyDisplayer editable = entry.getKey();
+            RendererPropertyDisplayer renderer = entry.getValue();
             assertPaintIdentically("Painting was not a pixel-for-pixel match between " + editable + " and " + renderer, editable, renderer);
             //            assertEquals("Preferred size of a renderer and an editor should match.  They do not for " + editable + " and " + renderer, getPreferredSize(editable), getPreferredSize(renderer));
         }

--- a/platform/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
@@ -379,17 +379,14 @@ abstract class AbstractFolder extends FileObject {
             return EMPTY_ARRAY;
         }
 
-        Iterator it = map.values().iterator();
-        ArrayList<FileObject> ll = new ArrayList<FileObject>(map.size() + 2);
+        ArrayList<FileObject> ll = new ArrayList<>(map.size() + 2);
 
-        while (it.hasNext()) {
-            Reference r = (Reference) it.next();
-
+        for (Reference<AbstractFolder> r : map.values()) {
             if (r == null) {
                 continue;
             }
 
-            AbstractFolder fo = (AbstractFolder) r.get();
+            AbstractFolder fo = r.get();
 
             if (fo != null /*&& (!fo.isFolder () || fo.map != null)*/    ) {
                 // if the file object exists and either is not folder (then

--- a/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
@@ -75,7 +75,7 @@ final class MultiFileObject extends AbstractFolder implements FileObject.Priorit
     /** list of objects that we delegate to and that already
     * has been created.
     */
-    private Set delegates;
+    private Set<FileObject> delegates;
 
     /** current delegate (the first object to delegate to), never null */
     private FileObject leader;
@@ -170,8 +170,8 @@ final class MultiFileObject extends AbstractFolder implements FileObject.Priorit
         MultiFileSystem mfs = getMultiFileSystem();
         FileSystem[] arr = mfs.getDelegates();
 
-        Set now = (delegates == null) ? Collections.EMPTY_SET : delegates;
-        Set<FileObject> del = new HashSet<FileObject>(arr.length * 2);
+        Set<FileObject> now = (delegates == null) ? Collections.emptySet() : delegates;
+        Set<FileObject> del = new HashSet<>(arr.length * 2);
         Number maxWeight = 0;
         FileObject led = null;
 
@@ -204,9 +204,7 @@ final class MultiFileObject extends AbstractFolder implements FileObject.Priorit
             }
         }
 
-        Iterator it = now.iterator();
-        while (it.hasNext()) {
-            FileObject fo = (FileObject) it.next();
+        for (FileObject fo : now) {
             fo.removeFileChangeListener(weakL);
         }
 

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
@@ -861,10 +861,8 @@ public final class XMLFileSystem extends AbstractFileSystem {
                 foAttrs = new XMLMapAttr();
             }
 
-            Iterator it = attrs.entrySet().iterator();
             boolean ch = false;
-            while (it.hasNext()) {
-                Map.Entry attrEntry = (Map.Entry) it.next();
+            for (Map.Entry<String, XMLMapAttr.Attr> attrEntry : attrs.entrySet()) {
                 Object prev = foAttrs.put(attrEntry.getKey(), attrEntry.getValue());
                 
                 ch |= (prev == null && attrEntry.getValue() != null) || !prev.equals(attrEntry.getValue());
@@ -1212,7 +1210,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
                     if (XMLMapAttr.Attr.isValid(key) != -1) {
                         XMLMapAttr.Attr attr = XMLMapAttr.createAttributeAndDecode(key, value);
                         XMLMapAttr attrMap = topRE.getAttr(true);
-                        Object retVal = attrMap.put(foName, attr);
+                        XMLMapAttr.Attr retVal = attrMap.put(foName, attr);
 
                         if (retVal != null) {
                             attrMap.put(foName, retVal);

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -108,8 +108,8 @@ import org.openide.util.io.NbObjectInputStream;
  * @author rmatous
  */
 @SuppressWarnings("unchecked")
-final class XMLMapAttr implements Map {
-    Map/*<String,Attr>*/ map;
+final class XMLMapAttr implements Map<String, XMLMapAttr.Attr> {
+    Map<String, XMLMapAttr.Attr> map;
 
     /** Creates new XMLMapAttr and delegetaor is instanced */
     public XMLMapAttr() {
@@ -155,11 +155,12 @@ final class XMLMapAttr implements Map {
     * @param p1 is name of attribute
     * @return attribute, which is hold in XMLMapAttr.Attr or null if such attribute doesn`t exist or isn`t able to construct form String representation
     */
-    public Object get(final Object p1) {
-        Object obj;
+    @Override
+    public Attr get(final Object p1) {
+        Attr obj;
 
         try {
-            obj = getAttribute(p1);
+            obj = (Attr) getAttribute(p1);
         } catch (Exception e) {
             obj = null;
             ExternalUtil.LOG.log(Level.INFO, p1.toString(), e);
@@ -172,7 +173,7 @@ final class XMLMapAttr implements Map {
      * @param params has sense only for methodvalue invocation; and only 2 parametres will be used
      * @return attribute, which is hold in XMLMapAttr.Attr or null if such attribute doesn`t exist or isn`t able to construct form String representation
      */
-    public Object get(final Object p1, Object[] params) {
+    public Object get(final String p1, Object[] params) {
         Object obj;
 
         try {
@@ -199,7 +200,7 @@ final class XMLMapAttr implements Map {
         attrName = (String) keyValuePair[0];
 
         synchronized (this) {
-            attr = (Attr) map.get(attrName);
+            attr = map.get(attrName);
         }
 
         Object retVal = null;
@@ -250,23 +251,24 @@ final class XMLMapAttr implements Map {
      * @return previous value associated with specified key, or null if there was no mapping for key.
      * A null return can also indicate that the HashMap previously associated null with the specified key.
      */
-    public synchronized Object put(final Object p1, final Object p2) {
+    @Override
+    public synchronized Attr put(final String p1, final Attr p2) {
         return put(p1, p2, true);
     }
 
-    synchronized Object put(final Object p1, final Object p2, boolean decode) {
+    synchronized Attr put(final String p1, final Object p2, boolean decode) {
         if ((p1 == null) || !(p1 instanceof String)) {
             return null;
         }
 
-        Object[] keyValuePair = ModifiedAttribute.translateInto((String) p1, p2);
+        Object[] keyValuePair = ModifiedAttribute.translateInto(p1, p2);
         String key = (String) keyValuePair[0];
         Object value = keyValuePair[1];
-        Object toStore;
+        Attr toStore;
         if (value == null) {
             toStore = null;
         } else if (value instanceof Attr) {
-            toStore = value;
+            toStore = (Attr) value;
         } else if (value instanceof Method && key.startsWith("methodvalue:")) { // NOI18N
             Method m = (Method)value;
             key = key.substring("methodvalue:".length()); // NOI18N
@@ -319,14 +321,14 @@ final class XMLMapAttr implements Map {
         }
 
         //pw.println(blockPrefix+"<fileobject name=\""+fileName+"\">");// NOI18N
-        SortedSet<String> attrNames = new TreeSet<String>();
-        Iterator entryIter = map.entrySet().iterator();
+        SortedSet<String> attrNames = new TreeSet<>();
+        Iterator<Entry<String, Attr>> entryIter = map.entrySet().iterator();
 
         while (entryIter.hasNext()) {
-            Map.Entry entry = (Map.Entry) entryIter.next();
+            Map.Entry<String, Attr> entry = entryIter.next();
 
-            String attrName = (String) entry.getKey();
-            Attr attr = (Attr) entry.getValue();
+            String attrName = entry.getKey();
+            Attr attr = entry.getValue();
 
             if ((attrName == null) || (attr == null) || (attrName.length() == 0) || (attr.isValid() == -1)) {
                 if ((attrName != null) && (attrName.length() != 0) && ((attr == null) || (attr.isValid() == -1))) {
@@ -339,11 +341,8 @@ final class XMLMapAttr implements Map {
             attrNames.add(attrName);
         }
 
-        entryIter = attrNames.iterator();
-
-        while (entryIter.hasNext()) {
-            String attrName = (String) entryIter.next();
-            Attr attr = (Attr) map.get(attrName);
+        for (String attrName : attrNames) {
+            Attr attr = map.get(attrName);
 
             if (attr != null) {
                 attr.transformMe();
@@ -386,10 +385,12 @@ final class XMLMapAttr implements Map {
         map.clear();
     }
 
-    public synchronized Object remove(Object p1) {
+    @Override
+    public synchronized Attr remove(Object p1) {
         return map.remove(p1);
     }
 
+    @Override
     public synchronized boolean containsValue(Object p1) {
         return map.containsValue(p1);
     }
@@ -399,20 +400,24 @@ final class XMLMapAttr implements Map {
         return map.hashCode();
     }
 
-    public synchronized java.util.Set<String> keySet() {
+    @Override
+    public synchronized Set<String> keySet() {
         return map.keySet();
     }
 
-    public synchronized java.util.Collection values() {
+    @Override
+    public synchronized java.util.Collection<Attr> values() {
         return map.values();
     }
 
     // XXX this is wrong - values not translated
-    public synchronized java.util.Set entrySet() {
+    @Override
+    public synchronized Set<Map.Entry<String, Attr>> entrySet() {
         return map.entrySet();
     }
 
-    public synchronized void putAll(java.util.Map p1) {
+    @Override
+    public synchronized void putAll(java.util.Map<? extends String,? extends Attr> p1) {
         map.putAll(p1);
     }
 

--- a/platform/openide.loaders/src/org/openide/loaders/DataLoaderPool.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataLoaderPool.java
@@ -570,10 +570,8 @@ implements java.io.Serializable {
                 // [PENDING] in the future a more efficient API may be introduced
                 // (actually currently you can look up with a template giving the name
                 // as part of the lookup item ID but this is not an official API)
-                Iterator modules = Lookup.getDefault().lookupAll(ModuleInfo.class).iterator();
                 boolean ok = false;
-                while (modules.hasNext()) {
-                    ModuleInfo module = (ModuleInfo)modules.next();
+                for (ModuleInfo module : Lookup.getDefault().lookupAll(ModuleInfo.class)) {
                     if (module.getCodeNameBase().equals(modulename)) {
                         if (module.isEnabled()) {
                             // Carry on.

--- a/platform/openide.loaders/src/org/openide/loaders/DataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataObject.java
@@ -273,11 +273,9 @@ implements Node.Cookie, Serializable, HelpCtx.Provider, Lookup.Provider {
     /** Mark all contained files as belonging to this loader.
      * If the files are rescanned (e.g. after a disposal), the current data loader will be given preference.
     */
-    protected final void markFiles () throws IOException {
-        Iterator en = files ().iterator ();
-        while (en.hasNext ()) {
-            FileObject fo = (FileObject)en.next ();
-            loader.markFile (fo);
+    protected final void markFiles() throws IOException {
+        for (FileObject fo : files()) {
+            loader.markFile(fo);
         }
     }
 

--- a/platform/openide.loaders/src/org/openide/loaders/MultiDataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/MultiDataObject.java
@@ -385,11 +385,11 @@ public class MultiDataObject extends DataObject {
      */
     private void removeAllInvalid () {
         ERR.log(Level.FINE, "removeAllInvalid, started {0}", this); // NOI18N
-        Iterator it = checkSecondary ().entrySet ().iterator ();
+        Iterator<Map.Entry<FileObject,Entry>> it = checkSecondary ().entrySet ().iterator ();
         boolean fire = false;
         while (it.hasNext ()) {
-            Map.Entry e = (Map.Entry)it.next ();
-            FileObject fo = (FileObject)e.getKey ();
+            Map.Entry<FileObject,Entry> e = it.next ();
+            FileObject fo = e.getKey ();
             if (fo == null || !fo.isValid ()) {
                 it.remove ();
                 if (ERR.isLoggable(Level.FINE)) {

--- a/platform/openide.loaders/src/org/openide/loaders/XMLEntityResolverChain.java
+++ b/platform/openide.loaders/src/org/openide/loaders/XMLEntityResolverChain.java
@@ -92,26 +92,22 @@ final class XMLEntityResolverChain implements EntityResolver {
      * @return An InputSource object describing the new input source, 
      *         or null to request that the parser open a regular URI connection to the system identifier.
      */
+    @Override
     public InputSource resolveEntity(String publicID, String systemID) throws SAXException, IOException {
-        
         // user's resolver chain
         SAXException lsex = null;
         IOException lioex = null;
         
         synchronized (resolverChain) {
-            Iterator it = resolverChain.iterator();
-            while (it.hasNext()) {
-                EntityResolver resolver = (EntityResolver) it.next();
+            for (EntityResolver resolver : resolverChain) {
                 try {
                     InputSource test = resolver.resolveEntity(publicID, systemID);
                     if (test == null) continue;
                     return test;
                 } catch (SAXException sex) {
                     lsex = sex;
-                    continue;
                 } catch (IOException ioex) {
                     lioex = ioex;
-                    continue;
                 }
             }
             

--- a/platform/openide.loaders/test/unit/src/org/openide/loaders/CreateFromTemplateTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/loaders/CreateFromTemplateTest.java
@@ -130,8 +130,9 @@ public class CreateFromTemplateTest extends NbTestCase {
             super(mo, fo);
         }
         
+        @Override
         protected java.text.Format createFormat(FileObject target, String n, String e) {
-            return new MapFormat(Collections.emptyMap());
+            return new MapFormat(Collections.<String, Object>emptyMap());
         }
     }
     

--- a/platform/openide.modules/test/unit/src/org/openide/modules/DependencyTest.java
+++ b/platform/openide.modules/test/unit/src/org/openide/modules/DependencyTest.java
@@ -76,11 +76,11 @@ public class DependencyTest extends NbTestCase {
     }
     
     public void testParseMultiple() throws Exception {
-        Set multiple = Dependency.create(Dependency.TYPE_MODULE, " org.foo/1 > 0.1, org.bar  ");
+        Set<Dependency> multiple = Dependency.create(Dependency.TYPE_MODULE, " org.foo/1 > 0.1, org.bar  ");
         assertTrue(multiple.size() == 2);
-        Iterator it = multiple.iterator();
-        Dependency d1 = (Dependency)it.next();
-        Dependency d2 = (Dependency)it.next();
+        Iterator<Dependency> it = multiple.iterator();
+        Dependency d1 = it.next();
+        Dependency d2 = it.next();
         if (d1.getName().equals("org.bar")) {
             // Swap so they are in order.
             Dependency tmp = d1;

--- a/platform/openide.nodes/nbproject/project.properties
+++ b/platform/openide.nodes/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.main.page=org/openide/nodes/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesRegistrationSupport.java
+++ b/platform/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesRegistrationSupport.java
@@ -45,9 +45,9 @@ public final class NodesRegistrationSupport {
     static final String PACKAGE = "packagePath"; //NOI18N
     static final String EDITOR_CLASS = "propertyEditorClass"; //NOI18N
     
-    private static AbstractRegistrator clsReg = null;
-    private static AbstractRegistrator beanInfoReg = null;
-    private static AbstractRegistrator pkgReg = null;
+    private static AbstractRegistrator<PEClassRegistration> clsReg = null;
+    private static AbstractRegistrator<BeanInfoRegistration> beanInfoReg = null;
+    private static AbstractRegistrator<PEPackageRegistration> pkgReg = null;
     
     private static List<String> originalPath = null;
     private static List<String> originalBeanInfoSearchPath = null;
@@ -55,13 +55,12 @@ public final class NodesRegistrationSupport {
     public static synchronized void registerPropertyEditors() {
         
         if (clsReg == null) {
-            clsReg = new AbstractRegistrator(PEClassRegistration.class) {
+            clsReg = new AbstractRegistrator<PEClassRegistration>(PEClassRegistration.class) {
 
                 @Override
                 void register() {
                     ClassLoader clsLoader = findClsLoader();
-                    for (Iterator it = lookupResult.allInstances().iterator(); it.hasNext();) {
-                        PEClassRegistration clsReg = (PEClassRegistration) it.next();
+                    for (PEClassRegistration clsReg : lookupResult.allInstances()) {
                         for (String type : clsReg.targetTypes) {
                             try {
                                 Class<?> cls = getClassFromCanonicalName(type);
@@ -83,13 +82,12 @@ public final class NodesRegistrationSupport {
         }
         
         if (pkgReg == null) {
-            pkgReg = new AbstractRegistrator(PEPackageRegistration.class) {
+            pkgReg = new AbstractRegistrator<PEPackageRegistration>(PEPackageRegistration.class) {
 
                 @Override
                 void register() {
-                    Set<String> newPath = new LinkedHashSet<String> ();
-                    for (Iterator it = lookupResult.allInstances().iterator(); it.hasNext();) {
-                        PEPackageRegistration pkgReg = (PEPackageRegistration) it.next();
+                    Set<String> newPath = new LinkedHashSet<>();
+                    for (PEPackageRegistration pkgReg : lookupResult.allInstances()) {
                         newPath.add(pkgReg.pkg);
                     }
                     newPath.addAll(originalPath);
@@ -108,13 +106,12 @@ public final class NodesRegistrationSupport {
         }
         
         if (beanInfoReg == null) {
-            beanInfoReg = new AbstractRegistrator(BeanInfoRegistration.class) {
+            beanInfoReg = new AbstractRegistrator<BeanInfoRegistration>(BeanInfoRegistration.class) {
 
                 @Override
                 void register() {
-                    Set<String> newPath = new LinkedHashSet<String> ();
-                    for (Iterator it = lookupResult.allInstances().iterator(); it.hasNext();) {
-                        BeanInfoRegistration biReg = (BeanInfoRegistration) it.next();
+                    Set<String> newPath = new LinkedHashSet<>();
+                    for (BeanInfoRegistration biReg : lookupResult.allInstances()) {
                         newPath.add(biReg.searchPath);
                     }
                     newPath.addAll(originalBeanInfoSearchPath);
@@ -237,11 +234,11 @@ public final class NodesRegistrationSupport {
         }
     }
     
-    private static abstract class AbstractRegistrator implements LookupListener {
-        Result lookupResult;
-        private final Class cls;
+    private static abstract class AbstractRegistrator<T> implements LookupListener {
+        Result<T> lookupResult;
+        private final Class<T> cls;
         
-        AbstractRegistrator(Class cls) {
+        AbstractRegistrator(Class<T> cls) {
             this.cls = cls;
             init();
             lookupResult = Lookup.getDefault().lookupResult(cls);

--- a/platform/openide.nodes/src/org/openide/nodes/CookieSet.java
+++ b/platform/openide.nodes/src/org/openide/nodes/CookieSet.java
@@ -201,7 +201,7 @@ public final class CookieSet extends Object implements Lookup.Provider {
             return;
         }
         Collection<? extends Lookup.Item<?>> items = lookup.lookupResult(clazz).allItems();
-        if (items.size() == 0) {
+        if (items.isEmpty()) {
             return;
         }
         AbstractLookup.Pair[] arr = new AbstractLookup.Pair[items.size()];
@@ -261,12 +261,12 @@ public final class CookieSet extends Object implements Lookup.Provider {
     }
 
     /** Returns list of all classes. */
-    static Set exitAllClassesMode(Object prev) {
+    static Set<Class<?>> exitAllClassesMode(Object prev) {
         Object cookie = QUERY_MODE.get();
         QUERY_MODE.set(prev);
 
         if (cookie instanceof HashSet) {
-            return (Set) cookie;
+            return (Set<Class<?>>) cookie;
         }
 
         return null;

--- a/platform/openide.nodes/src/org/openide/nodes/EntrySupportDefault.java
+++ b/platform/openide.nodes/src/org/openide/nodes/EntrySupportDefault.java
@@ -546,9 +546,7 @@ class EntrySupportDefault extends EntrySupport {
                 children.parent.fireSubNodesChange(false, arr, current);
             }
             // fire change of parent
-            Iterator it = nodes.iterator();
-            while (it.hasNext()) {
-                Node n = (Node) it.next();
+            for (Node n : nodes) {
                 n.deassignFrom(children);
                 n.fireParentNodeChange(children.parent, null);
             }

--- a/platform/openide.nodes/src/org/openide/nodes/NodeLookup.java
+++ b/platform/openide.nodes/src/org/openide/nodes/NodeLookup.java
@@ -23,7 +23,6 @@ import java.awt.EventQueue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import org.openide.util.Lookup.Template;
@@ -122,7 +121,7 @@ final class NodeLookup extends AbstractLookup {
     private void blockingBeforeLookup(Class<?> type) {
         if (type == Object.class) {
             // ok, this is likely query for everything
-            java.util.Set all;
+            Set<Class<?>> all;
             Object prev = null;
 
             try {
@@ -133,10 +132,7 @@ final class NodeLookup extends AbstractLookup {
                 all = CookieSet.exitAllClassesMode(prev);
             }
 
-            Iterator it = all.iterator();
-
-            while (it.hasNext()) {
-                Class c = (Class) it.next();
+            for (Class<?> c : all) {
                 updateLookupAsCookiesAreChanged(c);
             }
 

--- a/platform/openide.nodes/test/unit/src/org/openide/nodes/ChildrenArrayNodeAtShouldNotBeSlowTest.java
+++ b/platform/openide.nodes/test/unit/src/org/openide/nodes/ChildrenArrayNodeAtShouldNotBeSlowTest.java
@@ -20,7 +20,6 @@
 package org.openide.nodes;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.junit.RandomlyFails;
@@ -33,7 +32,7 @@ public class ChildrenArrayNodeAtShouldNotBeSlowTest extends NbTestCase {
     /** start time of the test */
     private long time;
     /** table with test resutls Integer -> Long */
-    private static HashMap times = new HashMap ();
+    private static Map<Integer, Long> times = new HashMap<>();
     /** node to work on */
     private Node node;
     
@@ -137,10 +136,7 @@ public class ChildrenArrayNodeAtShouldNotBeSlowTest extends NbTestCase {
         long max = Long.MIN_VALUE;
         int maxIndex = -1;
         {
-            Iterator it = times.entrySet ().iterator ();
-            int cnt = 0;
-            while (it.hasNext ()) {
-                Map.Entry en = (Map.Entry)it.next ();
+            for (Map.Entry<Integer, Long> en : times.entrySet()) {
                 error.append ("Test "); error.append (en.getKey ());
                 error.append (" took "); error.append (en.getValue ());
                 
@@ -153,8 +149,6 @@ public class ChildrenArrayNodeAtShouldNotBeSlowTest extends NbTestCase {
                     min = l.longValue ();
                 }
                 error.append (" ms\n");
-                
-                cnt++;
             }
         }
         

--- a/platform/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysTest.java
+++ b/platform/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysTest.java
@@ -30,13 +30,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -81,7 +79,6 @@ public class ChildrenKeysTest extends NbTestCase {
 
     public void testGetNodesFromTwoThreads57769() throws Exception {
         final Ticker tick1 = new Ticker();
-        final List who = new java.util.Vector();
         
         final int[] count = new int[1];
         Children children= new Children.Keys(lazy()) {
@@ -126,11 +123,6 @@ public class ChildrenKeysTest extends NbTestCase {
             StringWriter w = new StringWriter();
             PrintWriter pw = new PrintWriter(w);
             w.write("Just two nodes created: " + count[0] + " stacks:\n");
-            Iterator it = who.iterator();
-            while (it.hasNext()) {
-                Exception e = (Exception)it.next();
-                e.printStackTrace(pw);
-            }
             pw.close();
             
             fail(w.toString());
@@ -2175,7 +2167,7 @@ public class ChildrenKeysTest extends NbTestCase {
 
     public void testGetNodesFromTwoThreads57769WhenBlockingAtRightPlaces() throws Exception {
         final Ticker tick = new Ticker();
-        final List who = new java.util.Vector();
+        final List<Exception> who = new java.util.Vector<>();
         
         final int[] count = new int[1];
         class ChildrenKeys extends Children.Keys {
@@ -2242,9 +2234,7 @@ public class ChildrenKeysTest extends NbTestCase {
             StringWriter w = new StringWriter();
             PrintWriter pw = new PrintWriter(w);
             w.write("Just two nodes created: " + count[0] + " stacks:\n");
-            Iterator it = who.iterator();
-            while (it.hasNext()) {
-                Exception e = (Exception)it.next();
+            for (Exception e : who) {
                 e.printStackTrace(pw);
             }
             pw.close();

--- a/platform/openide.options/src/org/openide/options/SystemOption.java
+++ b/platform/openide.options/src/org/openide/options/SystemOption.java
@@ -131,17 +131,14 @@ public abstract class SystemOption extends SharedClassObject implements HelpCtx.
      */
     protected void reset() {
         synchronized (getLock()) {
-            Map m = (Map) getProperty(PROP_ORIGINAL_VALUES);
+            Map<?, ?> m = (Map<?, ?>) getProperty(PROP_ORIGINAL_VALUES);
 
             if ((m == null) || m.isEmpty()) {
                 return;
             }
 
-            java.util.Iterator it = m.entrySet().iterator();
 WHILE: 
-            while (it.hasNext()) {
-                Map.Entry e = (Map.Entry) it.next();
-
+            for (Map.Entry<?, ?> e : m.entrySet()) {
                 if (e.getValue() instanceof Box) {
                     Object value = ((Box) e.getValue()).value;
 

--- a/platform/openide.options/src/org/openide/options/VetoSystemOption.java
+++ b/platform/openide.options/src/org/openide/options/VetoSystemOption.java
@@ -45,11 +45,11 @@ public abstract class VetoSystemOption extends SystemOption {
     /** Lazy getter for veto hashtable.
     * @return the hashtable
     */
-    private HashSet getVeto() {
-        HashSet set = (HashSet) getProperty(PROP_VETO_SUPPORT);
+    private HashSet<VetoableChangeListener> getVeto() {
+        HashSet<VetoableChangeListener> set = (HashSet<VetoableChangeListener>) getProperty(PROP_VETO_SUPPORT);
 
         if (set == null) {
-            set = new HashSet();
+            set = new HashSet<>();
             putProperty(PROP_VETO_SUPPORT, set);
         }
 
@@ -84,14 +84,14 @@ public abstract class VetoSystemOption extends SystemOption {
     throws PropertyVetoException {
         PropertyChangeEvent ev = new PropertyChangeEvent(this, name, oldValue, newValue);
 
-        Iterator en;
+        HashSet<VetoableChangeListener> listeners;
 
         synchronized (getLock()) {
-            en = ((HashSet) getVeto().clone()).iterator();
+            listeners = (HashSet<VetoableChangeListener>) getVeto().clone();
         }
 
-        while (en.hasNext()) {
-            ((VetoableChangeListener) en.next()).vetoableChange(ev);
+        for (VetoableChangeListener listener : listeners) {
+            listener.vetoableChange(ev);
         }
     }
 }

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/ProxyLookup.java
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/ProxyLookup.java
@@ -147,10 +147,10 @@ public class ProxyLookup extends Lookup {
         
         class Notify implements Runnable {
             public void run() {
-                Iterator it = evAndListeners.iterator();
+                Iterator<Object> it = evAndListeners.iterator();
                 while (it.hasNext()) {
-                    LookupEvent ev = (LookupEvent)it.next();
-                    LookupListener l = (LookupListener)it.next();
+                    LookupEvent ev = (LookupEvent) it.next();
+                    LookupListener l = (LookupListener) it.next();
                     try {
                         l.resultChanged(ev);
                     } catch (RuntimeException x) {

--- a/platform/openide.util.lookup/test/unit/src/org/bar/Iterator2.java
+++ b/platform/openide.util.lookup/test/unit/src/org/bar/Iterator2.java
@@ -19,11 +19,13 @@
 
 package org.bar;
 
-public class Iterator2 implements java.util.Iterator {
+public class Iterator2<T> implements java.util.Iterator<T> {
+    @Override
     public boolean hasNext() {return false;}
     
-    public Object next() {return null;}
+    @Override
+    public T next() {return null;}
     
+    @Override
     public void remove() {}
-   
 }

--- a/platform/openide.util.lookup/test/unit/src/org/foo/impl/Iterator1.java
+++ b/platform/openide.util.lookup/test/unit/src/org/foo/impl/Iterator1.java
@@ -19,11 +19,14 @@
 
 package org.foo.impl;
 
-public class Iterator1 implements java.util.Iterator {
+public class Iterator1<T> implements java.util.Iterator<T> {
+    @Override
     public boolean hasNext() {return false;}
     
-    public Object next() {return null;}
+    @Override
+    public T next() {return null;}
     
+    @Override
     public void remove() {}
    
 }

--- a/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
@@ -441,7 +441,7 @@ public final class ImageUtilities {
         currentLoader = Thread.currentThread();
             
         if (loaderQuery == null) {
-            loaderQuery = Lookup.getDefault().lookup(new Lookup.Template<ClassLoader>(ClassLoader.class));
+            loaderQuery = Lookup.getDefault().lookup(new Lookup.Template<>(ClassLoader.class));
             loaderQuery.addLookupListener(
                 new LookupListener() {
                     public void resultChanged(LookupEvent ev) {
@@ -452,9 +452,9 @@ public final class ImageUtilities {
             );
         }
 
-        Iterator it = loaderQuery.allInstances().iterator();
+        Iterator<? extends ClassLoader> it = loaderQuery.allInstances().iterator();
         if (it.hasNext()) {
-            ClassLoader toReturn = (ClassLoader) it.next();
+            ClassLoader toReturn = it.next();
             if (currentLoader == Thread.currentThread()) {
                 currentLoader = toReturn;
             }

--- a/platform/openide.util/src/org/openide/util/BaseUtilities.java
+++ b/platform/openide.util/src/org/openide/util/BaseUtilities.java
@@ -1257,9 +1257,9 @@ widthcheck:  {
      */
     public static <T> List<T> topologicalSort(Collection<? extends T> c, Map<? super T, ? extends Collection<? extends T>> edges)
     throws TopologicalSortException {
-        Map<T,Boolean> finished = new HashMap<T,Boolean>();
-        List<T> r = new ArrayList<T>(Math.max(c.size(), 1));
-        List<T> cRev = new ArrayList<T>(c);
+        Map<T,Boolean> finished = new HashMap<>();
+        List<T> r = new ArrayList<>(Math.max(c.size(), 1));
+        List<T> cRev = new ArrayList<>(c);
         Collections.reverse(cRev);
 
         Iterator<T> it = cRev.iterator();
@@ -1304,7 +1304,7 @@ widthcheck:  {
                 return null;
             }
 
-            ArrayList<T> cycle = new ArrayList<T>();
+            ArrayList<T> cycle = new ArrayList<>();
             cycle.add(node);
             finished.put(node, null);
 

--- a/platform/openide.util/src/org/openide/util/MapFormat.java
+++ b/platform/openide.util/src/org/openide/util/MapFormat.java
@@ -66,7 +66,7 @@ public class MapFormat extends Format {
     private String rdel = "}"; // NOI18N
 
     /** Used formatting map */
-    private Map argmap;
+    private Map<String, ? extends Object> argmap;
 
     /** Offsets to {} expressions */
     private int[] offsets;
@@ -88,7 +88,7 @@ public class MapFormat extends Format {
     * For common work use  <code>format(pattern, arguments) </code>.
     * @param arguments keys and values to use in the format
     */
-    public MapFormat(Map arguments) {
+    public MapFormat(Map<String, ? extends Object> arguments) {
         super();
         setMap(arguments);
     }
@@ -310,14 +310,13 @@ public class MapFormat extends Format {
     */
     public String parse(String source) {
         StringBuffer sbuf = new StringBuffer(source);
-        Iterator key_it = argmap.keySet().iterator();
 
         //skipped = new RangeList();
         // What was this for??
         //process(source, "\"", "\""); // NOI18N
-        while (key_it.hasNext()) {
-            String it_key = (String) key_it.next();
-            String it_obj = formatObject(argmap.get(it_key));
+        for (Map.Entry<String, ? extends Object> keyEntry : argmap.entrySet()) {
+            String it_key = keyEntry.getKey();
+            String it_obj = formatObject(keyEntry.getValue());
             int it_idx = -1;
 
             do {
@@ -395,7 +394,7 @@ public class MapFormat extends Format {
     }
 
     /** Returns argument map */
-    public Map getMap() {
+    public Map<String, ? extends Object> getMap() {
         return argmap;
     }
 
@@ -407,7 +406,7 @@ public class MapFormat extends Format {
     *
     * @param map the argument map
     */
-    public void setMap(Map map) {
+    public void setMap(Map<String, ? extends Object> map) {
         argmap = map;
     }
 

--- a/platform/openide.util/src/org/openide/util/NbCollections.java
+++ b/platform/openide.util/src/org/openide/util/NbCollections.java
@@ -63,11 +63,9 @@ public class NbCollections {
      *         to the named type (or they may be null)
      * @throws ClassCastException if some entry in the raw set was not well-typed, and only if <code>strict</code> was true
      */
-    public static <E> Set<E> checkedSetByCopy(Set rawSet, Class<E> type, boolean strict) throws ClassCastException {
-        Set<E> s = new HashSet<E>(rawSet.size() * 4 / 3 + 1);
-        Iterator it = rawSet.iterator();
-        while (it.hasNext()) {
-            Object e = it.next();
+    public static <E> Set<E> checkedSetByCopy(Set<?> rawSet, Class<E> type, boolean strict) throws ClassCastException {
+        Set<E> s = new HashSet<>(rawSet.size() * 4 / 3 + 1);
+        for (Object e : rawSet) {
             try {
                 s.add(type.cast(e));
             } catch (ClassCastException x) {
@@ -91,11 +89,9 @@ public class NbCollections {
      *         to the named type (or they may be null)
      * @throws ClassCastException if some entry in the raw list was not well-typed, and only if <code>strict</code> was true
      */
-    public static <E> List<E> checkedListByCopy(List rawList, Class<E> type, boolean strict) throws ClassCastException {
-        List<E> l = (rawList instanceof RandomAccess) ? new ArrayList<E>(rawList.size()) : new LinkedList<E>();
-        Iterator it = rawList.iterator();
-        while (it.hasNext()) {
-            Object e = it.next();
+    public static <E> List<E> checkedListByCopy(List<?> rawList, Class<E> type, boolean strict) throws ClassCastException {
+        List<E> l = (rawList instanceof RandomAccess) ? new ArrayList<>(rawList.size()) : new LinkedList<>();
+        for (Object e : rawList) {
             try {
                 l.add(type.cast(e));
             } catch (ClassCastException x) {
@@ -120,11 +116,9 @@ public class NbCollections {
      *         to the named types (or they may be null)
      * @throws ClassCastException if some key or value in the raw map was not well-typed, and only if <code>strict</code> was true
      */
-    public static <K,V> Map<K,V> checkedMapByCopy(Map rawMap, Class<K> keyType, Class<V> valueType, boolean strict) throws ClassCastException {
-        Map<K,V> m2 = new HashMap<K,V>(rawMap.size() * 4 / 3 + 1);
-        Iterator it = rawMap.entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry e = (Map.Entry) it.next();
+    public static <K,V> Map<K,V> checkedMapByCopy(Map<?, ?> rawMap, Class<K> keyType, Class<V> valueType, boolean strict) throws ClassCastException {
+        Map<K,V> m2 = new HashMap<>(rawMap.size() * 4 / 3 + 1);
+        for (Map.Entry<? extends Object, ? extends Object> e : rawMap.entrySet()) {
             try {
                 m2.put(keyType.cast(e.getKey()), valueType.cast(e.getValue()));
             } catch (ClassCastException x) {
@@ -142,15 +136,16 @@ public class NbCollections {
 
         private static final Object WAITING = new Object();
 
-        private final Iterator it;
+        private final Iterator<?> it;
         private Object next = WAITING;
 
-        public CheckedIterator(Iterator it) {
+        public CheckedIterator(Iterator<?> it) {
             this.it = it;
         }
 
         protected abstract boolean accept(Object o);
 
+        @Override
         public boolean hasNext() {
             if (next != WAITING) {
                 return true;
@@ -165,6 +160,7 @@ public class NbCollections {
             return false;
         }
 
+        @Override
         public E next() {
             if (next == WAITING && !hasNext()) {
                 throw new NoSuchElementException();
@@ -176,6 +172,7 @@ public class NbCollections {
             return x;
         }
 
+        @Override
         public void remove() {
             it.remove();
         }
@@ -191,7 +188,7 @@ public class NbCollections {
      *               if true, {@link ClassCastException} may be thrown from an iterator operation
      * @return an iterator guaranteed to contain only objects of the requested type (or null)
      */
-    public static <E> Iterator<E> checkedIteratorByFilter(Iterator rawIterator, final Class<E> type, final boolean strict) {
+    public static <E> Iterator<E> checkedIteratorByFilter(Iterator<?> rawIterator, final Class<E> type, final boolean strict) {
         return new CheckedIterator<E>(rawIterator) {
             protected boolean accept(Object o) {
                 if (o == null) {
@@ -222,8 +219,8 @@ public class NbCollections {
      *               if true, a {@link ClassCastException} may arise during some set operation
      * @return a view over the raw set guaranteed to match the specified type
      */
-    public static <E> Set<E> checkedSetByFilter(Set rawSet, Class<E> type, boolean strict) {
-        return new CheckedSet<E>(rawSet, type, strict);
+    public static <E> Set<E> checkedSetByFilter(Set<?> rawSet, Class<E> type, boolean strict) {
+        return new CheckedSet<>(rawSet, type, strict);
     }
     private static final class CheckedSet<E> extends AbstractSet<E> implements Serializable {
 
@@ -264,9 +261,8 @@ public class NbCollections {
         @Override
         public int size() {
             int c = 0;
-            Iterator it = rawSet.iterator();
-            while (it.hasNext()) {
-                if (acceptEntry(it.next())) {
+            for (Object e : rawSet) {
+                if (acceptEntry(e)) {
                     c++;
                 }
             }
@@ -365,9 +361,8 @@ public class NbCollections {
             @Override
             public int size() {
                 int c = 0;
-                Iterator it = rawMap.entrySet().iterator();
-                while (it.hasNext()) {
-                    if (acceptEntry((Map.Entry) it.next())) {
+                for (Object e : rawMap.entrySet()) {
+                    if (acceptEntry((Map.Entry) e)) {
                         c++;
                     }
                 }
@@ -430,9 +425,8 @@ public class NbCollections {
         @Override
         public int size() {
             int c = 0;
-            Iterator it = rawMap.entrySet().iterator();
-            while (it.hasNext()) {
-                if (acceptEntry((Map.Entry) it.next())) {
+            for (Object e : rawMap.entrySet()) {
+                if (acceptEntry((Map.Entry) e)) {
                     c++;
                 }
             }

--- a/platform/openide.util/src/org/openide/util/RE13.java
+++ b/platform/openide.util/src/org/openide/util/RE13.java
@@ -121,8 +121,9 @@ ALL:
     }
 
     /** Data structure to needed to store the */
+    @Override
     public void init(String[] original, String[] newversion) {
-        ArrayList<Object> root = new ArrayList<Object>();
+        List<Object> root = new ArrayList<>();
 
         for (int i = 0; i < original.length; i++) {
             placeString(root, original[i], i);
@@ -139,7 +140,7 @@ ALL:
      */
     private static void placeString(List<Object> item, String s, int indx) {
         if (s.length() == 0) {
-            item.add(new Integer(indx));
+            item.add(indx);
 
             return;
         }
@@ -165,17 +166,17 @@ ALL:
                             // next is the list or null
                             List listForPref = (List) it.next();
 
-                            ArrayList<Object> switchList = new ArrayList<Object>();
+                            List<Object> switchList = new ArrayList<>();
                             it.set(switchList);
 
                             switchList.add(pref.substring(i));
                             switchList.add(listForPref);
 
                             if (i >= s.length()) {
-                                switchList.add(new Integer(indx));
+                                switchList.add(indx);
                             } else {
-                                ArrayList<Object> terminalList = new ArrayList<Object>();
-                                terminalList.add(new Integer(indx));
+                                List<Object> terminalList = new ArrayList<>();
+                                terminalList.add(indx);
 
                                 switchList.add(s.substring(i));
                                 switchList.add(terminalList);
@@ -199,8 +200,8 @@ ALL:
         //
         // ok new prefix in this item
         //
-        ArrayList<Object> id = new ArrayList<Object>();
-        id.add(new Integer(indx));
+        List<Object> id = new ArrayList<>();
+        id.add(indx);
 
         item.add(s);
         item.add(id);
@@ -214,40 +215,27 @@ ALL:
 
     /** Compress tree of Lists into tree of Objects.
      */
-    private static Object[] compress(List item) {
+    private static Object[] compress(List<Object> item) {
         Object[] arr = new Object[item.size()];
 
         Integer last = null;
 
-        Iterator it = item.iterator();
         int i = 0;
 
-        while (it.hasNext()) {
-            Object o = it.next();
-
+        for (Object o : item) {
             if (o instanceof Integer) {
                 if (last != null) {
                     throw new IllegalStateException();
                 }
 
                 last = (Integer) o;
-
-                continue;
-            }
-
-            if (o instanceof String) {
+            } else if (o instanceof String) {
                 arr[i++] = ((String) o).intern();
-
-                continue;
-            }
-
-            if (o instanceof List) {
+            } else if (o instanceof List) {
                 arr[i++] = compress((List) o);
-
-                continue;
+            } else {
+                throw new IllegalStateException();
             }
-
-            throw new IllegalStateException();
         }
 
         if (last != null) {

--- a/platform/openide.util/src/org/openide/util/Task.java
+++ b/platform/openide.util/src/org/openide/util/Task.java
@@ -68,7 +68,7 @@ public class Task extends Object implements Runnable {
     private boolean finished;
 
     /** listeners for the finish of task (TaskListener) */
-    private HashSet<TaskListener> list;
+    private HashSet<TaskListener> listeners;
 
     /** Create a new task.
     * The runnable should provide its own error-handling, as
@@ -195,7 +195,7 @@ public class Task extends Object implements Runnable {
     * @see #run
     */
     protected final void notifyFinished() {
-        Iterator it;
+        Iterator<TaskListener> it;
 
         synchronized (this) {
             finished = true;
@@ -203,15 +203,15 @@ public class Task extends Object implements Runnable {
             notifyAll();
 
             // fire the listeners
-            if (list == null) {
+            if (listeners == null) {
                 return;
             }
 
-            it = ((HashSet) list.clone()).iterator();
+            it = ((HashSet<TaskListener>) listeners.clone()).iterator();
         }
 
         while (it.hasNext()) {
-            TaskListener l = (TaskListener) it.next();
+            TaskListener l = it.next();
             l.taskFinished(this);
         }
     }
@@ -245,10 +245,10 @@ public class Task extends Object implements Runnable {
     public void addTaskListener(TaskListener l) {
         boolean callNow;
         synchronized (this) {
-            if (list == null) {
-                list = new HashSet<TaskListener>();
+            if (listeners == null) {
+                listeners = new HashSet<TaskListener>();
             }
-            list.add(l);
+            listeners.add(l);
             
             callNow = finished;
         }
@@ -262,11 +262,11 @@ public class Task extends Object implements Runnable {
     * @param l the listener to remove
     */
     public synchronized void removeTaskListener(TaskListener l) {
-        if (list == null) {
+        if (listeners == null) {
             return;
         }
 
-        list.remove(l);
+        listeners.remove(l);
     }
 
     public String toString() {

--- a/platform/openide.util/src/org/openide/util/io/NbObjectOutputStream.java
+++ b/platform/openide.util/src/org/openide/util/io/NbObjectOutputStream.java
@@ -27,7 +27,6 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -140,17 +139,14 @@ public class NbObjectOutputStream extends ObjectOutputStream {
         String classname = cl.getName();
 
         if (alreadyReported.add(classname)) {
-            Set<Class> serializingUniq = new HashSet<Class>();
+            Set<Class> serializingUniq = new HashSet<>();
             StringBuffer b = new StringBuffer("Serializable class "); // NOI18N
             b.append(classname);
             b.append(" does not declare serialVersionUID field. Encountered while storing: ["); // NOI18N
 
-            Iterator it = serializing.iterator();
             boolean first = true;
 
-            while (it.hasNext()) {
-                Class c = (Class) it.next();
-
+            for (Class c : serializing) {
                 if ((c != cl) && serializingUniq.add(c)) {
                     if (first) {
                         first = false;

--- a/platform/openide.util/test/unit/src/org/openide/util/NbCollectionsTest.java
+++ b/platform/openide.util/test/unit/src/org/openide/util/NbCollectionsTest.java
@@ -132,7 +132,7 @@ public class NbCollectionsTest extends NbTestCase {
     }
 
     public void testCheckedIteratorByFilter() throws Exception {
-        Iterator raw = Arrays.asList("one", 2, "three").iterator();
+        Iterator<?> raw = Arrays.asList("one", 2, "three").iterator();
         Iterator<String> strings = NbCollections.checkedIteratorByFilter(raw, String.class, false);
         assertTrue(strings.hasNext());
         assertEquals("one", strings.next());
@@ -154,7 +154,7 @@ public class NbCollectionsTest extends NbTestCase {
         assertTrue(strings.hasNext());
         assertEquals("three", strings.next());
         assertFalse(strings.hasNext());
-        List l = new ArrayList(Arrays.asList(new Object[] {"one", 2, "three"}));
+        List<?> l = new ArrayList(Arrays.asList(new Object[] {"one", 2, "three"}));
         raw = l.iterator();
         strings = NbCollections.checkedIteratorByFilter(raw, String.class, false);
         assertTrue(strings.hasNext());


### PR DESCRIPTION
There are several places where the compiler warns about rawtypes used for Iterator

   [repeat] /Users/martin/Repositories/git/netbeans/platform/openide.util/src/org/openide/util/TopologicalSortException.java:358: warning: [rawtypes] found raw type: Iterator
   [repeat]         public Iterator edges() {
   [repeat]                ^
   [repeat]   missing type arguments for generic class Iterator<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in interface Iterator

Convert this code to declare available types or similar ways to reduce/remove these warnings