### PR TITLE
[NETBEANS-3508] Fixed compiler warnings concerning rawtypes ContextAw…

### DIFF
--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/BreakpointType.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/BreakpointType.java
@@ -201,9 +201,9 @@ public abstract class BreakpointType {
          * @param attrs attributes loaded from layer.xml
          * @return new <code>ContextAwareService</code> instance
          */
-        static ContextAwareService createService(Map attrs) throws ClassNotFoundException {
-            String serviceName = (String) attrs.get(DebuggerProcessor.SERVICE_NAME);
-            String displayName = (String) attrs.get("displayName");
+        static ContextAwareService<BreakpointType> createService(Map<?, String> attrs) throws ClassNotFoundException {
+            String serviceName = attrs.get(DebuggerProcessor.SERVICE_NAME);
+            String displayName = attrs.get("displayName");
             return new BreakpointType.ContextAware(serviceName, displayName);
         }
 


### PR DESCRIPTION
…areService

There are compiler warnings about rawtype usage with ContextAwareService like the following
```
   [repeat] .../ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/BreakpointType.java:204: warning: [rawtypes] found raw type: ContextAwareService
   [repeat]         static ContextAwareService createService(Map attrs) throws ClassNotFoundException {
   [repeat]                ^
   [repeat]   missing type arguments for generic class ContextAwareService<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in interface ContextAwareService
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.