### PR TITLE
[NETBEANS-3462] Fixed compiler warnings concerning rawtypes SimpleFuture

### DIFF
--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ear/model/ApplicationMetadataModelImpl.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ear/model/ApplicationMetadataModelImpl.java
@@ -107,7 +107,7 @@ public class ApplicationMetadataModelImpl implements MetadataModelImplementation
     
     @Override
     public <R> Future<R> runReadActionWhenReady(final MetadataModelAction<ApplicationMetadata, R> action) throws IOException {
-        return new SimpleFuture(runReadAction(action));
+        return new SimpleFuture<>(runReadAction(action));
     }
     
     private FileObject getDeploymentDescriptor(final Project earProject) {


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a SimpleFuture like the following
```
 [nb-javac] .../enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/ear/model/ApplicationMetadataModelImpl.java:110: warning: [rawtypes] found raw type: SimpleFuture
 [nb-javac]         return new SimpleFuture(runReadAction(action));
 [nb-javac]                    ^
 [nb-javac]   missing type arguments for generic class SimpleFuture<R>
 [nb-javac]   where R is a type-variable:
 [nb-javac]     R extends Object declared in class SimpleFuture
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.