### PR TITLE
[NETBEANS-3502] Fixed compiler warnings concerning rawtypes ReadOnly

### DIFF
--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueNode.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueNode.java
@@ -197,7 +197,7 @@ public abstract class IssueNode<I> extends AbstractNode {
     /**
      * An IssueNode Property
      */
-    public abstract class IssueProperty<T> extends org.openide.nodes.PropertySupport.ReadOnly implements Comparable<IssueNode<I>.IssueProperty<T>> {
+    public abstract class IssueProperty<T> extends org.openide.nodes.PropertySupport.ReadOnly<T> implements Comparable<IssueNode<I>.IssueProperty<T>> {
         protected IssueProperty(String name, Class<T> type, String displayName, String shortDescription) {
             super(name, type, displayName, shortDescription);
         }

--- a/ide/image/src/org/netbeans/modules/image/ImageDataObject.java
+++ b/ide/image/src/org/netbeans/modules/image/ImageDataObject.java
@@ -226,7 +226,7 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
         
 
         /** Property representing for thumbanil property in the sheet. */
-        private static final class ThumbnailProperty extends PropertySupport.ReadOnly {
+        private static final class ThumbnailProperty extends PropertySupport.ReadOnly<Icon> {
             /** (Image) data object associated with. */
             private final DataObject obj;
             
@@ -239,7 +239,7 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
             }
             
             /** Gets value of property. Overrides superclass method. */
-            public Object getValue() throws InvocationTargetException {
+            public Icon getValue() throws InvocationTargetException {
                 try {
                     return new ImageIcon(obj.getPrimaryFile().getURL());
                 } catch (FileStateInvalidException fsie) {
@@ -320,7 +320,7 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
         } // End of class ThumbnailProperty.
 
        /** Property representing for image width property in the sheet. */
-       private final class ImageWidthProperty extends PropertySupport.ReadOnly {
+       private final class ImageWidthProperty extends PropertySupport.ReadOnly<Integer> {
           /** Constructs property. */
           public ImageWidthProperty() {
              super("width", Integer.class, // NOI18N
@@ -329,7 +329,7 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
           }
 
           /** Gets value of property. Overrides superclass method. */
-          public Object getValue() throws InvocationTargetException {
+          public Integer getValue() throws InvocationTargetException {
              try {
                 final Icon icon = new ImageIcon(getDataObject().getPrimaryFile().
                       getURL());
@@ -341,7 +341,7 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
        } // End of class ImageWidthProperty.
 
        /** Property representing for image height property in the sheet. */
-       private final class ImageHeightProperty extends PropertySupport.ReadOnly {
+       private final class ImageHeightProperty extends PropertySupport.ReadOnly<Integer> {
           /** Constructs property. */
           public ImageHeightProperty() {
              super("height", Integer.class, // NOI18N
@@ -352,7 +352,7 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
           }
 
           /** Gets value of property. Overrides superclass method. */
-          public Object getValue() throws InvocationTargetException {
+          public Integer getValue() throws InvocationTargetException {
              try {
                 final Icon icon = new ImageIcon(getDataObject().getPrimaryFile().
                       getURL());

--- a/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlPortNode.java
+++ b/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlPortNode.java
@@ -112,24 +112,24 @@ public class WsdlPortNode extends AbstractNode {
         }
         
         // Port name (from the wsdl)
-        ss.put( new PropertySupport.ReadOnly( "port", // NOI18N
+        ss.put( new PropertySupport.ReadOnly<String>( "port", // NOI18N
                 String.class,
                 NbBundle.getMessage(WsdlPortNode.class, "PORT_NAME_IN_WSDL"), // NOI18N
                 NbBundle.getMessage(WsdlPortNode.class, "PORT_NAME_IN_WSDL")) { // NOI18N
             @Override
-            public Object getValue() {
+            public String getValue() {
                 String portName = port.getName();
                 return portName;
             }
         });
         
         // URL for the wsdl file (entered by the user)
-        ss.put( new PropertySupport.ReadOnly( "URL", // NOI18N
+        ss.put( new PropertySupport.ReadOnly<String>( "URL", // NOI18N
                 String.class,
                 NbBundle.getMessage(WsdlPortNode.class, "WS_URL"), // NOI18N
                 NbBundle.getMessage(WsdlPortNode.class, "WS_URL")) { // NOI18N
             @Override
-            public Object getValue() {
+            public String getValue() {
                 return port.getParentSaas().getUrl();
             }
         });

--- a/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlSaasNode.java
+++ b/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlSaasNode.java
@@ -117,23 +117,23 @@ public class WsdlSaasNode extends SaasNode {
         }
         
         // Service name (from the wsdl)
-        ss.put( new PropertySupport.ReadOnly( "name", // NOI18N
+        ss.put( new PropertySupport.ReadOnly<String>( "name", // NOI18N
                 String.class,
                 NbBundle.getMessage(WsdlSaasNode.class, "PORT_NAME_IN_WSDL"), // NOI18N
                 NbBundle.getMessage(WsdlSaasNode.class, "PORT_NAME_IN_WSDL")) { // NOI18N
             @Override
-            public Object getValue() {
+            public String getValue() {
                 return getName();
             }
         });
         
         // URL for the wsdl file (entered by the user)
-        ss.put( new PropertySupport.ReadOnly( "URL", // NOI18N
+        ss.put( new PropertySupport.ReadOnly<String>( "URL", // NOI18N
                 String.class,
                 NbBundle.getMessage(WsdlSaasNode.class, "WS_URL"), // NOI18N
                 NbBundle.getMessage(WsdlSaasNode.class, "WS_URL")) { // NOI18N
             @Override
-            public Object getValue() {
+            public String getValue() {
                 return saas.getUrl();
             }
         });


### PR DESCRIPTION
There are compiler warnings about rawtype usage with a ReadOnly like the following
```
   [repeat] .../websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlPortNode.java:127: warning: [rawtypes] found raw type: ReadOnly
   [repeat]         ss.put( new PropertySupport.ReadOnly( "URL", // NOI18N
   [repeat]                                    ^
   [repeat]   missing type arguments for generic class ReadOnly<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in class ReadOnly
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.