### PR TITLE
[NETBEANS-3466] Fixed compiler warnings concerning rawtypes Stack

### DIFF
--- a/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
+++ b/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
@@ -482,10 +482,10 @@ public final class XMLSyntaxSupport extends ExtSyntaxSupport implements XMLToken
      * @param  offset of a child in parent
      * @return all tags used as children of given parent that precedes the offset
      */
-    public List getPreviousLevelTags( int offset) throws BadLocationException {
-        List result = new ArrayList();
-        Stack stack = new Stack();
-        Vector children = new Vector();
+    public List<String> getPreviousLevelTags( int offset) throws BadLocationException {
+        List<String> result = new ArrayList<>();
+        Stack<String> stack = new Stack<>();
+        Vector<String> children = new Vector<>();
         
         SyntaxElement elem = getElementChain( offset );
         if( elem != null ) {
@@ -540,9 +540,9 @@ public final class XMLSyntaxSupport extends ExtSyntaxSupport implements XMLToken
      * @param  offset of a child in parent
      * @return all tags used as children of given parent that follows the offset
      */
-    public List getFollowingLevelTags(int offset)throws BadLocationException{
-        Stack stack = new Stack();
-        Vector children = new Vector();
+    public List<String> getFollowingLevelTags(int offset)throws BadLocationException{
+        Stack<String> stack = new Stack<>();
+        Vector<String> children = new Vector<>();
         
         SyntaxElement elem = getElementChain( offset );
         if( elem != null ) {
@@ -551,7 +551,7 @@ public final class XMLSyntaxSupport extends ExtSyntaxSupport implements XMLToken
             if( offset > 0 ) {
                 elem = getElementChain( offset-1 );
             } else { // beginning of document too, not much we can do on empty doc
-                return new ArrayList();
+                return new ArrayList<>();
             }
         }
         

--- a/java/java.examples/nbproject/project.properties
+++ b/java/java.examples/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8

--- a/java/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectGenerator.java
+++ b/java/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectGenerator.java
@@ -124,7 +124,7 @@ public class J2SESampleProjectGenerator {
     
     private static FileObject createProjectFolder (File projectFolder) throws IOException {
         FileObject projLoc;
-        Stack nameStack = new Stack ();
+        Stack<String> nameStack = new Stack<>();
         while ((projLoc = FileUtil.toFileObject(projectFolder)) == null) {            
             nameStack.push(projectFolder.getName());
             projectFolder = projectFolder.getParentFile();            

--- a/java/xml.tools.java/nbproject/project.properties
+++ b/java/xml.tools.java/nbproject/project.properties
@@ -15,5 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
 disable.qa-functional.tests=true
 requires.nb.javac=true

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsParser.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsParser.java
@@ -36,12 +36,12 @@ public class SAXBindingsParser extends org.xml.sax.helpers.DefaultHandler {
     
     private SAXBindingsHandler handler;
     
-    private java.util.Stack context;
+    private java.util.Stack<Object[]> context;
         
     public SAXBindingsParser(final SAXBindingsHandler handler) {
         this.handler = handler;
         buffer = new StringBuffer(111);
-        context = new java.util.Stack();
+        context = new java.util.Stack<>();
     }
     
     public void setDocumentLocator(Locator locator) {

--- a/php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java
+++ b/php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java
@@ -265,7 +265,7 @@ public class PHPSamplesWizardIterator implements WizardDescriptor./*Progress*/In
     }
 
     private static FileObject createFolder(File dir) throws IOException {
-        Stack stack = new Stack();
+        Stack<String> stack = new Stack<>();
         while (!dir.exists()) {
             stack.push(dir.getName());
             dir = dir.getParentFile();
@@ -277,7 +277,7 @@ public class PHPSamplesWizardIterator implements WizardDescriptor./*Progress*/In
         }
         assert dirFO != null;
         while (!stack.isEmpty()) {
-            dirFO = dirFO.createFolder((String) stack.pop());
+            dirFO = dirFO.createFolder(stack.pop());
         }
         return dirFO;
     }

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLEngineImpl.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLEngineImpl.java
@@ -242,20 +242,20 @@ public class OQLEngineImpl {
             }
 
             if (q.className != null) {
-                Stack toInspect = new Stack();
-                Set inspected = new HashSet();
+                Stack<JavaClass> toInspect = new Stack<>();
+                Set<JavaClass> inspected = new HashSet<>();
 
                 toInspect.push(clazz);
 
-                Object inspecting = null;
+                JavaClass inspecting = null;
                 while(!toInspect.isEmpty()) {
                     inspecting = toInspect.pop();
                     inspected.add(inspecting);
-                    JavaClass clz = (JavaClass)inspecting;
+                    JavaClass clz = inspecting;
                     if (q.isInstanceOf) {
                         for(Object subclass : clz.getSubClasses()) {
                             if (!inspected.contains(subclass) && !toInspect.contains(subclass)) {
-                                toInspect.push(subclass);
+                                toInspect.push((JavaClass) subclass);
                             }
                         }
                     }

--- a/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/NbLexerCharStream.java
+++ b/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/NbLexerCharStream.java
@@ -32,7 +32,7 @@ public class NbLexerCharStream implements CharStream {
 
     private static final String STREAM_NAME = "NbLexerCharStream"; //NOI18N
     private final LexerInput li;
-    private final Stack<Integer> markers = new Stack();
+    private final Stack<Integer> markers = new Stack<>();
 
     public NbLexerCharStream(LexerRestartInfo lri) {
         this.li = lri.input();


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a Stack like the following
```
   [repeat] .../profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLEngineImpl.java:245: warning: [rawtypes] found raw type: Stack
   [repeat]                 Stack toInspect = new Stack();
   [repeat]                                       ^
   [repeat]   missing type arguments for generic class Stack<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in class Stack
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.