### PR TITLE
Ubuntu installs Chromium as a snap and the config directory is moved

### DIFF
--- a/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/chrome/ChromiumManagerAccessor.java
+++ b/webcommon/extbrowser.chrome/src/org/netbeans/modules/extbrowser/plugins/chrome/ChromiumManagerAccessor.java
@@ -85,7 +85,7 @@ public class ChromiumManagerAccessor implements ExtensionManagerAccessor {
                 return Utils.getUserPaths("/Library/Application Support/Chromium");// NOI18N
             } 
             else {
-                return Utils.getUserPaths("/.config/chromium");// NOI18N
+                return Utils.getUserPaths("/snap/chromium/current/.config/chromium", "/.config/chromium");// NOI18N
             }
         }
         


### PR DESCRIPTION
The problem results in netbeans not being able to find the installed plugin and
thus not loading the debugging support for HTML5/JS projects.