### PR TITLE
[NETBEANS-3428] Update FlatLaf from 0.21 to 0.22

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-E73FB712C60563982AECA87D03ACBA999080A53A com.formdev:flatlaf:0.21
+1DDE8147C324577DE87351CACF6123DCFEE64A64 com.formdev:flatlaf:0.22

--- a/platform/libs.flatlaf/external/flatlaf-0.22-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-0.22-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 0.21
-Files: flatlaf-0.21.jar
+Version: 0.22
+Files: flatlaf-0.22.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-0.21.jar=modules/ext/flatlaf-0.21.jar
+release.external/flatlaf-0.22.jar=modules/ext/flatlaf-0.22.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-0.21.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-0.21.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-0.22.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-0.22.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
This PR updates FlatLaf to 0.22, which includes following fixes/improvements for NetBeans:

- Changed ProgressBar styling to reduce height so that it fits better into the NB status bar.

Here is a full list of changes: https://github.com/JFormDesigner/FlatLaf/releases/tag/0.22