### PR TITLE
[NETBEANS-3632] - Upgrade dd-plist from 1.3 to 1.23

### DIFF
--- a/contrib/cordova.platforms.ios/nbproject/project.xml
+++ b/contrib/cordova.platforms.ios/nbproject/project.xml
@@ -56,7 +56,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.0</specification-version>
+                        <specification-version>1.14</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/libs.plist/external/binaries-list
+++ b/webcommon/libs.plist/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-F1FFEA79B6034718AC4298D60F98F10B878EC476 com.googlecode.plist:dd-plist:1.3
+F522894ABD90D6F5A15E9586E625407A7D50E80D com.googlecode.plist:dd-plist:1.23

--- a/webcommon/libs.plist/external/dd-plist-1.23-license.txt
+++ b/webcommon/libs.plist/external/dd-plist-1.23-license.txt
@@ -1,5 +1,5 @@
 Name: plist
-Version: 1.3
+Version: 1.23
 Description: An open source library to parse and generate property lists
 License: MIT-dd-plist
 Origin: https://github.com/3breadt/dd-plist

--- a/webcommon/libs.plist/manifest.mf
+++ b/webcommon/libs.plist/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.libs.plist
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/plist/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.13
+OpenIDE-Module-Specification-Version: 1.14
 

--- a/webcommon/libs.plist/nbproject/project.properties
+++ b/webcommon/libs.plist/nbproject/project.properties
@@ -14,10 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
-release.external/dd-plist-1.3.jar=modules/ext/dd-plist.jar
+release.external/dd-plist-1.23.jar=modules/ext/dd-plist.jar
 
 sigtest.gen.fail.on.error=false
 


### PR DESCRIPTION
Notes:
- More specific exceptions depending on the exact error
- Many performance improvements
- Several bug fixes
- Requires JDK 1.6 or later


[dd-plist Web Page](https://github.com/3breadt/dd-plist)

[dd-plist Release Notes](https://github.com/3breadt/dd-plist/releases)