### PR TITLE
[NETBEANS-3608] - cleanup hash raw types

### DIFF
--- a/enterprise/glassfish.eecommon/nbproject/project.properties
+++ b/enterprise/glassfish.eecommon/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.44.0
 

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/DomainEditor.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/DomainEditor.java
@@ -497,7 +497,7 @@ public class DomainEditor {
         NodeList propsNodeList = cpElement.getElementsByTagName(CONST_PROP);
 
         //Cycle through each property element
-        HashMap map = new HashMap();
+        HashMap<String, String> map = new HashMap<>();
         for (int j = 0; j < propsNodeList.getLength(); j++) {
             Node propNode = propsNodeList.item(j);
             NamedNodeMap propsMap = propNode.getAttributes();

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDWizardPanel.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDWizardPanel.java
@@ -46,8 +46,7 @@ public class WebLogicDDWizardPanel implements WizardDescriptor.Panel {
      * The visual component that displays this panel. If you need to access the
      * component from this class, just use getComponent().
      */
-//    private final Set<ChangeListener> listeners = new HashSet<ChangeListener>(1);
-    private final Set listeners = new HashSet(1);
+    private final Set<ChangeListener> listeners = new HashSet<ChangeListener>(1);
     private WebLogicDDVisualPanel component = new WebLogicDDVisualPanel();
     private WizardDescriptor wizardDescriptor;
     private Project project;
@@ -129,16 +128,13 @@ public class WebLogicDDWizardPanel implements WizardDescriptor.Panel {
     }
     
     protected final void fireChangeEvent() {
-//        Iterator<ChangeListener> it;
-        Iterator it;
+        Iterator<ChangeListener> it;
         synchronized (listeners) {
-//            it = new HashSet<ChangeListener>(listeners).iterator();
-            it = new HashSet(listeners).iterator();
+            it = new HashSet<ChangeListener>(listeners).iterator();
         }
         ChangeEvent ev = new ChangeEvent(this);
         while (it.hasNext()) {
-//            it.next().stateChanged(ev);
-            ((ChangeListener)it.next()).stateChanged(ev);
+            it.next().stateChanged(ev);
         }
     }
     

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/TaskEvent.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/TaskEvent.java
@@ -130,7 +130,7 @@ public enum TaskEvent {
      * conversion.
      */
     private static final Map<String, TaskEvent> stringValuesMap
-            = new HashMap(values().length);
+            = new HashMap<>(values().length);
 
     // Initialize backward String conversion <code>Map</code>.
     static {

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/TaskState.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/TaskState.java
@@ -65,7 +65,7 @@ public enum TaskState {
      * conversion.
      */
     private static final Map<String, TaskState> stringValuesMap
-            = new HashMap(values().length);
+            = new HashMap<>(values().length);
 
     // Initialize backward String conversion <code>Map</code>.
     static {

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishStatusCheck.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishStatusCheck.java
@@ -64,7 +64,7 @@ public enum GlassFishStatusCheck {
     /** Stored <code>String</code> values for backward <code>String</code>
      *  conversion. */
     private static final Map<String, GlassFishStatusCheck> stringValuesMap
-            = new HashMap(values().length);
+            = new HashMap<>(values().length);
     static {
         for (GlassFishStatusCheck state : GlassFishStatusCheck.values()) {
             stringValuesMap.put(state.toString().toUpperCase(), state);

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/DomainEditor.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/DomainEditor.java
@@ -492,7 +492,7 @@ public class DomainEditor {
         NodeList propsNodeList = cpElement.getElementsByTagName(CONST_PROP);
 
         //Cycle through each property element
-        HashMap map = new HashMap();
+        Map<String, String> map = new HashMap<>();
         for (int j = 0; j < propsNodeList.getLength(); j++) {
             Node propNode = propsNodeList.item(j);
             NamedNodeMap propsMap = propNode.getAttributes();

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDWizardPanel.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDWizardPanel.java
@@ -41,7 +41,7 @@ import org.netbeans.spi.project.ui.templates.support.Templates;
  */
 public class PayaraDDWizardPanel implements WizardDescriptor.Panel {
     
-    private final Set listeners = new HashSet(1);
+    private final Set<ChangeListener> listeners = new HashSet<>(1);
     private final PayaraDDVisualPanel component = new PayaraDDVisualPanel();
     private WizardDescriptor wizardDescriptor;
     private Project project;
@@ -117,13 +117,13 @@ public class PayaraDDWizardPanel implements WizardDescriptor.Panel {
     }
     
     protected final void fireChangeEvent() {
-        Iterator it;
+        Iterator<ChangeListener> it;
         synchronized (listeners) {
-            it = new HashSet(listeners).iterator();
+            it = new HashSet<ChangeListener>(listeners).iterator();
         }
         ChangeEvent ev = new ChangeEvent(this);
         while (it.hasNext()) {
-            ((ChangeListener)it.next()).stateChanged(ev);
+            it.next().stateChanged(ev);
         }
     }
     

--- a/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/DeployOnSaveManager.java
+++ b/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/DeployOnSaveManager.java
@@ -503,7 +503,7 @@ public final class DeployOnSaveManager {
 
                 // create target FOs map keyed by relative paths
                 java.util.Enumeration destFiles = destRoot.getChildren(true);
-                Map destMap = new HashMap();
+                Map<String, FileObject> destMap = new HashMap<>();
                 int rootPathLen = destRoot.getPath().length();
                 for (; destFiles.hasMoreElements();) {
                     FileObject destFO = (FileObject) destFiles.nextElement();

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/TaskEvent.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/TaskEvent.java
@@ -130,7 +130,7 @@ public enum TaskEvent {
      * conversion.
      */
     private static final Map<String, TaskEvent> stringValuesMap
-            = new HashMap(values().length);
+            = new HashMap<>(values().length);
 
     // Initialize backward String conversion <code>Map</code>.
     static {

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/TaskState.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/TaskState.java
@@ -65,7 +65,7 @@ public enum TaskState {
      * conversion.
      */
     private static final Map<String, TaskState> stringValuesMap
-            = new HashMap(values().length);
+            = new HashMap<>(values().length);
 
     // Initialize backward String conversion <code>Map</code>.
     static {

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraAdminInterface.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraAdminInterface.java
@@ -53,7 +53,7 @@ public enum PayaraAdminInterface {
      * conversion.
      */
     private static final Map<String, PayaraAdminInterface> stringValuesMap
-            = new HashMap(values().length);
+            = new HashMap<>(values().length);
 
     // Initialize backward String conversion <code>Map</code>.
     static {

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraStatusCheck.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraStatusCheck.java
@@ -64,7 +64,7 @@ public enum PayaraStatusCheck {
     /** Stored <code>String</code> values for backward <code>String</code>
      *  conversion. */
     private static final Map<String, PayaraStatusCheck> stringValuesMap
-            = new HashMap(values().length);
+            = new HashMap<>(values().length);
     static {
         for (PayaraStatusCheck state : PayaraStatusCheck.values()) {
             stringValuesMap.put(state.toString().toUpperCase(), state);

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraVersion.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/PayaraVersion.java
@@ -199,7 +199,7 @@ public enum PayaraVersion {
      * conversion.
      */
     private static final Map<String, PayaraVersion> stringValuesMap
-            = new HashMap(2 * values().length);
+            = new HashMap<>(2 * values().length);
 
     // Initialize backward String conversion Map.
     static {

--- a/groovy/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
+++ b/groovy/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
@@ -45,7 +45,7 @@ import org.openide.util.Lookup;
 @ProjectServiceProvider(service = ReplaceTokenProvider.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GradleJavaTokenProvider implements ReplaceTokenProvider {
 
-    private static final Set<String> SUPPORTED = Collections.unmodifiableSet(new HashSet(Arrays.asList(
+    private static final Set<String> SUPPORTED = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
             "selectedClass",       //NOI18N
             "selectedMethod",      //NOI18N
             "affectedBuildTasks"   //NOI18N

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/debug/GroovyBreakpointAnnotationListener.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/debug/GroovyBreakpointAnnotationListener.java
@@ -39,7 +39,7 @@ import org.netbeans.api.debugger.jpda.LineBreakpoint;
  */
 public class GroovyBreakpointAnnotationListener extends DebuggerManagerAdapter {
     
-    private HashMap breakpointToAnnotation = new HashMap ();
+    private HashMap<LineBreakpoint, Object> breakpointToAnnotation = new HashMap<>();
     private boolean listen = true;
     
     @Override

--- a/ide/db/src/org/netbeans/modules/db/explorer/DbDriverManager.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/DbDriverManager.java
@@ -59,7 +59,7 @@ public class DbDriverManager {
     
     private static final DbDriverManager DEFAULT = new DbDriverManager();
     
-    private Set registeredDrivers;
+    private Set<Driver> registeredDrivers;
     
     /**
      * Maps each connection to the driver used to create that connection.
@@ -165,7 +165,7 @@ public class DbDriverManager {
      */
     public synchronized void registerDriver(Driver driver) {
         if (registeredDrivers == null) {
-            registeredDrivers = new HashSet();
+            registeredDrivers = new HashSet<>();
         }
         registeredDrivers.add(driver);
     }

--- a/ide/editor.deprecated.pre65formatting/nbproject/project.properties
+++ b/ide/editor.deprecated.pre65formatting/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.38.0

--- a/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatter.java
+++ b/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatter.java
@@ -85,7 +85,7 @@ public class ExtFormatter extends Formatter implements FormatLayer {
     private static final Object NULL_VALUE = new Object();
 
     /** Map that contains the requested [setting-name, setting-value] pairs */
-    private final HashMap settingsMap = new HashMap();
+    private final HashMap<String, Object> settingsMap = new HashMap<>();
 
     private Acceptor indentHotCharsAcceptor;
     private boolean reindentWithTextBefore;

--- a/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatTokenPositionSupport.java
+++ b/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatTokenPositionSupport.java
@@ -43,7 +43,7 @@ class FormatTokenPositionSupport {
     private SaveSet lastSet;
 
     /** Map holding the [token, token-position-list] pairs. */
-    private final HashMap tokens2positionLists = new HashMap();
+    private final HashMap<TokenItem, ArrayList> tokens2positionLists = new HashMap<>();
 
     FormatTokenPositionSupport(FormatWriter formatWriter) {
         this.formatWriter = formatWriter;

--- a/ide/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/TableSorter.java
+++ b/ide/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/TableSorter.java
@@ -66,7 +66,7 @@ public class TableSorter extends AbstractTableModel {
     private JTableHeader tableHeader;
     private MouseListener mouseListener;
     private TableModelListener tableModelListener;
-    private Map columnComparators = new HashMap();
+    private Map<Class, Comparator> columnComparators = new HashMap<>();
     private List sortingColumns = new ArrayList();
 
     public TableSorter() {

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EditorContextDispatcher.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/EditorContextDispatcher.java
@@ -474,7 +474,7 @@ public final class EditorContextDispatcher {
         pcs.removePropertyChangeListener(l);
         // Also remove the listener from all MIME types
         synchronized (pcsByMIMEType) {
-            Set<String> MIMETypes = new HashSet(pcsByMIMEType.keySet());
+            Set<String> MIMETypes = new HashSet<>(pcsByMIMEType.keySet());
             for (String MIMEType : MIMETypes) {
                 PropertyChangeSupport _pcs = pcsByMIMEType.get(MIMEType);
                 _pcs.removePropertyChangeListener(l);
@@ -567,7 +567,7 @@ public final class EditorContextDispatcher {
                 Map<String, Reference<Object>> lastEvents;
                 synchronized (this) {
                     lastMIMEType = lastFiredMIMEType;
-                    lastEvents = new HashMap(lastMIMETypeEvents);
+                    lastEvents = new HashMap<>(lastMIMETypeEvents);
                     if (lastMIMEType != null && lastMIMEType.equals(oldMIMEType)) {
                         lastFiredMIMEType = null;
                         lastMIMETypeEvents.clear();

--- a/ide/xml.catalog.ui/nbproject/project.properties
+++ b/ide/xml.catalog.ui/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=2.10.0

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
@@ -272,7 +272,7 @@ final class CatalogNode extends BeanNode implements Refreshable, PropertyChangeL
         public void reload() {
             //if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug(" Reloading kids of " + peer + "..."); // NOI18N
 
-            Set previous = new HashSet(keys);
+            Set<String> previous = new HashSet<>(keys);
             keys.clear();
             Iterator it = peer.getPublicIDs();
             if (it != null) {

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionNodeView.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionNodeView.java
@@ -38,7 +38,7 @@ public abstract class SectionNodeView extends SectionView {
 
     private final XmlMultiViewDataObject dataObject;
     private SectionNode rootNode = null;
-    private HashMap nodes = new HashMap();
+    private HashMap<SectionNode, SectionNode> nodes = new HashMap<>();
 
     private final RequestProcessor.Task refreshTask = RequestProcessor.getDefault().create(new Runnable() {
         public void run() {

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionView.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.xml.multiview.ui;
 
 import javax.swing.JPanel;
 import java.awt.*;
+import java.util.Hashtable;
 
 import org.openide.nodes.Node;
 import org.netbeans.modules.xml.multiview.cookies.SectionFocusCookie;
@@ -34,7 +35,7 @@ import org.netbeans.modules.xml.multiview.cookies.SectionFocusCookie;
 public class SectionView extends PanelView implements SectionFocusCookie, ContainerPanel {
     private JPanel scrollPanel, filler;
     javax.swing.JScrollPane scrollPane;
-    private java.util.Hashtable map;
+    private Hashtable<Node, NodeSectionPanel> map;
     private int sectionCount=0;
     private NodeSectionPanel activePanel;
     private InnerPanelFactory factory = null;
@@ -59,7 +60,7 @@ public class SectionView extends PanelView implements SectionFocusCookie, Contai
     
     public void initComponents() {
         super.initComponents();
-        map = new java.util.Hashtable();
+        map = new Hashtable<>();
         setLayout(new java.awt.BorderLayout());
         scrollPanel = new JPanel();
         scrollPanel.setLayout(new java.awt.GridBagLayout());

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreePanelView.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/TreePanelView.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.xml.multiview.ui;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.HashMap;
 
 /**
  * TreePanelView.java
@@ -30,7 +31,7 @@ import java.awt.*;
  */
 public class TreePanelView extends PanelView {
 
-    java.util.HashMap map;
+    HashMap<String, TreePanel> map;
     JPanel cardPanel;
     CardLayout cardLayout;
     public TreePanelView() {
@@ -41,7 +42,7 @@ public class TreePanelView extends PanelView {
         setLayout(new BorderLayout());
         cardLayout = new CardLayout();
         cardPanel = new JPanel(cardLayout);
-        map = new java.util.HashMap();
+        map = new HashMap<>();
         JScrollPane scrollPane = new JScrollPane();
         scrollPane.setViewportView(cardPanel);
         add (scrollPane, BorderLayout.CENTER);

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
@@ -44,7 +44,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
 
     
     /** */
-    private static final Map publicNodeTypeNamesMap = new HashMap();
+    private static final Map<Class<?>, String> publicNodeTypeNamesMap = new HashMap();
 
 
     //

--- a/ide/xsl/nbproject/project.properties
+++ b/ide/xsl/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
@@ -55,13 +55,13 @@ public final class XSLGrammarQuery implements GrammarQuery{
      * allowed XSL children. Neither the element name keys nor the names in the
      * value set should contain the namespace prefix.
      */
-    private static Map elementDecls;
+    private static Map<String, Set> elementDecls;
 
     /** Contains a mapping from XSL namespace element names to set of names of
      * allowed XSL attributes for that element.  The element name keys should
      * not contain the namespace prefix.
      */
-    private static Map attrDecls;
+    private static Map<String, Set> attrDecls;
 
     /** A Set of XSL attributes which should be allowd for result elements*/
     private static Set resultElementAttr;
@@ -130,8 +130,8 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
     private static Map getElementDecls() {
         if (elementDecls == null) {
-            elementDecls = new HashMap();
-            attrDecls = new HashMap();
+            elementDecls = new HashMap<>();
+            attrDecls = new HashMap<>();
 
             // Commonly used variables
             Set emptySet = new TreeSet();

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
@@ -129,8 +129,8 @@ public class AntDebugger extends ActionsProviderSupport {
     
     // ActionsProvider .........................................................
     
-    private static final Set actions = new HashSet ();
-    private static final Set actionsToDisable = new HashSet ();
+    private static final Set<Object> actions = new HashSet<>();
+    private static final Set<Object> actionsToDisable = new HashSet<>();
     static {
         actions.add (ActionsManager.ACTION_KILL);
         actions.add (ActionsManager.ACTION_CONTINUE);
@@ -869,16 +869,16 @@ public class AntDebugger extends ActionsProviderSupport {
     /**
      * File as a script location is a key. Values are maps of name to Target.
      */
-    private Map nameToTargetByFiles = new HashMap();
+    private Map<File, Map<String, TargetLister.Target>> nameToTargetByFiles = new HashMap<>();
     /**
      * File as a script location is a key, values are project names.
      */
-    private Map projectNamesByFiles = new HashMap();
+    private Map<File, String> projectNamesByFiles = new HashMap<>();
     
     private synchronized TargetLister.Target findTarget(String name, File file) {
-        Map nameToTarget = (Map) nameToTargetByFiles.get(file);
+        Map<String, TargetLister.Target> nameToTarget = nameToTargetByFiles.get(file);
         if (nameToTarget == null) {
-            nameToTarget = new HashMap ();
+            nameToTarget = new HashMap<>();
             FileObject fo = FileUtil.toFileObject(file);
             DataObject dob;
             try {

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
@@ -279,10 +279,10 @@ public class DebuggerAntLogger extends AntLogger {
     }
     
     /** AntSession => AntDebugger */
-    private Map runningDebuggers = new HashMap ();
+    private Map<AntSession, AntDebugger> runningDebuggers  = new HashMap<>();
     /** AntDebugger => AntSession */
-    private Map runningDebuggers2 = new HashMap ();
-    private Set filesToDebug = new HashSet ();
+    private Map<AntDebugger, AntSession> runningDebuggers2 = new HashMap<>();
+    private Set<File> filesToDebug = new HashSet<>();
     /** File => WeakReference -> ExecutorTask */
     private Map fileExecutors = new HashMap();
     

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/IOManager.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/IOManager.java
@@ -45,7 +45,7 @@ public class IOManager {
 
     
     /** output writer Thread */
-    private Hashtable                       lines = new Hashtable ();
+    private Hashtable<String, Object> lines = new Hashtable<>();
     private Listener                        listener = new Listener ();
 
     

--- a/java/java.examples/src/org/netbeans/modules/java/examples/PanelConfigureProject.java
+++ b/java/java.examples/src/org/netbeans/modules/java/examples/PanelConfigureProject.java
@@ -66,7 +66,7 @@ final class PanelConfigureProject implements WizardDescriptor.Panel, WizardDescr
         return component.valid(wizardDescriptor);
     }
     
-    private final Set/*<ChangeListener>*/ listeners = new HashSet(1);
+    private final Set<ChangeListener> listeners = new HashSet<>(1);
     public final void addChangeListener(ChangeListener l) {
         synchronized (listeners) {
             listeners.add(l);
@@ -78,13 +78,13 @@ final class PanelConfigureProject implements WizardDescriptor.Panel, WizardDescr
         }
     }
     protected final void fireChangeEvent() {
-        Iterator it;
+        Iterator<ChangeListener> it;
         synchronized (listeners) {
-            it = new HashSet(listeners).iterator();
+            it = new HashSet<ChangeListener>(listeners).iterator();
         }
         ChangeEvent ev = new ChangeEvent(this);
         while (it.hasNext()) {
-            ((ChangeListener)it.next()).stateChanged(ev);
+            it.next().stateChanged(ev);
         }
     }
     

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/JPDAStart.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/JPDAStart.java
@@ -202,7 +202,7 @@ public class JPDAStart implements Runnable {
     private static class Listener extends DebuggerManagerAdapter {
         
         private MethodBreakpoint breakpoint;
-        private final Set debuggers = new HashSet();
+        private final Set<JPDADebugger> debuggers = new HashSet<>();
         
         
         Listener(MethodBreakpoint breakpoint) {

--- a/java/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ElementFactoryRegistry.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/settings/impl/ElementFactoryRegistry.java
@@ -134,7 +134,7 @@ public class ElementFactoryRegistry {
     
     public void addEmbeddedModelQNames(AbstractDocumentModel<?> embeddedModel) {
         if (knownEmbeddedModelTypes == null) {
-            knownEmbeddedModelTypes = new HashSet();
+            knownEmbeddedModelTypes = new HashSet<>();
         }
         if (! knownEmbeddedModelTypes.contains(embeddedModel.getClass())) {
             knownQNames().addAll(embeddedModel.getQNames());

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
@@ -159,11 +159,11 @@ public class SourceGroupSupport {
     }
 
     private static Map createFoldersToSourceGroupsMap(final SourceGroup[] sourceGroups) {
-        Map result;
+        Map<FileObject, SourceGroup> result;
         if (sourceGroups.length == 0) {
-            result = Collections.EMPTY_MAP;
+            result = Collections.emptyMap();
         } else {
-            result = new HashMap(2 * sourceGroups.length, .5f);
+            result = new HashMap<>(2 * sourceGroups.length, .5f);
             for (int i = 0; i < sourceGroups.length; i++) {
                 SourceGroup sourceGroup = sourceGroups[i];
                 result.put(sourceGroup.getRootFolder(), sourceGroup);
@@ -172,9 +172,9 @@ public class SourceGroupSupport {
         return result;
     }
 
-    private static Set/*<SourceGroup>*/ getTestSourceGroups(SourceGroup[] sourceGroups) {
+    private static Set<SourceGroup> getTestSourceGroups(SourceGroup[] sourceGroups) {
         Map foldersToSourceGroupsMap = createFoldersToSourceGroupsMap(sourceGroups);
-        Set testGroups = new HashSet();
+        Set<SourceGroup> testGroups = new HashSet<>();
         for (int i = 0; i < sourceGroups.length; i++) {
             testGroups.addAll(getTestTargets(sourceGroups[i], foldersToSourceGroupsMap));
         }

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerateDOMScannerSupport.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerateDOMScannerSupport.java
@@ -311,7 +311,7 @@ public class GenerateDOMScannerSupport implements XMLGenerateCookie {
     private String generateElementScanner(TreeElementDecl element) {
         
         Iterator it;
-        Set elements = new HashSet();
+        Set<String> elements = new HashSet<>();
         
         TreeElementDecl.ContentType type = element.getContentType();
         

--- a/platform/openide.actions/nbproject/project.properties
+++ b/platform/openide.actions/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.main.page=org/openide/actions/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/openide.actions/src/org/openide/actions/WorkspaceSwitchAction.java
+++ b/platform/openide.actions/src/org/openide/actions/WorkspaceSwitchAction.java
@@ -64,13 +64,13 @@ public class WorkspaceSwitchAction extends CallableSystemAction {
 
         final WindowManager pool = WindowManager.getDefault();
 
-        final Hashtable menu2Workspace = new Hashtable(10);
+        final Hashtable<ActionListener, Workspace> menu2Workspace = new Hashtable<>(10);
 
         // ^ maps listener on workspace
-        final Hashtable workspace2Menu = new Hashtable(10);
+        final Hashtable<Workspace, JRadioButtonMenuItem> workspace2Menu = new Hashtable<>(10);
 
         // ^ maps workspace to menuitem
-        final Hashtable workspace2Listener = new Hashtable(10);
+        final Hashtable<Workspace, ActionListener> workspace2Listener = new Hashtable<>(10);
 
         // ^ maps workspace to action listener
         final Workspace[] currentDeskRef = new Workspace[1];
@@ -173,8 +173,8 @@ public class WorkspaceSwitchAction extends CallableSystemAction {
                         for (int i = 0; i < newWorkspaces.length; i++) {
                           System.out.println ("New Value["+i+"]= "+newWorkspaces[i].getName());
                         }*/
-                        List newList = Arrays.asList(newWorkspaces);
-                        List oldList = Arrays.asList(oldWorkspaces);
+                        List<Workspace> newList = Arrays.asList(newWorkspaces);
+                        List<Workspace> oldList = Arrays.asList(oldWorkspaces);
 
                         // remove old
                         for (int i = 0; i < oldWorkspaces.length; i++) {

--- a/platform/openide.filesystems/src/org/openide/filesystems/DefaultAttributes.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/DefaultAttributes.java
@@ -887,7 +887,7 @@ public class DefaultAttributes extends Object implements AbstractFileSystem.Attr
             if (m == null) {
                 return Enumerations.empty();
             } else {
-                HashSet s = new HashSet(m.keySet());
+                HashSet<String> s = new HashSet<>(m.keySet());
 
                 return Collections.enumeration(s);
             }

--- a/platform/openide.options/src/org/openide/options/SystemOption.java
+++ b/platform/openide.options/src/org/openide/options/SystemOption.java
@@ -275,7 +275,7 @@ WHILE:
     */
     public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
         // hashtable that maps names of properties to setter methods
-        HashMap map = new HashMap();
+        HashMap<String, Method> map = new HashMap<>();
 
         try {
             synchronized (getLock()) {

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/ReachableObjects.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/ReachableObjects.java
@@ -42,7 +42,7 @@ public class ReachableObjects {
     public ReachableObjects(Instance root, final ReachableExcludes excludes) {
         this.root = root;
         this.excludes = excludes;
-        alreadyReached = new HashSet();
+        alreadyReached = new HashSet<>();
     }
 
     public Instance getRoot() {

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
@@ -334,10 +334,10 @@ public class Snapshot {
                 this.path = path;
             }
         }
-        Deque<State> stack = new ArrayDeque<State>();
-        Set ignored = new HashSet();
+        Deque<State> stack = new ArrayDeque<>();
+        Set<Object> ignored = new HashSet<>();
         
-        List<ReferenceChain> result = new ArrayList<ReferenceChain>();
+        List<ReferenceChain> result = new ArrayList<>();
         
         Iterator toInspect = getRoots();
         ReferenceChain path = null;

--- a/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/Target.java
+++ b/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/Target.java
@@ -42,7 +42,7 @@ public class Target implements SDK {
     private static final Logger LOG = Logger.getLogger(Target.class.getName());
 
     private Target() {
-        this.props = new HashMap();
+        this.props = new HashMap<>();
     }
     
     public static Collection<SDK> parse(String output) throws IOException {

--- a/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/ExternalBrowserPlugin.java
+++ b/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/ExternalBrowserPlugin.java
@@ -649,21 +649,21 @@ public final class ExternalBrowserPlugin {
     }
     
     private String createCloseTabMessage(int tabId) {
-        Map params = new HashMap();
+        Map<String, Integer> params = new HashMap<>();
         params.put( Message.TAB_ID, tabId );
         Message msg = new Message( Message.MessageType.CLOSE, params);
         return msg.toStringValue();
     }
 
     private String createAttachDebuggerMessage(int tabId) {
-        Map params = new HashMap();
+        Map<String, Integer> params = new HashMap<>();
         params.put( Message.TAB_ID, tabId );
         Message msg = new Message( Message.MessageType.ATTACH_DEBUGGER, params);
         return msg.toStringValue();
     }
 
     private String createDetachDebuggerMessage(int tabId) {
-        Map params = new HashMap();
+        Map<String, Integer> params = new HashMap<>();
         params.put( Message.TAB_ID, tabId );
         Message msg = new Message( Message.MessageType.DETACH_DEBUGGER, params);
         return msg.toStringValue();

--- a/webcommon/html.ojet/src/org/netbeans/modules/html/ojet/data/DataProviderImpl.java
+++ b/webcommon/html.ojet/src/org/netbeans/modules/html/ojet/data/DataProviderImpl.java
@@ -45,7 +45,7 @@ public class DataProviderImpl extends DataProvider {
     private static final String ZIP_PREFIX = "ojetdocs-";
     private static final String ZIP_EXTENSION = ".zip";
     protected static final String DEFAULT_VERSION = "2.0.0";
-    private static final HashMap<String, DataItemImpl.DataItemComponent> data = new HashMap();
+    private static final HashMap<String, DataItemImpl.DataItemComponent> data = new HashMap<>();
     private static DataItemImpl.DataItemModule moduleData = null;
     private static FileObject docRoot = null;
     private static String currentVersion;

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsFunctionImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsFunctionImpl.java
@@ -162,8 +162,8 @@ public class JsFunctionImpl extends DeclarationScopeImpl implements JsFunction {
         if (areReturnTypesResolved) {
             return Collections.emptyList();
         }
-        Collection<TypeUsage> returns = new HashSet();
-        HashSet<String> nameReturnTypes = new HashSet<String>();
+        Collection<TypeUsage> returns = new HashSet<>();
+        HashSet<String> nameReturnTypes = new HashSet<>();
         areReturnTypesResolved = true;
         for(TypeUsage type : returnTypes) {
              if (type.isResolved()) {

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/JsObjectImpl.java
@@ -384,7 +384,8 @@ public class JsObjectImpl extends JsElementImpl implements JsObject {
         this.kind = kind;
     }
 
-    protected Collection<TypeUsage> resolveAssignments(JsObject jsObject, int offset) {        Collection<String> visited = new HashSet();  // for preventing infinited loops
+    protected Collection<TypeUsage> resolveAssignments(JsObject jsObject, int offset) {
+        Collection<String> visited = new HashSet<>();  // for preventing infinited loops
         return resolveAssignments(jsObject, offset, visited);
     }
 


### PR DESCRIPTION
There are many places in hte code where the following warning msgs are printed.

   [repeat] /home/bwalker/src/netbeans/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFFrameworkProvider.java:127: warning: [rawtypes] found raw type: HashSet
   [repeat]         Set result = new HashSet();
   [repeat]                          ^
   [repeat]   missing type arguments for generic class HashSet<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in class HashSet

This code change cleans up a lot of those messages.