### PR TITLE
[NETBEANS-3443] - Upgrade h2 database from 1.4.196 to 1.4.200

### DIFF
--- a/ide/db.dataview/external/binaries-list
+++ b/ide/db.dataview/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-DD0034398D593AA3588C6773FAAC429BBD9AEA0E com.h2database:h2:1.4.196
+F7533FE7CB8E99C87A43D325A77B4B678AD9031A com.h2database:h2:1.4.200

--- a/ide/db.dataview/external/h2-1.4.200-license.txt
+++ b/ide/db.dataview/external/h2-1.4.200-license.txt
@@ -1,8 +1,8 @@
 Name: H2 Database Engine
-Version: 1.4.196
+Version: 1.4.200
 License: EPL-v10-h2
 Description: The H2 Database Enginge is a pure java database, that can be used in embedded and server mode.
-Origin: http://h2database.com
+Origin: https://h2database.com
 
 Eclipse Public License - Version 1.0
 

--- a/ide/db.dataview/nbproject/project.properties
+++ b/ide/db.dataview/nbproject/project.properties
@@ -17,7 +17,7 @@
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 test.unit.cp.extra=\
-        ${basedir}/external/h2-1.4.196.jar
+        ${basedir}/external/h2-1.4.200.jar
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\


### PR DESCRIPTION
Notes:
- Several Bug fixes and improvements
- Use OpenJDK instead of OracleJDK
- Add support for Java 11 to test suite

[H2 database Web Page](https://h2database.com/html/main.html)
[H2 database Release Notes](https://h2database.com/html/changelog.html)