### PR TITLE
[NETBEANS-3428] Update FlatLaf from 0.23 to 0.24 and other fixes

### DIFF
--- a/platform/api.search/src/org/netbeans/modules/search/BasicSearchForm.java
+++ b/platform/api.search/src/org/netbeans/modules/search/BasicSearchForm.java
@@ -26,7 +26,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.ItemSelectable;
-import java.awt.SystemColor;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
@@ -877,7 +876,6 @@ final class BasicSearchForm extends JPanel implements ChangeListener,
             c.insets = new Insets(5, 5, 5, 5);
             c.fill = GridBagConstraints.HORIZONTAL;
             JSeparator separator = new JSeparator(JSeparator.HORIZONTAL);
-            separator.setForeground(SystemColor.controlShadow);
             add(separator, c);
             row++;
         }

--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-BDBE1A7C4927622E88B73A90C3530E5F60659A62 com.formdev:flatlaf:0.23
+EF5EAB402A08F24C69FDA036E8E38A3C10310FA6 com.formdev:flatlaf:0.24

--- a/platform/libs.flatlaf/external/flatlaf-0.24-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-0.24-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 0.23
-Files: flatlaf-0.23.jar
+Version: 0.24
+Files: flatlaf-0.24.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-0.23.jar=modules/ext/flatlaf-0.23.jar
+release.external/flatlaf-0.24.jar=modules/ext/flatlaf-0.24.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-0.23.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-0.23.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-0.24.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-0.24.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -19,6 +19,10 @@ nb.dark.theme=true
 nb.preferred.color.profile=FlatLaf Dark
 
 
+nb.errorForeground=#DB5860
+nb.warningForeground=@foreground
+
+
 #---- EditorTab ----
 
 EditorTab.background=@background

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -20,12 +20,16 @@ Nb.LFCustoms={instance}org.netbeans.swing.laf.flatlaf.FlatLFCustoms
 
 nb.explorer.unfocusedSelBg=@selectionInactiveBackground
 nb.explorer.unfocusedSelFg=@selectionInactiveForeground
+nb.explorer.noFocusSelectionBackground=@selectionInactiveBackground
+nb.explorer.noFocusSelectionForeground=@selectionInactiveForeground
+
+controlShadow=$Component.borderColor
 
 
 #---- TabbedContainer ----
 
-TabbedContainer.editor.contentBorderColor=$TabbedPane.contentAreaColor
-TabbedContainer.view.contentBorderColor=$TabbedPane.contentAreaColor
+TabbedContainer.editor.contentBorderColor=$Component.borderColor
+TabbedContainer.view.contentBorderColor=$Component.borderColor
 
 
 #---- EditorTab ----
@@ -60,6 +64,9 @@ PropSheet.selectedSetForeground=@selectionForeground
 PropSheet.selectionBackground=@selectionBackground
 PropSheet.selectionForeground=@selectionForeground
 
+
+ETableHeader.ascendingIcon=$Table.ascendingSortIcon
+ETableHeader.descendingIcon=$Table.descendingSortIcon
 
 nb.html.link.foreground=$Component.linkColor
 nb.html.link.foreground.focus=$Component.linkColor

--- a/platform/openide.awt/src/org/openide/awt/HtmlLabelUI.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlLabelUI.java
@@ -209,7 +209,7 @@ class HtmlLabelUI extends LabelUI {
                 focus = Color.BLUE;
             }
 
-            if (!isGTK() && !isAqua() && !isNimbus()) {
+            if (!isGTK() && !isAqua() && !isNimbus() &&!isFlatLaf()) {
                 int x;
                 if (h.getType() == HtmlRendererImpl.Type.TABLE) {
                     x = 0; // in a table we want to have the whole row selected
@@ -510,6 +510,10 @@ class HtmlLabelUI extends LabelUI {
     
     static boolean isNimbus () {
         return "Nimbus".equals(UIManager.getLookAndFeel().getID());
+    }
+
+    static boolean isFlatLaf () {
+        return UIManager.getLookAndFeel().getID().startsWith("FlatLaf");
     }
 
     /** Get the system-wide unfocused selection background color */

--- a/platform/openide.explorer/src/org/openide/explorer/view/OutlineView.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/OutlineView.java
@@ -269,24 +269,28 @@ public class OutlineView extends JScrollPane {
             defaultTreeActionListener, KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0, false), JComponent.WHEN_FOCUSED
         );
 
-        final Color focusSelectionBackground = outline.getSelectionBackground();
-        final Color focusSelectionForeground = outline.getSelectionForeground();
-        outline.addFocusListener(new java.awt.event.FocusListener(){
-            @Override
-            public void focusGained(java.awt.event.FocusEvent ev) {
-                outline.setSelectionBackground(focusSelectionBackground);
-                outline.setSelectionForeground(focusSelectionForeground);
-            }
+        // toggle selection colors depending on whether table is focused or not
+        if (!UIManager.getLookAndFeel().getID().startsWith("FlatLaf")) {
+            final Color focusSelectionBackground = outline.getSelectionBackground();
+            final Color focusSelectionForeground = outline.getSelectionForeground();
+            outline.addFocusListener(new java.awt.event.FocusListener(){
+                @Override
+                public void focusGained(java.awt.event.FocusEvent ev) {
+                    outline.setSelectionBackground(focusSelectionBackground);
+                    outline.setSelectionForeground(focusSelectionForeground);
+                }
 
-            @Override
-            public void focusLost(java.awt.event.FocusEvent ev) {
-                outline.setSelectionBackground(SheetCell.getNoFocusSelectionBackground());
-                outline.setSelectionForeground(SheetCell.getNoFocusSelectionForeground());
-            }
+                @Override
+                public void focusLost(java.awt.event.FocusEvent ev) {
+                    outline.setSelectionBackground(SheetCell.getNoFocusSelectionBackground());
+                    outline.setSelectionForeground(SheetCell.getNoFocusSelectionForeground());
+                }
 
-        });
-        outline.setSelectionBackground(SheetCell.getNoFocusSelectionBackground());
-        outline.setSelectionForeground(SheetCell.getNoFocusSelectionForeground());
+            });
+            outline.setSelectionBackground(SheetCell.getNoFocusSelectionBackground());
+            outline.setSelectionForeground(SheetCell.getNoFocusSelectionForeground());
+        }
+
         TableColumnSelector tcs = Lookup.getDefault ().lookup (TableColumnSelector.class);
         if (tcs != null) {
             outline.setColumnSelector(tcs);


### PR DESCRIPTION
Improvements and fixes thru FlatLaf 0.24:
- smooth scrolling (in the same way as already in NB for Windows LaF)
- fixed missing borders in table header (e.g. in "Watches" view)
- removed border from "Change Visible Columns" icon button in right-top corner of tables (e.g. in "Watches" view)
- progress bar in "Flat Dark" theme is now blue

Other fixes in NB code:
- "Flat Dark" theme: lighter gray color for editor/view borders and separators in main window
- ascending/descending icons in table header replaced with FlatLaf icons
- get rid of the focus indicator (black rectangle) in trees (HtmlLabelUI.java)
- fixed unreadable info text in "Find in Project" dialog (in dark theme)
- fixed too bright separators in "Find in Project" dialog (in dark theme) (BasicSearchForm.java)
- fixed wrong selection colors in `OutlineView` (e.g. in "Watches" view)

Before:
![image](https://user-images.githubusercontent.com/5604048/72158734-3176ed80-33bb-11ea-95c5-168df84f21be.png)

After:
![image](https://user-images.githubusercontent.com/5604048/72158768-46ec1780-33bb-11ea-8b1d-7bfb43194ed2.png)

Before:
![image](https://user-images.githubusercontent.com/5604048/72159217-2bcdd780-33bc-11ea-997c-9a2667553c0a.png)

After:
![image](https://user-images.githubusercontent.com/5604048/72159232-338d7c00-33bc-11ea-93ae-6fdca62a9e7c.png)

Before:
![image](https://user-images.githubusercontent.com/5604048/72159248-41430180-33bc-11ea-9169-b62e7262301c.png)
The orange arrows indicate issues that are not yet fixed. There are JButton's with EmptyBorder between the parenthesis and JButton's have a minimum width in FlatLaf, whats the reason for the empty space between the parenthesis.

After:
![image](https://user-images.githubusercontent.com/5604048/72159327-63d51a80-33bc-11ea-8dd3-3ca6f18bf12c.png)
