### PR TITLE
[NETBEANS-3479] Fixed compiler warnings concerning rawtypes LinkedHas…

### DIFF
--- a/ide/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/PropertiesTest.java
+++ b/ide/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/PropertiesTest.java
@@ -457,7 +457,7 @@ public class PropertiesTest extends TestCase {
             DEFAULT_VALUES.put(PROPERTY_NAMES[9], Integer.SIZE);
             DEFAULT_VALUES.put(PROPERTY_NAMES[10], Long.reverse(Long.SIZE));
             DEFAULT_VALUES.put(PROPERTY_NAMES[11], Collections.singletonMap("key", "value"));
-            DEFAULT_VALUES.put(PROPERTY_NAMES[12], new LinkedHashMap());
+            DEFAULT_VALUES.put(PROPERTY_NAMES[12], new LinkedHashMap<Object, Object>());
             DEFAULT_VALUES.put(PROPERTY_NAMES[13], new Rectangle(10, 10, 20, 20));
             DEFAULT_VALUES.put(PROPERTY_NAMES[14], Short.MIN_VALUE);
             DEFAULT_VALUES.put(PROPERTY_NAMES[15], String.class.getName());

--- a/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/api/json/JsonFile.java
+++ b/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/api/json/JsonFile.java
@@ -70,7 +70,7 @@ public final class JsonFile {
     private static final ContainerFactory CONTAINER_FACTORY = new ContainerFactory() {
 
         @Override
-        public Map<Object, Object> createObjectContainer() {
+        public Map<String, Object> createObjectContainer() {
             return new LinkedHashMap<>();
         }
 

--- a/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/api/json/JsonFile.java
+++ b/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/api/json/JsonFile.java
@@ -70,13 +70,13 @@ public final class JsonFile {
     private static final ContainerFactory CONTAINER_FACTORY = new ContainerFactory() {
 
         @Override
-        public Map createObjectContainer() {
-            return new LinkedHashMap();
+        public Map<Object, Object> createObjectContainer() {
+            return new LinkedHashMap<>();
         }
 
         @Override
-        public List creatArrayContainer() {
-            return new ArrayList();
+        public List<Object> creatArrayContainer() {
+            return new ArrayList<>();
         }
 
     };


### PR DESCRIPTION
…hMap

There are compiler warnings about rawtype usage with a LinkedHashMap like the following
```
 [nb-javac] .../ide/spi.debugger.ui/test/unit/src/org/netbeans/api/debugger/PropertiesTest.java:460: warning: [rawtypes] found raw type: LinkedHashMap
 [nb-javac]             DEFAULT_VALUES.put(PROPERTY_NAMES[12], new LinkedHashMap());
 [nb-javac]                                                        ^
 [nb-javac]   missing type arguments for generic class LinkedHashMap<K,V>
 [nb-javac]   where K,V are type-variables:
 [nb-javac]     K extends Object declared in class LinkedHashMap
 [nb-javac]     V extends Object declared in class LinkedHashMap
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.
