### PR TITLE
[NETBEANS-3593] Make toolbar browser icon take advantage of improved HiDPI scaling.

### DIFF
--- a/ide/web.browser.api/src/org/netbeans/modules/web/browser/api/BrowserUISupport.java
+++ b/ide/web.browser.api/src/org/netbeans/modules/web/browser/api/BrowserUISupport.java
@@ -36,6 +36,7 @@ import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.modules.web.browser.ui.picker.BrowserCombo;
+import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.Parameters;
 
@@ -328,7 +329,7 @@ public final class BrowserUISupport {
             Component c = defaultRenderer.getListCellRendererComponent(list, getLongDisplayName(value), index, isSelected, cellHasFocus);
             if (c instanceof JLabel) {
                 JLabel l = (JLabel)c;
-                l.setIcon(new ImageIcon(value.getIconImage(true)));
+                l.setIcon(ImageUtilities.image2Icon(value.getIconImage(true)));
             }
             return c;
         }

--- a/platform/openide.awt/apichanges.xml
+++ b/platform/openide.awt/apichanges.xml
@@ -26,6 +26,20 @@
 <apidef name="awt">AWT API</apidef>
 </apidefs>
 <changes>
+    <change id="getArrowIcon">
+        <api name="awt"/>
+        <summary>Added factory class for drop-down buttons</summary>
+        <version major="7" minor="75"/>
+        <date day="13" month="12" year="2019"/>
+        <author login="ebakke"/>
+        <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
+        <description>
+        Add the DropDownButtonFactory.getArrowIcon method, to expose the HiDPI-enabled dropdown
+        arrow icon for use by other modules.
+        </description>
+        <class package="org.openide.awt" name="DropDownButtonFactory"/>
+        <issue number="NETBEANS-3581"/>
+    </change>
     <change id="ToggleActions">
         <api name="awt"/>
         <summary>Support model-based enabled and check state of actions</summary>

--- a/platform/openide.awt/src/org/openide/awt/DropDownButtonFactory.java
+++ b/platform/openide.awt/src/org/openide/awt/DropDownButtonFactory.java
@@ -23,6 +23,7 @@ import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JPopupMenu;
 import javax.swing.JToggleButton;
+import org.openide.awt.IconWithArrow.ArrowIcon;
 
 /**
  * Factory creating buttons with a small arrow icon that shows a popup menu when clicked.
@@ -69,5 +70,17 @@ public final class DropDownButtonFactory {
      */
     public static JToggleButton createDropDownToggleButton( Icon icon, JPopupMenu dropDownMenu ) {
         return new DropDownToggleButton( icon, dropDownMenu );
+    }
+
+    /**
+     * Get a dropdown button icon that is identical to those used in the dropdown buttons returned
+     * by other methods in this class. The returned icon scales properly on HiDPI screens.
+     *
+     * @since 7.74
+     * @param disabled whether to get a disabled version of the icon or not
+     * @return a dropdown arrow icon
+     */
+    public static Icon getArrowIcon(boolean disabled) {
+        return disabled ? ArrowIcon.INSTANCE_DEFAULT : ArrowIcon.INSTANCE_DISABLED;
     }
 }

--- a/platform/openide.awt/src/org/openide/awt/IconWithArrow.java
+++ b/platform/openide.awt/src/org/openide/awt/IconWithArrow.java
@@ -90,7 +90,7 @@ class IconWithArrow implements Icon {
         return GAP/2 + 5;
     }
 
-    private static class ArrowIcon extends VectorIcon {
+    static class ArrowIcon extends VectorIcon {
         public static final Icon INSTANCE_DEFAULT = new ArrowIcon(false);
         public static final Icon INSTANCE_DISABLED = new ArrowIcon(true);
         private final boolean disabled;

--- a/platform/openide.util.ui/src/org/openide/util/CachedHiDPIIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/CachedHiDPIIcon.java
@@ -37,6 +37,8 @@ import javax.swing.Icon;
  * Abstract base class for {@link javax.swing.Icon} implementations that need to cache scaled bitmap
  * representations for HiDPI displays. Bitmaps for multiple HiDPI scaling factors can be cached at
  * the same time, e.g. for multi-monitor setups. Thread-safe.
+ *
+ * @since 9.15
  */
 public abstract class CachedHiDPIIcon implements Icon {
     /**

--- a/platform/openide.util.ui/src/org/openide/util/spi/SVGLoader.java
+++ b/platform/openide.util.ui/src/org/openide/util/spi/SVGLoader.java
@@ -26,6 +26,8 @@ import org.openide.util.lookup.ServiceProvider;
 /**
  * SVG image loader. This is an optional service provider. If implemented, a single instance should
  * be placed in the default lookup (e.g. via the {@link ServiceProvider} annotation).
+ *
+ * @since 9.15
  */
 public interface SVGLoader {
     /**

--- a/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/browser/ActiveBrowserAction.java
+++ b/webcommon/web.clientproject.api/src/org/netbeans/modules/web/clientproject/browser/ActiveBrowserAction.java
@@ -36,6 +36,7 @@ import java.util.logging.Logger;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.ButtonGroup;
+import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JMenu;
@@ -60,6 +61,7 @@ import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
+import org.openide.awt.DropDownButtonFactory;
 import org.openide.awt.ToolbarPool;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
@@ -237,7 +239,7 @@ public class ActiveBrowserAction extends CallableSystemAction implements LookupL
         private WebBrowser wb;
 
         public SelectBrowserAction(ProjectBrowserProvider pbp, WebBrowser wb) {
-            super(BrowserUISupport.getLongDisplayName(wb), new ImageIcon(wb.getIconImage(isSmallToolbarIcon())));
+            super(BrowserUISupport.getLongDisplayName(wb), ImageUtilities.image2Icon(wb.getIconImage(isSmallToolbarIcon())));
             this.pbp = pbp;
             this.wb = wb;
         }
@@ -272,8 +274,8 @@ public class ActiveBrowserAction extends CallableSystemAction implements LookupL
                 showBrowserPickerPopup( button );
             }
         });
-        button.setDisabledIcon(new ImageIcon(badgeImageWithArrow(
-            ImageUtilities.loadImage(isSmallToolbarIcon() ? DISABLED_SMALL : DISABLED_LARGE))));
+        button.setDisabledIcon(badgeWithArrowIcon(
+            ImageUtilities.loadImage(isSmallToolbarIcon() ? DISABLED_SMALL : DISABLED_LARGE)));
         button.setEnabled(false);
         button.addPropertyChangeListener(new PropertyChangeListener() {
             @Override
@@ -350,8 +352,8 @@ public class ActiveBrowserAction extends CallableSystemAction implements LookupL
                 lastWebBrowser = null;
             }
             if (pbp == null) {
-                tb.setIcon(new ImageIcon(badgeImageWithArrow(ImageUtilities.loadImage(isSmallToolbarIcon() ? DISABLED_SMALL : DISABLED_LARGE)))); // NOI18N
-                tb.setDisabledIcon(new ImageIcon(badgeImageWithArrow(ImageUtilities.loadImage(isSmallToolbarIcon() ? DISABLED_SMALL : DISABLED_LARGE)))); // NOI18N
+                tb.setIcon(badgeWithArrowIcon(ImageUtilities.loadImage(isSmallToolbarIcon() ? DISABLED_SMALL : DISABLED_LARGE))); // NOI18N
+                tb.setDisabledIcon(badgeWithArrowIcon(ImageUtilities.loadImage(isSmallToolbarIcon() ? DISABLED_SMALL : DISABLED_LARGE))); // NOI18N
                 tb.setToolTipText(null);
             } else {
                 WebBrowser wb = pbp.getActiveBrowser();
@@ -364,7 +366,7 @@ public class ActiveBrowserAction extends CallableSystemAction implements LookupL
                     im = ImageUtilities.loadImage(isSmallToolbarIcon() ? GENERIC_SMALL : GENERIC_LARGE); // NOI18N
                     tb.setToolTipText(Bundle.ActiveBrowserAction_missingProject());
                 }
-                tb.setIcon(new ImageIcon(badgeImageWithArrow(im)));
+                tb.setIcon(badgeWithArrowIcon(im));
                 lastWebBrowser = wb;
             }
             tb.setEnabled(pbp != null);
@@ -375,14 +377,12 @@ public class ActiveBrowserAction extends CallableSystemAction implements LookupL
         }
     }
 
-    private Image badgeImageWithArrow(Image im) {
+    private Icon badgeWithArrowIcon(Image im) {
         // #235642
         assert im != null : "Image must be provided";
-        Image arrow = ImageUtilities.loadImage("org/openide/awt/resources/arrow.png"); // NOI18N
-        assert arrow != null : "Arrow image must be found";
-        return ImageUtilities.mergeImages(im,
-            arrow,
-            isSmallToolbarIcon() ? 20 : 28, isSmallToolbarIcon() ? 6 : 10); // NOI18N
+        return ImageUtilities.image2Icon(ImageUtilities.mergeImages(im,
+            ImageUtilities.icon2Image(DropDownButtonFactory.getArrowIcon(false)),
+            isSmallToolbarIcon() ? 20 : 28, isSmallToolbarIcon() ? 6 : 10)); // NOI18N
     }
 
     private void showBrowserPickerPopup( JButton invoker ) {


### PR DESCRIPTION
Ensure that the HiDPI icon scaling improvements made in NETBEANS-2614 (https://github.com/apache/netbeans/pull/1273) applies to the browser icon. See before/after screenshots.

API change: This adds a public method in DropDownButtonFactory to make the dropdown arrow icon available to other modules.

Also add some missing "since" annotations in the openide.util.ui module.

![browsericon](https://user-images.githubusercontent.com/886243/70831850-97268880-1dc1-11ea-9047-962a27d9f885.png)
