### PR TITLE
InputStream.read(<array>) may read less bytes than requested - using …

### DIFF
--- a/platform/o.n.bootstrap/src/org/netbeans/CLIHandler.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/CLIHandler.java
@@ -818,7 +818,7 @@ public abstract class CLIHandler extends Object {
                                     if (howMuch > outputArr.length) {
                                         outputArr = new byte[howMuch];
                                     }
-                                    replyStream.read(outputArr, 0, howMuch);
+                                    replyStream.readFully(outputArr, 0, howMuch);
                                     args.getOutputStream().write(outputArr, 0, howMuch);
                                     break;
                                 }
@@ -828,7 +828,7 @@ public abstract class CLIHandler extends Object {
                                     if (howMuch > outputArr.length) {
                                         outputArr = new byte[howMuch];
                                     }
-                                    replyStream.read(outputArr, 0, howMuch);
+                                    replyStream.readFully(outputArr, 0, howMuch);
                                     args.getErrorStream().write(outputArr, 0, howMuch);
                                     break;
                                 }


### PR DESCRIPTION
…readFully to read all requested bytes.

Unfortunately, I don't know how to test this. Basically, InputStream.read(<array>) is specified in such a way that if may read less bytes than requested. But the CLIHandler is not checking how many bytes where actually read, and so if the method reads a shorter chunk of bytes than expected, the method will continue and will interpret the next byte as a command/reply - but that byte is "random", and the server and client desynchronize and the connection effectively stops to work. Luckily, the instance of the InputStream here is a DataInputStream and it always had the readFully method, so we can use it.