### PR TITLE
[TRAVIS] Fix core network tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,15 @@ addons:
       - ant-optional
       - xvfb
       - openjfx
+      - groovy
+
 install:
   - export PATH="$PATH:$TRAVIS_BUILD_DIR/nbbuild/travis"
   - export DISPLAY=:99.0
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
   - sleep 3
+  - sudo $TRAVIS_BUILD_DIR/nbbuild/travis/fix_hosts_file.groovy
+
 script:
   - if [ "x$OPTS" == "x" ]; then OPTS="-quiet -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false"; fi
   - if [ "x$TARGET" == "x" ]; then TARGET="build"; fi
@@ -120,7 +124,7 @@ matrix:
             - hide-logs.sh ant $OPTS -f platform/core.kit test
             - hide-logs.sh ant $OPTS -f platform/core.multiview test
             - hide-logs.sh ant $OPTS -f platform/core.netigso test
-            #- hide-logs.sh ant $OPTS -f platform/core.network test
+            - hide-logs.sh ant $OPTS -f platform/core.network test
             - hide-logs.sh ant $OPTS -f platform/core.osgi test
             - hide-logs.sh ant $OPTS -f platform/core.output2 test
             - hide-logs.sh ant $OPTS -f platform/core.startup test

--- a/nbbuild/travis/fix_hosts_file.groovy
+++ b/nbbuild/travis/fix_hosts_file.groovy
@@ -1,0 +1,39 @@
+#!/usr/bin/env groovy
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* 
+ * Fixes Travis /etc/hosts to allow run platform/core.network tests.
+ * Proxy tests fails if they resolves that hostname ip is equals to localhost ip.
+ */
+
+def hostname = "hostname".execute().text.trim()
+
+def fixedHostsFileContent = new StringBuilder("## File modified by nbbuild/travis/fix_hosts_file.groovy\n")
+def hostsFile = new File('/etc/hosts')
+hostsFile.eachLine { line ->
+    if (line =~ /127.0.0.1/) {
+        fixedHostsFileContent.append("# ").append(line).append("\n")
+        fixedHostsFileContent.append(line - hostname).append("\n")
+    } else {
+        fixedHostsFileContent.append(line).append("\n")
+    }
+}
+
+hostsFile.write(fixedHostsFileContent.toString())


### PR DESCRIPTION
Fix core network tests when run in a Travis worker. 

Edits `/etc/hosts` to remove hostname in the localhost entry.

Before editing: 
```
## Managed by Chef on packer-5df1faf8-b61a-05e1-6e00-7c129c076cc3.c.eco-emissary-99515.internal :heart_eyes_cat:
## cookbook:: travis_build_environment
##     file:: templates/default/etc/cloud/templates/hosts.tmpl.erb
127.0.1.1 travis-job-adbfb820-92fd-40ed-9452-91ae7fb08218 travis-job-adbfb820-92fd-40ed-9452-91ae7fb08218 ip4-loopback xenial64
127.0.0.1 localhost nettuno travis vagrant travis-job-adbfb820-92fd-40ed-9452-91ae7fb08218 
```

After editing:
```
## File modified by nbbuild/travis/fix_hosts_file.groovy
## Managed by Chef on packer-5df1faf8-b61a-05e1-6e00-7c129c076cc3.c.eco-emissary-99515.internal :heart_eyes_cat:
## cookbook:: travis_build_environment
##     file:: templates/default/etc/cloud/templates/hosts.tmpl.erb
127.0.1.1 travis-job-adbfb820-92fd-40ed-9452-91ae7fb08218 travis-job-adbfb820-92fd-40ed-9452-91ae7fb08218 ip4-loopback xenial64
# 127.0.0.1 localhost nettuno travis vagrant travis-job-adbfb820-92fd-40ed-9452-91ae7fb08218 
127.0.0.1 localhost nettuno travis vagrant 
```