### PR TITLE
[NETBEANS-3450] Fixed compiler warnings concerning rawtypes Stream

### DIFF
--- a/ide/extexecution.process.jdk9/src/org/netbeans/modules/extexecution/process/jdk9/ProcessesImpl.java
+++ b/ide/extexecution.process.jdk9/src/org/netbeans/modules/extexecution/process/jdk9/ProcessesImpl.java
@@ -74,9 +74,9 @@ public class ProcessesImpl implements ProcessesImplementation {
 
         try {
             Object handle = PROCESS_TO_HANDLE.invoke(process, (Object[]) null);
-            try (Stream s = (Stream) PROCESS_HANDLE_DESCENDANTS.invoke(handle, (Object[]) null)) {
+            try (Stream<?> s = (Stream<?>) PROCESS_HANDLE_DESCENDANTS.invoke(handle, (Object[]) null)) {
                 destroy(handle);
-                s.forEach(ch ->  destroy(ch));
+                s.forEach(ch -> destroy(ch));
             }
         } catch (IllegalAccessException | IllegalArgumentException |InvocationTargetException ex) {
             throw new UnsupportedOperationException("The JDK 9 way of killing process tree has failed", ex); // NOI18N


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a Stream like the following
```
   [repeat] /Users/martin/Repositories/git/netbeans/ide/extexecution.process.jdk9/src/org/netbeans/modules/extexecution/process/jdk9/ProcessesImpl.java:77: warning: [rawtypes] found raw type: Stream
   [repeat]             try (Stream s = (Stream) PROCESS_HANDLE_DESCENDANTS.invoke(handle, (Object[]) null)) {
   [repeat]                  ^
   [repeat]   missing type arguments for generic class Stream<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in interface Stream
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.