### PR TITLE
[NETBEANS-3529] - Upgrade GraalVM Truffle from 19.0.0 to 19.3.0

### DIFF
--- a/webcommon/libs.truffleapi/external/binaries-list
+++ b/webcommon/libs.truffleapi/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-44DC0250304EE3EF6B26B9D869E3D6B677D0A2A6 org.graalvm.truffle:truffle-api:19.0.0
+3DC77031E53473954C8DA0895F45A7449B07B021 org.graalvm.truffle:truffle-api:19.3.0

--- a/webcommon/libs.truffleapi/external/truffle-api-19.3.0-license.txt
+++ b/webcommon/libs.truffleapi/external/truffle-api-19.3.0-license.txt
@@ -2,8 +2,8 @@ Name: Graal SDK and Truffle API
 Description: Graal SDK and Truffle API
 License: UPL
 Origin: https://github.com/oracle/graal
-Version: 19.0.0
-Files: truffle-api-19.0.0.jar
+Version: 19.3.0
+Files: truffle-api-19.3.0.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/webcommon/libs.truffleapi/nbproject/project.properties
+++ b/webcommon/libs.truffleapi/nbproject/project.properties
@@ -19,4 +19,4 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/truffle-api-19.0.0.jar=modules/ext/truffle-api-19.0.0.jar
+release.external/truffle-api-19.3.0.jar=modules/ext/truffle-api-19.3.0.jar

--- a/webcommon/libs.truffleapi/nbproject/project.xml
+++ b/webcommon/libs.truffleapi/nbproject/project.xml
@@ -50,8 +50,8 @@
                 <package>com.oracle.truffle.api.utilities</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/truffle-api-19.0.0.jar</runtime-relative-path>
-                <binary-origin>external/truffle-api-19.0.0.jar</binary-origin>
+                <runtime-relative-path>ext/truffle-api-19.3.0.jar</runtime-relative-path>
+                <binary-origin>external/truffle-api-19.3.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Notes:
- Added support for reading environment variables
- Deprecated many methods
- Improved debugger
- Added support for temporary files and directories

[GraalVM Truffle Web Page](https://github.com/oracle/graal/tree/master/truffle)

[GraalVM Truffle Release Notes](https://github.com/oracle/graal/blob/master/truffle/CHANGELOG.md)