### PR TITLE
[NETBEANS-3615] - enum is now a keyword and not an identifier

### DIFF
--- a/harness/nbjunit/test/unit/src/org/netbeans/testjunit/AskForOrgOpenideUtilEnumClass.java
+++ b/harness/nbjunit/test/unit/src/org/netbeans/testjunit/AskForOrgOpenideUtilEnumClass.java
@@ -41,7 +41,7 @@ public class AskForOrgOpenideUtilEnumClass extends TestCase {
             if (l == NbTestCase.class.getClassLoader()) {
                 fail("This test shall not be loaded by the same classloader!");
             }
-            Class<?> access = Class.forName("org.openide.util.enum.ArrayEnumeration");
+            Class<?> access = Class.forName("org.openide.util.enumeration.ArrayEnumeration");
             System.setProperty("en.one", "OK");
         } catch (Exception ex) {
             Logger.getLogger("testOne").log(Level.INFO, ex.getMessage(), ex);

--- a/java/performance/actionsframework/src/org/netbeans/actions/examples/MiniEdit.java
+++ b/java/performance/actionsframework/src/org/netbeans/actions/examples/MiniEdit.java
@@ -69,7 +69,7 @@ import org.netbeans.actions.spi.ProxyContextProvider;
 import org.netbeans.actions.simple.SimpleEngine;
 import org.netbeans.actions.spi.ContextProviderSupport;
 import org.openide.util.Utilities;
-import org.openide.util.enum.AlterEnumeration;
+import org.openide.util.enumeration.AlterEnumeration;
 import org.openide.util.enum.ArrayEnumeration;
 
 /**

--- a/platform/core.kit/test/perf/src/org/openide/util/enum/ArrayEnumTest.java
+++ b/platform/core.kit/test/perf/src/org/openide/util/enum/ArrayEnumTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 public class ArrayEnumTest extends EnumBenchmark {
 

--- a/platform/core.kit/test/perf/src/org/openide/util/enum/EnumBenchmark.java
+++ b/platform/core.kit/test/perf/src/org/openide/util/enum/EnumBenchmark.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 import java.util.Enumeration;
 import org.netbeans.performance.MultiInstanceIntArgBenchmark;

--- a/platform/core.kit/test/perf/src/org/openide/util/enum/Sequence2EnumTest.java
+++ b/platform/core.kit/test/perf/src/org/openide/util/enum/Sequence2EnumTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 public class Sequence2EnumTest extends EnumBenchmark {
 

--- a/platform/core.kit/test/perf/src/org/openide/util/enum/SequenceEnumTest.java
+++ b/platform/core.kit/test/perf/src/org/openide/util/enum/SequenceEnumTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 public class SequenceEnumTest extends EnumBenchmark {
 

--- a/platform/openide.util.enumerations/src/org/openide/util/enum/AlterEnumeration.java
+++ b/platform/openide.util.enumerations/src/org/openide/util/enum/AlterEnumeration.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 import java.util.Enumeration;
 

--- a/platform/openide.util.enumerations/src/org/openide/util/enum/ArrayEnumeration.java
+++ b/platform/openide.util.enumerations/src/org/openide/util/enum/ArrayEnumeration.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 import java.util.Enumeration;
 import java.util.NoSuchElementException;

--- a/platform/openide.util.enumerations/src/org/openide/util/enum/EmptyEnumeration.java
+++ b/platform/openide.util.enumerations/src/org/openide/util/enum/EmptyEnumeration.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 import java.util.Enumeration;
 import java.util.NoSuchElementException;

--- a/platform/openide.util.enumerations/src/org/openide/util/enum/FilterEnumeration.java
+++ b/platform/openide.util.enumerations/src/org/openide/util/enum/FilterEnumeration.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 import java.util.Enumeration;
 import java.util.NoSuchElementException;

--- a/platform/openide.util.enumerations/src/org/openide/util/enum/QueueEnumeration.java
+++ b/platform/openide.util.enumerations/src/org/openide/util/enum/QueueEnumeration.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 import java.util.Enumeration;
 import java.util.NoSuchElementException;

--- a/platform/openide.util.enumerations/src/org/openide/util/enum/RemoveDuplicatesEnumeration.java
+++ b/platform/openide.util.enumerations/src/org/openide/util/enum/RemoveDuplicatesEnumeration.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 import java.util.Enumeration;
 import java.util.HashSet;

--- a/platform/openide.util.enumerations/src/org/openide/util/enum/SequenceEnumeration.java
+++ b/platform/openide.util.enumerations/src/org/openide/util/enum/SequenceEnumeration.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 import java.util.Enumeration;
 

--- a/platform/openide.util.enumerations/src/org/openide/util/enum/SingletonEnumeration.java
+++ b/platform/openide.util.enumerations/src/org/openide/util/enum/SingletonEnumeration.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 import java.util.Enumeration;
 import java.util.NoSuchElementException;

--- a/platform/openide.util.enumerations/test/unit/src/org/openide/util/enum/OldEnumerationsTest.java
+++ b/platform/openide.util.enumerations/test/unit/src/org/openide/util/enum/OldEnumerationsTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.openide.util.enum;
+package org.openide.util.enummeration;
 
 import java.util.Collection;
 import java.util.Enumeration;


### PR DESCRIPTION
As of Java 1.5, the "enum" is a keyword and can not longer be used as an identifier.

Change the use of "package org.openide.util.enum" to "package org.openide.util.enumeration"..