### PR TITLE
[NETBEANS-3551] - Upgrade Apache Commons-IO from 1.4 to 2.6

### DIFF
--- a/platform/o.apache.commons.io/external/binaries-list
+++ b/platform/o.apache.commons.io/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-A8762D07E76CFDE2395257A5DA47BA7C1DBD3DCE commons-io:commons-io:1.4
+815893DF5F31DA2ECE4040FE0A12FD44B577AFAF commons-io:commons-io:2.6

--- a/platform/o.apache.commons.io/external/commons-io-2.6-license.txt
+++ b/platform/o.apache.commons.io/external/commons-io-2.6-license.txt
@@ -1,9 +1,9 @@
 Name: Apache Commons IO
 Description: Assist with developing IO functionality
 Origin: Apache Software Foundation
-Version: 1.4
+Version: 2.6
 License: Apache-2.0
-URL: http://commons.apache.org/io/
+URL: https://commons.apache.org/proper/commons-io/
 
 
 

--- a/platform/o.apache.commons.io/external/commons-io-2.6-notice.txt
+++ b/platform/o.apache.commons.io/external/commons-io-2.6-notice.txt
@@ -1,5 +1,5 @@
 Apache Commons IO
-Copyright 2001-2008 The Apache Software Foundation
+Copyright 2001-2019 The Apache Software Foundation
 
 This product includes software developed by
 The Apache Software Foundation (http://www.apache.org/).

--- a/platform/o.apache.commons.io/manifest.mf
+++ b/platform/o.apache.commons.io/manifest.mf
@@ -1,1 +1,2 @@
 OpenIDE-Module: org.apache.commons.io
+OpenIDE-Module-Specification-Version: 2.6

--- a/platform/o.apache.commons.io/nbproject/project.properties
+++ b/platform/o.apache.commons.io/nbproject/project.properties
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/commons-io-1.4.jar=modules/org-apache-commons-io.jar
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
+release.external/commons-io-2.6.jar=modules/org-apache-commons-io.jar
 is.autoload=true
 nbm.module.author=Tomas Stupka

--- a/platform/o.apache.commons.io/nbproject/project.xml
+++ b/platform/o.apache.commons.io/nbproject/project.xml
@@ -44,7 +44,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-apache-commons-io.jar</runtime-relative-path>
-                <binary-origin>external/commons-io-1.4.jar</binary-origin>
+                <binary-origin>external/commons-io-2.6.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Notes:
- Requires JDK 1.7 or later
- Compatibility with Java 9 module system
- Many fixed bugs
- Improved performance
- Deprecate `Charsets Charset` constants in favor of Java 7's `java.nio.charset.StandardCharsets`
- All `closeQuietly` overloads in `org.apache.commons.io.IOUtils` have been deprecated. Use the `try-with-resources` statement or handle suppressed exceptions manually.
- The class `org.apache.commons.io.FileSystemUtils` has been deprecated. Use equivalent methods in `java.nio.file.FileStore instead`.

[Apache Commons-IO Web Page](https://commons.apache.org/proper/commons-io/)
[Apache Commons-IO Release Notes](https://commons.apache.org/proper/commons-io/upgradeto2_6.html)