### PR TITLE
[NETBEANS-2523] Installer creates invalid Win Registry value

### DIFF
--- a/nbi/engine/native/jnilib/windows/src/jni_WindowsRegistry.c
+++ b/nbi/engine/native/jnilib/windows/src/jni_WindowsRegistry.c
@@ -430,7 +430,7 @@ JNIEXPORT void JNICALL Java_org_netbeans_installer_utils_system_windows_WindowsR
     DWORD  dword     = (DWORD) jValue;
     LPBYTE byteValue = (LPBYTE) &dword;
     
-    if (!setValue(getMode(jMode),getHKEY(jSection), key, name, REG_DWORD, byteValue, sizeof(name), 0)) {
+    if (!setValue(getMode(jMode),getHKEY(jSection), key, name, REG_DWORD, byteValue, sizeof(dword), 0)) {
         throwException(jEnv, "Cannot set value");
     }
     


### PR DESCRIPTION
The `WindowsRegistry_set32BitValue0()` function was incorrectly using the length of the Registry name (e.g. 'NoModify') as the the length of value. Since the Registry value we are setting is of type DWORD the length is indeed always exactly 4 bytes, regardless of OS bitness. 

Solution: `sizeof(dword)` will always return 4, but we might as well have hard-coded the 4.

Impact: The impact of bug has been seen when NBI sets the `NoModify` registry value in the `Uninstall` section of the Registry. The bug has existed for years but has only minor impact, for example with system analyzers flagging the 'NoModify' value as suspect or not being able to read the value with tools such as Powershell.