### PR TITLE
[NETBEANS-3602] - Upgrade Apache commons-fileupload from 1.3 to 1.4

### DIFF
--- a/enterprise/libs.commons_fileupload/external/binaries-list
+++ b/enterprise/libs.commons_fileupload/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-C89E540E4A12CB034FB973E12135839B5DE9A87E commons-fileupload:commons-fileupload:1.3
+F95188E3D372E20E7328706C37EF366E5D7859B0 commons-fileupload:commons-fileupload:1.4

--- a/enterprise/libs.commons_fileupload/external/commons-fileupload-1.3-notice.txt
+++ b/enterprise/libs.commons_fileupload/external/commons-fileupload-1.3-notice.txt
@@ -1,5 +1,0 @@
-Apache Commons FileUpload
-Copyright 2002-2013 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).

--- a/enterprise/libs.commons_fileupload/external/commons-fileupload-1.4-license.txt
+++ b/enterprise/libs.commons_fileupload/external/commons-fileupload-1.4-license.txt
@@ -1,9 +1,9 @@
 Name: Apache Commons FileUpload
-Version: 1.3
+Version: 1.4
 License: Apache-2.0
 OSR: 2970
 Description: File upload component
-Origin: http://commons.apache.org/proper/commons-fileupload/
+Origin: https://commons.apache.org/proper/commons-fileupload/
 
 
                                  Apache License

--- a/enterprise/libs.commons_fileupload/external/commons-fileupload-1.4-notice.txt
+++ b/enterprise/libs.commons_fileupload/external/commons-fileupload-1.4-notice.txt
@@ -1,0 +1,5 @@
+Apache Commons FileUpload
+Copyright 2002-2019 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).

--- a/enterprise/libs.commons_fileupload/manifest.mf
+++ b/enterprise/libs.commons_fileupload/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.libs.commons_fileupload/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/commons_fileupload/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.32
+OpenIDE-Module-Specification-Version: 1.33

--- a/enterprise/libs.commons_fileupload/nbproject/project.properties
+++ b/enterprise/libs.commons_fileupload/nbproject/project.properties
@@ -16,7 +16,8 @@
 # under the License.
 
 is.autoload=true
-
-release.external/commons-fileupload-1.3.jar=modules/ext/commons-fileupload-1.3.jar
+javac.compilerargs=-Xlint:all -Xlint:-serial
+javac.source=1.8
+release.external/commons-fileupload-1.4.jar=modules/ext/commons-fileupload-1.4.jar
 jnlp.indirect.jars=\
-    modules/ext/commons-fileupload-1.3.jar
+    modules/ext/commons-fileupload-1.4.jar

--- a/enterprise/libs.commons_fileupload/src/org/netbeans/libs/commons_fileupload/Bundle.properties
+++ b/enterprise/libs.commons_fileupload/src/org/netbeans/libs/commons_fileupload/Bundle.properties
@@ -19,5 +19,5 @@ OpenIDE-Module-Name=Commons FileUpload Integration
 OpenIDE-Module-Display-Category=Libraries
 OpenIDE-Module-Short-Description=This plugin bundles Commons FileUpload.
 OpenIDE-Module-Long-Description=\
-    The module bundles Apache Commons FileUpload version 1.3 \
-    from http://commons.apache.org/proper/commons-fileupload/.
+    The module bundles Apache Commons FileUpload version 1.4 \
+    from https://commons.apache.org/proper/commons-fileupload/.


### PR DESCRIPTION
Notes:
- Requires Java 6 or later
- Performance Improvement in MultipartStream
- Many bug fixes
- Security fixes:
  - CVE-2014-0050
  - CVE-2016-3092

[Apache commons-fileupload Web Page](https://commons.apache.org/proper/commons-fileupload/)
[Apache commons-fileupload Release Notes](https://dist.apache.org/repos/dist/release/commons/fileupload/RELEASE-NOTES.txt)