### PR TITLE
 [NETBEANS-3670] - cleanup addElement() unchecked calls

### DIFF
--- a/apisupport/apisupport.wizards/nbproject/project.properties
+++ b/apisupport/apisupport.wizards/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 requires.nb.javac=true

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/GUIRegistrationPanel.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/GUIRegistrationPanel.java
@@ -342,7 +342,7 @@ final class GUIRegistrationPanel extends BasicWizardIterator.Panel {
     private void createPositionModel(final JComboBox positionsCombo,
             final FileObject[] files,
             final LayerItemPresenter parent) {
-        DefaultComboBoxModel newModel = new DefaultComboBoxModel();
+        DefaultComboBoxModel<Position> newModel = new DefaultComboBoxModel<>();
         LayerItemPresenter previous = null;
         for (FileObject file : files) {
             if (file.getNameExt().endsWith(LayerUtil.HIDDEN)) {

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/VerifierSupport.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/VerifierSupport.java
@@ -79,6 +79,7 @@ import org.openide.util.NbBundle;
 import org.openide.windows.Mode;
 import org.openide.windows.TopComponent;
 import org.openide.windows.WindowManager;
+import org.netbeans.modules.j2ee.sun.dd.impl.verifier.Error;
 
 /**
  * Main TopComponent to display the output of the Sun J2EE Verifier Tool from an archive file.
@@ -128,10 +129,10 @@ public class VerifierSupport extends TopComponent {
         NbBundle.getMessage(VerifierSupport.class,STATUS_LIT),
         NbBundle.getMessage(VerifierSupport.class,"Test_Description"),      // NOI18N
         NbBundle.getMessage(VerifierSupport.class,"Result")};       // NOI18N
-    private Vector passResults = new Vector();
-    private Vector failResults = new Vector();
-    private Vector errorResults = new Vector();
-    private Vector warnResults = new Vector();
+    private Vector<Test> passResults = new Vector<>();
+    private Vector<Test> failResults = new Vector<>();
+    private Vector<Error> errorResults = new Vector<>();
+    private Vector<Test>  warnResults  = new Vector<>();
     private Vector naResults = new Vector();
     private Vector notImplementedResults = new Vector();
     private Vector notRunResults = new Vector();
@@ -882,7 +883,7 @@ public class VerifierSupport extends TopComponent {
      *
      * @param r
      */
-    public void saveErrorResultsForDisplay(org.netbeans.modules.j2ee.sun.dd.impl.verifier.Error r){
+    public void saveErrorResultsForDisplay(Error r){
         errorResults.addElement(r);
     }
     

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectServerPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectServerPanel.java
@@ -65,7 +65,7 @@ final class ProjectServerPanel extends javax.swing.JPanel implements DocumentLis
 
     private ProjectServerWizardPanel wizard;
     private boolean contextModified = false;
-    private final DefaultComboBoxModel serversModel = new DefaultComboBoxModel();
+    private final DefaultComboBoxModel<ServerInstanceWrapper> serversModel = new DefaultComboBoxModel<>();
     
     private J2eeVersionWarningPanel warningPanel;
     private boolean sharableProject;

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/VerifierSupport.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/VerifierSupport.java
@@ -79,6 +79,7 @@ import org.openide.util.NbBundle;
 import org.openide.windows.Mode;
 import org.openide.windows.TopComponent;
 import org.openide.windows.WindowManager;
+import org.netbeans.modules.j2ee.sun.dd.impl.verifier.Error;
 
 /**
  * Main TopComponent to display the output of the Sun J2EE Verifier Tool from an archive file.
@@ -128,10 +129,10 @@ public class VerifierSupport extends TopComponent {
         NbBundle.getMessage(VerifierSupport.class,STATUS_LIT),
         NbBundle.getMessage(VerifierSupport.class,"Test_Description"),      // NOI18N
         NbBundle.getMessage(VerifierSupport.class,"Result")};       // NOI18N
-    private Vector passResults = new Vector();
-    private Vector failResults = new Vector();
-    private Vector errorResults = new Vector();
-    private Vector warnResults = new Vector();
+    private Vector<Test> passResults = new Vector<>();
+    private Vector<Test> failResults = new Vector<>();
+    private Vector<Test> warnResults = new Vector<>();
+    private Vector<Error> errorResults = new Vector<>();
     private Vector naResults = new Vector();
     private Vector notImplementedResults = new Vector();
     private Vector notRunResults = new Vector();
@@ -882,7 +883,7 @@ public class VerifierSupport extends TopComponent {
      *
      * @param r
      */
-    public void saveErrorResultsForDisplay(org.netbeans.modules.j2ee.sun.dd.impl.verifier.Error r){
+    public void saveErrorResultsForDisplay(Error r){
         errorResults.addElement(r);
     }
     

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/WebClasspathPanel.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/WebClasspathPanel.java
@@ -46,7 +46,7 @@ import org.openide.util.NbBundle;
  */
 public class WebClasspathPanel extends javax.swing.JPanel implements HelpCtx.Provider {
 
-    private DefaultListModel listModel;
+    private DefaultListModel<String> listModel;
     /** Original project folder (not nbproject folder) */
     private File projectFolder = null;
     /** Freeform Project base folder */
@@ -263,9 +263,9 @@ public class WebClasspathPanel extends javax.swing.JPanel implements HelpCtx.Pro
         }
         for (int i = 0; i < indices.length; i++) {
             int index = indices[i];
-            Object o = listModel.remove(index);
+            String s = listModel.remove(index);
             index++;
-            listModel.add(index, o);
+            listModel.add(index, s);
             indices[i] = index;
         }
         classpath.setSelectedIndices(indices);
@@ -279,9 +279,9 @@ public class WebClasspathPanel extends javax.swing.JPanel implements HelpCtx.Pro
         }
         for (int i = 0; i < indices.length; i++) {
             int index = indices[i];
-            Object o = listModel.remove(index);
+            String s = listModel.remove(index);
             index--;
-            listModel.add(index, o);
+            listModel.add(index, s);
             indices[i] = index;
         }
         classpath.setSelectedIndices(indices);

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/AddFrameworkPanel.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/AddFrameworkPanel.java
@@ -46,7 +46,7 @@ public class AddFrameworkPanel extends javax.swing.JPanel {
     
     private void createFrameworksList(List usedFrameworks) {
         List frameworks = WebFrameworks.getFrameworks();
-	DefaultListModel model = new DefaultListModel();
+	DefaultListModel<WebFrameworkProvider> model = new DefaultListModel<>();
 	jListFrameworks.setModel(model);
         
 	for (int i = 0; i < frameworks.size(); i++) {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/wizards/PanelSupportedFrameworksVisual.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/wizards/PanelSupportedFrameworksVisual.java
@@ -462,10 +462,10 @@ public class PanelSupportedFrameworksVisual extends JPanel implements HelpCtx.Pr
      * Implements a TableModel.
      */
     public static final class FrameworksTableModel extends AbstractTableModel {
-        private DefaultListModel model;
+        private DefaultListModel<FrameworkModelItem> model;
         
         public FrameworksTableModel() {
-            model = new DefaultListModel();
+            model = new DefaultListModel<>();
         }
         
         public int getColumnCount() {

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/dialogs/AddActionPanel.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/dialogs/AddActionPanel.java
@@ -46,7 +46,7 @@ public class AddActionPanel extends javax.swing.JPanel implements ValidatingPane
         config=dObject;
         initComponents();
         List actions = StrutsConfigUtilities.getAllActionsInModule(dObject);
-        DefaultComboBoxModel model = (DefaultComboBoxModel)CBInputAction.getModel();
+        DefaultComboBoxModel<String> model = (DefaultComboBoxModel)CBInputAction.getModel();
         Iterator iter = actions.iterator();
         while (iter.hasNext())
             model.addElement(((Action)iter.next()).getAttributeValue("path")); //NOI18N

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/dialogs/AddForwardDialogPanel.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/dialogs/AddForwardDialogPanel.java
@@ -41,8 +41,8 @@ public class AddForwardDialogPanel extends javax.swing.JPanel implements Validat
         this.config=config;
         initComponents();
         List actions = StrutsConfigUtilities.getAllActionsInModule(config);
-        DefaultComboBoxModel model = (DefaultComboBoxModel)jComboBoxFwdAction.getModel();
-        DefaultComboBoxModel model1 = (DefaultComboBoxModel)jComboBoxLocationAction.getModel();
+        DefaultComboBoxModel<String> model  = (DefaultComboBoxModel<String>)jComboBoxFwdAction.getModel();
+        DefaultComboBoxModel<String> model1 = (DefaultComboBoxModel<String>)jComboBoxLocationAction.getModel();
         Iterator iter = actions.iterator();
         while (iter.hasNext()) {
             String actionPath=((Action)iter.next()).getAttributeValue("path"); //NOI18N

--- a/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
@@ -163,7 +163,7 @@ public final class DebuggerManager implements ContextProvider {
     private final Vector                      breakpoints = new Vector ();
     private boolean                           breakpointsInitializing = false;
     private boolean                           breakpointsInitialized = false;
-    private final Vector                      watches = new Vector ();
+    private final Vector<Watch>               watches = new Vector<>();
     private boolean                           watchesInitialized = false;
     private ThreadLocal<Boolean>              watchesInitializing = new ThreadLocal<Boolean>();
     private SessionListener                   sessionListener = new SessionListener ();
@@ -706,7 +706,7 @@ public final class DebuggerManager implements ContextProvider {
                 throw new IllegalArgumentException("Permutation of length "+permutation.length+", but have "+watches.size()+" watches.");
             }
             checkPermutation(permutation);
-            Vector v = (Vector) watches.clone ();
+            Vector<Watch> v = (Vector<Watch>)watches.clone();
             for (int i = 0; i < v.size(); i++) {
                 watches.set(permutation[i], v.get(i));
             }

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/ui/CssRuleCreateActionDialog.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/ui/CssRuleCreateActionDialog.java
@@ -63,7 +63,7 @@ public class CssRuleCreateActionDialog extends javax.swing.JPanel {
         String[] htmlTags = HtmlTags.getTags();
 
         // Optional prefix
-        DefaultComboBoxModel htmlTagsModel1 = new DefaultComboBoxModel();
+        DefaultComboBoxModel<String> htmlTagsModel1 = new DefaultComboBoxModel<>();
         htmlTagsModel1.addElement(NONE);
         htmlTagsModel1.addElement("a:link");
         htmlTagsModel1.addElement("a:visited");

--- a/ide/languages/nbproject/project.properties
+++ b/ide/languages/nbproject/project.properties
@@ -17,7 +17,7 @@
 build.compiler.deprecation=false
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.128.0
 

--- a/ide/languages/src/org/netbeans/modules/languages/dataobject/GLFFilesCustomEditor.java
+++ b/ide/languages/src/org/netbeans/modules/languages/dataobject/GLFFilesCustomEditor.java
@@ -46,7 +46,7 @@ public class GLFFilesCustomEditor extends javax.swing.JPanel {
         initComponents ();
         List<String> mimeTypes = getSupportedMimeTypes ();
         Collections.sort (mimeTypes);
-        DefaultListModel model = new DefaultListModel ();
+        DefaultListModel<String> model = new DefaultListModel<>();
         Iterator<String> it = mimeTypes.iterator ();
         while (it.hasNext ()) {
             String name = (String) it.next ();

--- a/ide/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchHistoryPanel.java
+++ b/ide/mercurial/src/org/netbeans/modules/mercurial/ui/log/SearchHistoryPanel.java
@@ -794,7 +794,7 @@ private void fileInfoCheckBoxActionPerformed(java.awt.event.ActionEvent evt) {//
     }
 
     private void initializeFilter () {
-        DefaultComboBoxModel filterModel = new DefaultComboBoxModel();
+        DefaultComboBoxModel<FilterKind> filterModel = new DefaultComboBoxModel<>();
         filterModel.addElement(FilterKind.ALL);
         filterModel.addElement(FilterKind.ID);
         filterModel.addElement(FilterKind.MESSAGE);

--- a/ide/mercurial/src/org/netbeans/modules/mercurial/ui/repository/ChangesetPickerPanel.java
+++ b/ide/mercurial/src/org/netbeans/modules/mercurial/ui/repository/ChangesetPickerPanel.java
@@ -445,7 +445,7 @@ private void btnFetchAllActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
         @Override
         public void perform () {
             try {
-                final DefaultListModel targetsModel = new DefaultListModel();
+                final DefaultListModel<HgLogMessage> targetsModel = new DefaultListModel<>();
                 final HgLogMessage displayedRevision = getDisplayedRevision();
                 if (displayedRevision == null) {
                     if (acceptSelection(NO_REVISION)) {

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/FolderBasedOptionPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/FolderBasedOptionPanel.java
@@ -76,7 +76,7 @@ public final class FolderBasedOptionPanel extends JPanel implements ActionListen
     }
 
     void update () {
-        DefaultComboBoxModel model = new DefaultComboBoxModel();
+        DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
         for (String mimeType : controller.getMimeTypes()) {
             model.addElement(mimeType);
         }

--- a/ide/options.editor/src/org/netbeans/modules/options/indentation/FormattingPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/indentation/FormattingPanel.java
@@ -108,7 +108,7 @@ public final class FormattingPanel extends JPanel implements PropertyChangeListe
 
         if (this.selector != null) {
             // Languages combobox model
-            DefaultComboBoxModel model = new DefaultComboBoxModel();
+            DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
             ArrayList<String> mimeTypes = new ArrayList<String>();
             mimeTypes.addAll(selector.getMimeTypes());
             Collections.sort(mimeTypes, new LanguagesComparator());
@@ -142,7 +142,7 @@ public final class FormattingPanel extends JPanel implements PropertyChangeListe
 
     public void propertyChange(PropertyChangeEvent evt) {
         if (evt.getPropertyName() == null || CustomizerSelector.PROP_MIMETYPE.equals(evt.getPropertyName())) {
-            DefaultComboBoxModel model = new DefaultComboBoxModel();
+            DefaultComboBoxModel<PreferencesCustomizer> model = new DefaultComboBoxModel();
             List<? extends PreferencesCustomizer> nue = selector.getCustomizers(selector.getSelectedMimeType());
             int preSelectIndex = 0;
             int idx = 0;

--- a/ide/project.ant.ui/src/org/netbeans/spi/project/support/ant/ui/LicenseHeadersPanel.java
+++ b/ide/project.ant.ui/src/org/netbeans/spi/project/support/ant/ui/LicenseHeadersPanel.java
@@ -328,7 +328,7 @@ class LicenseHeadersPanel extends javax.swing.JPanel {
     
     private void loadGlobalLicenses() {
         FileObject root = FileUtil.getConfigFile("Templates/Licenses");
-        DefaultComboBoxModel model = new DefaultComboBoxModel();
+        DefaultComboBoxModel<GlobalItem> model = new DefaultComboBoxModel<>();
         for (FileObject fo : root.getChildren()) {
             if (fo.getAttribute("template") == null) {
                 continue;

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ExitDialog.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ExitDialog.java
@@ -67,7 +67,7 @@ final public class ExitDialog extends JPanel implements ActionListener {
     private static boolean result = false;
 
     JList list;
-    DefaultListModel listModel;
+    DefaultListModel<DataObject> listModel;
 
     /** Constructs new dlg for unsaved files in filesystems marked 
      * for unmount.
@@ -75,7 +75,7 @@ final public class ExitDialog extends JPanel implements ActionListener {
     private ExitDialog (Set<DataObject> openedFiles) {
         setLayout (new BorderLayout ());
 
-        listModel = new DefaultListModel();
+        listModel = new DefaultListModel<>();
         
         Set<DataObject> set = getModifiedFiles (openedFiles);
         if (!set.isEmpty ()) {

--- a/ide/spellchecker/nbproject/project.properties
+++ b/ide/spellchecker/nbproject/project.properties
@@ -17,7 +17,7 @@
 # under the License.
 #
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 nbm.homepage=http://spellchecker.netbeans.org
 nbm.module.author=Jan Lahoda
 spec.version.base=1.42.0

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/SpellcheckerOptionsPanel.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/SpellcheckerOptionsPanel.java
@@ -516,7 +516,7 @@ public class SpellcheckerOptionsPanel extends javax.swing.JPanel {
     // End of variables declaration//GEN-END:variables
     
     private ListModel getInstalledDictionariesModel() {
-        DefaultListModel dlm = new DefaultListModel();
+        DefaultListModel<Locale> dlm = new DefaultListModel<>();
 
         for (Locale l : DictionaryProviderImpl.getInstalledDictionariesLocales()) {
             dlm.addElement(l);

--- a/ide/subversion/src/org/netbeans/modules/subversion/ui/copy/BranchPicker.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/ui/copy/BranchPicker.java
@@ -109,7 +109,7 @@ class BranchPicker {
     }
 
     private void initializeItems () {
-        DefaultListModel model = new DefaultListModel();
+        DefaultListModel<String> model = new DefaultListModel<>();
         model.addElement(ITEM_BRANCHES);
         model.addElement(ITEM_LOADING);
         model.addElement(ITEM_SEP);
@@ -141,7 +141,7 @@ class BranchPicker {
 
                             @Override
                             public void run () {
-                                DefaultListModel model = new DefaultListModel();
+                                DefaultListModel<String> model = new DefaultListModel<>();
                                 model.addElement(ITEM_BRANCHES);
                                 for (ISVNDirEntry e : entries.get(PREFIX_BRANCHES)) {
                                     model.addElement(branchesFolderPrefix + PREFIX_BRANCHES + "/" + e.getPath()); //NOI18N

--- a/ide/tasklist.ui/nbproject/project.properties
+++ b/ide/tasklist.ui/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 spec.version.base=1.38.0
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/AttachmentPanel.java
+++ b/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/AttachmentPanel.java
@@ -51,7 +51,7 @@ public class AttachmentPanel extends javax.swing.JPanel implements DocumentListe
     }
 
     private void initFileTypeCombo() {
-        DefaultComboBoxModel model = new DefaultComboBoxModel();
+        DefaultComboBoxModel<FileType> model = new DefaultComboBoxModel<>();
         ResourceBundle bundle = NbBundle .getBundle(AttachmentPanel.class);
         model.addElement(new FileType(null, bundle.getString("AttachmentPanel.fileType.automatic"))); // NOI18N
         model.addElement(new FileType("text/plain", bundle.getString("AttachmentPanel.fileType.textPlain"))); // NOI18N

--- a/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/ListValuePicker.java
+++ b/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/ListValuePicker.java
@@ -69,7 +69,7 @@ public class ListValuePicker extends javax.swing.JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(valuesLabel, label); 
         
         valuesList.setCellRenderer(new ListValueRenderer());
-        DefaultListModel model = new DefaultListModel();
+        DefaultListModel<ListValue> model = new DefaultListModel<>();
         for (ListValue lvalue : knownValues) {
             model.addElement(lvalue);
         }

--- a/ide/versioning.ui/nbproject/project.properties
+++ b/ide/versioning.ui/nbproject/project.properties
@@ -17,6 +17,6 @@
 
 is.eager=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 
 spec.version.base=1.29.0

--- a/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/options/GeneralOptionsPanel.java
+++ b/ide/versioning.ui/src/org/netbeans/modules/versioning/ui/options/GeneralOptionsPanel.java
@@ -91,7 +91,7 @@ final class GeneralOptionsPanel extends javax.swing.JPanel implements ActionList
     private void fillDisconnectedFolders () {
         if (cmbVersioningSystems.getSelectedItem() instanceof VersioningSystem) {
             String[] disconnected = Utils.getDisconnectedRoots(((VersioningSystem) cmbVersioningSystems.getSelectedItem()));
-            DefaultListModel model = new DefaultListModel();
+            DefaultListModel<String> model = new DefaultListModel<>();
             for (String f : disconnected) {
                 model.addElement(f);
             }

--- a/ide/web.browser.api/src/org/netbeans/modules/web/browser/ui/DeveloperToolbar.java
+++ b/ide/web.browser.api/src/org/netbeans/modules/web/browser/ui/DeveloperToolbar.java
@@ -144,7 +144,7 @@ public class DeveloperToolbar {
         panel.add( bar );
 
         //ZOOM combo box
-        DefaultComboBoxModel zoomModel = new DefaultComboBoxModel();
+        DefaultComboBoxModel<String> zoomModel = new DefaultComboBoxModel<>();
         zoomModel.addElement( "200%" ); //NOI18N
         zoomModel.addElement( "150%" ); //NOI18N
         zoomModel.addElement( "100%" ); //NOI18N

--- a/java/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateRelationshipPanel.java
+++ b/java/j2ee.jpa.verification/src/org/netbeans/modules/j2ee/jpa/verification/fixes/CreateRelationshipPanel.java
@@ -41,7 +41,7 @@ class CreateRelationshipPanel extends javax.swing.JPanel {
     public enum NameStatus {VALID, ILLEGAL_JAVA_ID, ILLEGAL_SQL_KEYWORD,  DUPLICATE};
     public enum AvailableSelection {INVERSE_ONLY, OWNING_ONLY, BOTH};
     private Collection<String> availableFields;
-    private DefaultComboBoxModel mdlAvailableFields = new DefaultComboBoxModel();
+    private DefaultComboBoxModel<String> mdlAvailableFields = new DefaultComboBoxModel<>();
     private FieldNameValidator nameValidator = null;
     private Border brdrBlack = BorderFactory.createLineBorder(Color.BLACK);
     private DialogDescriptor dlgDescriptor = null;

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathPanel.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/ClasspathPanel.java
@@ -67,7 +67,7 @@ public class ClasspathPanel extends javax.swing.JPanel implements HelpCtx.Provid
 
     private static final Logger LOG = Logger.getLogger(ClasspathPanel.class.getName());
 
-    private DefaultListModel listModel;
+    private DefaultListModel<String> listModel;
     private File lastChosenFile = null;
     private boolean isSeparateClasspath = true;
     private List<ProjectModel.CompilationUnitKey> compUnitsKeys;
@@ -101,7 +101,7 @@ public class ClasspathPanel extends javax.swing.JPanel implements HelpCtx.Provid
         initComponents();
         jTextArea1.setBackground(getBackground());
         jTextArea1.setDisabledTextColor(jLabel2.getForeground());
-        listModel = new DefaultListModel();
+        listModel = new DefaultListModel<>();
         classpath.setModel(listModel);
     }
 
@@ -499,9 +499,9 @@ public class ClasspathPanel extends javax.swing.JPanel implements HelpCtx.Provid
         }
         for (int i = 0; i < indices.length; i++) {
             int index = indices[i];
-            Object o = listModel.remove(index);
+            String s = listModel.remove(index);
             index++;
-            listModel.add(index, o);
+            listModel.add(index, s);
             indices[i] = index;
         }
         classpath.setSelectedIndices(indices);
@@ -516,9 +516,9 @@ public class ClasspathPanel extends javax.swing.JPanel implements HelpCtx.Provid
         }
         for (int i = 0; i < indices.length; i++) {
             int index = indices[i];
-            Object o = listModel.remove(index);
+            String s = listModel.remove(index);
             index--;
-            listModel.add(index, o);
+            listModel.add(index, s);
             indices[i] = index;
         }
         classpath.setSelectedIndices(indices);

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/OutputPanel.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/OutputPanel.java
@@ -41,7 +41,7 @@ import org.openide.util.NbBundle;
  */
 public class OutputPanel extends javax.swing.JPanel implements HelpCtx.Provider {
 
-    private DefaultListModel listModel;
+    private DefaultListModel<String> listModel;
     private File lastChosenFile = null;
     private boolean isSeparateClasspath = true;
     private List<ProjectModel.CompilationUnitKey> compUnitsKeys;
@@ -51,7 +51,7 @@ public class OutputPanel extends javax.swing.JPanel implements HelpCtx.Provider 
     public OutputPanel() {
         initComponents();
         jTextArea1.setBackground(getBackground());
-        listModel = new DefaultListModel();
+        listModel = new DefaultListModel<>();
         output.setModel(listModel);
         // XXX: for now only single selection
         output.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanelLogic.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanelLogic.java
@@ -115,8 +115,8 @@ public class HintsPanelLogic implements MouseListener, KeyListener, TreeSelectio
     private JCheckBox tasklistCheckBox;
     private JPanel customizerPanel;
     private JEditorPane descriptionTextArea;
-    private DefaultComboBoxModel defModel = new DefaultComboBoxModel();
-    private DefaultComboBoxModel depScanningModel = new DefaultComboBoxModel();
+    private DefaultComboBoxModel<String> defModel = new DefaultComboBoxModel<>();
+    private DefaultComboBoxModel<String> depScanningModel = new DefaultComboBoxModel<>();
     private String defLabel = NbBundle.getMessage(HintsPanel.class, "CTL_ShowAs_Label"); //NOI18N
     private String depScanningLabel = NbBundle.getMessage(HintsPanel.class, "CTL_Scope_Label"); //NOI18N
     private String depScanningDescription = NbBundle.getMessage(HintsPanel.class, "CTL_Scope_Desc"); //NOI18N

--- a/java/javadoc/src/org/netbeans/modules/javadoc/search/IndexSearch.java
+++ b/java/javadoc/src/org/netbeans/modules/javadoc/search/IndexSearch.java
@@ -103,9 +103,9 @@ public final class IndexSearch
     /* Holds split position if the quick view is disabled */
     private int oldSplit = DocumentationSettings.getDefault().getIdxSearchSplit();
 
-    private final DefaultListModel waitModel = new DefaultListModel();
-    private final DefaultListModel initModel = new DefaultListModel();
-    private final DefaultListModel notModel = new DefaultListModel();
+    private final DefaultListModel<DocIndexItem> waitModel = new DefaultListModel<>();
+    private final DefaultListModel<DocIndexItem> initModel = new DefaultListModel<>();
+    private final DefaultListModel<DocIndexItem> notModel  = new DefaultListModel<>();
     private boolean setDividerLocation;
 
     /** Initializes the Form */

--- a/java/maven.grammar/src/org/netbeans/modules/maven/codegen/NewLicensePanel.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/codegen/NewLicensePanel.java
@@ -164,7 +164,7 @@ public class NewLicensePanel extends javax.swing.JPanel {
         super.addNotify();
         
         assert nls != null : " The notificationLineSupport was not attached to the panel."; //NOI18N
-        DefaultListModel dlm = new DefaultListModel();
+        DefaultListModel<Tuple> dlm = new DefaultListModel<>();
         FileObject root = FileUtil.getConfigFile("Templates/Licenses");
         if (root != null) {
             for (FileObject lic : root.getChildren()) {

--- a/java/maven.grammar/src/org/netbeans/modules/maven/codegen/NewMirrorPanel.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/codegen/NewMirrorPanel.java
@@ -68,7 +68,7 @@ public class NewMirrorPanel extends javax.swing.JPanel {
         ALL_BUT_FOO,
         LIST
     };
-    private DefaultComboBoxModel urlmodel;
+    private DefaultComboBoxModel<String> urlmodel;
 
 
     public NewMirrorPanel(SettingsModel model) {

--- a/java/maven.graph/src/org/netbeans/modules/maven/graph/DependencyGraphTopComponent.java
+++ b/java/maven.graph/src/org/netbeans/modules/maven/graph/DependencyGraphTopComponent.java
@@ -254,7 +254,7 @@ public class DependencyGraphTopComponent extends TopComponent implements LookupL
                 return super.getListCellRendererComponent(list, msg, index, isSelected, cellHasFocus);
             }
         });
-        DefaultComboBoxModel mdl = new DefaultComboBoxModel();
+        DefaultComboBoxModel<List<String>> mdl = new DefaultComboBoxModel<>();
         mdl.addElement(Arrays.asList(new String[0]));
         mdl.addElement(Arrays.asList(new String[] {
             Artifact.SCOPE_PROVIDED,

--- a/platform/api.progress/src/org/netbeans/modules/progress/spi/TaskModel.java
+++ b/platform/api.progress/src/org/netbeans/modules/progress/spi/TaskModel.java
@@ -38,7 +38,7 @@ import org.netbeans.progress.module.DefaultHandleFactory;
  */
 public final class TaskModel {
     private DefaultListSelectionModel selectionModel;
-    private final DefaultListModel model;
+    private final DefaultListModel<InternalHandle> model;
     private InternalHandle explicit;
     private final LinkedHashSet<ListDataListener> dataListeners;
     private final LinkedHashSet<ListSelectionListener> selectionListeners;
@@ -46,7 +46,7 @@ public final class TaskModel {
     
     TaskModel(Executor eventExecutor) {
         selectionModel = new DefaultListSelectionModel();
-        model = new DefaultListModel();
+        model = new DefaultListModel<>();
         dataListeners = new LinkedHashSet<ListDataListener>();
         selectionListeners = new LinkedHashSet<ListSelectionListener>();
         TaskListener list = new TaskListener();

--- a/platform/core.execution/nbproject/project.properties
+++ b/platform/core.execution/nbproject/project.properties
@@ -17,6 +17,6 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 
 test.config.stableBTD.includes=**/*Test.class

--- a/platform/core.execution/src/org/netbeans/core/execution/beaninfo/editors/NbClassPathCustomEditor.java
+++ b/platform/core.execution/src/org/netbeans/core/execution/beaninfo/editors/NbClassPathCustomEditor.java
@@ -47,7 +47,7 @@ class NbClassPathCustomEditor extends javax.swing.JPanel {
     /** Property editor associated with. */
     private PropertyEditor editor;
     /** Model of list of class path items. */
-    private DefaultListModel listModel = new DefaultListModel();
+    private DefaultListModel<Object> listModel = new DefaultListModel<>();
     private boolean editable = true;
 
     

--- a/platform/o.n.core/src/org/netbeans/core/ExitDialog.java
+++ b/platform/o.n.core/src/org/netbeans/core/ExitDialog.java
@@ -64,7 +64,7 @@ public class ExitDialog extends JPanel implements java.awt.event.ActionListener 
     private static boolean result = false;
 
     JList list;
-    DefaultListModel listModel;
+    DefaultListModel<Savable> listModel;
 
     static final long serialVersionUID = 6039058107124767512L;
 
@@ -72,7 +72,7 @@ public class ExitDialog extends JPanel implements java.awt.event.ActionListener 
     public ExitDialog () {
         setLayout (new java.awt.BorderLayout ());
 
-        listModel = new DefaultListModel();
+        listModel = new DefaultListModel<>();
         for (Savable obj : Savable.REGISTRY.lookupAll(Savable.class)) {
             listModel.addElement(obj);
         }

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
@@ -2363,8 +2363,8 @@ public class ETable extends JTable {
         }
     }
     
-    private ComboBoxModel getSearchComboModel() {
-        DefaultComboBoxModel result = new DefaultComboBoxModel();
+    private ComboBoxModel<String> getSearchComboModel() {
+        DefaultComboBoxModel<String> result = new DefaultComboBoxModel();
         for (Enumeration<TableColumn> en = getColumnModel().getColumns(); en.hasMoreElements(); ) {
             TableColumn column = en.nextElement();
             if (column instanceof ETableColumn) {

--- a/platform/openide.awt/src/org/openide/awt/ColorComboBox.java
+++ b/platform/openide.awt/src/org/openide/awt/ColorComboBox.java
@@ -173,8 +173,8 @@ public final class ColorComboBox extends JComboBox {
         }
     }
 
-    private static DefaultComboBoxModel createModel( Color[] colors, String[] names, boolean allowCustomColors ) {
-        DefaultComboBoxModel model = new DefaultComboBoxModel();
+    private static DefaultComboBoxModel<ColorValue> createModel( Color[] colors, String[] names, boolean allowCustomColors ) {
+        DefaultComboBoxModel<ColorValue> model = new DefaultComboBoxModel<>();
 
         for( int i=0; i<colors.length; i++ ) {
             Color c = colors[i];

--- a/webcommon/html.ojet/src/org/netbeans/modules/html/ojet/ui/OJETPanel.java
+++ b/webcommon/html.ojet/src/org/netbeans/modules/html/ojet/ui/OJETPanel.java
@@ -54,7 +54,7 @@ public class OJETPanel extends javax.swing.JPanel implements CustomizerPanelImpl
     }
 
     private void initData() {
-        DefaultComboBoxModel model = new DefaultComboBoxModel();
+        DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
         for (String version: DataProviderImpl.getInstance().getAvailableVersions()) {
             model.addElement(version);
         }

--- a/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/breakpoints/ui/EventsBreakpointCustomizer.java
+++ b/webcommon/web.javascript.debugger/src/org/netbeans/modules/web/javascript/debugger/breakpoints/ui/EventsBreakpointCustomizer.java
@@ -96,7 +96,7 @@ public class EventsBreakpointCustomizer extends javax.swing.JPanel implements Co
     
     private void fillCategoryEvents() {
         Set<String> allEventCategories = EventsBreakpoint.getAllEventCategories();
-        DefaultListModel categoryModel = new DefaultListModel();
+        DefaultListModel<String> categoryModel = new DefaultListModel<>();
         for (String category : allEventCategories) {
             categoryModel.addElement(category);
         }
@@ -104,7 +104,7 @@ public class EventsBreakpointCustomizer extends javax.swing.JPanel implements Co
     }
     
     private void fillEvents(String category) {
-        DefaultListModel eventsModel = new DefaultListModel();
+        DefaultListModel<String> eventsModel = new DefaultListModel<>();
         Set<String> allEvents = EventsBreakpoint.getAllEvents(category);
         for (String event : allEvents) {
             eventsModel.addElement(event);


### PR DESCRIPTION
Cleanup a bunch of warnings related to uncheck call to addEelement()

[repeat] /home/bwalker/src/netbeans/platform/api.progress/src/org/netbeans/modules/progress/spi/TaskModel.java:67: warning: [unchecked] unchecked call to addElement(E) as a member of the raw type DefaultListModel
[repeat] model.addElement(handle);
[repeat] ^
[repeat] where E is a type-variable:
[repeat] E extends Object declared in class DefaultListModel
[repeat] 1 warning