### PR TITLE
NETBEANS-3685 New Group dialog allows to create a (none) group which …

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/groups/GroupEditPanel.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/groups/GroupEditPanel.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import static org.netbeans.modules.project.ui.groups.Bundle.*;
+import static org.netbeans.modules.project.ui.groups.ManageGroupsPanel.NONE_GOUP;
 import static org.netbeans.modules.project.ui.groups.NewGroupPanel.MAX_NAME;
 import org.netbeans.spi.project.ui.support.ProjectCustomizer;
 import org.netbeans.spi.project.ui.support.ProjectCustomizer.Category;
@@ -57,6 +58,10 @@ public abstract class GroupEditPanel extends JPanel{
             }
             Set<Group> otherGroups = Group.allGroups();
             otherGroups.remove(actualGroup);
+            if (name.equalsIgnoreCase(NONE_GOUP)) {
+                getCategory().setErrorMessage(WARN_GroupExists());
+                return false;
+            }
             for (Group group : otherGroups) {
                 if (name.equalsIgnoreCase(group.getName())) {
                     getCategory().setErrorMessage(WARN_GroupExists());

--- a/ide/projectui/src/org/netbeans/modules/project/ui/groups/ManageGroupsPanel.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/groups/ManageGroupsPanel.java
@@ -43,7 +43,7 @@ public class ManageGroupsPanel extends javax.swing.JPanel implements PropertyCha
 
     private static final RequestProcessor RP = new RequestProcessor(ManageGroupsPanel.class.getName());
     
-    private static final String NONE_GOUP = "(none)";
+    static final String NONE_GOUP = "(none)";
     
     /**
      * Creates new form ManageGroupPanel

--- a/ide/projectui/src/org/netbeans/modules/project/ui/groups/NewGroupPanel.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/groups/NewGroupPanel.java
@@ -34,6 +34,7 @@ import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.api.project.ui.OpenProjects;
 import static org.netbeans.modules.project.ui.groups.Bundle.*;
+import static org.netbeans.modules.project.ui.groups.ManageGroupsPanel.NONE_GOUP;
 import org.netbeans.spi.project.ui.support.ProjectChooser;
 import org.openide.NotificationLineSupport;
 import org.openide.filesystems.FileObject;
@@ -93,6 +94,9 @@ public class NewGroupPanel extends JPanel {
         String name = nameField.getText();
         if (name != null) {
             if (name.trim().length() <= 0 || name.trim().length() >= MAX_NAME) {
+                return false;
+            }
+            if (name.equalsIgnoreCase(NONE_GOUP)) {
                 return false;
             }
             for (Group group : Group.allGroups()) {
@@ -535,6 +539,9 @@ public class NewGroupPanel extends JPanel {
         if (name != null) {
             if (name.length() > MAX_NAME) {
                 notificationLineSupport.setErrorMessage(NewGroupPanel_too_long_warning());
+            }
+            if (name.equalsIgnoreCase(NONE_GOUP)) {
+                notificationLineSupport.setErrorMessage(NewGroupPanel_exists_warning());
             }
             for (Group group : Group.allGroups()) {
                 if (name.equalsIgnoreCase(group.getName())) {


### PR DESCRIPTION
…can't be removed

Add checks to prevent adding/editing a group named (none), set error messages to 'group exists' where applicable, also changes the visibility of ManageGroupsPanel.NONE_GOUP to package private (instead of private) to check for the same name