### PR TITLE
[NETBEANS-3503] Fixed compiler warnings concerning rawtypes IssueNode…

### DIFF
--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueNode.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueNode.java
@@ -197,7 +197,7 @@ public abstract class IssueNode<I> extends AbstractNode {
     /**
      * An IssueNode Property
      */
-    public abstract class IssueProperty<T> extends org.openide.nodes.PropertySupport.ReadOnly implements Comparable<IssueNode<I>.IssueProperty<T>> {
+    public abstract class IssueProperty<T> extends org.openide.nodes.PropertySupport.ReadOnly<T> implements Comparable<IssueNode<I>.IssueProperty<T>> {
         protected IssueProperty(String name, Class<T> type, String displayName, String shortDescription) {
             super(name, type, displayName, shortDescription);
         }
@@ -259,7 +259,7 @@ public abstract class IssueNode<I> extends AbstractNode {
             return IssueNode.this.getSummary();
         }
         @Override
-        public int compareTo(IssueProperty p) {
+        public int compareTo(IssueProperty<String> p) {
             if(p == null) return 1;
             String s1 = IssueNode.this.getSummary();
             String s2 = p.getSummary();
@@ -282,7 +282,7 @@ public abstract class IssueNode<I> extends AbstractNode {
             return issueImpl.getStatus() == IssueStatusProvider.Status.SEEN;
         }
         @Override
-        public int compareTo(IssueProperty p) {
+        public int compareTo(IssueProperty<Boolean> p) {
             if(p == null) return 1;
             Boolean b1 = IssueNode.this.wasSeen();
             Boolean b2 = p.getStatus() == IssueStatusProvider.Status.SEEN;

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueTable.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueTable.java
@@ -24,7 +24,6 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.TableColumnModelEvent;
 import javax.swing.table.TableColumn;
-import org.netbeans.modules.bugtracking.issuetable.IssueNode.IssueProperty;
 import org.openide.util.NbBundle;
 import javax.swing.event.AncestorListener;
 import javax.swing.event.AncestorEvent;
@@ -114,9 +113,9 @@ public class IssueTable implements MouseListener, AncestorListener, KeyListener,
     private final FindInQuerySupport findInQuerySupport;
     private boolean isSaved;
     
-    private static final Comparator<IssueProperty> nodeComparator = new Comparator<IssueProperty>() {
+    private static final Comparator<IssueNode<Object>.IssueProperty<Object>> nodeComparator = new Comparator<IssueNode<Object>.IssueProperty<Object>>() {
         @Override
-        public int compare(IssueProperty p1, IssueProperty p2) {
+        public int compare(IssueNode<Object>.IssueProperty<Object> p1, IssueNode<Object>.IssueProperty<Object> p2) {
             Integer sk1 = (Integer) p1.getValue("sortkey"); // NOI18N
             if (sk1 != null) {
                 Integer sk2 = (Integer) p2.getValue("sortkey"); // NOI18N

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRenderer.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRenderer.java
@@ -292,7 +292,7 @@ public class QueryTableCellRenderer extends DefaultTableCellRenderer {
 
     }
     
-    public static TableCellStyle getCellStyle(JTable table, IssueTable issueTable, IssueProperty p, boolean isSelected, int row) {
+    public static TableCellStyle getCellStyle(JTable table, IssueTable issueTable, IssueNode<?>.IssueProperty<?> p, boolean isSelected, int row) {
         TableCellStyle style = getDefaultCellStyle(table, issueTable, p, isSelected, row);
         try {
             // set text format and background depending on selection and issue status
@@ -343,7 +343,7 @@ public class QueryTableCellRenderer extends DefaultTableCellRenderer {
         }
         return style;
     }
-    public static TableCellStyle getDefaultCellStyle(JTable table, IssueTable issueTable, IssueProperty p, boolean isSelected, int row) {
+    public static TableCellStyle getDefaultCellStyle(JTable table, IssueTable issueTable, IssueNode<?>.IssueProperty<?> p, boolean isSelected, int row) {
         // set default values
         return new TableCellStyle(
             null,                                                                       // format
@@ -354,7 +354,7 @@ public class QueryTableCellRenderer extends DefaultTableCellRenderer {
         );
     }
 
-    private static Pattern getHightlightPattern(IssueTable issueTable, IssueProperty p) {
+    private static Pattern getHightlightPattern(IssueTable issueTable, IssueNode<?>.IssueProperty<?> p) {
         if(p instanceof IssueNode.SummaryProperty) {            
             SummaryTextFilter f = issueTable.getSummaryFilter();
             if(f != null && f.isHighLightingOn()) {

--- a/ide/bugtracking.commons/test/unit/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRendererTest.java
+++ b/ide/bugtracking.commons/test/unit/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRendererTest.java
@@ -98,7 +98,7 @@ public class QueryTableCellRendererTest {
         
         // issue seen, not selected
         RendererIssue rendererIssue = new RendererIssue(rendererRepository, "");
-        IssueProperty property = new RendererNode(rendererIssue, "some value", rendererRepository).createProperty();
+        RendererNode.RendererIssueProperty property = new RendererNode(rendererIssue, "some value", rendererRepository).createProperty();
         rendererQuery.containsIssue = true;
         boolean selected = false;
         setIssueValues(rendererRepository, rendererIssue, Status.SEEN, true);
@@ -188,7 +188,7 @@ public class QueryTableCellRendererTest {
         RendererRepository rendererRepository = new RendererRepository();
         RendererIssue issue = new RendererIssue(rendererRepository, "");
         RendererQuery query = new RendererQuery(rendererRepository);
-        IssueProperty property = new RendererNode(issue, "some value", rendererRepository).createProperty();
+        RendererNode.RendererIssueProperty property = new RendererNode(issue, "some value", rendererRepository).createProperty();
 
         IssueTable issueTable = new IssueTable(
                 TestKit.getRepository(rendererRepository).getId(),
@@ -265,7 +265,7 @@ public class QueryTableCellRendererTest {
         }
     }
     
-    private class RendererNode<TestIssue> extends IssueNode {
+    private class RendererNode extends IssueNode<TestIssue> {
 
         Object propertyValue;
         public RendererNode(RendererIssue issue, String value, RendererRepository rendererRepository) {
@@ -279,8 +279,8 @@ public class QueryTableCellRendererTest {
         protected Property<?>[] getProperties() {
             return new Property[0];
         }
-        class RendererIssueProperty extends IssueProperty {
-            public RendererIssueProperty(String arg0, Class name, String type, String displayName, Object value) {
+        class RendererIssueProperty extends IssueProperty<Object> {
+            public RendererIssueProperty(String arg0, Class<Object> name, String type, String displayName, Object value) {
                 super(arg0, name, type, displayName);
             }
             @Override


### PR DESCRIPTION
….IssueProperty

There are compiler warnings about rawtype usage with IssueNode.IssueProperty like the following
```
   [repeat] .../ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRenderer.java:357: warning: [rawtypes] found raw type: IssueNode.IssueProperty
   [repeat]     private static Pattern getHightlightPattern(IssueTable issueTable, IssueProperty p) {
   [repeat]                                                                        ^
   [repeat]   missing type arguments for generic class IssueNode<I>.IssueProperty<T>
   [repeat]   where T,I are type-variables:
   [repeat]     T extends Object declared in class IssueNode.IssueProperty
   [repeat]     I extends Object declared in class IssueNode
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.
