### PR TITLE
[NETBEANS-3455] Fixed compiler warnings concerning rawtypes SoftRefer…

### DIFF
--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/Index.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/Index.java
@@ -210,9 +210,9 @@ public final class Index {
 
                     value = new CacheValue(fieldsToLoad, result);
                     if ((result.size() * AVERAGE_BASIC_INFO_SIZE) < MAX_CACHE_VALUE_SIZE) {
-                        CACHE_INDEX_RESULT_SMALL.put(key, new SoftReference(value));
+                        CACHE_INDEX_RESULT_SMALL.put(key, new SoftReference<>(value));
                     } else {
-                        CACHE_INDEX_RESULT_LARGE.put(key, new SoftReference(value));
+                        CACHE_INDEX_RESULT_LARGE.put(key, new SoftReference<>(value));
                     }
                     logStats(result, false, fieldsToLoad);
                     return value.getResult();


### PR DESCRIPTION
…ence

There are compiler warnings about rawtype usage with a SoftReference like the following
```
    [repeat] .../webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/Index.java:215: warning: [rawtypes] found raw type: SoftReference
   [repeat]                         CACHE_INDEX_RESULT_LARGE.put(key, new SoftReference(value));
   [repeat]                                                               ^
   [repeat]   missing type arguments for generic class SoftReference<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in class SoftReference
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.