### PR TITLE
[NETBEANS-3530] - Upgrade GraalJS from 19.0.0 to 19.3.0

### DIFF
--- a/webcommon/libs.graaljs/external/binaries-list
+++ b/webcommon/libs.graaljs/external/binaries-list
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-7123118BFA4B0FF077D60985B784C148FAB724FE org.graalvm.js:js:19.0.0
-530ED62C07B9CD8C3E4BB0429B4243F6328E331F org.graalvm.regex:regex:19.0.0
+65984134F43A3A54FA9CB12577737E231E5DF360 org.graalvm.js:js:19.3.0
+1488B638A846E38BB87AD691037DD8D2347E22E1 org.graalvm.regex:regex:19.3.0
 7A4D00D5EC5FEBD252A6182E8B6E87A0A9821F81 com.ibm.icu:icu4j:62.1

--- a/webcommon/libs.graaljs/external/js-19.3.0-license.txt
+++ b/webcommon/libs.graaljs/external/js-19.3.0-license.txt
@@ -2,8 +2,8 @@ Name: Graal SDK and Truffle API
 Description: Graal SDK and Truffle API
 License: UPL
 Origin: https://github.com/oracle/graal
-Version: 19.0.0
-Files: js-19.0.0.jar regex-19.0.0.jar
+Version: 19.3.0
+Files: js-19.3.0.jar regex-19.3.0.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/webcommon/libs.graaljs/nbproject/project.properties
+++ b/webcommon/libs.graaljs/nbproject/project.properties
@@ -19,6 +19,6 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/js-19.0.0.jar=modules/ext/js-19.0.0.jar
-release.external/regex-19.0.0.jar=modules/ext/regex-19.0.0.jar
+release.external/js-19.3.0.jar=modules/ext/js-19.3.0.jar
+release.external/regex-19.3.0.jar=modules/ext/regex-19.3.0.jar
 release.external/icu4j-62.1.jar=modules/ext/icu4j-62.1.jar

--- a/webcommon/libs.graaljs/nbproject/project.xml
+++ b/webcommon/libs.graaljs/nbproject/project.xml
@@ -71,12 +71,12 @@
                 <package>com.oracle.js.parser.ir</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/js-19.0.0.jar</runtime-relative-path>
-                <binary-origin>external/js-19.0.0.jar</binary-origin>
+                <runtime-relative-path>ext/js-19.3.0.jar</runtime-relative-path>
+                <binary-origin>external/js-19.3.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/regex-19.0.0.jar</runtime-relative-path>
-                <binary-origin>external/regex-19.0.0.jar</binary-origin>
+                <runtime-relative-path>ext/regex-19.3.0.jar</runtime-relative-path>
+                <binary-origin>external/regex-19.3.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/icu4j-62.1.jar</runtime-relative-path>


### PR DESCRIPTION
Notes:
- Added support for date and time interop
- Updated ASM library to version 7.1.
- Updated Node.js to version 12.10.0.
- Many more...

[GraalJS Web Page](https://github.com/graalvm/graaljs)

[GraalJS Release Notes](https://github.com/graalvm/graaljs/blob/master/CHANGELOG.md)