### PR TITLE
[NETBEANS-3534] Corrected compiler warnings in Classfile Reader project

### DIFF
--- a/java/classfile/nbproject/project.properties
+++ b/java/classfile/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:all
+javac.compilerargs=-Xlint:all -Xlint:-serial -Werror
 javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/java/classfile/test/unit/src/org/netbeans/modules/classfile/ParamNameTest.java
+++ b/java/classfile/test/unit/src/org/netbeans/modules/classfile/ParamNameTest.java
@@ -34,7 +34,7 @@ import junit.textui.TestRunner;
  */
 public class ParamNameTest extends TestCase {
     ClassFile classFile;
-    List results;
+    List<String> results;
     
     String[] result = {
 	"void assertTrue(String message, boolean condition)",
@@ -91,14 +91,13 @@ public class ParamNameTest extends TestCase {
     }
 
     public void test() {
-        int counter = 0;
-        for (Iterator it = classFile.getMethods().iterator(); it.hasNext(); ) {
-            Method m = (Method) it.next();
-            if (m.getName().equals("<init>"))
+        for (Method m : classFile.getMethods()) {
+            if (m.getName().equals("<init>")) {
                 continue;
+            }
             String s = m.getReturnSignature() + ' ' + m.getName() + '(';
-            for (Iterator itPar = m.getParameters().iterator(); itPar.hasNext(); ) {
-                Parameter p = (Parameter) itPar.next();
+            for (Iterator<Parameter> itPar = m.getParameters().iterator(); itPar.hasNext(); ) {
+                Parameter p = itPar.next();
                 s += p.getDeclaration();
                 if (itPar.hasNext()) {
                     s += ", ";
@@ -107,7 +106,6 @@ public class ParamNameTest extends TestCase {
             s += ')';
             
             assertTrue("has \"" + s + "\"", results.contains(s));
-            counter++;
         }
     }
 

--- a/java/classfile/test/unit/src/regression/datafiles/test91098.java
+++ b/java/classfile/test/unit/src/regression/datafiles/test91098.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+@SuppressWarnings("deprecation") // test file
 public enum test91098 {
     A(1);
     private test91098(@Deprecated int x) {}


### PR DESCRIPTION
Fixed all compiler warnings concerning linter warnings types of

* deprecation and
* rawtypes.