### PR TITLE
[NETBEANS-3464] Fixed compiler warnings concerning rawtypes WeakSet

### DIFF
--- a/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/locals/VariablesTreeExpansionModel.java
+++ b/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/locals/VariablesTreeExpansionModel.java
@@ -44,8 +44,8 @@ public class VariablesTreeExpansionModel implements TreeExpansionModel {
     
     private static final Logger LOGGER = Logger.getLogger(VariablesTreeExpansionModel.class.getName());
 
-    private Set expandedNodes = new WeakSet();
-    private Set collapsedNodes = new WeakSet();
+    private Set<Object> expandedNodes = new WeakSet<>();
+    private Set<Object> collapsedNodes = new WeakSet<>();
 
     /**
      * Defines default state (collapsed, expanded) of given node.


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a WeakSet like the following
```
   [repeat] .../webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/locals/VariablesTreeExpansionModel.java:47: warning: [rawtypes] found raw type: WeakSet
   [repeat]     private Set expandedNodes = new WeakSet();
   [repeat]                                     ^
   [repeat]   missing type arguments for generic class WeakSet<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in class WeakSet
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.