### PR TITLE
[NETBEANS-3509] Fixed compiler warnings concerning rawtypes AbstractList

### DIFF
--- a/ide/xml.multiview/nbproject/project.properties
+++ b/ide/xml.multiview/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.45.0
 is.autoload=true

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionContainer.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionContainer.java
@@ -39,9 +39,7 @@ public class SectionContainer extends javax.swing.JPanel implements NodeSectionP
 
     //private HashMap map = new HashMap();
     //private JScrollPane scrollPane;
-    private Node activeNode=null;
     private SectionView sectionView;
-    private String title;
     private Node root;
     private boolean active;
     private int sectionCount=0;
@@ -66,7 +64,6 @@ public class SectionContainer extends javax.swing.JPanel implements NodeSectionP
         fillerEnd.setForeground(SectionVisualTheme.getFoldLineColor());
         Mnemonics.setLocalizedText(titleButton, title);
         titleButton.setToolTipText(titleButton.getText());
-        this.title=titleButton.getText();
         titleButton.addMouseListener(new org.openide.awt.MouseUtils.PopupMouseAdapter() {
             protected void showPopup(java.awt.event.MouseEvent e) {
                 JPopupMenu popup = getNode().getContextMenu();
@@ -174,7 +171,7 @@ public class SectionContainer extends javax.swing.JPanel implements NodeSectionP
         
         // the rest components have to be moved up
         java.awt.Component[] components = contentPanel.getComponents();
-        java.util.AbstractList removedPanels = new java.util.ArrayList(); 
+        java.util.List<NodeSectionPanel> removedPanels = new java.util.ArrayList<>();
         for (int i=0;i<components.length;i++) {
             if (components[i] instanceof NodeSectionPanel) {
                 NodeSectionPanel pan = (NodeSectionPanel)components[i];
@@ -187,7 +184,7 @@ public class SectionContainer extends javax.swing.JPanel implements NodeSectionP
             }
         }
         for (int i=0;i<removedPanels.size();i++) {
-            NodeSectionPanel pan = (NodeSectionPanel)removedPanels.get(i);
+            NodeSectionPanel pan = removedPanels.get(i);
             java.awt.GridBagConstraints gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = pan.getIndex();

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java
@@ -203,7 +203,7 @@ public class SectionView extends PanelView implements SectionFocusCookie, Contai
         
         // the rest components have to be moved up
         java.awt.Component[] components = scrollPanel.getComponents();
-        java.util.AbstractList removedPanels = new java.util.ArrayList();
+        java.util.List<NodeSectionPanel> removedPanels = new java.util.ArrayList<>();
         for (int i=0;i<components.length;i++) {
             if (components[i] instanceof NodeSectionPanel) {
                 NodeSectionPanel pan = (NodeSectionPanel)components[i];
@@ -216,7 +216,7 @@ public class SectionView extends PanelView implements SectionFocusCookie, Contai
             }
         }
         for (int i=0;i<removedPanels.size();i++) {
-            NodeSectionPanel pan = (NodeSectionPanel)removedPanels.get(i);
+            NodeSectionPanel pan = removedPanels.get(i);
             java.awt.GridBagConstraints gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = pan.getIndex();


### PR DESCRIPTION
There are compiler warnings about rawtype usage with AbstractList like the following
```
   [repeat] .../ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java:206: warning: [rawtypes] found raw type: AbstractList
   [repeat]         java.util.AbstractList removedPanels = new java.util.ArrayList();
   [repeat]                  ^
   [repeat]   missing type arguments for generic class AbstractList<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in class AbstractList
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.