### PR TITLE
[NETBEANS-3603] - Upgrade 'web.monitor' (tomcat:servlet-api) from 6.0.13 to 6.0.53

### DIFF
--- a/enterprise/web.monitor/external/binaries-list
+++ b/enterprise/web.monitor/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-D868F438F27DA38B3CCD253BCB859F06C1A1FE2C org.apache.tomcat:servlet-api:6.0.13
+90654F3E78EEA2876014468ED777CAF51F1F3B81 org.apache.tomcat:servlet-api:6.0.53

--- a/enterprise/web.monitor/external/servlet-api-6.0.53-license.txt
+++ b/enterprise/web.monitor/external/servlet-api-6.0.53-license.txt
@@ -1,8 +1,8 @@
 Name: Servlet API
 License: Apache-2.0
-Version: 6.0.13
+Version: 6.0.53
 Description: Java API for Servlet
-Origin: http://tomcat.apache.org
+Origin: https://tomcat.apache.org/
 Type: compile-time
 
                                  Apache License

--- a/enterprise/web.monitor/manifest.mf
+++ b/enterprise/web.monitor/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.web.monitor/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/web/monitor/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/web/monitor/resources/layer.xml
-OpenIDE-Module-Specification-Version: 1.49
+OpenIDE-Module-Specification-Version: 1.50
 OpenIDE-Module-Requires: org.openide.util.HttpServer$Impl
 AutoUpdate-Show-In-Client: false

--- a/enterprise/web.monitor/nbproject/project.properties
+++ b/enterprise/web.monitor/nbproject/project.properties
@@ -15,5 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-server.cp.extra=${schema2beans.dir}/modules/org-netbeans-modules-schema2beans.jar:${nb_all}/enterprise/web.monitor/external/servlet-api-6.0.13.jar
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
+server.cp.extra=${schema2beans.dir}/modules/org-netbeans-modules-schema2beans.jar:${nb_all}/enterprise/web.monitor/external/servlet-api-6.0.53.jar
 extra.module.files=modules/ext/org-netbeans-modules-web-httpmonitor.jar


### PR DESCRIPTION
Notes:
- Several bug fixes
- Fix 34 security vulnerabilities
- Improved performance
- Tomcat 6 has now reached end of life

[Apache Tomcat 6 Release Notes](https://tomcat.apache.org/tomcat-6.0-doc/changelog.html)