### PR TITLE
[NETBEANS-3460] Fixed compiler warnings concerning rawtypes TreeMap

### DIFF
--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/utils/StringPrefixTree.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/utils/StringPrefixTree.java
@@ -69,7 +69,7 @@ public class StringPrefixTree<Type> {
          */
         Node() {
             this.finalState = false;
-            this.next = new TreeMap();
+            this.next = new TreeMap<>();
         }
 
         /**
@@ -80,7 +80,7 @@ public class StringPrefixTree<Type> {
          */
         Node(Type value) {
             this.finalState = true;
-            this.next = new TreeMap();
+            this.next = new TreeMap<>();
             this.value = value;
         }
 

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/utils/StringPrefixTree.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/utils/StringPrefixTree.java
@@ -69,7 +69,7 @@ public class StringPrefixTree<Type> {
          */
         Node() {
             this.finalState = false;
-            this.next = new TreeMap();
+            this.next = new TreeMap<>();
         }
 
         /**
@@ -80,7 +80,7 @@ public class StringPrefixTree<Type> {
          */
         Node(Type value) {
             this.finalState = true;
-            this.next = new TreeMap();
+            this.next = new TreeMap<>();
             this.value = value;
         }
 

--- a/ide/ide.kit/nbproject/project.properties
+++ b/ide/ide.kit/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 test.config.installer.includes=\
     org/netbeans/test/ide/InstallationCompletenessTest.class
 test.config.au.includes=\

--- a/ide/ide.kit/test/qa-functional/src/org/netbeans/test/ide/BlacklistedClassesHandlerSingleton.java
+++ b/ide/ide.kit/test/qa-functional/src/org/netbeans/test/ide/BlacklistedClassesHandlerSingleton.java
@@ -78,7 +78,7 @@ public class BlacklistedClassesHandlerSingleton extends Handler implements Black
     private int violation;
     // TODO: Is it necessary to use synchronizedMap? Should the list be synchronized?
     final private Map blacklist = Collections.synchronizedMap(new HashMap());
-    final private Map whitelistViolators = Collections.synchronizedMap(new TreeMap());
+    final private Map<String, List<Exception>> whitelistViolators = Collections.synchronizedMap(new TreeMap<String, List<Exception>>());
     final private Set whitelist = Collections.synchronizedSortedSet(new TreeSet());
     final private Set previousWhitelist = Collections.synchronizedSortedSet(new TreeSet());
     final private Set newWhitelist = Collections.synchronizedSortedSet(new TreeSet());
@@ -368,9 +368,9 @@ public class BlacklistedClassesHandlerSingleton extends Handler implements Black
                         synchronized (whitelistViolators) {
                             // TODO: Probably we should synchronize by list
                             if (whitelistViolators.containsKey(className)) {
-                                ((List) whitelistViolators.get(className)).add(exc);
+                                whitelistViolators.get(className).add(exc);
                             } else {
-                                List exceptions = new ArrayList();
+                                List<Exception> exceptions = new ArrayList<>();
                                 exceptions.add(exc);
                                 whitelistViolators.put(className, exceptions);
                                 violation++;
@@ -753,11 +753,9 @@ public class BlacklistedClassesHandlerSingleton extends Handler implements Black
     public void filterViolators(String[] list) {
         if (list!=null) {
             StringBuilder violat =new StringBuilder();
-            final Set keySet = whitelistViolators.keySet();
+            final Set<String> keySet = whitelistViolators.keySet();
             int count = list.length;
-            Iterator iter = keySet.iterator();
-            while (iter.hasNext()) {
-                String violator = (String) iter.next();
+            for (String violator : keySet) {
                 boolean filtered = true;
                 for (int i = 0; i < count; i++) {
                     if (  (violator.toLowerCase().contains(list[i])) ) {

--- a/ide/jellytools.ide/nbproject/project.properties
+++ b/ide/jellytools.ide/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=3.40.0
 

--- a/ide/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/CollectBundleKeys.java
+++ b/ide/jellytools.ide/test/qa-functional/src/org/netbeans/jellytools/CollectBundleKeys.java
@@ -47,14 +47,12 @@ public class CollectBundleKeys {
         StringBuffer sb = new StringBuffer();
         byte b[] = new byte[1000];
         int i;
-        ArrayList dirs = new ArrayList();
+        ArrayList<File> dirs = new ArrayList<>();
         File sub[];
         dirs.add(new File(args[0]));
-        TreeMap bundles = new TreeMap();
-        String bundle, key;
-        TreeSet keys;
+        TreeMap<String, TreeSet<String>> bundles = new TreeMap<>();
         while (dirs.size() > 0) {
-            sub = ((File) dirs.remove(0)).listFiles();
+            sub = dirs.remove(0).listFiles();
             for (int j = 0; sub != null && j < sub.length; j++) {
                 if (sub[j].isDirectory()) {
                     dirs.add(sub[j]);
@@ -66,12 +64,12 @@ public class CollectBundleKeys {
                     in.close();
                     Matcher m = pat.matcher(sb);
                     while (m.find()) {
-                        bundle = m.group(2);
-                        key = m.group(3);
+                        String bundle = m.group(2);
+                        String key = m.group(3);
                         if (bundles.containsKey(bundle)) {
-                            ((TreeSet) bundles.get(bundle)).add(key);
+                            bundles.get(bundle).add(key);
                         } else {
-                            keys = new TreeSet();
+                            TreeSet<String> keys = new TreeSet<>();
                             keys.add(key);
                             bundles.put(bundle, keys);
                         }
@@ -79,19 +77,16 @@ public class CollectBundleKeys {
                 }
             }
         }
-        Iterator bi = bundles.keySet().iterator();
-        Iterator ki;
         int bs = 0, ks = 0;
         PrintStream out = new PrintStream(new FileOutputStream(args[1]));
-        while (bi.hasNext()) {
+        for (String bundle : bundles.keySet()) {
             bs++;
-            bundle = (String) bi.next();
-            ki = ((TreeSet) bundles.get(bundle)).iterator();
+            Iterator<String> ki = bundles.get(bundle).iterator();
             out.print(bundle + "=");
-            out.print((String) ki.next());
+            out.print(ki.next());
             ks++;
             while (ki.hasNext()) {
-                out.print("," + (String) ki.next());
+                out.print("," + ki.next());
                 ks++;
             }
             out.println();

--- a/ide/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/LookupTest.java
+++ b/ide/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/LookupTest.java
@@ -44,9 +44,9 @@ public class LookupTest  extends DebuggerApiTestBase {
     public void testCompoundLookup() throws Exception {
 
         Object stringInstance = "stringInstace";
-        HashMap hashMapInstance = new HashMap();
+        HashMap<?, ?> hashMapInstance = new HashMap<>();
         Socket socketInstance = new Socket();
-        TreeMap treeMapInstance = new TreeMap();
+        TreeMap<?, ?> treeMapInstance = new TreeMap<>();
         StringBuffer sbInstance = new StringBuffer();
         Object [] instances = new Object [] {
             stringInstance,
@@ -57,9 +57,9 @@ public class LookupTest  extends DebuggerApiTestBase {
         };
 
         Object stringInstance2 = "stringInstace";
-        HashMap hashMapInstance2 = new HashMap();
+        HashMap<?, ?> hashMapInstance2 = new HashMap<>();
         Socket socketInstance2 = new Socket();
-        TreeMap treeMapInstance2 = new TreeMap();
+        TreeMap<?, ?> treeMapInstance2 = new TreeMap<>();
         StringBuffer sbInstance2 = new StringBuffer();
         Object [] instances2 = new Object [] {
             stringInstance2,
@@ -139,9 +139,9 @@ public class LookupTest  extends DebuggerApiTestBase {
     public void testInstanceLookup() throws Exception {
 
         Object stringInstance = "stringInstace";
-        HashMap hashMapInstance = new HashMap();
+        HashMap<?, ?> hashMapInstance = new HashMap<>();
         Socket socketInstance = new Socket();
-        TreeMap treeMapInstance = new TreeMap();
+        TreeMap<?, ?> treeMapInstance = new TreeMap<>();
         StringBuffer sbInstance = new StringBuffer();
 
         Object [] instances = new Object [] {

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/ui/RequireJsPanel.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/ui/RequireJsPanel.java
@@ -285,7 +285,7 @@ final class RequireJsPanel extends JPanel implements HelpCtx.Provider {
     }
     
     private Map<String, String> getPathMappings() {
-        Map<String, String> mappings = new TreeMap();
+        Map<String, String> mappings = new TreeMap<>();
         for (int i = 0; i < pathMappingTableModel.getRowCount(); ++i) {
             String mapping = (String) pathMappingTableModel.getValueAt(i, COLUMN_MAPPING_PATH);
             String localPath = ((LocalPathCell) pathMappingTableModel.getValueAt(i, COLUMN_LOCAL_PATH)).getPath();


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a TreeMap like the following
```
 [nb-javac] ..../ide/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/LookupTest.java:62: warning: [rawtypes] found raw type: TreeMap
 [nb-javac]         TreeMap treeMapInstance2 = new TreeMap();
 [nb-javac]                                        ^
 [nb-javac]   missing type arguments for generic class TreeMap<K,V>
 [nb-javac]   where K,V are type-variables:
 [nb-javac]     K extends Object declared in class TreeMap
 [nb-javac]     V extends Object declared in class TreeMap
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.