### PR TITLE
[NETBEANS-3428] FlatLaf: Fixed colors of categories buttons in Options dialog

### DIFF
--- a/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
@@ -124,11 +124,12 @@ public class OptionsPanel extends JPanel {
     private final boolean isMac = UIManager.getLookAndFeel ().getID ().equals ("Aqua");
     private static final boolean isNimbus = UIManager.getLookAndFeel ().getID ().equals ("Nimbus");
     private static final boolean isMetal = UIManager.getLookAndFeel() instanceof MetalLookAndFeel;
+    private static final boolean isFlatLaf = UIManager.getLookAndFeel().getID().startsWith("FlatLaf");
     private final boolean isGTK = UIManager.getLookAndFeel ().getID ().equals ("GTK");
     private final Color selected = isMac ? new Color(221, 221, 221) : getSelectionBackground();
-    private final Color selectedB = isMac ? new Color(183, 183, 183) : new Color (149, 106, 197);
+    private final Color selectedB = isMac ? new Color(183, 183, 183) : (isFlatLaf ? selected : new Color (149, 106, 197));
     private final Color highlighted = isMac ? new Color(221, 221, 221) : getHighlightBackground();
-    private final Color highlightedB = new Color (152, 180, 226);
+    private final Color highlightedB = isFlatLaf ? highlighted : new Color (152, 180, 226);
     //private final Color iconViewBorder = new Color (127, 157, 185);
     private final ControllerListener controllerListener = new ControllerListener ();
     
@@ -393,7 +394,7 @@ public class OptionsPanel extends JPanel {
         showHint(true);
         
         pCategories = new JPanel (new BorderLayout ());
-        pCategories.setBorder (BorderFactory.createMatteBorder(0,0,1,0,Color.lightGray));        
+        pCategories.setBorder (BorderFactory.createMatteBorder(0,0,1,0,isFlatLaf ? UIManager.getColor("Separator.foreground"): Color.lightGray)); //NOI18N
         pCategories.setBackground (getTabPanelBackground());
         categoriesScrollPane = new JScrollPane(pCategories2, ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER, ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
         categoriesScrollPane.setBorder(null);
@@ -964,7 +965,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getTabPanelBackground() {
-        if( isMetal || isNimbus ) {
+        if( isMetal || isNimbus | isFlatLaf ) {
             Color res = UIManager.getColor( "Tree.background" ); //NOI18N
             if( null == res )
                 res = Color.white;
@@ -974,7 +975,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getTabPanelForeground() {
-        if( isMetal || isNimbus ) {
+        if( isMetal || isNimbus | isFlatLaf ) {
             Color res = UIManager.getColor( "Tree.foreground" ); //NOI18N
             if( null == res )
                 res = Color.black;
@@ -984,7 +985,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getSelectionBackground() {
-        if( isMetal || isNimbus ) {
+        if( isMetal || isNimbus | isFlatLaf ) {
             if( !Color.white.equals( getTabPanelBackground() ) ) {
                 Color res = UIManager.getColor( "Tree.selectionBackground" ); //NOI18N
                 if( null == res )
@@ -996,7 +997,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getHighlightBackground() {
-        if( isMetal || isNimbus ) {
+        if( isMetal || isNimbus | isFlatLaf ) {
             if( !Color.white.equals( getTabPanelBackground() ) ) {
                 Color res = UIManager.getColor( "Tree.selectionBackground" ); //NOI18N
                 if( null == res )

--- a/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
@@ -122,9 +122,9 @@ public class OptionsPanel extends JPanel {
 
     private Map<String, CategoryButton> buttons = new LinkedHashMap<String, CategoryButton>();    
     private final boolean isMac = UIManager.getLookAndFeel ().getID ().equals ("Aqua");
-    private static final boolean isNimbus = UIManager.getLookAndFeel ().getID ().equals ("Nimbus");
-    private static final boolean isMetal = UIManager.getLookAndFeel() instanceof MetalLookAndFeel;
-    private static final boolean isFlatLaf = UIManager.getLookAndFeel().getID().startsWith("FlatLaf");
+    private final boolean isNimbus = UIManager.getLookAndFeel ().getID ().equals ("Nimbus");
+    private final boolean isMetal = UIManager.getLookAndFeel() instanceof MetalLookAndFeel;
+    private final boolean isFlatLaf = UIManager.getLookAndFeel().getID().startsWith("FlatLaf");
     private final boolean isGTK = UIManager.getLookAndFeel ().getID ().equals ("GTK");
     private final Color selected = isMac ? new Color(221, 221, 221) : getSelectionBackground();
     private final Color selectedB = isMac ? new Color(183, 183, 183) : (isFlatLaf ? selected : new Color (149, 106, 197));
@@ -964,7 +964,7 @@ public class OptionsPanel extends JPanel {
         return retval;
     }
 
-    private static Color getTabPanelBackground() {
+    private Color getTabPanelBackground() {
         if( useUIDefaultsColors() ) {
             Color res = UIManager.getColor( "Tree.background" ); //NOI18N
             if( null == res )
@@ -974,7 +974,7 @@ public class OptionsPanel extends JPanel {
         return Color.white;
     }
 
-    private static Color getTabPanelForeground() {
+    private Color getTabPanelForeground() {
         if( useUIDefaultsColors() ) {
             Color res = UIManager.getColor( "Tree.foreground" ); //NOI18N
             if( null == res )
@@ -984,7 +984,7 @@ public class OptionsPanel extends JPanel {
         return Color.black;
     }
 
-    private static Color getSelectionBackground() {
+    private Color getSelectionBackground() {
         if( useUIDefaultsColors() ) {
             if( !Color.white.equals( getTabPanelBackground() ) ) {
                 Color res = UIManager.getColor( "Tree.selectionBackground" ); //NOI18N
@@ -996,7 +996,7 @@ public class OptionsPanel extends JPanel {
         return new Color (193, 210, 238);
     }
 
-    private static Color getHighlightBackground() {
+    private Color getHighlightBackground() {
         if( useUIDefaultsColors() ) {
             if( !Color.white.equals( getTabPanelBackground() ) ) {
                 Color res = UIManager.getColor( "Tree.selectionBackground" ); //NOI18N
@@ -1008,7 +1008,7 @@ public class OptionsPanel extends JPanel {
         return new Color (224, 232, 246);
     }
 
-    private static boolean useUIDefaultsColors() {
+    private boolean useUIDefaultsColors() {
         return isMetal || isNimbus || isFlatLaf;
     }
 
@@ -1238,7 +1238,7 @@ public class OptionsPanel extends JPanel {
     private static final Color COL_OVER_GRADIENT2 = new Color(163,184,203,128);
     private static final Color COL_OVER_GRADIENT3 = new Color(206,227,246,128);
 
-    private static final boolean isDefaultTabBackground = Color.white.equals( getTabPanelBackground() );
+    private final boolean isDefaultTabBackground = Color.white.equals( getTabPanelBackground() );
 
     private class NimbusCategoryButton extends CategoryButton {
 

--- a/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
@@ -965,7 +965,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getTabPanelBackground() {
-        if( isNative() ) {
+        if( useUIDefaultsColors() ) {
             Color res = UIManager.getColor( "Tree.background" ); //NOI18N
             if( null == res )
                 res = Color.white;
@@ -975,7 +975,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getTabPanelForeground() {
-        if( isNative() ) {
+        if( useUIDefaultsColors() ) {
             Color res = UIManager.getColor( "Tree.foreground" ); //NOI18N
             if( null == res )
                 res = Color.black;
@@ -985,7 +985,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getSelectionBackground() {
-        if( isNative() ) {
+        if( useUIDefaultsColors() ) {
             if( !Color.white.equals( getTabPanelBackground() ) ) {
                 Color res = UIManager.getColor( "Tree.selectionBackground" ); //NOI18N
                 if( null == res )
@@ -997,7 +997,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getHighlightBackground() {
-        if( isNative() ) {
+        if( useUIDefaultsColors() ) {
             if( !Color.white.equals( getTabPanelBackground() ) ) {
                 Color res = UIManager.getColor( "Tree.selectionBackground" ); //NOI18N
                 if( null == res )
@@ -1008,8 +1008,8 @@ public class OptionsPanel extends JPanel {
         return new Color (224, 232, 246);
     }
 
-    private static boolean isNative() {
-        return isMetal || isNimbus | isFlatLaf;
+    private static boolean useUIDefaultsColors() {
+        return isMetal || isNimbus || isFlatLaf;
     }
 
     // innerclasses ............................................................

--- a/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
@@ -965,7 +965,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getTabPanelBackground() {
-        if( isMetal || isNimbus | isFlatLaf ) {
+        if( isNative() ) {
             Color res = UIManager.getColor( "Tree.background" ); //NOI18N
             if( null == res )
                 res = Color.white;
@@ -975,7 +975,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getTabPanelForeground() {
-        if( isMetal || isNimbus | isFlatLaf ) {
+        if( isNative() ) {
             Color res = UIManager.getColor( "Tree.foreground" ); //NOI18N
             if( null == res )
                 res = Color.black;
@@ -985,7 +985,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getSelectionBackground() {
-        if( isMetal || isNimbus | isFlatLaf ) {
+        if( isNative() ) {
             if( !Color.white.equals( getTabPanelBackground() ) ) {
                 Color res = UIManager.getColor( "Tree.selectionBackground" ); //NOI18N
                 if( null == res )
@@ -997,7 +997,7 @@ public class OptionsPanel extends JPanel {
     }
 
     private static Color getHighlightBackground() {
-        if( isMetal || isNimbus | isFlatLaf ) {
+        if( isNative() ) {
             if( !Color.white.equals( getTabPanelBackground() ) ) {
                 Color res = UIManager.getColor( "Tree.selectionBackground" ); //NOI18N
                 if( null == res )
@@ -1006,6 +1006,10 @@ public class OptionsPanel extends JPanel {
             }
         }
         return new Color (224, 232, 246);
+    }
+
+    private static boolean isNative() {
+        return isMetal || isNimbus | isFlatLaf;
     }
 
     // innerclasses ............................................................


### PR DESCRIPTION
Simple fix for Options dialog categories button colors.

Uses existing colors from UI defaults.
So this should also work fine with other FlatLaf themes.

The magnifier left to the quick search field is hard to see, but this should be fixed with a SVG icon.

![image](https://user-images.githubusercontent.com/5604048/69893283-8b41bd80-130f-11ea-8e8f-f19b5b0152c2.png)
