### PR TITLE
[NETBEANS-3506] Fixed compiler warnings concerning rawtypes Configura…

### DIFF
--- a/groovy/gradle/src/org/netbeans/modules/gradle/api/execute/GradleCommandLine.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/api/execute/GradleCommandLine.java
@@ -861,7 +861,7 @@ public final class GradleCommandLine implements Serializable {
      * @param projectDir can be {@code null} if the project properties for JVM
      * arguments shall not be evaluated.
      */
-    public void configure(ConfigurableLauncher launcher, File projectDir) {
+    public void configure(ConfigurableLauncher<?> launcher, File projectDir) {
         List<String> jvmargs = getArgs(EnumSet.of(SYSTEM));
         addGradleSettingJvmargs(projectDir, jvmargs);
         launcher.setJvmArguments(jvmargs);
@@ -877,7 +877,7 @@ public final class GradleCommandLine implements Serializable {
      * @since 1.0
      * @param launcher the Launcher instance to configure.
      */
-    public void configure(ConfigurableLauncher launcher) {
+    public void configure(ConfigurableLauncher<?> launcher) {
         configure(launcher, null);
     }
 


### PR DESCRIPTION
…bleLauncher

There are compiler warnings about rawtype usage with ConfigurableLauncher like the following
```
   [repeat] .../groovy/gradle/src/org/netbeans/modules/gradle/api/execute/GradleCommandLine.java:864: warning: [rawtypes] found raw type: ConfigurableLauncher
   [repeat]     public void configure(ConfigurableLauncher launcher, File projectDir) {
   [repeat]                           ^
   [repeat]   missing type arguments for generic class ConfigurableLauncher<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends ConfigurableLauncher declared in interface ConfigurableLauncher
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.