### PR TITLE
[NETBEANS-3504] Fixed compiler warnings concerning rawtypes IssueNode…

### DIFF
--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRenderer.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRenderer.java
@@ -122,7 +122,7 @@ public class QueryTableCellRenderer extends DefaultTableCellRenderer {
         
         TableCellStyle style = null;
         if(value instanceof IssueNode.SeenProperty) {
-            IssueNode.SeenProperty ps = (IssueNode.SeenProperty) value;
+            IssueNode<?>.SeenProperty ps = (IssueNode<?>.SeenProperty) value;
             renderer.setIcon(!ps.getValue() ? seenValueIcon : null);
             renderer.setText("");                                               // NOI18N
         } 


### PR DESCRIPTION
….SeenProperty

There are compiler warnings about rawtype usage with IssueNode.SeenProperty like the following
```
   [repeat] .../ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/QueryTableCellRenderer.java:125: warning: [rawtypes] found raw type: IssueNode.SeenProperty
   [repeat]             IssueNode.SeenProperty ps = (IssueNode.SeenProperty) value;
   [repeat]                      ^
   [repeat]   missing type arguments for generic class IssueNode<I>.SeenProperty
   [repeat]   where I is a type-variable:
   [repeat]     I extends Object declared in class IssueNode
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.