### PR TITLE
Look for .mvn/maven.config in parent directories as well

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
+++ b/java/maven/src/org/netbeans/modules/maven/modelcache/MavenProjectCache.java
@@ -150,10 +150,13 @@ public final class MavenProjectCache {
         M2Configuration active = config.getActiveConfiguration();
         MavenExecutionResult res = null;
         try {
-            FileObject mavenConfig = projectDir.getFileObject(".mvn/maven.config");
             List<String> mavenConfigOpts = Collections.emptyList();
-            if (mavenConfig != null && mavenConfig.isData()) {
-                mavenConfigOpts = Arrays.asList(mavenConfig.asText().split("\\s+"));
+            for (FileObject root = projectDir; root != null; root = root.getParent()) {
+                FileObject mavenConfig = root.getFileObject(".mvn/maven.config");
+                if (mavenConfig != null && mavenConfig.isData()) {
+                    mavenConfigOpts = Arrays.asList(mavenConfig.asText().split("\\s+"));
+                    break;
+                }
             }
             final MavenExecutionRequest req = projectEmbedder.createMavenExecutionRequest();
             req.addActiveProfiles(active.getActivatedProfiles());

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectImplTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectImplTest.java
@@ -191,6 +191,29 @@ public class NbMavenProjectImplTest extends NbTestCase {
         assertEquals("1.8", slqr.getSourceLevel());
         assertEquals("1.6", testSlqr.getSourceLevel());
     }
+
+    public void testMavenConfigReactor() throws Exception {
+        writeMavenConfig("-Pnew");
+        TestFileUtils.writeFile(wd, "pom.xml", "<project><modelVersion>4.0.0</modelVersion>"
+                + "<groupId>test</groupId><artifactId>parent</artifactId><version>1.0</version><packaging>pom</packaging>"
+                + "<modules><module>mod</module></modules>"
+                + "</project>");
+        TestFileUtils.writeFile(wd, "mod/pom.xml", "<project><modelVersion>4.0.0</modelVersion>"
+                + "<parent><groupId>test</groupId><artifactId>parent</artifactId><version>1.0</version></parent>"
+                + "<artifactId>prj</artifactId>"
+                + "<properties><java>1.5</java><testJava>1.5</testJava></properties>"
+                + "<build><plugins><plugin><artifactId>maven-compiler-plugin</artifactId><version>2.1</version>"
+                + "<configuration><source>${java}</source><testSource>${testJava}</testSource></configuration></plugin></plugins></build>"
+                + "<profiles>"
+                + "<profile><id>new</id><properties><java>1.6</java></properties></profile>"
+                + "</profiles>"
+                + "</project>");
+        FileObject source = TestFileUtils.writeFile(wd, "mod/src/main/java/p/C.java", "package p; class C {}");
+        SourceLevelQuery.Result slqr = SourceLevelQuery.getSourceLevel2(source);
+        assertEquals("1.6", slqr.getSourceLevel());
+        // TODO listening to changes not yet implemented in FileProvider
+    }
+
     private void writeMavenConfig(String text) throws IOException, InterruptedException {
         // Need the touch call, since NbMavenProjectImpl.Updater checks timestamps.
         TestFileUtils.touch(TestFileUtils.writeFile(wd, ".mvn/maven.config", text), null);


### PR DESCRIPTION
Amends #1209 to better handle reactor builds where a `.mvn/` might be present at the root but we want to interpret a profile in a module. Not perfect but better than nothing.