### PR TITLE
[NETBEANS-3454] Fixed compiler warnings concerning rawtypes Reference

### DIFF
--- a/ide/db/test/unit/src/org/netbeans/modules/db/explorer/DbDriverManagerTest.java
+++ b/ide/db/test/unit/src/org/netbeans/modules/db/explorer/DbDriverManagerTest.java
@@ -206,7 +206,7 @@ public class DbDriverManagerTest extends TestBase {
     public void testNoJDBCDriverLeaks() throws Exception {
         JDBCDriver drv = createJDBCDriver();
         Driver driver = DbDriverManager.getDefault().getDriver(DriverImpl.DEFAULT_URL, drv);
-        Reference drvRef = new WeakReference(drv);
+        Reference<JDBCDriver> drvRef = new WeakReference<>(drv);
         drv = null;
 
         assertGC("Should be possible to GC the driver", drvRef);

--- a/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
@@ -48,7 +48,7 @@ import org.openide.util.lookup.Lookups;
 public abstract class GrammarQueryManager {
 
     // default instance
-    private static Reference instance;
+    private static Reference<GrammarQueryManager> instance;
     
     /**
      * Can this manager provide a grammar for given context?
@@ -92,12 +92,12 @@ public abstract class GrammarQueryManager {
      * @return Best effort instance.
      */
     public static synchronized GrammarQueryManager getDefault() {
-        Object cached = instance != null ? instance.get() : null;
+        GrammarQueryManager cached = instance != null ? instance.get() : null;
         if (cached == null) {
             cached = new DefaultQueryManager();
-            instance = new WeakReference(cached);
+            instance = new WeakReference<GrammarQueryManager>(cached);
         }
-        return (GrammarQueryManager) cached;        
+        return cached;
     }
 
     /**

--- a/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
+++ b/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.xml.text.syntax;
 
-import java.lang.ref.*;
 import java.util.*;
 
 import javax.swing.text.*;
@@ -50,7 +49,6 @@ import org.openide.util.WeakListeners;
  */
 public final class XMLSyntaxSupport extends ExtSyntaxSupport implements XMLTokenIDs {
     
-    private Reference reference = new SoftReference(null);  // cached helper
     private String systemId = null;  // cached refernce to DTD
     private String publicId = null;  // cached refernce to DTD
     private volatile boolean requestedAutoCompletion = false;

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateManagerImplTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UpdateManagerImplTest.java
@@ -43,7 +43,7 @@ public class UpdateManagerImplTest extends DefaultTestCase {
     public void testNoMemoryLeak() throws Exception {
         List<UpdateUnit> units = UpdateManagerImpl.getInstance().getUpdateUnits();
         assertTrue(units.size() != 0);
-        Reference ref = UpdateManagerImpl.getInstance().getCacheReference();
+        Reference<?> ref = UpdateManagerImpl.getInstance().getCacheReference();
         assertNotNull(ref);
         assertNotNull(ref.get());
         

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactorySizeTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectFactorySizeTest.java
@@ -59,13 +59,13 @@ public class FileObjectFactorySizeTest extends NbTestCase {
         //root + workdir
         assertEquals(2, fbs.getSize());
         assertEquals(2, fbs.getSize());
-        Reference rf = new  WeakReference(workDir.getParent());
+        Reference<FileObject> rf = new  WeakReference<>(workDir.getParent());
         assertGC("", rf);
         assertNull(((BaseFileObj)workDir).getExistingParent());
         assertEquals(2, fbs.getSize());
         fbs.getRoot().getFileObject(workDir.getPath());
         assertEquals(2, fbs.getSize());
-        rf = new  WeakReference(workDir.getParent());
+        rf = new  WeakReference<>(workDir.getParent());
         assertGC("", rf);
         assertNull(((BaseFileObj)workDir).getExistingParent());
         assertEquals(2, fbs.getSize());

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/LockForFileTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/LockForFileTest.java
@@ -206,7 +206,7 @@ public class LockForFileTest extends NbTestCase {
         LockForFile lock = LockForFile.tryLock(testFile);
         LOG.log(Level.INFO, "lock is here: {0}", lock);
         assertFalse(lock.isHardLocked());
-        Reference ref = new WeakReference(lock);
+        Reference<LockForFile> ref = new WeakReference<>(lock);
         lock = null;
         LOG.log(Level.INFO, "Hard Reference is cleared: {0}", ref);
         assertGC("", ref);

--- a/platform/openide.actions/src/org/openide/actions/MoveUpAction.java
+++ b/platform/openide.actions/src/org/openide/actions/MoveUpAction.java
@@ -45,7 +45,7 @@ public final class MoveUpAction extends NodeAction {
     private static Logger err = Logger.getLogger("org.openide.actions.MoveUpAction"); // NOI18N
 
     /** Holds index cookie on which we are listening */
-    private Reference curIndexCookie;
+    private Reference<Index> curIndexCookie;
 
     /* Initilizes the set of properties.
     */
@@ -61,7 +61,7 @@ public final class MoveUpAction extends NodeAction {
 
     /** Getter for curIndexCookie */
     private Index getCurIndexCookie() {
-        return ((curIndexCookie == null) ? null : (Index) curIndexCookie.get());
+        return ((curIndexCookie == null) ? null : curIndexCookie.get());
     }
 
     protected void performAction(Node[] activatedNodes) {

--- a/platform/openide.awt/src/org/openide/awt/ContextAction.java
+++ b/platform/openide.awt/src/org/openide/awt/ContextAction.java
@@ -322,7 +322,7 @@ implements Action, ContextAwareAction, ChangeListener, Runnable {
         
         void clear() {
             stopListeners();
-            Reference r = instDelegate;
+            Reference<Object> r = instDelegate;
             instDelegate = null;
             if (r != null) {
                 Object o = r.get();

--- a/platform/openide.awt/test/unit/src/org/netbeans/modules/openide/openide/awt/StatefulActionProcessorTest.java
+++ b/platform/openide.awt/test/unit/src/org/netbeans/modules/openide/openide/awt/StatefulActionProcessorTest.java
@@ -754,7 +754,7 @@ public class StatefulActionProcessorTest extends NbTestCase implements ContextGl
         
         reinitActionLookup();
         
-        Reference r = new WeakReference(mod);
+        Reference<ActionModel3> r = new WeakReference<>(mod);
         mod = null;
         assertGC("Action model must be GCed", r);
     }
@@ -813,7 +813,7 @@ public class StatefulActionProcessorTest extends NbTestCase implements ContextGl
         
         reinitActionLookup();
         
-        Reference r = new WeakReference(mod);
+        Reference<ActionModel3> r = new WeakReference<>(mod);
         instance = null;
         mod = null;
         assertGC("Action model must be GCed", r);
@@ -964,7 +964,7 @@ public class StatefulActionProcessorTest extends NbTestCase implements ContextGl
         
         reinitActionLookup();
         
-        Reference r = new WeakReference(mod);
+        Reference<ActionModel3> r = new WeakReference<>(mod);
         mod = null;
         assertGC("Action model must be GCed", r);
     }

--- a/platform/openide.compat/nbproject/project.properties
+++ b/platform/openide.compat/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 java.source=1.5
 

--- a/platform/openide.compat/src/org/openide/explorer/ExplorerPanel.java
+++ b/platform/openide.compat/src/org/openide/explorer/ExplorerPanel.java
@@ -71,7 +71,8 @@ public class ExplorerPanel extends TopComponent implements ExplorerManager.Provi
     /** mapping from ExplorerManagers to the ExplorerPanels they are associated
      * with. ExplorerManager -> Reference (ExplorerPanel)
      */
-    private static java.util.WeakHashMap panels = new java.util.WeakHashMap();
+    private static java.util.WeakHashMap<ExplorerManager, java.lang.ref.Reference<ExplorerPanel>> panels
+            = new java.util.WeakHashMap<>();
 
     /** the instance of the explorer manager*/
     private ExplorerManager manager;
@@ -109,7 +110,7 @@ public class ExplorerPanel extends TopComponent implements ExplorerManager.Provi
         }
 
         this.manager = manager;
-        panels.put(manager, new java.lang.ref.WeakReference(this));
+        panels.put(manager, new java.lang.ref.WeakReference<ExplorerPanel>(this));
 
         setLayout(new java.awt.BorderLayout());
         initActionMap(confirm);
@@ -138,8 +139,8 @@ public class ExplorerPanel extends TopComponent implements ExplorerManager.Provi
      * @param em the manager
      */
     static void associateActions(ExplorerActions actions, ExplorerManager em) {
-        java.lang.ref.Reference ref = (java.lang.ref.Reference) panels.get(em);
-        ExplorerPanel p = (ref == null) ? null : (ExplorerPanel) ref.get();
+        java.lang.ref.Reference<ExplorerPanel> ref = panels.get(em);
+        ExplorerPanel p = (ref == null) ? null : ref.get();
 
         if (p != null) {
             p.getActionMap().put(javax.swing.text.DefaultEditorKit.copyAction, actions.copyAction());
@@ -279,7 +280,7 @@ public class ExplorerPanel extends TopComponent implements ExplorerManager.Provi
 
         if (anObj instanceof ExplorerManager) {
             manager = (ExplorerManager) anObj;
-            panels.put(manager, new java.lang.ref.WeakReference(this));
+            panels.put(manager, new java.lang.ref.WeakReference<ExplorerPanel>(this));
             initActionMap(null);
             initListening();
 
@@ -291,7 +292,7 @@ public class ExplorerPanel extends TopComponent implements ExplorerManager.Provi
         // --- read all data from main stream, it is OK now ---
         try {
             manager = (ExplorerManager) obj.get();
-            panels.put(manager, new java.lang.ref.WeakReference(this));
+            panels.put(manager, new java.lang.ref.WeakReference<ExplorerPanel>(this));
             initActionMap(null);
             initListening();
         } catch (SafeException se) {

--- a/platform/openide.compat/src/org/openide/util/WeakListener.java
+++ b/platform/openide.compat/src/org/openide/util/WeakListener.java
@@ -44,13 +44,13 @@ import javax.swing.event.*;
 @Deprecated
 public abstract class WeakListener implements java.util.EventListener {
     /** weak reference to listener */
-    private Reference ref;
+    private Reference<EventListener> ref;
 
     /** class of the listener */
     Class listenerClass;
 
     /** weak reference to source */
-    private Reference source;
+    private Reference<Object> source;
 
     /**
      * @param listenerClass class/interface of the listener
@@ -88,7 +88,7 @@ public abstract class WeakListener implements java.util.EventListener {
         if (source == null) {
             this.source = null;
         } else {
-            this.source = new WeakReference(source);
+            this.source = new WeakReference<Object>(source);
         }
     }
 
@@ -103,14 +103,14 @@ public abstract class WeakListener implements java.util.EventListener {
     * @return null if there is no listener because it has been finalized
     */
     protected final java.util.EventListener get(java.util.EventObject ev) {
-        Object l = ref.get(); // get the consumer
+        EventListener l = ref.get(); // get the consumer
 
         // if the event consumer is gone, unregister us from the event producer
         if (l == null) {
             removeListener((ev == null) ? null : ev.getSource());
         }
 
-        return (EventListener) l;
+        return l;
     }
 
     /** Tries to find a remove method and invoke it.

--- a/platform/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
@@ -379,17 +379,14 @@ abstract class AbstractFolder extends FileObject {
             return EMPTY_ARRAY;
         }
 
-        Iterator it = map.values().iterator();
-        ArrayList<FileObject> ll = new ArrayList<FileObject>(map.size() + 2);
+        ArrayList<FileObject> ll = new ArrayList<>(map.size() + 2);
 
-        while (it.hasNext()) {
-            Reference r = (Reference) it.next();
-
+        for (Reference<AbstractFolder> r : map.values()) {
             if (r == null) {
                 continue;
             }
 
-            AbstractFolder fo = (AbstractFolder) r.get();
+            AbstractFolder fo = r.get();
 
             if (fo != null /*&& (!fo.isFolder () || fo.map != null)*/    ) {
                 // if the file object exists and either is not folder (then

--- a/platform/openide.filesystems/src/org/openide/filesystems/MemoryFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/MemoryFileSystem.java
@@ -144,9 +144,9 @@ final class MemoryFileSystem extends AbstractFileSystem implements AbstractFileS
 	FileObject fo = null;
         
         if (x != null) {
-            Reference ref = findReference(n);
+            Reference<? extends FileObject> ref = findReference(n);
             if (ref != null) {
-                fo = (FileObject)ref.get();
+                fo = ref.get();
                 retval = (fo != null) ? fo.isValid() : true;
             }   
         }

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
@@ -356,7 +356,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
      * @return true if the file is folder, false otherwise
      */
     private boolean isFolder(String name) {
-        Reference ref = findReference(name);
+        Reference<? extends FileObject> ref = findReference(name);
 
         if ((ref != null) && (ref instanceof FileObjRef)) {
             return ((FileObjRef) ref).isFolder();
@@ -373,7 +373,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
     * @exception FileNotFoundException if the file does not exists or is invalid
     */
     private InputStream getInputStream(String name) throws java.io.FileNotFoundException {
-        Reference ref = findReference(name);
+        Reference<? extends FileObject> ref = findReference(name);
 
         if ((ref != null) && (ref instanceof FileObjRef)) {
             return (((FileObjRef) ref).getInputStream(name));
@@ -390,7 +390,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
     * @exception FileNotFoundException if the file does not exists or is invalid
     */
     URL getURL(String name) throws java.io.FileNotFoundException {
-        Reference ref = findReference(name);
+        Reference<? extends FileObject> ref = findReference(name);
 
         if ((ref != null) && (ref instanceof FileObjRef)) {
             return ((FileObjRef) ref).createAbsoluteUrl(name);
@@ -401,7 +401,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
 
     /** Get size of stream*/
     private long getSize(String name) {
-        Reference ref = findReference(name);
+        Reference<? extends FileObject> ref = findReference(name);
 
         if ((ref != null) && (ref instanceof FileObjRef)) {
             return ((FileObjRef) ref).getSize(name);
@@ -412,7 +412,7 @@ public final class XMLFileSystem extends AbstractFileSystem {
 
     /**returns value of last modification*/
     private java.util.Date lastModified(String name) {
-        Reference ref = findReference(name);
+        Reference<? extends FileObject> ref = findReference(name);
 
         if ((ref != null) && (ref instanceof FileObjRef)) {
             return ((FileObjRef) ref).lastModified(name);

--- a/platform/openide.nodes/nbproject/project.properties
+++ b/platform/openide.nodes/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.main.page=org/openide/nodes/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/openide.nodes/src/org/openide/nodes/BeanChildren.java
+++ b/platform/openide.nodes/src/org/openide/nodes/BeanChildren.java
@@ -48,8 +48,8 @@ public class BeanChildren extends Children.Keys {
      * and child, resp.
      * See #7925.
      */
-    private static final java.util.Map<Node,Reference[]> nodes2Beans = 
-            new WeakHashMap<Node,Reference[]>(); // Map<Node,Reference<Object>[2]>
+    private static final java.util.Map<Node, Reference<?>[]> nodes2Beans
+            = new WeakHashMap<>(); // Map<Node,Reference<Object>[2]>
 
     /** bean context to work on */
     private BeanContext bean;
@@ -105,7 +105,7 @@ public class BeanChildren extends Children.Keys {
 
             // #7925: deleting from BeanChildren has no effect
             synchronized (nodes2Beans) {
-                nodes2Beans.put(n, new Reference[] { new WeakReference<BeanContext>(bean), new WeakReference<Object>(subbean) });
+                nodes2Beans.put(n, new Reference<?>[] { new WeakReference<BeanContext>(bean), new WeakReference<Object>(subbean) });
             }
 
             n.addNodeListener(contextL);
@@ -205,7 +205,7 @@ public class BeanChildren extends Children.Keys {
 
         public void nodeDestroyed(NodeEvent ev) {
             Node n = ev.getNode();
-            Reference[] refs;
+            Reference<?>[] refs;
 
             synchronized (nodes2Beans) {
                 refs = nodes2Beans.get(n);

--- a/platform/openide.nodes/src/org/openide/nodes/EntrySupportDefault.java
+++ b/platform/openide.nodes/src/org/openide/nodes/EntrySupportDefault.java
@@ -735,7 +735,7 @@ class EntrySupportDefault extends EntrySupport {
 
     /** Finalized.
      */
-    final void finalizedChildrenArray(Reference caller) {
+    final void finalizedChildrenArray(Reference<ChildrenArray> caller) {
         assert caller.get() == null : "Should be null";
         // usually in removeNotify setKeys is called => better require write access
         try {

--- a/platform/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysTest.java
+++ b/platform/openide.nodes/test/unit/src/org/openide/nodes/ChildrenKeysTest.java
@@ -816,7 +816,7 @@ public class ChildrenKeysTest extends NbTestCase {
             int counterDestroy = 0;
             Object key;
             
-            Reference createdNode;
+            Reference<Node> createdNode;
             
             K(boolean lazy, Object keyObject) {
                 super(lazy);
@@ -845,7 +845,7 @@ public class ChildrenKeysTest extends NbTestCase {
             protected Node[] createNodes(Object k) {
                 Node n = Node.EMPTY.cloneNode();
                 assertNull ("Just one created node", createdNode);
-                createdNode = new WeakReference (n);
+                createdNode = new WeakReference<>(n);
                 return new Node[] { n };
             }
         }

--- a/platform/openide.text/nbproject/project.properties
+++ b/platform/openide.text/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.main.page=org/openide/text/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/openide.text/src/org/openide/text/CloneableEditorSupport.java
+++ b/platform/openide.text/src/org/openide/text/CloneableEditorSupport.java
@@ -168,7 +168,7 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
     private Set<ChangeListener> listeners;
 
     /** last selected editor pane. */
-    private transient Reference<Pane> lastSelected[] = new Reference[] { null };
+    private transient Reference<Pane> lastSelected = null;
 
     /** The time of the last save to determine the real external modifications */
     private long lastSaveTime;
@@ -921,13 +921,11 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
     /** Returns the lastly selected Pane or null
      */
     final Pane getLastSelected() {
-        Reference<Pane> r = lastSelected[0];
-
-        return (r == null) ? null : r.get();
+        return (lastSelected == null) ? null : lastSelected.get();
     }
 
     final void setLastSelected(Pane lastSelected) {
-        this.lastSelected[0] = new WeakReference<Pane>(lastSelected);
+        this.lastSelected = new WeakReference<>(lastSelected);
     }
 
     //

--- a/platform/openide.util/test/unit/src/org/openide/util/RequestProcessorTest.java
+++ b/platform/openide.util/test/unit/src/org/openide/util/RequestProcessorTest.java
@@ -1628,8 +1628,8 @@ class R extends Object implements Runnable {
         }
     }
 
-    private static void doGc (int count, Reference toClear) {
-        java.util.ArrayList<byte[]> l = new java.util.ArrayList<byte[]> (count);
+    private static void doGc(int count, Reference<?> toClear) {
+        java.util.ArrayList<byte[]> l = new java.util.ArrayList<> (count);
         while (count-- > 0) {
             if (toClear != null && toClear.get () == null) break;
             


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a Reference like the following

 [nb-javac] .../platform/openide.util.ui/test/unit/src/org/openide/util/actions/CallbackSystemActionTest.java:102: warning: [rawtypes] found raw type: Reference
 [nb-javac]         Reference actionref = new WeakReference(systemaction);
 [nb-javac]         ^
 [nb-javac]   missing type arguments for generic class Reference<T>
 [nb-javac]   where T is a type-variable:
 [nb-javac]     T extends Object declared in class Reference

The aim is to change the code such that these warnings are no longer emitted by the compiler.