### PR TITLE
[NETBEANS-3525] - Upgrade Apache Lucene from 3.5.0 to 3.6.2

### DIFF
--- a/ide/libs.lucene/external/binaries-list
+++ b/ide/libs.lucene/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-90FF0731FAFB05C01FEE4F2247140D56E9C30A3B org.apache.lucene:lucene-core:3.5.0
+9EC77E2507F9CC01756964C71D91EFD8154A8C47 org.apache.lucene:lucene-core:3.6.2

--- a/ide/libs.lucene/external/lucene-core-3.6.2-license.txt
+++ b/ide/libs.lucene/external/lucene-core-3.6.2-license.txt
@@ -1,10 +1,10 @@
 Name: Apache Lucene
 Description: Java-based indexing and search technology
-Version: 3.5.0
+Version: 3.6.2
 Origin: Apache Software Foundation
 License: Apache-2.0-lucene
-URL: http://lucene.apache.org/
-Source: http://svn.apache.org/repos/asf/lucene/java/trunk
+URL: https://lucene.apache.org/core/
+Source: https://archive.apache.org/dist/lucene/java/3.6.2/
 
 
                                  Apache License

--- a/ide/libs.lucene/external/lucene-core-3.6.2-notice.txt
+++ b/ide/libs.lucene/external/lucene-core-3.6.2-notice.txt
@@ -1,5 +1,5 @@
 Apache Lucene
-Copyright 2011 The Apache Software Foundation
+Copyright 2019 The Apache Software Foundation
 
 The snowball stemmers in
   contrib/analyzers/common/src/java/net/sf/snowball

--- a/ide/libs.lucene/nbproject/project.properties
+++ b/ide/libs.lucene/nbproject/project.properties
@@ -16,5 +16,6 @@
 # under the License.
 
 is.autoload=true
-release.external/lucene-core-3.5.0.jar=modules/ext/lucene-core-3.5.0.jar
-
+javac.source=1.8
+javac.compilerargs=-Xlint -Xlint:-serial
+release.external/lucene-core-3.6.2.jar=modules/ext/lucene-core-3.6.2.jar

--- a/ide/libs.lucene/nbproject/project.xml
+++ b/ide/libs.lucene/nbproject/project.xml
@@ -29,8 +29,8 @@
                 <subpackages>org</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/lucene-core-3.5.0.jar</runtime-relative-path>
-                <binary-origin>external/lucene-core-3.5.0.jar</binary-origin>
+                <runtime-relative-path>ext/lucene-core-3.6.2.jar</runtime-relative-path>
+                <binary-origin>external/lucene-core-3.6.2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Notes;
- In addition to Java 5 and Java 6, this release has now full Java 7 support (minimum JDK 7u1 required).
- Many bug fixes
- Security fixes
- Improved performance

[Apache Lucene Web Page](https://lucene.apache.org/core/)
[Apache Lucene Releases](https://issues.apache.org/jira/projects/LUCENE?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page&status=released)
- [Apache Lucene Release Notes 3.6.0](https://mail-archives.apache.org/mod_mbox/lucene-general/201204.mbox/%3CCAOdYfZVLVvs392LDt5X0XvxT3V%2Ba0Y%2BORwNGfJpjBuBC0gFSAQ%40mail.gmail.com%3E)
- [Apache Lucene Release Notes 3.6.1](https://mail-archives.apache.org/mod_mbox/lucene-general/201207.mbox/%3C010a01cd6811%2422d72430%2468856c90%24%40apache.org%3E)
- [Apache Lucene Release Notes 3.6.2](https://mail-archives.apache.org/mod_mbox/lucene-general/201212.mbox/%3CCAOdYfZVtM21W%3DfKe8D82fCpKhrMEBBo7QjjmgZrp-tMv7stQhA%40mail.gmail.com%3E)