### PR TITLE
[NETBEANS-3533] Corrected compiler warnings in Classpath APIs project

### DIFF
--- a/ide/api.java.classpath/src/org/netbeans/api/java/classpath/ClassLoaderSupport.java
+++ b/ide/api.java.classpath/src/org/netbeans/api/java/classpath/ClassLoaderSupport.java
@@ -27,6 +27,7 @@ import java.security.CodeSource;
 import java.security.PermissionCollection;
 import java.security.Permissions;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -90,8 +91,8 @@ final class ClassLoaderSupport extends URLClassLoader implements FileChangeListe
      * @throws ClassNotFoundException
      */
     @Override
-    protected Class findClass (String name) throws ClassNotFoundException {
-        Class c = super.findClass (name);
+    protected Class<?> findClass (String name) throws ClassNotFoundException {
+        Class<?> c = super.findClass (name);
         if (c != null) {
             org.openide.filesystems.FileObject fo;
             String resName = name.replace('.', '/') + ".class"; // NOI18N
@@ -256,18 +257,18 @@ final class ClassLoaderSupport extends URLClassLoader implements FileChangeListe
     }
 
     private void removeAllListeners() {
-        Map.Entry[] removeListenerFrom;
+        List<Map.Entry<FileObject, Boolean>> removeListenerFrom;
         synchronized(lock){
             detachedFromCp = true;  //No need to add more listeners
             if (emittedFileObjects.isEmpty()) {
                 return;
             }
-            removeListenerFrom = emittedFileObjects.entrySet().toArray(new Map.Entry[emittedFileObjects.size()]);
+            removeListenerFrom = new ArrayList<>(emittedFileObjects.entrySet());
             emittedFileObjects.clear();
         }
-        for (Map.Entry e : removeListenerFrom) {
+        for (Map.Entry<FileObject, Boolean> e : removeListenerFrom) {
             if (e.getValue() == Boolean.TRUE) {
-                ((FileObject)e.getKey()).removeFileChangeListener(listener);
+                e.getKey().removeFileChangeListener(listener);
             }
         }
     }

--- a/ide/api.java.classpath/src/org/netbeans/api/java/queries/BinaryForSourceQuery.java
+++ b/ide/api.java.classpath/src/org/netbeans/api/java/queries/BinaryForSourceQuery.java
@@ -232,11 +232,11 @@ public final class BinaryForSourceQuery {
     static final class QueriesAccessorImpl extends QueriesAccessor {
         QueriesAccessorImpl() {
         }
-        private final Map<Object, Result2Impl> cache = new WeakHashMap<>();
+        private final Map<Object, Result2Impl<?>> cache = new WeakHashMap<>();
 
         @Override
         public synchronized <T> Result2 create(BinaryForSourceQueryImplementation2<T> impl, T value) {
-            Result2Impl result = cache.get(value);
+            Result2Impl<?> result = cache.get(value);
             if (result == null) {
                 result = new Result2Impl<>(impl, value);
                 cache.put(value, result);

--- a/ide/api.java.classpath/src/org/netbeans/modules/java/classpath/ClassPathAccessor.java
+++ b/ide/api.java.classpath/src/org/netbeans/modules/java/classpath/ClassPathAccessor.java
@@ -33,7 +33,7 @@ public abstract class ClassPathAccessor {
     public static synchronized ClassPathAccessor getDefault() {
         ClassPathAccessor instance = DEFAULT;
         if (instance == null) {
-            Class c = ClassPath.class;
+            Class<?> c = ClassPath.class;
             try {
                 Class.forName(c.getName(), true, c.getClassLoader());
                 instance = DEFAULT;

--- a/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/ClassPathTest.java
+++ b/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/ClassPathTest.java
@@ -158,7 +158,7 @@ public class ClassPathTest extends NbTestCase {
         assertTrue (cp.findResource("org/me/None.txt")==null);
         
         //findAllResources
-        List res = cp.findAllResources ("org/me/Foo.txt");
+        List<FileObject> res = cp.findAllResources ("org/me/Foo.txt");
         assertTrue (res.size() == 2);
         assertTrue (res.contains(testFo_1));
         assertTrue (res.contains(testFo_2));
@@ -339,8 +339,8 @@ public class ClassPathTest extends NbTestCase {
         }
 
         public synchronized void removeResource (URL resource) {
-            for (Iterator it = this.resources.iterator(); it.hasNext();) {
-                PathResourceImplementation pr = (PathResourceImplementation) it.next ();
+            for (Iterator<PathResourceImplementation> it = this.resources.iterator(); it.hasNext();) {
+                PathResourceImplementation pr = it.next ();
                 if (Arrays.asList(pr.getRoots()).contains (resource)) {
                     this.resources.remove (pr);
                     this.support.firePropertyChange (ClassPathImplementation.PROP_RESOURCES,null,null);

--- a/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/queries/BinaryForSourceQueryTest.java
+++ b/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/queries/BinaryForSourceQueryTest.java
@@ -52,7 +52,7 @@ public class BinaryForSourceQueryTest extends NbTestCase {
     
     @Override
     protected void setUp () throws IOException {
-        MockServices.setServices(new Class[] {CPProvider.class, SFBQImpl.class});
+        MockServices.setServices(new Class<?>[] {CPProvider.class, SFBQImpl.class});
         this.clearWorkDir();
         File wd = this.getWorkDir();
         FileObject root = FileUtil.toFileObject(wd);

--- a/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/queries/SourceForBinaryQueryTest.java
+++ b/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/queries/SourceForBinaryQueryTest.java
@@ -177,7 +177,7 @@ public class SourceForBinaryQueryTest extends NbTestCase {
                 fired.set(true);
             }
         });
-        ((LeafSFBQImpl)DelegatingSFBImpl.impl).lastResult.fire();
+        LeafSFBQImpl.lastResult.fire();
         res.removeChangeListener(l);
         assertTrue(fired.get());
     }
@@ -217,14 +217,14 @@ public class SourceForBinaryQueryTest extends NbTestCase {
         
         
         public Result findSourceRoots2(URL binaryRoot) {
-            if (this.impl == null) {
+            if (DelegatingSFBImpl.impl == null) {
                 throw new IllegalStateException ();
             }
-            else if (this.impl instanceof SourceForBinaryQueryImplementation2) {
-                return ((SourceForBinaryQueryImplementation2)this.impl).findSourceRoots2(binaryRoot);
+            else if (DelegatingSFBImpl.impl instanceof SourceForBinaryQueryImplementation2) {
+                return ((SourceForBinaryQueryImplementation2)DelegatingSFBImpl.impl).findSourceRoots2(binaryRoot);
             }
             else {
-                final SourceForBinaryQuery.Result result = this.impl.findSourceRoots(binaryRoot);
+                final SourceForBinaryQuery.Result result = DelegatingSFBImpl.impl.findSourceRoots(binaryRoot);
                 return result == null ? null : asResult(result);
             }
         }


### PR DESCRIPTION
Fixed all compiler warnings concerning linter warnings types of

* rawtypes and
* static.