### PR TITLE
[NETBEANS-3451] Fixed compiler warnings concerning rawtypes Iterable

### DIFF
--- a/java/java.source.ant/src/org/netbeans/modules/java/source/ant/ProjectRunnerImpl.java
+++ b/java/java.source.ant/src/org/netbeans/modules/java/source/ant/ProjectRunnerImpl.java
@@ -620,8 +620,8 @@ public class ProjectRunnerImpl implements JavaRunnerImplementation {
     }
 
     private static <T> List<T> getMultiValue(Map<String, ?> properties, String name, Class<T> type) {
-        Iterable v = (Iterable) properties.remove(name);
-        List<T>  result = new LinkedList<T>();
+        Iterable<?> v = (Iterable<?>) properties.remove(name);
+        List<T> result = new LinkedList<>();
 
         if (v == null) {
             return Collections.emptyList();

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
@@ -194,7 +194,7 @@ public class Utilities {
     private static final String SWITCH_EXPRESSION = "SWITCH_EXPRESSION";
     
 
-    public static <E> Iterable<E> checkedIterableByFilter(final Iterable raw, final Class<E> type, final boolean strict) {
+    public static <E> Iterable<E> checkedIterableByFilter(final Iterable<?> raw, final Class<E> type, final boolean strict) {
         return new Iterable<E>() {
             public Iterator<E> iterator() {
                 return NbCollections.checkedIteratorByFilter(raw.iterator(), type, strict);


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a Iterable like the following
```
   [repeat] .../java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java:197: warning: [rawtypes] found raw type: Iterable
   [repeat]     public static <E> Iterable<E> checkedIterableByFilter(final Iterable raw, final Class<E> type, final boolean strict) {
   [repeat]                                                                 ^
   [repeat]   missing type arguments for generic class Iterable<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in interface Iterable
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.