### PR TITLE
[NETBEANS-3564] Corrected compiler warnings in Search API

### DIFF
--- a/platform/api.search/nbproject/project.properties
+++ b/platform/api.search/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 is.autoload=true
 javac.source=1.8
-javac.compilerargs=-Xlint -Xlint:-serial
+javac.compilerargs=-Xlint:all -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/api.search/src/org/netbeans/modules/search/GraphicalSearchListener.java
+++ b/platform/api.search/src/org/netbeans/modules/search/GraphicalSearchListener.java
@@ -82,17 +82,13 @@ class GraphicalSearchListener extends SearchListener {
     }
 
     public void searchStarted() {
-
         progressHandle = ProgressHandleFactory.createHandle(
-                NbBundle.getMessage(ResultView.class,
-                "TEXT_SEARCHING___"), new Cancellable() {               //NOI18N
-
-            @Override
-            public boolean cancel() {
-                searchComposition.terminate();
-                return true;
-            }
-        });
+                NbBundle.getMessage(ResultView.class, "TEXT_SEARCHING___"), //NOI18N
+                () -> {
+                    searchComposition.terminate();
+                    return true;
+                },
+                null);
         progressHandle.start();
         resultViewPanel.searchStarted();
         searchComposition.getSearchResultsDisplayer().searchStarted();

--- a/platform/api.search/src/org/netbeans/modules/search/ReplaceTask.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ReplaceTask.java
@@ -72,7 +72,8 @@ public final class ReplaceTask implements Runnable {
         
         problems = new ArrayList<String>(4);
         progressHandle = ProgressHandleFactory.createHandle(
-                NbBundle.getMessage(getClass(), "LBL_Replacing"));      //NOI18N
+                NbBundle.getMessage(getClass(), "LBL_Replacing"), //NOI18N
+                null, null);
     }
     
     /**

--- a/platform/api.search/src/org/netbeans/modules/search/ui/FileObjectPropertySet.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ui/FileObjectPropertySet.java
@@ -30,8 +30,8 @@ import org.openide.nodes.Node.Property;
  */
 public class FileObjectPropertySet extends Node.PropertySet {
 
-    private FileObject fileObject;
-    Property[] properties;
+    private final FileObject fileObject;
+    private final Property<?>[] properties;
 
     public FileObjectPropertySet(FileObject fileObject) {
         this.fileObject = fileObject;

--- a/platform/api.search/test/unit/src/org/netbeans/api/search/SearchHistoryTest.java
+++ b/platform/api.search/test/unit/src/org/netbeans/api/search/SearchHistoryTest.java
@@ -61,6 +61,7 @@ public final class SearchHistoryTest extends NbTestCase {
         assertTrue(SearchHistory.getDefault().getSearchPatterns().size() == 10);
     }
     
+    @SuppressWarnings("deprecation") // tests deprecated APIs
     public void testLastSelectedListener() throws Exception{
         final boolean fired[] = new boolean[1];
         fired[0] = false;

--- a/platform/api.search/test/unit/src/org/netbeans/api/search/ui/SearchPatternControllerTest.java
+++ b/platform/api.search/test/unit/src/org/netbeans/api/search/ui/SearchPatternControllerTest.java
@@ -35,10 +35,10 @@ public class SearchPatternControllerTest {
 
     @Test
     public void testBindComboBox() {
-        JComboBox cb = new JComboBox();
+        JComboBox<?> cb = new JComboBox<>();
         SearchPatternController controller =
                 ComponentUtils.adjustComboForSearchPattern(cb);
-        JComboBox matchTypeCb = new JComboBox(new Object[]{
+        JComboBox<MatchType> matchTypeCb = new JComboBox<>(new MatchType[]{
             MatchType.BASIC, MatchType.LITERAL, MatchType.REGEXP});
         assertEquals(MatchType.BASIC, matchTypeCb.getSelectedItem());
         controller.bindMatchTypeComboBox(matchTypeCb);
@@ -110,10 +110,10 @@ public class SearchPatternControllerTest {
     private void checkExceptionsWhenEnsuringItemsAreCorrect(
             boolean exceptionExpected, String message, Object... comboItems) {
 
-        JComboBox cb = new JComboBox();
+        JComboBox<?> cb = new JComboBox<>();
         SearchPatternController controller =
                 ComponentUtils.adjustComboForSearchPattern(cb);
-        JComboBox matchTypeCb = new JComboBox(comboItems);
+        JComboBox<?> matchTypeCb = new JComboBox<>(comboItems);
         boolean thrown = false;
         try {
             controller.bindMatchTypeComboBox(matchTypeCb);
@@ -125,11 +125,11 @@ public class SearchPatternControllerTest {
 
     @Test
     public void testMatchTypeComboBoxWithUnsupportedTypes() {
-        JComboBox cb = new JComboBox();
+        JComboBox<?> cb = new JComboBox<>();
         SearchPatternController controller =
                 ComponentUtils.adjustComboForSearchPattern(cb);
-        JComboBox matchTypeCb = new JComboBox(
-                new Object[]{MatchType.LITERAL, MatchType.REGEXP});
+        JComboBox<MatchType> matchTypeCb = new JComboBox<>(
+                new MatchType[]{MatchType.LITERAL, MatchType.REGEXP});
         controller.bindMatchTypeComboBox(matchTypeCb);
         assertEquals(MatchType.LITERAL, matchTypeCb.getSelectedItem());
         controller.setSearchPattern(SearchPattern.create("test", false, false,

--- a/platform/api.search/test/unit/src/org/netbeans/modules/search/matcher/BufferedCharSequenceTest.java
+++ b/platform/api.search/test/unit/src/org/netbeans/modules/search/matcher/BufferedCharSequenceTest.java
@@ -121,6 +121,7 @@ public class BufferedCharSequenceTest {
     
     private int getLenght(TypeOfStream stype, TypeOfContent ctype, Charset cs, int size){
         InputStream stream = getInputStream(stype, ctype, cs);
+        @SuppressWarnings("deprecation")
         BufferedCharSequence instance = new BufferedCharSequence(stream, cs.newDecoder(), size);
         instance.setMaxBufferSize(10);
         return instance.length();
@@ -136,6 +137,7 @@ public class BufferedCharSequenceTest {
         int index = 0;        
         Charset cs = Charset.forName(UTF_8);
         InputStream stream = getInputStream(TypeOfStream.FILE, TypeOfContent.BYTE_0, cs);
+        @SuppressWarnings("deprecation")
         BufferedCharSequence instance = new BufferedCharSequence(stream, cs.newDecoder(), 0);
         instance.charAt(index);
     }
@@ -149,6 +151,7 @@ public class BufferedCharSequenceTest {
         int index = 0;
         Charset cs = Charset.forName(UTF_8);
         InputStream stream = getInputStream(TypeOfStream.BYTE, TypeOfContent.BYTE_0, cs);
+        @SuppressWarnings("deprecation")
         BufferedCharSequence instance = new BufferedCharSequence(stream, cs.newDecoder(), 0);
         instance.charAt(index);
     }
@@ -162,6 +165,7 @@ public class BufferedCharSequenceTest {
         for(TypeOfStream stype: TypeOfStream.values()) {
             try {
                 InputStream stream = getInputStream(stype, TypeOfContent.BYTE_1, cs);
+                @SuppressWarnings("deprecation")
                 BufferedCharSequence instance = new BufferedCharSequence(stream, cs.newDecoder(), 1);
                 char expResult = 'a';
                 char result = instance.charAt(index);
@@ -185,6 +189,7 @@ public class BufferedCharSequenceTest {
         Charset cs = Charset.forName(UTF_8);
         for(TypeOfStream stype: TypeOfStream.values()) {
             InputStream stream = getInputStream(stype, TypeOfContent.BYTE_10, cs);
+            @SuppressWarnings("deprecation")
             BufferedCharSequence instance = new BufferedCharSequence(stream, cs.newDecoder(), 10);
             instance.setMaxBufferSize(10);
             char result;
@@ -210,6 +215,7 @@ public class BufferedCharSequenceTest {
         Charset cs = Charset.forName(UTF_8);
         for(TypeOfStream stype: TypeOfStream.values()) {
             InputStream stream = getInputStream(stype, TypeOfContent.BYTE_10, cs);
+            @SuppressWarnings("deprecation")
             BufferedCharSequence instance = new BufferedCharSequence(stream, cs.newDecoder(), 10);
             instance.setMaxBufferSize(5);
             char result;
@@ -253,6 +259,7 @@ public class BufferedCharSequenceTest {
         System.out.println("toString");
         for(TypeOfStream stype: TypeOfStream.values()) {
             InputStream stream = getInputStream(stype, TypeOfContent.BYTE_10, cs_UTF_8);
+            @SuppressWarnings("deprecation")
             BufferedCharSequence instance = new BufferedCharSequence(stream, cs_UTF_8.newDecoder(), 10);
             instance.setMaxBufferSize(5);
             String expResult = TypeOfContent.BYTE_10.getContent();
@@ -312,6 +319,7 @@ public class BufferedCharSequenceTest {
         System.out.println("nextLineText@no line terminators in the file.");
         for(TypeOfStream stype: TypeOfStream.values()) {
             InputStream stream = getInputStream(stype, TypeOfContent.BYTE_10, cs_UTF_8);
+            @SuppressWarnings("deprecation")
             BufferedCharSequence instance = new BufferedCharSequence(stream, cs_UTF_8.newDecoder(), 10);
             assertEquals(0, instance.position());
             String expResult = TypeOfContent.BYTE_10.getContent();

--- a/platform/api.search/test/unit/src/org/netbeans/modules/search/matcher/SearchPerformanceComparator.form
+++ b/platform/api.search/test/unit/src/org/netbeans/modules/search/matcher/SearchPerformanceComparator.form
@@ -27,6 +27,7 @@
   </Properties>
   <SyntheticProperties>
     <SyntheticProperty name="formSizePolicy" type="int" value="1"/>
+    <SyntheticProperty name="generateCenter" type="boolean" value="false"/>
   </SyntheticProperties>
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="1"/>
@@ -179,6 +180,9 @@
           </StringArray>
         </Property>
       </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+      </AuxValues>
     </Component>
     <Component class="javax.swing.JLabel" name="jLabel4">
       <Properties>

--- a/platform/api.search/test/unit/src/org/netbeans/modules/search/matcher/SearchPerformanceComparator.java
+++ b/platform/api.search/test/unit/src/org/netbeans/modules/search/matcher/SearchPerformanceComparator.java
@@ -63,7 +63,7 @@ public class SearchPerformanceComparator extends javax.swing.JFrame {
         jLabel2 = new javax.swing.JLabel();
         regexpTextField = new javax.swing.JTextField();
         jLabel3 = new javax.swing.JLabel();
-        matcherComboBox = new javax.swing.JComboBox();
+        matcherComboBox = new javax.swing.JComboBox<>();
         jLabel4 = new javax.swing.JLabel();
         jLabel5 = new javax.swing.JLabel();
         jLabel6 = new javax.swing.JLabel();
@@ -91,7 +91,7 @@ public class SearchPerformanceComparator extends javax.swing.JFrame {
 
         jLabel3.setText(org.openide.util.NbBundle.getMessage(SearchPerformanceComparator.class, "SearchPerformanceComparator.jLabel3.text")); // NOI18N
 
-        matcherComboBox.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "Default (ML: BufferedCharSequence, SL: LineReader)", "MultiLineMappedMatcherBig", "MultiLineMappedMatcherSmall", "MultiLineStreamMatcher", "SingleLineStreamMatcher", "Iterator", "AsciiMultiLineMappedMatcher" }));
+        matcherComboBox.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Default (ML: BufferedCharSequence, SL: LineReader)", "MultiLineMappedMatcherBig", "MultiLineMappedMatcherSmall", "MultiLineStreamMatcher", "SingleLineStreamMatcher", "Iterator", "AsciiMultiLineMappedMatcher" }));
 
         jLabel4.setText(org.openide.util.NbBundle.getMessage(SearchPerformanceComparator.class, "SearchPerformanceComparator.jLabel4.text")); // NOI18N
 
@@ -328,7 +328,7 @@ public class SearchPerformanceComparator extends javax.swing.JFrame {
     private javax.swing.JLabel jLabel4;
     private javax.swing.JLabel jLabel5;
     private javax.swing.JLabel jLabel6;
-    private javax.swing.JComboBox matcherComboBox;
+    private javax.swing.JComboBox<String> matcherComboBox;
     private javax.swing.JLabel matchesLabel;
     private javax.swing.JTextField regexpTextField;
     private javax.swing.JTextField rootTextField;

--- a/platform/api.search/test/unit/src/org/netbeans/spi/search/SearchScopeDefinitionTest.java
+++ b/platform/api.search/test/unit/src/org/netbeans/spi/search/SearchScopeDefinitionTest.java
@@ -18,11 +18,10 @@
  */
 package org.netbeans.spi.search;
 
-import java.util.TimerTask;
 import java.util.concurrent.Semaphore;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.netbeans.api.search.provider.SearchInfo;
 import org.openide.util.Exceptions;


### PR DESCRIPTION
Fixed all compiler warnings concerning linter warnings types of

* deprecation,
* rawtypes and
* unchecked.