### PR TITLE
[NETBEANS-3532] Corrected compiler warnings in Editor Settings project

### DIFF
--- a/ide/editor.settings/nbproject/project.properties
+++ b/ide/editor.settings/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint:all
 javac.source=1.8
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml

--- a/ide/editor.settings/src/org/netbeans/api/editor/settings/AttributesUtilities.java
+++ b/ide/editor.settings/src/org/netbeans/api/editor/settings/AttributesUtilities.java
@@ -188,7 +188,7 @@ public final class AttributesUtilities {
         }
 
         public synchronized boolean containsAttributes(AttributeSet attributes) {
-            for(Enumeration names = attributes.getAttributeNames(); names.hasMoreElements(); ) {
+            for(Enumeration<?> names = attributes.getAttributeNames(); names.hasMoreElements(); ) {
                 Object name = names.nextElement();
                 Object value = attributes.getAttribute(name);
 

--- a/ide/editor.settings/src/org/netbeans/api/editor/settings/FontColorSettings.java
+++ b/ide/editor.settings/src/org/netbeans/api/editor/settings/FontColorSettings.java
@@ -59,6 +59,7 @@ public abstract class FontColorSettings {
     /**
      * @deprecated This should have never been made public. Nobody can listen on this property.
      */
+    @Deprecated
     public static final String PROP_FONT_COLORS = "fontColors"; //NOI18N
     
     /**

--- a/ide/editor.settings/src/org/netbeans/api/editor/settings/MultiKeyBinding.java
+++ b/ide/editor.settings/src/org/netbeans/api/editor/settings/MultiKeyBinding.java
@@ -77,7 +77,7 @@ public final class MultiKeyBinding {
      * @see #getKeyStrokeCount()
      */
     public KeyStroke getKeyStroke(int index) {
-        return (KeyStroke)keyStrokeList.get(index);
+        return keyStrokeList.get(index);
     }
     
     /**

--- a/ide/editor.settings/src/org/netbeans/modules/editor/settings/AttrSet.java
+++ b/ide/editor.settings/src/org/netbeans/modules/editor/settings/AttrSet.java
@@ -193,7 +193,7 @@ public abstract class AttrSet implements AttributeSet, Iterable<Object> {
      * @param valueType class that values should be of (used for debugging purposes only
      *  and may be null).
      */
-    private static synchronized void registerSharedKey(Object key, Class valueType) {
+    private static synchronized void registerSharedKey(Object key, Class<?> valueType) {
         if (!sharedKeys.containsKey(key)) {
             KeyWrapper keyWrapper = new KeyWrapper(key, valueType);
             sharedKeys.put(key, keyWrapper);
@@ -311,10 +311,10 @@ public abstract class AttrSet implements AttributeSet, Iterable<Object> {
     final AttrSet cachedOverride(Object override) {
         AttrSet attrSet;
         if (overrideCache == null) {
-            overrideCache = new WeakHashMap<AttrSet,WeakReference<AttrSet>>(4);
+            overrideCache = new WeakHashMap<>(4);
             attrSet = null;
         } else {
-            WeakReference<AttrSet> ref = (WeakReference<AttrSet>) ((Map<?,?>)overrideCache).get(override);
+            WeakReference<AttrSet> ref = overrideCache.get(override);
             attrSet = (ref != null) ? ref.get() : null;
         }
         overrideGets++;
@@ -906,13 +906,13 @@ public abstract class AttrSet implements AttributeSet, Iterable<Object> {
         
         final Object key;
 
-        final Class valueType;
+        final Class<?> valueType;
         
         final int order; // used for ordering pairs in sharedPairs array
 
         final int keyHashCode;
 
-        KeyWrapper(Object key, Class valueType) {
+        KeyWrapper(Object key, Class<?> valueType) {
             this.key = key;
             this.valueType = valueType;
             this.order = orderCounter++;

--- a/ide/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/AttrSetTesting.java
+++ b/ide/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/AttrSetTesting.java
@@ -73,8 +73,8 @@ final class AttrSetTesting {
 
     public static RandomTestContainer createContainer() throws Exception {
         RandomTestContainer container = new RandomTestContainer();
-        container.putProperty(SimpleWeakSet.class, new SimpleWeakSet()); // Weak map
-        container.putProperty(List.class, new ArrayList()); // List of the items (strongly referenced)
+        container.putProperty(SimpleWeakSet.class, new SimpleWeakSet<Object>()); // Weak map
+        container.putProperty(List.class, new ArrayList<Object>()); // List of the items (strongly referenced)
         container.addOp(new AddOp());
         container.addOp(new ForgetOp());
         container.addOp(new MergeOp());
@@ -204,7 +204,8 @@ final class AttrSetTesting {
 
         @Override
         protected void run(Context context) throws Exception {
-            List list = context.getInstance(List.class);
+            @SuppressWarnings("unchecked")
+            List<Object> list = context.getInstance(List.class);
             if (list.size() > 0) {
                 Random random = context.container().random();
                 int elementIndex = random.nextInt(list.size());
@@ -222,7 +223,8 @@ final class AttrSetTesting {
 
         @Override
         protected void run(Context context) throws Exception {
-            List list = context.getInstance(List.class);
+            @SuppressWarnings("unchecked")
+            List<Object> list = context.getInstance(List.class);
             if (list.size() > 0) {
                 Random random = context.container().random();
                 int attrCount = 1 + random.nextInt(MAX_MERGE_SETS_COUNT);

--- a/ide/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/SimpleWeakSetTesting.java
+++ b/ide/editor.settings/test/unit/src/org/netbeans/modules/editor/settings/SimpleWeakSetTesting.java
@@ -52,9 +52,9 @@ final class SimpleWeakSetTesting {
 
     public static RandomTestContainer createContainer() throws Exception {
         RandomTestContainer container = new RandomTestContainer();
-        container.putProperty(SimpleWeakSet.class, new SimpleWeakSet()); // Weak map
-        container.putProperty(List.class, new ArrayList()); // List of the items (strongly referenced)
-        container.putProperty(REMOVED_LIST, new ArrayList()); // List of items that were removed (reset during check)
+        container.putProperty(SimpleWeakSet.class, new SimpleWeakSet<Object>()); // Weak map
+        container.putProperty(List.class, new ArrayList<Object>()); // List of the items (strongly referenced)
+        container.putProperty(REMOVED_LIST, new ArrayList<Object>()); // List of items that were removed (reset during check)
         container.addOp(new AddOp());
         container.addOp(new AddHash0Op());
         container.addOp(new AddHash1Op());
@@ -101,8 +101,10 @@ final class SimpleWeakSetTesting {
     }
 
     public static void addElement(Context context, Object element) throws Exception {
-        SimpleWeakSet simpleWeakSet = context.getInstance(SimpleWeakSet.class);
-        List list = context.getInstance(List.class);
+        @SuppressWarnings("unchecked")
+        SimpleWeakSet<Object> simpleWeakSet = context.getInstance(SimpleWeakSet.class);
+        @SuppressWarnings("unchecked")
+        List<Object> list = context.getInstance(List.class);
         list.add(element);
         simpleWeakSet.getOrAdd(element, null);
 
@@ -114,9 +116,12 @@ final class SimpleWeakSetTesting {
     }
 
     public static void removeElement(Context context, int listIndex) throws Exception {
-        SimpleWeakSet simpleWeakSet = context.getInstance(SimpleWeakSet.class);
-        List removedList = (List) context.getProperty(REMOVED_LIST);
-        List list = context.getInstance(List.class);
+        @SuppressWarnings("unchecked")
+        SimpleWeakSet<Object> simpleWeakSet = context.getInstance(SimpleWeakSet.class);
+        @SuppressWarnings("unchecked")
+        List<Object> removedList = (List<Object>) context.getProperty(REMOVED_LIST);
+        @SuppressWarnings("unchecked")
+        List<Object> list = context.getInstance(List.class);
         Object element = list.remove(listIndex);
         removedList.add(element);
         Object removedElement = simpleWeakSet.remove(element);
@@ -130,7 +135,8 @@ final class SimpleWeakSetTesting {
     }
 
     public static void forgetElement(Context context, int listIndex) throws Exception {
-        List list = context.getInstance(List.class);
+        @SuppressWarnings("unchecked")
+        List<Object> list = context.getInstance(List.class);
         Object element = list.remove(listIndex);
 
         StringBuilder sb = context.logOpBuilder();
@@ -208,7 +214,8 @@ final class SimpleWeakSetTesting {
 
         @Override
         protected void run(Context context) throws Exception {
-            List list = context.getInstance(List.class);
+            @SuppressWarnings("unchecked")
+            List<Object> list = context.getInstance(List.class);
             if (list.size() > 0) {
                 Random random = context.container().random();
                 int elementIndex = random.nextInt(list.size());
@@ -226,7 +233,8 @@ final class SimpleWeakSetTesting {
 
         @Override
         protected void run(Context context) throws Exception {
-            List list = context.getInstance(List.class);
+            @SuppressWarnings("unchecked")
+            List<Object> list = context.getInstance(List.class);
             if (list.size() > 0) {
                 Random random = context.container().random();
                 int elementIndex = random.nextInt(list.size());
@@ -246,8 +254,10 @@ final class SimpleWeakSetTesting {
         @Override
         protected void run(Context context) throws Exception {
             // Check size of list and set
-            SimpleWeakSet simpleWeakSet = context.getInstance(SimpleWeakSet.class);
-            List list = context.getInstance(List.class);
+            @SuppressWarnings("unchecked")
+            SimpleWeakSet<Object> simpleWeakSet = context.getInstance(SimpleWeakSet.class);
+            @SuppressWarnings("unchecked")
+            List<Object> list = context.getInstance(List.class);
             System.gc();
             Thread.sleep(1);
             int listSize = list.size();
@@ -267,9 +277,12 @@ final class SimpleWeakSetTesting {
 
         @Override
         protected void check(final Context context) throws Exception {
-            SimpleWeakSet simpleWeakSet = context.getInstance(SimpleWeakSet.class);
-            List list = context.getInstance(List.class);
-            List removedList = (List) context.getProperty(REMOVED_LIST);
+            @SuppressWarnings("unchecked")
+            SimpleWeakSet<Object> simpleWeakSet = context.getInstance(SimpleWeakSet.class);
+            @SuppressWarnings("unchecked")
+            List<Object> list = context.getInstance(List.class);
+            @SuppressWarnings("unchecked")
+            List<Object> removedList = (List<Object>) context.getProperty(REMOVED_LIST);
             for (Object e : list) {
                 Object testE;
                 if (!e.equals(testE = simpleWeakSet.getOrAdd(e, null))) {


### PR DESCRIPTION
Fixed all compiler warnings concerning linter warnings types of

* cast,
* dep-ann,
* rawtypes and
* unchecked.