### PR TITLE
[NETBEANS-3631] - Upgrade Gson from 2.7 to 2.8.4

### DIFF
--- a/ide/c.google.gson/external/binaries-list
+++ b/ide/c.google.gson/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-751F548C85FA49F330CECBB1875893F971B33C4E com.google.code.gson:gson:2.7
+D0DE1CA9B69E69D1D497EE3C6009D015F64DAD57 com.google.code.gson:gson:2.8.4

--- a/ide/c.google.gson/external/gson-2.8.4-license.txt
+++ b/ide/c.google.gson/external/gson-2.8.4-license.txt
@@ -1,7 +1,7 @@
 Name: GSon
 Description: JSon serialization/deserialization library
 Origin: GitHub
-Version: 2.7
+Version: 2.8.4
 License: Apache-2.0
 
                                  Apache License

--- a/ide/c.google.gson/nbproject/project.properties
+++ b/ide/c.google.gson/nbproject/project.properties
@@ -14,6 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/gson-2.7.jar=modules/com-google-gson.jar
+release.external/gson-2.8.4.jar=modules/com-google-gson.jar
 is.autoload=true
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
 nbm.module.author=Jan Lahoda

--- a/ide/c.google.gson/nbproject/project.xml
+++ b/ide/c.google.gson/nbproject/project.xml
@@ -28,7 +28,7 @@
            <public-packages/>
            <class-path-extension>
                <runtime-relative-path>com-google-gson.jar</runtime-relative-path>
-               <binary-origin>external/gson-2.7.jar</binary-origin>
+               <binary-origin>external/gson-2.8.4.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Notes:
- New Features
- Numerous other bugfixes
- Version 2.8.5 has a backward incompatible change

[Gson Web Page](https://github.com/google/gson)

[Gson Release Notes](https://github.com/google/gson/blob/master/CHANGELOG.md)