### PR TITLE
[NETBEANS-3500] Fixed compiler warnings concerning rawtypes TreeSet

### DIFF
--- a/ide/ide.kit/test/qa-functional/src/org/netbeans/test/ide/BlacklistedClassesHandlerSingleton.java
+++ b/ide/ide.kit/test/qa-functional/src/org/netbeans/test/ide/BlacklistedClassesHandlerSingleton.java
@@ -79,9 +79,9 @@ public class BlacklistedClassesHandlerSingleton extends Handler implements Black
     // TODO: Is it necessary to use synchronizedMap? Should the list be synchronized?
     final private Map blacklist = Collections.synchronizedMap(new HashMap());
     final private Map<String, List<Exception>> whitelistViolators = Collections.synchronizedMap(new TreeMap<String, List<Exception>>());
-    final private Set whitelist = Collections.synchronizedSortedSet(new TreeSet());
-    final private Set previousWhitelist = Collections.synchronizedSortedSet(new TreeSet());
-    final private Set newWhitelist = Collections.synchronizedSortedSet(new TreeSet());
+    final private Set<String> whitelist = Collections.synchronizedSortedSet(new TreeSet<>());
+    final private Set<String> previousWhitelist = Collections.synchronizedSortedSet(new TreeSet<>());
+    final private Set<String> newWhitelist = Collections.synchronizedSortedSet(new TreeSet<>());
     private boolean whitelistEnabled = false;
     private boolean generatingWhitelist = false;
     private String whitelistFileName;
@@ -554,7 +554,7 @@ public class BlacklistedClassesHandlerSingleton extends Handler implements Black
     }
 
     public void reportDifference(PrintWriter out) {
-        Set list = whitelist;
+        Set<String> list = whitelist;
         String filename = whitelistFileName;
         if (previousWhitelistFileName != null) {
             list = previousWhitelist;
@@ -649,7 +649,7 @@ public class BlacklistedClassesHandlerSingleton extends Handler implements Black
         }
     }
 
-    private void loadWhiteList(String whitelistFileName, Set list) {
+    private void loadWhiteList(String whitelistFileName, Set<String> list) {
         try {
             if (whitelistFileName != null) {
                 readFile(new File(whitelistFileName), list);

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
@@ -233,7 +233,7 @@ final class CatalogNode extends BeanNode implements Refreshable, PropertyChangeL
         }
                 
         /** Contains public ID (String) instances. */
-        private final TreeSet keys = new TreeSet();
+        private final Set<String> keys = new TreeSet<>();
         
         public void addNotify() {            
             catalogListener = new Lis();

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogRootNode.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogRootNode.java
@@ -169,10 +169,10 @@ public final class CatalogRootNode extends AbstractNode implements Node.Cookie {
      * Kids driven by CatalogSettings. Only one instance may be used
      * since redefined equals() method.
      */
-    private static class RootChildren extends Children.Keys implements Comparator, PropertyChangeListener {
+    private static class RootChildren extends Children.Keys<Object> implements Comparator<Object>, PropertyChangeListener {
         
         /** Contains CatalogReader instances. */
-        private final TreeSet keys = new TreeSet(this);
+        private final TreeSet<Object> keys = new TreeSet<>(this);
         
         /**
           * Create new keys, register itself as listener.
@@ -220,7 +220,7 @@ public final class CatalogRootNode extends AbstractNode implements Node.Cookie {
         private void createKeys(CatalogSettings mounted) {
             keys.clear();
             if (mounted != null) {
-                Iterator it = mounted.getCatalogs(new Class[] {CatalogReader.class});
+                Iterator<CatalogReader> it = mounted.getCatalogs(new Class[] {CatalogReader.class});
                 while (it.hasNext()) {
                     keys.add(it.next());    //!!! use immutable key wrappers, some
                                             // instances may overwrite equals() so

--- a/ide/xml.catalog/nbproject/project.properties
+++ b/ide/xml.catalog/nbproject/project.properties
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.6
+javac.source=1.8
+javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=3.13.0
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/settings/CatalogSettings.java
+++ b/ide/xml.catalog/src/org/netbeans/modules/xml/catalog/settings/CatalogSettings.java
@@ -182,23 +182,22 @@ public final class CatalogSettings implements Externalizable {
      * @return providers of given class or all if passed <code>null/code> argument.
      *         It never returns null.
      */
-    public final synchronized Iterator getCatalogs(Class[] providerClasses) {
-
+    public final synchronized Iterator<CatalogReader> getCatalogs(Class[] providerClasses) {
         // compose global registrations and local(project) registrations
-        IteratorIterator it = new IteratorIterator();                       
+        IteratorIterator it = new IteratorIterator();
         it.add(mountedCatalogs.iterator());
         
-        Lookup.Template template = new Lookup.Template(CatalogReader.class);
-        Lookup.Result result = getUserCatalogsLookup().lookup(template);
+        Lookup.Template<CatalogReader> template = new Lookup.Template(CatalogReader.class);
+        Lookup.Result<CatalogReader> result = getUserCatalogsLookup().lookup(template);
         it.add(result.allInstances().iterator());
         
         if (providerClasses == null)
             return it;
         
-        ArrayList list = new ArrayList();
+        List<CatalogReader> list = new ArrayList<>();
         
         while (it.hasNext()) {
-            Object next = it.next();
+            CatalogReader next = (CatalogReader) it.next();
             // provider test
             boolean add = true;
             for (int i=0; i<providerClasses.length; i++) {

--- a/ide/xml.tax/nbproject/project.properties
+++ b/ide/xml.tax/nbproject/project.properties
@@ -18,7 +18,7 @@
 extra.module.files=modules/ext/org-netbeans-tax.jar
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 spec.version.base=1.53.0
 # Apache's XNI API - parser implementation used internally by module
 xni-impl.jar=${libs.xerces.dir}/modules/ext/xerces-2.8.0.jar

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
@@ -44,7 +44,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
 
     
     /** */
-    private static final Map<Class<?>, String> publicNodeTypeNamesMap = new HashMap();
+    private static final Map<Class<?>, String> publicNodeTypeNamesMap = new HashMap<>();
 
 
     //
@@ -82,7 +82,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
     private final TreeNodeFilter filter;
     
     /** */
-    private final List nodeTypesList;
+    private final List<Class<?>> nodeTypesList;
 
     /** */
     private NodeTypesTableModel tableModel;
@@ -96,7 +96,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
     /** Creates new TreeNodeFilterEditor */
     public TreeNodeFilterCustomEditor (TreeNodeFilter filter) {
         this.filter = filter;
-        this.nodeTypesList = new LinkedList (Arrays.asList (filter.getNodeTypes()));
+        this.nodeTypesList = new LinkedList<>(Arrays.asList((Class<?>[]) filter.getNodeTypes()));
         
         initComponents();
         ownInitComponents();
@@ -132,7 +132,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
 //          Arrays.sort (array, new NamedClassComparator());
 //          JComboBox cb = new JComboBox (array);
 
-        JComboBox cb = new JComboBox (getPublicNodeTypesInheritanceTree());
+        JComboBox<Item> cb = new JComboBox<>(getPublicNodeTypesInheritanceTree());
         cb.setEditable (false);
         DefaultCellEditor dce = new DefaultCellEditor (cb);
 //          dce.setClickCountToStart (2);
@@ -149,7 +149,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
         short acceptPolicy = acceptRadioButton.isSelected() ?
             TreeNodeFilter.ACCEPT_TYPES :
             TreeNodeFilter.REJECT_TYPES;
-        Class[] nodeTypes = (Class[])nodeTypesList.toArray (new Class[0]);
+        Class<?>[] nodeTypes = nodeTypesList.toArray(new Class<?>[0]);
 
         return new TreeNodeFilter (nodeTypes, acceptPolicy);
     }
@@ -376,7 +376,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
         }
 
         /** Returns the class for a model. */
-        public Class getColumnClass (int index) {
+        public Class<?> getColumnClass (int index) {
             return Class.class;
         }
 
@@ -405,7 +405,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
                 return;
             }
 
-            Class type = null;
+            Class<?> type = null;
 
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("--> setValue: " + val.getClass().getName() + " -- '" + val + "'"); // NOI18N
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("--> setValue: row    = " + row); // NOI18N
@@ -457,10 +457,10 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
     private static class NamedClass {
 
         /** */
-        private final Class clazz;
+        private final Class<?> clazz;
         
         /** */
-        public NamedClass (Class clazz) {
+        public NamedClass (Class<?> clazz) {
             this.clazz = clazz;
         }
 
@@ -468,7 +468,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
         /**
          */
         public String toString () {
-            String name = (String)publicNodeTypeNamesMap.get (clazz);
+            String name = publicNodeTypeNamesMap.get (clazz);
 
             if ( name == null ) {
                 name = clazz.getName();
@@ -497,11 +497,11 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
     /**
      *
      */
-    private static class NamedClassComparator implements Comparator {
+    private static class NamedClassComparator implements Comparator<Item> {
 
         /**
          */
-        public int compare (Object obj1, Object obj2) throws ClassCastException {
+        public int compare (Item obj1, Item obj2) throws ClassCastException {
             return (obj1.toString().compareTo (obj2.toString()));
         }
 
@@ -520,12 +520,12 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
     //
 
     /** */
-    private static Vector publicNodeTypesInheritanceTree;
+    private static Vector<Item> publicNodeTypesInheritanceTree;
 
 
     /**
      */
-    private static Vector getPublicNodeTypesInheritanceTree () {
+    private static Vector<Item> getPublicNodeTypesInheritanceTree () {
         if ( publicNodeTypesInheritanceTree == null ) {
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("Init Set"); // NOI18N
             
@@ -542,7 +542,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
                 }
             }
             
-            publicNodeTypesInheritanceTree = new Vector();
+            publicNodeTypesInheritanceTree = new Vector<>();
             fillPublicNodeTypesInheritanceTree (rootItem.layer, ""); // NOI18N
 
             Item.itemMap.clear();
@@ -555,7 +555,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
     
     /**
      */
-    private static void fillPublicNodeTypesInheritanceTree (Set layer, String prefix) {
+    private static void fillPublicNodeTypesInheritanceTree (Set<Item> layer, String prefix) {
         Iterator<Item> it = layer.iterator();
         while ( it.hasNext() ) {
             Item item = it.next();
@@ -593,17 +593,17 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
      */
     private static class Item {
         /** */
-        private static Map itemMap;
+        private static Map<Class<?>, Item> itemMap;
 
         /** */
         private final NamedClass clazz;
         /** */
-        private final Set        layer;
+        private final Set<Item>  layer;
         /** */
         private final String     prefix;
 
         /** */
-        private Item (NamedClass clazz, Set layer, String prefix) {
+        private Item (NamedClass clazz, Set<Item> layer, String prefix) {
             this.clazz  = clazz;
             this.layer  = layer;
             this.prefix = prefix;
@@ -616,7 +616,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
 
         /** */
         private Item (NamedClass clazz) {
-            this (clazz, new TreeSet (new NamedClassComparator()), new String());
+            this(clazz, new TreeSet<>(new NamedClassComparator()), new String());
         }
 
         /** */
@@ -649,12 +649,12 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
 
         /**
          */
-        private static Item getItem (Class clazz) {
+        private static Item getItem (Class<?> clazz) {
             if ( itemMap == null ) {
-                itemMap = new HashMap();
+                itemMap = new HashMap<>();
             }
             
-            Item item = (Item) itemMap.get (clazz);
+            Item item = itemMap.get (clazz);
             if ( item == null ) {
                 itemMap.put (clazz, item = new Item (new NamedClass (clazz)));
             }
@@ -663,15 +663,15 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
 
         /**
          */
-        private static void insertItemIntoLayer (Set layer, Item newItem) {
+        private static void insertItemIntoLayer (Set<Item> layer, Item newItem) {
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("\n\nInsert newItem : " + newItem); // NOI18N
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("       Item : set = " + layer); // NOI18N
 
             boolean inserted = false;
 
-            Object[] array = layer.toArray();
+            Item[] array = layer.toArray(new Item[0]);
             for (int i = 0; i < array.length; i++) {
-                Item item = (Item) array[i];
+                Item item = array[i];
             
                 if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("       Item : item [" + i + "] = " + item); // NOI18N
 
@@ -728,7 +728,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
 
     // debug
     public static final void main (String[] args) throws Exception {
-        Vector vector = getPublicNodeTypesInheritanceTree();
+        Vector<Item> vector = getPublicNodeTypesInheritanceTree();
 
 //          Iterator it = vector.iterator();
 //          System.out.println ("+==================================="); // NOI18N

--- a/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
@@ -55,28 +55,28 @@ public final class XSLGrammarQuery implements GrammarQuery{
      * allowed XSL children. Neither the element name keys nor the names in the
      * value set should contain the namespace prefix.
      */
-    private static Map<String, Set> elementDecls;
+    private static Map<String, Set<String>> elementDecls;
 
     /** Contains a mapping from XSL namespace element names to set of names of
      * allowed XSL attributes for that element.  The element name keys should
      * not contain the namespace prefix.
      */
-    private static Map<String, Set> attrDecls;
+    private static Map<String, Set<String>> attrDecls;
 
     /** A Set of XSL attributes which should be allowd for result elements*/
-    private static Set resultElementAttr;
+    private static Set<String> resultElementAttr;
 
     /** An object which indicates that result element should be allowed in a element Set */
     private static String resultElements = "RESULT_ELEMENTS_DUMMY_STRING"; // NOI18N
 
     /** A Set of elements which should be allowed at template level in XSL stylesheet */
-    private static Set template;
+    private static Set<String> template;
 
     /** Contains a mapping from XSL namespace element names to an attribute name which
      * should contain XPath expression.  The element name keys should
      * not contain the namespace prefix.
      */
-    private static Map exprAttributes;
+    private static Map<String, String> exprAttributes;
 
     /** A set containing all functions allowed in XSLT */
     private static Set xslFunctions;
@@ -128,41 +128,41 @@ public final class XSLGrammarQuery implements GrammarQuery{
     //////////////////////////////////////////7
     // Getters for the static members
 
-    private static Map getElementDecls() {
+    private static Map<String, Set<String>> getElementDecls() {
         if (elementDecls == null) {
             elementDecls = new HashMap<>();
             attrDecls = new HashMap<>();
 
             // Commonly used variables
-            Set emptySet = new TreeSet();
+            Set<String> emptySet = new TreeSet<>();
             String spaceAtt = "xml:space";  // NOI18N
-            Set tmpSet;
+            Set<String> tmpSet;
 
             ////////////////////////////////////////////////
             // Initialize common sets
 
-            Set charInstructions = new TreeSet(Arrays.asList(new String[]{"apply-templates", // NOI18N
+            Set<String> charInstructions = new TreeSet<>(Arrays.asList(new String[]{"apply-templates", // NOI18N
             "call-template","apply-imports","for-each","value-of", // NOI18N
             "copy-of","number","choose","if","text","copy", // NOI18N
             "variable","message","fallback"})); // NOI18N
 
-            Set instructions = new TreeSet(charInstructions);
+            Set<String> instructions = new TreeSet<>(charInstructions);
             instructions.addAll(Arrays.asList(new String[]{"processing-instruction", // NOI18N
             "comment","element","attribute"})); // NOI18N
 
-            Set charTemplate = charInstructions; // We don't care about PCDATA
+            Set<String> charTemplate = charInstructions; // We don't care about PCDATA
 
-            template = new TreeSet(instructions);
+            template = new TreeSet<>(instructions);
             template.add(resultElements);
 
-            Set topLevel = new TreeSet(Arrays.asList(new String[]{"import","include","strip-space", // NOI18N
+            Set<String> topLevel = new TreeSet<>(Arrays.asList(new String[]{"import","include","strip-space", // NOI18N
             "preserve-space","output","key","decimal-format","attribute-set", // NOI18N
             "variable","param","template","namespace-alias"})); // NOI18N
 
-            Set topLevelAttr = new TreeSet(Arrays.asList(new String[]{"extension-element-prefixes", // NOI18N
+            Set<String> topLevelAttr = new TreeSet<>(Arrays.asList(new String[]{"extension-element-prefixes", // NOI18N
             "exclude-result-prefixes","id","version",spaceAtt})); // NOI18N
 
-            resultElementAttr = new TreeSet(Arrays.asList(new String[]{"extension-element-prefixes", // NOI18N
+            resultElementAttr = new TreeSet<>(Arrays.asList(new String[]{"extension-element-prefixes", // NOI18N
             "exclude-result-prefixes","use-attribute-sets","version"})); // NOI18N
 
             ////////////////////////////////////////////////
@@ -178,68 +178,68 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
             // xsl:import
             elementDecls.put("import", emptySet); // NOI18N
-            attrDecls.put("import", new TreeSet(Arrays.asList(new String[]{"href"}))); // NOI18N
+            attrDecls.put("import", new TreeSet<>(Arrays.asList(new String[]{"href"}))); // NOI18N
 
             // xxsl:include
             elementDecls.put("include", emptySet); // NOI18N
-            attrDecls.put("include", new TreeSet(Arrays.asList(new String[]{"href"}))); // NOI18N
+            attrDecls.put("include", new TreeSet<>(Arrays.asList(new String[]{"href"}))); // NOI18N
 
             // xsl:strip-space
             elementDecls.put("strip-space", emptySet); // NOI18N
-            attrDecls.put("strip-space", new TreeSet(Arrays.asList(new String[]{"elements"}))); // NOI18N
+            attrDecls.put("strip-space", new TreeSet<>(Arrays.asList(new String[]{"elements"}))); // NOI18N
 
             // xsl:preserve-space
             elementDecls.put("preserve-space", emptySet); // NOI18N
-            attrDecls.put("preserve-space", new TreeSet(Arrays.asList(new String[]{"elements"}))); // NOI18N
+            attrDecls.put("preserve-space", new TreeSet<>(Arrays.asList(new String[]{"elements"}))); // NOI18N
 
             // xsl:output
             elementDecls.put("output", emptySet); // NOI18N
-            attrDecls.put("output", new TreeSet(Arrays.asList(new String[]{"method", // NOI18N
+            attrDecls.put("output", new TreeSet<>(Arrays.asList(new String[]{"method", // NOI18N
             "version","encoding","omit-xml-declaration","standalone","doctype-public", // NOI18N
             "doctype-system","cdata-section-elements","indent","media-type"}))); // NOI18N
 
             // xsl:key
             elementDecls.put("key", emptySet); // NOI18N
-            attrDecls.put("key", new TreeSet(Arrays.asList(new String[]{"name","match","use"}))); // NOI18N
+            attrDecls.put("key", new TreeSet<>(Arrays.asList(new String[]{"name","match","use"}))); // NOI18N
 
             // xsl:decimal-format
             elementDecls.put("decimal-format", emptySet); // NOI18N
-            attrDecls.put("decimal-format", new TreeSet(Arrays.asList(new String[]{"name", // NOI18N
+            attrDecls.put("decimal-format", new TreeSet<>(Arrays.asList(new String[]{"name", // NOI18N
             "decimal-separator","grouping-separator","infinity","minus-sign","NaN", // NOI18N
             "percent","per-mille","zero-digit","digit","pattern-separator"}))); // NOI18N
 
             // xsl:namespace-alias
             elementDecls.put("namespace-alias", emptySet); // NOI18N
-            attrDecls.put("namespace-alias", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("namespace-alias", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "stylesheet-prefix","result-prefix"}))); // NOI18N
 
             // xsl:template
-            tmpSet = new TreeSet(instructions);
+            tmpSet = new TreeSet<>(instructions);
             tmpSet.add(resultElements);
             tmpSet.add("param"); // NOI18N
             elementDecls.put("template", tmpSet); // NOI18N
-            attrDecls.put("template", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("template", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "match","name","priority","mode",spaceAtt}))); // NOI18N
 
             // xsl:value-of
             elementDecls.put("value-of", emptySet); // NOI18N
-            attrDecls.put("value-of", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("value-of", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
             "select","disable-output-escaping"}))); // NOI18N
 
             // xsl:copy-of
             elementDecls.put("copy-of", emptySet); // NOI18N
-            attrDecls.put("copy-of", new TreeSet(Arrays.asList(new String[]{"select"}))); // NOI18N
+            attrDecls.put("copy-of", new TreeSet<>(Arrays.asList(new String[]{"select"}))); // NOI18N
 
             // xsl:number
             elementDecls.put("number", emptySet); // NOI18N
-            attrDecls.put("number", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("number", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "level","count","from","value","format","lang","letter-value", // NOI18N
                 "grouping-separator","grouping-size"}))); // NOI18N
 
             // xsl:apply-templates
-            elementDecls.put("apply-templates", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            elementDecls.put("apply-templates", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "sort","with-param"}))); // NOI18N
-            attrDecls.put("apply-templates", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("apply-templates", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "select","mode"}))); // NOI18N
 
             // xsl:apply-imports
@@ -247,125 +247,125 @@ public final class XSLGrammarQuery implements GrammarQuery{
             attrDecls.put("apply-imports", emptySet); // NOI18N
 
             // xsl:for-each
-            tmpSet = new TreeSet(instructions);
+            tmpSet = new TreeSet<>(instructions);
             tmpSet.add(resultElements);
             tmpSet.add("sort"); // NOI18N
             elementDecls.put("for-each", tmpSet); // NOI18N
-            attrDecls.put("for-each", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("for-each", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
             "select",spaceAtt}))); // NOI18N
 
             // xsl:sort
             elementDecls.put("sort", emptySet); // NOI18N
-            attrDecls.put("sort", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("sort", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "select","lang","data-type","order","case-order"}))); // NOI18N
 
             // xsl:if
             elementDecls.put("if", template); // NOI18N
-            attrDecls.put("if", new TreeSet(Arrays.asList(new String[]{"test",spaceAtt}))); // NOI18N
+            attrDecls.put("if", new TreeSet<>(Arrays.asList(new String[]{"test",spaceAtt}))); // NOI18N
 
             // xsl:choose
-            elementDecls.put("choose", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            elementDecls.put("choose", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "when","otherwise"}))); // NOI18N
-            attrDecls.put("choose", new TreeSet(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
+            attrDecls.put("choose", new TreeSet<>(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
 
             // xsl:when
             elementDecls.put("when", template); // NOI18N
-            attrDecls.put("when", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("when", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "test",spaceAtt}))); // NOI18N
 
             // xsl:otherwise
             elementDecls.put("otherwise", template); // NOI18N
-            attrDecls.put("otherwise", new TreeSet(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
+            attrDecls.put("otherwise", new TreeSet<>(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
 
             // xsl:attribute-set
-            elementDecls.put("sort", new TreeSet(Arrays.asList(new String[]{"attribute"}))); // NOI18N
-            attrDecls.put("attribute-set", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            elementDecls.put("sort", new TreeSet<>(Arrays.asList(new String[]{"attribute"}))); // NOI18N
+            attrDecls.put("attribute-set", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","use-attribute-sets"}))); // NOI18N
 
             // xsl:call-template
-            elementDecls.put("call-template", new TreeSet(Arrays.asList(new String[]{"with-param"}))); // NOI18N
-            attrDecls.put("call-template", new TreeSet(Arrays.asList(new String[]{"name"}))); // NOI18N
+            elementDecls.put("call-template", new TreeSet<>(Arrays.asList(new String[]{"with-param"}))); // NOI18N
+            attrDecls.put("call-template", new TreeSet<>(Arrays.asList(new String[]{"name"}))); // NOI18N
 
             // xsl:with-param
             elementDecls.put("with-param", template); // NOI18N
-            attrDecls.put("with-param", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("with-param", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","select"}))); // NOI18N
 
             // xsl:variable
             elementDecls.put("variable", template); // NOI18N
-            attrDecls.put("variable", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("variable", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","select"}))); // NOI18N
 
             // xsl:param
             elementDecls.put("param", template); // NOI18N
-            attrDecls.put("param", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("param", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","select"}))); // NOI18N
 
             // xsl:text
             elementDecls.put("text", emptySet); // NOI18N
-            attrDecls.put("text", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("text", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "disable-output-escaping"}))); // NOI18N
 
             // xsl:processing-instruction
             elementDecls.put("processing-instruction", charTemplate); // NOI18N
-            attrDecls.put("processing-instruction", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("processing-instruction", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name",spaceAtt}))); // NOI18N
 
             // xsl:element
             elementDecls.put("element", template); // NOI18N
-            attrDecls.put("element", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("element", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","namespace","use-attribute-sets",spaceAtt}))); // NOI18N
 
             // xsl:attribute
             elementDecls.put("attribute", charTemplate); // NOI18N
-            attrDecls.put("attribute", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("attribute", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 "name","namespace",spaceAtt}))); // NOI18N
 
             // xsl:comment
             elementDecls.put("comment", charTemplate); // NOI18N
-            attrDecls.put("comment", new TreeSet(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
+            attrDecls.put("comment", new TreeSet<>(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
 
             // xsl:copy
             elementDecls.put("copy", template); // NOI18N
-            attrDecls.put("copy", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("copy", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 spaceAtt,"use-attribute-sets"}))); // NOI18N
 
             // xsl:message
             elementDecls.put("message", template); // NOI18N
-            attrDecls.put("message", new TreeSet(Arrays.asList(new String[]{ // NOI18N
+            attrDecls.put("message", new TreeSet<>(Arrays.asList(new String[]{ // NOI18N
                 spaceAtt,"terminate"}))); // NOI18N
 
             // xsl:fallback
             elementDecls.put("fallback", template); // NOI18N
-            attrDecls.put("fallback", new TreeSet(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
+            attrDecls.put("fallback", new TreeSet<>(Arrays.asList(new String[]{spaceAtt}))); // NOI18N
         }
         return elementDecls;
     }
 
-    private static Map getAttrDecls() {
+    private static Map<String, Set<String>> getAttrDecls() {
         if (attrDecls == null) {
             getElementDecls();
         }
         return attrDecls;
     }
 
-    private static Set getResultElementAttr() {
+    private static Set<String> getResultElementAttr() {
         if (resultElementAttr == null) {
             getElementDecls();
         }
         return resultElementAttr;
     }
 
-    private static Set getTemplate() {
+    private static Set<String> getTemplate() {
         if (template == null) {
             getElementDecls();
         }
         return template;
     }
 
-    private static Set getXslFunctions() {
+    private static Set<String> getXslFunctions() {
         if (xslFunctions == null) {
-            xslFunctions = new TreeSet(Arrays.asList(new String[]{
+            xslFunctions = new TreeSet<>(Arrays.asList(new String[]{
                 "boolean(","ceiling(","concat(", "contains(","count(","current()","document(", // NOI18N
                 "false()", "floor(","format-number(","generate-id(", // NOI18N
                 "id(","local-name(","key(","lang(","last()","name(","namespace-uri(", "normalize-space(", // NOI18N
@@ -376,9 +376,9 @@ public final class XSLGrammarQuery implements GrammarQuery{
         return xslFunctions;
     }
 
-    private static Set getXPathAxes() {
+    private static Set<String> getXPathAxes() {
         if (xpathAxes == null) {
-            xpathAxes = new TreeSet(Arrays.asList(new String[]{"ancestor::", "ancestor-or-self::", // NOI18N
+            xpathAxes = new TreeSet<>(Arrays.asList(new String[]{"ancestor::", "ancestor-or-self::", // NOI18N
             "attribute::", "child::", "descendant::", "descendant-or-self::", "following::", // NOI18N
             "following-sibling::", "namespace::", "parent::", "preceding::", // NOI18N
             "preceding-sibling::", "self::"})); // NOI18N
@@ -386,9 +386,9 @@ public final class XSLGrammarQuery implements GrammarQuery{
         return xpathAxes;
     }
 
-    private static Map getExprAttributes() {
+    private static Map<String, String> getExprAttributes() {
         if (exprAttributes == null) {
-            exprAttributes = new HashMap();
+            exprAttributes = new HashMap<>();
             exprAttributes.put("key", "use"); // NOI18N
             exprAttributes.put("value-of", "select"); // NOI18N
             exprAttributes.put("copy-of", "select"); // NOI18N
@@ -415,7 +415,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
      * Support completions of elements defined by XSLT spec and by the <output>
      * doctype attribute (in result space).
      */
-    public Enumeration queryElements(HintContext ctx) {
+    public Enumeration<GrammarResult> queryElements(HintContext ctx) {
         Node node = ((Node)ctx).getParentNode();
 
         String prefix = ctx.getCurrentPrefix();
@@ -427,10 +427,10 @@ public final class XSLGrammarQuery implements GrammarQuery{
             if (prefixList.size() == 0) return org.openide.util.Enumerations.empty();
 
             String firstXslPrefixWithColon = prefixList.get(0) + ":"; // NOI18N
-            Set elements;
+            Set<String> elements;
             if (el.getTagName().startsWith(firstXslPrefixWithColon)) {
                 String parentNCName = el.getTagName().substring(firstXslPrefixWithColon.length());
-                elements = (Set) getElementDecls().get(parentNCName);
+                elements = getElementDecls().get(parentNCName);
             } else {
                 // Children of result elements should always be the template set
                 elements = getTemplate();
@@ -439,7 +439,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
             // First we add the Result elements
             if (elements != null  && resultGrammarQuery != null && elements.contains(resultElements)) {
                 ResultHintContext resultHintContext = new ResultHintContext(ctx, firstXslPrefixWithColon, null);
-                Enumeration resultEnum = resultGrammarQuery.queryElements(resultHintContext);
+                Enumeration<GrammarResult> resultEnum = resultGrammarQuery.queryElements(resultHintContext);
                 while (resultEnum.hasMoreElements()) {
                     list.put(resultEnum.nextElement());
                 }
@@ -450,7 +450,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
             // Finally we add xsl namespace elements with other prefixes than the first one
             for (int prefixInd = 1; prefixInd < prefixList.size(); prefixInd++) {
-                String curPrefix = (String)prefixList.get(prefixInd) + ":"; // NOI18N
+                String curPrefix = prefixList.get(prefixInd) + ":"; // NOI18N
                 Node curNode = el;
                 String curName = null;
                 while(curNode != null && null != (curName = curNode.getNodeName()) && !curName.startsWith(curPrefix)) {
@@ -496,23 +496,22 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
         String curXslPrefix = null;
         for (int ind = 0; ind < prefixList.size(); ind++) {
-            if (elTagName.startsWith((String)prefixList.get(ind) + ":")){ // NOI18N
-                curXslPrefix = (String)prefixList.get(ind) + ":"; // NOI18N
+            if (elTagName.startsWith(prefixList.get(ind) + ":")){ // NOI18N
+                curXslPrefix = prefixList.get(ind) + ":"; // NOI18N
                 break;
             }
         }
 
-        Set possibleAttributes;
+        Set<String> possibleAttributes;
         if (curXslPrefix != null) {
             // Attributes of XSL element
-            possibleAttributes = (Set) getAttrDecls().get(el.getTagName().substring(curXslPrefix.length()));
+            possibleAttributes = getAttrDecls().get(el.getTagName().substring(curXslPrefix.length()));
         } else {
             // XSL Attributes of Result element
-            possibleAttributes = new TreeSet();
+            possibleAttributes = new TreeSet<>();
             if (prefixList.size() > 0) {
-                Iterator it = getResultElementAttr().iterator();
-                while ( it.hasNext()) {
-                    possibleAttributes.add((String)prefixList.get(0) + ":" + (String) it.next()); // NOI18N
+                for (String resAttr : getResultElementAttr()) {
+                    possibleAttributes.add(prefixList.get(0) + ":" + resAttr); // NOI18N
                 }
             }
         }
@@ -815,14 +814,12 @@ public final class XSLGrammarQuery implements GrammarQuery{
      *          of the names in the elements.
      * @param startWith Elements should only be added to enum if they start with this string
      */
-    private static void addXslElementsToEnum(QueueEnumeration enumX, Set elements, String namespacePrefix, String startWith) {
+    private static void addXslElementsToEnum(QueueEnumeration enumX, Set<String> elements, String namespacePrefix, String startWith) {
         if (elements == null) return;
         if (startWith.startsWith(namespacePrefix) || namespacePrefix.startsWith(startWith)) {
-            Iterator it = elements.iterator();
-            while ( it.hasNext()) {
-                Object next = it.next();
+            for (String next : elements) {
                 if (next != resultElements) {
-                    String nextText = namespacePrefix + (String)next;
+                    String nextText = namespacePrefix + next;
                     if (nextText.startsWith(startWith)) {
                         // TODO pass true for empty elements
                         enumX.put(new MyElement(nextText, false));
@@ -832,10 +829,8 @@ public final class XSLGrammarQuery implements GrammarQuery{
         }
     }
 
-    private static void addItemsToEnum(QueueEnumeration enumX, Set set, String startWith, String prefix) {
-        Iterator it = set.iterator();
-        while ( it.hasNext()) {
-            String nextText = (String)it.next();
+    private static void addItemsToEnum(QueueEnumeration enumX, Set<String> set, String startWith, String prefix) {
+        for (String nextText : set) {
             if (nextText.startsWith(startWith)) {
                 enumX.put(new MyText(prefix + nextText));
             }
@@ -874,7 +869,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
         boolean outputFound = false;
         if (prefixList.size() > 0) {
-            String outputElName = (String)prefixList.get(0) + ":output"; // NOI18N
+            String outputElName = prefixList.get(0) + ":output"; // NOI18N
             Node childOfRoot = rootNode.getFirstChild();
             while (childOfRoot != null) {
                 String childNodeName = childOfRoot.getNodeName();
@@ -1117,23 +1112,23 @@ public final class XSLGrammarQuery implements GrammarQuery{
         }
     }
 
-    private static class QueueEnumeration implements Enumeration {
-        private java.util.LinkedList list = new LinkedList ();
+    private static class QueueEnumeration implements Enumeration<GrammarResult> {
+        private java.util.LinkedList<GrammarResult> list = new LinkedList<>();
         
         public boolean hasMoreElements () {
             return !list.isEmpty ();
         }        
         
-        public Object nextElement () {
+        public GrammarResult nextElement () {
             return list.removeFirst ();
         }        
 
-        public void put (Object[] arr) {
-            list.addAll (Arrays.asList (arr));
+        public void put(GrammarResult[] arr) {
+            list.addAll(Arrays.asList(arr));
         }
-        public void put (Object o) {
-            list.add (o);
+
+        public void put(GrammarResult o) {
+            list.add(o);
         }
-        
     } // end of QueueEnumeration
 }

--- a/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java
+++ b/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java
@@ -186,7 +186,7 @@ public class MIMEResolverProcessor extends LayerGeneratingProcessor {
         return unq(Arrays.asList(array));
     }
 
-    private Set<String> unq(Collection collection) {
+    private Set<String> unq(Collection<String> collection) {
         Set<String> s = new TreeSet<>();
         s.addAll(collection);
         return s;

--- a/platform/openide.filesystems/src/org/openide/filesystems/DefaultAttributes.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/DefaultAttributes.java
@@ -447,7 +447,7 @@ public class DefaultAttributes extends Object implements AbstractFileSystem.Attr
             split(oldName, arr);
 
             Table t = loadTable(arr[0]);
-            Map v = (Map) t.remove(arr[1]);
+            XMLMapAttr v = t.remove(arr[1]);
 
             //      System.out.println ("ARg[0] = " + arr[0] + " arr[1] = " + arr[1] + " value: " + v); // NOI18N
             if (v == null) {
@@ -775,7 +775,7 @@ public class DefaultAttributes extends Object implements AbstractFileSystem.Attr
     /** Table that hold mapping between files and attributes.
     * Hold mapping of type (String, Map (String, Object))
     */
-    final static class Table extends HashMap implements Externalizable {
+    final static class Table extends HashMap<String, XMLMapAttr> implements Externalizable {
         static final long serialVersionUID = 2353458763249746934L;
 
         /** name of folder we belong to */
@@ -812,7 +812,7 @@ public class DefaultAttributes extends Object implements AbstractFileSystem.Attr
          * @return attribute or null (if not found)
          */
         public Object getAttr(String fileName, String attrName) {
-            XMLMapAttr m = (XMLMapAttr) get(fileName);
+            XMLMapAttr m = get(fileName);
 
             if (m != null) {
                 Object o = null;
@@ -862,7 +862,7 @@ public class DefaultAttributes extends Object implements AbstractFileSystem.Attr
          * @param obj - attribute
          */
         final void setAttr(String fileName, String attrName, Object obj) {
-            XMLMapAttr m = (XMLMapAttr) get(fileName);
+            XMLMapAttr m = get(fileName);
 
             if (m == null) {
                 m = new XMLMapAttr(); //HashMap (7);//XMLMapAttr();
@@ -882,7 +882,7 @@ public class DefaultAttributes extends Object implements AbstractFileSystem.Attr
         /** Enum of attributes for one file.
         */
         public Enumeration<String> attrs(String fileName) {
-            Map m = (Map) get(fileName);
+            XMLMapAttr m = get(fileName);
 
             if (m == null) {
                 return Enumerations.empty();
@@ -1035,12 +1035,12 @@ public class DefaultAttributes extends Object implements AbstractFileSystem.Attr
          */
         public void writeToXML(PrintWriter pw) /*throws IOException */ {
             // list of names
-            Iterator<String> it = new TreeSet(keySet()).iterator();
+            Iterator<String> it = new TreeSet<>(keySet()).iterator();
             XMLMapAttr.writeHeading(pw);
 
             while (it.hasNext()) {
                 String file = it.next();
-                XMLMapAttr attr = (XMLMapAttr) get(file);
+                XMLMapAttr attr = get(file);
 
                 if ((attr != null) && !attr.isEmpty()) {
                     attr.write(pw, file, "    "); // NOI18N
@@ -1086,7 +1086,7 @@ public class DefaultAttributes extends Object implements AbstractFileSystem.Attr
 
             while (it.hasNext()) {
                 String file = it.next();
-                Map attr = (Map) get(file);
+                XMLMapAttr attr = get(file);
 
                 if ((attr != null) && !attr.isEmpty()) {
                     oo.writeObject(file);

--- a/webcommon/web.webkit.tooling/src/org/netbeans/modules/web/webkit/tooling/networkmonitor/ModelItem.java
+++ b/webcommon/web.webkit.tooling/src/org/netbeans/modules/web/webkit/tooling/networkmonitor/ModelItem.java
@@ -327,31 +327,30 @@ class ModelItem implements PropertyChangeListener {
         }
         doc.insertString(doc.getLength(), "\n", defaultStyle);
         doc.insertString(doc.getLength(), "Request Headers\n", paragraphStyle);
-        printHeaders(pane, requestHeaders, doc, boldStyle, defaultStyle);
+        printHeaders(requestHeaders, doc, boldStyle, defaultStyle);
 
         if (getResponseHeaders() != null) {
             doc.insertString(doc.getLength(), "\n", defaultStyle);
             doc.insertString(doc.getLength(), "Response Headers\n", paragraphStyle);
-            printHeaders(pane, getResponseHeaders(), doc, boldStyle, defaultStyle);
+            printHeaders(getResponseHeaders(), doc, boldStyle, defaultStyle);
         }
     }
 
-    private void printHeaders(JTextPane pane, JSONObject headers,
+    private void printHeaders(JSONObject headers,
             StyledDocument doc, Style boldStyle, Style defaultStyle) throws BadLocationException {
 
         assert headers != null;
-        Set keys = new TreeSet(new Comparator<Object>() {
+        Set<String> keys = new TreeSet<>(new Comparator<String>() {
             @Override
-            public int compare(Object o1, Object o2) {
-                return ((String)o1).compareToIgnoreCase((String)o2);
+            public int compare(String o1, String o2) {
+                return o1.compareToIgnoreCase(o2);
             }
 
         });
         keys.addAll(headers.keySet());
-        for (Object oo : keys) {
-            String key = (String)oo;
+        for (String key : keys) {
             doc.insertString(doc.getLength(), key+": ", boldStyle);
-            String value = (String)headers.get(key);
+            String value = (String) headers.get(key);
             doc.insertString(doc.getLength(), value+"\n", defaultStyle);
         }
     }


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a TreeSet like the following
```
   [repeat] .../ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java:511: warning: [rawtypes] found raw type: TreeSet
   [repeat]             possibleAttributes = new TreeSet();
   [repeat]                                      ^
   [repeat]   missing type arguments for generic class TreeSet<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in class TreeSet
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.