### PR TITLE
[NETBEANS-3542] - cleanup unchecked conversion warnings..

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ProjectWhiteListQueryImplementation.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/queries/ProjectWhiteListQueryImplementation.java
@@ -104,7 +104,7 @@ public class ProjectWhiteListQueryImplementation implements WhiteListQueryImplem
     private void fireChangeAllExistingResults(final TreeSet<String> privatePackages) {
             final Set<ProjectWhiteListImplementation> set;
             synchronized (results) {
-                set = new HashSet(results);
+                set = new HashSet<>(results);
             }
 
             RP.post(new Runnable() {

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenWhiteListQueryImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenWhiteListQueryImpl.java
@@ -330,7 +330,7 @@ public class MavenWhiteListQueryImpl implements WhiteListQueryImplementation {
         assert Thread.holdsLock(LOCK);
         final Set<MavenWhiteListImplementation> set;
         synchronized (results) {
-            set = new HashSet(results);
+            set = new HashSet<>(results);
         }
         RP.post(new Runnable() {
             @Override

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishAdminInterface.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishAdminInterface.java
@@ -53,7 +53,7 @@ public enum GlassFishAdminInterface {
      * conversion.
      */
     private static final Map<String, GlassFishAdminInterface> stringValuesMap
-            = new HashMap(values().length);
+            = new HashMap<>(values().length);
 
     // Initialize backward String conversion <code>Map</code>.
     static {

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
@@ -195,7 +195,7 @@ public enum GlassFishVersion {
      * conversion.
      */
     private static final Map<String, GlassFishVersion> stringValuesMap
-            = new HashMap(2 * values().length);
+            = new HashMap<>(2 * values().length);
 
     // Initialize backward String conversion Map.
     static {

--- a/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
@@ -992,7 +992,7 @@ public final class DebuggerManager implements ContextProvider {
                 initDebuggerManagerListeners ();
 
                 createdBreakpoints = new ArrayList<>();
-                originatingListeners = new HashMap();
+                originatingListeners = new HashMap<>();
 
                 Vector l = (Vector) listeners.clone ();
                 int i, k = l.size ();

--- a/ide/api.debugger/src/org/netbeans/api/debugger/LazyArrayList.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/LazyArrayList.java
@@ -208,7 +208,7 @@ class LazyArrayList<T> extends ArrayList<T> {
     private void shiftLazyEntries(int from, final int by) {
         // Set<Integer> indexes = new TreeSet(lazyEntries.keySet());
         // if (by > 0) indexes = indexes.descendingSet(); - Since JDK 6.
-        TreeSet<Integer> indexes = new TreeSet(new Comparator<Integer>() {
+        Set<Integer> indexes = new TreeSet<>(new Comparator<Integer>() {
             public int compare(Integer o1, Integer o2) {
                 int i1 = o1;
                 int i2 = o2;

--- a/ide/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
+++ b/ide/api.debugger/src/org/netbeans/debugger/registry/DebuggerProcessor.java
@@ -347,7 +347,7 @@ public class DebuggerProcessor extends LayerGeneratingProcessor {
     }
 
     private boolean implementsInterfaces(Element e, String classNames) {
-        Set<String> interfaces = new HashSet(Arrays.asList(classNames.split("[, ]+")));
+        Set<String> interfaces = new HashSet<>(Arrays.asList(classNames.split("[, ]+")));
         return implementsInterfaces(e, interfaces);
     }
 

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/csl/CssCompletion.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/csl/CssCompletion.java
@@ -98,7 +98,7 @@ public class CssCompletion implements CodeCompletionHandler {
     /**
      * Units which shouldn't appear in the code completion.
      */
-    private static final Collection<String> HIDDEN_UNITS = new HashSet(Arrays.asList(new String[]{"!hash_color_code"}));
+    private static final Collection<String> HIDDEN_UNITS = new HashSet<>(Arrays.asList(new String[]{"!hash_color_code"}));
 
     //unit testing support
     static String[] TEST_USED_COLORS;

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/DocumentViewPanelProvider.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/DocumentViewPanelProvider.java
@@ -40,7 +40,7 @@ import org.openide.util.lookup.ServiceProvider;
 public class DocumentViewPanelProvider implements CssStylesPanelProvider {
 
     private static String DOCUMENT_PANEL_ID = "static_document";
-    private static Collection<String> MIME_TYPES = new HashSet(Arrays.asList(new String[]{"text/css", "text/html", "text/xhtml"}));
+    private static Collection<String> MIME_TYPES = new HashSet<>(Arrays.asList(new String[]{"text/css", "text/html", "text/xhtml"}));
     private DocumentViewPanel panel;
     
     @Override

--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
@@ -168,7 +168,7 @@ final class CodeTemplatesModel {
                     abbreviation,
                     tableModel.getDescription(idx),
                     tableModel.getText(idx),
-                    new ArrayList(tableModel.getContexts(idx)),
+                    new ArrayList<String>(tableModel.getContexts(idx)),
                     tableModel.getUniqueId(idx),
                     mimeType
                 );

--- a/ide/editor.lib2/src/org/netbeans/api/editor/EditorRegistry.java
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/EditorRegistry.java
@@ -747,7 +747,7 @@ public final class EditorRegistry {
             if (!item.ignoreAncestorChange) {
                 // Only start timer when ancestor changes are not ignored.
                 // Use weak ref to component since if the timer would not fire the component would not get released
-                final Reference<JComponent> componentRef = new WeakReference(component);
+                final Reference<JComponent> componentRef = new WeakReference<>(component);
                 item.runningTimer = new Timer(BEFORE_REMOVE_DELAY,
                     new ActionListener() {
                         public @Override void actionPerformed(ActionEvent e) {

--- a/ide/editor.lib2/src/org/netbeans/api/editor/caret/CaretTransaction.java
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/caret/CaretTransaction.java
@@ -176,7 +176,7 @@ final class CaretTransaction {
             if (dotChanged || markChanged) {
                 editorCaret.ensureValidInfo(caretItem);
                 if (expandFoldPositions == null) {
-                    expandFoldPositions = new ArrayList(2);
+                    expandFoldPositions = new ArrayList<>(2);
                 }
                 if (dotChanged) {
                     caretItem.setDotPos(dotPos);

--- a/ide/gsf.testrunner.ui/nbproject/project.properties
+++ b/ide/gsf.testrunner.ui/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultPanelTree.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultPanelTree.java
@@ -299,7 +299,7 @@ final class ResultPanelTree extends JPanel implements ExplorerManager.Provider, 
     }
 
     Set<Testcase> getFailedTests(){
-        Set<Testcase> failedTests = new HashSet();
+        Set<Testcase> failedTests = new HashSet<>();
         for(Testcase tc:displayHandler.getSession().getAllTestCases()){
             if (Status.isFailureOrError(tc.getStatus())){
                 failedTests.add(tc);

--- a/ide/jumpto/src/org/netbeans/modules/jumpto/common/ItemRenderer.java
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/common/ItemRenderer.java
@@ -89,7 +89,7 @@ public final class ItemRenderer<T> extends DefaultListCellRenderer implements Ch
 
         @NonNull
         public ItemRenderer<T> build() {
-            return new ItemRenderer(
+            return new ItemRenderer<T>(
                     list,
                     caseSensitive,
                     colorPrefered,
@@ -114,7 +114,7 @@ public final class ItemRenderer<T> extends DefaultListCellRenderer implements Ch
             @NonNull final JList<T> list,
             @NonNull final ButtonModel caseSensitive,
             @NonNull final Convertor<T> convertor) {
-            return new Builder(list, caseSensitive, convertor);
+            return new Builder<T>(list, caseSensitive, convertor);
         }
     }
 

--- a/ide/mercurial/src/org/netbeans/modules/mercurial/HistoryRegistry.java
+++ b/ide/mercurial/src/org/netbeans/modules/mercurial/HistoryRegistry.java
@@ -71,7 +71,7 @@ public class HistoryRegistry {
         HgLogMessage[] history = 
                 HgCommand.getLogMessages(
                     repository,
-                    new HashSet(Arrays.asList(files)), 
+                    new HashSet<File>(Arrays.asList(files)), 
                     fromRevision, 
                     toRevision, 
                     false, // show merges

--- a/ide/projectapi/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementation.java
+++ b/ide/projectapi/src/org/netbeans/modules/projectapi/SimpleFileOwnerQueryImplementation.java
@@ -90,7 +90,7 @@ public class SimpleFileOwnerQueryImplementation implements FileOwnerQueryImpleme
     
     private final Set<FileObject> warnedAboutBrokenProjects = new WeakSet<FileObject>();
         
-    private Map<FileObject, Reference<Project>> projectCache = new WeakHashMap();    
+    private Map<FileObject, Reference<Project>> projectCache = new WeakHashMap<>();    
     /**
      * 
      * #111892
@@ -143,7 +143,7 @@ public class SimpleFileOwnerQueryImplementation implements FileOwnerQueryImpleme
                     }
                     if (p != null) {
                         synchronized (cacheLock) {
-                            WeakReference<Project> rp = new WeakReference(p);
+                            WeakReference<Project> rp = new WeakReference<>(p);
                             for (FileObject fldr : folders) {
                                 projectCache.put(fldr, rp);
                             }

--- a/ide/projectuiapi/nbproject/project.properties
+++ b/ide/projectuiapi/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 spec.version.base=1.95.0
 is.autoload=true
 javadoc.arch=${basedir}/arch.xml

--- a/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesLegacy.java
+++ b/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesLegacy.java
@@ -42,7 +42,7 @@ public final class ProjectTemplateAttributesLegacy implements CreateFromTemplate
     public Map<String, ?> attributesFor(DataObject template, DataFolder target, String name) {
         FileObject targetF = target.getPrimaryFile();
         Project prj = FileOwnerQuery.getOwner(targetF);
-        Map<String, Object> all = new HashMap();
+        Map<String, Object> all = new HashMap<>();
         if (prj != null) {
             // call old providers
             Collection<? extends CreateFromTemplateAttributesProvider> oldProvs = prj.getLookup().lookupAll(CreateFromTemplateAttributesProvider.class);

--- a/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesProvider.java
+++ b/ide/projectuiapi/src/org/netbeans/modules/project/uiapi/ProjectTemplateAttributesProvider.java
@@ -60,7 +60,7 @@ public final class ProjectTemplateAttributesProvider implements CreateFromTempla
         FileObject targetF = desc.getTarget();
         String name = desc.getProposedName();
         Project prj = FileOwnerQuery.getOwner(targetF);
-        Map<String, Object> all = new HashMap();
+        Map<String, Object> all = new HashMap<>();
         boolean needFill = true;
         if (prj != null) {
             // call old providers

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebuggingViewComponent.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebuggingViewComponent.java
@@ -571,7 +571,7 @@ public class DebuggingViewComponent extends TopComponent implements org.openide.
             if (currentThread != null) {
                 DVThread thread = threadMadeCurrentRef != null ? threadMadeCurrentRef.get() : null;
                 if (thread != currentThread) {
-                    threadToScrollRef = new WeakReference(currentThread);
+                    threadToScrollRef = new WeakReference<>(currentThread);
                 }
             }
             refreshView();
@@ -625,7 +625,7 @@ public class DebuggingViewComponent extends TopComponent implements org.openide.
     }
 
     void makeThreadCurrent(DVThread thread) {
-        threadMadeCurrentRef = new WeakReference(thread);
+        threadMadeCurrentRef = new WeakReference<>(thread);
         thread.makeCurrent();
     }
 

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/ThreadsListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/ThreadsListener.java
@@ -46,7 +46,7 @@ public class ThreadsListener extends DebuggerManagerAdapter {
     private static PropertyChangeSupport pchs = new PropertyChangeSupport(ThreadsListener.class);
     private static final ThreadsPropertyChangeListener tpchl = new ThreadsPropertyChangeListener();
     
-    final LinkedList<DVThread> currentThreadsHistory = new LinkedList();
+    final LinkedList<DVThread> currentThreadsHistory = new LinkedList<>();
     final BreakpointHits hits = new BreakpointHits();
     private Map<DVSupport, DebuggerListener> debuggerToListener = new WeakHashMap<DVSupport, DebuggerListener>();
     private DVSupport currentDebugger = null;

--- a/ide/spi.navigator/src/org/netbeans/modules/navigator/NavigatorController.java
+++ b/ide/spi.navigator/src/org/netbeans/modules/navigator/NavigatorController.java
@@ -897,7 +897,7 @@ public final class NavigatorController implements LookupListener, PropertyChange
 
         void setNodes(Node[] nodes) {
             if (nodes != null && nodes.length > 0) {
-                List<Lookup> l = new LinkedList();
+                List<Lookup> l = new LinkedList<>();
                 l.add(panelLookup);
                 for (Node n : nodes) {
                     if (!panelLookup.lookupResult(Object.class).allInstances().containsAll(

--- a/ide/spi.tasklist/nbproject/project.properties
+++ b/ide/spi.tasklist/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 spec.version.base=1.42.0

--- a/ide/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListNode.java
+++ b/ide/team.commons/src/org/netbeans/modules/team/commons/treelist/TreeListNode.java
@@ -338,7 +338,7 @@ public abstract class TreeListNode extends ListNode {
         private Thread t = null;
 
         public void run() {
-            final List<TreeListNode> res[] = new List[1];
+            final List<TreeListNode>[] res = new List[1];
             Runnable r = new Runnable() {
                 public void run() {
                     res[0] = createChildren();

--- a/ide/team.commons/src/org/netbeans/modules/team/ide/spi/IDEProject.java
+++ b/ide/team.commons/src/org/netbeans/modules/team/ide/spi/IDEProject.java
@@ -37,7 +37,7 @@ public abstract class IDEProject {
     private final Icon icon;
     private final URL url;
 
-    private final List<DeleteListener> deleteListeners = new CopyOnWriteArrayList();
+    private final List<DeleteListener> deleteListeners = new CopyOnWriteArrayList<>();
 
     protected IDEProject(String displayName, Icon icon, URL url) {
         this.displayName = displayName;

--- a/ide/versioning.util/src/org/netbeans/modules/turbo/CacheIndex.java
+++ b/ide/versioning.util/src/org/netbeans/modules/turbo/CacheIndex.java
@@ -82,7 +82,7 @@ public abstract class CacheIndex {
             values.addAll(c);
         }
 
-        Set<File> ret = new HashSet();
+        Set<File> ret = new HashSet<>();
         for (Set<File> valuesSet : values) {
             synchronized(this) {
                 ret.addAll(valuesSet);

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
@@ -85,7 +85,7 @@ class DTDGrammar implements ExtendedGrammarQuery {
     public Enumeration queryEntities(String prefix) {
         if (entities == null) return org.openide.util.Enumerations.empty();
         
-        LinkedList list = new LinkedList();
+        List list = new LinkedList();
         Iterator it = entities.iterator();
         while ( it.hasNext()) {
             String next = (String) it.next();

--- a/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/SyntaxElement.java
+++ b/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/SyntaxElement.java
@@ -61,7 +61,7 @@ public abstract class SyntaxElement implements org.netbeans.modules.xml.text.api
         this.support = support;
         this.offset = first.getOffset();
         this.length = to-offset;
-        this.first = new WeakReference(first);
+        this.first = new WeakReference<>(first);
     }
     
     /** returns an instance of first TokenItem of this SyntaxElement.

--- a/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/Source.java
+++ b/java/debugger.jpda.js/src/org/netbeans/modules/debugger/jpda/js/source/Source.java
@@ -64,7 +64,7 @@ public final class Source {
 
     private final String name;
     private final JPDAClassType classType;
-    private final ObservableSet<JPDAClassType> functionClassTypes = new ObservableSet();
+    private final ObservableSet<JPDAClassType> functionClassTypes = new ObservableSet<>();
     private final URL url;          // The original file source
     private final URL runtimeURL;   // The current content in runtime, or null when equal to 'url'
     private final int contentLineShift; // Line shift of 'url' content in 'runtimeURL'. Can not be negative.

--- a/java/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberPanelUI.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/navigation/ClassMemberPanelUI.java
@@ -114,7 +114,7 @@ public class ClassMemberPanelUI extends javax.swing.JPanel
     private static final String CMD_HISTORY = "history";    //NOI18N
     private static final int MIN_HISTORY_WIDTH = 50;
     private static final int HISTORY_HEIGHT = 20;
-    private static final ThreadLocal<Boolean> ignoreJavaDoc = new ThreadLocal();
+    private static final ThreadLocal<Boolean> ignoreJavaDoc = new ThreadLocal<>();
 
     private final ExplorerManager manager = new ExplorerManager();
     private final MyBeanTreeView elementView;

--- a/java/jshell.support/src/org/netbeans/modules/jshell/editor/SnippetClassGenerator.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/editor/SnippetClassGenerator.java
@@ -144,7 +144,7 @@ public class SnippetClassGenerator implements Runnable {
     }
     
     private boolean declarationsDependsOn(Snippet snip) {
-        Deque<Snippet> candidates = new ArrayDeque();
+        Deque<Snippet> candidates = new ArrayDeque<>();
         candidates.add(snip);
         while (!candidates.isEmpty()) {
             Snippet c = candidates.poll();

--- a/java/junit.ant.ui/nbproject/project.properties
+++ b/java/junit.ant.ui/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 requires.nb.javac=true

--- a/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/JUnitProjectOpenedHook.java
+++ b/java/junit.ant.ui/src/org/netbeans/modules/junit/ant/ui/JUnitProjectOpenedHook.java
@@ -222,7 +222,7 @@ public class JUnitProjectOpenedHook implements LookupProvider {
             } else {
                 res = ProjectProblemsProvider.Result.create(ProjectProblemsProvider.Status.UNRESOLVED, "No resolution for the problem");
             }
-            RunnableFuture<ProjectProblemsProvider.Result> f = new FutureTask(new Runnable() {
+            RunnableFuture<ProjectProblemsProvider.Result> f = new FutureTask<>(new Runnable() {
                 @Override
                 public void run() {
                 }

--- a/java/junit.ant/src/org/netbeans/modules/junit/ant/JUnitExecutionManager.java
+++ b/java/junit.ant/src/org/netbeans/modules/junit/ant/JUnitExecutionManager.java
@@ -209,7 +209,7 @@ public class JUnitExecutionManager implements RerunHandler{
             FileObject tmpDir = FileUtil.toFileObject(new File(System.getProperty("java.io.tmpdir")).getCanonicalFile());
             FileObject targetFO = tmpDir.createFolder("junit-custom-" + id);                //NOI18N
 //            DataFolder targetDF = DataFolder.findFolder(targetFO);
-            Map<String,Object> params = new HashMap();
+            Map<String,Object> params = new HashMap<>();
             String testStr = "";
             for(String testClass: toTest.keySet()){
                 testStr += "<test name=\"" + testClass + "\" methods=\"" + toTest.get(testClass) + "\" todir=\"${test.result.dir.custom}\"/>\n"; //NOI18N

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/NexusRepositoryIndexerImpl.java
@@ -1181,7 +1181,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
 
     @Override
     public ResultImplementation<NBVersionInfo> findVersionsByClass(final String className, List<RepositoryInfo> repos) {
-        ResultImpl<NBVersionInfo> result = new ResultImpl(new Redo<NBVersionInfo>() {
+        ResultImpl<NBVersionInfo> result = new ResultImpl<>(new Redo<NBVersionInfo>() {
             @Override
             public void run(ResultImpl<NBVersionInfo> result) {
                 findVersionsByClass(className, result, result.getSkipped(), false);
@@ -1315,7 +1315,7 @@ public class NexusRepositoryIndexerImpl implements RepositoryIndexerImplementati
         Map<String, NBGroupInfo> groupMap = new HashMap<String, NBGroupInfo>();
         Map<String, NBArtifactInfo> artifactMap = new HashMap<String, NBArtifactInfo>();
         List<NBGroupInfo> groupInfos = new ArrayList<NBGroupInfo>(result.getResults());
-        ResultImpl<NBVersionInfo> res = new ResultImpl(new Redo<NBVersionInfo>() {
+        ResultImpl<NBVersionInfo> res = new ResultImpl<>(new Redo<NBVersionInfo>() {
 
             @Override
             public void run(ResultImpl<NBVersionInfo> result) {

--- a/java/maven.model/nbproject/project.properties
+++ b/java/maven.model/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ElementFactoryRegistry.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ElementFactoryRegistry.java
@@ -134,7 +134,7 @@ public class ElementFactoryRegistry {
     
     public void addEmbeddedModelQNames(AbstractDocumentModel embeddedModel) {
         if (knownEmbeddedModelTypes == null) {
-            knownEmbeddedModelTypes = new HashSet();
+            knownEmbeddedModelTypes = new HashSet<>();
         }
         if (! knownEmbeddedModelTypes.contains(embeddedModel.getClass())) {
             knownQNames().addAll(embeddedModel.getQNames());

--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -975,7 +975,7 @@ public final class NbMavenProjectImpl implements Project {
         }
 
         synchronized void attachAll() {
-            this.filesToWatch = new ArrayList(Arrays.asList(fileProvider.getFiles()));
+            this.filesToWatch = new ArrayList<>(Arrays.asList(fileProvider.getFiles()));
             
             filesToWatch.addAll(getParents()); 
             Collections.sort(filesToWatch);

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
@@ -132,11 +132,11 @@ public class Utilities {
             return N_A;
         }       
         if (!archiveCertificates.isEmpty()) {
-            Collection<Certificate> c = new HashSet(trustedCertificates);
+            Collection<Certificate> c = new HashSet<>(trustedCertificates);
             c.retainAll(archiveCertificates);
             if (c.isEmpty()) {                
-                Map<Principal, X509Certificate> certSubjectsMap = new HashMap();               
-                Set<Principal> certIssuersSet = new HashSet();
+                Map<Principal, X509Certificate> certSubjectsMap = new HashMap<>();               
+                Set<Principal> certIssuersSet = new HashSet<>();
                 for (Certificate cert : archiveCertificates) {
                     if (cert != null) {
                         X509Certificate x509Cert = (X509Certificate) cert;
@@ -147,7 +147,7 @@ public class Utilities {
                     }
                 }
                 
-                Map<X509Certificate, X509Certificate> candidates = new HashMap();
+                Map<X509Certificate, X509Certificate> candidates = new HashMap<>();
                     
                 for (Principal p : certSubjectsMap.keySet()) {
                     // cert chain may not be ordered - trust anchor could before certificate itself

--- a/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallUnitWizardModel.java
+++ b/platform/autoupdate.ui/src/org/netbeans/modules/autoupdate/ui/wizards/UninstallUnitWizardModel.java
@@ -38,7 +38,7 @@ public class UninstallUnitWizardModel extends OperationWizardModel {
     /**
      * The nested install operation
      */
-    private OperationContainer  installContainer;
+    private OperationContainer<InstallSupport>  installContainer;
     private OperationContainer<OperationSupport> customContainer;
     
     /**

--- a/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
@@ -100,13 +100,13 @@ public class LocalAddressUtils {
     private static Future<InetAddress[]> fut2;
     private static Future<List<InetAddress>> fut3;
 
-    private static final Callable<InetAddress> C1 = new Callable(){
+    private static final Callable<InetAddress> C1 = new Callable<InetAddress>(){
         @Override
         public InetAddress call() throws UnknownHostException  {
             return InetAddress.getLocalHost();
         }
     };
-    private static final Callable<InetAddress[]> C2 = new Callable(){
+    private static final Callable<InetAddress[]> C2 = new Callable<InetAddress[]>(){
         @Override
         public InetAddress[] call() throws UnknownHostException  {
             try {
@@ -117,7 +117,7 @@ public class LocalAddressUtils {
             }
         }
     };
-    private static final Callable<List<InetAddress>> C3 = new Callable(){
+    private static final Callable<List<InetAddress>> C3 = new Callable<List<InetAddress>>(){
         @Override
         public List<InetAddress> call() {
             return getLocalNetworkInterfaceAddr();

--- a/platform/core.windows/src/org/netbeans/core/windows/LazyLoader.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/LazyLoader.java
@@ -41,7 +41,7 @@ final class LazyLoader {
     private static final boolean NO_LAZY_LOADING = Boolean.getBoolean( "nb.core.windows.no.lazy.loading" ); //NOI!8N
     private boolean isActive = false;
     private boolean isLoading = false;
-    private final Map<ModeImpl, LazyMode> lazyModes = new HashMap(15);
+    private final Map<ModeImpl, LazyMode> lazyModes = new HashMap<>(15);
 
     public LazyLoader() {
         WindowManagerImpl.getInstance().addWindowSystemListener( new WindowSystemListener() {
@@ -158,7 +158,7 @@ final class LazyLoader {
     private static class LazyMode implements Comparable<LazyMode> {
         private int selectedTCposition;
         private final ModeImpl mode;
-        private final Map<String, Integer> id2position = new HashMap(30);
+        private final Map<String, Integer> id2position = new HashMap<>(30);
 
         public LazyMode( ModeImpl mode ) {
             this.mode = mode;

--- a/platform/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/FolderPathLookup.java
+++ b/platform/editor.mimelookup.impl/src/org/netbeans/modules/editor/mimelookup/impl/FolderPathLookup.java
@@ -79,7 +79,7 @@ public final class FolderPathLookup extends AbstractLookup {
      * when asked for both empty and non-empty mime-types).
      * This is crucial for some of the MimeLookup clients.
      */
-    private static final Map<FileObject,InstanceItem> fo2item = new HashMap(128);
+    private static final Map<FileObject,InstanceItem> fo2item = new HashMap<>(128);
     
     static InstanceItem getInstanceItem(FileObject fo, InstanceItem ignoreItem) {
         FileObject real = fo;
@@ -222,7 +222,7 @@ public final class FolderPathLookup extends AbstractLookup {
         if (v != null) {
             return v.allInstances();
         }
-        final Lookup.Result<CustomInstanceFactory> fr[] = new Lookup.Result[1];
+        final Lookup.Result<CustomInstanceFactory>[] fr = new Lookup.Result[1];
         // ensure the system - global Lookup is used
         Lookups.executeWith(null, new Runnable() {
             public void run() {

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/ProvidedExtensionsProxy.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/ProvidedExtensionsProxy.java
@@ -263,7 +263,7 @@ public class ProvidedExtensionsProxy extends ProvidedExtensions {
 
     @Override
     public Object getAttribute(final File file, final String attrName) {
-        final AtomicReference<Object> value = new AtomicReference();
+        final AtomicReference<Object> value = new AtomicReference<>();
         for (BaseAnnotationProvider provider : annotationProviders) {
             final InterceptionListener iListener = (provider != null) ? provider.getInterceptionListener() : null;
             if (iListener instanceof ProvidedExtensions) {

--- a/platform/o.n.bootstrap/src/org/netbeans/PackageAttrsCache.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/PackageAttrsCache.java
@@ -71,7 +71,7 @@ final class PackageAttrsCache implements Stamps.Updater {
             }
         }
         if (tmp == null) {
-            cache = new ConcurrentHashMap();
+            cache = new ConcurrentHashMap<>();
             Stamps.getModulesJARs().scheduleSave(this, CACHE, false);
         } else {
             cache = Collections.unmodifiableMap(tmp);

--- a/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java
+++ b/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java
@@ -187,7 +187,7 @@ public class MIMEResolverProcessor extends LayerGeneratingProcessor {
     }
 
     private Set<String> unq(Collection collection) {
-        Set<String> s = new TreeSet();
+        Set<String> s = new TreeSet<>();
         s.addAll(collection);
         return s;
     }

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/KeymapModel.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/KeymapModel.java
@@ -548,7 +548,7 @@ public class KeymapModel {
             public void run() {
                 KL k = keymapData;
                 if (k != null) {
-                    Map newMap = new HashMap<String, Map<ShortcutAction,Set<String>>>();
+                    Map<String, Map<ShortcutAction,Set<String>>> newMap = new HashMap<>();
                     newMap.putAll(k.keyMaps);
                     newMap.put(profile, m);
                     k.keyMaps = newMap;

--- a/platform/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutsFinderImpl.java
+++ b/platform/options.keymap/src/org/netbeans/modules/options/keymap/ShortcutsFinderImpl.java
@@ -196,7 +196,7 @@ public class ShortcutsFinderImpl implements ShortcutsFinder {
             synchronized (this) {
                 res = shortcutsCache.get(profile);
                 if (res == null) {
-                    Map m = new HashMap(shortcutsCache);
+                    Map<String, Map<ShortcutAction, Set<String>>> m = new HashMap<>(shortcutsCache);
                     m.put(profile, profileMap);
                     shortcutsCache = m;
                     res = profileMap;

--- a/platform/sampler/nbproject/project.properties
+++ b/platform/sampler/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/sampler/src/org/netbeans/modules/sampler/SamplesOutputStream.java
+++ b/platform/sampler/src/org/netbeans/modules/sampler/SamplesOutputStream.java
@@ -68,8 +68,8 @@ class SamplesOutputStream {
         outStream = os;
         writeHeader(os);
 //        out = new ObjectOutputStream(os);
-        lastThreadInfos = new HashMap();
-        steCache = new WeakHashMap(8*1024);
+        lastThreadInfos = new HashMap<>();
+        steCache = new WeakHashMap<>(8*1024);
         samples = new ArrayList<Sample>(1024);
     }
 
@@ -106,7 +106,7 @@ class SamplesOutputStream {
         }
         addSample(new Sample(time, sameT, newT));
         // remove dead threads
-        Set<Long> ids = new HashSet(lastThreadInfos.keySet());
+        Set<Long> ids = new HashSet<>(lastThreadInfos.keySet());
         ids.removeAll(tids);
         lastThreadInfos.keySet().removeAll(ids);
     }

--- a/profiler/profiler.attach/src/org/netbeans/modules/profiler/attach/steps/BasicAttachStepsProvider.java
+++ b/profiler/profiler.attach/src/org/netbeans/modules/profiler/attach/steps/BasicAttachStepsProvider.java
@@ -87,7 +87,7 @@ public class BasicAttachStepsProvider extends AttachStepsProvider {
     protected String currentARCH = LINK_64ARCH;
     
     
-    private final Set<ChangeListener> listeners = new HashSet();
+    private final Set<ChangeListener> listeners = new HashSet<>();
     
     public synchronized final void addChangeListener(ChangeListener listener) {
         listeners.add(listener);

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/AbstractHeapWalkerNode.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/AbstractHeapWalkerNode.java
@@ -74,7 +74,7 @@ public abstract class AbstractHeapWalkerNode extends HeapWalkerNode {
     private Map<Object, Integer> getIndexes() {
         if (indexes == null) {
             HeapWalkerNode[] chldrn = getChildren();
-            indexes = new HashMap(chldrn.length * 4 / 3);
+            indexes = new HashMap<>(chldrn.length * 4 / 3);
             for (int i = 0; i < chldrn.length; i++)
                 indexes.put(chldrn[i], i);
         }

--- a/profiler/profiler.options/nbproject/project.properties
+++ b/profiler/profiler.options/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/profiler/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/ProfilerOptionsContainer.java
+++ b/profiler/profiler.options/src/org/netbeans/modules/profiler/options/ui/v2/ProfilerOptionsContainer.java
@@ -109,7 +109,7 @@ public class ProfilerOptionsContainer extends ProfilerOptionsPanel {
         
         scrollIncrement = new JCheckBox("XXX").getPreferredSize().height; // NOI18N
         
-        JList<ProfilerOptionsPanel> categoriesList = new JList(categoriesModel) {
+        JList<ProfilerOptionsPanel> categoriesList = new JList<ProfilerOptionsPanel>(categoriesModel) {
             public Dimension getPreferredSize() {
                 Dimension dim = super.getPreferredSize();
                 dim.width = Math.max(dim.width + 20, 140);

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/ReferenceChain.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/ReferenceChain.java
@@ -39,7 +39,7 @@ final public class ReferenceChain {
     private static char TYPE_CLASS = 1;
     
     public ReferenceChain(Heap heap, Object obj, ReferenceChain next) {
-        this.obj = new WeakReference(obj);
+        this.obj = new WeakReference<>(obj);
         this.next = next;
         this.heap = heap;
         
@@ -60,7 +60,7 @@ final public class ReferenceChain {
             } else if (type == TYPE_CLASS) {
                 o = heap.getJavaClassByID(id);
             }
-            obj = new WeakReference(o);
+            obj = new WeakReference<>(o);
         }
         return o;
     }

--- a/profiler/profiler.projectsupport/nbproject/project.properties
+++ b/profiler/profiler.projectsupport/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 requires.nb.javac=true

--- a/profiler/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/ProjectUtilities.java
+++ b/profiler/profiler.projectsupport/src/org/netbeans/modules/profiler/projectsupport/utilities/ProjectUtilities.java
@@ -84,7 +84,7 @@ public class ProjectUtilities {
     }
 
     public static Project[] getOpenedProjects() {
-        Set<Project> projects = new HashSet();
+        Set<Project> projects = new HashSet<>();
         for (Project project : OpenProjects.getDefault().getOpenProjects()) // #256930
             if (!project.getClass().getName().equals("org.netbeans.modules.project.ui.LazyProject")) // NOI18N
                 projects.add(project);

--- a/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AVD.java
+++ b/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AVD.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 import java.util.HashMap;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -45,10 +46,10 @@ import org.openide.util.Exceptions;
 public class AVD implements Device {
 
     private String name;
-    private HashMap<String, String> props;
+    private Map<String, String> props;
 
     private AVD() {
-        this.props = new HashMap();
+        this.props = new HashMap<>();
     }
     
     public static Collection<Device> parse(String output) throws IOException {

--- a/webcommon/cordova/src/org/netbeans/modules/cordova/project/CordovaCustomizerPanel.java
+++ b/webcommon/cordova/src/org/netbeans/modules/cordova/project/CordovaCustomizerPanel.java
@@ -299,14 +299,14 @@ public class CordovaCustomizerPanel extends javax.swing.JPanel implements Action
             }
 
 
-            HashSet<CordovaPlugin> pluginsToAdd = new HashSet();
+            HashSet<CordovaPlugin> pluginsToAdd = new HashSet<>();
             pluginsToAdd.addAll(selected);
 
             //plugins to install
             pluginsToAdd.removeAll(getCurrent());
 
             //plugins to remove
-            HashSet<CordovaPlugin> pluginsToRemove = new HashSet();
+            HashSet<CordovaPlugin> pluginsToRemove = new HashSet<>();
             pluginsToRemove.addAll(getCurrent());
             pluginsToRemove.removeAll(selected);
 

--- a/webcommon/html.angular/src/org/netbeans/modules/html/angular/AngularJsEmbeddingProviderPlugin.java
+++ b/webcommon/html.angular/src/org/netbeans/modules/html/angular/AngularJsEmbeddingProviderPlugin.java
@@ -78,8 +78,8 @@ public class AngularJsEmbeddingProviderPlugin extends JsEmbeddingProviderPlugin 
     private HashMap<String, String> propertyToFqn;
     
     public AngularJsEmbeddingProviderPlugin() {
-        this.stack = new LinkedList();
-        this.propertyToFqn = new HashMap();
+        this.stack = new LinkedList<>();
+        this.propertyToFqn = new HashMap<>();
     }
 
     @Override

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
@@ -56,8 +56,8 @@ public class JsObjectImpl extends JsElementImpl implements JsObject {
     private Identifier declarationName;
     private JsObject parent;
     final private List<Occurrence> occurrences = new ArrayList<Occurrence>();
-    final private NavigableMap<Integer, Collection<TypeUsage>> assignments = new TreeMap<Integer, Collection<TypeUsage>>();
-    final private Map<String, Integer>assignmentsReverse = new HashMap();
+    final private NavigableMap<Integer, Collection<TypeUsage>> assignments = new TreeMap<>();
+    final private Map<String, Integer>assignmentsReverse = new HashMap<>();
     private int countOfAssignments = 0;
     private boolean hasName;
     private Documentation documentation;
@@ -389,7 +389,7 @@ public class JsObjectImpl extends JsElementImpl implements JsObject {
     }
 
     protected Collection<TypeUsage> resolveAssignments(JsObject jsObject, int offset, Collection<String> visited) {
-        Collection<TypeUsage> result = new HashSet();
+        Collection<TypeUsage> result = new HashSet<>();
         String fqn = jsObject.getFullyQualifiedName();
         if (visited.contains(fqn)) {
             return result;

--- a/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsUtils.java
+++ b/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/NodeJsUtils.java
@@ -219,8 +219,8 @@ public class NodeJsUtils {
                 return null;
             }
             final StyledDocument document = ec.openDocument();
-            final AtomicReference<String> docContentRef = new AtomicReference();
-            final AtomicReference<BadLocationException> bleRef = new AtomicReference();
+            final AtomicReference<String> docContentRef = new AtomicReference<>();
+            final AtomicReference<BadLocationException> bleRef = new AtomicReference<>();
             document.render(new Runnable() {
 
                 @Override

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/RequireJsDataProvider.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/RequireJsDataProvider.java
@@ -77,7 +77,7 @@ public class RequireJsDataProvider {
     /**
      * Translating names from documentation to the real option names
      */
-    private final static HashMap<String, String> TRANSLATE_NAME = new HashMap();
+    private final static HashMap<String, String> TRANSLATE_NAME = new HashMap<>();
 
     static {
         TRANSLATE_NAME.put("moduleconfig", "config");//NOI18N

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/FSCompletionItem.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/FSCompletionItem.java
@@ -157,7 +157,7 @@ public class FSCompletionItem implements CompletionProposal {
 
         public FSElementHandle(FileObject fo) {
             this.fo = fo;
-            this.representedFiles = new HashSet(1);
+            this.representedFiles = new HashSet<>(1);
             representedFiles.add(fo);
         }
 

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/FSCompletionUtils.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/FSCompletionUtils.java
@@ -65,7 +65,7 @@ public class FSCompletionUtils {
 
         assert relativeTo != null;
 
-        List<CompletionProposal> result = new LinkedList();
+        List<CompletionProposal> result = new LinkedList<>();
 
         int lastSlash = prefix.lastIndexOf('/');
         String pathPrefix;
@@ -79,7 +79,7 @@ public class FSCompletionUtils {
             filePrefix = prefix;
         }
 
-        Set<FileObject> directories = new HashSet();
+        Set<FileObject> directories = new HashSet<>();
         File prefixFile = null;
         if (pathPrefix != null && !pathPrefix.startsWith(".")) { //NOI18N
             if (pathPrefix.length() == 0 && prefix.startsWith(SLASH)) {
@@ -233,7 +233,7 @@ public class FSCompletionUtils {
                 Exceptions.printStackTrace(ex);
             }
             Collection<String> basePaths = new ArrayList<>();
-            Map<String, String> configPaths = new HashMap();
+            Map<String, String> configPaths = new HashMap<>();
 
             if (rIndex != null) {
                 basePaths = rIndex.getBasePaths();

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/RequireJSCodeCompletion.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/RequireJSCodeCompletion.java
@@ -284,7 +284,7 @@ public class RequireJSCodeCompletion implements CompletionProvider {
                     }
                 }
 
-                Map<String, String> mappings = new HashMap();
+                Map<String, String> mappings = new HashMap<>();
                 if (rIndex != null) {
                     mappings.putAll(rIndex.getPathMappings(writtenPath));
                 }

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/index/RequireJsIndex.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/index/RequireJsIndex.java
@@ -49,7 +49,7 @@ public class RequireJsIndex {
     private static final Logger LOGGER = Logger.getLogger(RequireJsIndex.class.getSimpleName());
 
     private final QuerySupport querySupport;
-    private static final Map<Project, RequireJsIndex> INDEXES = new WeakHashMap();
+    private static final Map<Project, RequireJsIndex> INDEXES = new WeakHashMap<>();
     private static boolean areProjectsOpen = false;
 
     public static RequireJsIndex get(Project project) throws IOException {

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/index/RequireJsIndexer.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/editor/index/RequireJsIndexer.java
@@ -55,12 +55,12 @@ public class RequireJsIndexer extends EmbeddingIndexer {
     public static final String FIELD_PACKAGES = "pk"; //NOI18N
     public static final String FIELD_SOURCE_ROOT = "sr"; //NOI18N
 
-    private static final ThreadLocal<Map<URI, Collection<? extends TypeUsage>>> exposedTypes = new ThreadLocal();
-    private static final ThreadLocal<Map<URI, Map<String, String>>> pathsMapping = new ThreadLocal();
-    private static final ThreadLocal<Map<URI, String>> basePath = new ThreadLocal();
-    private static final ThreadLocal<Map<URI, Collection<String>>> usedPlugins = new ThreadLocal();
-    private static final ThreadLocal<Map<URI, Map<String, String>>> packageLocations = new ThreadLocal();
-    private static final ThreadLocal<Map<URI, String>> sourceRoot = new ThreadLocal();
+    private static final ThreadLocal<Map<URI, Collection<? extends TypeUsage>>> exposedTypes = new ThreadLocal<>();
+    private static final ThreadLocal<Map<URI, Map<String, String>>> pathsMapping = new ThreadLocal<>();
+    private static final ThreadLocal<Map<URI, String>> basePath = new ThreadLocal<>();
+    private static final ThreadLocal<Map<URI, Collection<String>>> usedPlugins = new ThreadLocal<>();
+    private static final ThreadLocal<Map<URI, Map<String, String>>> packageLocations = new ThreadLocal<>();
+    private static final ThreadLocal<Map<URI, String>> sourceRoot = new ThreadLocal<>();
 
     @Override
     protected void index(Indexable indexable, Parser.Result parserResult, Context context) {

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/ui/RequireJsPanel.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/ui/RequireJsPanel.java
@@ -285,7 +285,7 @@ final class RequireJsPanel extends JPanel implements HelpCtx.Provider {
     }
     
     private Map<String, String> getPathMappings() {
-        Map<String, String> mappings = new TreeMap();
+        Map<String, String> mappings = new TreeMap<>();
         for (int i = 0; i < pathMappingTableModel.getRowCount(); ++i) {
             String mapping = (String) pathMappingTableModel.getValueAt(i, COLUMN_MAPPING_PATH);
             String localPath = ((LocalPathCell) pathMappingTableModel.getValueAt(i, COLUMN_LOCAL_PATH)).getPath();

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/ClientSideProjectLogicalView.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/ClientSideProjectLogicalView.java
@@ -928,7 +928,7 @@ public class ClientSideProjectLogicalView implements LogicalViewProvider {
         public void stateChanged(ChangeEvent event) {
             Node[] children = original.getChildren().getNodes();
             if (event instanceof VisibilityQueryChangeEvent) {
-                Set<FileObject> fileObjects = new HashSet(Arrays.asList(((VisibilityQueryChangeEvent) event).getFileObjects()));
+                Set<FileObject> fileObjects = new HashSet<>(Arrays.asList(((VisibilityQueryChangeEvent) event).getFileObjects()));
                 for (Node child : children) {
                     if (fileObjects.contains(child.getLookup().lookup(FileObject.class))) {
                         refreshNodes(new Node[] {child});


### PR DESCRIPTION
There are a LOT of the following warnings in the build..

   [repeat] /home/bwalker/src/netbeans/platform/openide.filesystems/src/org/netbeans/modules/openide/filesystems/declmime/MIMEResolverProcessor.java:190: warning: [unchecked] unchecked conversion
   [repeat]         Set<String> s = new TreeSet();
   [repeat]                         ^
   [repeat]   required: Set<String>
   [repeat]   found:    TreeSet

This change cleans up many of these.. But, it's not complete as there are so many of them..