### PR TITLE
[NETBEANS-3478] Fixed compiler warnings concerning rawtypes EnumSet

### DIFF
--- a/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/SemanticHighlighterBase.java
+++ b/java/java.editor.base/src/org/netbeans/modules/java/editor/base/semantic/SemanticHighlighterBase.java
@@ -335,9 +335,7 @@ public abstract class SemanticHighlighterBase extends JavaParserResultTask {
     }
     
         
-    private boolean hasAllTypes(List<Use> uses, Collection<UseTypes> types) {
-        EnumSet e = EnumSet.copyOf(types);
-        
+    private boolean hasAllTypes(List<Use> uses, EnumSet<UseTypes> types) {
         for (Use u : uses) {
             if (types.isEmpty()) {
                 return true;

--- a/webcommon/javascript2.knockout/src/org/netbeans/modules/javascript2/knockout/model/KnockoutExportInterceptor.java
+++ b/webcommon/javascript2.knockout/src/org/netbeans/modules/javascript2/knockout/model/KnockoutExportInterceptor.java
@@ -103,7 +103,7 @@ public class KnockoutExportInterceptor implements FunctionInterceptor {
                     LOGGER.log(Level.FINE, "Exporting property {0} to {1} as {2}",
                             new Object[] {name, object.getFullyQualifiedName(), value.getFullyQualifiedName()});
                 }
-                EnumSet modifiers = EnumSet.copyOf(value.getModifiers());
+                EnumSet<Modifier> modifiers = EnumSet.copyOf(value.getModifiers());
                 modifiers.remove(Modifier.STATIC);
                 object.addProperty(name,
                         factory.newReference(object, name, offsetRange, value, true, modifiers));

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/IndexedElement.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/IndexedElement.java
@@ -390,7 +390,7 @@ public class IndexedElement implements JsElement {
         }
         
         public static Set<Modifier> getModifiers(int flag) {
-            EnumSet result = EnumSet.noneOf(Modifier.class);
+            EnumSet<Modifier> result = EnumSet.noneOf(Modifier.class);
             if ((flag & PRIVATE) != 0) result.add(Modifier.PRIVATE);
             if ((flag & PUBLIC) != 0) result.add(Modifier.PUBLIC);
             if ((flag & STATIC) != 0) result.add(Modifier.STATIC);


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a EnumSet like the following
```
   [repeat] .../webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/api/IndexedElement.java:393: warning: [rawtypes] found raw type: EnumSet
   [repeat]             EnumSet result = EnumSet.noneOf(Modifier.class);
   [repeat]             ^
   [repeat]   missing type arguments for generic class EnumSet<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Enum<E> declared in class EnumSet
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.