### PR TITLE
[NETBEANS-3559] Corrected compiler warnings in Bootstrap project.

### DIFF
--- a/platform/o.n.bootstrap/nbproject/project.properties
+++ b/platform/o.n.bootstrap/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint -Xlint:-serial
+javac.compilerargs=-Xlint:all -Xlint:-serial -Xlint:-processing -Werror
 javac.source=1.8
 module.jar.dir=lib
 module.jar.basename=boot.jar

--- a/platform/o.n.bootstrap/src/org/netbeans/FixedModule.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/FixedModule.java
@@ -219,7 +219,7 @@ final class FixedModule extends Module {
     /** Turn on the classloader. Passed a list of parent modules to use.
      * The parents should already have had their classloaders initialized.
      */
-    protected void classLoaderUp(Set parents) throws IOException {
+    protected void classLoaderUp(Set<Module> parents) throws IOException {
         return; // no need
     }
     

--- a/platform/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/JarClassLoader.java
@@ -205,7 +205,7 @@ public class JarClassLoader extends ProxyClassLoader {
     }
     
     @Override
-    protected Class doLoadClass(String pkgName, String name) {
+    protected Class<?> doLoadClass(String pkgName, String name) {
         String path = name.replace('.', '/').concat(".class"); // NOI18N
         
         // look up the Sources and return a class based on their content
@@ -1139,6 +1139,7 @@ public class JarClassLoader extends ProxyClassLoader {
             return new JarFile(src.file); // #134424
         }
 
+        @SuppressWarnings("rawtypes")
         public @Override Object getContent(Class[] classes) throws IOException {
             if (Arrays.asList(classes).contains(ClassLoader.class)) {
                 return loader;

--- a/platform/o.n.bootstrap/src/org/netbeans/Module.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Module.java
@@ -567,7 +567,9 @@ public abstract class Module extends ModuleInfo {
                 findResources.setAccessible(true);
             }
             ClassLoader cl = getClassLoader();
-            return (Enumeration<URL>) findResources.invoke(cl, resources); // NOI18N
+            @SuppressWarnings("unchecked")
+            Enumeration<URL> en = (Enumeration<URL>) findResources.invoke(cl, resources); // NOI18N
+            return en;
         } catch (Exception x) {
             Exceptions.printStackTrace(x);
             return Enumerations.empty();

--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleInstaller.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleInstaller.java
@@ -191,7 +191,7 @@ public abstract class ModuleInstaller {
      * @since org.netbeans.core/1 > 1.6
      * @see "#27853"
      */
-    public void refineClassLoader(Module m, List parents) {
+    public void refineClassLoader(Module m, List<? extends ClassLoader> parents) {
         // do nothing
     }
 

--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -299,7 +299,7 @@ public final class ModuleManager extends Modules {
         return completeLookup;
     }
     // Access from ChangeFirer:
-    final void fireModulesCreatedDeleted(Set created, Set deleted) {
+    final void fireModulesCreatedDeleted(Set<Module> created, Set<Module> deleted) {
         if (Util.err.isLoggable(Level.FINE)) {
             Util.err.fine("lookup created: " + created + " deleted: " + deleted);
         }
@@ -311,7 +311,7 @@ public final class ModuleManager extends Modules {
      * @see #PROP_MODULES
      */
     public Set<Module> getModules() {
-        return new HashSet<Module>(modules);
+        return new HashSet<>(modules);
     }
 
     final int getModuleCount() {
@@ -731,7 +731,7 @@ public final class ModuleManager extends Modules {
         }
 
         @Override
-        protected synchronized Class loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
             ProxyClassLoader priviledged = null;
             NetigsoLoader osgi = null;
             if (!name.startsWith("java.")) { // NOI18N
@@ -896,7 +896,7 @@ public final class ModuleManager extends Modules {
         return installer.refineProvides (m);
     }
     /** Used by Module to communicate with the ModuleInstaller re. classloader. */
-    public ClassLoader refineClassLoader(Module m, List parents) {
+    public ClassLoader refineClassLoader(Module m, List<? extends ClassLoader> parents) {
         // #27853:
         installer.refineClassLoader(m, parents);
         // if fragment, integrate into the host's classloader. Should be called under mutex()

--- a/platform/o.n.bootstrap/src/org/netbeans/NbInstrumentation.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/NbInstrumentation.java
@@ -151,11 +151,13 @@ final class NbInstrumentation implements Instrumentation {
         return false;
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public Class[] getAllLoadedClasses() {
         return new Class[0];
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     public Class[] getInitiatedClasses(ClassLoader loader) {
         return new Class[0];

--- a/platform/o.n.bootstrap/src/org/netbeans/NetigsoHandle.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/NetigsoHandle.java
@@ -166,7 +166,9 @@ final class NetigsoHandle {
         }
         List<Module> clone;
         synchronized (toEnable) {
-            clone = (List<Module>) toEnable.clone();
+            @SuppressWarnings("unchecked")
+            List<Module> cloneTmp = (List<Module>) toEnable.clone();
+            clone = cloneTmp;
             toEnable.clear();
         }
         if (!clone.isEmpty()) {
@@ -196,7 +198,7 @@ final class NetigsoHandle {
         
         ClassLoader frameworkLoader = f.findFrameworkClassLoader();
         
-        Class[] stack = TopSecurityManager.getStack();
+        Class<?>[] stack = TopSecurityManager.getStack();
         for (int i = 0; i < stack.length; i++) {
             ClassLoader sl = stack[i].getClassLoader();
             if (sl == null) {

--- a/platform/o.n.bootstrap/src/org/netbeans/NetigsoModule.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/NetigsoModule.java
@@ -241,7 +241,7 @@ final class NetigsoModule extends Module {
         }
 
         @Override
-        protected Class loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
             try {
                 return delegate().loadClass(name, resolve);
             } catch (IllegalStateException ex) {

--- a/platform/o.n.bootstrap/src/org/netbeans/PatchByteCode.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/PatchByteCode.java
@@ -88,6 +88,7 @@ public final class PatchByteCode {
             Properties props = new Properties();
             props.load(new InputStreamReader(istm, "UTF-8")); // NOI18N
             
+            @SuppressWarnings("unchecked")
             Enumeration<String> en = (Enumeration<String>)props.propertyNames();
             
             while (en.hasMoreElements()) {

--- a/platform/o.n.bootstrap/src/org/netbeans/ProxyClassLoader.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ProxyClassLoader.java
@@ -120,9 +120,9 @@ public class ProxyClassLoader extends ClassLoader {
      * @exception ClassNotFoundException if the class could not be found
      */
     @Override
-    protected synchronized Class loadClass(String name, boolean resolve)
+    protected synchronized Class<?> loadClass(String name, boolean resolve)
                                             throws ClassNotFoundException {
-        final Class cls = doFindClass(name);
+        final Class<?> cls = doFindClass(name);
         if (resolve) resolveClass(cls); 
         return cls; 
     }
@@ -239,7 +239,7 @@ public class ProxyClassLoader extends ClassLoader {
     private static final Set<String> arbitraryLoadWarnings = Collections.synchronizedSet(new HashSet<String>());
 
     /** May return null */ 
-    private synchronized Class selfLoadClass(String pkg, String name) { 
+    private synchronized Class<?> selfLoadClass(String pkg, String name) { 
         Class<?> cls = findLoadedClass(name); 
         if (cls == null) {
             try {
@@ -265,7 +265,7 @@ public class ProxyClassLoader extends ClassLoader {
      * @param  name the name of the class
      * @return the resulting <code>Class</code> object or <code>null</code>
      */
-    protected Class doLoadClass(String pkg, String name) {
+    protected Class<?> doLoadClass(String pkg, String name) {
         return null;
     }
     

--- a/platform/o.n.bootstrap/src/org/netbeans/Stamps.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Stamps.java
@@ -986,7 +986,8 @@ public final class Stamps {
             dos.writeUTF(codeName);
             dos.writeUTF(relPath);
         } else {
-            Collection coll = (Collection) out;
+            @SuppressWarnings("unchecked")
+            Collection<String> coll = (Collection<String>) out;
             coll.add(codeName);
             coll.add(relPath);
         }

--- a/platform/o.n.bootstrap/src/org/netbeans/TopSecurityManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/TopSecurityManager.java
@@ -165,7 +165,7 @@ public class TopSecurityManager extends SecurityManager {
     }
     
     static boolean officialExit = false;
-    static Class[] getStack() {
+    static Class<?>[] getStack() {
         SecurityManager s = System.getSecurityManager();
         TopSecurityManager t;
         if (s instanceof TopSecurityManager) {
@@ -197,6 +197,7 @@ public class TopSecurityManager extends SecurityManager {
         super.checkExit(status);
     }
 
+    @SuppressWarnings("deprecation")
     public boolean checkTopLevelWindow(Object window) {
         return checkTopLevelWindow(new AWTPermission("showWindowWithoutWarningBanner"), window); // NOI18N
     }
@@ -387,6 +388,7 @@ public class TopSecurityManager extends SecurityManager {
 
     private final Set<Class<?>> warnedSunMisc = new WeakSet<>();
     private final Set<String> callerWhiteList = createCallerWhiteList();
+    @SuppressWarnings("deprecation")
     public void checkMemberAccess(Class<?> clazz, int which) {
         final String n = clazz.getName();
         if (n.startsWith("sun.misc")) { // NOI18N
@@ -570,7 +572,7 @@ public class TopSecurityManager extends SecurityManager {
 //        }
 //    }
 //
-    private Class getInsecureClass() {
+    private Class<?> getInsecureClass() {
 
         Class<?>[] ctx = getClassContext();
         boolean firstACClass = false;
@@ -607,7 +609,7 @@ LOOP:   for (int i = 0; i < ctx.length; i++) {
     }
 
     /** Checks if the class is loaded through the nbfs URL */
-    static boolean isSecureClass(final Class clazz) {
+    static boolean isSecureClass(final Class<?> clazz) {
         URL source = getClassURL(clazz);
         if (source != null) {
             return isSecureProtocol(source.getProtocol());
@@ -618,7 +620,7 @@ LOOP:   for (int i = 0; i < ctx.length; i++) {
     
     /** @return a protocol through which was the class loaded (file://...) or null
     */
-    static URL getClassURL(Class clazz) {
+    static URL getClassURL(Class<?> clazz) {
         java.security.CodeSource cs = clazz.getProtectionDomain().getCodeSource();                                                     
         if (cs != null) {
             URL url = cs.getLocation();
@@ -628,7 +630,7 @@ LOOP:   for (int i = 0; i < ctx.length; i++) {
         }
     }
 
-    static Field getUrlField(Class clazz) {
+    static Field getUrlField(Class<?> clazz) {
         if (urlField == null) {
             try {
                 Field[] fds = clazz.getDeclaredFields();

--- a/platform/o.n.bootstrap/src/org/netbeans/Util.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Util.java
@@ -454,9 +454,8 @@ public final class Util {
         /** Fire changes to all result listeners. */
         public void changed() {
             synchronized (results) {
-                Iterator it = results.iterator();
-                while (it.hasNext()) {
-                    ((ModuleResult)it.next()).changed();
+                for (ModuleResult moduleResult : results) {
+                    moduleResult.changed();
                 }
             }
         }

--- a/platform/o.n.bootstrap/test/unit/src/org/fakepkg/FakeHandler.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/fakepkg/FakeHandler.java
@@ -30,7 +30,7 @@ import org.netbeans.CLIHandler;
 @org.openide.util.lookup.ServiceProvider(service=org.netbeans.CLIHandler.class)
 public class FakeHandler extends CLIHandler {
     public static Runnable toRun;
-    public static Map chained;
+    public static Map<CLIHandler.Args, Integer> chained;
 
     /** Creates a new instance of FakeHandler */
     public FakeHandler() {
@@ -46,7 +46,7 @@ public class FakeHandler extends CLIHandler {
 
     protected int cli(CLIHandler.Args args) {
         if (chained != null) {
-            Integer i = (Integer)chained.get(args);
+            Integer i = chained.get(args);
             return i.intValue();
         }
         return 0;

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/CountingSecurityManager.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/CountingSecurityManager.java
@@ -23,7 +23,7 @@ import java.io.FileDescriptor;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.security.Permission;
-import junit.framework.Assert;
+import org.junit.Assert;
 
 /**
  *

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleFactoryAlienTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleFactoryAlienTest.java
@@ -349,8 +349,8 @@ public class ModuleFactoryAlienTest extends SetupHid {
         }
 
         @Override
-        protected synchronized Class loadClass(String name, boolean resolve) throws ClassNotFoundException {
-            Class c = findLoadedClass(name);
+        protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            Class<?> c = findLoadedClass(name);
             if (c != null) {
                 return c;
             }

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleFactoryTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleFactoryTest.java
@@ -191,7 +191,7 @@ public class ModuleFactoryTest extends ModuleManagerTest {
         public void reload() throws IOException {
         }
         @Override
-        protected void classLoaderUp(Set parents) throws IOException {
+        protected void classLoaderUp(Set<Module> parents) throws IOException {
             classloader = new JarClassLoader(Collections.<File>emptyList(), new ClassLoader[] {new NoOpClassLoader()});
         }
         @Override
@@ -220,7 +220,7 @@ public class ModuleFactoryTest extends ModuleManagerTest {
         NoOpClassLoader() {
 	    super(ClassLoader.getSystemClassLoader());
 	}
-        protected @Override Class loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        protected @Override Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
             if ("java.lang.String".equals(name)) {
                 throw new ClassNotFoundException("NoOpClassLoader cannot load " + name);
             }

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerTest.java
@@ -206,7 +206,7 @@ public class ModuleManagerTest extends SetupHid {
             }
             assertEquals(Collections.EMPTY_SET, m1.getProblems());
             assertEquals(Collections.EMPTY_SET, m2.getProblems());
-            List toEnable = mgr.simulateEnable(Collections.singleton(m2));
+            List<Module> toEnable = mgr.simulateEnable(Collections.singleton(m2));
             assertEquals("correct result of simulateEnable", Arrays.asList(m1, m2), toEnable);
             mgr.enable(Collections.singleton(m2));
             assertEquals(Arrays.asList(
@@ -259,7 +259,7 @@ public class ModuleManagerTest extends SetupHid {
             }
             assertEquals(Collections.EMPTY_SET, m1.getProblems());
             assertEquals(Collections.EMPTY_SET, m2.getProblems());
-            List toEnable = mgr.simulateEnable(Collections.singleton(m1));
+            List<Module> toEnable = mgr.simulateEnable(Collections.singleton(m1));
             assertEquals("correct result of simulateEnable", Arrays.asList(m1, m2), toEnable);
             mgr.enable(Collections.singleton(m1));
             assertEquals(Arrays.asList(
@@ -304,7 +304,7 @@ public class ModuleManagerTest extends SetupHid {
             Module m1 = mgr.create(new File(jars, "simple-module.jar"), null, false, true, false);
             Module m2 = mgr.create(new File(jars, "depends-on-simple-module.jar"), null, false, false, false);
             Module m3 = mgr.create(new File(jars, "dep-on-dep-on-simple.jar"), null, false, false, true);
-            List toEnable = mgr.simulateEnable(Collections.singleton(m2));
+            List<Module> toEnable = mgr.simulateEnable(Collections.singleton(m2));
             assertEquals("correct result of simulateEnable", Arrays.asList(m1, m2, m3), toEnable);
             mgr.enable(Collections.singleton(m2));
             assertEquals(Arrays.asList(
@@ -360,13 +360,13 @@ public class ModuleManagerTest extends SetupHid {
             assertTrue(m1.isEnabled());
             assertFalse(m2.isEnabled());
             assertTrue(m3.isEnabled());
-            List toEnable = mgr.simulateEnable(Collections.singleton(m2));
+            List<Module> toEnable = mgr.simulateEnable(Collections.singleton(m2));
             assertEquals("correct result of simulateEnable", Collections.singletonList(m2), toEnable);
             mgr.enable(Collections.singleton(m2));
             assertTrue(m1.isEnabled());
             assertTrue(m2.isEnabled());
             assertTrue(m3.isEnabled());
-            List toDisable = mgr.simulateDisable(Collections.singleton(m2));
+            List<Module> toDisable = mgr.simulateDisable(Collections.singleton(m2));
             assertEquals("correct result of simulateDisable", Collections.singletonList(m2), toDisable);
             mgr.disable(Collections.singleton(m2));
             assertTrue(m1.isEnabled());
@@ -629,7 +629,7 @@ public class ModuleManagerTest extends SetupHid {
             // Make sure that classloading is OK:
             Module m = mgr.create(new File(jars, "depends-on-lib-undecl.jar"), null, false, false, false);
             mgr.enable(m);
-            Class c = m.getClassLoader().loadClass("org.dol.User");
+            Class<?> c = m.getClassLoader().loadClass("org.dol.User");
             Object o = c.newInstance();
             Field f = c.getField("val");
             assertEquals(42, f.getInt(o));
@@ -862,7 +862,7 @@ public class ModuleManagerTest extends SetupHid {
         try {
             Module m = mgr.create(new File(jars, "patchable.jar"), null, false, false, false);
             mgr.enable(m);
-            Class c = m.getClassLoader().loadClass("pkg.subpkg.A");
+            Class<?> c = m.getClassLoader().loadClass("pkg.subpkg.A");
             Field f = c.getField("val");
             Object o = c.newInstance();
             assertEquals(25, f.getInt(o));
@@ -913,7 +913,7 @@ public class ModuleManagerTest extends SetupHid {
                 m2,
                 Arrays.asList(m1, m2)
             ), installer.args);
-            Class testclazz = Class.forName("org.prov_foo.Clazz", true, m1.getClassLoader());
+            Class<?> testclazz = Class.forName("org.prov_foo.Clazz", true, m1.getClassLoader());
             try {
                 Class.forName("org.prov_foo.Clazz", true, m2.getClassLoader());
                 fail("Should not be able to access classes due to prov-req deps only");
@@ -1161,7 +1161,7 @@ public class ModuleManagerTest extends SetupHid {
                 m1,
                 Arrays.asList(m2, m1)
             ), installer.args);
-            Class testclazz = Class.forName("org.prov_foo.Clazz", true, m1.getClassLoader());
+            Class<?> testclazz = Class.forName("org.prov_foo.Clazz", true, m1.getClassLoader());
             try {
                 Class.forName("org.prov_foo.Clazz", true, m2.getClassLoader());
                 fail("Should not be able to access classes due to prov-req deps only");
@@ -1227,7 +1227,7 @@ public class ModuleManagerTest extends SetupHid {
             // m3 is eager module, which depends on m2
             Module m3 = mgr.create(new File(jars, "dep-on-needs_foo-simple.jar"), null, false, false, true);
             
-            mgr.enable(Collections.EMPTY_SET);
+            mgr.enable(Collections.emptySet());
             // since m1 is disabled, eager module m3 should be still disabled
             assertFalse("Incorrectly enabled m1",m1.isEnabled());
             assertFalse("Incorrectly enabled m2",m2.isEnabled());
@@ -1326,7 +1326,7 @@ public class ModuleManagerTest extends SetupHid {
                 m1,
                 Arrays.asList(m2, m1)
             ), installer.args);
-            Class testclazz = Class.forName("org.prov_foo.Clazz", true, m1.getClassLoader());
+            Class<?> testclazz = Class.forName("org.prov_foo.Clazz", true, m1.getClassLoader());
             try {
                 Class.forName("org.prov_foo.Clazz", true, m2.getClassLoader());
                 fail("Should not be able to access classes due to prov-req deps only");
@@ -1475,7 +1475,7 @@ public class ModuleManagerTest extends SetupHid {
                 m3 = mgr.create(copyJar(m2.getJarFile(), manifest), null, false, true, false);
             }
             
-            Set allThreeModules = new HashSet<Module>(Arrays.asList(m1, m3, m2));
+            Set<Module> allThreeModules = new HashSet<>(Arrays.asList(m1, m3, m2));
             
             toEnable = mgr.simulateEnable(new HashSet<Module>(m2List));
             assertEquals("all 3 need to be enabled", allThreeModules, new HashSet<Module>(toEnable));
@@ -1855,7 +1855,7 @@ public class ModuleManagerTest extends SetupHid {
         try {
             Module m = mgr.create(jar, null, false, false, false);
             mgr.enable(m);
-            Class c = m.getClassLoader().loadClass("org.foo.Something");
+            Class<?> c = m.getClassLoader().loadClass("org.foo.Something");
             URL u = m.getClassLoader().getResource("org/foo/Something.class");
             URLConnection uc = u.openConnection();
             assertNotNull("connetion", uc);
@@ -1864,9 +1864,9 @@ public class ModuleManagerTest extends SetupHid {
             mgr.disable(m);
             mgr.delete(m);
 
-            WeakReference<Class> refC = new WeakReference<Class>(c);
-            WeakReference<URL> refU = new WeakReference<URL>(u);
-            WeakReference<URLConnection> refUC = new WeakReference<URLConnection>(uc);
+            WeakReference<Class<?>> refC = new WeakReference<>(c);
+            WeakReference<URL> refU = new WeakReference<>(u);
+            WeakReference<URLConnection> refUC = new WeakReference<>(uc);
 
             c = null;
             u = null;
@@ -2238,31 +2238,31 @@ public class ModuleManagerTest extends SetupHid {
             Module m1 = mgr.create(new File(jars, "simple-module.jar"), null, false, false, false);
             Module m2 = mgr.create(new File(jars, "depends-on-simple-module.jar"), null, false, false, false);
             Module m3 = mgr.create(new File(jars, "dep-on-dep-on-simple.jar"), null, false, false, false);
-            Set<Module> m1m2 = new HashSet<Module>(Arrays.asList(m1, m2));
-            Set<Module> m2m3 = new HashSet<Module>(Arrays.asList(m2, m3));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, false));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, true));
-            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m1, true, false));
-            assertEquals(m2m3, mgr.getModuleInterdependencies(m1, true, true));
-            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, false));
-            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, true));
-            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, false));
-            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, true));
-            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m3, false, false));
-            assertEquals(m1m2, mgr.getModuleInterdependencies(m3, false, true));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, false));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, true));
+            Set<Module> m1m2 = new HashSet<>(Arrays.asList(m1, m2));
+            Set<Module> m2m3 = new HashSet<>(Arrays.asList(m2, m3));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, false, true));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, true, true));
+            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m1, true, false, true));
+            assertEquals(m2m3, mgr.getModuleInterdependencies(m1, true, true, true));
+            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, false, true));
+            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, true, true));
+            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, false, true));
+            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, true, true));
+            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m3, false, false, true));
+            assertEquals(m1m2, mgr.getModuleInterdependencies(m3, false, true, true));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, false, true));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, true, true));
             m1 = mgr.create(new File(jars, "prov-foo.jar"), null, false, false, false);
             m2 = mgr.create(new File(jars, "prov-foo-bar.jar"), null, false, false, false);
             m3 = mgr.create(new File(jars, "req-foo.jar"), null, false, false, false);
             Module m4 = mgr.create(new File(jars, "prov-baz.jar"), null, false, false, false);
             Module m5 = mgr.create(new File(jars, "req-foo-baz.jar"), null, false, false, false);
-            m1m2 = new HashSet<Module>(Arrays.asList(m1, m2));
-            assertEquals(m1m2, mgr.getModuleInterdependencies(m3, false, true));
-            Set<Module> m1m2m4 = new HashSet<Module>(Arrays.asList(m1, m2, m4));
-            assertEquals(m1m2m4, mgr.getModuleInterdependencies(m5, false, true));
-            Set<Module> m3m5 = new HashSet<Module>(Arrays.asList(m3, m5));
-            assertEquals(m3m5, mgr.getModuleInterdependencies(m1, true, true));
+            m1m2 = new HashSet<>(Arrays.asList(m1, m2));
+            assertEquals(m1m2, mgr.getModuleInterdependencies(m3, false, true, true));
+            Set<Module> m1m2m4 = new HashSet<>(Arrays.asList(m1, m2, m4));
+            assertEquals(m1m2m4, mgr.getModuleInterdependencies(m5, false, true, true));
+            Set<Module> m3m5 = new HashSet<>(Arrays.asList(m3, m5));
+            assertEquals(m3m5, mgr.getModuleInterdependencies(m1, true, true, true));
             // XXX could do more...
         } finally {
             mgr.mutexPrivileged().exitWriteAccess();
@@ -2295,20 +2295,20 @@ public class ModuleManagerTest extends SetupHid {
             Module m1 = mgr.create(f1, null, false, false, false);
             Module m2 = mgr.create(f2, null, false, false, false);
             Module m3 = mgr.create(f3, null, false, false, false);
-            Set<Module> m1m2 = new HashSet<Module>(Arrays.asList(m1, m2));
-            Set<Module> m2m3 = new HashSet<Module>(Arrays.asList(m2, m3));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, false));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, true));
-            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m1, true, false));
-            assertEquals(m2m3, mgr.getModuleInterdependencies(m1, true, true));
-            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, false));
-            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, true));
-            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, false));
-            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, true));
-            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m3, false, false));
-            assertEquals(m1m2, mgr.getModuleInterdependencies(m3, false, true));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, false));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, true));
+            Set<Module> m1m2 = new HashSet<>(Arrays.asList(m1, m2));
+            Set<Module> m2m3 = new HashSet<>(Arrays.asList(m2, m3));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, false, true));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, true, true));
+            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m1, true, false, true));
+            assertEquals(m2m3, mgr.getModuleInterdependencies(m1, true, true, true));
+            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, false, true));
+            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, true, true));
+            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, false, true));
+            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, true, true));
+            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m3, false, false, true));
+            assertEquals(m1m2, mgr.getModuleInterdependencies(m3, false, true, true));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, false, true));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, true, true));
         } finally {
             mgr.mutexPrivileged().exitWriteAccess();
         }
@@ -2342,20 +2342,20 @@ public class ModuleManagerTest extends SetupHid {
             Module m1 = mgr.create(f1, null, false, false, false);
             Module m2 = mgr.create(f2, null, false, false, false);
             Module m3 = mgr.create(f3, null, false, false, false);
-            Set<Module> m1m2 = new HashSet<Module>(Arrays.asList(m1, m2));
-            Set<Module> m2m3 = new HashSet<Module>(Arrays.asList(m2, m3));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, false));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, true));
-            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m1, true, false));
-            assertEquals(m2m3, mgr.getModuleInterdependencies(m1, true, true));
-            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, false));
-            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, true));
-            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, false));
-            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, true));
-            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m3, false, false));
-            assertEquals(m1m2, mgr.getModuleInterdependencies(m3, false, true));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, false));
-            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, true));
+            Set<Module> m1m2 = new HashSet<>(Arrays.asList(m1, m2));
+            Set<Module> m2m3 = new HashSet<>(Arrays.asList(m2, m3));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, false, true));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m1, false, true, true));
+            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m1, true, false, true));
+            assertEquals(m2m3, mgr.getModuleInterdependencies(m1, true, true, true));
+            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, false, true));
+            assertEquals(Collections.singleton(m1), mgr.getModuleInterdependencies(m2, false, true, true));
+            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, false, true));
+            assertEquals(Collections.singleton(m3), mgr.getModuleInterdependencies(m2, true, true, true));
+            assertEquals(Collections.singleton(m2), mgr.getModuleInterdependencies(m3, false, false, true));
+            assertEquals(m1m2, mgr.getModuleInterdependencies(m3, false, true, true));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, false, true));
+            assertEquals(Collections.EMPTY_SET, mgr.getModuleInterdependencies(m3, true, true, true));
         } finally {
             mgr.mutexPrivileged().exitWriteAccess();
         }
@@ -2378,18 +2378,18 @@ public class ModuleManagerTest extends SetupHid {
             jar = new File(dir, "client.jar");
             TestFileUtils.writeZipFile(jar, "META-INF/MANIFEST.MF:OpenIDE-Module: client\nOpenIDE-Module-Module-Dependencies: api\n\n");
             Module client = mgr.create(jar, null, false, false, false);
-            assertEquals(Collections.singleton(api), mgr.getModuleInterdependencies(impl, false, false));
-            assertEquals(Collections.singleton(api), mgr.getModuleInterdependencies(impl, false, true));
-            assertEquals(Collections.singleton(api), mgr.getModuleInterdependencies(impl, true, false));
-            assertEquals(new HashSet<Module>(Arrays.asList(api, client)), mgr.getModuleInterdependencies(impl, true, true));
-            assertEquals(Collections.singleton(api), mgr.getModuleInterdependencies(client, false, false));
-            assertEquals(new HashSet<Module>(Arrays.asList(api, impl)), mgr.getModuleInterdependencies(client, false, true));
-            assertEquals(Collections.emptySet(), mgr.getModuleInterdependencies(client, true, false));
-            assertEquals(Collections.emptySet(), mgr.getModuleInterdependencies(client, true, true));
-            assertEquals(Collections.singleton(impl), mgr.getModuleInterdependencies(api, false, false));
-            assertEquals(Collections.singleton(impl), mgr.getModuleInterdependencies(api, false, true));
-            assertEquals(new HashSet<Module>(Arrays.asList(impl, client)), mgr.getModuleInterdependencies(api, true, false));
-            assertEquals(new HashSet<Module>(Arrays.asList(impl, client)), mgr.getModuleInterdependencies(api, true, true));
+            assertEquals(Collections.singleton(api), mgr.getModuleInterdependencies(impl, false, false, true));
+            assertEquals(Collections.singleton(api), mgr.getModuleInterdependencies(impl, false, true, true));
+            assertEquals(Collections.singleton(api), mgr.getModuleInterdependencies(impl, true, false, true));
+            assertEquals(new HashSet<Module>(Arrays.asList(api, client)), mgr.getModuleInterdependencies(impl, true, true, true));
+            assertEquals(Collections.singleton(api), mgr.getModuleInterdependencies(client, false, false, true));
+            assertEquals(new HashSet<Module>(Arrays.asList(api, impl)), mgr.getModuleInterdependencies(client, false, true, true));
+            assertEquals(Collections.emptySet(), mgr.getModuleInterdependencies(client, true, false, true));
+            assertEquals(Collections.emptySet(), mgr.getModuleInterdependencies(client, true, true, true));
+            assertEquals(Collections.singleton(impl), mgr.getModuleInterdependencies(api, false, false, true));
+            assertEquals(Collections.singleton(impl), mgr.getModuleInterdependencies(api, false, true, true));
+            assertEquals(new HashSet<Module>(Arrays.asList(impl, client)), mgr.getModuleInterdependencies(api, true, false, true));
+            assertEquals(new HashSet<Module>(Arrays.asList(impl, client)), mgr.getModuleInterdependencies(api, true, true, true));
         } finally {
             mgr.mutexPrivileged().exitWriteAccess();
         }
@@ -2408,15 +2408,15 @@ public class ModuleManagerTest extends SetupHid {
             jar = new File(dir, "b.jar");
             TestFileUtils.writeZipFile(jar, "META-INF/MANIFEST.MF:OpenIDE-Module: b\nOpenIDE-Module-Needs: T2\nOpenIDE-Module-Provides: T1\n\n");
             Module b = mgr.create(jar, null, false, false, false);
-            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, false, false));
-            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, false, true));
-            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, true, false));
-            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, true, true));
-            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, false, false));
-            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, false, true));
-            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, true, false));
-            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, true, true));
-            Set<Module> both = new HashSet<Module>(Arrays.asList(a, b));
+            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, false, false, true));
+            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, false, true, true));
+            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, true, false, true));
+            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, true, true, true));
+            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, false, false, true));
+            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, false, true, true));
+            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, true, false, true));
+            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, true, true, true));
+            Set<Module> both = new HashSet<>(Arrays.asList(a, b));
             assertEquals(both, new HashSet<Module>(mgr.simulateEnable(Collections.singleton(a))));
             assertEquals(both, new HashSet<Module>(mgr.simulateEnable(Collections.singleton(b))));
             mgr.enable(both);
@@ -2432,15 +2432,15 @@ public class ModuleManagerTest extends SetupHid {
             jar = new File(dir, "b.jar");
             TestFileUtils.writeZipFile(jar, "META-INF/MANIFEST.MF:OpenIDE-Module: b\nOpenIDE-Module-Needs: T2\nOpenIDE-Module-Provides: T1\n\n");
             b = mgr.create(jar, null, false, false, false);
-            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, false, false));
-            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, false, true));
-            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, true, false));
-            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, true, true));
-            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, false, false));
-            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, false, true));
-            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, true, false));
-            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, true, true));
-            both = new HashSet<Module>(Arrays.asList(a, b));
+            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, false, false, true));
+            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, false, true, true));
+            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, true, false, true));
+            assertEquals(Collections.singleton(a), mgr.getModuleInterdependencies(b, true, true, true));
+            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, false, false, true));
+            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, false, true, true));
+            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, true, false, true));
+            assertEquals(Collections.singleton(b), mgr.getModuleInterdependencies(a, true, true, true));
+            both = new HashSet<>(Arrays.asList(a, b));
             assertEquals(both, new HashSet<Module>(mgr.simulateEnable(Collections.singleton(a))));
             assertEquals(both, new HashSet<Module>(mgr.simulateEnable(Collections.singleton(b))));
             mgr.enable(both);
@@ -2694,9 +2694,9 @@ public class ModuleManagerTest extends SetupHid {
             mgr.enable(mod1);
             Module mod2 = mgr.create(mod2JAR, null, false, false, false);
             mgr.enable(mod2);
-            Class c1 = mod1.getClassLoader().loadClass("pkg.C1");
-            Class c2 = mod1.getClassLoader().loadClass("pkg.C2");
-            Class c3 = mod2.getClassLoader().loadClass("pkg.C3");
+            Class<?> c1 = mod1.getClassLoader().loadClass("pkg.C1");
+            Class<?> c2 = mod1.getClassLoader().loadClass("pkg.C2");
+            Class<?> c3 = mod2.getClassLoader().loadClass("pkg.C3");
             assertTrue(mod1.owns(c1));
             assertTrue(mod1.owns(c2));
             assertFalse(mod1.owns(c3));
@@ -2721,10 +2721,10 @@ public class ModuleManagerTest extends SetupHid {
             assertEquals(l, mod1.getClassLoader());
             Module mod2 = mgr.createFixed(loadManifest(mod2JAR), null, l);
             mgr.enable(mod2);
-            Class c1 = l.loadClass("pkg.C1");
+            Class<?> c1 = l.loadClass("pkg.C1");
             assertEquals(l, c1.getClassLoader());
-            Class c2 = l.loadClass("pkg.C2");
-            Class c3 = l.loadClass("pkg.C3");
+            Class<?> c2 = l.loadClass("pkg.C2");
+            Class<?> c3 = l.loadClass("pkg.C3");
             assertTrue(mod1.owns(c1));
             assertTrue(mod1.owns(c2));
             assertFalse(mod1.owns(c3));
@@ -2808,7 +2808,7 @@ public class ModuleManagerTest extends SetupHid {
         // m1 autoload, m2 normal, m3 eager
         Module m1 = mgr.create(new File(jars, "host-module.jar"), null, false, false, false);
         Module m2 = mgr.create(new File(jars, "fragment-module.jar"), null, false, false, false);
-        List toEnable = mgr.simulateEnable(Collections.singleton(m2));
+        List<Module> toEnable = mgr.simulateEnable(Collections.singleton(m2));
         
         assertTrue("Host will be enabled", toEnable.contains(m1));
         assertTrue("Known fragment must be merged in", toEnable.contains(m2));
@@ -2824,7 +2824,7 @@ public class ModuleManagerTest extends SetupHid {
         // m1 autoload, m2 normal, m3 eager
         Module m1 = mgr.create(new File(jars, "host-module.jar"), null, false, false, false);
         Module m2 = mgr.create(new File(jars, "fragment-module.jar"), null, false, false, false);
-        List toEnable = mgr.simulateEnable(Collections.singleton(m2));
+        List<Module> toEnable = mgr.simulateEnable(Collections.singleton(m2));
         
         assertTrue("Host will be enabled", toEnable.contains(m1));
         assertTrue("Known fragment must be merged in", toEnable.contains(m2));

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/PatchByteCodeTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/PatchByteCodeTest.java
@@ -41,9 +41,9 @@ public class PatchByteCodeTest extends NbTestCase {
 
     public static class C {
         static final long x = 123L; // test CONSTANT_Long, tricky!
-        private C(boolean _) {}
+        private C(boolean doNotCare) {}
         @PatchedPublic
-        private C(int _) {}
+        private C(int doNotCare) {}
         private void m1() {}
         @PatchedPublic
         private void m2() {}
@@ -124,7 +124,7 @@ public class PatchByteCodeTest extends NbTestCase {
                 } catch (IOException x) {
                     throw new ClassNotFoundException(name, x);
                 }
-                Class c = defineClass(name, data, 0, data.length);
+                Class<?> c = defineClass(name, data, 0, data.length);
                 if (resolve) {
                     resolveClass(c);
                 }

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassLoaderNB11PackageAnnotationsTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassLoaderNB11PackageAnnotationsTest.java
@@ -49,7 +49,7 @@ public class ProxyClassLoaderNB11PackageAnnotationsTest extends NbTestCase {
             }
 
             @Override
-            protected Class doLoadClass(String pkg, String name) {
+            protected Class<?> doLoadClass(String pkg, String name) {
                 if (name.startsWith(TEST_PACKAGE)) {
                     ByteArrayOutputStream baos = new ByteArrayOutputStream();
                     InputStream is = PackageClassLoader.class.getClassLoader().getResourceAsStream(name.replace('.', '/') + ".class");
@@ -80,7 +80,7 @@ public class ProxyClassLoaderNB11PackageAnnotationsTest extends NbTestCase {
         }
 
         final ProxyClassLoader cl = new PackageClassLoader();
-        final Class<? extends Annotation> annotClz = (Class<? extends Annotation>) cl.loadClass(TEST_PACKAGE + ".NB11PackageTestAnnotation");
+        final Class<? extends Annotation> annotClz = cl.loadClass(TEST_PACKAGE + ".NB11PackageTestAnnotation").asSubclass(Annotation.class);
         final Package pkg = annotClz.getPackage();
         final Object annot = pkg.getAnnotation(annotClz);
         assertTrue("Annotation not found", annot != null);

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassLoaderTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassLoaderTest.java
@@ -42,16 +42,16 @@ public class ProxyClassLoaderTest extends SetupHid {
 
     public void testAmbiguousDelegation() throws Exception {
         class CL extends ProxyClassLoader {
-            final Class[] owned;
+            final Class<?>[] owned;
             final String name;
-            CL(ClassLoader[] parents, String _name, Class... _owned) {
+            CL(ClassLoader[] parents, String _name, Class<?>... _owned) {
                 super(parents, false);
                 addCoveredPackages(Collections.singleton("org.netbeans"));
                 name = _name;
                 owned = _owned;
             }
-            protected @Override Class doLoadClass(String pkg, String name) {
-                for (Class c : owned) {
+            protected @Override Class<?> doLoadClass(String pkg, String name) {
+                for (Class<?> c : owned) {
                     if (name.equals(c.getName())) {
                         ByteArrayOutputStream baos = new ByteArrayOutputStream();
                         InputStream is = CL.class.getClassLoader().getResourceAsStream(name.replace('.', '/') + ".class");
@@ -86,7 +86,7 @@ public class ProxyClassLoaderTest extends SetupHid {
         assertEquals(l3, l3.loadClass(B.class.getName()).getClassLoader());
         assertEquals(l1, l3.loadClass(B.class.getName()).getMethod("a").invoke(null).getClass().getClassLoader());
         try {
-            Class c = l4.loadClass(A.class.getName());
+            Class<?> c = l4.loadClass(A.class.getName());
             fail("arbitrarily loaded A from " + c.getClassLoader());
         } catch (ClassNotFoundException x) {/* OK */}
         try {
@@ -206,8 +206,8 @@ public class ProxyClassLoaderTest extends SetupHid {
             }
 
             @Override
-            protected synchronized Class loadClass(String name, boolean resolve) throws ClassNotFoundException {
-                Class c = findLoadedClass(name);
+            protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                Class<?> c = findLoadedClass(name);
                 if (c != null) {
                     return c;
                 }

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassPackagesTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ProxyClassPackagesTest.java
@@ -25,9 +25,6 @@ import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Set;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
 import org.netbeans.junit.NbTestCase;
 import org.openide.util.test.TestFileUtils;
 

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ProxyURLStreamHandlerFactoryTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ProxyURLStreamHandlerFactoryTest.java
@@ -73,7 +73,7 @@ public class ProxyURLStreamHandlerFactoryTest extends NbTestCase {
         os.write(10);
         os.close();
         
-        URL u = new URL("jar:" + f.toURL() + "!/test.txt");
+        URL u = new URL("jar:" + f.toURI().toURL() + "!/test.txt");
         DataInputStream is = new DataInputStream(u.openStream());
         byte[] arr = new byte[100];
         is.readFully(arr, 0, 1);

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/SetupHid.java
@@ -129,11 +129,9 @@ public abstract class SetupHid extends NbTestCase {
         OutputStream os = new FileOutputStream(jar);
         try {
             JarOutputStream jos = new JarOutputStream(os, m);
-            Iterator it = contents.entrySet().iterator();
-            while (it.hasNext()) {
-                Map.Entry entry = (Map.Entry) it.next();
-                String path = (String) entry.getKey();
-                byte[] data = ((String) entry.getValue()).getBytes("UTF-8");
+            for (Map.Entry<String, String> entry : contents.entrySet()) {
+                String path = entry.getKey();
+                byte[] data = entry.getValue().getBytes("UTF-8");
                 JarEntry je = new JarEntry(path);
                 je.setSize(data.length);
                 CRC32 crc = new CRC32();


### PR DESCRIPTION
Fixed all compiler warnings concerning linter warnings types of

* deprecation,
* rawtypes and
* unchecked.

As all compiler warning in this project could be fixed / suppressed when appropriate the flag `-Werror` was added to build property `javac.compilerargs`.