### PR TITLE
[TRAVIS] Compile and run tests in macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -472,3 +472,20 @@ matrix:
             - ant $OPTS -f php/php.composer test
             #- ant $OPTS -f php/php.dbgp test
             - ant $OPTS -f php/php.doctrine2 test
+            
+        - name: MacOS tests
+          language: java
+          os: osx
+          jdk: openjdk11
+          addons:
+            homebrew:
+              packages:
+                - ant
+          env:
+            - OPTS="-silent -Dcluster.config=platform -Dpermit.jdk9.builds=true -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true -Dvanilla.javac.exists=true"
+          before_script:
+            - ant $OPTS clean
+            - ant $OPTS build
+          script:
+            - ant $OPTS -f platform/masterfs.macosx test
+            - ant $OPTS -f platform/core.network test

--- a/platform/core.network/test/unit/src/org/netbeans/core/network/utils/hname/mac/HostnameUtilsMacTest.java
+++ b/platform/core.network/test/unit/src/org/netbeans/core/network/utils/hname/mac/HostnameUtilsMacTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.core.network.utils.hname.mac;
+
+import com.sun.jna.Platform;
+import org.junit.Test;
+import org.netbeans.junit.NbTestCase;
+
+/**
+ *
+ * @author Hector Espert
+ */
+public class HostnameUtilsMacTest extends NbTestCase {
+
+    public HostnameUtilsMacTest(String name) {
+        super(name);
+    }
+
+    @Override
+    public boolean canRun() {
+        return super.canRun() && Platform.isMac();
+    }
+    
+    @Test
+    public void testCLibGetHostname() throws Exception {
+        assertNotNull(HostnameUtilsMac.cLibGetHostname());
+    }
+    
+}

--- a/platform/masterfs.macosx/nbproject/project.xml
+++ b/platform/masterfs.macosx/nbproject/project.xml
@@ -49,6 +49,23 @@
                     <compile-dependency/>
                 </dependency>
             </module-dependencies>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.insane</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.libs.junit4</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <compile-dependency/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
             <public-packages/>
         </data>
     </configuration>


### PR DESCRIPTION
- Compile platform modules in macOS environment
- Add OSXNotifier test class based in LinuxNotifier235632Test
- Run `platform/masterfs.macosx` tests in macOS environment