### PR TITLE
[NETBEANS-3428] FlatLaf: fixes for form designer

### DIFF
--- a/java/form/src/org/netbeans/modules/form/FormLoaderSettings.java
+++ b/java/form/src/org/netbeans/modules/form/FormLoaderSettings.java
@@ -472,12 +472,13 @@ public class FormLoaderSettings implements HelpCtx.Provider   {
      * @return background color of the designer.
      */
     public java.awt.Color getFormDesignerBackgroundColor() {
-        Color defaultBackground = UIManager.getColor( "Tree.background" ); //NOI18N
-        if( null == defaultBackground )
+        Color defaultBackground = UIManager.getColor("nb.formdesigner.designer.background"); //NOI18N
+        if (defaultBackground == null)
+            defaultBackground = UIManager.getColor("Tree.background"); //NOI18N
+        if (defaultBackground == null)
             defaultBackground = Color.white;
         int rgb = getPreferences().getInt(PROP_FORMDESIGNER_BACKGROUND_COLOR , defaultBackground.getRGB());
         return new Color(rgb);        
-        
     }
 
     /**
@@ -497,9 +498,11 @@ public class FormLoaderSettings implements HelpCtx.Provider   {
      * @return color of the border of the designer.
      */
     public java.awt.Color getFormDesignerBorderColor() {
-        int rgb = getPreferences().getInt(PROP_FORMDESIGNER_BORDER_COLOR , new Color(224, 224, 255).getRGB());
+        Color defaultBackground = UIManager.getColor("nb.formdesigner.designer.borderColor"); //NOI18N
+        if (defaultBackground == null)
+            defaultBackground = new Color(224, 224, 255);
+        int rgb = getPreferences().getInt(PROP_FORMDESIGNER_BORDER_COLOR , defaultBackground.getRGB());
         return new Color(rgb);        
-        
     }
 
     /**

--- a/java/form/src/org/netbeans/modules/form/FormLoaderSettings.java
+++ b/java/form/src/org/netbeans/modules/form/FormLoaderSettings.java
@@ -472,7 +472,7 @@ public class FormLoaderSettings implements HelpCtx.Provider   {
      * @return background color of the designer.
      */
     public java.awt.Color getFormDesignerBackgroundColor() {
-        Color defaultBackground = UIManager.getColor("nb.formdesigner.designer.background"); //NOI18N
+        Color defaultBackground = UIManager.getColor("nb.formdesigner.background"); //NOI18N
         if (defaultBackground == null)
             defaultBackground = UIManager.getColor("Tree.background"); //NOI18N
         if (defaultBackground == null)
@@ -498,7 +498,7 @@ public class FormLoaderSettings implements HelpCtx.Provider   {
      * @return color of the border of the designer.
      */
     public java.awt.Color getFormDesignerBorderColor() {
-        Color defaultBackground = UIManager.getColor("nb.formdesigner.designer.borderColor"); //NOI18N
+        Color defaultBackground = UIManager.getColor("nb.formdesigner.borderColor"); //NOI18N
         if (defaultBackground == null)
             defaultBackground = new Color(224, 224, 255);
         int rgb = getPreferences().getInt(PROP_FORMDESIGNER_BORDER_COLOR , defaultBackground.getRGB());

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -59,6 +59,22 @@ SlidingButton.attentionBackground=$ViewTab.attentionBackground
 SlidingButton.attentionForeground=$ViewTab.attentionForeground
 
 
+#---- PropSheet ----
+
+PropSheet.setBackground=lighten(@background,10%)
+PropSheet.setForeground=@foreground
+
+
+#---- formdesigner ----
+
+nb.formdesigner.designer.borderColor=#687e95
+nb.formdesigner.gap.fixed.color=darken(@background,2%)
+nb.formdesigner.gap.resizing.color=darken(@background,2%)
+nb.formdesigner.gap.min.color=darken(@background,5%)
+nb.formdesigner.gap.border.color=lighten(@background,10%)
+nb.formdesigner.saw.color=lighten(@background,15%)
+
+
 #---- HeapView ----
 
 # border

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -67,7 +67,7 @@ PropSheet.setForeground=@foreground
 
 #---- formdesigner ----
 
-nb.formdesigner.designer.borderColor=#687e95
+nb.formdesigner.borderColor=#687e95
 nb.formdesigner.gap.fixed.color=darken(@background,2%)
 nb.formdesigner.gap.resizing.color=darken(@background,2%)
 nb.formdesigner.gap.min.color=darken(@background,5%)

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
@@ -20,6 +20,7 @@
 package org.netbeans.swing.laf.flatlaf;
 
 import com.formdev.flatlaf.util.UIScale;
+import java.awt.Color;
 import javax.swing.UIManager;
 import org.netbeans.swing.laf.flatlaf.ui.FlatTabControlIcon;
 import org.netbeans.swing.plaf.LFCustoms;
@@ -38,6 +39,9 @@ public class FlatLFCustoms extends LFCustoms {
     @Override
     public Object[] createApplicationSpecificKeysAndValues() {
         return new Object[] {
+            // necessary for org.openide.explorer.propertysheet.PropertySheet and others
+            CONTROLFONT, UIManager.getFont("Label.font"),
+
             EDITOR_TAB_DISPLAYER_UI, "org.netbeans.swing.laf.flatlaf.ui.FlatEditorTabDisplayerUI", // NOI18N
             VIEW_TAB_DISPLAYER_UI, "org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI", // NOI18N
             SLIDING_BUTTON_UI, "org.netbeans.swing.laf.flatlaf.ui.FlatSlidingButtonUI", // NOI18N
@@ -63,6 +67,12 @@ public class FlatLFCustoms extends LFCustoms {
             "nb.multitabs.button.left.icon", FlatTabControlIcon.get(TabControlButton.ID_SCROLL_LEFT_BUTTON), // NOI18N
             "nb.multitabs.button.right.icon", FlatTabControlIcon.get(TabControlButton.ID_SCROLL_RIGHT_BUTTON), // NOI18N
             "nb.multitabs.button.rollover", true, // NOI18N
+
+            // Change some colors from ColorUIResource to Color because they are used as
+            // background colors for checkboxes (e.g. in org.netbeans.modules.palette.ui.CategoryButton),
+            // which in FlatLaf paint background only if background color is not a UIResource.
+            "PropSheet.setBackground", new Color(UIManager.getColor("PropSheet.setBackground").getRGB()),
+            "PropSheet.selectedSetBackground", new Color(UIManager.getColor("PropSheet.selectedSetBackground").getRGB()),
         };
     }
 }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -52,6 +52,15 @@ TabControlIcon.close.rolloverBackground=#c74f50
 TabControlIcon.close.rolloverForeground=#fff
 TabControlIcon.arc=2
 
+
+#---- PropSheet ----
+
+PropSheet.selectedSetBackground=@selectionBackground
+PropSheet.selectedSetForeground=@selectionForeground
+PropSheet.selectionBackground=@selectionBackground
+PropSheet.selectionForeground=@selectionForeground
+
+
 nb.html.link.foreground=$Component.linkColor
 nb.html.link.foreground.focus=$Component.linkColor
 nb.html.link.foreground.visited=#628FB5

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
@@ -55,3 +55,9 @@ SlidingButton.hoverBackground=$ViewTab.hoverBackground
 SlidingButton.selectedBackground=darken($SlidingButton.hoverBackground,10%)
 SlidingButton.attentionBackground=$ViewTab.attentionBackground
 SlidingButton.attentionForeground=$ViewTab.attentionForeground
+
+
+#---- PropSheet ----
+
+PropSheet.setBackground=darken(@background,10%)
+PropSheet.setForeground=@foreground


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/5604048/71779328-36503180-2fb6-11ea-897a-c91ea1381b24.png)

After:

![image](https://user-images.githubusercontent.com/5604048/71779331-3f410300-2fb6-11ea-8dd3-3d2665fdfb0f.png)

Before:

![image](https://user-images.githubusercontent.com/5604048/71779336-45cf7a80-2fb6-11ea-9ef5-34894da14084.png)

After:

![image](https://user-images.githubusercontent.com/5604048/71779340-4e27b580-2fb6-11ea-8de9-a7b71d25db14.png)

The reason for the too small icons in the above images is that I took the screenshots running NB in Java 8 on a150% HiDPI screen.