### PR TITLE
[NETBEANS-3477] Fixed compiler warnings concerning rawtypes Enum

### DIFF
--- a/ide/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/GenerateElementsIndex.java
+++ b/ide/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/GenerateElementsIndex.java
@@ -739,14 +739,14 @@ public class GenerateElementsIndex extends NbTestCase {
         writeEnumCollection(fasecs, "FormAssociatedElementsCategory", out);
     }
 
-    private void writeEnumCollection(Collection<? extends Enum> enumCollection, String enumName, Writer out) throws IOException {
+    private void writeEnumCollection(Collection<? extends Enum<?>> enumCollection, String enumName, Writer out) throws IOException {
         if (enumCollection.isEmpty()) {
             out.write("EnumSet.noneOf(");
             out.write(enumName);
             out.write(".class), ");
         } else {
             out.write("EnumSet.of(");
-            for (Iterator<? extends Enum> i = enumCollection.iterator(); i.hasNext();) {
+            for (Iterator<? extends Enum<?>> i = enumCollection.iterator(); i.hasNext();) {
                 Enum ct = i.next();
                 out.write(enumName);
                 out.write(".");

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/FSWrapper.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/code/FSWrapper.java
@@ -205,6 +205,7 @@ public class FSWrapper {
 
     private static final Object MARKER = new Object();
     
+    @SuppressWarnings("unchecked")
     private static Object computeAttributeValue(ClassLoader loader, FileObject folder, String attributeName, Class<?> returnType, Object defaulValue) throws ClassNotFoundException {
         Object result = folder.getAttribute(attributeName);
 
@@ -245,6 +246,7 @@ public class FSWrapper {
             if (returnType.isEnum()) {
                 String fqn = (String) result;
                 int lastDot = fqn.lastIndexOf('.');
+                @SuppressWarnings("rawtypes")
                 Class<? extends Enum> enumClass = (Class<? extends Enum>) loader.loadClass(fqn.substring(0, lastDot));
 
                 result = Enum.valueOf(enumClass, fqn.substring(lastDot + 1));


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a Enum like the following
```
 [nb-javac] .../ide/html.parser/test/unit/src/org/netbeans/modules/html/parser/model/GenerateElementsIndex.java:749: warning: [rawtypes] found raw type: Enum
 [nb-javac]             for (Iterator<? extends Enum> i = enumCollection.iterator(); i.hasNext();) {
 [nb-javac]                                     ^
 [nb-javac]   missing type arguments for generic class Enum<E>
 [nb-javac]   where E is a type-variable:
 [nb-javac]     E extends Enum<E> declared in class Enum
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.