### PR TITLE
[NETBEANS-3486] Fixed compiler warnings concerning rawtypes Concurren…

### DIFF
--- a/platform/o.n.bootstrap/src/org/netbeans/PackageAttrsCache.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/PackageAttrsCache.java
@@ -71,7 +71,7 @@ final class PackageAttrsCache implements Stamps.Updater {
             }
         }
         if (tmp == null) {
-            cache = new ConcurrentHashMap();
+            cache = new ConcurrentHashMap<>();
             Stamps.getModulesJARs().scheduleSave(this, CACHE, false);
         } else {
             cache = Collections.unmodifiableMap(tmp);


### PR DESCRIPTION
…tHashMap

There are compiler warnings about rawtype usage with a ConcurrentHashMap like the following
```
   [repeat] .../platform/o.n.bootstrap/src/org/netbeans/PackageAttrsCache.java:74: warning: [rawtypes] found raw type: ConcurrentHashMap
   [repeat]             cache = new ConcurrentHashMap();
   [repeat]                         ^
   [repeat]   missing type arguments for generic class ConcurrentHashMap<K,V>
   [repeat]   where K,V are type-variables:
   [repeat]     K extends Object declared in class ConcurrentHashMap
   [repeat]     V extends Object declared in class ConcurrentHashMap
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.