### PR TITLE
[NETBEANS-3535] Corrected compiler warnings in XML Tools API UI project

### DIFF
--- a/ide/api.xml.ui/nbproject/project.properties
+++ b/ide/api.xml.ui/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
-javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
+javac.compilerargs=-Xlint:all

--- a/ide/api.xml.ui/src/org/netbeans/api/xml/cookies/CookieMessage.java
+++ b/ide/api.xml.ui/src/org/netbeans/api/xml/cookies/CookieMessage.java
@@ -132,7 +132,7 @@ public final class CookieMessage {
      * @param  klass Requested detail subclass.
      * @return Instance of requested structured detail or <code>null</code>.
      */
-    public Object getDetail(Class klass) {
+    public <T> T getDetail(Class<T> klass) {
         return details.lookup(klass);
     }
 

--- a/ide/api.xml.ui/src/org/netbeans/spi/xml/cookies/SharedXMLSupport.java
+++ b/ide/api.xml.ui/src/org/netbeans/spi/xml/cookies/SharedXMLSupport.java
@@ -302,7 +302,7 @@ class SharedXMLSupport {
 
         // report which parser implementation is used
         
-        Class klass = parser.getClass();
+        Class<?> klass = parser.getClass();
         try {
             ProtectionDomain domain = klass.getProtectionDomain();
             CodeSource source = domain.getCodeSource();
@@ -455,7 +455,7 @@ class SharedXMLSupport {
         if (res==null) return null;
         NsHandler nsHandler = getNamespaces(is); 
         String[] namespaces = nsHandler.getNamespaces();
-        List loc = new ArrayList();
+        List<String> loc = new ArrayList<>();
         for (int i=0;i<namespaces.length;i++) {
             String ns = namespaces[i];
             if (nsHandler.mapping.containsKey(ns)) {
@@ -501,12 +501,12 @@ class SharedXMLSupport {
     }
     
     private static class NsHandler extends org.xml.sax.helpers.DefaultHandler {
-        Set namespaces;
-        private Map mapping;
+        Set<String> namespaces;
+        private Map<String, String> mapping;
 
         NsHandler() {
-            namespaces=new HashSet();
-            mapping = new HashMap();
+            namespaces=new HashSet<>();
+            mapping = new HashMap<>();
         }
         
         public void startElement(String uri, String localName, String rawName, Attributes atts) throws SAXException {

--- a/ide/api.xml.ui/test/unit/src/org/netbeans/spi/xml/cookies/SharedXMLSupportTest.java
+++ b/ide/api.xml.ui/test/unit/src/org/netbeans/spi/xml/cookies/SharedXMLSupportTest.java
@@ -132,7 +132,7 @@ public class SharedXMLSupportTest extends TestCase {
     private static class Observer implements CookieObserver {
         private int warnings;
         public void receive(CookieMessage msg) {
-            if (msg.getLevel() >= msg.WARNING_LEVEL) {
+            if (msg.getLevel() >= CookieMessage.WARNING_LEVEL) {
                 warnings++;
             }
         }

--- a/ide/api.xml.ui/test/unit/src/org/netbeans/spi/xml/cookies/TransformableSupportTest.java
+++ b/ide/api.xml.ui/test/unit/src/org/netbeans/spi/xml/cookies/TransformableSupportTest.java
@@ -92,7 +92,7 @@ public class TransformableSupportTest extends NbTestCase {
         
         public void receive(CookieMessage msg) {
             receives++;
-            if (msg.getLevel() >= msg.WARNING_LEVEL) {
+            if (msg.getLevel() >= CookieMessage.WARNING_LEVEL) {
                 warnings++;
             }
         }


### PR DESCRIPTION
Fixed all compiler warnings concerning linter warnings types of

* rawtypes,
* static and
* unchecked.