### PR TITLE
[NETBEANS-3629] - Upgrade Byte Buddy from 1.7.9 to 1.10.6

### DIFF
--- a/java/spi.java.hints/external/binaries-list
+++ b/java/spi.java.hints/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-51218A01A882C04D0ABA8C028179CCE488BBCB58 net.bytebuddy:byte-buddy:1.7.9
+1A745B7EF012EA7B96D7D6F1FAE5AFAC11FCEE3D net.bytebuddy:byte-buddy:1.10.6

--- a/java/spi.java.hints/external/byte-buddy-1.10.6-license.txt
+++ b/java/spi.java.hints/external/byte-buddy-1.10.6-license.txt
@@ -1,5 +1,5 @@
 Name: Byte Buddy
-Version: 1.7.9
+Version: 1.10.6
 Description: Code Generation Library
 License: Apache-2.0+BSD-INRIA
 Origin: Byte Buddy

--- a/java/spi.java.hints/nbproject/project.properties
+++ b/java/spi.java.hints/nbproject/project.properties
@@ -17,8 +17,8 @@
 is.autoload=true
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=1.37.0
+spec.version.base=1.38.0
 requires.nb.javac=true
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-release.external/byte-buddy-1.7.9.jar=modules/ext/byte-buddy-1.7.9.jar
+release.external/byte-buddy-1.10.6.jar=modules/ext/byte-buddy-1.10.6.jar

--- a/java/spi.java.hints/nbproject/project.xml
+++ b/java/spi.java.hints/nbproject/project.xml
@@ -518,8 +518,8 @@
                 <package>org.netbeans.spi.java.hints.support</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/byte-buddy-1.7.9.jar</runtime-relative-path>
-                <binary-origin>external/byte-buddy-1.7.9.jar</binary-origin>
+                <runtime-relative-path>ext/byte-buddy-1.10.6.jar</runtime-relative-path>
+                <binary-origin>external/byte-buddy-1.10.6.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Notes:
- Update to ASM 7.2
- Java 14 compatibility
- Add experimental support for Java 15.
- Reduce byte code level to Java 5
- Several performance improvements
- Several bug fixes
- Security  improvements
- Remove Lombok and add methods using Byte Buddy plugin

[Byte Buddy Web Page](http://bytebuddy.net)

[Byte Buddy Release Notes](https://github.com/raphw/byte-buddy/blob/master/release-notes.md)