### PR TITLE
[NETBEANS-3522] - Upgrade Apache commons-codec from 1.3 to 1.13

### DIFF
--- a/ide/o.apache.commons.codec/build.xml
+++ b/ide/o.apache.commons.codec/build.xml
@@ -22,13 +22,13 @@
 <project name="ide/o.apache.commons.codec" default="build" basedir=".">
     <import file="../../nbbuild/templates/projectized.xml"/>
     <target name="jar" depends="-define-FileCRC32Calculator">
-        <FileCRC32Calculator file="external/commons-codec-1.3.jar" property="o.apache.commons.codec.crc32" />
+        <FileCRC32Calculator file="external/commons-codec-1.13.jar" property="o.apache.commons.codec.crc32" />
         <jar jarfile="${cluster}/${module.jar}">
-            <zipfileset src="external/commons-codec-1.3.jar"/>
+            <zipfileset src="external/commons-codec-1.13.jar"/>
             <manifest>
                 <attribute name="Bundle-SymbolicName" value="org.apache.commons.codec"/>
-                <attribute name="Bundle-Version" value="1.3.0"/>
-                <attribute name="Export-Package" value="org.apache.commons.codec;version=&quot;1.3.0&quot;,org.apache.commons.codec.binary;version=&quot;1.3.0&quot;,org.apache.commons.codec.digest;version=&quot;1.3.0&quot;,org.apache.commons.codec.language;version=&quot;1.3.0&quot;,org.apache.commons.codec.net;version=&quot;1.3.0&quot;"/>
+                <attribute name="Bundle-Version" value="1.13.0"/>
+                <attribute name="Export-Package" value="org.apache.commons.codec;version=&quot;1.13.0&quot;,org.apache.commons.codec.binary;version=&quot;1.13.0&quot;,org.apache.commons.codec.digest;version=&quot;1.13.0&quot;,org.apache.commons.codec.language;version=&quot;1.13.0&quot;,org.apache.commons.codec.net;version=&quot;1.13.0&quot;"/>
                 <attribute name="NB-Original-CRC" value="${o.apache.commons.codec.crc32}"/>
             </manifest>
         </jar>

--- a/ide/o.apache.commons.codec/external/binaries-list
+++ b/ide/o.apache.commons.codec/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-FD32786786E2ADB664D5ECC965DA47629DCA14BA commons-codec:commons-codec:1.3
+3F18E1AA31031D89DB6F01BA05D501258CE69D2C commons-codec:commons-codec:1.13

--- a/ide/o.apache.commons.codec/external/commons-codec-1.13-license.txt
+++ b/ide/o.apache.commons.codec/external/commons-codec-1.13-license.txt
@@ -1,9 +1,9 @@
 Name: Apache Commons Codec
 Origin: Apache Software Foundation
-Version: 1.3
+Version: 1.13
 License: Apache-2.0
 Description: Provides implementations of common encoders and decoders.
-URL: http://commons.apache.org/codec/
+URL: https://commons.apache.org/proper/commons-codec/
 
                                  Apache License
                            Version 2.0, January 2004

--- a/ide/o.apache.commons.codec/external/commons-codec-1.13-notice.txt
+++ b/ide/o.apache.commons.codec/external/commons-codec-1.13-notice.txt
@@ -1,0 +1,3 @@
+This product includes software developed by
+The Apache Software Foundation (https://www.apache.org/).
+

--- a/ide/o.apache.commons.codec/external/commons-codec-1.3-notice.txt
+++ b/ide/o.apache.commons.codec/external/commons-codec-1.3-notice.txt
@@ -1,3 +1,0 @@
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-

--- a/ide/o.apache.commons.codec/nbproject/project.properties
+++ b/ide/o.apache.commons.codec/nbproject/project.properties
@@ -15,4 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
+javac.source=1.8
+javac.compilerargs=-Xlint -Xlint:-serial
 nbm.module.author=Tomas Stupka

--- a/ide/o.apache.commons.codec/nbproject/project.xml
+++ b/ide/o.apache.commons.codec/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-apache-commons-codec.jar</runtime-relative-path>
-                <binary-origin>external/commons-codec-1.3.jar</binary-origin>
+                <binary-origin>external/commons-codec-1.13.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-binary-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-binary-overlaps
@@ -43,7 +43,6 @@ extra/ */
 python*/jython-*/javalib/ */
 
 # Libraries from the bundled Java Card SDK which are also used by the IDE
-javacard/JCDK3.0.2_ConnectedEdition/lib/commons-codec-1.3.jar ide/modules/ext/apache-commons-codec-1.3.jar
 javacard/JCDK3.0.2_ConnectedEdition/lib/commons-logging-1.1.jar ide/modules/ext/commons-logging-1.1.jar
 javacard/JCDK3.0.2_ConnectedEdition/lib/ant-contrib-1.0b3.jar mobility/modules/ext/ant-contrib-1.0b3.jar
 javacard/JCDK3.0.2_ConnectedEdition/lib/commons-httpclient-3.0.jar mobility/modules/ext/commons-httpclient-3.0.jar


### PR DESCRIPTION
Notes:
- Requires Java 1.7
- Add methods for SHA-3, SHA-224, SHA-256, SHA-384, and SHA-512
- Improved testing suite, performance and documentation
- Many Security fixes
- 67 Fixed Bugs
- 59 New Features
- 1 Removed Method (NetBeans does not use it):
   - Base64.discardWhitespace(byte[])

[Apache Commons-Codec Web Page](https://commons.apache.org/proper/commons-codec/)
[Apache Commons-Codec Release Notes](https://commons.apache.org/proper/commons-codec/changes-report.html)