### PR TITLE
[NETBEANS-3595] Enable actions to execute spock tests

### DIFF
--- a/groovy/gradle.java/src/org/netbeans/modules/gradle/java/JavaActionProvider.java
+++ b/groovy/gradle.java/src/org/netbeans/modules/gradle/java/JavaActionProvider.java
@@ -111,7 +111,7 @@ public class JavaActionProvider extends DefaultGradleActionsProvider {
                             case COMMAND_DEBUG_TEST_SINGLE:
                             case COMMAND_RUN_SINGLE_METHOD:
                             case COMMAND_DEBUG_SINGLE_METHOD:
-                                if ("text/x-java".equals(fo.getMIMEType())) { //NOI18N
+                                if ("text/x-java".equals(fo.getMIMEType()) || "text/x-groovy".equals(fo.getMIMEType())) { //NOI18N
                                     File f = FileUtil.toFile(fo);
                                     GradleJavaSourceSet sourceSet = gjp.containingSourceSet(f);
                                     ret = sourceSet != null && sourceSet.isTestSourceSet() && sourceSet.getSourceType(f) != RESOURCES;

--- a/groovy/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
+++ b/groovy/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
@@ -23,16 +23,16 @@
 <actions>
     <apply-for plugins="java">
         <action name="test.single">
-            <args>--rerun-tasks test --tests ${selectedClass}</args>
+            <args>--rerun-tasks test --tests "${selectedClass}"</args>
         </action>
         <action name="run.single.method">
-            <args>--rerun-tasks test --tests ${selectedMethod}</args>
+            <args>--rerun-tasks test --tests "${selectedMethod}"</args>
         </action>
         <action name="debug.single.method">
-            <args>--rerun-tasks test --debug-jvm --tests ${selectedMethod}</args>
+            <args>--rerun-tasks test --debug-jvm --tests "${selectedMethod}"</args>
         </action>
         <action name="debug.test.single">
-            <args>--rerun-tasks test --debug-jvm --tests ${selectedClass}</args>
+            <args>--rerun-tasks test --debug-jvm --tests "${selectedClass}"</args>
         </action>
 
         <action name="javadoc">


### PR DESCRIPTION
Enabling following actions on groovy files to support execution of spock tests in gradle projects:
- Test Package
- Test File / Debug Test File
- Run Focused Test Method / Debug Focused Test Method

Fix handling of spock test methods containing spaces.
