### PR TITLE
[NETBEANS-3487] Fixed compiler warnings concerning rawtypes DSWeakRef…

### DIFF
--- a/platform/openide.loaders/src/org/openide/loaders/DataShadow.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataShadow.java
@@ -1204,7 +1204,7 @@ public class DataShadow extends MultiDataObject implements DataObject.Container 
             }
             
             if (o instanceof DSWeakReference) {
-                DSWeakReference him = (DSWeakReference) o;
+                DSWeakReference<?> him = (DSWeakReference<?>) o;
                 return mine.equals(him.get());
             }
             


### PR DESCRIPTION
…erence

There are compiler warnings about rawtype usage with a DSWeakReference like the following
```
   [repeat] .../platform/openide.loaders/src/org/openide/loaders/DataShadow.java:1207: warning: [rawtypes] found raw type: DSWeakReference
   [repeat]                 DSWeakReference him = (DSWeakReference) o;
   [repeat]                 ^
   [repeat]   missing type arguments for generic class DSWeakReference<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in class DSWeakReference
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.