### PR TITLE
[NETBEANS-3428] FlatLaf: colors for history, versioning, debugger, bugtracking, etc

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -108,14 +108,68 @@ nb.heapview.grid4.end=@textComponentBackground
 nb.heapview.mintick.color=#adc386
 nb.heapview.maxtick.color=#958f17
 
+
 # startpage
 nb.startpage.defaultbackground=true
 # Darkred and darkblue from NB Icon palette
 nb.startpage.contentheader.color1=#a5073e
 nb.startpage.contentheader.color2=#1b6Ac8
 
+# editor
+nb.editor.errorstripe.caret.color=@foreground
+
 # wizard
 nb.wizard.hideimage=true
+
+# debugger
+nb.debugger.debugging.currentThread=#316838
+nb.debugger.debugging.highlightColor=darken($nb.debugger.debugging.currentThread,5%)
+nb.debugger.debugging.BPHits=rgb(65, 65, 0)
+nb.debugger.debugging.bars.BPHits=rgb(120, 120, 25)
+nb.debugger.debugging.bars.currentThread=lighten($nb.debugger.debugging.currentThread,5%)
+
+# bug tracking
+nb.bugtracking.comment.background=@background
+nb.bugtracking.comment.background=#f00
+nb.bugtracking.comment.foreground=@foreground
+nb.bugtracking.label.highlight=rgb(205, 205, 0)
+nb.bugtracking.table.background=$Table.background
+nb.bugtracking.table.background=#0f0
+nb.bugtracking.table.background.alternate=darken($Table.background,5%)
+nb.bugtracking.new.color=rgb(73, 210, 73)
+nb.bugtracking.modified.color=rgb(26, 184, 255)
+nb.bugtracking.obsolete.color=rgb(142, 142, 142)
+nb.bugtracking.conflict.color=rgb(255, 100, 100)
+
+# db.dataview
+nb.dataview.table.grid=$Table.gridColor
+nb.dataview.table.altbackground=darken($Table.background,5%)
+nb.dataview.tablecell.focused=rgb(13, 41, 62)
+nb.dataview.tablecell.edited.selected.foreground=rgb(255, 184, 26)
+nb.dataview.tablecell.edited.unselected.foreground=rgb(26, 184, 255)
+
+# autoupdate
+nb.autoupdate.search.highlight=rgb(13, 41, 62)
+
+# git
+nb.versioning.added.color=rgb(73, 210, 73)
+nb.versioning.modified.color=rgb(26, 184, 255)
+nb.versioning.deleted.color=rgb(255, 175, 175)
+nb.versioning.conflicted.color=rgb(255, 100, 100)
+nb.versioning.ignored.color=rgb(142, 142, 142)
+nb.versioning.remotemodification.color=#000
+nb.versioning.textannotation.color=#fff
+nb.versioning.tooltip.background.color=rgb(92, 92, 66)
+
+# diff
+nb.diff.added.color=rgb(43, 85, 43)
+nb.diff.changed.color=rgb(40, 85, 112)
+nb.diff.deleted.color=rgb(85, 43, 43)
+nb.diff.applied.color=rgb(68, 113, 82)
+nb.diff.notapplied.color=rgb(67, 105, 141)
+nb.diff.unresolved.color=rgb(130, 30, 30)
+nb.diff.sidebar.deleted.color=rgb(85, 43, 43)
+nb.diff.sidebar.changed.color=rgb(30, 75, 112)
 
 # output
 nb.output.foreground=@foreground
@@ -128,3 +182,17 @@ nb.output.warning.foreground=#FFC66D
 nb.output.failure.foreground=#FF4040
 nb.output.success.foreground=#A8C023
 nb.output.debug.foreground=#808080
+
+# AddModulePanel
+selection.highlight=rgb(202, 152, 0)
+
+# browser picker
+Nb.browser.picker.background.light=rgb(116,116,116)
+Nb.browser.picker.foreground.light=rgb(192,192,192)
+
+# search in projects
+nb.search.sandbox.highlight=@selectionBackground
+nb.search.sandbox.regexp.wrong=rgb(255, 71, 71)
+
+# Windows file chooser places bar (at left side; class sun.swing.WindowsPlacesBar)
+[win]ToolBar.shadow=@background

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -23,6 +23,7 @@ nb.explorer.unfocusedSelFg=@selectionInactiveForeground
 nb.explorer.noFocusSelectionBackground=@selectionInactiveBackground
 nb.explorer.noFocusSelectionForeground=@selectionInactiveForeground
 
+Tree.textBackground=$Tree.background
 controlShadow=$Component.borderColor
 
 
@@ -69,6 +70,7 @@ ETableHeader.ascendingIcon=$Table.ascendingSortIcon
 ETableHeader.descendingIcon=$Table.descendingSortIcon
 
 nb.html.link.foreground=$Component.linkColor
+nb.html.link.foreground.hover=darken($Component.linkColor,5%)
 nb.html.link.foreground.focus=$Component.linkColor
 nb.html.link.foreground.visited=#628FB5
 
@@ -91,3 +93,6 @@ nb.core.ui.balloon.mouseOverGradientStartColor=$ToolTip.background
 nb.core.ui.balloon.mouseOverGradientFinishColor=$ToolTip.background
 nb.core.ui.balloon.defaultGradientStartColor=$ToolTip.background
 nb.core.ui.balloon.defaultGradientFinishColor=$ToolTip.background
+
+# popup switcher
+nb.popupswitcher.border=1,1,1,1,$PopupMenu.borderColor


### PR DESCRIPTION
This PR adds a lot of missing colors to "FlatLaf Dark" LAF.

I've searched the the three other Dark LAFs for missing colors and copied them to FlatLaf.
Some with modifications, but many without.

This PR fixes also NETBEANS-3688.

Debugging view:
![image](https://user-images.githubusercontent.com/5604048/72229341-2afc9780-35ae-11ea-91b7-4e7d01e7b06f.png)

Files with versioning highlighting (maybe it is necessary to click "Reset colors" button in "Options > Fonts & Colors > Versioning" to get new colors):
![image](https://user-images.githubusercontent.com/5604048/72229254-6185e280-35ad-11ea-98a8-32955a24c71c.png)

File chooser on Windows fix:
![image](https://user-images.githubusercontent.com/5604048/72229098-3058e280-35ac-11ea-9827-81284309d2ea.png)

Tasks view fix:
![image](https://user-images.githubusercontent.com/5604048/72229152-9cd3e180-35ac-11ea-9429-2c0445f290a7.png)
