### PR TITLE
[NETBEANS-3476] - cleanup redundant casts..

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/CommonServerSupport.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/CommonServerSupport.java
@@ -457,8 +457,7 @@ public class CommonServerSupport
         VMIntrospector vmi = Lookups.forPath(Util.GF_LOOKUP_PATH).lookup(VMIntrospector.class);
         FutureTask<TaskState> task = new FutureTask<TaskState>(
                 new StartTask(this, getRecognizers(), vmi,
-                (String[]) (endState == ServerState.STOPPED_JVM_PROFILER
-                ? new String[]{""} : null),
+                endState == ServerState.STOPPED_JVM_PROFILER ? new String[]{""} : null,
                 startServerListener, stateListener));
         startTask = task;
         RP.post(task);

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/utils/StringPrefixTree.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/utils/StringPrefixTree.java
@@ -320,7 +320,7 @@ public class StringPrefixTree<Type> {
         while((item = stack.getLast())!= null) {
             // Tree step down.
             if (item.child.hasNext()) {
-                stack.addLast(new StackItem((Node)item.child.next()));
+                stack.addLast(new StackItem(item.child.next()));
             // Current node processing and tree setep up.
             } else {
                 item.node.destroy();

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/PersistenceProviderSupplierImpl.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/PersistenceProviderSupplierImpl.java
@@ -60,7 +60,7 @@ public final class PersistenceProviderSupplierImpl implements PersistenceProvide
     @Override
     public List<Provider> getSupportedProviders() {
         try {
-            J2eeModuleProvider j2eeModuleProvider = (J2eeModuleProvider) project.getLookup().lookup(J2eeModuleProvider.class);
+            J2eeModuleProvider j2eeModuleProvider = project.getLookup().lookup(J2eeModuleProvider.class);
             String serverInstanceId = j2eeModuleProvider.getServerInstanceID();
             ServerInstance si = serverInstanceId != null ? Deployment.getDefault().getServerInstance(serverInstanceId) : null;
             J2eePlatform platform = null;

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/J2EEProjectProperties.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/J2EEProjectProperties.java
@@ -158,7 +158,7 @@ public final class J2EEProjectProperties {
         String instanceId = null;
         String instance = eval.getProperty(J2EE_SERVER_INSTANCE);
         if (instance != null) {
-            J2eeModuleProvider jmp = (J2eeModuleProvider) project.getLookup().lookup(J2eeModuleProvider.class);
+            J2eeModuleProvider jmp = project.getLookup().lookup(J2eeModuleProvider.class);
             String sdi = jmp.getServerInstanceID();
             if (sdi != null) {
                 String id = Deployment.getDefault().getServerID(sdi);

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/logicalview/AbstractLogicalViewProvider.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/logicalview/AbstractLogicalViewProvider.java
@@ -688,7 +688,7 @@ public abstract class AbstractLogicalViewProvider implements LogicalViewProvider
             if (p == null) {
                 return this;
             }
-            J2eeModuleProvider provider = (J2eeModuleProvider) p.getLookup().lookup(J2eeModuleProvider.class);
+            J2eeModuleProvider provider = p.getLookup().lookup(J2eeModuleProvider.class);
             if (provider == null) {
                 return this;
             }

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectServerWizardPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectServerWizardPanel.java
@@ -126,7 +126,7 @@ public final class ProjectServerWizardPanel implements WizardDescriptor.Panel, W
     public void storeSettings(Object settings) {
         WizardDescriptor d = (WizardDescriptor) settings;
         component.store(d);
-        ((WizardDescriptor) d).putProperty("NewProjectWizard_Title", null); // NOI18N
+        d.putProperty("NewProjectWizard_Title", null); // NOI18N
     }
 
 }

--- a/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/JPAStuffImpl.java
+++ b/enterprise/maven.j2ee/src/org/netbeans/modules/maven/j2ee/JPAStuffImpl.java
@@ -96,7 +96,7 @@ public class JPAStuffImpl implements JPAModuleInfo, JPADataSourcePopulator,
 
     @Override
     public Boolean isJPAVersionSupported(String version) {
-        J2eeModuleProvider j2eeModuleProvider = (J2eeModuleProvider) project.getLookup().lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider j2eeModuleProvider = project.getLookup().lookup(J2eeModuleProvider.class);
         J2eePlatform platform  = Deployment.getDefault().getJ2eePlatform(j2eeModuleProvider.getServerInstanceID());
         
         if (platform == null) {

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/CommonServerSupport.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/CommonServerSupport.java
@@ -466,8 +466,7 @@ public class CommonServerSupport
         VMIntrospector vmi = Lookups.forPath(Util.PF_LOOKUP_PATH).lookup(VMIntrospector.class);
         FutureTask<TaskState> task = new FutureTask<TaskState>(
                 new StartTask(this, getRecognizers(), vmi,
-                (String[]) (endState == ServerState.STOPPED_JVM_PROFILER
-                ? new String[]{""} : null),
+                endState == ServerState.STOPPED_JVM_PROFILER ? new String[]{""} : null,
                 startServerListener, stateListener));
         startTask = task;
         RP.post(task);

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/ui/IpComboBox.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/ui/IpComboBox.java
@@ -307,8 +307,7 @@ public class IpComboBox extends JComboBox<IpComboBox.InetAddr> {
         for (i = 0; i < count; i++) {
             InetAddr element = dataModel.getElementAt(i);
             // Passed IP address has highest priority.
-            if (((InetAddress) ip).equals(
-                    element.getIp())) {
+            if (ip.equals(element.getIp())) {
                 super.setSelectedItem(element);
                 isSelectedSet = true;
                 break;

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDVisualPanel.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDVisualPanel.java
@@ -55,7 +55,7 @@ public final class PayaraDDVisualPanel extends JPanel {
         // figure out which ones exist already
         // 
         Lookup lookup = project.getLookup();
-        J2eeModuleProvider provider = (J2eeModuleProvider) lookup.lookup(J2eeModuleProvider.class);
+        J2eeModuleProvider provider = lookup.lookup(J2eeModuleProvider.class);
         J2eeModule j2eeModule = provider.getJ2eeModule();
         payaraDDFileName = getConfigFileName(j2eeModule,provider.getServerInstanceID());
 

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/ResourceRegistrationHelper.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/ResourceRegistrationHelper.java
@@ -175,7 +175,7 @@ public class ResourceRegistrationHelper {
             if (key.indexOf("property.") != -1) { // NOI18N
                 props.add(key);
             }
-            String localValue = (String) localData.get(key);
+            String localValue = localData.get(key);
             if (localValue != null) {
                 if (remoteValue == null || !localValue.equals(remoteValue)) {
                     changedData.put(remoteDataKey, localValue);

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/verifier/VerifierImpl.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/verifier/VerifierImpl.java
@@ -102,7 +102,7 @@ public  class VerifierImpl extends org.netbeans.modules.j2ee.deployment.plugins.
         J2eeModuleProvider modProvider = null;
         Project holdingProj = FileOwnerQuery.getOwner(target);
         if (holdingProj != null){
-            modProvider = (J2eeModuleProvider) holdingProj.getLookup().lookup(J2eeModuleProvider.class);
+            modProvider = holdingProj.getLookup().lookup(J2eeModuleProvider.class);
         }
         return modProvider;
     }

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/utils/StringPrefixTree.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/utils/StringPrefixTree.java
@@ -320,7 +320,7 @@ public class StringPrefixTree<Type> {
         while((item = stack.getLast())!= null) {
             // Tree step down.
             if (item.child.hasNext()) {
-                stack.addLast(new StackItem((Node)item.child.next()));
+                stack.addLast(new StackItem(item.child.next()));
             // Current node processing and tree setep up.
             } else {
                 item.node.destroy();

--- a/enterprise/web.el/src/org/netbeans/modules/web/el/ELTypeUtilities.java
+++ b/enterprise/web.el/src/org/netbeans/modules/web/el/ELTypeUtilities.java
@@ -956,7 +956,7 @@ public final class ELTypeUtilities {
                                     return;
                                 } else {
                                     if (propertyType != null) {
-                                        enclosing = getTypeFor(info, ((ExecutableElement) propertyType).getReturnType().toString());
+                                        enclosing = getTypeFor(info, propertyType.getReturnType().toString());
                                     }
                                 }
                             }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigDataObject.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigDataObject.java
@@ -82,7 +82,7 @@ public class JSFConfigDataObject extends MultiDataObject implements org.openide.
         cookies.add(JSFConfigEditorSupport.class, this);
 
         //Lookup JSFConfigEditorContext for Page Flow Editor multiview
-        cookies.assign(JSFConfigEditorContext.class, new JSFConfigEditorContextImpl((JSFConfigDataObject)this));
+        cookies.assign(JSFConfigEditorContext.class, new JSFConfigEditorContextImpl(this));
 
         // Creates Check XML and Validate XML context actions
         InputSource in = DataObjectAdapters.inputSource(this);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigEditorSupport.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigEditorSupport.java
@@ -477,7 +477,7 @@ public class JSFConfigEditorSupport extends DataEditorSupport
          */
         @Override
         public org.openide.windows.CloneableOpenSupport findCloneableOpenSupport() {
-            return (JSFConfigEditorSupport) getDataObject().getCookie(JSFConfigEditorSupport.class);
+            return getDataObject().getCookie(JSFConfigEditorSupport.class);
         }
     }
 }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/JSFConfigurationPanelVisual.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/JSFConfigurationPanelVisual.java
@@ -248,7 +248,7 @@ public class JSFConfigurationPanelVisual extends javax.swing.JPanel implements H
                 }
 
                 // searching in server registered JSF libraries
-                J2eeModuleProvider j2eeModuleProvider = (J2eeModuleProvider) project.getLookup().lookup(J2eeModuleProvider.class);
+                J2eeModuleProvider j2eeModuleProvider = project.getLookup().lookup(J2eeModuleProvider.class);
                 Set<ServerLibraryDependency> deps = getServerDependencies(j2eeModuleProvider);
                 for (ServerLibraryDependency serverLibraryDependency : deps) {
                     if (serverLibraryDependency.getName().startsWith("jsf")) { //NOI18N

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceGroup.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceGroup.java
@@ -102,7 +102,7 @@ public class WebServiceGroup {
             Iterator<WebServiceGroupListener> iter = listeners.iterator();
             while(iter.hasNext()) {
                 WebServiceGroupEvent evt = new  WebServiceGroupEvent(webServiceId, getId());
-                ((WebServiceGroupListener)iter.next()).webServiceAdded(evt);
+                iter.next().webServiceAdded(evt);
             }
         }else if (!quietly) {
             // This is a hack to make the nodes to appear while restoring 
@@ -110,7 +110,7 @@ public class WebServiceGroup {
             Iterator<WebServiceGroupListener> iter = listeners.iterator();
             while(iter.hasNext()) {
                 WebServiceGroupEvent evt = new  WebServiceGroupEvent(webServiceId, getId());
-                ((WebServiceGroupListener)iter.next()).webServiceAdded(evt);
+                iter.next().webServiceAdded(evt);
             }
         }
     }
@@ -124,7 +124,7 @@ public class WebServiceGroup {
             Iterator<WebServiceGroupListener> iter = listeners.iterator();
             while(iter.hasNext()) {
                 WebServiceGroupEvent evt = new  WebServiceGroupEvent(webServiceId, getId());
-                ((WebServiceGroupListener)iter.next()).webServiceRemoved(evt);
+                iter.next().webServiceRemoved(evt);
             }
         }
     }
@@ -134,7 +134,7 @@ public class WebServiceGroup {
         Iterator<WebServiceGroupListener> iter = listeners.iterator();
         while(iter.hasNext()) {
             WebServiceGroupEvent evt = new  WebServiceGroupEvent(webServiceId, getId());
-            ((WebServiceGroupListener)iter.next()).webServiceRemoved(evt);
+            iter.next().webServiceRemoved(evt);
         }
     }
     

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceListModel.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceListModel.java
@@ -231,7 +231,7 @@ public class WebServiceListModel {
              * it and the set is modified.
              * - David Botterill 5/6/2004.
              */
-            String[] webserviceIds = (String[]) getWebServiceGroup(groupId).getWebServiceIds().toArray(new String[0]);
+            String[] webserviceIds = getWebServiceGroup(groupId).getWebServiceIds().toArray(new String[0]);
             for (int ii = 0; null != webserviceIds && ii < webserviceIds.length; ii++) {
                 WebServiceManager.getInstance().removeWebService(getWebService(webserviceIds[ii]));
             }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/TestWebServiceMethodDlg.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/TestWebServiceMethodDlg.java
@@ -151,7 +151,7 @@ public class TestWebServiceMethodDlg extends JPanel implements ActionListener, M
                     }
                 }
 
-                URL[] urls = (URL[]) urlList.toArray(new URL[0]);
+                URL[] urls = urlList.toArray(new URL[0]);
                 /**
                  * Delegate to the module's classloader since core/startup/NbInstaller
                  * overrides the JAX-WS 2.0 jars present in JDK 6

--- a/groovy/gradle.test/src/org/netbeans/modules/gradle/test/GradleTestProgressListener.java
+++ b/groovy/gradle.test/src/org/netbeans/modules/gradle/test/GradleTestProgressListener.java
@@ -85,7 +85,7 @@ public final class GradleTestProgressListener implements ProgressListener, Gradl
     }
 
     private void processTestProgress(TestProgressEvent evt) {
-        TestOperationDescriptor desc = (TestOperationDescriptor) evt.getDescriptor();
+        TestOperationDescriptor desc = evt.getDescriptor();
         if (evt instanceof TestStartEvent) {
             TestStartEvent start = (TestStartEvent) evt;
             if (desc.getParent() == null) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/GroovyIndexer.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/GroovyIndexer.java
@@ -97,7 +97,7 @@ public class GroovyIndexer extends EmbeddingIndexer {
             indexerFirstRun = indexerThisStartTime;
         }
 
-        GroovyParserResult r = (GroovyParserResult) ASTUtils.getParseResult(parserResult);
+        GroovyParserResult r = ASTUtils.getParseResult(parserResult);
         ASTNode root = ASTUtils.getRoot(r);
 
         if (root == null) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyVirtualSourceProvider.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyVirtualSourceProvider.java
@@ -433,7 +433,7 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
             if (stats == null || stats.isEmpty()) {
                 return null;
             }
-            Statement stat = (Statement) stats.get(0);
+            Statement stat = stats.get(0);
             if (!(stat instanceof ExpressionStatement)) {
                 return null;
             }

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/debug/GroovyToggleBreakpointActionProvider.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/debug/GroovyToggleBreakpointActionProvider.java
@@ -50,7 +50,7 @@ public class GroovyToggleBreakpointActionProvider extends ActionsProviderSupport
     }
     
     public GroovyToggleBreakpointActionProvider (ContextProvider contextProvider) {
-        debugger = (JPDADebugger) contextProvider.lookupFirst(null, JPDADebugger.class);
+        debugger = contextProvider.lookupFirst(null, JPDADebugger.class);
         debugger.addPropertyChangeListener (JPDADebugger.PROP_STATE, this);
         Context.addPropertyChangeListener (this);
         setEnabled (ActionsManager.ACTION_TOGGLE_BREAKPOINT, false);

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/actions/MaximizeWindowAction.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/actions/MaximizeWindowAction.java
@@ -116,7 +116,7 @@ public class MaximizeWindowAction extends Action {
             public void run() {
                 WindowManager wm = WindowManager.getDefault();
                 TopComponent tc = (TopComponent) tco.getSource();
-                Mode mode = (Mode) wm.findMode(tc);
+                Mode mode = wm.findMode(tc);
                 if (mode == null) {
                     throw new JemmyException("Mode not found for " + tc);
                 }

--- a/harness/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ClasspathCustomEditorOperator.java
+++ b/harness/jellytools.platform/src/org/netbeans/jellytools/properties/editors/ClasspathCustomEditorOperator.java
@@ -258,7 +258,7 @@ public class ClasspathCustomEditorOperator extends NbDialogOperator {
         for (int i=0; i<model.getSize(); i++) {
             data.add(model.getElementAt(i).toString());
         }
-        return (String[])data.toArray(new String[data.size()]);
+        return data.toArray(new String[data.size()]);
     }
     
     /** Performs verification by accessing all sub-components */    

--- a/ide/api.xml.ui/src/org/netbeans/spi/xml/cookies/DataObjectAdapters.java
+++ b/ide/api.xml.ui/src/org/netbeans/spi/xml/cookies/DataObjectAdapters.java
@@ -81,7 +81,7 @@ public final class DataObjectAdapters {
         
         public Reader getCharacterStream() {
 
-            EditorCookie editor = (EditorCookie) dataObject.getCookie(EditorCookie.class);
+            EditorCookie editor = dataObject.getCookie(EditorCookie.class);
 
             if (editor != null) {
                 Document doc = editor.getDocument();

--- a/ide/api.xml/src/org/netbeans/api/xml/services/UserCatalog.java
+++ b/ide/api.xml/src/org/netbeans/api/xml/services/UserCatalog.java
@@ -51,7 +51,7 @@ public abstract class UserCatalog {
      * @return UserCatalog registered in default Lookup or <code>null</code>.
      */
     public static UserCatalog getDefault() {
-        return (UserCatalog) Lookup.getDefault().lookup(UserCatalog.class);
+        return Lookup.getDefault().lookup(UserCatalog.class);
     }
     
     /**

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/PropertiesReader.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/PropertiesReader.java
@@ -334,7 +334,7 @@ public class PropertiesReader {
                     out[outLen++] = aChar;
                 }
             } else {
-                out[outLen++] = (char) aChar;
+                out[outLen++] = aChar;
             }
         }
         return new String(out, 0, outLen);

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/CreateRulePanel.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/CreateRulePanel.java
@@ -991,7 +991,7 @@ public class CreateRulePanel extends javax.swing.JPanel {
     private static Document getDocument(FileObject file) {
         try {
             DataObject d = DataObject.find(file);
-            EditorCookie ec = (EditorCookie) d.getLookup().lookup(EditorCookie.class);
+            EditorCookie ec = d.getLookup().lookup(EditorCookie.class);
 
             if (ec == null) {
                 return null;

--- a/ide/db/src/org/netbeans/modules/db/explorer/DbDriverManager.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/DbDriverManager.java
@@ -144,7 +144,7 @@ public class DbDriverManager {
             if (!conn2Driver.containsKey(existingConn)) {
                 throw new IllegalArgumentException("A connection not obtained through DbDriverManager was passed."); // NOI18N
             }
-            driver = (Driver)conn2Driver.get(existingConn);
+            driver = conn2Driver.get(existingConn);
         }
         if (driver != null) {
             Connection newConn = driver.connect(databaseURL, props);
@@ -259,7 +259,7 @@ public class DbDriverManager {
     private ClassLoader getClassLoader(JDBCDriver driver) {
         ClassLoader loader = null;
         synchronized (driver2Loader) {
-            loader = (ClassLoader)driver2Loader.get(driver);
+            loader = driver2Loader.get(driver);
             if (loader == null) {
                 loader = new DbURLClassLoader(driver.getURLs());
                 if (LOG) {

--- a/ide/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/AuthenticationSettingsPanel.java
+++ b/ide/dlight.nativeexecution.nb/src/org/netbeans/modules/nativeexecution/ui/AuthenticationSettingsPanel.java
@@ -147,7 +147,7 @@ public class AuthenticationSettingsPanel extends ValidateablePanel {
                 if (index != -1) {
                     Rectangle checkBounds = ((AuthentificationCheckboxListRenderer)list.getCellRenderer()).check.getBounds();
                     if (event.getPoint().x <= checkBounds.width) {
-                        AuthenticationCheckboxListItem item = (AuthenticationCheckboxListItem) list.getModel().getElementAt(index);
+                        AuthenticationCheckboxListItem item = list.getModel().getElementAt(index);
                         item.setSelected(!item.isSelected());
                         list.repaint(list.getCellBounds(index, index));
                     }

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Win32APISupport.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/support/Win32APISupport.java
@@ -29,7 +29,7 @@ import com.sun.jna.win32.W32APIOptions;
 
 public interface Win32APISupport extends StdCallLibrary {
 
-    final Win32APISupport INSTANCE = (Win32APISupport) Native.load("kernel32", Win32APISupport.class, W32APIOptions.UNICODE_OPTIONS); // NOI18N
+    final Win32APISupport INSTANCE = Native.load("kernel32", Win32APISupport.class, W32APIOptions.UNICODE_OPTIONS); // NOI18N
 
     /* http://msdn.microsoft.com/en-us/library/ms683179(VS.85).aspx */
     HANDLE GetCurrentProcess();

--- a/ide/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java
+++ b/ide/editor.breadcrumbs/src/org/netbeans/modules/editor/breadcrumbs/BreadCrumbComponent.java
@@ -170,7 +170,7 @@ public class BreadCrumbComponent<T extends JLabel&Renderer> extends JComponent i
             i++;
         }
 
-        setPreferredSize(new Dimension((int) (xTotal + (nodes.length - 1) * (LEFT_SEPARATOR_INSET + SEPARATOR.getIconWidth() + RIGHT_SEPARATOR_INSET) + START_INSET), USABLE_HEIGHT/*(int) (height + 2 * INSET_HEIGHT)*/));
+        setPreferredSize(new Dimension((xTotal + (nodes.length - 1) * (LEFT_SEPARATOR_INSET + SEPARATOR.getIconWidth() + RIGHT_SEPARATOR_INSET) + START_INSET), USABLE_HEIGHT/*(int) (height + 2 * INSET_HEIGHT)*/));
     }
     
     @Override

--- a/ide/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosNamePanel.java
+++ b/ide/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/MacrosNamePanel.java
@@ -48,7 +48,7 @@ class MacrosNamePanel extends javax.swing.JPanel {
     public MacrosNamePanel() {
         initComponents();
         regularColor = nameField.getForeground();
-        errColor = (Color)UIManager.getDefaults().getColor("nb.errorForeground"); // NOI18N
+        errColor = UIManager.getDefaults().getColor("nb.errorForeground"); // NOI18N
         setErrorMessage(null);
     }
 

--- a/ide/html.validation/src/org/netbeans/modules/html/validation/NbValidationTransaction.java
+++ b/ide/html.validation/src/org/netbeans/modules/html/validation/NbValidationTransaction.java
@@ -849,8 +849,7 @@ public class NbValidationTransaction extends ValidationTransaction {
         sourceReader.addCharacterHandler(sourceCode);
         reader = new IdFilter(xmlParser.getXMLReader());
         if (lexicalHandler != null) {
-            xmlParser.setProperty("http://xml.org/sax/properties/lexical-handler",
-                    (LexicalHandler) lexicalHandler);
+            xmlParser.setProperty("http://xml.org/sax/properties/lexical-handler", lexicalHandler);
         }
 
         reader.setFeature("http://xml.org/sax/features/string-interning", true);

--- a/ide/jellytools.ide/src/org/netbeans/jellytools/EditorOperator.java
+++ b/ide/jellytools.ide/src/org/netbeans/jellytools/EditorOperator.java
@@ -264,7 +264,7 @@ public class EditorOperator extends TopComponentOperator {
     private Object getLine(int lineNumber) {
         Document doc = txtEditorPane().getDocument();
         DataObject od = (DataObject) doc.getProperty(Document.StreamDescriptionProperty);
-        Set set = ((LineCookie) od.getCookie(LineCookie.class)).getLineSet();
+        Set set = (od.getCookie(LineCookie.class)).getLineSet();
         try {
             return set.getCurrent(lineNumber - 1);
         } catch (IndexOutOfBoundsException e) {
@@ -752,7 +752,7 @@ public class EditorOperator extends TopComponentOperator {
         if (combo != null) {
             index++;
         }
-        return new AbstractButtonOperator(AbstractButtonOperator.waitAbstractButton((Container) toolbar,
+        return new AbstractButtonOperator(AbstractButtonOperator.waitAbstractButton(toolbar,
                 ComponentSearcher.getTrueChooser("AbstractButton"), index));
     }
 

--- a/ide/notifications/src/org/netbeans/modules/notifications/filter/FilterEditor.java
+++ b/ide/notifications/src/org/netbeans/modules/notifications/filter/FilterEditor.java
@@ -414,7 +414,7 @@ private void onNewFilter(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_onNe
         }
 
         public NotificationFilter get(int i) {
-            return (NotificationFilter) filters.get(i);
+            return filters.get(i);
         }
 
         public boolean add(NotificationFilter f) {

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/lucene/LayeredDocumentIndex.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/lucene/LayeredDocumentIndex.java
@@ -339,7 +339,7 @@ public final class LayeredDocumentIndex implements DocumentIndex2.Transactional 
         @Override
         public E next() {
             //xxx: Cast to workaround javac 1.6.0_29 bug
-            return (E) (base.hasNext() ? base.next() : overlay.next());
+            return (base.hasNext() ? base.next() : overlay.next());
         }
 
         @Override

--- a/ide/server/src/org/netbeans/modules/server/ui/wizard/AddServerInstanceWizard.java
+++ b/ide/server/src/org/netbeans/modules/server/ui/wizard/AddServerInstanceWizard.java
@@ -393,7 +393,7 @@ public class AddServerInstanceWizard extends WizardDescriptor {
                 return null;
             }
 
-            WizardDescriptor.InstantiatingIterator iterator = (WizardDescriptor.InstantiatingIterator)iterators.get(server);
+            WizardDescriptor.InstantiatingIterator iterator = iterators.get(server);
             if (iterator != null) {
                 return iterator;
             }

--- a/ide/server/src/org/netbeans/modules/server/ui/wizard/ServerWizardVisual.java
+++ b/ide/server/src/org/netbeans/modules/server/ui/wizard/ServerWizardVisual.java
@@ -220,7 +220,7 @@ public class ServerWizardVisual extends javax.swing.JPanel {
     }
 
     private void fillDisplayName(ServerWizardProvider server) {
-        String name = (String) displayNames.get(server);
+        String name = displayNames.get(server);
         if (name == null || name.length() == 0) {
             name = generateDisplayName(server);
         }

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/TapPanel.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/TapPanel.java
@@ -81,7 +81,7 @@ public final class TapPanel extends javax.swing.JPanel {
     private static Adap getAdapter () {
         Adap result = null;
         if ( adapRef != null ) {
-            result = (Adap) adapRef.get ();
+            result = adapRef.get ();
         }
         if ( result == null ) {
             result = new Adap ();

--- a/ide/target.iterator/src/org/netbeans/modules/target/iterator/api/BrowseFolders.java
+++ b/ide/target.iterator/src/org/netbeans/modules/target/iterator/api/BrowseFolders.java
@@ -413,8 +413,7 @@ public class BrowseFolders extends JPanel implements ExplorerManager.Provider, L
                 Node selection[] = browsePanel.getExplorerManager().getSelectedNodes();
                 
                 if ( selection != null && selection.length > 0 ) {
-                    DataObject dobj = (DataObject)selection[0].getLookup().
-                        lookup( DataObject.class );
+                    DataObject dobj = selection[0].getLookup().lookup(DataObject.class);
                     if (dobj!=null && dobj.getClass().isAssignableFrom(target)) {
                         result = dobj.getPrimaryFile();
                     }

--- a/ide/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Terminal.java
+++ b/ide/terminal.nb/src/org/netbeans/modules/terminal/ioprovider/Terminal.java
@@ -1125,7 +1125,7 @@ public final class Terminal extends JComponent {
     }
 
     public void setHyperlinkListener(final HyperlinkListener hyperlinkListener) {
-	((ActiveTerm) term).setActionListener(new ActiveTermListener() {
+	term.setActionListener(new ActiveTermListener() {
 	    public void action(ActiveRegion r, InputEvent e) {
 		if (r.isLink()) {
 		    String url = (String) r.getUserObject();

--- a/ide/terminal.nb/src/org/netbeans/modules/terminal/support/OpenInEditorAction.java
+++ b/ide/terminal.nb/src/org/netbeans/modules/terminal/support/OpenInEditorAction.java
@@ -96,7 +96,7 @@ public final class OpenInEditorAction implements Runnable {
                 if (lineNumber == -1) {
                     ed.open();
                 } else {
-                    lc = (LineCookie) dobj.getLookup().lookup(LineCookie.class);
+                    lc = dobj.getLookup().lookup(LineCookie.class);
                     SwingUtilities.invokeLater(this);
                 }
             } else {

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/AddCatalogEntryAction.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/AddCatalogEntryAction.java
@@ -45,7 +45,7 @@ public class AddCatalogEntryAction extends NodeAction {
     }
 
     public static void perform(org.openide.nodes.Node[] activatedNodes) {
-        CatalogNode node = (CatalogNode) activatedNodes[0].getCookie(CatalogNode.class);
+        CatalogNode node = activatedNodes[0].getCookie(CatalogNode.class);
         CatalogWriter catalog = (CatalogWriter)node.getCatalogReader();
         CatalogEntryPanel panel = new CatalogEntryPanel();
         DialogDescriptor dd = new DialogDescriptor(panel,

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogAction.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogAction.java
@@ -101,13 +101,13 @@ public class CatalogAction implements ActionListener {
         
         // ActionListener
         public void actionPerformed (ActionEvent ev) {
-            Node [] nodes = (Node []) cp.getExplorerManager ().getSelectedNodes ();
+            Node[] nodes = cp.getExplorerManager().getSelectedNodes();
             assert nodes != null && nodes.length > 0 : "Selected templates cannot be null or empty.";
             Set<Node> nodes2open = getNodes2Open (nodes);
             assert ! nodes2open.isEmpty () : "Selected templates to open cannot by empty for nodes " + Arrays.asList (nodes);
             Iterator<Node> it = nodes2open.iterator();
             while (it.hasNext ()) {
-                Node n = (Node) it.next ();
+                Node n = it.next();
                 ViewCookie vc = n.getLookup().lookup(ViewCookie.class);
                 if (vc != null) {
                     vc.view();

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogEntryNode.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogEntryNode.java
@@ -90,7 +90,7 @@ final class CatalogEntryNode extends BeanNode implements EditCookie, Node.Cookie
             boolean editPossible=false;
             if (fo!=null) {
                 DataObject obj = DataObject.find(fo);
-                EditCookie editCookie = (EditCookie)obj.getCookie(EditCookie.class);
+                EditCookie editCookie = obj.getCookie(EditCookie.class);
                 if (editCookie!=null) {
                     editPossible=true;
                     editCookie.edit();

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
@@ -351,7 +351,7 @@ final class CatalogNode extends BeanNode implements Refreshable, PropertyChangeL
             for (int i = 0; i<activatedNodes.length; i++) {
                 try {
                     Node me = activatedNodes[i];
-                    CatalogNode self = (CatalogNode) me.getCookie(CatalogNode.class);
+                    CatalogNode self = me.getCookie(CatalogNode.class);
                     self.destroy();
                 } catch (IOException ex) {
                     //Util.THIS.debug("Cannot unmount XML entity catalog!", ex);

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ItemOptionHelper.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ItemOptionHelper.java
@@ -47,7 +47,7 @@ public abstract class ItemOptionHelper implements ActionListener, Refreshable {
     public ItemOptionHelper(XmlMultiViewDataSynchronizer synchronizer, ButtonGroup group) {
         
         this.synchronizer = synchronizer;
-        buttons = (AbstractButton[]) Collections.list(group.getElements()).toArray(new AbstractButton[0]);
+        buttons = Collections.list(group.getElements()).toArray(new AbstractButton[0]);
         AbstractButton unmatchedOpt = null;
         for (int i = 0; i < buttons.length; i++) {
             final AbstractButton button = buttons[i];

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewEditorSupport.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewEditorSupport.java
@@ -702,7 +702,7 @@ public class XmlMultiViewEditorSupport extends DataEditorSupport implements Seri
         
         protected void reloadModelFromData() {
             if (loading == 0) {
-                Utils.replaceDocument((StyledDocument)getDocument(), dObj.getDataCache().getStringData());
+                Utils.replaceDocument(getDocument(), dObj.getDataCache().getStringData());
             }
         }
     }

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewElement.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/XmlMultiViewElement.java
@@ -124,7 +124,7 @@ public class XmlMultiViewElement extends AbstractMultiViewElement implements jav
         if (xmlEditor == null) {
             xmlEditor = (XmlMultiViewEditorSupport.XmlCloneableEditor) dObj.getEditorSupport().createCloneableEditor();
             final ActionMap map = xmlEditor.getActionMap();
-            SaveAction act = (SaveAction) SystemAction.get(SaveAction.class);
+            SaveAction act = SystemAction.get(SaveAction.class);
             KeyStroke stroke = KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask());
             xmlEditor.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(stroke, "save"); //NOI18N
             map.put("save", act); //NOI18N

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/AbstractDesignEditor.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/AbstractDesignEditor.java
@@ -66,7 +66,7 @@ public abstract class AbstractDesignEditor extends TopComponent implements Explo
             KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_F1, 0), ACTION_INVOKE_HELP);
         map.put(ACTION_INVOKE_HELP, helpAction);
         
-        SaveAction act = (SaveAction) org.openide.util.actions.SystemAction.get(SaveAction.class);
+        SaveAction act = org.openide.util.actions.SystemAction.get(SaveAction.class);
         KeyStroke stroke = KeyStroke.getKeyStroke(java.awt.event.KeyEvent.VK_S,
                 java.awt.Toolkit.getDefaultToolkit().getMenuShortcutKeyMask());
 
@@ -161,7 +161,7 @@ public abstract class AbstractDesignEditor extends TopComponent implements Explo
      */
     public void open(){
         if (contentView!=null)
-            ((PanelView)contentView).open();
+            contentView.open();
     }
     
     /**

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeElementAttributeListCustomizer.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeElementAttributeListCustomizer.java
@@ -473,7 +473,7 @@ public class TreeElementAttributeListCustomizer extends JPanel implements Custom
          */
         public void addRow () {
             
-            TreeAttribute attr = (TreeAttribute) Lib.createAttributeDialog(true);
+            TreeAttribute attr = Lib.createAttributeDialog(true);
             if (attr != null) {
                 boolean toSet = true;
                 TreeAttribute oldAttribute = (TreeAttribute) peer.get (attr.getTreeName());

--- a/ide/xml/src/org/netbeans/modules/xml/DTDDataObject.java
+++ b/ide/xml/src/org/netbeans/modules/xml/DTDDataObject.java
@@ -110,7 +110,7 @@ public final class DTDDataObject extends MultiDataObject implements XMLDataObjec
     protected Node createNodeDelegate () {
         if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("--> DTDDataObject.createNodeDelegate: this = " + this);
 
-        DataNodeCreator dataNodeCreator = (DataNodeCreator) Lookup.getDefault().lookup (DataNodeCreator.class);
+        DataNodeCreator dataNodeCreator = Lookup.getDefault().lookup (DataNodeCreator.class);
         DataNode dataNode = null;
 
         if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("-*- DTDD   O     .createNodeDelegate: dataNodeCreator = " + dataNodeCreator);

--- a/ide/xml/src/org/netbeans/modules/xml/XMLDataObject.java
+++ b/ide/xml/src/org/netbeans/modules/xml/XMLDataObject.java
@@ -159,7 +159,7 @@ public final class XMLDataObject extends org.openide.loaders.XMLDataObject
     protected Node createNodeDelegate () {
         if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("--> XMLDataObject.createNodeDelegate: this = " + this);
 
-        DataNodeCreator dataNodeCreator = (DataNodeCreator) Lookup.getDefault().lookup (DataNodeCreator.class);
+        DataNodeCreator dataNodeCreator = Lookup.getDefault().lookup (DataNodeCreator.class);
         Node dataNode = null;
 
         if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("-*- XMLD   O     .createNodeDelegate: dataNodeCreator = " + dataNodeCreator);

--- a/ide/xml/src/org/netbeans/modules/xml/sync/DataObjectSyncSupport.java
+++ b/ide/xml/src/org/netbeans/modules/xml/sync/DataObjectSyncSupport.java
@@ -73,7 +73,7 @@ public class DataObjectSyncSupport extends SyncSupport implements Synchronizator
      */
     protected Representation[] getRepresentations() {
         synchronized (reps) {
-            return (Representation[]) reps.toArray(new Representation[reps.size()]);
+            return reps.toArray(new Representation[reps.size()]);
         }
     }
 

--- a/ide/xsl/src/org/netbeans/modules/xsl/transform/TransformPerformer.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/transform/TransformPerformer.java
@@ -164,7 +164,7 @@ public class TransformPerformer {
                     TransformableCookie transformable = null;
                     boolean xslt = TransformUtil.isXSLTransformation(dataObject);
                     if ( xslt == false ) {
-                        transformable = (TransformableCookie) nodes[i].getCookie(TransformableCookie.class);
+                        transformable = nodes[i].getCookie(TransformableCookie.class);
                     }
                     SinglePerformer performer = new SinglePerformer(transformable, dataObject, xslt);
                     performer.setLastInBatch(i == (nodes.length -1));

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/VariablesModel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/VariablesModel.java
@@ -42,8 +42,7 @@ public class VariablesModel implements TreeModel, NodeModel, TableModel {
     
     
     public VariablesModel (ContextProvider contextProvider) {
-        debugger = (AntDebugger) contextProvider.lookupFirst 
-            (null, AntDebugger.class);
+        debugger = contextProvider.lookupFirst(null, AntDebugger.class);
         debugger.setVariablesModel(this);
     }
     

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/WatchesModel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/WatchesModel.java
@@ -46,7 +46,7 @@ public class WatchesModel implements NodeModelFilter, TableModel {
     
     
     public WatchesModel (ContextProvider contextProvider) {
-        debugger = (AntDebugger) contextProvider.lookupFirst 
+        debugger = contextProvider.lookupFirst 
             (null, AntDebugger.class);
         debugger.setWatchesModel(this);
     }

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointModel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointModel.java
@@ -62,8 +62,7 @@ public class BreakpointModel implements NodeModel {
     public String getDisplayName (Object node) throws UnknownTypeException {
         if (node instanceof AntBreakpoint) {
             AntBreakpoint breakpoint = (AntBreakpoint) node;
-            FileObject fileObject = (FileObject) breakpoint.getLine ().
-                getLookup ().lookup (FileObject.class);
+            FileObject fileObject = breakpoint.getLine().getLookup().lookup(FileObject.class);
             return fileObject.getNameExt () + ":" + 
                 (breakpoint.getLine ().getLineNumber () + 1);
         }

--- a/java/beans/src/org/netbeans/modules/beans/PatternNode.java
+++ b/java/beans/src/org/netbeans/modules/beans/PatternNode.java
@@ -318,7 +318,7 @@ public class PatternNode extends AbstractNode {
                     if ( !oldSubs.contains(newSub) && node.getChildren() != Children.LEAF) {                                           
                         pattern.getPatternAnalyser().getUI().expandNode(node); // Make sure new nodes get expanded
                     }     
-                    ((PatternNode)node).updateRecursively( newSub ); // update the node recursively
+                    node.updateRecursively( newSub ); // update the node recursively
                 }
            }
         }

--- a/java/beans/src/org/netbeans/modules/beans/beaninfo/BiToggleAction.java
+++ b/java/beans/src/org/netbeans/modules/beans/beaninfo/BiToggleAction.java
@@ -84,8 +84,8 @@ public class BiToggleAction extends NodeAction  {
         for(int i = 0; i <activatedNodes.length; i++ ) {
             if( activatedNodes[i].getCookie( BiFeatureNode.class ) == null )
                 return false;
-            BiFeature biFeature = ((BiFeatureNode)activatedNodes[i].getCookie( BiFeatureNode.class )).getBiFeature();
-            BiAnalyser biAnalyser = ((BiFeatureNode)activatedNodes[i].getCookie( BiFeatureNode.class )).getBiAnalyser();
+            BiFeature biFeature = (activatedNodes[i].getCookie( BiFeatureNode.class )).getBiFeature();
+            BiAnalyser biAnalyser = (activatedNodes[i].getCookie( BiFeatureNode.class )).getBiAnalyser();
             if( ( biFeature instanceof BiFeature.Property || biFeature instanceof BiFeature.IdxProperty ) && biAnalyser.isNullProperties() )
                 return false;
             if( biFeature instanceof BiFeature.EventSet && biAnalyser.isNullEventSets() )
@@ -111,7 +111,7 @@ public class BiToggleAction extends NodeAction  {
 
         for(int i = 0; i < nodes.length; i++ ) {
             if( nodes[i].getCookie( BiFeatureNode.class ) != null )
-                ((BiFeatureNode)nodes[i].getCookie( BiFeatureNode.class )).toggleSelection();
+                (nodes[i].getCookie( BiFeatureNode.class )).toggleSelection();
         }
 
     }

--- a/java/dbschema/src/org/netbeans/modules/dbschema/DBMemoryCollection.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/DBMemoryCollection.java
@@ -107,7 +107,7 @@ class DBMemoryCollection {
         if (_elms != null)
             return _elms;
         else
-            return (DBElement[]) Arrays.asList(_template).toArray(new DBElement[_template.length]);
+            return Arrays.asList(_template).toArray(new DBElement[_template.length]);
     }
 
     /** Returns an element specified by the name from this collection.

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/CaptureSchemaAction.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/CaptureSchemaAction.java
@@ -84,7 +84,7 @@ public class CaptureSchemaAction extends CallableSystemAction {
                             wizard.setTitle(bundle.getString("WizardTitleName"));
                             
                             if(nId >= 0) {
-                                wizard.setTargetFolder((DataFolder) n[nId].getCookie(DataFolder.class));
+                                wizard.setTargetFolder(n[nId].getCookie(DataFolder.class));
                                 wizard.instantiate(templates[j]);
                             } else
                                 wizard.instantiate(templates[j]);

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementsCollection.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementsCollection.java
@@ -56,7 +56,7 @@ public class DBElementsCollection implements DBElementProperties {
         if (_elms != null)
             return _elms;
         else
-            return (DBElement[]) Arrays.asList(_template).toArray(new DBElement[_template.length]);
+            return Arrays.asList(_template).toArray(new DBElement[_template.length]);
 
     }
     

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -176,7 +176,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
      */
     public TableElement[] getTables() {
         DBElement[] dbe = tables.getElements();
-        return (TableElement[]) Arrays.asList(dbe).toArray(new TableElement[dbe.length]);
+        return Arrays.asList(dbe).toArray(new TableElement[dbe.length]);
     }
 
     /** Find a table by name.

--- a/java/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupport.java
+++ b/java/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupport.java
@@ -228,7 +228,7 @@ public final class MethodModelSupport {
             }
         }
 
-        return (MethodTree) GeneratorUtilities.get(workingCopy).importFQNs(result);
+        return GeneratorUtilities.get(workingCopy).importFQNs(result);
     }
     
     /**

--- a/java/java.examples/src/org/netbeans/modules/java/examples/PanelConfigureProject.java
+++ b/java/java.examples/src/org/netbeans/modules/java/examples/PanelConfigureProject.java
@@ -102,7 +102,7 @@ final class PanelConfigureProject implements WizardDescriptor.Panel, WizardDescr
     public void storeSettings(Object settings) {
         WizardDescriptor d = (WizardDescriptor) settings;
         component.store(d);
-        ((WizardDescriptor) d).putProperty("NewProjectWizard_Title", null); // NOI18N
+        d.putProperty("NewProjectWizard_Title", null); // NOI18N
     }
     
 }

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/jdkselection/JdkConfiguration.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/jdkselection/JdkConfiguration.java
@@ -263,7 +263,7 @@ public class JdkConfiguration {
     }
 
     private static String getPlatformID(JavaPlatform platform) {
-        String s = (String) platform.getProperties().get("platform.ant.name"); // NOI18N
+        String s = platform.getProperties().get("platform.ant.name"); // NOI18N
         if (s != null) {
             return s;
         } else {

--- a/java/java.hints.test/src/org/netbeans/modules/java/hints/test/BootClassPathUtil.java
+++ b/java/java.hints.test/src/org/netbeans/modules/java/hints/test/BootClassPathUtil.java
@@ -82,7 +82,7 @@ public class BootClassPathUtil {
                     urls.add(fo.toURL());
                 }
             }
-            return ClassPathSupport.createClassPath((URL[])urls.toArray(new URL[0]));
+            return ClassPathSupport.createClassPath(urls.toArray(new URL[0]));
         } else {
             try {
                 Class.forName("org.netbeans.ProxyURLStreamHandlerFactory").getMethod("register")

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanel.java
@@ -310,7 +310,7 @@ public final class HintsPanel extends javax.swing.JPanel   {
         errorTreeModel = constructTM(hints, !batchOnly && !filterSuggestions);
 
         if (filter != null) {
-             ((OptionsFilter) filter).installFilteringModel(errorTree, errorTreeModel, new AcceptorImpl());
+             filter.installFilteringModel(errorTree, errorTreeModel, new AcceptorImpl());
         } else {
             setModel(errorTreeModel);
         }

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/AsyncJavaSymbolDescriptor.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/AsyncJavaSymbolDescriptor.java
@@ -215,7 +215,7 @@ final class AsyncJavaSymbolDescriptor extends JavaSymbolDescriptorBase implement
             final Set<?> pkgs = new HashSet<>(getPackages(syms).keySet());
             final Set<?> clzs = new HashSet<>(getClasses(syms).keySet());
             jt.getElements().getTypeElement("java.lang.Object"); // Ensure proper javac initialization
-            final TypeElement te = (TypeElement) ElementUtils.getTypeElementByBinaryName(jt,
+            final TypeElement te = ElementUtils.getTypeElementByBinaryName(jt,
                     ElementHandleAccessor.getInstance().getJVMSignature(getOwner())[0]);
             if (te != null) {
                 if (ident.equals(getSimpleName(te, null, caseSensitive))) {

--- a/java/jshell.support/src/org/netbeans/modules/jshell/editor/RunScriptAction.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/editor/RunScriptAction.java
@@ -330,7 +330,7 @@ public class RunScriptAction extends TextAction
     }
     
     static JTextComponent findComponent(Lookup lookup) {
-        EditorCookie ec = (EditorCookie) lookup.lookup(EditorCookie.class);
+        EditorCookie ec = lookup.lookup(EditorCookie.class);
         if (ec != null) {
             JEditorPane panes[] = ec.getOpenedPanes();
             if (panes != null && panes.length > 0) {

--- a/java/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/LocationAwareMavenXpp3Writer.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/LocationAwareMavenXpp3Writer.java
@@ -181,13 +181,13 @@ public class LocationAwareMavenXpp3Writer {
             writeValue(serializer, "jdk", activation.getJdk(), activation);
         }
         if (activation.getOs() != null) {
-            writeActivationOS((ActivationOS) activation.getOs(), "os", serializer);
+            writeActivationOS(activation.getOs(), "os", serializer);
         }
         if (activation.getProperty() != null) {
-            writeActivationProperty((ActivationProperty) activation.getProperty(), "property", serializer);
+            writeActivationProperty(activation.getProperty(), "property", serializer);
         }
         if (activation.getFile() != null) {
-            writeActivationFile((ActivationFile) activation.getFile(), "file", serializer);
+            writeActivationFile(activation.getFile(), "file", serializer);
         }
         serializer.endTag(NAMESPACE, tagName).flush();
         logLocation(activation, "", start, b.length());
@@ -316,7 +316,7 @@ public class LocationAwareMavenXpp3Writer {
             logLocation(build, "filters", start2, b.length());
         }
         if (build.getPluginManagement() != null) {
-            writePluginManagement((PluginManagement) build.getPluginManagement(), "pluginManagement", serializer);
+            writePluginManagement(build.getPluginManagement(), "pluginManagement", serializer);
         }
         if ((build.getPlugins() != null) && (build.getPlugins().size() > 0)) {
             serializer.startTag(NAMESPACE, "plugins");
@@ -376,7 +376,7 @@ public class LocationAwareMavenXpp3Writer {
             logLocation(buildBase, "filters", start2, b.length());
         }
         if (buildBase.getPluginManagement() != null) {
-            writePluginManagement((PluginManagement) buildBase.getPluginManagement(), "pluginManagement", serializer);
+            writePluginManagement(buildBase.getPluginManagement(), "pluginManagement", serializer);
         }
         if ((buildBase.getPlugins() != null) && (buildBase.getPlugins().size() > 0)) {
             serializer.startTag(NAMESPACE, "plugins");

--- a/java/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/Modifications.java
+++ b/java/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/Modifications.java
@@ -71,7 +71,7 @@ public final class Modifications implements org.netbeans.modules.refactoring.spi
 
     private void commit(final FileObject fileObject, final List<Difference> differences, Writer outWriter) throws IOException {
         DataObject dataObj = DataObject.find(fileObject);
-        EditorCookie editorCookie = dataObj != null ? (EditorCookie) dataObj.getCookie(EditorCookie.class) : null;
+        EditorCookie editorCookie = dataObj != null ? dataObj.getCookie(EditorCookie.class) : null;
         // if editor cookie was found and user does not provided his own
         // writer where he wants to see changes, commit the changes to
         // found document.

--- a/java/testng.ant/src/org/netbeans/modules/testng/ant/TestNGOutputReader.java
+++ b/java/testng.ant/src/org/netbeans/modules/testng/ant/TestNGOutputReader.java
@@ -951,7 +951,7 @@ final class TestNGOutputReader {
     private void testStarted(String suiteName, String testCase, String parameters, String values) {
         suiteName = testSession.getCurrentSuite().getName();
         testSession.setCurrentSuite(suiteName);
-        TestNGTestcase tc = ((TestNGTestSuite) ((TestNGTestSession) testSession).getCurrentSuite()).getTestCase(testCase, values);
+        TestNGTestcase tc = ((TestNGTestSuite)testSession.getCurrentSuite()).getTestCase(testCase, values);
         if (tc == null) {
             tc = new TestNGTestcase(testCase, parameters, values, testSession);
             testSession.addTestCase(tc);
@@ -968,7 +968,7 @@ final class TestNGOutputReader {
     private void testFinished(String st, String suiteName, String testCase, String parameters, String values, String duration) {
         suiteName = testSession.getCurrentSuite().getName();
         testSession.setCurrentSuite(suiteName);
-        TestNGTestcase tc = ((TestNGTestSuite) ((TestNGTestSession) testSession).getCurrentSuite()).getTestCase(testCase, values);
+        TestNGTestcase tc = ((TestNGTestSuite)testSession.getCurrentSuite()).getTestCase(testCase, values);
         CoreManager testngManager = getManagerProvider();
         if (tc == null) {
             //TestNG does not log invoke message for junit tests...

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/actions/GenerateDOMScannerAction.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/actions/GenerateDOMScannerAction.java
@@ -80,7 +80,7 @@ public class GenerateDOMScannerAction extends XMLGenerateAction implements Colle
         if (node.length == 0) {
             return false;
         }
-        DataObject dobj = (DataObject) node[0].getLookup().lookup(DataObject.class);
+        DataObject dobj = node[0].getLookup().lookup(DataObject.class);
         if (dobj == null) {
             return false;
         }

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/actions/GenerateDocumentHandlerAction.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/actions/GenerateDocumentHandlerAction.java
@@ -81,7 +81,7 @@ public class GenerateDocumentHandlerAction extends XMLGenerateAction implements 
         if (node.length == 0) {
             return false;
         }
-        DataObject dobj = (DataObject) node[0].getLookup().lookup(DataObject.class);
+        DataObject dobj = node[0].getLookup().lookup(DataObject.class);
         if (dobj == null) {
             return false;
         }

--- a/php/php.smarty/src/org/netbeans/modules/php/smarty/editor/actions/ToggleBlockCommentAction.java
+++ b/php/php.smarty/src/org/netbeans/modules/php/smarty/editor/actions/ToggleBlockCommentAction.java
@@ -65,7 +65,7 @@ public class ToggleBlockCommentAction extends BaseAction {
                 @Override
                 public void run() {
                     final AtomicBoolean commentIt = new AtomicBoolean(true);
-                    final TokenSequence<TplTopTokenId> ts = (TokenSequence<TplTopTokenId>) LexerUtils.getTplTopTokenSequence(doc, caretOffset);
+                    final TokenSequence<TplTopTokenId> ts = LexerUtils.getTplTopTokenSequence(doc, caretOffset);
                     final TplMetaData tplMetaData = TplUtils.getProjectPropertiesForFileObject(Source.create(doc).getFileObject());
 
                     // XXX - clean up needed

--- a/platform/core.network/src/org/netbeans/core/network/utils/hname/unix/CLib.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/hname/unix/CLib.java
@@ -26,7 +26,7 @@ import com.sun.jna.Native;
  */
 interface CLib extends Library {
 
-    CLib INSTANCE = (CLib) Native.load("c", CLib.class);
+    CLib INSTANCE = Native.load("c", CLib.class);
 
     public int gethostname(byte[] hostname, int bufferSize);
 }

--- a/platform/core.startup/src/org/netbeans/core/startup/Asm.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Asm.java
@@ -395,7 +395,7 @@ final class Asm {
                 targetMethod.access & (~Opcodes.ACC_STATIC), CONSTRUCTOR_NAME,
                 desc,
                 targetMethod.signature,
-                (String[])targetMethod.exceptions.toArray(new String[targetMethod.exceptions.size()]));
+                targetMethod.exceptions.toArray(new String[targetMethod.exceptions.size()]));
 
         mn.visibleAnnotations = targetMethod.visibleAnnotations;
         mn.visibleParameterAnnotations = targetMethod.visibleParameterAnnotations;

--- a/platform/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/FolderPathLookup.java
+++ b/platform/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/FolderPathLookup.java
@@ -236,7 +236,7 @@ public final class FolderPathLookup extends AbstractLookup {
             IllegalAccessException, InvocationTargetException, NoSuchMethodException {
         T r = null;
         for (CustomInstanceFactory fif : getInstanceFactories()) {
-            r = (T)fif.createInstance(type);
+            r = fif.createInstance(type);
             if (r != null) {
                 break;
             }

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/NamingFactory.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/naming/NamingFactory.java
@@ -250,7 +250,7 @@ public final class NamingFactory {
         int index = Math.abs(key) % names.length;
         NameRef ref = getReference(names[index], file.getFile());
 
-        FileNaming cachedElement = (ref != null) ? (FileNaming) ref.get() : null;
+        FileNaming cachedElement = (ref != null) ? ref.get() : null;
         Boolean cachedIsDirectory = null;
         Boolean fileIsDirectory = null;
         if (ignoreCache) {

--- a/platform/openide.compat/src/org/openide/explorer/ExplorerActions.java
+++ b/platform/openide.compat/src/org/openide/explorer/ExplorerActions.java
@@ -482,7 +482,7 @@ public class ExplorerActions {
 
     /** If our clipboard is not found return the default system clipboard. */
     private static Clipboard getClipboard() {
-        Clipboard c = (java.awt.datatransfer.Clipboard) org.openide.util.Lookup.getDefault().lookup(
+        Clipboard c = org.openide.util.Lookup.getDefault().lookup(
                 java.awt.datatransfer.Clipboard.class
             );
 

--- a/profiler/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/AppletSupport.java
+++ b/profiler/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/AppletSupport.java
@@ -123,7 +123,7 @@ public class AppletSupport {
                 JavaPlatform[] installedPlatforms = pm.getPlatforms(null, new Specification("j2se", null)); //NOI18N
 
                 for (int i = 0; i < installedPlatforms.length; i++) {
-                    String antName = (String) installedPlatforms[i].getProperties().get("platform.ant.name"); //NOI18N
+                    String antName = installedPlatforms[i].getProperties().get("platform.ant.name"); //NOI18N
 
                     if ((antName != null) && antName.equals(activePlatform)) {
                         platform = installedPlatforms[i];

--- a/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AndroidConfigurationPanel.java
+++ b/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AndroidConfigurationPanel.java
@@ -156,7 +156,7 @@ public class AndroidConfigurationPanel extends javax.swing.JPanel {
             public void run() {
                 avdCombo.setEnabled(true);
                 avdCombo.setRenderer(new DeviceRenderer());
-                final AVD[] avds = (AVD[]) avDs.toArray(new AVD[avDs.size()]);
+                final AVD[] avds = avDs.toArray(new AVD[avDs.size()]);
                 avdCombo.setModel(new DefaultComboBoxModel(avds));
                 for (AVD avd : avds) {
                     if (avd.getName().equals(config.getProperty(Device.DEVICE_PROP))) {//NOI18N

--- a/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AndroidDebugTransport.java
+++ b/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AndroidDebugTransport.java
@@ -117,7 +117,7 @@ public class AndroidDebugTransport extends MobileDebugTransport implements WebSo
     public boolean attach() {
         try {
             String s = ProcessUtilities.callProcess(
-                    ((AndroidPlatform) AndroidPlatform.getDefault()).getAdbCommand(), 
+                    AndroidPlatform.getDefault().getAdbCommand(), 
                     true, 
                     AndroidPlatform.DEFAULT_TIMEOUT, 
                     "forward", // NOI18N

--- a/webcommon/cordova/src/org/netbeans/modules/cordova/CordovaPerformer.java
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/CordovaPerformer.java
@@ -249,7 +249,7 @@ public class CordovaPerformer implements BuildPerformer {
                                         project, 
                                         Lookups.fixed(
                                             mapper, 
-                                            ImageUtilities.loadImage("org/netbeans/modules/cordova/platforms/ios/ios" + (String) (device.isEmulator()?"simulator16.png":"device16.png")), 
+                                            ImageUtilities.loadImage("org/netbeans/modules/cordova/platforms/ios/ios" + (device.isEmulator()?"simulator16.png":"device16.png")), 
                                             getConfig(project).getId()), 
                                         false);
                             }

--- a/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/Utils.java
+++ b/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/Utils.java
@@ -420,7 +420,7 @@ public final class Utils {
             char[] pszPath = new char[Shell32.MAX_PATH];
             try {
                 if (Shell32_INSTANCE == null) {
-                    Shell32_INSTANCE = (Shell32) Native.load("shell32", Shell32.class, W32APIOptions.UNICODE_OPTIONS);
+                    Shell32_INSTANCE = Native.load("shell32", Shell32.class, W32APIOptions.UNICODE_OPTIONS);
                 }
                 int hResult = Shell32_INSTANCE.SHGetFolderPath(null, Shell32.CSIDL_LOCAL_APPDATA,
                         null, Shell32.SHGFP_TYPE_CURRENT, pszPath);

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelElementFactory.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelElementFactory.java
@@ -194,7 +194,7 @@ class ModelElementFactory {
         if (newObject.hasExactName()) {
             newObject.addOccurrence(newObject.getDeclarationName().getOffsetRange());
         }
-        return (JsObjectImpl)newObject;
+        return newObject;
     }
     
     @CheckForNull

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -911,7 +911,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
         } else {
             JsObject property = fncParent.getProperty(modelBuilder.getFunctionName(functionNode));
             if (property == null && functionNode.isStrict()) {
-                property = ((DeclarationScopeImpl)modelBuilder.getCurrentDeclarationScope()).getProperty(modelBuilder.getFunctionName(functionNode));
+                property = modelBuilder.getCurrentDeclarationScope().getProperty(modelBuilder.getFunctionName(functionNode));
             }
             if(!(property instanceof JsFunction)) {
                 property = fncParent.getProperty(modelBuilder.getGlobal().getName() + modelBuilder.getFunctionName(functionNode));

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/OccurrenceBuilder.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/OccurrenceBuilder.java
@@ -200,7 +200,7 @@ public class OccurrenceBuilder {
         JsDocumentationHolder holder = JsDocumentationSupport.getDocumentationHolder(parserResult);
         if (holder.getOccurencesMap().containsKey(jsObject.getName())) {
             for (OffsetRange offsetRange : holder.getOccurencesMap().get(jsObject.getName())) {
-                ((JsObjectImpl)jsObject).addOccurrence(offsetRange);
+                jsObject.addOccurrence(offsetRange);
             }
         }
     }

--- a/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/eval/ui/WebCodeEvaluator.java
+++ b/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/eval/ui/WebCodeEvaluator.java
@@ -109,7 +109,7 @@ public class WebCodeEvaluator extends CodeEvaluator.EvaluatorService {
         
         private CodeEvaluator.Result.DefaultHistoryItem getHistoryItem(final String expr, final ScopedRemoteObject result) {
             if (result != null) {
-                RemoteObject var = ((ScopedRemoteObject) result).getRemoteObject();
+                RemoteObject var = result.getRemoteObject();
                 RemoteObject.Type type = var.getType();
                 String typeStr;
                 if (type == RemoteObject.Type.OBJECT) {

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/CustomClientEditorDrop.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/CustomClientEditorDrop.java
@@ -123,7 +123,7 @@ public class CustomClientEditorDrop implements ActiveEditorDrop {
         if (d == null) {
             return null;
         }
-        EditorCookie ec = (EditorCookie) d.getCookie(EditorCookie.class);
+        EditorCookie ec = d.getCookie(EditorCookie.class);
         if (ec == null || ec.getOpenedPanes() == null) {
             return null;
         }

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/RestClientEditorDrop.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/RestClientEditorDrop.java
@@ -128,7 +128,7 @@ public class RestClientEditorDrop implements ActiveEditorDrop {
         if (d == null) {
             return null;
         }
-        EditorCookie ec = (EditorCookie) d.getCookie(EditorCookie.class);
+        EditorCookie ec = d.getCookie(EditorCookie.class);
         if (ec == null || ec.getOpenedPanes() == null) {
             return null;
         }

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/SoapClientEditorDrop.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/SoapClientEditorDrop.java
@@ -120,7 +120,7 @@ public class SoapClientEditorDrop implements ActiveEditorDrop {
         if (d == null) {
             return null;
         }
-        EditorCookie ec = (EditorCookie) d.getCookie(EditorCookie.class);
+        EditorCookie ec = d.getCookie(EditorCookie.class);
         if (ec == null || ec.getOpenedPanes() == null) {
             return null;
         }

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/SoapServiceClientEditorDrop.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/ui/SoapServiceClientEditorDrop.java
@@ -170,7 +170,7 @@ public class SoapServiceClientEditorDrop implements ActiveEditorDrop {
         if (d == null) {
             return null;
         }
-        EditorCookie ec = (EditorCookie) d.getLookup().lookup(EditorCookie.class);
+        EditorCookie ec = d.getLookup().lookup(EditorCookie.class);
         if (ec == null || ec.getOpenedPanes() == null) {
             return null;
         }


### PR DESCRIPTION
There are a lot of places where the compiler tells us we are using redundant casts..

   [repeat] /home/bwalker/src/netbeans/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyVirtualSourceProvider.java:436: warning: [cast] redundant cast to Statement
   [repeat]             Statement stat = (Statement) stats.get(0);
   [repeat]                              ^

This change removes all the redundant casts..