### PR TITLE
[NETBEANS-3550] - cleanup warnings related to deprecated JUnit Asserts

### DIFF
--- a/harness/nbjunit/src/org/netbeans/junit/ControlFlow.java
+++ b/harness/nbjunit/src/org/netbeans/junit/ControlFlow.java
@@ -32,7 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 /** Basic skeleton for logging test case.
  *

--- a/harness/nbjunit/src/org/netbeans/junit/Log.java
+++ b/harness/nbjunit/src/org/netbeans/junit/Log.java
@@ -41,7 +41,7 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 import org.netbeans.junit.internal.NbModuleLogHandler;
 

--- a/harness/nbjunit/src/org/netbeans/junit/MockServices.java
+++ b/harness/nbjunit/src/org/netbeans/junit/MockServices.java
@@ -37,7 +37,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 
 /**

--- a/harness/nbjunit/src/org/netbeans/junit/NbModuleSuite.java
+++ b/harness/nbjunit/src/org/netbeans/junit/NbModuleSuite.java
@@ -53,7 +53,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
-import junit.framework.Assert;
+import org.junit.Assert;
 import junit.framework.AssertionFailedError;
 import junit.framework.Protectable;
 import junit.framework.Test;

--- a/java/java.hints.test/src/org/netbeans/modules/java/hints/test/api/HintTest.java
+++ b/java/java.hints.test/src/org/netbeans/modules/java/hints/test/api/HintTest.java
@@ -54,11 +54,11 @@ import java.util.regex.Pattern;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.Document;
 import javax.tools.Diagnostic;
-import junit.framework.Assert;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertNotSame;
-import static junit.framework.Assert.assertTrue;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 import static junit.framework.TestCase.assertFalse;
 
 import org.netbeans.api.editor.mimelookup.MimeLookup;

--- a/java/performance/src/org/netbeans/modules/performance/utilities/MeasureStartupTimeTestCase.java
+++ b/java/performance/src/org/netbeans/modules/performance/utilities/MeasureStartupTimeTestCase.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 /**
  * Measure startup time by org.netbeans.core.perftool.StartLog. Number of starts


### PR DESCRIPTION
There are quite a few errors msgs that are easy to fix..

    [repeat] /home/bwalker/src/netbeans/harness/nbjunit/src/org/netbeans/junit/NbModuleSuite.java:56: warning: [deprecation] Assert in junit.framework has been deprecated
   [repeat] import junit.framework.Assert;
   [repeat]                       ^

The simple fix is to use the org.junit.Assert class..

-import junit.framework.Assert;
+import org.junit.Assert;

Everything stays the same..