### PR TITLE
[NETBEANS-3628] - Upgrade jersey-core from 1.5 to 1.18.6

### DIFF
--- a/enterprise/websvc.rest/external/binaries-list
+++ b/enterprise/websvc.rest/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-955FA871051ACD23841FF75087B190278228920A com.sun.jersey:jersey-core:1.5
+7AE45787634401A7E71DB35D45F742C0E7BA03B9 com.sun.jersey:jersey-core:1.18.6

--- a/enterprise/websvc.rest/external/jersey-core-1.18.6-license.txt
+++ b/enterprise/websvc.rest/external/jersey-core-1.18.6-license.txt
@@ -1,9 +1,9 @@
 Name: Jersey-core
-Version: 1.5
+Version: 1.18.6
 Description: Jersey-core
 License: CDDL-1.1
 Origin: Oracle
-Files: jersey-core-1.5.jar
+Files: jersey-core-1.18.6.jar
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/websvc.rest/manifest.mf
+++ b/enterprise/websvc.rest/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.websvc.rest/0
 OpenIDE-Module-Layer: org/netbeans/modules/websvc/rest/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/websvc/rest/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.36
+OpenIDE-Module-Specification-Version: 1.37
 OpenIDE-Module-Needs: javax.script.ScriptEngine.freemarker
 AutoUpdate-Show-In-Client: false

--- a/enterprise/websvc.rest/nbproject/project.properties
+++ b/enterprise/websvc.rest/nbproject/project.properties
@@ -18,10 +18,11 @@
 #
 
 is.autoload=true
-release.external/jersey-core-1.5.jar=modules/ext/jersey2/jersey-core-1.5.jar
+release.external/jersey-core-1.18.6.jar=modules/ext/jersey2/jersey-core-1.18.6.jar
 
 is.eager=true
-javac.source=1.6
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
 requires.nb.javac=true
 
 test-unit-sys-prop.java.awt.headless=true

--- a/enterprise/websvc.rest/nbproject/project.xml
+++ b/enterprise/websvc.rest/nbproject/project.xml
@@ -644,8 +644,8 @@
                 <package>org.netbeans.modules.websvc.rest.client</package>
             </friend-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/jersey2/jersey-core-1.5.jar</runtime-relative-path>
-		<binary-origin>external/jersey-core-1.5.jar</binary-origin>
+                <runtime-relative-path>ext/jersey2/jersey-core-1.18.6.jar</runtime-relative-path>
+		<binary-origin>external/jersey-core-1.18.6.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Notes:
- Several bug fixes
- Many improvements
- Version 1.19+ has [breaking changes](https://github.com/jersey/jersey-1.x/releases?after=post-1.12)
  
[Jersey-core web page](https://eclipse-ee4j.github.io/jersey/)