### PR TITLE
[NETBEANS-3428] Update FlatLaf from 0.18 to 0.20

### DIFF
--- a/platform/o.n.swing.flatlaf/external/binaries-list
+++ b/platform/o.n.swing.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-356560D31A23AF7A0112B5906398DDDAC15C3124 com.formdev:flatlaf:0.18
+A63B86E9C63430FE0CCD3950876E6F76639CDD1C com.formdev:flatlaf:0.20

--- a/platform/o.n.swing.flatlaf/external/flatlaf-0.20-license.txt
+++ b/platform/o.n.swing.flatlaf/external/flatlaf-0.20-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 0.18
-Files: flatlaf-0.18.jar
+Version: 0.20
+Files: flatlaf-0.20.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/o.n.swing.flatlaf/nbproject/project.properties
+++ b/platform/o.n.swing.flatlaf/nbproject/project.properties
@@ -19,4 +19,4 @@ is.autoload=true
 javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 
-release.external/flatlaf-0.18.jar=modules/ext/com-formdev-flatlaf.jar
+release.external/flatlaf-0.20.jar=modules/ext/com-formdev-flatlaf.jar

--- a/platform/o.n.swing.flatlaf/nbproject/project.xml
+++ b/platform/o.n.swing.flatlaf/nbproject/project.xml
@@ -53,7 +53,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>ext/com-formdev-flatlaf.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-0.18.jar</binary-origin>
+                <binary-origin>external/flatlaf-0.20.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Hi there, I'm Karl, creator of FlatLaf. This is my first (but not last) PR. Hope it is OK 😉 

This PR updates FlatLaf to 0.20, which includes following fixes/improvements for NetBeans:

- ComboBox: Fixed issues with NetBeans `org.openide.awt.ColorComboBox`
  component.
- Fixed color of links in HTML text.
- Button: Make button square if button text is "..." or a single character.
- Look and feel identifier returned by `FlatLaf.getID()` now always starts with
  "FlatLaf". Use `UIManager.getLookAndFeel().getID().startsWith( "FlatLaf" )` to
  check whether the current look and feel is FlatLaf.

Here is a full list of changes: https://github.com/JFormDesigner/FlatLaf/releases/tag/0.20