### PR TITLE
[NETBEANS-3480] Fixed compiler warnings concerning rawtypes LinkedHas…

### DIFF
--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
@@ -306,9 +306,9 @@ final class CodeTemplatesModel {
             if (ret == null) {
                 CodeTemplateDescription ctd = codeTemplatesMap.get(abbreviation);
                 final boolean[] afterInit = {false};
-                ret = new LinkedHashSet() {
+                ret = new LinkedHashSet<String>() {
                     @Override
-                    public boolean add(Object e) {
+                    public boolean add(String e) {
                         boolean b = super.add(e);
                         if (b && afterInit[0]) {
                             TM.this.fireChanged();

--- a/ide/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/AnnotationViewDataImplTest.java
+++ b/ide/editor.errorstripe/test/unit/src/org/netbeans/modules/editor/errorstripe/AnnotationViewDataImplTest.java
@@ -218,10 +218,10 @@ public class AnnotationViewDataImplTest extends NbTestCase {
         TestMark mark2 = new TestMark(Status.STATUS_OK, null, null, new int[] {2, 2});
         TestMark mark3 = new TestMark(Status.STATUS_OK, null, null, new int[] {4, 6});
         
-        List marks = Arrays.asList(new Mark[]{mark1, mark2});
-        List marksOnlyFirst = Arrays.asList(new Mark[]{mark1});
-        List marksOnlySecond = Arrays.asList(new Mark[]{mark2});
-        List marksFirstAndThird = Arrays.asList(new Mark[]{mark1, mark3});
+        List<Mark> marks = Arrays.asList(new Mark[]{mark1, mark2});
+        List<Mark> marksOnlyFirst = Arrays.asList(new Mark[]{mark1});
+        List<Mark> marksOnlySecond = Arrays.asList(new Mark[]{mark2});
+        List<Mark> marksFirstAndThird = Arrays.asList(new Mark[]{mark1, mark3});
         
         TestMarkProvider provider = new TestMarkProvider(marks, UpToDateStatus.UP_TO_DATE_OK);
         TestMarkProviderCreator creator = TestMarkProviderCreator.getDefault();
@@ -231,12 +231,12 @@ public class AnnotationViewDataImplTest extends NbTestCase {
         AnnotationView aView = new AnnotationView(editor);
         AnnotationViewDataImpl data = (AnnotationViewDataImpl) aView.getData();
         
-        Collection mergedMarks;
-        SortedMap map;
+        Collection<Mark> mergedMarks;
+        SortedMap<Integer, List<Mark>> map;
         
         mergedMarks = data.getMergedMarks();
         
-        assertEquals(new LinkedHashSet(marks), mergedMarks);
+        assertEquals(new LinkedHashSet<Mark>(marks), mergedMarks);
         
         map = data.getMarkMap();
         
@@ -247,7 +247,7 @@ public class AnnotationViewDataImplTest extends NbTestCase {
         
         mergedMarks = data.getMergedMarks();
         
-        assertEquals(new LinkedHashSet(marksOnlyFirst), mergedMarks);
+        assertEquals(new LinkedHashSet<Mark>(marksOnlyFirst), mergedMarks);
         
         map = data.getMarkMap();
         
@@ -258,7 +258,7 @@ public class AnnotationViewDataImplTest extends NbTestCase {
         
         mergedMarks = data.getMergedMarks();
         
-        assertEquals(new LinkedHashSet(marksFirstAndThird), mergedMarks);
+        assertEquals(new LinkedHashSet<Mark>(marksFirstAndThird), mergedMarks);
         
         map = data.getMarkMap();
         
@@ -283,7 +283,7 @@ public class AnnotationViewDataImplTest extends NbTestCase {
         
         mergedMarks = data.getMergedMarks();
         
-        assertEquals(new LinkedHashSet(marksFirstAndThird), mergedMarks);
+        assertEquals(new LinkedHashSet<Mark>(marksFirstAndThird), mergedMarks);
         
         map = data.getMarkMap();
         

--- a/php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java
+++ b/php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java
@@ -79,7 +79,7 @@ public class PHPSamplesWizardIterator implements WizardDescriptor./*Progress*/In
     }
 
     public Set/*<FileObject>*/ instantiate(/*ProgressHandle handle*/) throws IOException {
-        Set resultSet = new LinkedHashSet();
+        Set<FileObject> resultSet = new LinkedHashSet<>();
         File dirF = FileUtil.normalizeFile((File) wiz.getProperty(WizardProperties.PROJ_DIR));
         createFolder(dirF);
 

--- a/platform/templatesui/src/org/netbeans/modules/templatesui/AbstractWizard.java
+++ b/platform/templatesui/src/org/netbeans/modules/templatesui/AbstractWizard.java
@@ -121,7 +121,7 @@ implements WizardDescriptor.InstantiatingIterator<WizardDescriptor> {
             name(tw.getTargetName()).
             withParameters(params).build();
                     
-            Set<DataObject> objs = new LinkedHashSet(result.size() * 2);
+            Set<DataObject> objs = new LinkedHashSet<>(result.size() * 2);
             for (FileObject fileObject : result) {
                 objs.add(DataObject.find(fileObject));
             }


### PR DESCRIPTION
…hSet

There are compiler warnings about rawtype usage with a LinkedHashSet like the following
```
   [repeat] .../php/php.samples/src/org/netbeans/modules/php/samples/PHPSamplesWizardIterator.java:82: warning: [rawtypes] found raw type: LinkedHashSet
   [repeat]         Set resultSet = new LinkedHashSet();
   [repeat]                             ^
   [repeat]   missing type arguments for generic class LinkedHashSet<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in class LinkedHashSet
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.