### PR TITLE
[NETBEANS-3428] Fix the border of QuickSearch

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -91,3 +91,6 @@ nb.core.ui.balloon.mouseOverGradientStartColor=$ToolTip.background
 nb.core.ui.balloon.mouseOverGradientFinishColor=$ToolTip.background
 nb.core.ui.balloon.defaultGradientStartColor=$ToolTip.background
 nb.core.ui.balloon.defaultGradientFinishColor=$ToolTip.background
+
+# QuickSearch
+nb.quicksearch.border=1,1,1,1,@background


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1381701/72227859-142a5680-3556-11ea-8088-0d1f51c8685f.png)
![image](https://user-images.githubusercontent.com/1381701/72227874-2efccb00-3556-11ea-8be8-6e7519e3c5bc.png)

I thought it would better fit a 1 sized border with background color than a one with the usual lighter gray component color.