### PR TITLE
[NETBEANS-3511] Fixed compiler warnings concerning rawtypes AbstractD…

### DIFF
--- a/java/maven.grammar/src/org/netbeans/modules/maven/codegen/AbstractGenerator.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/codegen/AbstractGenerator.java
@@ -37,7 +37,7 @@ import org.openide.util.NbBundle.Messages;
  *
  * @author mkleint
  */
-public abstract class AbstractGenerator<T extends AbstractDocumentModel> implements CodeGenerator {
+public abstract class AbstractGenerator<T extends AbstractDocumentModel<? extends DocumentComponent<?>>> implements CodeGenerator {
     protected final JTextComponent component;
     protected final T model;
 

--- a/java/maven.model/src/org/netbeans/modules/maven/model/ModelOperation.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/ModelOperation.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.maven.model;
 
 import org.netbeans.modules.xml.xam.dom.AbstractDocumentModel;
+import org.netbeans.modules.xml.xam.dom.DocumentComponent;
 
 /**
  * A single model modifying operation unit. Used by the {@link org.netbeans.modules.maven.model.Utilities}
@@ -30,7 +31,7 @@ import org.netbeans.modules.xml.xam.dom.AbstractDocumentModel;
  *
  * @author mkleint
  */
-public interface ModelOperation<T extends AbstractDocumentModel> {
+public interface ModelOperation<T extends AbstractDocumentModel<? extends DocumentComponent<?>>> {
 
     /**
      * perform modifications on the model passed as parameter.

--- a/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ElementFactoryRegistry.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ElementFactoryRegistry.java
@@ -132,7 +132,7 @@ public class ElementFactoryRegistry {
         return knownNames;
     }
     
-    public void addEmbeddedModelQNames(AbstractDocumentModel embeddedModel) {
+    public void addEmbeddedModelQNames(AbstractDocumentModel<?> embeddedModel) {
         if (knownEmbeddedModelTypes == null) {
             knownEmbeddedModelTypes = new HashSet();
         }

--- a/java/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ElementFactoryRegistry.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ElementFactoryRegistry.java
@@ -132,7 +132,7 @@ public class ElementFactoryRegistry {
         return knownNames;
     }
     
-    public void addEmbeddedModelQNames(AbstractDocumentModel embeddedModel) {
+    public void addEmbeddedModelQNames(AbstractDocumentModel<?> embeddedModel) {
         if (knownEmbeddedModelTypes == null) {
             knownEmbeddedModelTypes = new HashSet();
         }


### PR DESCRIPTION
…ocumentModel

There are compiler warnings about rawtype usage with AbstractDocumentModel like the following
```
   [repeat] .../java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ElementFactoryRegistry.java:135: warning: [rawtypes] found raw type: AbstractDocumentModel
   [repeat]     public void addEmbeddedModelQNames(AbstractDocumentModel embeddedModel) {
   [repeat]                                        ^
   [repeat]   missing type arguments for generic class AbstractDocumentModel<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends DocumentComponent<T> declared in class AbstractDocumentModel
```
The aim is to change the code such that these warnings are no longer emitted by the compiler.