### PR TITLE
Building on JDK9+ failes caused by -Werror

### DIFF
--- a/java/classfile/nbproject/project.properties
+++ b/java/classfile/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.compilerargs=-Xlint:all -Xlint:-serial -Werror
+javac.compilerargs=-Xlint:all -Xlint:-serial
 javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/o.n.bootstrap/nbproject/project.properties
+++ b/platform/o.n.bootstrap/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:all -Xlint:-serial -Xlint:-processing -Werror
+javac.compilerargs=-Xlint:all -Xlint:-serial -Xlint:-processing
 javac.source=1.8
 module.jar.dir=lib
 module.jar.basename=boot.jar


### PR DESCRIPTION
The two commits: 

- [NETBEANS-3559 Corrected compiler warnings in Bootstrap project.](https://github.com/apache/netbeans/commit/1f0916ad1a923)
- [NETBEANS-3534 Corrected compiler warnings in Classfile Reader project](https://github.com/apache/netbeans/commit/0eb938809158b7515b404d834966768e7a3e63c0)

introduced the `-Werror` javac argument. The argument causes the build to fail on JDK9+:

```
-do-compile:
 [nb-javac] Compiling 40 source files to /home/matthias/src/netbeans/platform/o.n.bootstrap/build/classes
   [repeat] warning: [options] bootstrap class path not set in conjunction with -source 8
   [repeat] error: warnings found and -Werror specified
   [repeat] error: warnings found and -Werror specified
   [repeat] error: warnings found and -Werror specified
   [repeat] error: warnings found and -Werror specified
   [repeat] 4 errors
   [repeat] 1 warning
  [nbmerge] Failed to build target: all-o.n.bootstrap
```