### PR TITLE
[NETBEANS-3507] Fixed compiler warnings concerning rawtypes ArgumentP…

### DIFF
--- a/groovy/gradle/src/org/netbeans/modules/gradle/api/execute/GradleCommandLine.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/api/execute/GradleCommandLine.java
@@ -450,7 +450,7 @@ public final class GradleCommandLine implements Serializable {
         while (it.hasNext()) {
             String arg = it.next();
             Argument parg = null;
-            for (ArgumentParser parser : PARSERS) {
+            for (ArgumentParser<? extends Argument> parser : PARSERS) {
                 parg = parser.parse(arg, it);
                 if (parg != null) {
                     arguments.add(parg);


### PR DESCRIPTION
…arser

There are compiler warnings about rawtype usage with ArgumentParser like the following
```
   [repeat] .../groovy/gradle/src/org/netbeans/modules/gradle/api/execute/GradleCommandLine.java:453: warning: [rawtypes] found raw type: ArgumentParser
   [repeat]             for (ArgumentParser parser : PARSERS) {
   [repeat]                  ^
   [repeat]   missing type arguments for generic class ArgumentParser<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Argument declared in interface ArgumentParser
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.