### PR TITLE
[NETBEANS-3581] Improvements to DropDownButton/DropDownToggleButton

### DIFF
--- a/platform/openide.awt/src/org/openide/awt/DropDownButton.java
+++ b/platform/openide.awt/src/org/openide/awt/DropDownButton.java
@@ -24,7 +24,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -78,11 +77,8 @@ class DropDownButton extends JButton {
 
         resetIcons();
 
-        addPropertyChangeListener(  DropDownButtonFactory.PROP_DROP_DOWN_MENU,new PropertyChangeListener() {
-            @Override
-            public void propertyChange( PropertyChangeEvent e ) {
-                resetIcons();
-            }
+        addPropertyChangeListener(DropDownButtonFactory.PROP_DROP_DOWN_MENU, (PropertyChangeEvent e) -> {
+            resetIcons();
         });
 
         addMouseMotionListener( new MouseMotionAdapter() {
@@ -177,11 +173,8 @@ class DropDownButton extends JButton {
                     Ignore any such button press while the popup is closing, to avoid interpreting
                     the press as a click to open the menu again. */
                     popupClosingInProgress = true;
-                    SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            popupClosingInProgress = false;
-                        }
+                    SwingUtilities.invokeLater(() -> {
+                        popupClosingInProgress = false;
                     });
                 }
 
@@ -358,7 +351,7 @@ class DropDownButton extends JButton {
 
         @Override
         public void setPressed(boolean b) {
-            if( mouseInArrowArea || _pressed )
+            if( _pressed || b && mouseInArrowArea)
                 return;
             super.setPressed( b );
         }

--- a/platform/openide.awt/src/org/openide/awt/DropDownToggleButton.java
+++ b/platform/openide.awt/src/org/openide/awt/DropDownToggleButton.java
@@ -24,7 +24,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -77,11 +76,8 @@ class DropDownToggleButton extends JToggleButton {
         
         resetIcons();
         
-        addPropertyChangeListener(  DropDownButtonFactory.PROP_DROP_DOWN_MENU,new PropertyChangeListener() {
-            @Override
-            public void propertyChange( PropertyChangeEvent e ) {
-                resetIcons();
-            }
+        addPropertyChangeListener(DropDownButtonFactory.PROP_DROP_DOWN_MENU, (PropertyChangeEvent e) -> {
+            resetIcons();
         });
         
         addMouseMotionListener( new MouseMotionAdapter() {
@@ -176,11 +172,8 @@ class DropDownToggleButton extends JToggleButton {
                     Ignore any such button press while the popup is closing, to avoid interpreting
                     the press as a click to open the menu again. */
                     popupClosingInProgress = true;
-                    SwingUtilities.invokeLater(new Runnable() {
-                        @Override
-                        public void run() {
-                            popupClosingInProgress = false;
-                        }
+                    SwingUtilities.invokeLater(() -> {
+                        popupClosingInProgress = false;
                     });
                 }
 
@@ -352,7 +345,7 @@ class DropDownToggleButton extends JToggleButton {
         
         @Override
         public void setPressed(boolean b) {
-            if( mouseInArrowArea || _pressed )
+            if( _pressed || b && mouseInArrowArea)
                 return;
             super.setPressed( b );
         }


### PR DESCRIPTION
DropDownButton/DropDownToggleButton are most commonly used in the various NetBeans toolbars--there is one pair of DropDownButton buttons in the editor toolbar, for instance.

(I use both DropDownButton and DropDownToggleButton in my NetBeans Platform application, and have tested both there. I have tested DropDownButton in the IDE as well. There are no current uses of DropDownToggleButton in the IDE.)

Details:
* Copy an old bugfix from DropDownButton to DropDownToggleButton (an added
  updateRollover call), to fix a problem where the latter would show the wrong
  icon after an icon change.
* Fix a bug where DropDownButton would occasionally get in a state where two
  mouse clicks were required to open it.
* Prevent dropdown button menus from showing up when the button is disabled.
* If DropDownButton has no action listeners registered, allow the user to click
  anywhere in the button area (not just the arrow area on the side) to open the
  dropdown menu.
* Review all differences between DropDownButton and DropDownToggleButton, and
  make sure they are legitimate. (These two classes are nearly identical, save
  for a few changes.)

![dropdown button examples](https://user-images.githubusercontent.com/886243/70830207-b3c0c180-1dbd-11ea-8b07-7c3b792cddc3.png)
