### PR TITLE
[NETBEANS-3465] Fixed compiler warnings concerning rawtypes ReadWrite

### DIFF
--- a/platform/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EnumPropertyEditorTest.java
+++ b/platform/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EnumPropertyEditorTest.java
@@ -78,7 +78,7 @@ public class EnumPropertyEditorTest extends NbTestCase {
         CHOCOLATE, VANILLA, STRAWBERRY
     }
 
-    private static class EProp extends PropertySupport.ReadWrite {
+    private static class EProp extends PropertySupport.ReadWrite<E> {
 
         private E e = E.VANILLA;
 
@@ -86,12 +86,12 @@ public class EnumPropertyEditorTest extends NbTestCase {
             super("eval", E.class, "E Val", "E value");
         }
 
-        public Object getValue() throws IllegalAccessException, InvocationTargetException {
+        public E getValue() throws IllegalAccessException, InvocationTargetException {
             return e;
         }
 
-        public void setValue(Object val) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-            e = (E) val;
+        public void setValue(E val) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+            e = val;
         }
 
     }


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a ReadWrite like the following
```
 [nb-javac] .../platform/openide.explorer/test/unit/src/org/openide/explorer/propertysheet/EnumPropertyEditorTest.java:81: warning: [rawtypes] found raw type: ReadWrite
 [nb-javac]     private static class EProp extends PropertySupport.ReadWrite {
 [nb-javac]                                                       ^
 [nb-javac]   missing type arguments for generic class ReadWrite<T>
 [nb-javac]   where T is a type-variable:
 [nb-javac]     T extends Object declared in class ReadWrite
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.