### PR TITLE
[NETBEANS-3488] Fixed compiler warnings concerning rawtypes BasicTask

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/BasicTask.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/BasicTask.java
@@ -188,7 +188,7 @@ public abstract class BasicTask<V> implements Callable<V> {
         ////////////////////////////////////////////////////////////////////////
 
         /** Command execution task. */
-        private final BasicTask task;
+        private final BasicTask<?> task;
 
         /** New state of current command execution. */
         private final TaskState result;
@@ -214,7 +214,7 @@ public abstract class BasicTask<V> implements Callable<V> {
          * @param event  Event that caused  state change.
          * @param msgKey Message bundle key.
          */
-        protected StateChange(final BasicTask task, final TaskState result,
+        protected StateChange(final BasicTask<?> task, final TaskState result,
                 final TaskEvent event, final String msgKey) {
             this.task = task;
             this.result = result;
@@ -232,7 +232,7 @@ public abstract class BasicTask<V> implements Callable<V> {
          * @param msgKey  Message bundle key.
          * @param msgArgs Message arguments.
          */
-        protected StateChange(final BasicTask task, final TaskState result,
+        protected StateChange(final BasicTask<?> task, final TaskState result,
                 final TaskEvent event, final String msgKey,
                 final String... msgArgs) {
             this.task = task;

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/BasicTask.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/BasicTask.java
@@ -188,7 +188,7 @@ public abstract class BasicTask<V> implements Callable<V> {
         ////////////////////////////////////////////////////////////////////////
 
         /** Command execution task. */
-        private final BasicTask task;
+        private final BasicTask<?> task;
 
         /** New state of current command execution. */
         private final TaskState result;
@@ -214,7 +214,7 @@ public abstract class BasicTask<V> implements Callable<V> {
          * @param event  Event that caused  state change.
          * @param msgKey Message bundle key.
          */
-        protected StateChange(final BasicTask task, final TaskState result,
+        protected StateChange(final BasicTask<?> task, final TaskState result,
                 final TaskEvent event, final String msgKey) {
             this.task = task;
             this.result = result;
@@ -232,7 +232,7 @@ public abstract class BasicTask<V> implements Callable<V> {
          * @param msgKey  Message bundle key.
          * @param msgArgs Message arguments.
          */
-        protected StateChange(final BasicTask task, final TaskState result,
+        protected StateChange(final BasicTask<?> task, final TaskState result,
                 final TaskEvent event, final String msgKey,
                 final String... msgArgs) {
             this.task = task;


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a BasicTask like the following
```
   [repeat] .../enterprise/payara.common/src/org/netbeans/modules/payara/common/BasicTask.java:235: warning: [rawtypes] found raw type: BasicTask
   [repeat]         protected StateChange(final BasicTask task, final TaskState result,
   [repeat]                                     ^
   [repeat]   missing type arguments for generic class BasicTask<V>
   [repeat]   where V is a type-variable:
   [repeat]     V extends Object declared in class BasicTask
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.