### PR TITLE
Updating BugZilla URLs from old Oracle infra to the new ASF one

### DIFF
--- a/nbbuild/javadoctools/apichanges.xsl
+++ b/nbbuild/javadoctools/apichanges.xsl
@@ -65,7 +65,7 @@ committed to the repository for legal reasons. You need to download it:
     <xsl:output method="html"/>
 
     <!-- Overridable parameters: -->
-    <xsl:param name="issue-url-base" select="'https://netbeans.org/bugzilla/show_bug.cgi?id='"/>
+    <xsl:param name="issue-url-base" select="'https://bz.apache.org/netbeans/show_bug.cgi?id='"/>
     <xsl:param name="apache-issue-url-base" select="'https://issues.apache.org/jira/browse/'"/>
     <xsl:param name="javadoc-url-base" select="'???'"/>
 


### PR DESCRIPTION
Now that we have a static snapshot of former NetBeans BugZilla hosted on Apache infrastructure it looks like a good idea to update links everywhere. For example in JavaDoc templates.