### PR TITLE
[NETBEANS-3449] remove warning related to use of EMPTY_SET

### DIFF
--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
@@ -410,7 +410,7 @@ public class InternationalizationResourceBundleBrandingPanel extends AbstractBra
 
         @Override
         protected void removeNotify() {
-            setKeys(Collections.EMPTY_SET);
+            setKeys(Collections.emptySet());
         }
 
         private void refreshList() {
@@ -533,7 +533,7 @@ public class InternationalizationResourceBundleBrandingPanel extends AbstractBra
 
         @Override
         protected void removeNotify() {
-            setKeys(Collections.EMPTY_SET);
+            setKeys(Collections.emptySet());
         }
 
         private void refreshList() {

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/ResourceBundleBrandingPanel.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/ResourceBundleBrandingPanel.java
@@ -375,7 +375,7 @@ public class ResourceBundleBrandingPanel extends AbstractBrandingPanel
 
         @Override
         protected void removeNotify() {
-            setKeys(Collections.EMPTY_SET);
+            setKeys(Collections.emptySet());
         }
 
         private void refreshList() {
@@ -498,7 +498,7 @@ public class ResourceBundleBrandingPanel extends AbstractBrandingPanel
 
         @Override
         protected void removeNotify() {
-            setKeys(Collections.EMPTY_SET);
+            setKeys(Collections.emptySet());
         }
 
         private void refreshList() {

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2MessageDestinationManager.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2MessageDestinationManager.java
@@ -75,7 +75,7 @@ public class Hk2MessageDestinationManager implements  MessageDestinationDeployme
             // TODO : need to account for a remote domain here?
             return readMessageDestinations(domainXml, "/domain/", null);
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/db/Hk2DatasourceManager.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/db/Hk2DatasourceManager.java
@@ -149,7 +149,7 @@ public class Hk2DatasourceManager implements DatasourceManager {
             return readDatasources(
                     domainXml, "/domain/", null, server.getVersion(), false);
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDWizardIterator.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDWizardIterator.java
@@ -90,7 +90,7 @@ public final class WebLogicDDWizardIterator implements WizardDescriptor.Instanti
     
     @Override
     public Set instantiate() throws IOException {
-        Set result = Collections.EMPTY_SET;
+        Set result = Collections.emptySet();
         WebLogicDDWizardPanel wizardPanel = (WebLogicDDWizardPanel) panels[0];
         
         File configDir = wizardPanel.getSelectedLocation();

--- a/enterprise/j2ee.ejbrefactoring/src/org/netbeans/modules/j2ee/ejbrefactoring/EjbRefactoringPlugin.java
+++ b/enterprise/j2ee.ejbrefactoring/src/org/netbeans/modules/j2ee/ejbrefactoring/EjbRefactoringPlugin.java
@@ -224,7 +224,7 @@ public class EjbRefactoringPlugin implements RefactoringPlugin {
             if (emod != null) {
                 projects.add(affectedProject);
             } else {
-                return Collections.EMPTY_SET;
+                return Collections.emptySet();
             }
             for (Project project : OpenProjects.getDefault().getOpenProjects()) {
                 Object isJ2eeApp = project.getLookup().lookup(J2eeApplicationProvider.class);

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2MessageDestinationManager.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/Hk2MessageDestinationManager.java
@@ -75,7 +75,7 @@ public class Hk2MessageDestinationManager implements  MessageDestinationDeployme
             // TODO : need to account for a remote domain here?
             return readMessageDestinations(domainXml, "/domain/", null);
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/db/Hk2DatasourceManager.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/db/Hk2DatasourceManager.java
@@ -149,7 +149,7 @@ public class Hk2DatasourceManager implements DatasourceManager {
             return readDatasources(
                     domainXml, "/domain/", null, server.getVersion(), false);
         } else {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 

--- a/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/plugin/POMManager.java
+++ b/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/plugin/POMManager.java
@@ -449,7 +449,7 @@ public class POMManager {
                                 .stream()
                                 .map(Repository::getId)
                                 .collect(toSet()) 
-                        : Collections.EMPTY_SET;
+                        : Collections.emptySet();
                 for (org.apache.maven.model.Repository repository : sourceModel.getRepositories()) {
                     if (!existingRepositories.contains(repository.getId())) {
                         Repository repo = pomModel.getFactory().createRepository();

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/BrowseFolders.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/BrowseFolders.java
@@ -240,7 +240,7 @@ public class BrowseFolders extends javax.swing.JPanel implements ExplorerManager
         
         @Override
         protected void removeNotify() {
-            setKeys( Collections.EMPTY_SET );
+            setKeys( Collections.emptySet());
             super.removeNotify();
         }
         

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigUtilities.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigUtilities.java
@@ -247,7 +247,7 @@ public class JSFConfigUtilities {
     }
 
     public static Set extendJsfFramework(FileObject fileObject, boolean createWelcomeFile) {
-        Set result = Collections.EMPTY_SET;
+        Set result = Collections.emptySet();
         if (fileObject == null) {
             return result;
         }

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/dialogs/BrowseFolders.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/dialogs/BrowseFolders.java
@@ -190,7 +190,7 @@ public class BrowseFolders extends javax.swing.JPanel implements ExplorerManager
         }
         
         protected void removeNotify() {
-            setKeys( Collections.EMPTY_SET );
+            setKeys( Collections.emptySet());
             super.removeNotify();
         }
         

--- a/ide/api.debugger/src/org/netbeans/api/debugger/Breakpoint.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/Breakpoint.java
@@ -64,8 +64,8 @@ public abstract class Breakpoint {
     private String                      validityMessage;
     private int                         hitCountFilter;
     private HIT_COUNT_FILTERING_STYLE   hitCountFilteringStyle;
-    private volatile Set<Breakpoint>    breakpointsToEnable = Collections.EMPTY_SET;
-    private volatile Set<Breakpoint>    breakpointsToDisable = Collections.EMPTY_SET;
+    private volatile Set<Breakpoint>    breakpointsToEnable = Collections.emptySet();
+    private volatile Set<Breakpoint>    breakpointsToDisable = Collections.emptySet();
     
     { pcs = new PropertyChangeSupport (this); }
 

--- a/ide/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffContentPanel.java
+++ b/ide/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffContentPanel.java
@@ -76,8 +76,8 @@ class DiffContentPanel extends JPanel implements HighlightsContainer,Lookup.Prov
         editorPane.putClientProperty(DiffHighlightsLayerFactory.HIGHLITING_LAYER_ID, this);
         if (!isFirst) {
             // disable focus traversal, but permit just the up-cycle on ESC key
-            editorPane.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, Collections.EMPTY_SET);
-            editorPane.setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, Collections.EMPTY_SET);
+            editorPane.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERSAL_KEYS, Collections.emptySet());
+            editorPane.setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERSAL_KEYS, Collections.emptySet());
             editorPane.setFocusTraversalKeys(KeyboardFocusManager.UP_CYCLE_TRAVERSAL_KEYS, Collections.singleton(
                     KeyStroke.getAWTKeyStroke(KeyEvent.VK_ESCAPE, InputEvent.SHIFT_DOWN_MASK)));
             

--- a/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldOptionsController.java
+++ b/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/FoldOptionsController.java
@@ -116,9 +116,8 @@ public class FoldOptionsController extends OptionsPanelController implements Pre
         changed = false;
     }
     
-    private Collection<String> updatedLangs = Collections.EMPTY_SET;
-    
-    private Collection<String> legacyLangs = Collections.EMPTY_SET;
+    private Collection<String> updatedLangs = Collections.emptySet();
+    private Collection<String> legacyLangs  = Collections.emptySet();
     
     private void initLanguages() {
         Set<String> mimeTypes = EditorSettings.getDefault().getAllMimeTypes();

--- a/ide/html/src/org/netbeans/modules/html/palette/BrowseFolders.java
+++ b/ide/html/src/org/netbeans/modules/html/palette/BrowseFolders.java
@@ -277,7 +277,7 @@ public class BrowseFolders extends JPanel implements ExplorerManager.Provider {
         }
 
         protected void removeNotify() {
-            setKeys(Collections.EMPTY_SET);
+            setKeys(Collections.emptySet());
             super.removeNotify();
         }
 

--- a/ide/localhistory/src/org/netbeans/modules/localhistory/LocalHistory.java
+++ b/ide/localhistory/src/org/netbeans/modules/localhistory/LocalHistory.java
@@ -110,7 +110,7 @@ public class LocalHistory {
         
         String rootPaths = System.getProperty("netbeans.localhistory.historypath");
         if(rootPaths == null || rootPaths.trim().equals("")) {            
-            userDefinedRoots = Collections.EMPTY_SET;               
+            userDefinedRoots = Collections.emptySet();               
         } else {
             String[] paths = rootPaths.split(";");
             userDefinedRoots = new HashSet<String>(paths.length);

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
@@ -673,7 +673,7 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
             final Set<Component> initiallyOpenedMinimized;
             if (componentsInitiallyOpened.isEmpty()) {
                 initiallyOpened = Collections.emptyList();
-                initiallyOpenedMinimized = Collections.EMPTY_SET;
+                initiallyOpenedMinimized = Collections.emptySet();
             } else {
                 initiallyOpened = new ArrayList<Component>();
                 initiallyOpenedMinimized = new HashSet<>();

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebuggingViewComponent.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebuggingViewComponent.java
@@ -779,7 +779,7 @@ public class DebuggingViewComponent extends TopComponent implements org.openide.
                         // collect all deadlocked threads
                         Set<DVThread> deadlockedThreads;
                         if (deadlocks == null) {
-                            deadlockedThreads = Collections.EMPTY_SET;
+                            deadlockedThreads = Collections.emptySet();
                         } else {
                             deadlockedThreads = new HashSet<DVThread>();
                             for (Deadlock deadlock : deadlocks) {

--- a/ide/target.iterator/src/org/netbeans/modules/target/iterator/api/BrowseFolders.java
+++ b/ide/target.iterator/src/org/netbeans/modules/target/iterator/api/BrowseFolders.java
@@ -300,7 +300,7 @@ public class BrowseFolders extends JPanel implements ExplorerManager.Provider, L
         
         @Override
         protected void removeNotify() {
-            setKeys( Collections.EMPTY_SET );
+            setKeys( Collections.emptySet());
             super.removeNotify();
         }
         

--- a/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/IssueSettingsStorage.java
+++ b/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/IssueSettingsStorage.java
@@ -83,7 +83,7 @@ public class IssueSettingsStorage {
             l.release();
         }
                 
-        return Collections.EMPTY_SET;
+        return Collections.emptySet();
     }
     
     private Properties load(File file, String repoUrl, String id) throws IOException {

--- a/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/ObservableSet.java
+++ b/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/ObservableSet.java
@@ -40,7 +40,7 @@ public class ObservableSet<E> implements Set<E> {
     
     private final PropertyChangeSupport pchs = new PropertyChangeSupport(this);
     
-    private Set<E> set = Collections.EMPTY_SET;
+    private Set<E> set = Collections.emptySet();
     
     @Override
     public int size() {
@@ -74,7 +74,7 @@ public class ObservableSet<E> implements Set<E> {
 
     @Override
     public boolean add(E e) {
-        if (set == Collections.EMPTY_SET) {
+        if (set == Collections.emptySet()) {
             set = Collections.synchronizedSet(new HashSet<E>());
         }
         boolean added = set.add(e);

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ActionsPanel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ActionsPanel.java
@@ -307,7 +307,7 @@ private void cbSuspendActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIR
         breakpoint.setBreakpointsToDisable(createBreakpointsSet(breakpointsToDisableGroup));
         /*
         if (breakpointsToDisableGroup == null || breakpointsToDisableGroup == NONE_BREAKPOINT_GROUP) {
-            breakpoint.setBreakpointsToDisable(Collections.EMPTY_SET);
+            breakpoint.setBreakpointsToDisable(Collections.emptySet());
         } else {
             TestGroupProperties tgp = createTestProperties(breakpointsToDisableGroup);
             if (tgp != null) {
@@ -318,7 +318,7 @@ private void cbSuspendActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIR
                 if (!customGroup.isEmpty()) {
                     breakpoint.setBreakpointsToDisable(new BreakpointsFromGroup(customGroup));
                 } else {
-                    breakpoint.setBreakpointsToDisable(Collections.EMPTY_SET);
+                    breakpoint.setBreakpointsToDisable(Collections.emptySet());
                 }
             }
         }
@@ -327,7 +327,7 @@ private void cbSuspendActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIR
     
     private static Set<Breakpoint> createBreakpointsSet(Object selectedGroup) {
         if (selectedGroup == null || selectedGroup == NONE_BREAKPOINT_GROUP) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         } else {
             TestGroupProperties tgp = createTestProperties(selectedGroup);
             if (tgp != null) {
@@ -338,7 +338,7 @@ private void cbSuspendActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIR
                 if (!customGroup.isEmpty()) {
                     return new BreakpointsFromGroup(customGroup);
                 } else {
-                    return Collections.EMPTY_SET;
+                    return Collections.emptySet();
                 }
             }
         }

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/SmartSteppingFilterImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/SmartSteppingFilterImpl.java
@@ -70,10 +70,9 @@ public class SmartSteppingFilterImpl implements SmartSteppingFilter {
         Set<String> patterns;
         if (options.getBoolean("UseStepFilters", true)) {
             patterns = (Set<String>) classFiltersProperties.getCollection (
-                    "enabled",
-                    Collections.EMPTY_SET);
+                    "enabled", Collections.emptySet());
         } else {
-            patterns = Collections.EMPTY_SET;
+            patterns = Collections.emptySet();
         }
         synchronized (filter) {
             filter.clear();

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsReader.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsReader.java
@@ -310,7 +310,7 @@ public class BreakpointsReader implements Properties.Reader, PropertyChangeListe
         if (bpGroup != null) {
             return new BreakpointsFromGroup(new TestGroupProperties(bpGroup));
         }
-        return Collections.EMPTY_SET;
+        return Collections.emptySet();
     }
     
     private static void setBreakpointsFromGroup(Properties properties, String base, Set<Breakpoint> breakpointsFromGroup) {

--- a/java/maven/src/org/netbeans/modules/maven/ProjectOpenedHookImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/ProjectOpenedHookImpl.java
@@ -462,7 +462,7 @@ public class ProjectOpenedHookImpl extends ProjectOpenedHook {
     private Set<String> getDoNotIndexRepos() {
         String st = System.getProperty("maven.indexing.doNotAutoIndex");
         if(st == null || "".equals(st)) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
         String[] repos = st.split(";");
         return new HashSet<>(Arrays.asList(repos));

--- a/nbi/engine/src/org/netbeans/installer/utils/UninstallUtils.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/UninstallUtils.java
@@ -107,7 +107,7 @@ public class UninstallUtils {
             Set<File> clustersRootsList = getClustersRoots();
 
             if (clustersRootsList == null || clustersRootsList.isEmpty()) {
-                return Collections.EMPTY_SET;
+                return Collections.emptySet();
             }
             
             FileFilter onlyXmlFilter = new FileFilter() {
@@ -165,7 +165,7 @@ public class UninstallUtils {
                 };
                 clustersRoots = new HashSet<File>(Arrays.asList(installationLoc.listFiles(onlyDirFilter)));
             } else {
-                clustersRoots = Collections.EMPTY_SET;
+                clustersRoots = Collections.emptySet();
             }
         }
 

--- a/php/php.twig/src/org/netbeans/modules/php/twig/editor/completion/TwigElement.java
+++ b/php/php.twig/src/org/netbeans/modules/php/twig/editor/completion/TwigElement.java
@@ -93,7 +93,7 @@ public interface TwigElement extends ElementHandle {
 
         @Override
         public Set<Modifier> getModifiers() {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
 
         @Override

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleUpdateUnitImpl.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/ModuleUpdateUnitImpl.java
@@ -114,7 +114,7 @@ public class ModuleUpdateUnitImpl extends UpdateUnitImpl {
     
     private static Set<Module> findVisibleAncestor(Module module, Set<Module> seen) {
         if (! seen.add(module)) {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
         Set<Module> visible = new HashSet<Module> ();
         ModuleManager manager = module.getManager();

--- a/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
+++ b/platform/openide.dialogs/src/org/openide/WizardDescriptor.java
@@ -242,7 +242,7 @@ public class WizardDescriptor extends DialogDescriptor {
     private final JButton cancelButton = new JButton();
     private final JButton previousButton = new JButton();
     private FinishAction finishOption;
-    private Set<Object> newObjects = Collections.EMPTY_SET;
+    private Set<Object> newObjects = Collections.emptySet();
 
     /** a component with wait cursor */
     private Component waitingComponent;
@@ -1529,7 +1529,7 @@ public class WizardDescriptor extends DialogDescriptor {
             ((InstantiatingIterator) data.getIterator(this)).initialize(this);
         }
 
-        newObjects = Collections.EMPTY_SET;
+        newObjects = Collections.emptySet();
     }
 
     private void callUninitialize() {

--- a/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
@@ -170,7 +170,7 @@ final class MultiFileObject extends AbstractFolder implements FileObject.Priorit
         MultiFileSystem mfs = getMultiFileSystem();
         FileSystem[] arr = mfs.getDelegates();
 
-        Set now = (delegates == null) ? Collections.EMPTY_SET : delegates;
+        Set now = (delegates == null) ? Collections.emptySet(): delegates;
         Set<FileObject> del = new HashSet<FileObject>(arr.length * 2);
         Number maxWeight = 0;
         FileObject led = null;

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsElementImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsElementImpl.java
@@ -81,7 +81,7 @@ public abstract class JsElementImpl implements JsElement {
             LOG.log(Level.WARNING, "Suspicious offset range of element at \n", new Throwable());
         }
         this.offsetRange = offsetRange;
-        this.modifiers = modifiers == null ? Collections.EMPTY_SET: modifiers;
+        this.modifiers = modifiers == null ? Collections.emptySet(): modifiers;
         this.isDeclared = isDeclared;
         assert mimeType == null || 
                isCorrectMimeType(mimeType) : mimeType;

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/FSCompletionItem.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/FSCompletionItem.java
@@ -189,7 +189,7 @@ public class FSCompletionItem implements CompletionProposal {
 
         @Override
         public Set<Modifier> getModifiers() {
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
 
         @Override

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/SimpleHandle.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/SimpleHandle.java
@@ -68,7 +68,7 @@ public class SimpleHandle implements ElementHandle {
 
     @Override
     public Set<Modifier> getModifiers() {
-        return Collections.EMPTY_SET;
+        return Collections.emptySet();
     }
 
     @Override


### PR DESCRIPTION
There are places where the following warning pops up..

   [repeat] /home/bwalker/src/netbeans/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebuggingViewComponent.java:782: warning: [unchecked] unchecked conversion
   [repeat]                             deadlockedThreads = Collections.EMPTY_SET;
   [repeat]                                                            ^
   [repeat]   required: Set<DVThread>
   [repeat]   found:    Set

This change removes all instances of this warning.. Usually it's difficult for me to remove a whole class of warnings.. This makes me happy..