### PR TITLE
[NETBEANS-3458] Fixed compiler warnings concerning rawtypes Performer

### DIFF
--- a/platform/openide.awt/src/org/openide/awt/ContextAction.java
+++ b/platform/openide.awt/src/org/openide/awt/ContextAction.java
@@ -458,7 +458,7 @@ implements Action, ContextAwareAction, ChangeListener, Runnable {
                 return true;
             }
             if (obj instanceof Performer) {
-                Performer l = (Performer)obj;
+                Performer<?> l = (Performer<?>) obj;
                 return delegate.equals(l.delegate);
             }
             return false;


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a Performer like the following
```
   [repeat] .../platform/openide.awt/src/org/openide/awt/ContextAction.java:461: warning: [rawtypes] found raw type: Performer
   [repeat]                 Performer l = (Performer)obj;
   [repeat]                 ^
   [repeat]   missing type arguments for generic class Performer<Data>
   [repeat]   where Data is a type-variable:
   [repeat]     Data extends Object declared in class Performer
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.