### PR TITLE
[NETBEANS-3428] FlatLaf: fixes for check renderers and search combobox

### DIFF
--- a/ide/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
+++ b/ide/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
@@ -92,13 +92,15 @@ public class SearchComboBoxEditor implements ComboBoxEditor {
             } else {
                 scrollPane.setBorder(new EmptyBorder(borderInsets));
             }
+        } else {
+            scrollPane.setBorder(BorderFactory.createEmptyBorder());
         }
         scrollPane.setFont(referenceTextField.getFont());
         scrollPane.setBackground(referenceTextField.getBackground());
         int preferredHeight = referenceTextField.getPreferredSize().height;
         Dimension spDim = scrollPane.getPreferredSize();
         spDim.height = preferredHeight + getLFHeightAdjustment();
-        if (!isCurrentLF("Aqua")) {  //NOI18N 
+        if (!isCurrentLF("Aqua")) {  //NOI18N
             spDim.height += margin.bottom + margin.top; //borderInsets.top + borderInsets.bottom;
         }
         scrollPane.setPreferredSize(spDim);

--- a/ide/spi.palette/src/org/netbeans/modules/palette/ui/CheckRenderer.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/ui/CheckRenderer.java
@@ -48,12 +48,7 @@ class CheckRenderer extends JPanel implements TreeCellRenderer {
         this.settings = settings;
         setLayout(null);
         add(check = new JCheckBox());
-        Color c = UIManager.getColor("Tree.textBackground"); //NOI18N
-        if (c == null) {
-            //May be null on GTK L&F
-            c = Color.WHITE;
-        }
-        check.setBackground(c); // NOI18N
+        check.setOpaque(false);
         Dimension dim = check.getPreferredSize();
         check.setPreferredSize(checkDim);
     }

--- a/java/maven/src/org/netbeans/modules/maven/dependencies/CheckRenderer.java
+++ b/java/maven/src/org/netbeans/modules/maven/dependencies/CheckRenderer.java
@@ -48,12 +48,7 @@ public class CheckRenderer extends JPanel implements TreeCellRenderer {
             check = null;
         } else {
             add(check = new JCheckBox());
-            Color c = UIManager.getColor("Tree.textBackground"); //NOI18N
-            if (c == null) {
-                //May be null on GTK L&F
-                c = Color.WHITE;
-            }
-            check.setBackground(c);
+            check.setOpaque(false);
             Dimension dim = check.getPreferredSize();
             check.setPreferredSize(checkDim);
         }

--- a/php/php.project/src/org/netbeans/modules/php/project/connections/ui/transfer/tree/CheckRenderer.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/connections/ui/transfer/tree/CheckRenderer.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.php.project.connections.ui.transfer.tree;
 
-import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Graphics;
@@ -28,7 +27,6 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTree;
-import javax.swing.UIManager;
 import javax.swing.tree.TreeCellRenderer;
 import javax.swing.tree.TreePath;
 import org.openide.explorer.view.NodeRenderer;
@@ -65,12 +63,7 @@ final class CheckRenderer extends JPanel implements TreeCellRenderer {
 
         setLayout(null);
         add(check);
-        Color c = UIManager.getColor("Tree.textBackground"); // NOI18N
-        if (c == null) {
-            // may be null on GTK L&F
-            c = Color.WHITE;
-        }
-        check.setBackground(c);
+        check.setOpaque(false);
         check.setPreferredSize(CHECK_DIM);
     }
 


### PR DESCRIPTION
Fixes for check renderers and search combobox:
- check renderers had wrong background
- search checkbox had double border

Before:

![image](https://user-images.githubusercontent.com/5604048/71781972-09f7dd80-2fd5-11ea-8d9c-a816034783ac.png)

After:

![image](https://user-images.githubusercontent.com/5604048/71781975-167c3600-2fd5-11ea-94e5-79901e9f3a6d.png)
