### PR TITLE
[NETBEANS-3438] - Upgrade bouncycastle from 1.63 to 1.64

### DIFF
--- a/ide/bcpg/external/bcpg-jdk15on-1.64-license.txt
+++ b/ide/bcpg/external/bcpg-jdk15on-1.64-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle Java OpenPGP/BCPG
-Version: 1.63
+Version: 1.64
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcpg/external/binaries-list
+++ b/ide/bcpg/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-A93A004E30BA70FEB94213BD9ADB3BB5295361EF org.bouncycastle:bcpg-jdk15on:1.63
+56956A8C63CCADF62E7C678571CF86F30BD84441 org.bouncycastle:bcpg-jdk15on:1.64

--- a/ide/bcpg/nbproject/project.properties
+++ b/ide/bcpg/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcpg-jdk15on-1.63.jar=modules/bcpg.jar
+release.external/bcpg-jdk15on-1.64.jar=modules/bcpg.jar
 is.autoload=true

--- a/ide/bcpg/nbproject/project.xml
+++ b/ide/bcpg/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcpg.jar</runtime-relative-path>
-                <binary-origin>external/bcpg-jdk15on-1.63.jar</binary-origin>
+                <binary-origin>external/bcpg-jdk15on-1.64.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcprov/external/bcprov-jdk15on-1.64-license.txt
+++ b/ide/bcprov/external/bcprov-jdk15on-1.64-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle Java Provider
-Version: 1.63
+Version: 1.64
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcprov/external/binaries-list
+++ b/ide/bcprov/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-C996F9C64DC0E94E2D2AE962CC7B7CAD7744FCC8 org.bouncycastle:bcprov-jdk15on:1.63
+1467DAC1B787B5AD2A18201C0C281DF69882259E org.bouncycastle:bcprov-jdk15on:1.64

--- a/ide/bcprov/nbproject/project.properties
+++ b/ide/bcprov/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcprov-jdk15on-1.63.jar=modules/bcprov.jar
+release.external/bcprov-jdk15on-1.64.jar=modules/bcprov.jar
 is.autoload=true

--- a/ide/bcprov/nbproject/project.xml
+++ b/ide/bcprov/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcprov.jar</runtime-relative-path>
-                <binary-origin>external/bcprov-jdk15on-1.63.jar</binary-origin>
+                <binary-origin>external/bcprov-jdk15on-1.64.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Notes:
This release is primarily a security release to fix a regression in the ASN.1 
library that was introduced in 1.63 ([CVE-2019-17359](https://nvd.nist.gov/vuln/detail/CVE-2019-17359))

[Bouncycastle Web Page](https://bouncycastle.org/latest_releases.html)

[Bouncycastle Releases Notes](https://bouncycastle.org/releasenotes.html)