### PR TITLE
Avoid lookup query in logging which may lead to deadlocks

### DIFF
--- a/platform/core.startup/nbproject/project.properties
+++ b/platform/core.startup/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 javadoc.arch=${basedir}/arch.xml
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.7
+javac.source=1.8
 javadoc.apichanges=${basedir}/apichanges.xml
 module.jar.dir=core
 module.jar.basename=core.jar

--- a/platform/core.startup/src/org/netbeans/core/startup/TopLogging.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/TopLogging.java
@@ -409,32 +409,36 @@ public final class TopLogging {
 
         public LookupDel() {
             handlers = Lookup.getDefault().lookupResult(Handler.class);
-            instances = handlers.allInstances();
-            instances.size(); // initialize
+            resultChanged(null);
+            assert instances != null;
             handlers.addLookupListener(this);
         }
 
 
+        @Override
         public void publish(LogRecord record) {
             for (Handler h : instances) {
                 h.publish(record);
             }
         }
 
+        @Override
         public void flush() {
             for (Handler h : instances) {
                 h.flush();
             }
         }
 
+        @Override
         public void close() throws SecurityException {
             for (Handler h : instances) {
                 h.close();
             }
         }
 
+        @Override
         public void resultChanged(LookupEvent ev) {
-            instances = handlers.allInstances();
+            instances = new ArrayList<>(handlers.allInstances());
         }
     } // end of LookupDel
 

--- a/platform/core.startup/src/org/netbeans/core/startup/TopLogging.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/TopLogging.java
@@ -57,7 +57,6 @@ import org.openide.filesystems.FileUtil;
 import org.openide.modules.Places;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
-import org.openide.util.LookupEvent;
 import org.openide.util.LookupListener;
 import org.openide.util.NbBundle;
 
@@ -77,35 +76,13 @@ public final class TopLogging {
     public TopLogging() {
         AWTHandler.install();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        PrintStream ps = new PrintStream(os);
-
-        Collection<Logger> keep = new LinkedList<Logger>();
         Properties properties = System.getProperties();
-        for (String key : properties.stringPropertyNames()) {
-            
-            if ("sun.os.patch.level".equals(key)) { // NOI18N
-                // skip this property as it does not mean level of logging
-                continue;
-            }
-
-            String v = properties.getProperty(key);
-            if (v == null) {
-                continue;
-            }
-
-            if (key.endsWith(".level")) {
-                ps.print(key);
-                ps.print('=');
-                ps.println(v);
-                keep.add(Logger.getLogger(key.substring(0, key.length() - 6)));
-            }
-        }
-        ps.close();
+        configureFromProperties(os, properties);
         try {
             StartLog.unregister();
             LogManager.getLogManager().readConfiguration(new ByteArrayInputStream(os.toByteArray()));
         } catch (IOException ex) {
-            ex.printStackTrace();
+            ex.printStackTrace(OLD_ERR);
         } finally {
             StartLog.register();
         }
@@ -122,6 +99,29 @@ public final class TopLogging {
             logger.addHandler (streamHandler ());
         }
         logger.addHandler(new LookupDel());
+    }
+
+    private Collection<Logger> configureFromProperties(ByteArrayOutputStream os, Properties properties) {
+        try (PrintStream ps = new PrintStream(os)) {
+            Collection<Logger> keep = new LinkedList<>();
+            for (String key : properties.stringPropertyNames()) {
+                if ("sun.os.patch.level".equals(key)) { // NOI18N
+                    // skip this property as it does not mean level of logging
+                    continue;
+                }
+                String v = properties.getProperty(key);
+                if (v == null) {
+                    continue;
+                }
+                if (key.endsWith(".level")) {
+                    ps.print(key);
+                    ps.print('=');
+                    ps.println(v);
+                    keep.add(Logger.getLogger(key.substring(0, key.length() - 6)));
+                }
+            }
+            return keep;
+        }
     }
 
     /**
@@ -168,15 +168,15 @@ public final class TopLogging {
         }
 
         // initializes the properties
-        new TopLogging();
+        TopLogging logging = new TopLogging();
         // next time invoke the constructor of TopLogging itself please
         System.setProperty("java.util.logging.config.class", p);
 
         if (verbose) {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
-            PrintStream ps = new PrintStream(os);
-            printSystemInfo(ps);
-            ps.close();
+            try (PrintStream ps = new PrintStream(os)) {
+                logging.printSystemInfo(ps);
+            }
             try {
                 Logger logger = Logger.getLogger(TopLogging.class.getName()); // NOI18N
                 logger.log(Level.INFO, os.toString("utf-8"));
@@ -197,7 +197,7 @@ public final class TopLogging {
     }
 
 
-    private static void printSystemInfo(PrintStream ps) {
+    private void printSystemInfo(PrintStream ps) {
         DateFormat df = DateFormat.getDateTimeInstance(DateFormat.FULL, DateFormat.FULL, Locale.US);
         Date date = new Date();
 
@@ -205,7 +205,7 @@ public final class TopLogging {
         ps.println(">Log Session: "+df.format (date)); // NOI18N
         ps.println(">System Info: "); // NOI18N
 
-        List<File> clusters = new ArrayList<File>();
+        List<File> clusters = new ArrayList<>();
         String nbdirs = System.getProperty("netbeans.dirs");
         if (nbdirs != null) { // noted in #67862: should show all clusters here.
             StringTokenizer tok = new StringTokenizer(nbdirs, File.pathSeparator);
@@ -225,20 +225,20 @@ public final class TopLogging {
             File buildInfo = new File(cluster, "build_info"); // NOI18N
             if (buildInfo.isFile()) {
                 try {
-                    Reader r = new FileReader(buildInfo);
-                    try {
+                    try (Reader r = new FileReader(buildInfo)) {
                         BufferedReader b = new BufferedReader(r);
-                        String line;
                         Pattern p = Pattern.compile("Hg ID:    ([0-9a-f]{12})"); // NOI18N
-                        while ((line = b.readLine()) != null) {
+                        for (;;) {
+                            String line = b.readLine();
+                            if (line == null) {
+                                break;
+                            }
                             Matcher m = p.matcher(line);
                             if (m.matches()) {
                                 ps.print(" (#" + m.group(1) + ")"); // NOI18N
                                 break;
                             }
                         }
-                    } finally {
-                        r.close();
                     }
                 } catch (IOException x) {
                     x.printStackTrace(ps);
@@ -401,17 +401,19 @@ public final class TopLogging {
         TopSecurityManager.exit(exit);
     }
 
-    private static final class LookupDel extends Handler
-    implements LookupListener {
-        private Lookup.Result<Handler> handlers;
+    private static final class LookupDel extends Handler {
+        private final Lookup.Result<Handler> handlers;
         private Collection<? extends Handler> instances;
 
 
-        public LookupDel() {
+        LookupDel() {
             handlers = Lookup.getDefault().lookupResult(Handler.class);
-            resultChanged(null);
+            LookupListener onChange = (__) -> {
+                instances = new ArrayList<>(handlers.allInstances());
+            };
+            onChange.resultChanged(null);
             assert instances != null;
-            handlers.addLookupListener(this);
+            handlers.addLookupListener(onChange);
         }
 
 
@@ -434,11 +436,6 @@ public final class TopLogging {
             for (Handler h : instances) {
                 h.close();
             }
-        }
-
-        @Override
-        public void resultChanged(LookupEvent ev) {
-            instances = new ArrayList<>(handlers.allInstances());
         }
     } // end of LookupDel
 

--- a/platform/core.startup/src/org/netbeans/core/startup/TopLogging.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/TopLogging.java
@@ -401,6 +401,11 @@ public final class TopLogging {
         TopSecurityManager.exit(exit);
     }
 
+    static void exit(int exit, Throwable t) {
+        t.printStackTrace(OLD_ERR);
+        exit(exit);
+    }
+
     private static final class LookupDel extends Handler {
         private final Lookup.Result<Handler> handlers;
         private Collection<? extends Handler> instances;

--- a/platform/core.startup/src/org/netbeans/core/startup/TopThreadGroup.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/TopThreadGroup.java
@@ -97,14 +97,7 @@ final class TopThreadGroup extends ThreadGroup implements Runnable {
         try {
             Main.start (args);
         } catch (Throwable t) {
-            t.printStackTrace();
-            // System is probably broken, so don't just sit there with the splash screen open.
-            try {
-                Thread.sleep(10000);
-            } catch (InterruptedException x) {
-                Exceptions.printStackTrace(x);
-            }
-            TopSecurityManager.exit(2);
+            TopLogging.exit(2, t);
         } finally {
             synchronized (this) {
                 finished = true;

--- a/platform/openide.util.lookup/src/org/openide/util/Lookup.java
+++ b/platform/openide.util.lookup/src/org/openide/util/Lookup.java
@@ -271,14 +271,8 @@ public abstract class Lookup {
      * Find all instances corresponding to a given class.
      * Equivalent to calling {@link #lookupResult} and asking for {@link Lookup.Result#allInstances} but slightly more convenient.
      * Subclasses may override this method to produce the same semantics more efficiently.
-     * <div class="nonnormative">
      * <p>Example usage:</p>
-     * <pre>
-     * for (MyService svc : Lookup.getDefault().lookupAll(MyService.class)) {
-     *     svc.useMe();
-     * }
-     * </pre>
-     * </div>
+     * {@codesnippet org.openide.util.lookup.SampleLookupUsages#iterate}
      * @param clazz the supertype of the result
      * @return all currently available instances of that type
      * @since org.openide.util 6.10
@@ -474,8 +468,20 @@ public abstract class Lookup {
          */
         public abstract void removeLookupListener(LookupListener l);
 
-        /** Get all instances in the result. The return value type
-         * should be List instead of Collection, but it is too late to change it.
+        /** Get all instances in the result. The return value is an
+         * unmodifiable list (hence the type
+         * should be {@link List} as the order matters, but the {@link Collection}
+         * is kept for compatibility reasons) of all instances present in
+         * the {@link Result} right now that will never change its content.
+         * <p></p>
+         * <div class="nonnormative">
+         * While the returned collection never changes its content, some
+         * implementation like {@link ProxyLookup} may
+         * <a href="@TOP@/apichanges.html#lazy.proxy.lookup">compute the content
+         * lazily</a>. At least
+         * <a href="https://github.com/apache/netbeans/pull/1739">once</a>
+         * such behavior resulted in a deadlock.
+         * </div>
          * @return unmodifiable collection of all instances that will never change its content
          */
         public abstract Collection<? extends T> allInstances();
@@ -493,9 +499,20 @@ public abstract class Lookup {
         }
 
         /** Get all registered items.
-         * This should include all pairs of instances together
-         * with their classes, IDs, and so on. The return value type
-         * should be List instead of Collection, but it is too late to change it.
+         * This includes all pairs of instances together
+         * with their classes, {@link Item#getId() IDs}, and so on.
+         * The return value is an unmodifiable list (hence the type
+         * should be {@link List} as the order matters, but the {@link Collection}
+         * is kept for compatibility reasons) of all {@link Item items} present in
+         * the {@link Result} right now that will never change its content.
+         * <p></p>
+         * <div class="nonnormative">
+         * While the returned collection never changes its content, some
+         * implementation like {@link ProxyLookup} may
+         * <a href="@TOP@/apichanges.html#lazy.proxy.lookup">compute the content
+         * lazily</a>.
+         * </div>
+         *
          * @return unmodifiable collection of {@link Lookup.Item} that will never change its content
          *
          * @since 1.8

--- a/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/SampleLookupUsages.java
+++ b/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/SampleLookupUsages.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.util.lookup;
+
+import static junit.framework.TestCase.assertEquals;
+import org.junit.Test;
+import org.openide.util.Lookup;
+
+public class SampleLookupUsages {
+    @Test
+    public void iterate() {
+        counter = 0;
+        // BEGIN: org.openide.util.lookup.SampleLookupUsages#iterate
+        for (MyService svc : Lookup.getDefault().lookupAll(MyService.class)) {
+            svc.useMe();
+        }
+        // END: org.openide.util.lookup.SampleLookupUsages#iterate
+        assertEquals("MyServiceImpl has been called", 1, counter);
+    }
+
+    public interface MyService {
+        void useMe();
+    }
+
+    static int counter;
+
+    @ServiceProvider(service = MyService.class)
+    public static final class MyServiceImpl implements MyService {
+        @Override
+        public void useMe() {
+            counter++;
+        }
+    }
+}


### PR DESCRIPTION
There has been a deadlock in OracleLabs IGV:
```

"On Start/Stop" #46 daemon prio=1 os_prio=0 tid=0x00007fa5f89a3000 nid=0xa2d6 in Object.wait() [0x00007fa79aa84000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:502)
	at org.openide.util.Task.waitFinished(Task.java:110)
	- locked <0x000000058398da88> (a org.openide.util.RequestProcessor$Task)
	at org.openide.util.RequestProcessor$Task.waitFinished(RequestProcessor.java:1672)
	at org.openide.loaders.FolderInstance.waitFinished(FolderInstance.java:307)
	at org.openide.loaders.FolderLookup$ProxyLkp.beforeLookup(FolderLookup.java:398)
	at org.openide.util.lookup.ProxyLookup.beforeLookup(ProxyLookup.java:184)
	at org.openide.util.lookup.ProxyLookup$R.myBeforeLookup(ProxyLookup.java:650)
	at org.openide.util.lookup.ProxyLookup$R.beforeLookup(ProxyLookup.java:672)
	at org.openide.util.lookup.ProxyLookup$LazyCollection.computeDelegate(ProxyLookup.java:1100)
	at org.openide.util.lookup.ProxyLookup$LazyCollection.access$900(ProxyLookup.java:1030)
	at org.openide.util.lookup.ProxyLookup$LazyCollection$1.hasNext(ProxyLookup.java:1230)
	at org.netbeans.core.startup.TopLogging$LookupDel.publish(TopLogging.java:419)
	at java.util.logging.Logger.log(Logger.java:738)
	at java.util.logging.Logger.doLog(Logger.java:765)
	at java.util.logging.Logger.log(Logger.java:851)
	at org.openide.filesystems.Ordering.getOrder(Ordering.java:189)
	at org.openide.filesystems.MIMESupport$CachedFileObject.declarativeResolvers(MIMESupport.java:252)
	- locked <0x00000005d06699b8> (a java.lang.Class for org.openide.filesystems.MIMESupport$CachedFileObject)
	at org.openide.filesystems.MIMESupport$CachedFileObject.getResolvers(MIMESupport.java:197)
	at org.openide.filesystems.MIMESupport$CachedFileObject.resolveMIME(MIMESupport.java:340)
	at org.openide.filesystems.MIMESupport$CachedFileObject.getMIMEType(MIMESupport.java:287)
	at org.openide.filesystems.MIMESupport.findMIMEType(MIMESupport.java:111)
	at org.openide.filesystems.FileUtil.getMIMEType(FileUtil.java:1300)
	at org.openide.filesystems.FileObject.getMIMEType(FileObject.java:642)
	at org.openide.filesystems.MultiFileObject.getMIMEType(MultiFileObject.java:623)
	at org.openide.filesystems.MultiFileObject.getMIMEType(MultiFileObject.java:623)
	at org.openide.loaders.DataLoaderPool.allLoaders(DataLoaderPool.java:307)
	at org.openide.loaders.DataLoaderPool.findDataObject(DataLoaderPool.java:505)
	at org.openide.loaders.DataLoaderPool.findDataObject(DataLoaderPool.java:468)
	at org.openide.loaders.DataObject.find(DataObject.java:601)
	at org.netbeans.modules.java.platform.DefaultJavaPlatformProvider.getDefaultPlatformByHint(DefaultJavaPlatformProvider.java:169)
	at org.netbeans.modules.java.platform.DefaultJavaPlatformProvider.getDefaultPlatform(DefaultJavaPlatformProvider.java:101)
	at org.netbeans.api.java.platform.JavaPlatformManager.getDefaultPlatform(JavaPlatformManager.java:85)
	at org.netbeans.api.java.platform.JavaPlatform.getDefault(JavaPlatform.java:190)
	at org.graalvm.visualizer.source.java.impl.GPRPlatformRegistrar.run(GPRPlatformRegistrar.java:41)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)

"Default RequestProcessor" #45 daemon prio=10 os_prio=0 tid=0x00007fa5f8372000 nid=0xa2d5 runnable [0x00007fa79ad9b000]
   java.lang.Thread.State: RUNNABLE
	at sun.nio.ch.ServerSocketChannelImpl.accept0(Native Method)
	at sun.nio.ch.ServerSocketChannelImpl.accept(ServerSocketChannelImpl.java:422)
	at sun.nio.ch.ServerSocketChannelImpl.accept(ServerSocketChannelImpl.java:250)
	- locked <0x0000000580ff30d0> (a java.lang.Object)
	at org.graalvm.visualizer.connection.Server$1.run(Server.java:188)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)

"On Start/Stop" #44 daemon prio=1 os_prio=0 tid=0x00007fa5f84ba800 nid=0xa2d4 in Object.wait() [0x00007fa79ae9b000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:502)
	at org.openide.util.Task.waitFinished(Task.java:110)
	- locked <0x000000058398da88> (a org.openide.util.RequestProcessor$Task)
	at org.openide.util.RequestProcessor$Task.waitFinished(RequestProcessor.java:1672)
	at org.openide.loaders.FolderInstance.waitFinished(FolderInstance.java:307)
	at org.openide.loaders.FolderLookup$ProxyLkp.beforeLookup(FolderLookup.java:398)
	at org.openide.util.lookup.ProxyLookup.beforeLookup(ProxyLookup.java:184)
	at org.openide.util.lookup.ProxyLookup$R.myBeforeLookup(ProxyLookup.java:650)
	at org.openide.util.lookup.ProxyLookup$R.beforeLookup(ProxyLookup.java:672)
	at org.openide.util.lookup.ProxyLookup$R.myBeforeLookup(ProxyLookup.java:659)
	at org.openide.util.lookup.ProxyLookup$R.computeResult(ProxyLookup.java:528)
	at org.openide.util.lookup.ProxyLookup$R.allInstances(ProxyLookup.java:488)
	at org.openide.util.lookup.ProxyLookup$R.allInstances(ProxyLookup.java:484)
	at org.openide.filesystems.URLMapper.getInstances(URLMapper.java:229)
	at org.openide.filesystems.URLMapper.findURL(URLMapper.java:114)
	at org.openide.filesystems.FileObject.toURL(FileObject.java:1216)
	at org.netbeans.modules.project.libraries.LibrariesStorage$1.call(LibrariesStorage.java:259)
	at org.netbeans.modules.project.libraries.LibrariesStorage$1.call(LibrariesStorage.java:256)
	at org.netbeans.modules.project.libraries.FileLockManager.readAction(FileLockManager.java:53)
	at org.netbeans.modules.project.libraries.LibrariesStorage.readLibrary(LibrariesStorage.java:254)
	at org.netbeans.modules.project.libraries.LibrariesStorage.loadFromStorage(LibrariesStorage.java:142)
	at org.netbeans.modules.project.libraries.LibrariesStorage.initStorage(LibrariesStorage.java:219)
	at org.netbeans.modules.project.libraries.LibrariesStorage.getLibraries(LibrariesStorage.java:322)
	at org.netbeans.modules.project.libraries.LibrariesModule.run(LibrariesModule.java:47)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)

"Folder recognizer" #43 daemon prio=1 os_prio=0 tid=0x00007fa5f8a97000 nid=0xa2d3 waiting for monitor entry [0x00007fa79af9d000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at org.openide.filesystems.MIMESupport$CachedFileObject.getResolvers(MIMESupport.java:161)
	- waiting to lock <0x00000005d06699b8> (a java.lang.Class for org.openide.filesystems.MIMESupport$CachedFileObject)
	at org.openide.filesystems.MIMESupport$CachedFileObject.resolveMIME(MIMESupport.java:340)
	at org.openide.filesystems.MIMESupport$CachedFileObject.getMIMEType(MIMESupport.java:287)
	at org.openide.filesystems.MIMESupport.findMIMEType(MIMESupport.java:111)
	at org.openide.filesystems.FileUtil.getMIMEType(FileUtil.java:1300)
	at org.openide.filesystems.FileObject.getMIMEType(FileObject.java:642)
	at org.openide.filesystems.MultiFileObject.getMIMEType(MultiFileObject.java:623)
	at org.openide.filesystems.MultiFileObject.getMIMEType(MultiFileObject.java:623)
	at org.openide.loaders.DataLoaderPool.allLoaders(DataLoaderPool.java:307)
	at org.openide.loaders.DataLoaderPool.findDataObject(DataLoaderPool.java:505)
	at org.openide.loaders.FolderList.createBoth(FolderList.java:743)
	at org.openide.loaders.FolderList.getObjects(FolderList.java:539)
	at org.openide.loaders.FolderList.access$600(FolderList.java:52)
	at org.openide.loaders.FolderList$ListTask.computeResult(FolderList.java:938)
	at org.openide.loaders.FolderList$ListTask.run(FolderList.java:914)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)

"Bundle File Closer" #39 daemon prio=5 os_prio=0 tid=0x00007fa5f8e51800 nid=0xa2ce in Object.wait() [0x00007fa79b5b6000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:502)
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.getNextEvent(EventManager.java:400)
	- locked <0x00000005d09b90a0> (a org.eclipse.osgi.framework.eventmgr.EventManager$EventThread)
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:336)

"Framework Event Dispatcher" #37 daemon prio=5 os_prio=0 tid=0x00007fa5f832e800 nid=0xa2cc in Object.wait() [0x00007fa79b801000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:502)
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.getNextEvent(EventManager.java:400)
	- locked <0x00000005d09b9350> (a org.eclipse.osgi.framework.eventmgr.EventManager$EventThread)
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:336)

"Framework Active Thread" #34 prio=5 os_prio=0 tid=0x00007fa5f8377800 nid=0xa2ca in Object.wait() [0x00007fa79ba03000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at org.eclipse.osgi.framework.internal.core.Framework.run(Framework.java:1870)
	- locked <0x00000005d00fbf60> (a org.eclipse.osgi.framework.internal.core.Framework)
	at java.lang.Thread.run(Thread.java:748)

"main" #32 prio=5 os_prio=0 tid=0x00007fa818671800 nid=0xa2c8 in Object.wait() [0x00007fa7a0efb000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:502)
	at org.openide.util.Task.waitFinished(Task.java:110)
	- locked <0x000000058398da88> (a org.openide.util.RequestProcessor$Task)
	at org.openide.util.RequestProcessor$Task.waitFinished(RequestProcessor.java:1672)
	at org.openide.loaders.FolderInstance.waitFinished(FolderInstance.java:307)
	at org.openide.loaders.FolderLookup$ProxyLkp.beforeLookup(FolderLookup.java:398)
	at org.openide.util.lookup.ProxyLookup.lookup(ProxyLookup.java:189)
	at org.openide.util.lookup.ProxyLookup.lookup(ProxyLookup.java:197)
	at org.netbeans.modules.javahelp.Installer.restored(Installer.java:55)
	at org.netbeans.core.startup.NbInstaller.loadCode(NbInstaller.java:447)
	at org.netbeans.core.startup.NbInstaller.loadImpl(NbInstaller.java:370)
	at org.netbeans.core.startup.NbInstaller.access$000(NbInstaller.java:77)
	at org.netbeans.core.startup.NbInstaller$1.run(NbInstaller.java:322)
	at org.openide.filesystems.FileUtil$2.run(FileUtil.java:412)
	at org.openide.filesystems.EventControl.runAtomicAction(EventControl.java:102)
	at org.openide.filesystems.FileSystem.runAtomicAction(FileSystem.java:494)
	at org.openide.filesystems.FileUtil.runAtomicAction(FileUtil.java:396)
	at org.openide.filesystems.FileUtil.runAtomicAction(FileUtil.java:416)
	at org.netbeans.core.startup.NbInstaller.load(NbInstaller.java:319)
	at org.netbeans.ModuleManager.enable(ModuleManager.java:1449)
	at org.netbeans.ModuleManager.enable(ModuleManager.java:1254)
	at org.netbeans.core.startup.ModuleList.installNew(ModuleList.java:315)
	at org.netbeans.core.startup.ModuleList.trigger(ModuleList.java:251)
	at org.netbeans.core.startup.ModuleSystem.restore(ModuleSystem.java:298)
	at org.netbeans.core.startup.Main.getModuleSystem(Main.java:156)
	at org.netbeans.core.startup.Main.getModuleSystem(Main.java:125)
	at org.netbeans.core.startup.Main.start(Main.java:282)
	at org.netbeans.core.startup.TopThreadGroup.run(TopThreadGroup.java:98)
	at java.lang.Thread.run(Thread.java:748)

"Netigso Events" #31 daemon prio=1 os_prio=0 tid=0x00007fa818667800 nid=0xa2c7 in Object.wait() [0x00007fa7a0ffd000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	- waiting on <0x00000005d08edd30> (a org.netbeans.modules.openide.util.DefaultMutexImplementation$QueueCell)
	at org.netbeans.modules.openide.util.DefaultMutexImplementation$QueueCell.sleep(DefaultMutexImplementation.java:1165)
	- locked <0x00000005d08edd30> (a org.netbeans.modules.openide.util.DefaultMutexImplementation$QueueCell)
	at org.netbeans.modules.openide.util.DefaultMutexImplementation.enterImpl(DefaultMutexImplementation.java:434)
	at org.netbeans.modules.openide.util.DefaultMutexImplementation.enter(DefaultMutexImplementation.java:341)
	at org.netbeans.modules.openide.util.DefaultMutexImplementation.postRequest(DefaultMutexImplementation.java:962)
	at org.netbeans.modules.openide.util.DefaultMutexImplementation.postReadRequest(DefaultMutexImplementation.java:287)
	at org.openide.util.Mutex.postReadRequest(Mutex.java:346)
	at org.netbeans.core.netigso.Netigso$1.run(Netigso.java:413)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)

"CLI Requests Server" #30 daemon prio=5 os_prio=0 tid=0x00007fa81857a000 nid=0xa2c6 runnable [0x00007fa7a86d0000]
   java.lang.Thread.State: RUNNABLE
	at java.net.PlainSocketImpl.socketAccept(Native Method)
	at java.net.AbstractPlainSocketImpl.accept(AbstractPlainSocketImpl.java:409)
	at java.net.ServerSocket.implAccept(ServerSocket.java:545)
	at java.net.ServerSocket.accept(ServerSocket.java:513)
	at org.netbeans.CLIHandler$Server.run(CLIHandler.java:1078)

"Active Reference Queue Daemon" #29 daemon prio=1 os_prio=0 tid=0x00007fa818463800 nid=0xa2c5 in Object.wait() [0x00007fa7a8bd1000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	- waiting on <0x0000000080215508> (a java.lang.ref.ReferenceQueue$Lock)
	at java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:144)
	- locked <0x0000000080215508> (a java.lang.ref.ReferenceQueue$Lock)
	at org.openide.util.lookup.implspi.ActiveQueue$Impl.removeSuper(ActiveQueue.java:70)
	at org.openide.util.lookup.implspi.ActiveQueue$Daemon.run(ActiveQueue.java:108)

"Dump Stack Watchdog" #25 prio=5 os_prio=0 tid=0x00007fa8182a9000 nid=0xa2c4 in Object.wait() [0x00007fa7a954c000]
   java.lang.Thread.State: WAITING (on object monitor)
	at java.lang.Object.wait(Native Method)
	at java.lang.Object.wait(Object.java:502)
	at org.openide.util.Task.waitFinished(Task.java:110)
	- locked <0x000000058398da88> (a org.openide.util.RequestProcessor$Task)
	at org.openide.util.RequestProcessor$Task.waitFinished(RequestProcessor.java:1672)
	at org.openide.loaders.FolderInstance.waitFinished(FolderInstance.java:307)
	at org.openide.loaders.FolderLookup$ProxyLkp.beforeLookup(FolderLookup.java:398)
	at org.openide.util.lookup.ProxyLookup.beforeLookup(ProxyLookup.java:184)
	at org.openide.util.lookup.ProxyLookup$R.myBeforeLookup(ProxyLookup.java:650)
	at org.openide.util.lookup.ProxyLookup$R.beforeLookup(ProxyLookup.java:672)
	at org.openide.util.lookup.ProxyLookup$LazyCollection.computeDelegate(ProxyLookup.java:1100)
	at org.openide.util.lookup.ProxyLookup$LazyCollection.access$900(ProxyLookup.java:1030)
	at org.openide.util.lookup.ProxyLookup$LazyCollection$1.hasNext(ProxyLookup.java:1230)
	at org.netbeans.core.startup.TopLogging$LookupDel.publish(TopLogging.java:419)
	at java.util.logging.Logger.log(Logger.java:738)
	at java.util.logging.Logger.doLog(Logger.java:765)
	at java.util.logging.Logger.log(Logger.java:788)
	at java.util.logging.Logger.warning(Logger.java:1477)
	at org.graalvm.visualizer.mxprojects.DumpStack.run(DumpStack.java:48)
	at java.util.TimerThread.mainLoop(Timer.java:555)
	at java.util.TimerThread.run(Timer.java:505)
```
The best solution to the problem is to avoid querying lookup from `org.netbeans.core.startup.TopLogging$LookupDel.publish` which is what this PR provides.