### PR TITLE
[NETBEANS-3519] Corrected compiler warnings in Output Window project

### DIFF
--- a/platform/core.output2/nbproject/project.properties
+++ b/platform/core.output2/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 
 test.config.stableBTD.includes=**/*Test.class

--- a/platform/core.output2/src/org/netbeans/core/output2/FindDialogPanel.form
+++ b/platform/core.output2/src/org/netbeans/core/output2/FindDialogPanel.form
@@ -46,6 +46,7 @@
         </Property>
       </Properties>
       <AuxValues>
+        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value=""/>
         <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="4"/>
       </AuxValues>
       <Constraints>
@@ -59,6 +60,7 @@
         <Property name="editable" type="boolean" value="true"/>
       </Properties>
       <AuxValues>
+        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
         <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="4"/>
       </AuxValues>
       <Constraints>

--- a/platform/core.output2/src/org/netbeans/core/output2/FindDialogPanel.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/FindDialogPanel.java
@@ -41,7 +41,7 @@ class FindDialogPanel extends javax.swing.JPanel {
 
     private static Reference<FindDialogPanel> panel = null;
     private JButton acceptButton;
-    private static Vector<Object> history = new Vector<Object>();
+    private static Vector<String> history = new Vector<>();
     
     /** Initializes the Form */
     FindDialogPanel() {
@@ -57,7 +57,7 @@ class FindDialogPanel extends javax.swing.JPanel {
         findWhat.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(FindDialogPanel.class, "ACSD_Find_What"));
         acceptButton.getAccessibleContext().setAccessibleDescription(NbBundle.getMessage(FindDialogPanel.class, "ACSD_FindBTN"));
 
-        findWhat.setModel(new DefaultComboBoxModel(history));
+        findWhat.setModel(new DefaultComboBoxModel<>(history));
         findWhat.getEditor().addActionListener(new ActionListener() {
 
             public void actionPerformed(ActionEvent e) {
@@ -112,7 +112,7 @@ class FindDialogPanel extends javax.swing.JPanel {
         java.awt.GridBagConstraints gridBagConstraints;
 
         findWhatLabel = new javax.swing.JLabel();
-        findWhat = new javax.swing.JComboBox();
+        findWhat = new javax.swing.JComboBox<>();
         chbRegExp = new javax.swing.JCheckBox();
         chbMatchCase = new javax.swing.JCheckBox();
 
@@ -159,7 +159,7 @@ class FindDialogPanel extends javax.swing.JPanel {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JCheckBox chbMatchCase;
     private javax.swing.JCheckBox chbRegExp;
-    protected javax.swing.JComboBox findWhat;
+    protected javax.swing.JComboBox<String> findWhat;
     protected javax.swing.JLabel findWhatLabel;
     // End of variables declaration//GEN-END:variables
 
@@ -169,7 +169,7 @@ class FindDialogPanel extends javax.swing.JPanel {
     }
 
     private void updateHistory() {
-        Object pattern = findWhat.getEditor().getItem();
+        String pattern = (String) findWhat.getEditor().getItem();
 
         history.add( 0, pattern );
         for ( int i = history.size() - 1; i > 0; i-- ) {

--- a/platform/core.output2/src/org/netbeans/core/output2/options/LinkStyleModel.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/options/LinkStyleModel.java
@@ -32,7 +32,7 @@ import org.openide.util.NbBundle;
     "LBL_Underline=Underline", //NOI18N
     "LBL_None=None" //NOI18N
 })
-public class LinkStyleModel implements ComboBoxModel {
+public class LinkStyleModel implements ComboBoxModel<Object> {
 
     private class LinkStyleItem {
 

--- a/platform/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.form
+++ b/platform/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.form
@@ -263,6 +263,7 @@
           </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ColorComboBox()"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;?&gt;"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JComboBox" name="cmbBackgroundColor">
@@ -279,6 +280,7 @@
           </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ColorComboBox()"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;?&gt;"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JComboBox" name="cmbErrorColor">
@@ -295,6 +297,7 @@
           </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ColorComboBox()"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;?&gt;"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JComboBox" name="cmbStandardColor">
@@ -311,6 +314,7 @@
           </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ColorComboBox()"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;?&gt;"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JLabel" name="lblFontSize">
@@ -361,6 +365,9 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cmbLinkStyleActionPerformed"/>
           </Events>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;Object&gt;"/>
+          </AuxValues>
         </Component>
         <Component class="javax.swing.JLabel" name="lblLinkStyle">
           <Properties>
@@ -394,6 +401,7 @@
           </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ColorComboBox()"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;?&gt;"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JLabel" name="jLabel1">
@@ -431,6 +439,7 @@
           </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ColorComboBox()"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;?&gt;"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JLabel" name="jLabel2">
@@ -472,6 +481,7 @@
           </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ColorComboBox()"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;?&gt;"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JComboBox" name="cmbWarningColor">
@@ -485,6 +495,7 @@
           </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ColorComboBox()"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;?&gt;"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JComboBox" name="cmbFailureColor">
@@ -498,6 +509,7 @@
           </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ColorComboBox()"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;?&gt;"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JComboBox" name="cmbSuccessColor">
@@ -511,6 +523,7 @@
           </Events>
           <AuxValues>
             <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="new ColorComboBox()"/>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;?&gt;"/>
           </AuxValues>
         </Component>
       </SubComponents>

--- a/platform/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/options/OutputSettingsPanel.java
@@ -92,7 +92,7 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
         lblFontSize = new javax.swing.JLabel();
         spnFontSize = new javax.swing.JSpinner();
         btnSelectFont = new javax.swing.JButton();
-        cmbLinkStyle = new javax.swing.JComboBox();
+        cmbLinkStyle = new javax.swing.JComboBox<>();
         lblLinkStyle = new javax.swing.JLabel();
         fldFontFamily = new javax.swing.JTextField();
         cmbImportantLinkColor = new ColorComboBox();
@@ -502,7 +502,7 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
         updateControlsByModel();
     }
 
-    private void selectColor(JComboBox combo, Color color) {
+    private void selectColor(JComboBox<?> combo, Color color) {
         ((ColorComboBox) combo).setSelectedColor(color);
     }
 
@@ -530,17 +530,17 @@ public final class OutputSettingsPanel extends javax.swing.JPanel {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnRestore;
     private javax.swing.JButton btnSelectFont;
-    private javax.swing.JComboBox cmbBackgroundColor;
-    private javax.swing.JComboBox cmbDebugColor;
-    private javax.swing.JComboBox cmbErrorColor;
-    private javax.swing.JComboBox cmbFailureColor;
-    private javax.swing.JComboBox cmbImportantLinkColor;
-    private javax.swing.JComboBox cmbInputColor;
-    private javax.swing.JComboBox cmbLinkColor;
-    private javax.swing.JComboBox cmbLinkStyle;
-    private javax.swing.JComboBox cmbStandardColor;
-    private javax.swing.JComboBox cmbSuccessColor;
-    private javax.swing.JComboBox cmbWarningColor;
+    private javax.swing.JComboBox<?> cmbBackgroundColor;
+    private javax.swing.JComboBox<?> cmbDebugColor;
+    private javax.swing.JComboBox<?> cmbErrorColor;
+    private javax.swing.JComboBox<?> cmbFailureColor;
+    private javax.swing.JComboBox<?> cmbImportantLinkColor;
+    private javax.swing.JComboBox<?> cmbInputColor;
+    private javax.swing.JComboBox<?> cmbLinkColor;
+    private javax.swing.JComboBox<Object> cmbLinkStyle;
+    private javax.swing.JComboBox<?> cmbStandardColor;
+    private javax.swing.JComboBox<?> cmbSuccessColor;
+    private javax.swing.JComboBox<?> cmbWarningColor;
     private javax.swing.JTextField fldFontFamily;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel2;

--- a/platform/core.output2/test/unit/src/org/netbeans/core/output2/LifecycleTest.java
+++ b/platform/core.output2/test/unit/src/org/netbeans/core/output2/LifecycleTest.java
@@ -490,25 +490,14 @@ public class LifecycleTest extends NbTestCase {
         IOContainer container = IOContainer.getDefault();
         JComponent comp = null;
         try {
-            try {
-                Field f = container.getClass().getDeclaredField("provider");
-                f.setAccessible(true);
-                IOContainer.Provider prov = (IOContainer.Provider) f.get(container);
-                Method m = prov.getClass().getDeclaredMethod("impl", new Class[0]);
-                m.setAccessible(true);
-                comp = (JComponent) m.invoke(prov);
-            } catch (InvocationTargetException ex) {
-                Exceptions.printStackTrace(ex);
-            } catch (NoSuchMethodException ex) {
-                Exceptions.printStackTrace(ex);
-            } catch (IllegalArgumentException ex) {
-                Exceptions.printStackTrace(ex);
-            } catch (IllegalAccessException ex) {
-                Exceptions.printStackTrace(ex);
-            }
-        } catch (NoSuchFieldException ex) {
-            Exceptions.printStackTrace(ex);
-        } catch (SecurityException ex) {
+            Field f = container.getClass().getDeclaredField("provider");
+            f.setAccessible(true);
+            IOContainer.Provider prov = (IOContainer.Provider) f.get(container);
+            Method m = prov.getClass().getDeclaredMethod("impl", new Class<?>[0]);
+            m.setAccessible(true);
+            comp = (JComponent) m.invoke(prov);
+        } catch (InvocationTargetException | NoSuchMethodException | IllegalArgumentException
+                | IllegalAccessException | NoSuchFieldException | SecurityException ex) {
             Exceptions.printStackTrace(ex);
         }
         return comp;

--- a/platform/core.output2/test/unit/src/org/netbeans/core/output2/NbIOTest.java
+++ b/platform/core.output2/test/unit/src/org/netbeans/core/output2/NbIOTest.java
@@ -26,7 +26,6 @@ import java.io.Reader;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Random;
 import java.util.concurrent.Semaphore;
-import static junit.framework.Assert.assertEquals;
 import junit.framework.TestCase;
 import org.openide.util.Exceptions;
 import org.openide.windows.IOColorLines;

--- a/platform/core.output2/test/unit/src/org/netbeans/core/output2/OutputTabTest.java
+++ b/platform/core.output2/test/unit/src/org/netbeans/core/output2/OutputTabTest.java
@@ -151,7 +151,7 @@ public class OutputTabTest extends NbTestCase {
     public void testOptionsListener() throws InvocationTargetException,
             InterruptedException {
 
-        final NbIO nbio = (NbIO) io;
+        final NbIO nbio = io;
         nbio.closeInputOutput();
         EventQueue.invokeAndWait(new Runnable() {
             @Override


### PR DESCRIPTION
Fixed all compiler warnings concerning linter warnings types of
* cast,
* deprecation,
* rawtypes and
* unchecked.
