### PR TITLE
Add runtime dependency for JSR305 and export annotations

### DIFF
--- a/platform/api.annotations.common/nbproject/project.properties
+++ b/platform/api.annotations.common/nbproject/project.properties
@@ -23,3 +23,4 @@ javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 
 cp.extra=external/jsr305-3.0.2.jar
+release.external/jsr305-3.0.2.jar=modules/ext/jsr305-3.0.2.jar

--- a/platform/api.annotations.common/nbproject/project.xml
+++ b/platform/api.annotations.common/nbproject/project.xml
@@ -26,8 +26,15 @@
             <code-name-base>org.netbeans.api.annotations.common</code-name-base>
             <module-dependencies/>
             <public-packages>
+                <package>javax.annotation</package>
+                <package>javax.annotation.concurrent</package>
+                <package>javax.annotation.meta</package>
                 <package>org.netbeans.api.annotations.common</package>
             </public-packages>
+            <class-path-extension>
+                <runtime-relative-path>ext/jsr305-3.0.2.jar</runtime-relative-path>
+                <binary-origin>external/jsr305-3.0.2.jar</binary-origin>
+            </class-path-extension>
         </data>
     </configuration>
 </project>


### PR DESCRIPTION
The annotations defined in the Common Annotations module depend
on the annotations defined in JSR305. If they are not present, a
warning is generated from javac.