### PR TITLE
[NETBEANS-3630] - Upgrade javaee8.api binaries

### DIFF
--- a/enterprise/j2ee.platform/build.xml
+++ b/enterprise/j2ee.platform/build.xml
@@ -31,17 +31,17 @@
     <target name="-check-prepared-doc">
         <condition property="j2ee.platform.doccreated" value="present">
             <and>
-                <available file="external/generated-javaee-api-7.0-javadoc.jar" />
+                <available file="external/generated-javaee-api-8.0.1-javadoc.jar" />
             </and>
         </condition>
     </target>
 
     <target name="prepare-doc" depends="-check-prepared-doc" unless="j2ee.platform.doccreated">
-        <delete file="external/generated-javaee-api-7.0-javadoc.jar" />
+        <delete file="external/generated-javaee-api-8.0.1-javadoc.jar" />
 
         <!-- repackage doc file into the format netbeans used prior to switching to the maven central artefact -->
-        <jar destfile="external/generated-javaee-api-7.0-javadoc.jar">
-            <zipfileset src="external/javaee-api-7.0-javadoc.jar" includes="**" prefix="docs/api" />
+        <jar destfile="external/generated-javaee-api-8.0.1-javadoc.jar">
+            <zipfileset src="external/javaee-api-8.0.1-javadoc.jar" includes="**" prefix="docs/api" />
         </jar>
     </target>
 </project>

--- a/enterprise/j2ee.platform/external/binaries-list
+++ b/enterprise/j2ee.platform/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-CC1024CBFA7C3A9CC84485603A7D458BFD2F3B4A javax:javaee-api:7.0:javadoc
+1C74AB243269D20AB01D3237D58F59662F07C1E3 javax:javaee-api:8.0.1:javadoc

--- a/enterprise/j2ee.platform/external/generated-javaee-api-8.0.1-javadoc-license.txt
+++ b/enterprise/j2ee.platform/external/generated-javaee-api-8.0.1-javadoc-license.txt
@@ -1,8 +1,9 @@
-Name: Java(TM) Enterprise Edition 7 API Documentation
-Version: 7.0
+Name: Java(TM) Enterprise Edition 8 API Documentation
+Version: 8.0.1
 Description: Java(TM) Enterprise Edition 7 API Documentation
 License: CDDL-1.0
-Origin: Oracle (http://glassfish.dev.java.net)
+Origin: Generated from javaee-api-8.0.1-javadoc.jar
+Type: generated
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 

--- a/enterprise/j2ee.platform/external/javaee-api-8.0.1-javadoc-license.txt
+++ b/enterprise/j2ee.platform/external/javaee-api-8.0.1-javadoc-license.txt
@@ -1,9 +1,8 @@
-Name: Java(TM) Enterprise Edition 7 API Documentation
-Version: 7.0
-Description: Java(TM) Enterprise Edition 7 API Documentation
+Name: Java(TM) Enterprise Edition 8 API Documentation
+Version: 8.0.1
+Description: Java(TM) Enterprise Edition 8 API Documentation
 License: CDDL-1.0
-Origin: Generated from javaee-api-7.0-javadoc.jar
-Type: generated
+Origin: Oracle (https://javaee.github.io/)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
 

--- a/enterprise/j2ee.platform/manifest.mf
+++ b/enterprise/j2ee.platform/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.j2ee.platform/1
-OpenIDE-Module-Specification-Version: 1.37
+OpenIDE-Module-Specification-Version: 1.38
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/j2ee/platform/Bundle.properties
 AutoUpdate-Show-In-Client: false
 

--- a/enterprise/j2ee.platform/nbproject/project.properties
+++ b/enterprise/j2ee.platform/nbproject/project.properties
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-release.external/generated-javaee-api-7.0-javadoc.jar=docs/javaee-doc-api.jar
+javac.compilerargs=-Xlint:all -Xlint:-serial
+javac.source=1.8
+release.external/generated-javaee-api-8.0.1-javadoc.jar=docs/javaee-doc-api.jar
 
 javadoc.arch=${basedir}/arch.xml

--- a/enterprise/javaee8.api/external/binaries-list
+++ b/enterprise/javaee8.api/external/binaries-list
@@ -14,17 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-5595992A15BF40CEDA8A831C77ECFE4043F8F161 javax:javaee-api:8.0
-DD21587DD7515F8DDAD285CF019A6ACB18D6E3BA javax:javaee-web-api:8.0
-479C1E06DB31C432330183F5CAE684163F186146 javax.annotation:javax.annotation-api:1.2
+515A40C1F19802A18A187F59BFBE445A62218A04 javax:javaee-api:8.0.1
+876355210738C6F2ECAF75E84FE59B9957CDD496 javax:javaee-web-api:8.0.1
+934C04D3CFEF185A8008E7BF34331B79730A9D43 javax.annotation:javax.annotation-api:1.3.2
 2A642453AB5CE7A506B46164DE8258EE463A9197 javax.faces:javax.faces-api:2.3
 5FAAA3864FF6025CE69809B60D65BDA3E358610C javax.jms:javax.jms-api:2.0.1
-A055C648842C4954C1F7DB7254F45D9AD565E278 com.sun.mail:javax.mail:1.6.0
-AE40E0864EB1E92C48BF82A2A3399CBBF523FB79 javax.resource:javax.resource-api:1.7
-DFA282CEA1495277168697CB5C349EC29F82947C javax.management.j2ee:javax.management.j2ee-api:1.1.1
-5CFDC878B7A5A533F373493BE9F7B24E34C01800 javax.security.jacc:javax.security.jacc-api:1.5
-C392610C40AA3E0E7B57C47A1B561D4B3F974FAC javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.0
+935151EB71BEFF17A2FFAC15DD80184A99A0514F com.sun.mail:javax.mail:1.6.2
+F86B4D697ECD992EC6C4C6053736DB16D41DC57F javax.resource:javax.resource-api:1.7.1
+0901948EA655DDE5127EC8B14069ED98D84AC669 javax.management.j2ee:javax.management.j2ee-api:1.1.2
+841BCEA36398EE4C25E7A79A8E8391B78AAD750A javax.security.jacc:javax.security.jacc-api:1.6
+CC4240956C4E8A7231AADD919FDEE8FE39A2E50D javax.enterprise.concurrent:javax.enterprise.concurrent-api:1.1
 2562072EF44E364529EBF7C48CF44E4568CBD8F5 javax.batch:javax.batch-api:1.0.1
-020FD338DD025EAFC226CA90BD7CDCC60015D75D javax.enterprise.deploy:javax.enterprise.deploy-api:1.6
-C1E6D1DE3BA048B9D36FAA122D7BCA20ABCF12B0 javax.xml.registry:javax.xml.registry-api:1.0.7
-E21E7F033112BC4BCF54234EDB5AA5D782D4B568 javax.xml.rpc:javax.xml.rpc-api:1.1.1
+DE2D1B615E9E027ADBDD467F4223162EF35404AB javax.enterprise.deploy:javax.enterprise.deploy-api:1.7
+E3C69DEDAEA3D9B8D286DE02FE792D1E2525A971 javax.xml.registry:javax.xml.registry-api:1.0.8
+CA48388F25715BA40058CE8C20712636F6ECE617 javax.xml.rpc:javax.xml.rpc-api:1.1.2

--- a/enterprise/javaee8.api/external/javaee-api-8.0.1-license.txt
+++ b/enterprise/javaee8.api/external/javaee-api-8.0.1-license.txt
@@ -1,8 +1,9 @@
-Name: JavaEE Web API 8.0
-Version: 8.0
+Name: JavaEE API 8.0.1
+Version: 8.0.1
 License: CDDL-1.1
-Description: JavaEE Web API 8.0
-Origin: GlassFish Community (https://mvnrepository.com/artifact/javax/javaee-web-api/8.0)
+Description: JavaEE API 8.0.1
+Origin: GlassFish Community (https://mvnrepository.com/artifact/javax/javaee-api/8.0.1)
+
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/external/javaee-web-api-8.0.1-license.txt
+++ b/enterprise/javaee8.api/external/javaee-web-api-8.0.1-license.txt
@@ -1,8 +1,8 @@
-Name: Javax Annotation API
-Version: 1.2
+Name: JavaEE Web API 8.0.1
+Version: 8.0.1
 License: CDDL-1.1
-Description: Javax Annotation API 1.2
-Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api/1.2)
+Description: JavaEE Web API 8.0.1
+Origin: GlassFish Community (https://mvnrepository.com/artifact/javax/javaee-web-api/8.0.1)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/external/javax.annotation-api-1.3.2-license.txt
+++ b/enterprise/javaee8.api/external/javax.annotation-api-1.3.2-license.txt
@@ -1,8 +1,8 @@
-Name: JavaMail API
-Version: 1.6.0
+Name: Javax Annotation API
+Version: 1.3.2
 License: CDDL-1.1
-Description: JavaMail API 1.6.0
-Origin: GlassFish Community (https://mvnrepository.com/artifact/com.sun.mail/javax.mail/1.6.0)
+Description: Javax Annotation API 1.3.2
+Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api/1.3.2)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/external/javax.enterprise.concurrent-api-1.1-license.txt
+++ b/enterprise/javaee8.api/external/javax.enterprise.concurrent-api-1.1-license.txt
@@ -1,9 +1,8 @@
-Name: JavaEE API 8.0
-Version: 8.0
+Name: Javax Concurrent API
+Version: 1.1
 License: CDDL-1.1
-Description: JavaEE API 8.0
-Origin: GlassFish Community (https://mvnrepository.com/artifact/javax/javaee-api/8.0)
-
+Description: Javax Concurrent API 1.1
+Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.enterprise.concurrent/javax.enterprise.concurrent-api/1.1)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/external/javax.enterprise.deploy-api-1.7-license.txt
+++ b/enterprise/javaee8.api/external/javax.enterprise.deploy-api-1.7-license.txt
@@ -1,8 +1,8 @@
 Name: Javax Deploy API
-Version: 1.6
+Version: 1.7
 License: CDDL-1.1
-Description: Javax Deploy API 1.6
-Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.enterprise.deploy/javax.enterprise.deploy-api/1.6)
+Description: Javax Deploy API 1.7
+Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.enterprise.deploy/javax.enterprise.deploy-api/1.7)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/external/javax.mail-1.6.2-license.txt
+++ b/enterprise/javaee8.api/external/javax.mail-1.6.2-license.txt
@@ -1,8 +1,8 @@
-Name: Javax Concurrent API
-Version: 1.0
+Name: JavaMail API
+Version: 1.6.2
 License: CDDL-1.1
-Description: Javax Concurrent API 1.0
-Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.enterprise.concurrent/javax.enterprise.concurrent-api/1.0)
+Description: JavaMail API 1.6.2
+Origin: GlassFish Community (https://mvnrepository.com/artifact/com.sun.mail/javax.mail/1.6.2)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/external/javax.management.j2ee-api-1.1.2-license.txt
+++ b/enterprise/javaee8.api/external/javax.management.j2ee-api-1.1.2-license.txt
@@ -1,8 +1,8 @@
-Name: Javax Resource API
-Version: 1.7
+Name: Javax Management J2EE API
+Version: 1.1.2
 License: CDDL-1.1
-Description: Javax Resource API 1.7
-Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.resource/javax.resource-api/1.7)
+Description: Javax Management J2EE API 1.1.2
+Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.management.j2ee/javax.management.j2ee-api/1.1.2)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/external/javax.resource-api-1.7.1-license.txt
+++ b/enterprise/javaee8.api/external/javax.resource-api-1.7.1-license.txt
@@ -1,8 +1,8 @@
-Name: Javax XML Registry API
-Version: 1.0.7
+Name: Javax Resource API
+Version: 1.7.1
 License: CDDL-1.1
-Description: Javax XML Registry API 1.0.7
-Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.xml.registry/javax.xml.registry-api/1.0.7)
+Description: Javax Resource API 1.7.1
+Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.resource/javax.resource-api/1.7.1)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/external/javax.security.jacc-api-1.6-license.txt
+++ b/enterprise/javaee8.api/external/javax.security.jacc-api-1.6-license.txt
@@ -1,8 +1,8 @@
-Name: Javax XML RPC API
-Version: 1.1.1
+Name: Java Authorization Contract For Containers API
+Version: 1.6
 License: CDDL-1.1
-Description: Javax XML RPC API 1.1.1
-Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.xml.rpc/javax.xml.rpc-api/1.1.1)
+Description: Java Authorization Contract For Containers API 1.6
+Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.security.jacc/javax.security.jacc-api/1.6)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/external/javax.xml.registry-api-1.0.8-license.txt
+++ b/enterprise/javaee8.api/external/javax.xml.registry-api-1.0.8-license.txt
@@ -1,8 +1,8 @@
-Name: Javax Management J2EE API
-Version: 1.1.1
+Name: Javax XML Registry API
+Version: 1.0.8
 License: CDDL-1.1
-Description: Javax Management J2EE API 1.1.1
-Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.management.j2ee/javax.management.j2ee-api/1.1.1)
+Description: Javax XML Registry API 1.0.8
+Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.xml.registry/javax.xml.registry-api/1.0.8)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/external/javax.xml.rpc-api-1.1.2-license.txt
+++ b/enterprise/javaee8.api/external/javax.xml.rpc-api-1.1.2-license.txt
@@ -1,8 +1,8 @@
-Name: Java Authorization Contract For Containers API
-Version: 1.5
+Name: Javax XML RPC API
+Version: 1.1.2
 License: CDDL-1.1
-Description: Java Authorization Contract For Containers API 1.5
-Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.security.jacc/javax.security.jacc-api/1.5)
+Description: Javax XML RPC API 1.1.2
+Origin: GlassFish Community (https://mvnrepository.com/artifact/javax.xml.rpc/javax.xml.rpc-api/1.1.2)
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/enterprise/javaee8.api/manifest.mf
+++ b/enterprise/javaee8.api/manifest.mf
@@ -3,5 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.javaee8.api
 OpenIDE-Module-Layer: org/netbeans/modules/javaee8/api/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/javaee8/api/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.10
+OpenIDE-Module-Specification-Version: 1.11
 

--- a/enterprise/javaee8.api/nbproject/project.properties
+++ b/enterprise/javaee8.api/nbproject/project.properties
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.6
-release.external/javaee-api-8.0.jar=modules/ext/javaee-api-8.0.jar
-release.external/javaee-web-api-8.0.jar=modules/ext/javaee-web-api-8.0.jar
+javac.compilerargs=-Xlint:all -Xlint:-serial
+javac.source=1.8
+release.external/javaee-api-8.0.1.jar=modules/ext/javaee-api-8.0.jar
+release.external/javaee-web-api-8.0.1.jar=modules/ext/javaee-web-api-8.0.jar

--- a/enterprise/javaee8.api/src/org/netbeans/modules/javaee8/api/javaee-api-8.0.xml
+++ b/enterprise/javaee8.api/src/org/netbeans/modules/javaee8/api/javaee-api-8.0.xml
@@ -35,7 +35,7 @@
     <properties>
         <property>
             <name>maven-dependencies</name>
-            <value>javax:javaee-api:8.0:jar</value>
+            <value>javax:javaee-api:8.0.1:jar</value>
         </property>
     </properties>
 </library>

--- a/enterprise/javaee8.api/src/org/netbeans/modules/javaee8/api/javaee-web-api-8.0.xml
+++ b/enterprise/javaee8.api/src/org/netbeans/modules/javaee8/api/javaee-web-api-8.0.xml
@@ -35,7 +35,7 @@
     <properties>
         <property>
             <name>maven-dependencies</name>
-            <value>javax:javaee-web-api:8.0:jar</value>
+            <value>javax:javaee-web-api:8.0.1:jar</value>
         </property>
     </properties>
 </library>

--- a/enterprise/web.jsf.editor/build.xml
+++ b/enterprise/web.jsf.editor/build.xml
@@ -25,7 +25,7 @@
     <target name="-check-prepared-zip">
         <condition property="web.jsf.editor.generated-zip-created" value="present">
             <and>
-                <available file="external/generated-jsf-api-docs-2.0.zip" />
+                <available file="external/generated-jsf-api-docs-2.3.zip" />
             </and>
         </condition>
     </target>
@@ -39,10 +39,10 @@
             </condition>
         </fail>
         
-        <echo message="Creating generated-jsf-api-docs-2.0.zip"/>
+        <echo message="Creating generated-jsf-api-docs-2.3.zip"/>
         <mkdir dir="build/jsf_editor_api_location"/>
         <unzip src="${jars_location}/javax.faces-api-2.3-javadoc.jar" dest="build/jsf_editor_api_location/" />
-        <zip destfile="./external/generated-jsf-api-docs-2.0.zip">
+        <zip destfile="./external/generated-jsf-api-docs-2.3.zip">
             <fileset dir="./build/jsf_editor_api_location/javadocs/">
                 <exclude name="**/*.png"/>
                 <exclude name="**/*.cur"/>

--- a/enterprise/web.jsf.editor/build.xml
+++ b/enterprise/web.jsf.editor/build.xml
@@ -41,7 +41,7 @@
         
         <echo message="Creating generated-jsf-api-docs-2.0.zip"/>
         <mkdir dir="build/jsf_editor_api_location"/>
-        <unzip src="${jars_location}/javax.faces-api-2.0-javadoc.jar" dest="build/jsf_editor_api_location/" />
+        <unzip src="${jars_location}/javax.faces-api-2.3-javadoc.jar" dest="build/jsf_editor_api_location/" />
         <zip destfile="./external/generated-jsf-api-docs-2.0.zip">
             <fileset dir="./build/jsf_editor_api_location/javadocs/">
                 <exclude name="**/*.png"/>

--- a/enterprise/web.jsf.editor/external/binaries-list
+++ b/enterprise/web.jsf.editor/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-99174A847198F105C399A6D394AB36B42605CA33 javax.faces:javax.faces-api:2.0:javadoc
+FE08EF23CAB2CD726BE35F2A267805CFBDE46894 javax.faces:javax.faces-api:2.3:javadoc

--- a/enterprise/web.jsf.editor/external/generated-jsf-api-docs-2.3-license.txt
+++ b/enterprise/web.jsf.editor/external/generated-jsf-api-docs-2.3-license.txt
@@ -1,6 +1,7 @@
 Name: Java Server Faces API documentation
-Version: 2.0
+Version: 2.3
 License: CDDL-1.1
+Type: generated
 Description: Java Server Faces API documentation
 Origin: Oracle
 

--- a/enterprise/web.jsf.editor/external/javax.faces-api-2.3-javadoc-license.txt
+++ b/enterprise/web.jsf.editor/external/javax.faces-api-2.3-javadoc-license.txt
@@ -1,7 +1,6 @@
 Name: Java Server Faces API documentation
-Version: 2.0
+Version: 2.3
 License: CDDL-1.1
-Type: generated
 Description: Java Server Faces API documentation
 Origin: Oracle
 

--- a/enterprise/web.jsf.editor/manifest.mf
+++ b/enterprise/web.jsf.editor/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.web.jsf.editor
 OpenIDE-Module-Layer: org/netbeans/modules/web/jsf/editor/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/web/jsf/editor/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.58
+OpenIDE-Module-Specification-Version: 1.59
 AutoUpdate-Show-In-Client: false

--- a/enterprise/web.jsf.editor/nbproject/project.properties
+++ b/enterprise/web.jsf.editor/nbproject/project.properties
@@ -25,7 +25,7 @@ test-unit-sys-prop.web.project.jars=\
 
 requires.nb.javac=true
 
-release.external/generated-jsf-api-docs-2.0.zip=docs/jsf-api-docs.zip
+release.external/generated-jsf-api-docs-2.3.zip=docs/jsf-api-docs.zip
 
 test-unit-sys-prop.netbeans.dirs=${netbeans.dest.dir}/${nb.cluster.enterprise.dir}
 


### PR DESCRIPTION
Notes:
- Update JSR-250 Common Annotations for the Java Platform Maintenance Review 3
- Update javaee from 8.0 to 8.0.1
- Update javax.mail from 1.6.0 to 1.6.2
- Update javax.resource-api from 1.7 to 1.7.1
- Update javax.management.j2ee-api from 1.1.1 to 1.1.2
- Update javax.security.jacc-api from 1.5 to 1.6
- Update javax.enterprise.concurrent-api from 1.0 to 1.1
- Update javax.enterprise.deploy-api from 1.6 to 1.7
- Update javax.xml.registry-api from 1.0.7 to 1.0.8
- Update javax.xml.rpc-api from 1.1.1 to 1.1.2
- Update module 'j2ee.platform' (javadoc) from 7.0 to 8.0.1
- Update module 'web.jsf.editor' (javadoc) from 2.0 to 2.3

[JAVA EE 8 Spec](https://github.com/javaee/javaee-spec/blob/master/download/JavaEE8_Platform_Spec_FinalRelease.pdf)
See page 159 for the technologies with their required versions