### PR TITLE
[NETBEANS-3463] Fixed compiler warnings concerning rawtypes Observabl…

### DIFF
--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/ObservableAction.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/ObservableAction.java
@@ -147,7 +147,7 @@ public abstract class ObservableAction<T>
         List<ObservableActionListener<T>> ll =
                 new ArrayList<>(listeners);
 
-        for (ObservableActionListener l : ll) {
+        for (ObservableActionListener<T> l : ll) {
             l.actionStarted(this);
         }
     }


### PR DESCRIPTION
…eActionListener

There are compiler warnings about rawtype usage with a ObservableActionListener like the following
```
   [repeat] .../ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/ObservableAction.java:150: warning: [rawtypes] found raw type: ObservableActionListener
   [repeat]         for (ObservableActionListener l : ll) {
   [repeat]              ^
   [repeat]   missing type arguments for generic class ObservableActionListener<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in interface ObservableActionListener
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.