### PR TITLE
[NETBEANS-3459] Fixed compiler warnings concerning rawtypes TargetPan…

### DIFF
--- a/ide/target.iterator/src/org/netbeans/modules/target/iterator/api/TargetChooserPanel.java
+++ b/ide/target.iterator/src/org/netbeans/modules/target/iterator/api/TargetChooserPanel.java
@@ -213,11 +213,11 @@ public final class TargetChooserPanel<T> implements WizardDescriptor.Panel {
     }
 
     private void loadProvider( ) {
-        Collection<? extends TargetPanelProvider> providers = 
-            Lookup.getDefault().lookupAll( TargetPanelProvider.class );
-        for (TargetPanelProvider targetPanelProvider : providers) {
-            if ( targetPanelProvider.isApplicable( myId)){
-                myProvider = (TargetPanelProvider<T>)targetPanelProvider;
+        Collection<? extends TargetPanelProvider<T>> providers
+                = (Collection<? extends TargetPanelProvider<T>>) Lookup.getDefault().lookupAll(TargetPanelProvider.class);
+        for (TargetPanelProvider<T> targetPanelProvider : providers) {
+            if (targetPanelProvider.isApplicable(myId)) {
+                myProvider = targetPanelProvider;
                 break;
             }
         }


### PR DESCRIPTION
…elProvider

There are compiler warnings about rawtype usage with a TargetPanelProvider like the following
```
   [repeat] .../ide/target.iterator/src/org/netbeans/modules/target/iterator/api/TargetChooserPanel.java:218: warning: [rawtypes] found raw type: TargetPanelProvider
   [repeat]         for (TargetPanelProvider targetPanelProvider : providers) {
   [repeat]              ^
   [repeat]   missing type arguments for generic class TargetPanelProvider<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in interface TargetPanelProvider
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.