### PR TITLE
NETBEANS-3547 Support vendor specific JVM options in Payara Server

### DIFF
--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/ServerTasks.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/ServerTasks.java
@@ -164,11 +164,11 @@ public class ServerTasks {
             }
         }
 
-        JDKVersion javaVersion = args.getJavaVersion() != null ? args.getJavaVersion() : IDE_JDK_VERSION;
+        JDKVersion javaVersion = IDE_JDK_VERSION != null ? IDE_JDK_VERSION : args.getJavaVersion() ;
         List<String> optList
                 = jvmConfigReader.getJvmOptions()
                         .stream()
-                        .filter(fullOption -> JDKVersion.isCorrectJDK(javaVersion, fullOption.minVersion, fullOption.maxVersion))
+                        .filter(fullOption -> JDKVersion.isCorrectJDK(javaVersion, fullOption.vendor, fullOption.minVersion, fullOption.maxVersion))
                         .map(fullOption -> fullOption.option)
                         .collect(toList());
 

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/parser/JvmConfigReader.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/parser/JvmConfigReader.java
@@ -201,6 +201,7 @@ public class JvmConfigReader extends NodeListener implements XMLReader {
     public static class JvmOption {
 
         public final String option;
+        public final Optional<String> vendor;
         public final Optional<JDKVersion> minVersion;
         public final Optional<JDKVersion> maxVersion;
 
@@ -217,11 +218,19 @@ public class JvmConfigReader extends NodeListener implements XMLReader {
         public JvmOption(String option) {
             Matcher matcher = PATTERN.matcher(option);
             if (matcher.matches()) {
-                this.minVersion = Optional.ofNullable(JDKVersion.toValue(matcher.group(1)));
+                if (matcher.group(1).contains("-")) { // NOI18N
+                    String[] parts = matcher.group(1).split("-"); // NOI18N
+                    this.vendor = Optional.ofNullable(parts[0]);
+                    this.minVersion = Optional.ofNullable(JDKVersion.toValue(parts[1]));
+                } else {
+                    this.vendor = Optional.empty();
+                    this.minVersion = Optional.ofNullable(JDKVersion.toValue(matcher.group(1)));
+                }
                 this.maxVersion = Optional.ofNullable(JDKVersion.toValue(matcher.group(2)));
                 this.option = matcher.group(3);
             } else {
                 this.option = option;
+                this.vendor = Optional.empty();
                 this.minVersion = Optional.empty();
                 this.maxVersion = Optional.empty();
             }
@@ -229,6 +238,7 @@ public class JvmConfigReader extends NodeListener implements XMLReader {
 
         public JvmOption(String option, String minVersion, String maxVersion) {
             this.option = option;
+            this.vendor = Optional.empty();
             this.minVersion = Optional.ofNullable(JDKVersion.toValue(minVersion));
             this.maxVersion = Optional.ofNullable(JDKVersion.toValue(maxVersion));
         }


### PR DESCRIPTION
The code changes only affect Payara related code. It is a feature to support vendor specific JVM options in Payara Server.