### PR TITLE
[NETBEANS-3485] Fixed compiler warnings concerning rawtypes Enumerati…

### DIFF
--- a/harness/o.n.insane/src/org/netbeans/insane/model/Support.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/model/Support.java
@@ -70,7 +70,7 @@ public final class Support {
         Set<Object> visited = new HashSet<Object>(queue);
         while (!queue.isEmpty()) {
             PathElement act = queue.remove(0);
-            Enumeration en = act.getItem().incomming();
+            Enumeration<Object> en = act.getItem().incomming();
             while(en.hasMoreElements()) {
                 Object o = en.nextElement();
                 if (o instanceof String) {

--- a/harness/o.n.insane/src/org/netbeans/insane/model/XmlHeapModel.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/model/XmlHeapModel.java
@@ -73,7 +73,8 @@ class XmlHeapModel implements org.netbeans.insane.model.HeapModel {
 
     static class MemItem implements Item {
         // a list of Items, Strings and one null
-        private Object[] refs = new Object[] {null};
+        private Object[] incommingRefs = new Object[0];
+        private Item[] outgoingRefs = new Item[0];
         private int id;
         private int size;
         private String type;
@@ -100,11 +101,11 @@ class XmlHeapModel implements org.netbeans.insane.model.HeapModel {
         }
 
         public Enumeration<Object> incomming() {
-            return new RefEnum(true, refs);
+            return new RefEnum<Object>(incommingRefs);
         }
 
         public Enumeration<Item> outgoing() {
-            return new RefEnum(false, refs);
+            return new RefEnum<Item>(outgoingRefs);
         }
     
         public int getId() {
@@ -122,17 +123,17 @@ class XmlHeapModel implements org.netbeans.insane.model.HeapModel {
 
         // parsing impl
         void addIncomming(Object incomming) {
-            Object[] nr = new Object[refs.length+1];
+            Object[] nr = new Object[incommingRefs.length + 1];
             nr[0] = incomming;
-            System.arraycopy(refs, 0, nr, 1, refs.length);
-            refs = nr;
+            System.arraycopy(incommingRefs, 0, nr, 1, incommingRefs.length);
+            incommingRefs = nr;
         }
 
-        void addOutgoing(Object outgoing) {
-            Object[] nr = new Object[refs.length+1];
-            nr[refs.length] = outgoing;
-            System.arraycopy(refs, 0, nr, 0, refs.length);
-            refs = nr;
+        void addOutgoing(Item outgoing) {
+            Item[] nr = new Item[outgoingRefs.length+1];
+            nr[outgoingRefs.length] = outgoing;
+            System.arraycopy(outgoingRefs, 0, nr, 0, outgoingRefs.length);
+            outgoingRefs = nr;
         }
     }
 
@@ -209,26 +210,28 @@ class XmlHeapModel implements org.netbeans.insane.model.HeapModel {
         return Integer.parseInt(s, 16);
     }
 
-    // An enumeration over object array, enumeration either pre-null items
-    // or post-null items
-    private static class RefEnum implements Enumeration {
+    // An enumeration over object array
+    private static class RefEnum<T> implements Enumeration<T> {
+
         int ptr;
-        Object[] items;
-        RefEnum(boolean first, Object[] data) {
+        T[] items;
+
+        RefEnum(T[] data) {
             items = data;
-            if (!first) while (data[ptr++] != null);
         }
 
+        @Override
         public boolean hasMoreElements() {
-            return ptr < items.length && items[ptr] != null;
+            return ptr < items.length;
         }
 
-        public Object nextElement() {
-            if (hasMoreElements()) return items[ptr++];
+        @Override
+        public T nextElement() {
+            if (hasMoreElements()) {
+                return items[ptr++];
+            }
             throw new NoSuchElementException();
         }
     }
-
-
 }
                                       

--- a/platform/autoupdate.services/libsrc/org/netbeans/updater/UpdateTracking.java
+++ b/platform/autoupdate.services/libsrc/org/netbeans/updater/UpdateTracking.java
@@ -206,7 +206,7 @@ public final class UpdateTracking {
         
         String dirs = System.getProperty("netbeans.dirs"); // NOI18N
         if (dirs != null) {
-            Enumeration en = new StringTokenizer (dirs, File.pathSeparator);
+            Enumeration<Object> en = new StringTokenizer (dirs, File.pathSeparator);
             while (en.hasMoreElements ()) {
                 File f = new File ((String)en.nextElement ());
                 // this prevents autoupdate from accessing this 

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/IDEInitializer.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/api/autoupdate/IDEInitializer.java
@@ -111,9 +111,9 @@ public class IDEInitializer extends ProxyLookup {
     
     public static void cleanWorkDir () {
         try {
-            Enumeration en = lfs.getRoot ().getChildren (false);
+            Enumeration<? extends FileObject> en = lfs.getRoot().getChildren(false);
             while (en.hasMoreElements ()) 
-                ((FileObject) en.nextElement ()).delete ();
+                en.nextElement().delete();
         } catch (IOException ex) {
             ex.printStackTrace ();
         }

--- a/platform/core.multiview/src/org/netbeans/core/multiview/TabsComponent.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/TabsComponent.java
@@ -142,7 +142,7 @@ class TabsComponent extends JPanel {
 		}
 	    }
         }
-        Enumeration en = model.getButtonGroup().getElements();
+        Enumeration<AbstractButton> en = model.getButtonGroup().getElements();
         while (en.hasMoreElements()) {
             JToggleButton but = (JToggleButton)en.nextElement();
             but.setPreferredSize(new Dimension(prefWidth + 10, prefHeight));
@@ -274,7 +274,7 @@ class TabsComponent extends JPanel {
 		prefWidth = Math.max(button.getPreferredSize().width, prefWidth);
 	    }
         }
-        Enumeration en = model.getButtonGroupSplit().getElements();
+        Enumeration<AbstractButton> en = model.getButtonGroupSplit().getElements();
         while (en.hasMoreElements()) {
             JToggleButton but = (JToggleButton)en.nextElement();
             Insets ins = but.getBorder().getBorderInsets(but);
@@ -359,7 +359,7 @@ class TabsComponent extends JPanel {
 
     private void syncSplitButtonsWithModel() {
         model.setFreezeTabButtons( true );
-	Enumeration en = model.getButtonGroupSplit().getElements();
+	Enumeration<AbstractButton> en = model.getButtonGroupSplit().getElements();
 	while (en.hasMoreElements()) {
 	    JToggleButton but = (JToggleButton) en.nextElement();
             TabsButtonModel buttonModel = ( TabsButtonModel ) but.getModel();
@@ -373,7 +373,7 @@ class TabsComponent extends JPanel {
 
     private void syncButtonsWithModel() {
         model.setFreezeTabButtons( true );
-	Enumeration en = model.getButtonGroup().getElements();
+	Enumeration<AbstractButton> en = model.getButtonGroup().getElements();
 	while (en.hasMoreElements()) {
 	    JToggleButton but = (JToggleButton) en.nextElement();
             TabsButtonModel buttonModel = ( TabsButtonModel ) but.getModel();
@@ -513,7 +513,7 @@ class TabsComponent extends JPanel {
     }
 
     void changeActiveManually(MultiViewDescription desc) {
-        Enumeration en = model.getButtonGroup().getElements();
+        Enumeration<AbstractButton> en = model.getButtonGroup().getElements();
 	MultiViewDescription activeDescription = model.getActiveDescription();
 	if (activeDescription instanceof ContextAwareDescription && ((ContextAwareDescription) activeDescription).isSplitDescription()) {
 	    en = model.getButtonGroupSplit().getElements();
@@ -549,7 +549,7 @@ class TabsComponent extends JPanel {
     }
 
     void changeVisibleManually(MultiViewDescription desc) {
-        Enumeration en = model.getButtonGroup().getElements();
+        Enumeration<AbstractButton> en = model.getButtonGroup().getElements();
 	MultiViewDescription activeDescription = model.getActiveDescription();
 	if (activeDescription instanceof ContextAwareDescription && ((ContextAwareDescription) activeDescription).isSplitDescription()) {
 	    en = model.getButtonGroupSplit().getElements();
@@ -703,7 +703,7 @@ class TabsComponent extends JPanel {
 
     void requestFocusForSelectedButton() {
         bar.setFocusable(true);
-        Enumeration en = model.getButtonGroup().getElements();
+        Enumeration<AbstractButton> en = model.getButtonGroup().getElements();
         while (en.hasMoreElements()) {
             JToggleButton but = (JToggleButton)en.nextElement();
             if (model.getButtonGroup().isSelected(but.getModel())) {

--- a/platform/core.multiview/src/org/netbeans/core/spi/multiview/text/MultiViewCloneableEditor.java
+++ b/platform/core.multiview/src/org/netbeans/core/spi/multiview/text/MultiViewCloneableEditor.java
@@ -40,6 +40,7 @@ import org.openide.text.NbDocument.CustomToolbar;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle.Messages;
+import org.openide.windows.CloneableTopComponent;
 import org.openide.windows.TopComponent;
 
 /**
@@ -197,7 +198,7 @@ class MultiViewCloneableEditor extends CloneableEditor  implements MultiViewElem
     @Override
     public CloseOperationState canCloseElement() {
         final CloneableEditorSupport sup = getLookup().lookup(CloneableEditorSupport.class);
-        Enumeration en = getReference().getComponents();
+        Enumeration<CloneableTopComponent> en = getReference().getComponents();
         if (en.hasMoreElements()) {
             en.nextElement();
             if (en.hasMoreElements()) {

--- a/platform/core.netigso/src/org/netbeans/core/netigso/Netigso.java
+++ b/platform/core.netigso/src/org/netbeans/core/netigso/Netigso.java
@@ -188,7 +188,7 @@ implements Cloneable, Stamps.Updater {
 
     /** contributed by Alex Bowen (trajar@netbeans.org) */
     private void injectSystemProperties(Map configProps) {
-        for (Enumeration e = System.getProperties().propertyNames(); e.hasMoreElements(); ) {
+        for (Enumeration<?> e = System.getProperties().propertyNames(); e.hasMoreElements(); ) {
             String key = e.nextElement().toString();
             if (key.startsWith("felix.") || key.startsWith("org.osgi.framework.")) { // NOI18N
                 configProps.put(key, System.getProperty(key));
@@ -275,12 +275,12 @@ implements Cloneable, Stamps.Updater {
                 try {
                     SELF_QUERY.set(true);
                     if (findCoveredPkgs(exported)) {
-                        Enumeration en = b.findEntries("", null, true);
+                        Enumeration<URL> en = b.findEntries("", null, true);
                         if (en == null) {
                             LOG.log(Level.INFO, "Bundle {0}: {1} is empty", new Object[] { b.getBundleId(), b.getSymbolicName() });
                         } else {
                             while (en.hasMoreElements()) {
-                                URL url = (URL) en.nextElement();
+                                URL url = en.nextElement();
                                 if (url.getFile().startsWith("/META-INF")) {
                                     pkgs.add(url.getFile().substring(9));
                                     continue;

--- a/platform/core.netigso/src/org/netbeans/core/netigso/NetigsoLoader.java
+++ b/platform/core.netigso/src/org/netbeans/core/netigso/NetigsoLoader.java
@@ -67,7 +67,7 @@ final class NetigsoLoader extends ProxyClassLoader {
             LOG.log(Level.WARNING, "Trying to load resource before initialization finished {0}", name);
             return Enumerations.empty();
         }
-        Enumeration ret = null;
+        Enumeration<URL> ret = null;
         try {
             if (b.getState() != Bundle.UNINSTALLED) {
                 ret = b.getResources(name);

--- a/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiActivationVisibleTest.java
+++ b/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoOSGiActivationVisibleTest.java
@@ -192,7 +192,7 @@ public class NetigsoOSGiActivationVisibleTest extends SetupHid {
     }
     
     public void testResourcesFromBundle() throws Exception {
-        Enumeration res = toEnable.getResources("org/foo/Something.txt");
+        Enumeration<URL> res = toEnable.getResources("org/foo/Something.txt");
         assertEnumeration("Bundle can get its own resources", res);
     }
 
@@ -203,19 +203,19 @@ public class NetigsoOSGiActivationVisibleTest extends SetupHid {
 
     public void testResourcesDirectFromBundle() throws Exception {
         Method loadResource = directBundle.getMethod("loadResources", String.class, ClassLoader.class);
-        Enumeration res = (Enumeration) loadResource.invoke(null, "org/foo/Something.txt", null);
+        Enumeration<URL> res = (Enumeration<URL>) loadResource.invoke(null, "org/foo/Something.txt", null);
         assertEnumeration("Bundle knows how to own resource from its classloader", res);
     }
 
     public void testResourcesDirectViaModuleClassLoader() throws Exception {
         Method loadResource = directBundle.getMethod("loadResources", String.class, ClassLoader.class);
-        Enumeration res = (Enumeration) loadResource.invoke(null, "org/foo/Something.txt", someModule.getClassLoader());
+        Enumeration<URL> res = (Enumeration<URL>) loadResource.invoke(null, "org/foo/Something.txt", someModule.getClassLoader());
         assertEnumeration("Module knows how to own resource from its classloader", res);
     }
 
     public void testResourcesFromContextClassLoader() throws Exception {
         Method loadResource = directBundle.getMethod("loadResources", String.class, ClassLoader.class);
-        Enumeration res = (Enumeration) loadResource.invoke(null, "org/foo/Something.txt", Thread.currentThread().getContextClassLoader());
+        Enumeration<URL> res = (Enumeration<URL>) loadResource.invoke(null, "org/foo/Something.txt", Thread.currentThread().getContextClassLoader());
         assertEnumeration("Contxt class loader loads resource from disabled modules too", res);
     }
 

--- a/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoSelfQueryTest.java
+++ b/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/NetigsoSelfQueryTest.java
@@ -283,15 +283,15 @@ public class NetigsoSelfQueryTest extends NetigsoHid {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
-        public Class loadClass(String string) throws ClassNotFoundException {
+        public Class<?> loadClass(String string) throws ClassNotFoundException {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
-        public Enumeration getResources(String string) throws IOException {
+        public Enumeration<?> getResources(String string) throws IOException {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
-        public Enumeration getEntryPaths(String string) {
+        public Enumeration<?> getEntryPaths(String string) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
@@ -303,7 +303,7 @@ public class NetigsoSelfQueryTest extends NetigsoHid {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
-        public Enumeration findEntries(String string, String string1, boolean bln) {
+        public Enumeration<URL> findEntries(String string, String string1, boolean bln) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
@@ -311,7 +311,7 @@ public class NetigsoSelfQueryTest extends NetigsoHid {
             return handler.get();
         }
 
-        public Map getSignerCertificates(int i) {
+        public Map<?, ?> getSignerCertificates(int i) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
@@ -513,15 +513,15 @@ public class NetigsoSelfQueryTest extends NetigsoHid {
             return "org.test";
         }
 
-        public Class loadClass(String string) throws ClassNotFoundException {
+        public Class<?> loadClass(String string) throws ClassNotFoundException {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
-        public Enumeration getResources(String string) throws IOException {
+        public Enumeration<?> getResources(String string) throws IOException {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
-        public Enumeration getEntryPaths(String string) {
+        public Enumeration<?> getEntryPaths(String string) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
@@ -533,7 +533,7 @@ public class NetigsoSelfQueryTest extends NetigsoHid {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
-        public Enumeration findEntries(String string, String string1, boolean bln) {
+        public Enumeration<URL> findEntries(String string, String string1, boolean bln) {
             Set<URL> set = new HashSet<URL>();
             try {
                 if (archive.fromArchive("org/test/pkg/MyClass.class") != null) {

--- a/platform/core.startup/src/org/netbeans/core/startup/NbInstaller.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/NbInstaller.java
@@ -602,9 +602,9 @@ final class NbInstaller extends ModuleInstaller {
                     continue;
                 }
             }
-            Enumeration e = m.findResources("META-INF/generated-layer.xml"); // NOI18N
+            Enumeration<URL> e = m.findResources("META-INF/generated-layer.xml"); // NOI18N
             while (e.hasMoreElements()) {
-                URL u = (URL)e.nextElement();
+                URL u = e.nextElement();
                 theseurls.add(u);
             }
         }

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/ExLocalFileSystem.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/ExLocalFileSystem.java
@@ -88,7 +88,7 @@ public class ExLocalFileSystem extends LocalFileSystem {
         * @param name the file
         * @return enumeration of keys (as strings)
         */
-        public synchronized Enumeration attributes(String name) {
+        public synchronized Enumeration<String> attributes(String name) {
             return super.attributes(transformName (name));
         }
 

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/BaseFileObjectTestHid.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/BaseFileObjectTestHid.java
@@ -478,9 +478,9 @@ public class BaseFileObjectTestHid extends TestBaseHid{
             public void fileDeleted(FileEvent fe) {
                 fe.getFile().getChildren();
                 fe.getFile().getParent().getChildren();
-                Enumeration en =  fe.getFile().getParent().getChildren(true);
+                Enumeration<? extends FileObject> en =  fe.getFile().getParent().getChildren(true);
                 while(en.hasMoreElements()) {
-                    if (fe.getFile().equals((FileObject)en.nextElement())) {
+                    if (fe.getFile().equals(en.nextElement())) {
                         fail(fe.getFile().getPath());
                     }
                 }

--- a/platform/netbinox/src/org/netbeans/modules/netbinox/EmptyBundleFile.java
+++ b/platform/netbinox/src/org/netbeans/modules/netbinox/EmptyBundleFile.java
@@ -46,8 +46,8 @@ final class EmptyBundleFile extends BundleFile {
     }
 
     @Override
-    public Enumeration getEntryPaths(String string) {
-        return Collections.enumeration(Collections.emptyList());
+    public Enumeration<String> getEntryPaths(String string) {
+        return Collections.enumeration(Collections.<String>emptyList());
     }
 
     @Override

--- a/platform/netbinox/src/org/netbeans/modules/netbinox/NetigsoBundleFile.java
+++ b/platform/netbinox/src/org/netbeans/modules/netbinox/NetigsoBundleFile.java
@@ -93,8 +93,8 @@ final class NetigsoBundleFile extends BundleFile {
     }
 
     @Override
-    public Enumeration getEntryPaths(String string) {
-        return Collections.enumeration(Collections.emptyList());
+    public Enumeration<String> getEntryPaths(String string) {
+        return Collections.enumeration(Collections.<String>emptyList());
     }
 
     @Override

--- a/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/ExternalDirectoryTest.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/ExternalDirectoryTest.java
@@ -74,7 +74,6 @@ public class ExternalDirectoryTest extends SetupHid {
         ModuleSystem ms = Main.getModuleSystem();
         mgr = ms.getManager();
         mgr.mutexPrivileged().enterWriteAccess();
-        Enumeration en;
         int checks = 0;
         
         System.setProperty("activated.checkentries", "/org/test/x.txt");
@@ -94,13 +93,13 @@ public class ExternalDirectoryTest extends SetupHid {
                     sb.append("No root URL for ").append(b.getSymbolicName()).append("\n");
                 }
                 
-                en = b.findEntries("/", null, true);
+                Enumeration<URL> en = b.findEntries("/", null, true);
                 if (en == null) {
                     sb.append("No entries for ").append(b.getSymbolicName()).append("\n");
                     continue;
                 }
                 while (en.hasMoreElements()) {
-                    URL u = (URL) en.nextElement();
+                    URL u = en.nextElement();
                     final String ef = u.toExternalForm();
                     int pref = ef.indexOf("/org/");
                     int last = ef.lastIndexOf("/");

--- a/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxLibraryTest.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetbinoxLibraryTest.java
@@ -18,22 +18,13 @@
  */
 package org.netbeans.modules.netbinox;
 
-import java.util.Enumeration;
-import org.eclipse.osgi.baseadaptor.bundlefile.BundleEntry;
-import org.eclipse.osgi.baseadaptor.bundlefile.BundleFile;
 import org.netbeans.core.startup.*;
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.util.Locale;
-import org.eclipse.osgi.baseadaptor.BaseData;
-import org.eclipse.osgi.framework.adaptor.BundleData;
-import org.eclipse.osgi.framework.internal.core.AbstractBundle;
 import org.netbeans.Module;
 import org.netbeans.ModuleManager;
 import org.netbeans.SetupHid;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 
 /**
  * Is loading of libraries OK?
@@ -65,8 +56,6 @@ public class NetbinoxLibraryTest extends SetupHid {
         ModuleSystem ms = Main.getModuleSystem();
         mgr = ms.getManager();
         mgr.mutexPrivileged().enterWriteAccess();
-        Enumeration en;
-        int checks = 0;
         try {
             System.setProperty("activated.library", "does.not.exist");
             

--- a/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoActivationTest.java
+++ b/platform/netbinox/test/unit/src/org/netbeans/modules/netbinox/NetigsoActivationTest.java
@@ -65,7 +65,6 @@ public class NetigsoActivationTest extends SetupHid {
         ModuleSystem ms = Main.getModuleSystem();
         mgr = ms.getManager();
         mgr.mutexPrivileged().enterWriteAccess();
-        Enumeration en;
         int checks = 0;
         try {
             File simpleModule = new File(jars, "activate.jar");
@@ -92,13 +91,13 @@ public class NetigsoActivationTest extends SetupHid {
                 }
                 assertNotNull("All our bundles have BundleFile", bFile);
                 
-                en = b.findEntries("/", null, true);
+                Enumeration<URL> en = b.findEntries("/", null, true);
                 if (en == null) {
                     sb.append("No entries for ").append(b.getSymbolicName()).append("\n");
                     continue;
                 }
                 while (en.hasMoreElements()) {
-                    URL u = (URL) en.nextElement();
+                    URL u = en.nextElement();
                     final String ef = u.toExternalForm();
                     int pref = ef.indexOf("/org/");
                     int last = ef.lastIndexOf("/");

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
@@ -1449,11 +1449,10 @@ public class ETable extends JTable {
         }
 
         if (modelColumn != TableModelEvent.ALL_COLUMNS) {
-            Enumeration enumeration = getColumnModel().getColumns();
+            Enumeration<TableColumn> enumeration = getColumnModel().getColumns();
             TableColumn aColumn;
-            int index = 0;
             while (enumeration.hasMoreElements()) {
-                aColumn = (TableColumn)enumeration.nextElement();
+                aColumn = enumeration.nextElement();
                 if (aColumn.getModelIndex() == modelColumn) {
                     ETableColumn etc = (ETableColumn)aColumn;
                     if ((! etc.isSorted()) && (quickFilterColumn != modelColumn)){
@@ -1951,9 +1950,9 @@ public class ETable extends JTable {
      * Compute the preferredVidths of all columns.
      */
     void updatePreferredWidths() {
-        Enumeration en = getColumnModel().getColumns();
+        Enumeration<TableColumn> en = getColumnModel().getColumns();
         while (en.hasMoreElements()) {
-            Object obj = en.nextElement();
+            TableColumn obj = en.nextElement();
             if (obj instanceof ETableColumn) {
                 ETableColumn etc = (ETableColumn) obj;
                 etc.updatePreferredWidth(this, false);
@@ -2285,8 +2284,8 @@ public class ETable extends JTable {
         @Override
         public void itemStateChanged(java.awt.event.ItemEvent itemEvent) {
             Object selItem = searchCombo.getSelectedItem();
-            for (Enumeration en = getColumnModel().getColumns(); en.hasMoreElements(); ) {
-                Object column = en.nextElement();
+            for (Enumeration<TableColumn> en = getColumnModel().getColumns(); en.hasMoreElements(); ) {
+                TableColumn column = en.nextElement();
                 if (column instanceof ETableColumn) {
                     ETableColumn etc = (ETableColumn)column;
                     Object value = etc.getHeaderValue();
@@ -2366,8 +2365,8 @@ public class ETable extends JTable {
     
     private ComboBoxModel getSearchComboModel() {
         DefaultComboBoxModel result = new DefaultComboBoxModel();
-        for (Enumeration en = getColumnModel().getColumns(); en.hasMoreElements(); ) {
-            Object column = en.nextElement();
+        for (Enumeration<TableColumn> en = getColumnModel().getColumns(); en.hasMoreElements(); ) {
+            TableColumn column = en.nextElement();
             if (column instanceof ETableColumn) {
                 ETableColumn etc = (ETableColumn)column;
                 Object value = etc.getHeaderValue();

--- a/platform/openide.awt/test/unit/src/org/openide/awt/NotificationCategoryFactoryTest.java
+++ b/platform/openide.awt/test/unit/src/org/openide/awt/NotificationCategoryFactoryTest.java
@@ -27,11 +27,6 @@ import java.net.URLStreamHandlerFactory;
 import java.util.Enumeration;
 import java.util.List;
 import junit.framework.Assert;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNull;
-import static junit.framework.Assert.fail;
 import org.netbeans.junit.Manager;
 import org.netbeans.junit.NbTestCase;
 import org.openide.awt.NotificationDisplayer.Category;
@@ -178,9 +173,9 @@ public class NotificationCategoryFactoryTest extends NbTestCase {
 
         public static void cleanWorkDir() {
             try {
-                Enumeration en = lfs.getRoot().getChildren(false);
+                Enumeration<? extends FileObject> en = lfs.getRoot().getChildren(false);
                 while (en.hasMoreElements()) {
-                    ((FileObject) en.nextElement()).delete();
+                    en.nextElement().delete();
                 }
             } catch (IOException ex) {
                 ex.printStackTrace();

--- a/platform/openide.execution.compat8/src/org/openide/execution/NbClassPathCompat.java
+++ b/platform/openide.execution.compat8/src/org/openide/execution/NbClassPathCompat.java
@@ -77,10 +77,10 @@ public class NbClassPathCompat {
 
 
         Env env = new Env ();
-        Enumeration en = cap.fileSystems ();
+        Enumeration<? extends FileSystem> en = cap.fileSystems();
         while (en.hasMoreElements ()) {
             try {
-                FileSystem fs = (FileSystem)en.nextElement ();
+                FileSystem fs = en.nextElement();
                 FileSystemCompat.compat(fs).prepareEnvironment((FileSystem$Environment)env);
             } catch (EnvironmentNotSupportedException ex) {
                 // store the exception

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
@@ -2555,10 +2555,10 @@ public class FileObjectTestHid extends TestBaseHid {
         try {
             for (int i = 0; i < names.length; i++) 
                 file1.setAttribute(names[i],"value");
-                        
-             Enumeration en = file1.getAttributes();
+
+            Enumeration<String> en = file1.getAttributes();
              while (en.hasMoreElements()) {
-                String name = (String)en.nextElement();
+                String name = en.nextElement();
                 fsAssert ("Expected getAttributes return this key: "+ name,namesList.contains(name));
                 compareList.add (name);
              }            

--- a/platform/openide.loaders/src/org/openide/loaders/MultiFileLoader.java
+++ b/platform/openide.loaders/src/org/openide/loaders/MultiFileLoader.java
@@ -160,9 +160,9 @@ public abstract class MultiFileLoader extends DataLoader {
                     if (loaderPrimary != null && dataObject.getPrimaryFile() != loaderPrimary) {
                         ERR.log(Level.FINE, "Which is different than primary of found: {0}", dataObject); // NOI18N
 
-                        Enumeration before = DataLoaderPool.getDefault().allLoaders(fo);
+                        Enumeration<DataObject.Factory> before = DataLoaderPool.getDefault().allLoaders(fo);
                         while (before.hasMoreElements()) {
-                            Object o = before.nextElement();
+                            DataObject.Factory o = before.nextElement();
                             if (o == mfl) {
                                 ERR.log(Level.FINE, "Returning null"); // NOI18N
                                 return null;

--- a/platform/openide.loaders/test/unit/src/org/openide/loaders/CanYouCreateFolderLookupFromHandleFindSlowVersionTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/loaders/CanYouCreateFolderLookupFromHandleFindSlowVersionTest.java
@@ -124,8 +124,8 @@ public class CanYouCreateFolderLookupFromHandleFindSlowVersionTest extends Loggi
         public Pool() {
         }
         
-        public Enumeration loaders() {
-            return Enumerations.singleton(DataLoader.getLoader(MyLoader.class));
+        public Enumeration<DataLoader> loaders() {
+            return Enumerations.<DataLoader>singleton(DataLoader.getLoader(MyLoader.class));
         }
     }
     

--- a/platform/openide.loaders/test/unit/src/org/openide/loaders/CanYouCreateFolderLookupFromHandleFindTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/loaders/CanYouCreateFolderLookupFromHandleFindTest.java
@@ -69,7 +69,7 @@ public class CanYouCreateFolderLookupFromHandleFindTest extends NbTestCase {
      * and that one does not check META-INF/services.
      */
     public static final class Pool extends DataLoaderPool {
-        protected Enumeration loaders() {
+        protected Enumeration<? extends DataLoader> loaders() {
             return Enumerations.singleton(SharedClassObject.findObject(MyLoader.class, true));
         }
     }

--- a/platform/openide.loaders/test/unit/src/org/openide/loaders/CanYouQueryFolderLookupFromHandleFindTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/loaders/CanYouQueryFolderLookupFromHandleFindTest.java
@@ -240,7 +240,7 @@ public class CanYouQueryFolderLookupFromHandleFindTest extends NbTestCase {
         public Pool() {
         }
         
-        public Enumeration loaders() {
+        public Enumeration<? extends DataLoader> loaders() {
             return Enumerations.singleton(DataLoader.getLoader(MyLoader.class));
         }
     }

--- a/platform/openide.loaders/test/unit/src/org/openide/loaders/CanYouQueryFromRenameTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/loaders/CanYouQueryFromRenameTest.java
@@ -295,8 +295,8 @@ public class CanYouQueryFromRenameTest extends LoggingTestCaseHid {
         public Pool() {
         }
         
-        public Enumeration loaders() {
-            return Enumerations.singleton(DataLoader.getLoader(MyLoader.class));
+        public Enumeration<? extends DataLoader> loaders() {
+            return Enumerations.<DataLoader>singleton(DataLoader.getLoader(MyLoader.class));
         }
     }
     

--- a/platform/openide.loaders/test/unit/src/org/openide/loaders/ConnectionSupportTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/loaders/ConnectionSupportTest.java
@@ -156,7 +156,7 @@ public class ConnectionSupportTest extends TestCase {
         public Pool () {
         }
 
-        public Enumeration loaders () {
+        public Enumeration<? extends DataLoader> loaders() {
             if (loaders == null) {
                 return Enumerations.empty ();
             }

--- a/platform/openide.loaders/test/unit/src/org/openide/loaders/DataFolderCopyMoreWindowsLikeTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/loaders/DataFolderCopyMoreWindowsLikeTest.java
@@ -84,7 +84,7 @@ public class DataFolderCopyMoreWindowsLikeTest extends TestCase {
             StringBuffer sb = new StringBuffer (msg);
             sb.append (" - cannot find ");
             sb.append (name);
-            Enumeration en = FileUtil.getConfigRoot().getChildren (true);
+            Enumeration<? extends FileObject> en = FileUtil.getConfigRoot().getChildren(true);
             while (en.hasMoreElements ()) {
                 sb.append ('\n');
                 sb.append ("    ");

--- a/platform/openide.loaders/test/unit/src/org/openide/loaders/DataFolderIndexTest.java
+++ b/platform/openide.loaders/test/unit/src/org/openide/loaders/DataFolderIndexTest.java
@@ -195,7 +195,7 @@ public class DataFolderIndexTest extends NbTestCase {
         public static DataLoader extra;
         
         
-        protected java.util.Enumeration loaders () {
+        protected java.util.Enumeration<? extends DataLoader> loaders () {
             if (extra == null) {
                 return org.openide.util.Enumerations.empty ();
             } else {

--- a/platform/openide.util.ui/src/org/openide/ServiceType.java
+++ b/platform/openide.util.ui/src/org/openide/ServiceType.java
@@ -258,13 +258,13 @@ public abstract class ServiceType extends Object implements Serializable, HelpCt
         */
         @Deprecated
         public ServiceType find(Class clazz) {
-            Enumeration en = services();
+            Enumeration<ServiceType> en = services();
 
             while (en.hasMoreElements()) {
-                Object o = en.nextElement();
+                ServiceType o = en.nextElement();
 
                 if (o.getClass() == clazz) {
-                    return (ServiceType) o;
+                    return o;
                 }
             }
 
@@ -281,10 +281,10 @@ public abstract class ServiceType extends Object implements Serializable, HelpCt
         * @return the desired type or <code>null</code> if it does not exist
         */
         public ServiceType find(String name) {
-            Enumeration en = services();
+            Enumeration<ServiceType> en = services();
 
             while (en.hasMoreElements()) {
-                ServiceType o = (ServiceType) en.nextElement();
+                ServiceType o = en.nextElement();
 
                 if (name.equals(o.getName())) {
                     return o;
@@ -356,11 +356,11 @@ public abstract class ServiceType extends Object implements Serializable, HelpCt
 
                 // try to find the executor by name
                 ServiceType.Registry r = Lookup.getDefault().lookup(ServiceType.Registry.class);
-                Enumeration en = r.services(clazz);
+                Enumeration<? extends ServiceType> en = r.services(clazz);
                 ServiceType some = r.find(clazz);
 
                 while (en.hasMoreElements()) {
-                    ServiceType t = (ServiceType) en.nextElement();
+                    ServiceType t = en.nextElement();
 
                     if (!serviceTypeClass.isInstance(t)) {
                         // ignore non instances

--- a/platform/openide.util.ui/test/unit/src/org/openide/util/UtilitiesTranslateTest.java
+++ b/platform/openide.util.ui/test/unit/src/org/openide/util/UtilitiesTranslateTest.java
@@ -209,7 +209,7 @@ public class UtilitiesTranslateTest extends NbTestCase {
         }
      
         
-        protected Enumeration findResources (String res) throws IOException {
+        protected Enumeration<java.net.URL> findResources (String res) throws IOException {
             if (file != null) {
                 return Enumerations.singleton (getClass ().getResource (file));
             } else {

--- a/platform/openide.util/src/org/openide/util/NbCollections.java
+++ b/platform/openide.util/src/org/openide/util/NbCollections.java
@@ -451,9 +451,9 @@ public class NbCollections {
      *               if true, {@link ClassCastException} may be thrown from an enumeration operation
      * @return an enumeration guaranteed to contain only objects of the requested type (or null)
      */
-    public static <E> Enumeration<E> checkedEnumerationByFilter(Enumeration rawEnum, final Class<E> type, final boolean strict) {
+    public static <E> Enumeration<E> checkedEnumerationByFilter(Enumeration<?> rawEnum, final Class<E> type, final boolean strict) {
         @SuppressWarnings("unchecked")
-        Enumeration<Object> _rawEnum = rawEnum;
+        Enumeration<?> _rawEnum = rawEnum;
         return Enumerations.<Object,E>filter(_rawEnum, new Enumerations.Processor<Object,E>() {
             public E process(Object o, Collection<Object> ignore) {
                 if (o == null) {

--- a/platform/openide.util/test/unit/src/org/openide/util/EnumerationsTest.java
+++ b/platform/openide.util/test/unit/src/org/openide/util/EnumerationsTest.java
@@ -123,7 +123,7 @@ public class EnumerationsTest extends NbTestCase {
     //
     
     public void testEmptyIsEmpty() {
-        Enumeration e = empty();
+        Enumeration<?> e = empty();
         assertFalse(e.hasMoreElements());
         try {
             e.nextElement();
@@ -134,7 +134,7 @@ public class EnumerationsTest extends NbTestCase {
     }
     
     public void testSingleIsSingle() {
-        Enumeration e = singleton(this);
+        Enumeration<EnumerationsTest> e = singleton(this);
         assertTrue(e.hasMoreElements());
         assertEquals("Returns me", this, e.nextElement());
         assertFalse("Now it is empty", e.hasMoreElements());
@@ -220,7 +220,7 @@ public class EnumerationsTest extends NbTestCase {
         }
         
         WeakEnum weak = new WeakEnum();
-        Enumeration en = removeDuplicates(weak);
+        Enumeration<Object> en = removeDuplicates(weak);
         
         assertTrue("Has some elements", en.hasMoreElements());
         assertEquals("And the first one is get", weak.i1, en.nextElement());
@@ -256,7 +256,7 @@ public class EnumerationsTest extends NbTestCase {
         }
         Pr p = new Pr();
         
-        Enumeration en = queue(
+        Enumeration<Integer> en = queue(
                 Collections.nCopies(1, 0), p
                 );
         

--- a/platform/openide.util/test/unit/src/org/openide/util/NbCollectionsTest.java
+++ b/platform/openide.util/test/unit/src/org/openide/util/NbCollectionsTest.java
@@ -394,7 +394,7 @@ public class NbCollectionsTest extends NbTestCase {
     }
 
     public void testCheckedEnumerationByFilter() throws Exception {
-        Enumeration raw = Collections.enumeration(Arrays.asList("one", 2, "three"));
+        Enumeration<?> raw = Collections.enumeration(Arrays.asList("one", 2, "three"));
         Enumeration<String> strings = NbCollections.checkedEnumerationByFilter(raw, String.class, false);
         assertTrue(strings.hasMoreElements());
         assertEquals("one", strings.nextElement());
@@ -404,7 +404,7 @@ public class NbCollectionsTest extends NbTestCase {
     }
 
     public void testCheckedEnumerationByFilterStrict() throws Exception {
-        Enumeration raw = Collections.enumeration(Arrays.asList("one", 2, "three"));
+        Enumeration<?> raw = Collections.enumeration(Arrays.asList("one", 2, "three"));
         Enumeration<String> strings = NbCollections.checkedEnumerationByFilter(raw, String.class, true);
         try {
             Collections.list(strings);


### PR DESCRIPTION
…on in projects of cluster config platform

There are compiler warnings about rawtype usage with a Enumeration like the following
```
   [repeat] .../platform/openide.util.ui/src/org/openide/ServiceType.java:359: warning: [rawtypes] found raw type: Enumeration
   [repeat]                 Enumeration en = r.services(clazz);
   [repeat]                 ^
   [repeat]   missing type arguments for generic class Enumeration<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in interface Enumeration
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.
