### PR TITLE
[NETBEANS-3505] Fixed compiler warnings concerning rawtypes GrowingLi…

### DIFF
--- a/javafx/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/options/GrowingComboBox.java
+++ b/javafx/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/options/GrowingComboBox.java
@@ -37,7 +37,7 @@ import javax.swing.event.PopupMenuListener;
  */
 public class GrowingComboBox extends javax.swing.JPanel {
     private static final String SEPARATOR = "---";
-    final public static class GrowingListModel<T> implements ComboBoxModel {
+    public static final class GrowingListModel<T> implements ComboBoxModel<Object> {
         final private Set<ListDataListener> listeners = new CopyOnWriteArraySet<ListDataListener>();
         final private List<T> predefinedList = new ArrayList<T>();
         final private List<T> userList = new ArrayList<T>();
@@ -244,7 +244,7 @@ public class GrowingComboBox extends javax.swing.JPanel {
                 return super.getListCellRendererComponent(list, s, index, isSelected, cellHasFocus);
             }
         });
-        combo.setModel(new GrowingListModel());
+        combo.setModel(new GrowingListModel<Object>());
     }
 
     /**


### PR DESCRIPTION
…stModel

There are compiler warnings about rawtype usage with GrowingListModel like the following
```
   [repeat] .../javafx/javafx2.scenebuilder/src/org/netbeans/modules/javafx2/scenebuilder/options/GrowingComboBox.java:247: warning: [rawtypes] found raw type: GrowingListModel
   [repeat]         combo.setModel(new GrowingListModel());
   [repeat]                            ^
   [repeat]   missing type arguments for generic class GrowingListModel<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in class GrowingListModel
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.