### PR TITLE
[NETBEANS-3623] - Add javadoc for JDK 15 early access

### DIFF
--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
@@ -63,6 +63,7 @@ public final class J2SEPlatformDefaultJavadocImpl implements J2SEPlatformDefault
         OFFICIAL_JAVADOC.put("12", "https://docs.oracle.com/en/java/javase/12/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("13", "https://docs.oracle.com/en/java/javase/13/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("14", "https://download.java.net/java/early_access/jdk14/docs/api/"); // NOI18N Early access
+        OFFICIAL_JAVADOC.put("15", "https://download.java.net/java/early_access/jdk15/docs/api/"); // NOI18N Early access
     }
 
     @Override


### PR DESCRIPTION
Spec:
https://openjdk.java.net/projects/jdk/15/spec/

Javadoc:
https://download.java.net/java/early_access/jdk15/docs/api/