### PR TITLE
[NETBEANS-3461] Fixed compiler warnings concerning rawtypes FutureTask

### DIFF
--- a/java/junit.ant.ui/nbproject/project.properties
+++ b/java/junit.ant.ui/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 requires.nb.javac=true

--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/JUnitProjectOpenedHook.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/JUnitProjectOpenedHook.java
@@ -222,7 +222,7 @@ public class JUnitProjectOpenedHook implements LookupProvider {
             } else {
                 res = ProjectProblemsProvider.Result.create(ProjectProblemsProvider.Status.UNRESOLVED, "No resolution for the problem");
             }
-            RunnableFuture<ProjectProblemsProvider.Result> f = new FutureTask(new Runnable() {
+            RunnableFuture<ProjectProblemsProvider.Result> f = new FutureTask<>(new Runnable() {
                 @Override
                 public void run() {
                 }


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a FutureTask like the following
```
 [nb-javac] .../java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/JUnitProjectOpenedHook.java:225: warning: [rawtypes] found raw type: FutureTask
 [nb-javac]             RunnableFuture<ProjectProblemsProvider.Result> f = new FutureTask(new Runnable() {
 [nb-javac]                                                                    ^
 [nb-javac]   missing type arguments for generic class FutureTask<V>
 [nb-javac]   where V is a type-variable:
 [nb-javac]     V extends Object declared in class FutureTask
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.