### PR TITLE
[NETBEANS-3489] Fixed compiler warnings concerning rawtypes Callable

### DIFF
--- a/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
@@ -100,33 +100,20 @@ public class LocalAddressUtils {
     private static Future<InetAddress[]> fut2;
     private static Future<List<InetAddress>> fut3;
 
-    private static final Callable<InetAddress> C1 = new Callable<InetAddress>(){
-        @Override
-        public InetAddress call() throws UnknownHostException  {
-            return InetAddress.getLocalHost();
+    private static final Callable<InetAddress> C1 = () -> InetAddress.getLocalHost();
+    private static final Callable<InetAddress[]> C2 = () -> {
+        try {
+            String hostname = HostnameUtils.getNetworkHostname();
+            return InetAddress.getAllByName(hostname);
+        } catch (NativeException ex) {
+            throw new UnknownHostException(ex.getMessage() + ", error code : " + ex.getErrorCode());
         }
     };
-    private static final Callable<InetAddress[]> C2 = new Callable<InetAddress[]>(){
-        @Override
-        public InetAddress[] call() throws UnknownHostException  {
-            try {
-                String hostname = HostnameUtils.getNetworkHostname();
-                return InetAddress.getAllByName(hostname);
-            } catch (NativeException ex) {
-                throw new UnknownHostException(ex.getMessage() + ", error code : " + ex.getErrorCode());
-            }
-        }
-    };
-    private static final Callable<List<InetAddress>> C3 = new Callable<List<InetAddress>>(){
-        @Override
-        public List<InetAddress> call() {
-            return getLocalNetworkInterfaceAddr();
-        }
-    };
+    private static final Callable<List<InetAddress>> C3 = () -> getLocalNetworkInterfaceAddr();
+
     static {
         refreshNetworkInfo(false);
     }
-    
     
     private LocalAddressUtils() {
     }


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a Callable like the following
```
   [repeat] .../platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java:103: warning: [rawtypes] found raw type: Callable
   [repeat]     private static final Callable<InetAddress> C1 = new Callable(){
   [repeat]                                                         ^
   [repeat]   missing type arguments for generic class Callable<V>
   [repeat]   where V is a type-variable:
   [repeat]     V extends Object declared in interface Callable
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.