### PR TITLE
[NETBEANS-3560] Codeception - warning in log does not mark test as failed

### DIFF
--- a/php/php.codeception/src/org/netbeans/modules/php/codeception/run/CodeceptionLogParser.java
+++ b/php/php.codeception/src/org/netbeans/modules/php/codeception/run/CodeceptionLogParser.java
@@ -95,6 +95,7 @@ public final class CodeceptionLogParser extends DefaultHandler {
                 processTestCase(attributes);
                 break;
             case "failure": // NOI18N
+            case "warning": // NOI18N
                 startTestFailure(attributes);
                 break;
             case "error": // NOI18N
@@ -117,6 +118,7 @@ public final class CodeceptionLogParser extends DefaultHandler {
                 testCase = null;
                 break;
             case "failure": // NOI18N
+            case "warning": // NOI18N
             case "error": // NOI18N
                 endTestContent();
                 break;

--- a/php/php.codeception/test/unit/data/codeception-log-warning-phpunit-suite.xml
+++ b/php/php.codeception/test/unit/data/codeception-log-warning-phpunit-suite.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="unit" tests="1" assertions="0" errors="0" failures="1" skipped="0" time="0.020000">
+    <testcase name="testGetBar" class="ProjectX\FooTest" classname="ProjectX.FooTest" file="/home/kacer/projectx/tests/unit/FooTest.php" line="6" assertions="0" time="0.020000">
+      <warning type="PHPUnit\Framework\Warning">ProjectX\FooTest::testGetBar
+Trying to configure method "getBarAAA" which cannot be configured because it does not exist, has not been specified, is final, or is static
+
+</warning>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/php/php.codeception/test/unit/src/org/netbeans/modules/php/codeception/run/CodeceptionLogParserTest.java
+++ b/php/php.codeception/test/unit/src/org/netbeans/modules/php/codeception/run/CodeceptionLogParserTest.java
@@ -184,6 +184,38 @@ public class CodeceptionLogParserTest extends NbTestCase {
         assertEquals("/home/junichi11/NetBeansProjects/codeception/tests/acceptance/WelcomeCept.php:6", testCase.getStackTrace()[2]);
     }
 
+
+    public void testParseLogWithWarningPhpUnitSuite() throws Exception {
+        Reader reader = createReader("codeception-log-warning-phpunit-suite.xml");
+        TestSessionVo testSession = new TestSessionVo();
+
+        CodeceptionLogParser.parse(reader, testSession);
+        assertEquals(20, testSession.getTime());
+        assertEquals(1, testSession.getTests());
+
+        // test suites & test cases
+        assertEquals(1, testSession.getTestSuites().size());
+
+        // 1st
+        TestSuiteVo testSuite = testSession.getTestSuites().get(0);
+        assertEquals("unit", testSuite.getName());
+        assertEquals(null, testSuite.getLocation());
+        assertEquals(20, testSuite.getTime());
+        assertEquals(1, testSuite.getTestCases().size());
+
+        TestCaseVo testCase = testSuite.getTestCases().get(0);
+        assertEquals("ProjectX\\FooTest", testCase.getClassName());
+        assertEquals("testGetBar", testCase.getName());
+        assertEquals("/home/kacer/projectx/tests/unit/FooTest.php", testCase.getFile());
+        assertEquals(6, testCase.getLine());
+        assertEquals(20, testCase.getTime());
+        assertTrue(testCase.isFailure());
+        assertFalse(testCase.isError());
+        assertEquals(TestCase.Status.FAILED, testCase.getStatus());
+        assertEquals(1, testCase.getStackTrace().length);
+        assertEquals("Trying to configure method \"getBarAAA\" which cannot be configured because it does not exist, has not been specified, is final, or is static", testCase.getStackTrace()[0]);
+    }
+
     private Reader createReader(String filename) throws FileNotFoundException {
         return new BufferedReader(new FileReader(new File(getDataDir(), filename)));
     }


### PR DESCRIPTION
Marks test with warning in log as failed.