### PR TITLE
LocalAddressUtils#getMostLikelyLocalInetAddresses fails if list contains loopback

### DIFF
--- a/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
+++ b/platform/core.network/src/org/netbeans/core/network/utils/LocalAddressUtils.java
@@ -436,10 +436,10 @@ public class LocalAddressUtils {
         IpAddressUtils.removeLoopback(filteredList);
         
         try {
-            List<InetAddress> localHostAddresses = Arrays.asList(getLocalHostAddresses(ipTypePref));
+            List<InetAddress> localHostAddresses = new ArrayList<>(Arrays.asList(getLocalHostAddresses(ipTypePref)));
             IpAddressUtils.removeLoopback(localHostAddresses);
             
-            if (localHostAddresses != null && !localHostAddresses.isEmpty()) {
+            if (!localHostAddresses.isEmpty()) {
                 List<InetAddress> tmpList = new ArrayList<>(5);
                 for (InetAddress addr : filteredList) {
                     if (localHostAddresses.contains(addr)) {


### PR DESCRIPTION
The problem is located in IpAddressUtils#removeLoopback. The method
expects, that the supplied list provides an Iterator, that supports
remove.

The list returned by Arrays#asList does not provide that, it is just a
view on the array.