### PR TITLE
Other tweaks to FlatDark color profile.

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-INI-tokenColorings.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-INI-tokenColorings.xml
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
 <fontscolors>
     <fontcolor name="comment" default="comment"/>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-INI-tokenColorings.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-INI-tokenColorings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+<fontscolors>
+    <fontcolor name="comment" default="comment"/>
+    <fontcolor name="equals" default="operator"/>
+    <fontcolor name="error" default="error"/>
+    <fontcolor name="key" default="keyword"/>
+    <fontcolor name="section_delim" default="number"><font style="bold"/></fontcolor>
+    <fontcolor name="section" default="number"/>
+    <fontcolor name="value" default="string"/>
+    <fontcolor name="whitespace"/>
+</fontscolors>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-Properties-tokenColorings.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-Properties-tokenColorings.xml
@@ -22,8 +22,8 @@
 <!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
 <fontscolors>
     <fontcolor name="properties-equal-sign" default="operator" foreColor="gray"/>
-    <fontcolor name="properties-key" default="default" foreColor="ffcc7832"/>
+    <fontcolor name="properties-key" default="keyword"/>
     <fontcolor name="properties-line-comment" default="comment"/>
-    <fontcolor name="properties-text" default="default"><font style="bold"/></fontcolor>
+    <fontcolor name="properties-text" default="default"/>
     <fontcolor name="properties-value" default="string"/>
 </fontscolors>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-annotations.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-annotations.xml
@@ -21,94 +21,111 @@
 -->
 <!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
 <fontscolors>
-    <fontcolor name="Breakpoint_broken" bgColor="darkGray"/>
-    <fontcolor name="Breakpoint_stroke" bgColor="darkGray"/>
-    <fontcolor name="Breakpoint" bgColor="ff5b3535"/>
-    <fontcolor name="CallSite" bgColor="ffe7e1ef"/>
-    <fontcolor name="ClassBreakpoint_stroke"/>
+    <fontcolor name="Breakpoint" bgColor="ff4B1919"/>
+    <fontcolor name="Breakpoint_broken" bgColor="ff372B2B"/>
+    <fontcolor name="Breakpoint_stroke" bgColor="ff372B2B"/>
+    <fontcolor name="CallSite" bgColor="ff796977"/>
     <fontcolor name="ClassBreakpoint"/>
-    <fontcolor name="CondBreakpoint_broken" bgColor="darkGray"/>
-    <fontcolor name="CondBreakpoint_stroke" bgColor="darkGray"/>
-    <fontcolor name="CondBreakpoint" bgColor="ff5b3535"/>
+    <fontcolor name="ClassBreakpoint_stroke"/>
+    <fontcolor name="CondBreakpoint" bgColor="ff4B1919"/>
+    <fontcolor name="CondBreakpoint_broken" bgColor="ff372B2B"/>
+    <fontcolor name="CondBreakpoint_stroke" bgColor="ff372B2B"/>
     <fontcolor name="CurrentExpression" bgColor="ffd1ffbc"/>
-    <fontcolor name="CurrentExpressionLine_BP" bgColor="ffe9ffe6"/>
-    <fontcolor name="CurrentExpressionLine_CBP" bgColor="ffe9ffe6"/>
-    <fontcolor name="CurrentExpressionLine_DBP" bgColor="ffe9ffe6"/>
-    <fontcolor name="CurrentExpressionLine_DCBP" bgColor="ffe9ffe6"/>
-    <fontcolor name="CurrentExpressionLine" bgColor="ffe9ffe6"/>
-    <fontcolor name="CurrentPC" bgColor="ffbde6aa"/>
-    <fontcolor name="CurrentPC2_BP" bgColor="ff5b3535"/>
-    <fontcolor name="CurrentPC2_DBP" bgColor="ffdcdcd8"/>
-    <fontcolor name="CurrentPC2" bgColor="ffbde6aa"/>
-    <fontcolor name="CurrentPC2LinePart" bgColor="ffbde6aa"/>
-    <fontcolor name="CurrentPCLinePart" bgColor="ffbde6aa"/>
-    <fontcolor name="Dbx_Bpt_broken_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_broken" bgColor="ff4B1919"/>
-    <fontcolor name="Dbx_Bpt_cmpx_broken_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_cmpx_broken" bgColor="ff4B1919"/>
-    <fontcolor name="Dbx_Bpt_cmpx_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_cmpx_hit_broken_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_cmpx_hit_broken" bgColor="ff283C26"/>
-    <fontcolor name="Dbx_Bpt_cmpx_hit_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_cmpx_hit" bgColor="ff283C26"/>
-    <fontcolor name="Dbx_Bpt_cmpx" bgColor="ff4B1919"/>
-    <fontcolor name="Dbx_Bpt_compound_hit" bgColor="ff283C26"/>
-    <fontcolor name="Dbx_Bpt_compound" bgColor="ff4B1919"/>
-    <fontcolor name="Dbx_Bpt_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_hit_broken_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_hit_broken" bgColor="ff283C26"/>
-    <fontcolor name="Dbx_Bpt_hit_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_hit" bgColor="ff283C26"/>
+    <fontcolor name="CurrentExpressionLine" bgColor="ff1E501C"/>
+    <fontcolor name="CurrentExpressionLine_BP" bgColor="ff1E501C"/>
+    <fontcolor name="CurrentExpressionLine_CBP" bgColor="ff1E501C"/>
+    <fontcolor name="CurrentExpressionLine_DBP" bgColor="ff1E501C"/>
+    <fontcolor name="CurrentExpressionLine_DCBP" bgColor="ff1E501C"/>
+    <fontcolor name="CurrentPC" bgColor="ff283C26"/>
+    <fontcolor name="CurrentPC2" bgColor="ff283C26"/>
+    <fontcolor name="CurrentPC2_BP" bgColor="ff4B1919"/>
+    <fontcolor name="CurrentPC2_DBP" bgColor="ff372B2B"/>
+    <fontcolor name="CurrentPC2LinePart" bgColor="ff283C26"/>
+    <fontcolor name="CurrentPCLinePart" bgColor="ff283C26"/>
     <fontcolor name="Dbx_Bpt" bgColor="ff3a2323"/>
+    <fontcolor name="Dbx_Bpt_broken" bgColor="ff4B1919"/>
+    <fontcolor name="Dbx_Bpt_broken_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_cmpx" bgColor="ff4B1919"/>
+    <fontcolor name="Dbx_Bpt_cmpx_broken" bgColor="ff4B1919"/>
+    <fontcolor name="Dbx_Bpt_cmpx_broken_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_cmpx_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_cmpx_hit" bgColor="ff283C26"/>
+    <fontcolor name="Dbx_Bpt_cmpx_hit_broken" bgColor="ff283C26"/>
+    <fontcolor name="Dbx_Bpt_cmpx_hit_broken_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_cmpx_hit_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_compound" bgColor="ff4B1919"/>
+    <fontcolor name="Dbx_Bpt_compound_hit" bgColor="ff283C26"/>
+    <fontcolor name="Dbx_Bpt_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_hit" bgColor="ff283C26"/>
+    <fontcolor name="Dbx_Bpt_hit_broken" bgColor="ff283C26"/>
+    <fontcolor name="Dbx_Bpt_hit_broken_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_hit_dis" bgColor="ff372B2B"/>
     <fontcolor name="Dbx_PC" bgColor="ff283C26"/>
-    <fontcolor name="debugger-mixed_BP_broken" bgColor="darkGray"/>
-    <fontcolor name="debugger-mixed_BP" bgColor="ff5b3535"/>
-    <fontcolor name="debugger-multi_BPCBP_broken" bgColor="darkGray"/>
-    <fontcolor name="debugger-multi_BPCBP" bgColor="ff5b3535"/>
-    <fontcolor name="debugger-multi_DBPCBP" bgColor="darkGray"/>
-    <fontcolor name="debugger-PC_BP_broken" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_BP_stroke" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_BP" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_CBP_broken" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_CBP_stroke" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_CBP" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_DBP_stroke" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_DBP" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_DCBP_stroke" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_DCBP" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_mixedBP_broken" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_mixedBP" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_multi_BPCBP_broken" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_multi_BPCBP" bgColor="ffbde6aa"/>
-    <fontcolor name="debugger-PC_multi_DBPCBP" bgColor="ffbde6aa"/>
-    <fontcolor name="DisabledBreakpoint_stroke" bgColor="darkGray"/>
-    <fontcolor name="DisabledBreakpoint" bgColor="darkGray"/>
-    <fontcolor name="DisabledClassBreakpoint_stroke"/>
+    <fontcolor name="debugger-mixed_BP" bgColor="ff4B1919"/>
+    <fontcolor name="debugger-mixed_BP_broken" bgColor="ff372B2B"/>
+    <fontcolor name="debugger-multi_BPCBP" bgColor="ff4B1919"/>
+    <fontcolor name="debugger-multi_BPCBP_broken" bgColor="ff372B2B"/>
+    <fontcolor name="debugger-multi_DBPCBP" bgColor="ff372B2B"/>
+    <fontcolor name="debugger-PC_BP" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_BP_broken" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_BP_stroke" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_CBP" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_CBP_broken" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_CBP_stroke" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_DBP" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_DBP_stroke" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_DCBP" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_DCBP_stroke" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_mixedBP" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_mixedBP_broken" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_multi_BPCBP" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_multi_BPCBP_broken" bgColor="ff283C26"/>
+    <fontcolor name="debugger-PC_multi_DBPCBP" bgColor="ff283C26"/>
+    <fontcolor name="DisabledBreakpoint" bgColor="ff372B2B"/>
+    <fontcolor name="DisabledBreakpoint_stroke" bgColor="ff372B2B"/>
     <fontcolor name="DisabledClassBreakpoint"/>
-    <fontcolor name="DisabledCondBreakpoint_stroke" bgColor="darkGray"/>
-    <fontcolor name="DisabledCondBreakpoint" bgColor="darkGray"/>
-    <fontcolor name="DisabledFieldBreakpoint_stroke"/>
+    <fontcolor name="DisabledClassBreakpoint_stroke"/>
+    <fontcolor name="DisabledCondBreakpoint" bgColor="ff372B2B"/>
+    <fontcolor name="DisabledCondBreakpoint_stroke" bgColor="ff372B2B"/>
     <fontcolor name="DisabledFieldBreakpoint"/>
-    <fontcolor name="DisabledMethodBreakpoint_stroke"/>
+    <fontcolor name="DisabledFieldBreakpoint_stroke"/>
     <fontcolor name="DisabledMethodBreakpoint"/>
+    <fontcolor name="DisabledMethodBreakpoint_stroke"/>
     <fontcolor name="editor-bookmark"/>
-    <fontcolor name="FieldBreakpoint_stroke"/>
     <fontcolor name="FieldBreakpoint"/>
-    <fontcolor name="loadgenProfilingPoint" bgColor="ffb4e4fc"/>
-    <fontcolor name="loadgenProfilingPointD" bgColor="ffdcdcd8"/>
-    <fontcolor name="MethodBreakpoint_stroke"/>
+    <fontcolor name="FieldBreakpoint_stroke"/>
+    <fontcolor name="loadgenProfilingPoint" bgColor="ff508098"/>
+    <fontcolor name="loadgenProfilingPointD" bgColor="ff2B2B41"/>
     <fontcolor name="MethodBreakpoint"/>
+    <fontcolor name="MethodBreakpoint_stroke"/>
+    <fontcolor name="org-netbeans-modules-cnd-cpp-parser_annotation_err" waveUnderlined="red"/>
+    <fontcolor name="org-netbeans-modules-cnd-highligh-semantic-markoccurrences"/>
+    <fontcolor name="org-netbeans-modules-cnd-highlight-security-error"/>
+    <fontcolor name="org-netbeans-modules-cnd-highlight-security-warning"/>
+    <fontcolor name="org-netbeans-modules-cnd-navigation-extended_is_specialized"/>
+    <fontcolor name="org-netbeans-modules-cnd-navigation-extended_specializes"/>
+    <fontcolor name="org-netbeans-modules-cnd-navigation-is_overridden"/>
+    <fontcolor name="org-netbeans-modules-cnd-navigation-is_overridden_combined"/>
+    <fontcolor name="org-netbeans-modules-cnd-navigation-is_overridden_combined_pseudo"/>
+    <fontcolor name="org-netbeans-modules-cnd-navigation-is_overridden_pseudo"/>
+    <fontcolor name="org-netbeans-modules-cnd-navigation-is_specialized"/>
+    <fontcolor name="org-netbeans-modules-cnd-navigation-overrides"/>
+    <fontcolor name="org-netbeans-modules-cnd-navigation-overrides_pseudo"/>
+    <fontcolor name="org-netbeans-modules-cnd-navigation-specializes"/>
     <fontcolor name="org-netbeans-modules-editor-annotations-has_implementations"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements"/>
     <fontcolor name="org-netbeans-modules-editor-annotations-implements-has-implementations-combined"/>
     <fontcolor name="org-netbeans-modules-editor-annotations-implements-is-overridden-combined"/>
-    <fontcolor name="org-netbeans-modules-editor-annotations-implements"/>
     <fontcolor name="org-netbeans-modules-editor-annotations-intercepted"/>
     <fontcolor name="org-netbeans-modules-editor-annotations-is_overridden"/>
     <fontcolor name="org-netbeans-modules-editor-annotations-override-is-overridden-combined"/>
     <fontcolor name="org-netbeans-modules-editor-annotations-overrides"/>
     <fontcolor name="org-netbeans-modules-git-Annotation"/>
+    <fontcolor name="org-netbeans-modules-git-remote-Annotation"/>
     <fontcolor name="org-netbeans-modules-mercurial-Annotation"/>
+    <fontcolor name="org-netbeans-modules-mercurial-remote-Annotation"/>
     <fontcolor name="org-netbeans-modules-subversion-Annotation"/>
+    <fontcolor name="org-netbeans-modules-subversion-remote-Annotation"/>
     <fontcolor name="org-netbeans-modules-tomcat5-error" bgColor="ffff8080"/>
     <fontcolor name="org-netbeans-modules-versioning-annotate-Annotation"/>
     <fontcolor name="org-netbeans-modules-web-beans-annotations-decorated-bean"/>
@@ -117,36 +134,35 @@
     <fontcolor name="org-netbeans-modules-web-beans-annotations-injection-point"/>
     <fontcolor name="org-netbeans-modules-web-beans-annotations-observer"/>
     <fontcolor name="org-netbeans-modules-web-core-syntax-JspParserErrorAnnotation" waveUnderlined="red"/>
-    <fontcolor name="org-netbeans-modules-xml-error" bgColor="ff5b3535"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err_fixable"/>
+    <fontcolor name="org-netbeans-modules-xml-error" bgColor="ffffa0a0"/>
     <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err_fixable"/>
     <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo_fixable" foreColor="ffa8c023"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"/>
     <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo" foreColor="ffa8c023"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo_fixable" foreColor="ffa8c023"/>
     <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"/>
     <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn"/>
-    <fontcolor name="OtherThread_BP_broken" bgColor="ffbde6aa"/>
-    <fontcolor name="OtherThread_BP" bgColor="fffc9d9f"/>
-    <fontcolor name="OtherThread_DBP" bgColor="darkGray"/>
-    <fontcolor name="OtherThread_PC_BP" bgColor="ffbde6aa"/>
-    <fontcolor name="OtherThread_PC" bgColor="ffbde6aa"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"/>
     <fontcolor name="OtherThread"/>
-    <fontcolor name="OtherThreads_BP_broken" bgColor="ffbde6aa"/>
-    <fontcolor name="OtherThreads_BP" bgColor="fffc9d9f"/>
-    <fontcolor name="OtherThreads_DBP" bgColor="darkGray"/>
-    <fontcolor name="OtherThreads_PC_BP" bgColor="ffbde6aa"/>
+    <fontcolor name="OtherThread_BP" bgColor="ff4B1919"/>
+    <fontcolor name="OtherThread_BP_broken" bgColor="ff283C26"/>
+    <fontcolor name="OtherThread_DBP" bgColor="ff372B2B"/>
+    <fontcolor name="OtherThread_PC" bgColor="ff283C26"/>
+    <fontcolor name="OtherThread_PC_BP" bgColor="ff283C26"/>
     <fontcolor name="OtherThreads"/>
+    <fontcolor name="OtherThreads_BP" bgColor="ff4B1919"/>
+    <fontcolor name="OtherThreads_BP_broken" bgColor="ff283C26"/>
+    <fontcolor name="OtherThreads_DBP" bgColor="ff372B2B"/>
+    <fontcolor name="OtherThreads_PC_BP" bgColor="ff283C26"/>
     <fontcolor name="PHPError" waveUnderlined="red"/>
     <fontcolor name="PHPNotice" waveUnderlined="ffc0c000"/>
     <fontcolor name="PHPWarning" waveUnderlined="ffc0c000"/>
-    <fontcolor name="PinnedWatch"/>
-    <fontcolor name="resetResultsProfilingPoint" bgColor="ffb4e4fc"/>
-    <fontcolor name="resetResultsProfilingPointD" bgColor="ffdcdcd8"/>
-    <fontcolor name="stopwatchProfilingPoint" bgColor="ffb4e4fc"/>
-    <fontcolor name="stopwatchProfilingPointD" bgColor="ffdcdcd8"/>
-    <fontcolor name="takeSnapshotProfilingPoint" bgColor="ffb4e4fc"/>
-    <fontcolor name="takeSnapshotProfilingPointD" bgColor="ffdcdcd8"/>
+    <fontcolor name="resetResultsProfilingPoint" bgColor="ff508098"/>
+    <fontcolor name="resetResultsProfilingPointD" bgColor="ff2B2B41"/>
+    <fontcolor name="stopwatchProfilingPoint" bgColor="ff508098"/>
+    <fontcolor name="stopwatchProfilingPointD" bgColor="ff2B2B41"/>
+    <fontcolor name="takeSnapshotProfilingPoint" bgColor="ff508098"/>
+    <fontcolor name="takeSnapshotProfilingPointD" bgColor="ff2B2B41"/>
 </fontscolors>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-annotations.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-annotations.xml
@@ -21,132 +21,132 @@
 -->
 <!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
 <fontscolors>
-  <fontcolor name="Breakpoint_broken" bgColor="darkGray"/>
-  <fontcolor name="Breakpoint_stroke" bgColor="darkGray"/>
-  <fontcolor name="Breakpoint" bgColor="ff5b3535"/>
-  <fontcolor name="CallSite" bgColor="ffe7e1ef"/>
-  <fontcolor name="ClassBreakpoint_stroke"/>
-  <fontcolor name="ClassBreakpoint"/>
-  <fontcolor name="CondBreakpoint_broken" bgColor="darkGray"/>
-  <fontcolor name="CondBreakpoint_stroke" bgColor="darkGray"/>
-  <fontcolor name="CondBreakpoint" bgColor="ff5b3535"/>
-  <fontcolor name="CurrentExpression" bgColor="ffd1ffbc"/>
-  <fontcolor name="CurrentExpressionLine_BP" bgColor="ffe9ffe6"/>
-  <fontcolor name="CurrentExpressionLine_CBP" bgColor="ffe9ffe6"/>
-  <fontcolor name="CurrentExpressionLine_DBP" bgColor="ffe9ffe6"/>
-  <fontcolor name="CurrentExpressionLine_DCBP" bgColor="ffe9ffe6"/>
-  <fontcolor name="CurrentExpressionLine" bgColor="ffe9ffe6"/>
-  <fontcolor name="CurrentPC" bgColor="ffbde6aa"/>
-  <fontcolor name="CurrentPC2_BP" bgColor="ff5b3535"/>
-  <fontcolor name="CurrentPC2_DBP" bgColor="ffdcdcd8"/>
-  <fontcolor name="CurrentPC2" bgColor="ffbde6aa"/>
-  <fontcolor name="CurrentPC2LinePart" bgColor="ffbde6aa"/>
-  <fontcolor name="CurrentPCLinePart" bgColor="ffbde6aa"/>
-  <fontcolor name="Dbx_Bpt_broken_dis" bgColor="ff372B2B"/>
-  <fontcolor name="Dbx_Bpt_broken" bgColor="ff4B1919"/>
-  <fontcolor name="Dbx_Bpt_cmpx_broken_dis" bgColor="ff372B2B"/>
-  <fontcolor name="Dbx_Bpt_cmpx_broken" bgColor="ff4B1919"/>
-  <fontcolor name="Dbx_Bpt_cmpx_dis" bgColor="ff372B2B"/>
-  <fontcolor name="Dbx_Bpt_cmpx_hit_broken_dis" bgColor="ff372B2B"/>
-  <fontcolor name="Dbx_Bpt_cmpx_hit_broken" bgColor="ff283C26"/>
-  <fontcolor name="Dbx_Bpt_cmpx_hit_dis" bgColor="ff372B2B"/>
-  <fontcolor name="Dbx_Bpt_cmpx_hit" bgColor="ff283C26"/>
-  <fontcolor name="Dbx_Bpt_cmpx" bgColor="ff4B1919"/>
-  <fontcolor name="Dbx_Bpt_compound_hit" bgColor="ff283C26"/>
-  <fontcolor name="Dbx_Bpt_compound" bgColor="ff4B1919"/>
-  <fontcolor name="Dbx_Bpt_dis" bgColor="ff372B2B"/>
-  <fontcolor name="Dbx_Bpt_hit_broken_dis" bgColor="ff372B2B"/>
-  <fontcolor name="Dbx_Bpt_hit_broken" bgColor="ff283C26"/>
-  <fontcolor name="Dbx_Bpt_hit_dis" bgColor="ff372B2B"/>
-  <fontcolor name="Dbx_Bpt_hit" bgColor="ff283C26"/>
-  <fontcolor name="Dbx_Bpt" bgColor="ff3a2323"/>
-  <fontcolor name="Dbx_PC" bgColor="ff283C26"/>
-  <fontcolor name="debugger-mixed_BP_broken" bgColor="darkGray"/>
-  <fontcolor name="debugger-mixed_BP" bgColor="ff5b3535"/>
-  <fontcolor name="debugger-multi_BPCBP_broken" bgColor="darkGray"/>
-  <fontcolor name="debugger-multi_BPCBP" bgColor="ff5b3535"/>
-  <fontcolor name="debugger-multi_DBPCBP" bgColor="darkGray"/>
-  <fontcolor name="debugger-PC_BP_broken" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_BP_stroke" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_BP" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_CBP_broken" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_CBP_stroke" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_CBP" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_DBP_stroke" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_DBP" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_DCBP_stroke" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_DCBP" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_mixedBP_broken" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_mixedBP" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_multi_BPCBP_broken" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_multi_BPCBP" bgColor="ffbde6aa"/>
-  <fontcolor name="debugger-PC_multi_DBPCBP" bgColor="ffbde6aa"/>
-  <fontcolor name="DisabledBreakpoint_stroke" bgColor="darkGray"/>
-  <fontcolor name="DisabledBreakpoint" bgColor="darkGray"/>
-  <fontcolor name="DisabledClassBreakpoint_stroke"/>
-  <fontcolor name="DisabledClassBreakpoint"/>
-  <fontcolor name="DisabledCondBreakpoint_stroke" bgColor="darkGray"/>
-  <fontcolor name="DisabledCondBreakpoint" bgColor="darkGray"/>
-  <fontcolor name="DisabledFieldBreakpoint_stroke"/>
-  <fontcolor name="DisabledFieldBreakpoint"/>
-  <fontcolor name="DisabledMethodBreakpoint_stroke"/>
-  <fontcolor name="DisabledMethodBreakpoint"/>
-  <fontcolor name="editor-bookmark"/>
-  <fontcolor name="FieldBreakpoint_stroke"/>
-  <fontcolor name="FieldBreakpoint"/>
-  <fontcolor name="loadgenProfilingPoint" bgColor="ffb4e4fc"/>
-  <fontcolor name="loadgenProfilingPointD" bgColor="ffdcdcd8"/>
-  <fontcolor name="MethodBreakpoint_stroke"/>
-  <fontcolor name="MethodBreakpoint"/>
-  <fontcolor name="org-netbeans-modules-editor-annotations-has_implementations"/>
-  <fontcolor name="org-netbeans-modules-editor-annotations-implements-has-implementations-combined"/>
-  <fontcolor name="org-netbeans-modules-editor-annotations-implements-is-overridden-combined"/>
-  <fontcolor name="org-netbeans-modules-editor-annotations-implements"/>
-  <fontcolor name="org-netbeans-modules-editor-annotations-intercepted"/>
-  <fontcolor name="org-netbeans-modules-editor-annotations-is_overridden"/>
-  <fontcolor name="org-netbeans-modules-editor-annotations-override-is-overridden-combined"/>
-  <fontcolor name="org-netbeans-modules-editor-annotations-overrides"/>
-  <fontcolor name="org-netbeans-modules-git-Annotation"/>
-  <fontcolor name="org-netbeans-modules-mercurial-Annotation"/>
-  <fontcolor name="org-netbeans-modules-subversion-Annotation"/>
-  <fontcolor name="org-netbeans-modules-tomcat5-error" bgColor="ffff8080"/>
-  <fontcolor name="org-netbeans-modules-versioning-annotate-Annotation"/>
-  <fontcolor name="org-netbeans-modules-web-beans-annotations-decorated-bean"/>
-  <fontcolor name="org-netbeans-modules-web-beans-annotations-delegate-point"/>
-  <fontcolor name="org-netbeans-modules-web-beans-annotations-event"/>
-  <fontcolor name="org-netbeans-modules-web-beans-annotations-injection-point"/>
-  <fontcolor name="org-netbeans-modules-web-beans-annotations-observer"/>
-  <fontcolor name="org-netbeans-modules-web-core-syntax-JspParserErrorAnnotation" waveUnderlined="red"/>
-  <fontcolor name="org-netbeans-modules-xml-error" bgColor="ff5b3535"/>
-  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err_fixable"/>
-  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err"/>
-  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"/>
-  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint"/>
-  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo_fixable" foreColor="ffa8c023"/>
-  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo" foreColor="ffa8c023"/>
-  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"/>
-  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier"/>
-  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"/>
-  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn"/>
-  <fontcolor name="OtherThread_BP_broken" bgColor="ffbde6aa"/>
-  <fontcolor name="OtherThread_BP" bgColor="fffc9d9f"/>
-  <fontcolor name="OtherThread_DBP" bgColor="darkGray"/>
-  <fontcolor name="OtherThread_PC_BP" bgColor="ffbde6aa"/>
-  <fontcolor name="OtherThread_PC" bgColor="ffbde6aa"/>
-  <fontcolor name="OtherThread"/>
-  <fontcolor name="OtherThreads_BP_broken" bgColor="ffbde6aa"/>
-  <fontcolor name="OtherThreads_BP" bgColor="fffc9d9f"/>
-  <fontcolor name="OtherThreads_DBP" bgColor="darkGray"/>
-  <fontcolor name="OtherThreads_PC_BP" bgColor="ffbde6aa"/>
-  <fontcolor name="OtherThreads"/>
-  <fontcolor name="PHPError" waveUnderlined="red"/>
-  <fontcolor name="PHPNotice" waveUnderlined="ffc0c000"/>
-  <fontcolor name="PHPWarning" waveUnderlined="ffc0c000"/>
-  <fontcolor name="PinnedWatch"/>
-  <fontcolor name="resetResultsProfilingPoint" bgColor="ffb4e4fc"/>
-  <fontcolor name="resetResultsProfilingPointD" bgColor="ffdcdcd8"/>
-  <fontcolor name="stopwatchProfilingPoint" bgColor="ffb4e4fc"/>
-  <fontcolor name="stopwatchProfilingPointD" bgColor="ffdcdcd8"/>
-  <fontcolor name="takeSnapshotProfilingPoint" bgColor="ffb4e4fc"/>
-  <fontcolor name="takeSnapshotProfilingPointD" bgColor="ffdcdcd8"/>
+    <fontcolor name="Breakpoint_broken" bgColor="darkGray"/>
+    <fontcolor name="Breakpoint_stroke" bgColor="darkGray"/>
+    <fontcolor name="Breakpoint" bgColor="ff5b3535"/>
+    <fontcolor name="CallSite" bgColor="ffe7e1ef"/>
+    <fontcolor name="ClassBreakpoint_stroke"/>
+    <fontcolor name="ClassBreakpoint"/>
+    <fontcolor name="CondBreakpoint_broken" bgColor="darkGray"/>
+    <fontcolor name="CondBreakpoint_stroke" bgColor="darkGray"/>
+    <fontcolor name="CondBreakpoint" bgColor="ff5b3535"/>
+    <fontcolor name="CurrentExpression" bgColor="ffd1ffbc"/>
+    <fontcolor name="CurrentExpressionLine_BP" bgColor="ffe9ffe6"/>
+    <fontcolor name="CurrentExpressionLine_CBP" bgColor="ffe9ffe6"/>
+    <fontcolor name="CurrentExpressionLine_DBP" bgColor="ffe9ffe6"/>
+    <fontcolor name="CurrentExpressionLine_DCBP" bgColor="ffe9ffe6"/>
+    <fontcolor name="CurrentExpressionLine" bgColor="ffe9ffe6"/>
+    <fontcolor name="CurrentPC" bgColor="ffbde6aa"/>
+    <fontcolor name="CurrentPC2_BP" bgColor="ff5b3535"/>
+    <fontcolor name="CurrentPC2_DBP" bgColor="ffdcdcd8"/>
+    <fontcolor name="CurrentPC2" bgColor="ffbde6aa"/>
+    <fontcolor name="CurrentPC2LinePart" bgColor="ffbde6aa"/>
+    <fontcolor name="CurrentPCLinePart" bgColor="ffbde6aa"/>
+    <fontcolor name="Dbx_Bpt_broken_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_broken" bgColor="ff4B1919"/>
+    <fontcolor name="Dbx_Bpt_cmpx_broken_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_cmpx_broken" bgColor="ff4B1919"/>
+    <fontcolor name="Dbx_Bpt_cmpx_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_cmpx_hit_broken_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_cmpx_hit_broken" bgColor="ff283C26"/>
+    <fontcolor name="Dbx_Bpt_cmpx_hit_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_cmpx_hit" bgColor="ff283C26"/>
+    <fontcolor name="Dbx_Bpt_cmpx" bgColor="ff4B1919"/>
+    <fontcolor name="Dbx_Bpt_compound_hit" bgColor="ff283C26"/>
+    <fontcolor name="Dbx_Bpt_compound" bgColor="ff4B1919"/>
+    <fontcolor name="Dbx_Bpt_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_hit_broken_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_hit_broken" bgColor="ff283C26"/>
+    <fontcolor name="Dbx_Bpt_hit_dis" bgColor="ff372B2B"/>
+    <fontcolor name="Dbx_Bpt_hit" bgColor="ff283C26"/>
+    <fontcolor name="Dbx_Bpt" bgColor="ff3a2323"/>
+    <fontcolor name="Dbx_PC" bgColor="ff283C26"/>
+    <fontcolor name="debugger-mixed_BP_broken" bgColor="darkGray"/>
+    <fontcolor name="debugger-mixed_BP" bgColor="ff5b3535"/>
+    <fontcolor name="debugger-multi_BPCBP_broken" bgColor="darkGray"/>
+    <fontcolor name="debugger-multi_BPCBP" bgColor="ff5b3535"/>
+    <fontcolor name="debugger-multi_DBPCBP" bgColor="darkGray"/>
+    <fontcolor name="debugger-PC_BP_broken" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_BP_stroke" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_BP" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_CBP_broken" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_CBP_stroke" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_CBP" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_DBP_stroke" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_DBP" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_DCBP_stroke" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_DCBP" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_mixedBP_broken" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_mixedBP" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_multi_BPCBP_broken" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_multi_BPCBP" bgColor="ffbde6aa"/>
+    <fontcolor name="debugger-PC_multi_DBPCBP" bgColor="ffbde6aa"/>
+    <fontcolor name="DisabledBreakpoint_stroke" bgColor="darkGray"/>
+    <fontcolor name="DisabledBreakpoint" bgColor="darkGray"/>
+    <fontcolor name="DisabledClassBreakpoint_stroke"/>
+    <fontcolor name="DisabledClassBreakpoint"/>
+    <fontcolor name="DisabledCondBreakpoint_stroke" bgColor="darkGray"/>
+    <fontcolor name="DisabledCondBreakpoint" bgColor="darkGray"/>
+    <fontcolor name="DisabledFieldBreakpoint_stroke"/>
+    <fontcolor name="DisabledFieldBreakpoint"/>
+    <fontcolor name="DisabledMethodBreakpoint_stroke"/>
+    <fontcolor name="DisabledMethodBreakpoint"/>
+    <fontcolor name="editor-bookmark"/>
+    <fontcolor name="FieldBreakpoint_stroke"/>
+    <fontcolor name="FieldBreakpoint"/>
+    <fontcolor name="loadgenProfilingPoint" bgColor="ffb4e4fc"/>
+    <fontcolor name="loadgenProfilingPointD" bgColor="ffdcdcd8"/>
+    <fontcolor name="MethodBreakpoint_stroke"/>
+    <fontcolor name="MethodBreakpoint"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-has_implementations"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements-has-implementations-combined"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements-is-overridden-combined"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-intercepted"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-is_overridden"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-override-is-overridden-combined"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-overrides"/>
+    <fontcolor name="org-netbeans-modules-git-Annotation"/>
+    <fontcolor name="org-netbeans-modules-mercurial-Annotation"/>
+    <fontcolor name="org-netbeans-modules-subversion-Annotation"/>
+    <fontcolor name="org-netbeans-modules-tomcat5-error" bgColor="ffff8080"/>
+    <fontcolor name="org-netbeans-modules-versioning-annotate-Annotation"/>
+    <fontcolor name="org-netbeans-modules-web-beans-annotations-decorated-bean"/>
+    <fontcolor name="org-netbeans-modules-web-beans-annotations-delegate-point"/>
+    <fontcolor name="org-netbeans-modules-web-beans-annotations-event"/>
+    <fontcolor name="org-netbeans-modules-web-beans-annotations-injection-point"/>
+    <fontcolor name="org-netbeans-modules-web-beans-annotations-observer"/>
+    <fontcolor name="org-netbeans-modules-web-core-syntax-JspParserErrorAnnotation" waveUnderlined="red"/>
+    <fontcolor name="org-netbeans-modules-xml-error" bgColor="ff5b3535"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo_fixable" foreColor="ffa8c023"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo" foreColor="ffa8c023"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn"/>
+    <fontcolor name="OtherThread_BP_broken" bgColor="ffbde6aa"/>
+    <fontcolor name="OtherThread_BP" bgColor="fffc9d9f"/>
+    <fontcolor name="OtherThread_DBP" bgColor="darkGray"/>
+    <fontcolor name="OtherThread_PC_BP" bgColor="ffbde6aa"/>
+    <fontcolor name="OtherThread_PC" bgColor="ffbde6aa"/>
+    <fontcolor name="OtherThread"/>
+    <fontcolor name="OtherThreads_BP_broken" bgColor="ffbde6aa"/>
+    <fontcolor name="OtherThreads_BP" bgColor="fffc9d9f"/>
+    <fontcolor name="OtherThreads_DBP" bgColor="darkGray"/>
+    <fontcolor name="OtherThreads_PC_BP" bgColor="ffbde6aa"/>
+    <fontcolor name="OtherThreads"/>
+    <fontcolor name="PHPError" waveUnderlined="red"/>
+    <fontcolor name="PHPNotice" waveUnderlined="ffc0c000"/>
+    <fontcolor name="PHPWarning" waveUnderlined="ffc0c000"/>
+    <fontcolor name="PinnedWatch"/>
+    <fontcolor name="resetResultsProfilingPoint" bgColor="ffb4e4fc"/>
+    <fontcolor name="resetResultsProfilingPointD" bgColor="ffdcdcd8"/>
+    <fontcolor name="stopwatchProfilingPoint" bgColor="ffb4e4fc"/>
+    <fontcolor name="stopwatchProfilingPointD" bgColor="ffdcdcd8"/>
+    <fontcolor name="takeSnapshotProfilingPoint" bgColor="ffb4e4fc"/>
+    <fontcolor name="takeSnapshotProfilingPointD" bgColor="ffdcdcd8"/>
 </fontscolors>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-annotations.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-annotations.xml
@@ -21,148 +21,132 @@
 -->
 <!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
 <fontscolors>
-    <fontcolor name="Breakpoint" bgColor="ff4B1919"/>
-    <fontcolor name="Breakpoint_broken" bgColor="ff372B2B"/>
-    <fontcolor name="Breakpoint_stroke" bgColor="ff372B2B"/>
-    <fontcolor name="CallSite" bgColor="ff796977"/>
-    <fontcolor name="ClassBreakpoint"/>
-    <fontcolor name="ClassBreakpoint_stroke"/>
-    <fontcolor name="CondBreakpoint" bgColor="ff4B1919"/>
-    <fontcolor name="CondBreakpoint_broken" bgColor="ff372B2B"/>
-    <fontcolor name="CondBreakpoint_stroke" bgColor="ff372B2B"/>
-    <fontcolor name="CurrentExpression" bgColor="ffd1ffbc"/>
-    <fontcolor name="CurrentExpressionLine" bgColor="ff1E501C"/>
-    <fontcolor name="CurrentExpressionLine_BP" bgColor="ff1E501C"/>
-    <fontcolor name="CurrentExpressionLine_CBP" bgColor="ff1E501C"/>
-    <fontcolor name="CurrentExpressionLine_DBP" bgColor="ff1E501C"/>
-    <fontcolor name="CurrentExpressionLine_DCBP" bgColor="ff1E501C"/>
-    <fontcolor name="CurrentPC" bgColor="ff283C26"/>
-    <fontcolor name="CurrentPC2" bgColor="ff283C26"/>
-    <fontcolor name="CurrentPC2_BP" bgColor="ff4B1919"/>
-    <fontcolor name="CurrentPC2_DBP" bgColor="ff372B2B"/>
-    <fontcolor name="CurrentPC2LinePart" bgColor="ff283C26"/>
-    <fontcolor name="CurrentPCLinePart" bgColor="ff283C26"/>
-    <fontcolor name="Dbx_Bpt" bgColor="ff3a2323"/>
-    <fontcolor name="Dbx_Bpt_broken" bgColor="ff4B1919"/>
-    <fontcolor name="Dbx_Bpt_broken_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_cmpx" bgColor="ff4B1919"/>
-    <fontcolor name="Dbx_Bpt_cmpx_broken" bgColor="ff4B1919"/>
-    <fontcolor name="Dbx_Bpt_cmpx_broken_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_cmpx_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_cmpx_hit" bgColor="ff283C26"/>
-    <fontcolor name="Dbx_Bpt_cmpx_hit_broken" bgColor="ff283C26"/>
-    <fontcolor name="Dbx_Bpt_cmpx_hit_broken_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_cmpx_hit_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_compound" bgColor="ff4B1919"/>
-    <fontcolor name="Dbx_Bpt_compound_hit" bgColor="ff283C26"/>
-    <fontcolor name="Dbx_Bpt_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_hit" bgColor="ff283C26"/>
-    <fontcolor name="Dbx_Bpt_hit_broken" bgColor="ff283C26"/>
-    <fontcolor name="Dbx_Bpt_hit_broken_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_Bpt_hit_dis" bgColor="ff372B2B"/>
-    <fontcolor name="Dbx_PC" bgColor="ff283C26"/>
-    <fontcolor name="debugger-mixed_BP" bgColor="ff4B1919"/>
-    <fontcolor name="debugger-mixed_BP_broken" bgColor="ff372B2B"/>
-    <fontcolor name="debugger-multi_BPCBP" bgColor="ff4B1919"/>
-    <fontcolor name="debugger-multi_BPCBP_broken" bgColor="ff372B2B"/>
-    <fontcolor name="debugger-multi_DBPCBP" bgColor="ff372B2B"/>
-    <fontcolor name="debugger-PC_BP" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_BP_broken" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_BP_stroke" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_CBP" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_CBP_broken" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_CBP_stroke" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_DBP" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_DBP_stroke" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_DCBP" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_DCBP_stroke" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_mixedBP" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_mixedBP_broken" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_multi_BPCBP" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_multi_BPCBP_broken" bgColor="ff283C26"/>
-    <fontcolor name="debugger-PC_multi_DBPCBP" bgColor="ff283C26"/>
-    <fontcolor name="DisabledBreakpoint" bgColor="ff372B2B"/>
-    <fontcolor name="DisabledBreakpoint_stroke" bgColor="ff372B2B"/>
-    <fontcolor name="DisabledClassBreakpoint"/>
-    <fontcolor name="DisabledClassBreakpoint_stroke"/>
-    <fontcolor name="DisabledCondBreakpoint" bgColor="ff372B2B"/>
-    <fontcolor name="DisabledCondBreakpoint_stroke" bgColor="ff372B2B"/>
-    <fontcolor name="DisabledFieldBreakpoint"/>
-    <fontcolor name="DisabledFieldBreakpoint_stroke"/>
-    <fontcolor name="DisabledMethodBreakpoint"/>
-    <fontcolor name="DisabledMethodBreakpoint_stroke"/>
-    <fontcolor name="editor-bookmark"/>
-    <fontcolor name="FieldBreakpoint"/>
-    <fontcolor name="FieldBreakpoint_stroke"/>
-    <fontcolor name="loadgenProfilingPoint" bgColor="ff508098"/>
-    <fontcolor name="loadgenProfilingPointD" bgColor="ff2B2B41"/>
-    <fontcolor name="MethodBreakpoint"/>
-    <fontcolor name="MethodBreakpoint_stroke"/>
-    <fontcolor name="org-netbeans-modules-cnd-cpp-parser_annotation_err" waveUnderlined="red"/>
-    <fontcolor name="org-netbeans-modules-cnd-highligh-semantic-markoccurrences"/>
-    <fontcolor name="org-netbeans-modules-cnd-highlight-security-error"/>
-    <fontcolor name="org-netbeans-modules-cnd-highlight-security-warning"/>
-    <fontcolor name="org-netbeans-modules-cnd-navigation-extended_is_specialized"/>
-    <fontcolor name="org-netbeans-modules-cnd-navigation-extended_specializes"/>
-    <fontcolor name="org-netbeans-modules-cnd-navigation-is_overridden"/>
-    <fontcolor name="org-netbeans-modules-cnd-navigation-is_overridden_combined"/>
-    <fontcolor name="org-netbeans-modules-cnd-navigation-is_overridden_combined_pseudo"/>
-    <fontcolor name="org-netbeans-modules-cnd-navigation-is_overridden_pseudo"/>
-    <fontcolor name="org-netbeans-modules-cnd-navigation-is_specialized"/>
-    <fontcolor name="org-netbeans-modules-cnd-navigation-overrides"/>
-    <fontcolor name="org-netbeans-modules-cnd-navigation-overrides_pseudo"/>
-    <fontcolor name="org-netbeans-modules-cnd-navigation-specializes"/>
-    <fontcolor name="org-netbeans-modules-editor-annotations-has_implementations"/>
-    <fontcolor name="org-netbeans-modules-editor-annotations-implements"/>
-    <fontcolor name="org-netbeans-modules-editor-annotations-implements-has-implementations-combined"/>
-    <fontcolor name="org-netbeans-modules-editor-annotations-implements-is-overridden-combined"/>
-    <fontcolor name="org-netbeans-modules-editor-annotations-intercepted"/>
-    <fontcolor name="org-netbeans-modules-editor-annotations-is_overridden"/>
-    <fontcolor name="org-netbeans-modules-editor-annotations-override-is-overridden-combined"/>
-    <fontcolor name="org-netbeans-modules-editor-annotations-overrides"/>
-    <fontcolor name="org-netbeans-modules-git-Annotation"/>
-    <fontcolor name="org-netbeans-modules-git-remote-Annotation"/>
-    <fontcolor name="org-netbeans-modules-mercurial-Annotation"/>
-    <fontcolor name="org-netbeans-modules-mercurial-remote-Annotation"/>
-    <fontcolor name="org-netbeans-modules-subversion-Annotation"/>
-    <fontcolor name="org-netbeans-modules-subversion-remote-Annotation"/>
-    <fontcolor name="org-netbeans-modules-tomcat5-error" bgColor="ffff8080"/>
-    <fontcolor name="org-netbeans-modules-versioning-annotate-Annotation"/>
-    <fontcolor name="org-netbeans-modules-web-beans-annotations-decorated-bean"/>
-    <fontcolor name="org-netbeans-modules-web-beans-annotations-delegate-point"/>
-    <fontcolor name="org-netbeans-modules-web-beans-annotations-event"/>
-    <fontcolor name="org-netbeans-modules-web-beans-annotations-injection-point"/>
-    <fontcolor name="org-netbeans-modules-web-beans-annotations-observer"/>
-    <fontcolor name="org-netbeans-modules-web-core-syntax-JspParserErrorAnnotation" waveUnderlined="red"/>
-    <fontcolor name="org-netbeans-modules-xml-error" bgColor="ffffa0a0"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err_fixable"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo" foreColor="ffa8c023"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo_fixable" foreColor="ffa8c023"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn"/>
-    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"/>
-    <fontcolor name="OtherThread"/>
-    <fontcolor name="OtherThread_BP" bgColor="ff4B1919"/>
-    <fontcolor name="OtherThread_BP_broken" bgColor="ff283C26"/>
-    <fontcolor name="OtherThread_DBP" bgColor="ff372B2B"/>
-    <fontcolor name="OtherThread_PC" bgColor="ff283C26"/>
-    <fontcolor name="OtherThread_PC_BP" bgColor="ff283C26"/>
-    <fontcolor name="OtherThreads"/>
-    <fontcolor name="OtherThreads_BP" bgColor="ff4B1919"/>
-    <fontcolor name="OtherThreads_BP_broken" bgColor="ff283C26"/>
-    <fontcolor name="OtherThreads_DBP" bgColor="ff372B2B"/>
-    <fontcolor name="OtherThreads_PC_BP" bgColor="ff283C26"/>
-    <fontcolor name="PHPError" waveUnderlined="red"/>
-    <fontcolor name="PHPNotice" waveUnderlined="ffc0c000"/>
-    <fontcolor name="PHPWarning" waveUnderlined="ffc0c000"/>
-    <fontcolor name="resetResultsProfilingPoint" bgColor="ff508098"/>
-    <fontcolor name="resetResultsProfilingPointD" bgColor="ff2B2B41"/>
-    <fontcolor name="stopwatchProfilingPoint" bgColor="ff508098"/>
-    <fontcolor name="stopwatchProfilingPointD" bgColor="ff2B2B41"/>
-    <fontcolor name="takeSnapshotProfilingPoint" bgColor="ff508098"/>
-    <fontcolor name="takeSnapshotProfilingPointD" bgColor="ff2B2B41"/>
+  <fontcolor name="Breakpoint_broken" bgColor="darkGray"/>
+  <fontcolor name="Breakpoint_stroke" bgColor="darkGray"/>
+  <fontcolor name="Breakpoint" bgColor="ff5b3535"/>
+  <fontcolor name="CallSite" bgColor="ffe7e1ef"/>
+  <fontcolor name="ClassBreakpoint_stroke"/>
+  <fontcolor name="ClassBreakpoint"/>
+  <fontcolor name="CondBreakpoint_broken" bgColor="darkGray"/>
+  <fontcolor name="CondBreakpoint_stroke" bgColor="darkGray"/>
+  <fontcolor name="CondBreakpoint" bgColor="ff5b3535"/>
+  <fontcolor name="CurrentExpression" bgColor="ffd1ffbc"/>
+  <fontcolor name="CurrentExpressionLine_BP" bgColor="ffe9ffe6"/>
+  <fontcolor name="CurrentExpressionLine_CBP" bgColor="ffe9ffe6"/>
+  <fontcolor name="CurrentExpressionLine_DBP" bgColor="ffe9ffe6"/>
+  <fontcolor name="CurrentExpressionLine_DCBP" bgColor="ffe9ffe6"/>
+  <fontcolor name="CurrentExpressionLine" bgColor="ffe9ffe6"/>
+  <fontcolor name="CurrentPC" bgColor="ffbde6aa"/>
+  <fontcolor name="CurrentPC2_BP" bgColor="ff5b3535"/>
+  <fontcolor name="CurrentPC2_DBP" bgColor="ffdcdcd8"/>
+  <fontcolor name="CurrentPC2" bgColor="ffbde6aa"/>
+  <fontcolor name="CurrentPC2LinePart" bgColor="ffbde6aa"/>
+  <fontcolor name="CurrentPCLinePart" bgColor="ffbde6aa"/>
+  <fontcolor name="Dbx_Bpt_broken_dis" bgColor="ff372B2B"/>
+  <fontcolor name="Dbx_Bpt_broken" bgColor="ff4B1919"/>
+  <fontcolor name="Dbx_Bpt_cmpx_broken_dis" bgColor="ff372B2B"/>
+  <fontcolor name="Dbx_Bpt_cmpx_broken" bgColor="ff4B1919"/>
+  <fontcolor name="Dbx_Bpt_cmpx_dis" bgColor="ff372B2B"/>
+  <fontcolor name="Dbx_Bpt_cmpx_hit_broken_dis" bgColor="ff372B2B"/>
+  <fontcolor name="Dbx_Bpt_cmpx_hit_broken" bgColor="ff283C26"/>
+  <fontcolor name="Dbx_Bpt_cmpx_hit_dis" bgColor="ff372B2B"/>
+  <fontcolor name="Dbx_Bpt_cmpx_hit" bgColor="ff283C26"/>
+  <fontcolor name="Dbx_Bpt_cmpx" bgColor="ff4B1919"/>
+  <fontcolor name="Dbx_Bpt_compound_hit" bgColor="ff283C26"/>
+  <fontcolor name="Dbx_Bpt_compound" bgColor="ff4B1919"/>
+  <fontcolor name="Dbx_Bpt_dis" bgColor="ff372B2B"/>
+  <fontcolor name="Dbx_Bpt_hit_broken_dis" bgColor="ff372B2B"/>
+  <fontcolor name="Dbx_Bpt_hit_broken" bgColor="ff283C26"/>
+  <fontcolor name="Dbx_Bpt_hit_dis" bgColor="ff372B2B"/>
+  <fontcolor name="Dbx_Bpt_hit" bgColor="ff283C26"/>
+  <fontcolor name="Dbx_Bpt" bgColor="ff3a2323"/>
+  <fontcolor name="Dbx_PC" bgColor="ff283C26"/>
+  <fontcolor name="debugger-mixed_BP_broken" bgColor="darkGray"/>
+  <fontcolor name="debugger-mixed_BP" bgColor="ff5b3535"/>
+  <fontcolor name="debugger-multi_BPCBP_broken" bgColor="darkGray"/>
+  <fontcolor name="debugger-multi_BPCBP" bgColor="ff5b3535"/>
+  <fontcolor name="debugger-multi_DBPCBP" bgColor="darkGray"/>
+  <fontcolor name="debugger-PC_BP_broken" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_BP_stroke" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_BP" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_CBP_broken" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_CBP_stroke" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_CBP" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_DBP_stroke" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_DBP" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_DCBP_stroke" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_DCBP" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_mixedBP_broken" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_mixedBP" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_multi_BPCBP_broken" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_multi_BPCBP" bgColor="ffbde6aa"/>
+  <fontcolor name="debugger-PC_multi_DBPCBP" bgColor="ffbde6aa"/>
+  <fontcolor name="DisabledBreakpoint_stroke" bgColor="darkGray"/>
+  <fontcolor name="DisabledBreakpoint" bgColor="darkGray"/>
+  <fontcolor name="DisabledClassBreakpoint_stroke"/>
+  <fontcolor name="DisabledClassBreakpoint"/>
+  <fontcolor name="DisabledCondBreakpoint_stroke" bgColor="darkGray"/>
+  <fontcolor name="DisabledCondBreakpoint" bgColor="darkGray"/>
+  <fontcolor name="DisabledFieldBreakpoint_stroke"/>
+  <fontcolor name="DisabledFieldBreakpoint"/>
+  <fontcolor name="DisabledMethodBreakpoint_stroke"/>
+  <fontcolor name="DisabledMethodBreakpoint"/>
+  <fontcolor name="editor-bookmark"/>
+  <fontcolor name="FieldBreakpoint_stroke"/>
+  <fontcolor name="FieldBreakpoint"/>
+  <fontcolor name="loadgenProfilingPoint" bgColor="ffb4e4fc"/>
+  <fontcolor name="loadgenProfilingPointD" bgColor="ffdcdcd8"/>
+  <fontcolor name="MethodBreakpoint_stroke"/>
+  <fontcolor name="MethodBreakpoint"/>
+  <fontcolor name="org-netbeans-modules-editor-annotations-has_implementations"/>
+  <fontcolor name="org-netbeans-modules-editor-annotations-implements-has-implementations-combined"/>
+  <fontcolor name="org-netbeans-modules-editor-annotations-implements-is-overridden-combined"/>
+  <fontcolor name="org-netbeans-modules-editor-annotations-implements"/>
+  <fontcolor name="org-netbeans-modules-editor-annotations-intercepted"/>
+  <fontcolor name="org-netbeans-modules-editor-annotations-is_overridden"/>
+  <fontcolor name="org-netbeans-modules-editor-annotations-override-is-overridden-combined"/>
+  <fontcolor name="org-netbeans-modules-editor-annotations-overrides"/>
+  <fontcolor name="org-netbeans-modules-git-Annotation"/>
+  <fontcolor name="org-netbeans-modules-mercurial-Annotation"/>
+  <fontcolor name="org-netbeans-modules-subversion-Annotation"/>
+  <fontcolor name="org-netbeans-modules-tomcat5-error" bgColor="ffff8080"/>
+  <fontcolor name="org-netbeans-modules-versioning-annotate-Annotation"/>
+  <fontcolor name="org-netbeans-modules-web-beans-annotations-decorated-bean"/>
+  <fontcolor name="org-netbeans-modules-web-beans-annotations-delegate-point"/>
+  <fontcolor name="org-netbeans-modules-web-beans-annotations-event"/>
+  <fontcolor name="org-netbeans-modules-web-beans-annotations-injection-point"/>
+  <fontcolor name="org-netbeans-modules-web-beans-annotations-observer"/>
+  <fontcolor name="org-netbeans-modules-web-core-syntax-JspParserErrorAnnotation" waveUnderlined="red"/>
+  <fontcolor name="org-netbeans-modules-xml-error" bgColor="ff5b3535"/>
+  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err_fixable"/>
+  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err"/>
+  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"/>
+  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint"/>
+  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo_fixable" foreColor="ffa8c023"/>
+  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo" foreColor="ffa8c023"/>
+  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"/>
+  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier"/>
+  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"/>
+  <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn"/>
+  <fontcolor name="OtherThread_BP_broken" bgColor="ffbde6aa"/>
+  <fontcolor name="OtherThread_BP" bgColor="fffc9d9f"/>
+  <fontcolor name="OtherThread_DBP" bgColor="darkGray"/>
+  <fontcolor name="OtherThread_PC_BP" bgColor="ffbde6aa"/>
+  <fontcolor name="OtherThread_PC" bgColor="ffbde6aa"/>
+  <fontcolor name="OtherThread"/>
+  <fontcolor name="OtherThreads_BP_broken" bgColor="ffbde6aa"/>
+  <fontcolor name="OtherThreads_BP" bgColor="fffc9d9f"/>
+  <fontcolor name="OtherThreads_DBP" bgColor="darkGray"/>
+  <fontcolor name="OtherThreads_PC_BP" bgColor="ffbde6aa"/>
+  <fontcolor name="OtherThreads"/>
+  <fontcolor name="PHPError" waveUnderlined="red"/>
+  <fontcolor name="PHPNotice" waveUnderlined="ffc0c000"/>
+  <fontcolor name="PHPWarning" waveUnderlined="ffc0c000"/>
+  <fontcolor name="PinnedWatch"/>
+  <fontcolor name="resetResultsProfilingPoint" bgColor="ffb4e4fc"/>
+  <fontcolor name="resetResultsProfilingPointD" bgColor="ffdcdcd8"/>
+  <fontcolor name="stopwatchProfilingPoint" bgColor="ffb4e4fc"/>
+  <fontcolor name="stopwatchProfilingPointD" bgColor="ffdcdcd8"/>
+  <fontcolor name="takeSnapshotProfilingPoint" bgColor="ffb4e4fc"/>
+  <fontcolor name="takeSnapshotProfilingPointD" bgColor="ffdcdcd8"/>
 </fontscolors>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/layer.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/layer.xml
@@ -106,6 +106,15 @@
                     </folder>
                 </folder>
             </folder>
+            <folder name="x-ini">
+                <folder name="FontsColors">
+                    <folder name="FlatLafDark">
+                        <folder name="Defaults">
+                            <file name="org-netbeans-modules-ini-token-colorings.xml" url="fontscolors/FlatLafDark-INI-tokenColorings.xml"/>
+                        </folder>
+                    </folder>
+                </folder>
+            </folder>
             <folder name="x-java">
                 <folder name="FontsColors">
                     <folder name="FlatLafDark">


### PR DESCRIPTION
Tweaked mostly debug breakpoints colors and properties files colors.
Added token colorings for INI files.

This is a followup PR to #1768.

Before:
![before](https://user-images.githubusercontent.com/1875690/71024046-5b165f00-2104-11ea-98c7-0c31f69cde56.png)

After:
![after](https://user-images.githubusercontent.com/1875690/71024055-61a4d680-2104-11ea-91f1-91e78bc015f3.png)

Color scheme of properties files is visually equivalent, I have only made cleanups to the definition.