### PR TITLE
[NETBEANS-3441] - Upgrade apache compress from 1.8.1 to 1.19

### DIFF
--- a/ide/libs.commons_compress/external/binaries-list
+++ b/ide/libs.commons_compress/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-A698750C16740FD5B3871425F4CB3BBAA87F529D org.apache.commons:commons-compress:1.8.1
+7E65777FB451DDAB6A9C054BEB879E521B7EAB78 org.apache.commons:commons-compress:1.19

--- a/ide/libs.commons_compress/external/commons-compress-1.19-license.txt
+++ b/ide/libs.commons_compress/external/commons-compress-1.19-license.txt
@@ -1,8 +1,8 @@
 Name: Commons Compress
-Version: 1.8.1
+Version: 1.19
 OSR: 19203
-Description: The Apache Commons Compress library defines an API for working with ar, cpio, Unix dump, tar, zip, gzip, XZ, Pack200, bzip2, 7z, arj, lzma, snappy, DEFLATE and Z files.
-Origin: http://commons.apache.org/compress/
+Description: The Apache Commons Compress library defines an API for working with ar, cpio, Unix dump, tar, zip, gzip, XZ, Pack200, bzip2, 7z, arj, lzma, snappy, DEFLATE, lz4, Brotli, Zstandard, DEFLATE64 and Z files.
+Origin: https://commons.apache.org/proper/commons-compress/index.html
 License: Apache-2.0
 
                                  Apache License

--- a/ide/libs.commons_compress/external/commons-compress-1.19-notice.txt
+++ b/ide/libs.commons_compress/external/commons-compress-1.19-notice.txt
@@ -1,8 +1,8 @@
 Apache Commons Compress
-Copyright 2002-2017 The Apache Software Foundation
+Copyright 2002-2019 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org//).
 
 The files in the package org.apache.commons.compress.archivers.sevenz
 were derived from the LZMA SDK, version 9.20 (C/ and CPP/7zip/),

--- a/ide/libs.commons_compress/nbproject/project.properties
+++ b/ide/libs.commons_compress/nbproject/project.properties
@@ -17,6 +17,6 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
-release.external/commons-compress-1.8.1.jar=modules/ext/commons-compress-1.8.1.jar
+javac.source=1.8
+release.external/commons-compress-1.19.jar=modules/ext/commons-compress-1.19.jar
 spec.version.base=0.13.0

--- a/ide/libs.commons_compress/nbproject/project.xml
+++ b/ide/libs.commons_compress/nbproject/project.xml
@@ -32,8 +32,8 @@
                 <package>org.apache.commons.compress.archivers.tar</package>
             </friend-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/commons-compress-1.8.1.jar</runtime-relative-path>
-                <binary-origin>external/commons-compress-1.8.1.jar</binary-origin>
+                <runtime-relative-path>ext/commons-compress-1.19.jar</runtime-relative-path>
+                <binary-origin>external/commons-compress-1.19.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/libs.commons_compress/src/org/netbeans/libs/commons_compress/Bundle.properties
+++ b/ide/libs.commons_compress/src/org/netbeans/libs/commons_compress/Bundle.properties
@@ -20,4 +20,4 @@ OpenIDE-Module-Display-Category=Libraries
 OpenIDE-Module-Short-Description=This plugin bundles Commons Compress.
 OpenIDE-Module-Long-Description=\
     The module bundles Apache Commons Compress \
-    from http://commons.apache.org/compress/.
+    from https://commons.apache.org/proper/commons-compress/index.html/.

--- a/ide/libs.commons_compress/src/org/netbeans/libs/commons_compress/mf-layer.xml
+++ b/ide/libs.commons_compress/src/org/netbeans/libs/commons_compress/mf-layer.xml
@@ -27,7 +27,7 @@
             <file name="org-netbeans-lib-commons_compress-antlibrary.instance">
                 <attr name="instanceCreate" methodvalue="org.apache.tools.ant.module.spi.AutomaticExtraClasspath.url"/>
                 <attr name="instanceOf" stringvalue="org.apache.tools.ant.module.spi.AutomaticExtraClasspathProvider"/>
-                <attr name="url" urlvalue="nbinst://org.netbeans.libs.commons_compress/modules/ext/commons-compress-1.8.1.jar"/>
+                <attr name="url" urlvalue="nbinst://org.netbeans.libs.commons_compress/modules/ext/commons-compress-1.19.jar"/>
             </file>
         </folder>
     </folder>


### PR DESCRIPTION
Notes:
- Add support for lz4, Brotli, Zstandard and DEFLATE64 archives.
- Requires Java 7
- Convert all tests to JUnit4
- 79 Bug fixes
- 17 New Features
- 53 Improvements

[Apache Commons Compress Web Page](https://commons.apache.org/proper/commons-compress/index.html)
[Apache Commons Compress Release Notes](https://issues.apache.org/jira/projects/COMPRESS?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page&status=released)