### PR TITLE
[NETBEANS-3444] - Upgrade Apache Derby DB from 10.2.2.0 & 10.14.1.0 to 10.14.2.0

### DIFF
--- a/enterprise/j2ee.ejbcore/test/unit/data/derby-sample.dbschema
+++ b/enterprise/j2ee.ejbcore/test/unit/data/derby-sample.dbschema
@@ -3017,7 +3017,7 @@
           <name>derby-sample</name>
         </OBJECT>
       </_name>
-      <_driverVersion>10.1.3.1</_driverVersion>
+      <_driverVersion>10.14.2.0</_driverVersion>
       <_catalog>
         <OBJECT CLASS="com.sun.forte4j.modules.dbmodel.DBIdentifier" ID="org.netbeans.modules.dbschema.DBIdentifier4307037">
           <name></name>
@@ -3026,7 +3026,7 @@
       <element>
         <OBJECT REFERENCE="org.netbeans.modules.dbschema.SchemaElement2050233071"/>
       </element>
-      <_databaseProductVersion>10.1.3.1</_databaseProductVersion>
+      <_databaseProductVersion>10.14.2.0</_databaseProductVersion>
       <_driver>org.apache.derby.jdbc.ClientDriver</_driver>
       <_databaseProductName>Apache Derby</_databaseProductName>
       <_schema>

--- a/ide/db.metadata.model/external/binaries-list
+++ b/ide/db.metadata.model/external/binaries-list
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-F787C9B484CD7526F866C21D8925C4DACE467F8A org.apache.derby:derby:10.2.2.0
-
+7EFAD40EF52FBB1F08142F07A83B42D29E47D8CE org.apache.derby:derby:10.14.2.0
 C264E2114579474D13DD808A510FC74E762DDA8C mysql:mysql-connector-java:5.1.23

--- a/ide/db.metadata.model/external/derby-10.14.2.0-license.txt
+++ b/ide/db.metadata.model/external/derby-10.14.2.0-license.txt
@@ -1,7 +1,8 @@
 Name: Derby
-Version: 10.2.2.0
+Version: 10.14.2.0
 License: Apache-2.0
-OSR: 3320
+Type: compile-time
+Comment: Dependency required to run the unittests of the DB support
 Description: Apache Derby, an Apache DB subproject, is an open source relational database implemented entirely in Java
 Origin: http://db.apache.org/derby/
 

--- a/ide/db.metadata.model/external/derby-10.14.2.0-notice.txt
+++ b/ide/db.metadata.model/external/derby-10.14.2.0-notice.txt
@@ -8,7 +8,7 @@
 =========================================================================
 
 Apache Derby
-Copyright 2004-2015 The Apache Software Foundation
+Copyright 2004-2019 The Apache Software Foundation
 
 This product includes software developed by
 The Apache Software Foundation (http://www.apache.org/).

--- a/ide/db.metadata.model/nbproject/project.properties
+++ b/ide/db.metadata.model/nbproject/project.properties
@@ -18,7 +18,7 @@
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
-test.unit.cp.extra=external/derby-10.2.2.0.jar\:external/mysql-connector-java-5.1.23.jar
+test.unit.cp.extra=external/derby-10.14.2.0.jar\:external/mysql-connector-java-5.1.23.jar
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/ide/db/external/binaries-list
+++ b/ide/db/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-F787C9B484CD7526F866C21D8925C4DACE467F8A org.apache.derby:derby:10.2.2.0
+7EFAD40EF52FBB1F08142F07A83B42D29E47D8CE org.apache.derby:derby:10.14.2.0

--- a/ide/db/external/derby-10.14.2.0-license.txt
+++ b/ide/db/external/derby-10.14.2.0-license.txt
@@ -1,8 +1,7 @@
 Name: Derby
-Version: 10.2.2.0
+Version: 10.14.2.0
 License: Apache-2.0
-Type: compile-time
-Comment: Dependency required to run the unittests of the DB support
+OSR: 3320
 Description: Apache Derby, an Apache DB subproject, is an open source relational database implemented entirely in Java
 Origin: http://db.apache.org/derby/
 

--- a/ide/db/external/derby-10.14.2.0-notice.txt
+++ b/ide/db/external/derby-10.14.2.0-notice.txt
@@ -8,7 +8,7 @@
 =========================================================================
 
 Apache Derby
-Copyright 2004-2015 The Apache Software Foundation
+Copyright 2004-2019 The Apache Software Foundation
 
 This product includes software developed by
 The Apache Software Foundation (http://www.apache.org/).

--- a/ide/db/nbproject/project.properties
+++ b/ide/db/nbproject/project.properties
@@ -38,7 +38,7 @@ lib.cp=\
 
 
 test.unit.cp.extra=\
-    ${nb_all}/db/external/derby-10.2.2.0.jar
+    ${nb_all}/db/external/derby-10.14.2.0.jar
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/ide/db/test/unit/src/org/netbeans/modules/db/test/DBTestBase.java
+++ b/ide/db/test/unit/src/org/netbeans/modules/db/test/DBTestBase.java
@@ -53,7 +53,7 @@ import org.openide.nodes.Node;
 
 /**
  * This class is a useful base test class that provides initial setup
- * to get a connecxtion and also a number of utility routines
+ * to get a connection and also a number of utility routines
  * 
  * @author <a href="mailto:david@vancouvering.com">David Van Couvering</a>
  */
@@ -679,7 +679,7 @@ public abstract class DBTestBase extends TestBase {
         }
         username = System.getProperty(USERNAME_PROPERTY, "DBTESTS");
         password = System.getProperty(PASSWORD_PROPERTY, "DBTESTS");
-        driverJar = System.getProperty(DRIVER_JARPATH_PROPERTY, "nball:///ide/db/external/derby-10.2.2.0.jar");
+        driverJar = System.getProperty(DRIVER_JARPATH_PROPERTY, "nball:///ide/db/external/derby-10.14.2.0.jar");
 
         driverJar = convertPath(driverJar);
     }

--- a/ide/derby/build.xml
+++ b/ide/derby/build.xml
@@ -35,8 +35,8 @@
             <arg value="etc/sample.sql"/>
             <sysproperty key="derby.system.home" value="${build.dir}/sampledb" />
             <classpath>
-                <pathelement location="external/derby-10.14.1.0.jar"/>
-                <pathelement location="external/derbytools-10.14.1.0.jar"/>
+                <pathelement location="external/derby-10.14.2.0.jar"/>
+                <pathelement location="external/derbytools-10.14.2.0.jar"/>
             </classpath>
         </java>
         <zip basedir="${build.dir}/sampledb/sample"

--- a/ide/derby/external/binaries-list
+++ b/ide/derby/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-B4066214637F88A3778314AECADF0539C43855F4 org.apache.derby:derbytools:10.14.1.0
-3BCD8B1AF3F8CD022D54D331E00064776BE04F9C org.apache.derby:derby:10.14.1.0
+338D5A54B4089C80414FE0ECB3899D521DA69B26 org.apache.derby:derbytools:10.14.2.0
+7EFAD40EF52FBB1F08142F07A83B42D29E47D8CE org.apache.derby:derby:10.14.2.0

--- a/ide/derby/external/derby-10.14.2.0-license.txt
+++ b/ide/derby/external/derby-10.14.2.0-license.txt
@@ -1,11 +1,11 @@
 Name: Apache Derby
 Origin: https://db.apache.org/derby/
-Version: 10.14.1.0
+Version: 10.14.2.0
 License: Apache-2.0
 Type: compile-time
 Comment: Dependency used to create sample database from sql
 Description: Apache Derby, an Apache DB subproject, is an open source relational database implemented entirely in Java and available under the Apache License, Version 2.0.
-Files: derby-10.14.1.0.jar, derbytools-10.14.1.0.jar
+Files: derby-10.14.2.0.jar, derbytools-10.14.2.0.jar
 
                                  Apache License
                            Version 2.0, January 2004

--- a/ide/derby/src/org/netbeans/modules/derby/DerbyOptions.java
+++ b/ide/derby/src/org/netbeans/modules/derby/DerbyOptions.java
@@ -64,7 +64,7 @@ public class DerbyOptions {
     static final String PROP_DERBY_LOCATION = "location"; // NOI18N
     static final String PROP_DERBY_SYSTEM_HOME = "systemHome"; // NOI18N
 
-    static final String INST_DIR = "db-derby-10.1.1.0"; // NOI18N
+    static final String INST_DIR = "db-derby-10.14.2.0"; // NOI18N
 
     public static final String DRIVER_CLASS_NET = "org.apache.derby.jdbc.ClientDriver"; // NOI18N
     public static final String DRIVER_CLASS_EMBEDDED = "org.apache.derby.jdbc.EmbeddedDriver"; // NOI18N
@@ -397,9 +397,9 @@ public class DerbyOptions {
                     outd.write("<properties>\n<property>\n"); //NOI18N
                     outd.write("<name>maven-dependencies</name>\n"); //NOI18N
                     outd.write("<value>\n"); //NOI18N
-                    outd.write("org.apache.derby:derby:10.11.1.1:jar\n"); //NOI18N
-                    outd.write("org.apache.derby:derbyclient:10.11.1.1:jar\n"); //NOI18N
-                    outd.write("org.apache.derby:derbynet:10.11.1.1:jar\n"); //NOI18N
+                    outd.write("org.apache.derby:derby:10.14.2.0:jar\n"); //NOI18N
+                    outd.write("org.apache.derby:derbyclient:10.14.2.0:jar\n"); //NOI18N
+                    outd.write("org.apache.derby:derbynet:10.14.2.0:jar\n"); //NOI18N
                     outd.write("</value>\n"); //NOI18N
                     outd.write("</property>\n</properties>\n"); //NOI18N
                     outd.write("</library>\n"); //NOI18N

--- a/java/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/entitygenerator/Issue92031.dbschema
+++ b/java/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/entitygenerator/Issue92031.dbschema
@@ -25,14 +25,14 @@
       <element>
         <OBJECT REFERENCE="org.netbeans.modules.dbschema.SchemaElement-729775034"/>
       </element>
-      <_databaseProductVersion>10.2.1.7 - (453926)</_databaseProductVersion>
+      <_databaseProductVersion>10.14.2.0</_databaseProductVersion>
       <_username>app</_username>
       <_name>
         <OBJECT CLASS="com.sun.forte4j.modules.dbmodel.DBIdentifier" ID="org.netbeans.modules.dbschema.DBIdentifier23081943">
           <name>APP_JavaApplication15_1</name>
         </OBJECT>
       </_name>
-      <_driverVersion>10.2.1.7 - (453926)</_driverVersion>
+      <_driverVersion>10.14.2.0</_driverVersion>
       <_databaseProductName>Apache Derby</_databaseProductName>
       <tables>
         <OBJECT CLASS="com.sun.forte4j.modules.dbmodel.jdbcimpl.DBElementsCollection" ID="org.netbeans.modules.dbschema.jdbcimpl.DBElementsCollection29520102">

--- a/java/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/sampledb.dbschema
+++ b/java/j2ee.persistence/test/unit/src/org/netbeans/modules/j2ee/persistence/wizard/fromdb/sampledb.dbschema
@@ -25,14 +25,14 @@
       <element>
         <OBJECT REFERENCE="org.netbeans.modules.dbschema.SchemaElement1975566248"/>
       </element>
-      <_databaseProductVersion>10.2.1.7 - (453926)</_databaseProductVersion>
+      <_databaseProductVersion>10.14.2.0</_databaseProductVersion>
       <_username>app</_username>
       <_name>
         <OBJECT CLASS="com.sun.forte4j.modules.dbmodel.DBIdentifier" ID="org.netbeans.modules.dbschema.DBIdentifier19371362">
           <name>sampledb</name>
         </OBJECT>
       </_name>
-      <_driverVersion>10.2.1.7 - (453926)</_driverVersion>
+      <_driverVersion>10.14.2.0</_driverVersion>
       <_databaseProductName>Apache Derby</_databaseProductName>
       <tables>
         <OBJECT CLASS="com.sun.forte4j.modules.dbmodel.jdbcimpl.DBElementsCollection" ID="org.netbeans.modules.dbschema.jdbcimpl.DBElementsCollection29531053">

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -78,6 +78,7 @@ ide/lsp.client/external/org.eclipse.xtext.xbase.lib-2.14.0.jar java/java.lsp.ser
 
 # Derby jar is used when run tests, so we can ignore the duplicates
 ide/db/external/derby-10.14.2.0.jar ide/db.metadata.model/external/derby-10.14.2.0.jar
+ide/derby/external/derby-10.14.2.0.jar ide/db.metadata.model/external/derby-10.14.2.0.jar
 
 # Amazon Beanstalk SDK has frequently changing dependencies, so they are better kept separate
 enterprise/libs.amazon/external/httpclient-4.5.5.jar groovy/gradle/external/gradle-4.10.2-bin.zip

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -77,7 +77,7 @@ ide/lsp.client/external/org.eclipse.xtend.lib.macro-2.14.0.jar java/java.lsp.ser
 ide/lsp.client/external/org.eclipse.xtext.xbase.lib-2.14.0.jar java/java.lsp.server/external/org.eclipse.xtext.xbase.lib-2.14.0.jar
 
 # Derby jar is used when run tests, so we can ignore the duplicates
-ide/db/external/derby-10.2.2.0.jar ide/db.metadata.model/external/derby-10.2.2.0.jar
+ide/db/external/derby-10.14.2.0.jar ide/db.metadata.model/external/derby-10.14.2.0.jar
 
 # Amazon Beanstalk SDK has frequently changing dependencies, so they are better kept separate
 enterprise/libs.amazon/external/httpclient-4.5.5.jar groovy/gradle/external/gradle-4.10.2-bin.zip


### PR DESCRIPTION
Notes from 10.2.2.0:
- Improve Performance and Memory Usage
- Derby supports the Java 8 enhancements to JDBC 4.2
- Faster query compilation
- Derby runs on the small CP2 profile of Java 8 (JEP-161)
- Many bug, security, testing, and documentation fixes

Notes from 10.14.1.0:
- 2 Bug fixes

[Apache Derby Web page](https://db.apache.org/derby/)

[Apache Derby Release Notes](https://db.apache.org/derby/#News)