### PR TITLE
[NETBEANS-3501] Fixed compiler warnings concerning rawtypes Privilege…

### DIFF
--- a/groovy/groovy.editor/nbproject/project.properties
+++ b/groovy/groovy.editor/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 
 nbm.homepage=http://wiki.netbeans.org/groovy
 nbm.module.author=Martin Adamek, Petr Hejl, Matthias Schmidt, Martin Janicek

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ClassNodeCache.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ClassNodeCache.java
@@ -22,7 +22,6 @@ import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyResourceLoader;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -303,20 +302,9 @@ public final class ClassNodeCache {
         
         private final ClassNodeCache cache;
 
-        private final GroovyResourceLoader resourceLoader = new GroovyResourceLoader() {
-
-            @Override
-            public URL loadGroovySource(final String filename) throws MalformedURLException {
-                URL file = AccessController.doPrivileged(new PrivilegedAction<URL>() {
-
-                    @Override
-                    public URL run() {
-                        return getSourceFile(filename);
-                    }
-                });
-                return file;
-            }
-        };
+        private final GroovyResourceLoader resourceLoader
+                = (String filename) -> AccessController.doPrivileged(
+                        (PrivilegedAction<URL>) () -> getSourceFile(filename));
 
         public ParsingClassLoader(
                 @NonNull ClassPath path,

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ClassNodeCache.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ClassNodeCache.java
@@ -307,10 +307,10 @@ public final class ClassNodeCache {
 
             @Override
             public URL loadGroovySource(final String filename) throws MalformedURLException {
-                URL file = (URL) AccessController.doPrivileged(new PrivilegedAction() {
+                URL file = AccessController.doPrivileged(new PrivilegedAction<URL>() {
 
                     @Override
-                    public Object run() {
+                    public URL run() {
                         return getSourceFile(filename);
                     }
                 });


### PR DESCRIPTION
…dAction

There are compiler warnings about rawtype usage with a PrivilegedAction like the following
```
   [repeat] .../groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ClassNodeCache.java:310: warning: [rawtypes] found raw type: PrivilegedAction
   [repeat]                 URL file = (URL) AccessController.doPrivileged(new PrivilegedAction() {
   [repeat]                                                                    ^
   [repeat]   missing type arguments for generic class PrivilegedAction<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in interface PrivilegedAction
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.