### PR TITLE
[NETBEANS-3510] Fixed compiler warnings concerning rawtypes Action

### DIFF
--- a/ide/xml/test/unit/src/org/netbeans/modules/xml/XMLDataObjectMimeTypeTest.java
+++ b/ide/xml/test/unit/src/org/netbeans/modules/xml/XMLDataObjectMimeTypeTest.java
@@ -76,11 +76,7 @@ public final class XMLDataObjectMimeTypeTest extends NbTestCase {
 
     private void waitForAWT() throws Exception {
         // just wait till all the stuff from AWT is finished
-        Mutex.EVENT.readAccess(new Mutex.Action() {
-            public Object run() {
-                return null;
-            }
-        });
+        Mutex.EVENT.readAccess((Mutex.Action) () -> null);
     }
 
     protected void tearDown() throws Exception {
@@ -89,7 +85,7 @@ public final class XMLDataObjectMimeTypeTest extends NbTestCase {
         super.tearDown();
         if (obj != null) {
             CloseCookie cc;
-            cc = (CloseCookie)obj.getCookie(CloseCookie.class);
+            cc = obj.getCookie(CloseCookie.class);
             if (cc != null) {
                 cc.close();
             }


### PR DESCRIPTION
There are compiler warnings about rawtype usage with Action like the following
```
 [nb-javac] .../ide/xml/test/unit/src/org/netbeans/modules/xml/XMLDataObjectMimeTypeTest.java:79: warning: [rawtypes] found raw type: Action
 [nb-javac]         Mutex.EVENT.readAccess(new Mutex.Action() {
 [nb-javac]                                         ^
 [nb-javac]   missing type arguments for generic class Action<T>
 [nb-javac]   where T is a type-variable:
 [nb-javac]     T extends Object declared in interface Action
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.