### PR TITLE
[NETBEANS-2954] Fix broken tab dragging on HiDPI displays (Windows)

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/view/dnd/DragAndDropFeedbackVisualizer.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/dnd/DragAndDropFeedbackVisualizer.java
@@ -128,8 +128,10 @@ public class DragAndDropFeedbackVisualizer {
     }
 
     public void update(DragSourceDragEvent e) {
-        if( null != dragWindow )
-            dragWindow.setLocation( e.getLocation().x-dragOffset.x, e.getLocation().y-dragOffset.y );
+        if( null != dragWindow ) {
+            Point location = WindowDnDManager.getLocationWorkaround(e);
+            dragWindow.setLocation( location.x-dragOffset.x, location.y-dragOffset.y );
+        }
     }
 
     public void dispose( boolean dropSuccessful ) {

--- a/platform/core.windows/src/org/netbeans/core/windows/view/dnd/TopComponentDragSupport.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/dnd/TopComponentDragSupport.java
@@ -568,11 +568,12 @@ implements AWTEventListener, DragSourceListener, DragSourceMotionListener {
             final Set<Component> floatingFrames = windowDnDManager.getFloatingFrames();
             // Finally schedule the "drop" task later to be able to
             // detect if ESC was pressed.
+            final Point location = WindowDnDManager.getLocationWorkaround(evt);
             RequestProcessor.getDefault().post(new Runnable() {
                 @Override
                 public void run() {
                     SwingUtilities.invokeLater(createDropIntoFreeAreaTask(
-                            evt, WindowDnDManager.getLocationWorkaround(evt), floatingFrames));
+                            evt, location, floatingFrames));
                 }},
                 350 // XXX #21918, Neccessary to skip after possible ESC key event.
             );

--- a/platform/core.windows/src/org/netbeans/core/windows/view/dnd/TopComponentDragSupport.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/dnd/TopComponentDragSupport.java
@@ -572,7 +572,7 @@ implements AWTEventListener, DragSourceListener, DragSourceMotionListener {
                 @Override
                 public void run() {
                     SwingUtilities.invokeLater(createDropIntoFreeAreaTask(
-                            evt, evt.getLocation(), floatingFrames));
+                            evt, WindowDnDManager.getLocationWorkaround(evt), floatingFrames));
                 }},
                 350 // XXX #21918, Neccessary to skip after possible ESC key event.
             );
@@ -589,8 +589,7 @@ implements AWTEventListener, DragSourceListener, DragSourceMotionListener {
             return true;
         }
         
-        // Gets location.
-        Point location = evt.getLocation();
+        Point location = WindowDnDManager.getLocationWorkaround(evt);
         if(location == null) {
             return true;
         }

--- a/platform/core.windows/src/org/netbeans/core/windows/view/dnd/WindowDnDManager.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/dnd/WindowDnDManager.java
@@ -115,10 +115,13 @@ implements DropTargetGlassPane.Observer, DropTargetGlassPane.Informer {
 
     /**
      * Get the location of a {@link DragSourceEvent}, incorporating a workaround for a JDK bug on
-     * HiDPI screens on Windows. See NETBEANS-2954.
+     * HiDPI screens on Windows. See NETBEANS-2954. This method should be called only while the
+     * mouse pointer is still likely to be in the same position as it was when the event was
+     * originally created.
      */
     public static Point getLocationWorkaround(DragSourceEvent evt) {
-        if (Utilities.isWindows()) {
+        Point ret = evt.getLocation();
+        if (Utilities.isWindows() && ret != null) {
             /* Workaround for JDK bug where DragSourceEvent.getLocation() returns incorrect screen
             coordinates for displays with HiDPI scaling on Windows. Use MouseInfo.getPointerInfo
             instead; that one handles HiDPI displays correctly. In the JDK codebase, the bug can be
@@ -142,10 +145,10 @@ implements DropTargetGlassPane.Observer, DropTargetGlassPane.Informer {
             the DPI scaling level. This is not done in awt_DnDDS.cpp, however. */
             PointerInfo pointerInfo = MouseInfo.getPointerInfo();
             if (pointerInfo != null) {
-                return pointerInfo.getLocation();
+                ret = pointerInfo.getLocation();
             }
         }
-        return evt.getLocation();
+        return ret;
     }
     
     /** Indicates whether the window drag and drop is enabled. */

--- a/platform/core.windows/src/org/netbeans/core/windows/view/dnd/WindowDnDManager.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/dnd/WindowDnDManager.java
@@ -35,6 +35,7 @@ import org.netbeans.core.windows.*;
 import org.netbeans.core.windows.view.*;
 import org.netbeans.core.windows.view.ui.*;
 import org.openide.util.Lookup;
+import org.openide.util.Utilities;
 import org.openide.util.WeakSet;
 import org.openide.windows.TopComponent;
 
@@ -111,8 +112,41 @@ implements DropTargetGlassPane.Observer, DropTargetGlassPane.Informer {
              AWTEvent.MOUSE_EVENT_MASK | AWTEvent.MOUSE_MOTION_EVENT_MASK
         );
     }
-    
 
+    /**
+     * Get the location of a {@link DragSourceEvent}, incorporating a workaround for a JDK bug on
+     * HiDPI screens on Windows. See NETBEANS-2954.
+     */
+    public static Point getLocationWorkaround(DragSourceEvent evt) {
+        if (Utilities.isWindows()) {
+            /* Workaround for JDK bug where DragSourceEvent.getLocation() returns incorrect screen
+            coordinates for displays with HiDPI scaling on Windows. Use MouseInfo.getPointerInfo
+            instead; that one handles HiDPI displays correctly. In the JDK codebase, the bug can be
+            seen by comparing the correct implementation of MouseInfo.getPointerInfo at
+
+              java.desktop/windows/native/libawt/windows/MouseInfo.cpp
+              (see Java_sun_awt_windows_WMouseInfoPeer_fillPointWithCoords )
+
+            with the function AwtDragSource::GiveFeedback, which initiates the creation of
+            DragSourceEvent objects, in
+
+              java.desktop/windows/native/libawt/windows/awt_DnDDS.cpp
+              (see GetCursorPos, call_dSCenter, and call_dSCmotion calls in
+              AwtDragSource::GiveFeedback)
+
+            In both cases the screen coordinates of the mouse pointer is retrieved using the
+            "GetCursorPos" Windows API function. This one seems to return device coordinates rather
+            than logical coordinates, presumably because the java.exe executable (and the NetBeans
+            launcher, since NETBEANS-1227) declares itself to be fully DPI-aware. In MouseInfo.cpp,
+            extra code is added to convert the device coordinates to logical coordinates based on
+            the DPI scaling level. This is not done in awt_DnDDS.cpp, however. */
+            PointerInfo pointerInfo = MouseInfo.getPointerInfo();
+            if (pointerInfo != null) {
+                return pointerInfo.getLocation();
+            }
+        }
+        return evt.getLocation();
+    }
     
     /** Indicates whether the window drag and drop is enabled. */
     public static boolean isDnDEnabled() {
@@ -990,7 +1024,7 @@ implements DropTargetGlassPane.Observer, DropTargetGlassPane.Informer {
                 debugLog("dragMouseMoved evt=" + evt); // NOI18N
             }
             
-            Point location = evt.getLocation();
+            Point location = WindowDnDManager.getLocationWorkaround(evt);
             if(location == null) {
                 return;
             }


### PR DESCRIPTION
On Windows, on displays that have a HiDPI scaling set (e.g. 150% or 200%), drag-and-drop to reposition editors and modes in the NetBeans window system does not work properly. See https://issues.apache.org/jira/browse/NETBEANS-2954 .

This appears to be due to a JDK bug, where java.awt.dnd.DragSourceEvent.getLocation() returns the wrong screen coordinate when HiDPI displays are involved. The workaround is to use MouseInfo.getPointerInfo() instead--that one works correctly.

Both MouseInfo and DragSourceEvent get their coordinates from a call to the "GetCursorPos" Windows API function. The latter returns device coordinates rather than logical coordinates for DPI-aware applications (including java.exe and the netbeans launcher since https://github.com/apache/netbeans/pull/883 ).

But in the implementation of MouseInfo.getPointerInfo(), extra code was added to convert the device coordinates to logical coordinates, as part of the original JDK patch which introduced HiDPI support on Windows. See Java_sun_awt_windows_WMouseInfoPeer_fillPointWithCoords in https://github.com/openjdk/jdk/blame/6bab0f539fba8fb441697846347597b4a0ade428/src/java.desktop/windows/native/libawt/windows/MouseInfo.cpp . This was forgotten in the code that initializes the coordinates for DragSourceEvent (see GetCursorPos call for call_dSCenter/call_dSCmotion in https://github.com/openjdk/jdk/blob/1440dc39400f89b7df8af2249f30eaf5092c1574/src/java.desktop/windows/native/libawt/windows/awt_DnDDS.cpp ).

The workaround was tested on both single and multi-monitor setups.

In a few remaining cases, involving multi-monitor setups with different DPI scaling factors, the semi-transparent preview thumbnail that appears while dragging an editor may end up on the wrong screen. This is due to a different JDK bug ( https://bugs.openjdk.java.net/browse/JDK-8211999 ). In these cases, however, the orange tab outline, which appears during dragging to illustrate where the tab would end up if dropped, does appear in the correct place, which makes this less of a usability issue.