### PR TITLE
More stabilization of the vanilla javac indexer.

### DIFF
--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/CompileWorkerTestBase.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/CompileWorkerTestBase.java
@@ -20,10 +20,14 @@ package org.netbeans.modules.java.source.indexing;
 
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import java.io.File;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -128,6 +132,10 @@ public abstract class CompileWorkerTestBase extends NbTestCase {
     }
 
     protected ParsingOutput runIndexing(List<CompileTuple> files, List<CompileTuple> virtualFiles) throws Exception {
+        return runIndexing(files, virtualFiles, Collections.emptyList());
+    }
+
+    protected ParsingOutput runIndexing(List<CompileTuple> files, List<CompileTuple> virtualFiles, List<CompileTuple> extraSourceFiles) throws Exception {
         TransactionContext txc = TransactionContext.beginStandardTransaction(src.toURL(), true, ()->false, false);
         Factory f = new JavaCustomIndexer.Factory();
         Context ctx = SPIAccessor.getInstance().createContext(CacheFolder.getDataFolder(src.toURL()), src.toURL(), f.getIndexerName(), f.getIndexVersion(), LuceneIndexFactory.getDefault(), false, false, true, SPIAccessor.getInstance().createSuspendStatus(new SuspendStatusImpl() {
@@ -151,6 +159,13 @@ public abstract class CompileWorkerTestBase extends NbTestCase {
         toIndex.addAll(files);
         toIndex.addAll(virtualFiles);
         
+        for (CompileTuple extra : extraSourceFiles) {
+            try (OutputStream out = FileUtil.createData(extraSrc, extra.indexable.getRelativePath()).getOutputStream();
+                 Writer w = new OutputStreamWriter(out)) {
+                w.append(extra.jfo.getCharContent(true));
+            }
+        }
+
         ParsingOutput result = runCompileWorker(ctx, javaContext, toIndex);
         
         txc.commit();
@@ -171,13 +186,16 @@ public abstract class CompileWorkerTestBase extends NbTestCase {
         FileObject wd = FileUtil.toFileObject(wdFile);
         assertNotNull(wd);
         src = FileUtil.createFolder(wd, "src");
+        extraSrc = FileUtil.createFolder(wd, "extraSrc");
         FileObject buildRoot = FileUtil.createFolder(wd, "build");
         FileObject cache = FileUtil.createFolder(wd, "cache");
+        ClassPath sourcePath = ClassPathSupport.createClassPath(src, extraSrc);
 
-        SourceUtilsTestUtil.prepareTest(src, buildRoot, cache);
+        SourceUtilsTestUtil.prepareTest(sourcePath, buildRoot, cache, new FileObject[0]);
     }
     
     private FileObject src;
+    private FileObject extraSrc;
     private String sourceLevel;
     
     private FileObject createSrcFile(String pathAndName, String content) throws Exception {

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -333,6 +333,79 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
         //TODO: check file content!!!
     }
 
+    public void testArrayType() throws Exception {
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test4.java", "package test; public class Test4 { public void test(Undef[] undef1, Undef undef2) { undef1.invoke(undef2); } }")),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
+                     createdFiles);
+        //TODO: check file content!!!
+    }
+
+    public void testStaticInitializer() throws Exception {
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test4.java", "package test; public class Test4 { static { undef1.invoke(undef2); } }")),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
+                     createdFiles);
+        //TODO: check file content!!!
+    }
+
+    public void testJLObject() throws Exception {
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("java/lang/Object.java", "package java.lang; public class Object { }")),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/java/lang/Object.sig")),
+                     createdFiles);
+        //TODO: check file content!!!
+    }
+
+    public void testFromOtherSourceRootBroken() throws Exception {
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test4.java", "package test; public class Test4 extends extra.Extra { }")),
+                                           Arrays.asList(),
+                                           Arrays.asList(compileTuple("extra/Extra.java", "package extra; public class Extra { private void get() { undef(); } }")));
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test4.sig")),
+                     createdFiles);
+        //TODO: check file content!!!
+    }
+
     public static void noop() {}
 
     @Override

--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBEnter.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBEnter.java
@@ -18,8 +18,13 @@
  */
 package org.netbeans.lib.nbjavac.services;
 
+import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Symtab;
+import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.Enter;
+import com.sun.tools.javac.comp.Env;
+import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.TreeInfo;
@@ -42,11 +47,14 @@ public class NBEnter extends Enter {
 
     private final CancelService cancelService;
     private final Symtab syms;
+    private final NBJavaCompiler compiler;
 
     public NBEnter(Context context) {
         super(context);
         cancelService = CancelService.instance(context);
         syms = Symtab.instance(context);
+        JavaCompiler c = JavaCompiler.instance(context);
+        compiler = c instanceof NBJavaCompiler ? (NBJavaCompiler) c : null;
     }
 
     @Override
@@ -68,4 +76,14 @@ public class NBEnter extends Enter {
     protected int getIndex(JCClassDecl clazz) {
         return clazz instanceof IndexedClassDecl ? ((IndexedClassDecl) clazz).index : -1;
     }
+
+    @Override
+    public Env<AttrContext> getEnv(TypeSymbol sym) {
+        Env<AttrContext> env = super.getEnv(sym);
+        if (compiler != null) {
+            compiler.maybeInvokeDesugarCallback(env);
+        }
+        return env;
+    }
+
 }

--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBJavaCompiler.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBJavaCompiler.java
@@ -18,12 +18,17 @@
  */
 package org.netbeans.lib.nbjavac.services;
 
+import com.sun.tools.javac.comp.AttrContext;
+import com.sun.tools.javac.comp.Env;
 import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Pair;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Queue;
+import java.util.function.Consumer;
 
 /**
  *
@@ -40,6 +45,7 @@ public class NBJavaCompiler extends JavaCompiler {
     }
 
     private final CancelService cancelService;
+    private Consumer<Env<AttrContext>> desugarCallback;
 
     public NBJavaCompiler(Context context) {
         super(context);
@@ -63,4 +69,28 @@ public class NBJavaCompiler extends JavaCompiler {
     private void setOrigin(String origin) {
         fileManager.handleOption("apt-origin", Collections.singletonList(origin).iterator());
     }
+
+    public void setDesugarCallback(Consumer<Env<AttrContext>> callback) {
+        this.desugarCallback = callback;
+    }
+
+    private boolean desugaring;
+
+    @Override
+    protected void desugar(Env<AttrContext> env, Queue<Pair<Env<AttrContext>, JCTree.JCClassDecl>> results) {
+        boolean prevDesugaring = desugaring;
+        try {
+            desugaring = true;
+        super.desugar(env, results);
+        } finally {
+            desugaring = prevDesugaring;
+        }
+    }
+
+    void maybeInvokeDesugarCallback(Env<AttrContext> env) {
+        if (desugaring && desugarCallback != null) {
+            desugarCallback.accept(env);
+        }
+    }
+
 }


### PR DESCRIPTION
This increases stability of indexing without nb-javac when there are errors in the source code - in particular when some classes are missing. Before, this lead to more exceptions/broken caches.