### PR TITLE
[NETBEANS-3666] improve performance of multitabs on startup if many files are open

### DIFF
--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabDataRenderer.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabDataRenderer.java
@@ -149,7 +149,7 @@ public class TabDataRenderer implements TableCellRenderer {
             // The HTML rendering makes startup slow (and CPU load high).
             // To workaround this, remove the leading "<html>" if text does not
             // contain HTML tags or entities.
-            String prefix = "<html>";
+            String prefix = "<html>"; // NOI18N
             if (text.startsWith(prefix)
                     && text.indexOf('<', prefix.length()) < 0
                     && text.indexOf('&', prefix.length()) < 0) {

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabDataRenderer.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabDataRenderer.java
@@ -141,6 +141,21 @@ public class TabDataRenderer implements TableCellRenderer {
                     icon = i;
                 }
             }
+
+            // On startup, this method is invoked very often if many files are open
+            // (~60000 times for 200 open files).
+            // The text (usually a filename) always starts with "<html>",
+            // but does not contain other HTML tags.
+            // The HTML rendering makes startup slow (and CPU load high).
+            // To workaround this, remove the leading "<html>" if text does not
+            // contain HTML tags or entities.
+            String prefix = "<html>";
+            if (text.startsWith(prefix)
+                    && text.indexOf('<', prefix.length()) < 0
+                    && text.indexOf('&', prefix.length()) < 0) {
+                text = text.substring(prefix.length());
+            }
+
             renderer.label.setText( text );
             renderer.label.setIcon( icon );
             renderer.tabData = tab;


### PR DESCRIPTION
This is an attempt to fix/workaround the startup performance problem if many files are open and multitabs are used (which is not the default).

There are actually two problems:

1. `getPreferredWidth()` is invoked very often from the multitabs table listener (~60000 times for 200 open files)
2. the text (usually a filename) is always HTML (but does not contain other HTML tags), which involves slow HTML parsing

This PR addresses only 2.