### PR TITLE
[NETBEANS-3695] - not proper to use a static variable through a refer…

### DIFF
--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/RunTimeDDCatalog.java
@@ -614,9 +614,9 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
         Enumeration en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
             Node next = (Node) en.nextElement();
-            if (next.getNodeType() == next.DOCUMENT_TYPE_NODE) {
+            if (next.getNodeType() == Node.DOCUMENT_TYPE_NODE) {
                 return null; // null for web.xml specified by DTD
-            } else if (next.getNodeType() == next.ELEMENT_NODE) {
+            } else if (next.getNodeType() == Node.ELEMENT_NODE) {
                 Element element = (Element) next;
                 String tag = element.getTagName();
                 if (EJB_JAR_TAG.equals(tag)) {  // NOI18N

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/RunTimeDDCatalog.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/RunTimeDDCatalog.java
@@ -591,9 +591,9 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
         Enumeration en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
             Node next = (Node) en.nextElement();
-            if (next.getNodeType() == next.DOCUMENT_TYPE_NODE) {
+            if (next.getNodeType() == Node.DOCUMENT_TYPE_NODE) {
                 return null; // null for web.xml specified by DTD
-            } else if (next.getNodeType() == next.ELEMENT_NODE) {
+            } else if (next.getNodeType() == Node.ELEMENT_NODE) {
                 Element element = (Element) next;
                 String tag = element.getTagName();
                 if (EJB_JAR_TAG.equals(tag)) {  // NOI18N

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/ui/ConfigurationsComboModel.java
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/ui/ConfigurationsComboModel.java
@@ -179,7 +179,7 @@ public class ConfigurationsComboModel extends AbstractListModel implements Combo
 
         @Override
         public void keyPressed(KeyEvent ke) {
-            if (ke.getKeyCode() == ke.VK_ENTER || ke.getKeyCode() == ke.VK_ESCAPE) {
+            if (ke.getKeyCode() == KeyEvent.VK_ENTER || ke.getKeyCode() == KeyEvent.VK_ESCAPE) {
                 confirm(ke);
             }
         }

--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Authentication.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/Authentication.java
@@ -150,7 +150,7 @@ public final class Authentication {
             throw new IllegalArgumentException("Invalid ssh key file " + filename); // NOI18N
         }
 
-        type = type.SSH_KEY;
+        type = Type.SSH_KEY;
         sshKeyFile = filename;
     }
 

--- a/ide/image/src/org/netbeans/modules/image/ImagePrintSupport.java
+++ b/ide/image/src/org/netbeans/modules/image/ImagePrintSupport.java
@@ -63,7 +63,7 @@ public class ImagePrintSupport implements PrintCookie, Printable, ImageObserver 
             throws IllegalArgumentException {
         try{
             AffineTransform af = new AffineTransform();
-            if( pf.getOrientation() == pf.LANDSCAPE ){
+            if( pf.getOrientation() == PageFormat.LANDSCAPE ){
             }else{
                 af.translate(pf.getImageableX(), pf.getImageableY());
             }

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/TapPanel.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/TapPanel.java
@@ -314,7 +314,7 @@ public final class TapPanel extends javax.swing.JPanel {
             if ( c.length > 0 ) {
                 Dimension d2 = c[ 0 ].getPreferredSize ();
                 if ( tp.isExpanded () ) {
-                    int top = tp.getOrientation () == tp.UP ? 0 : tp.getMinimumHeight ();
+                    int top = tp.getOrientation () == TapPanel.UP ? 0 : tp.getMinimumHeight ();
                     int height = Math.min ( tp.getHeight () - tp.getMinimumHeight (), d2.height );
                     c[ 0 ].setBounds ( 0, top, tp.getWidth (), height );
                 } else {

--- a/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/LinkButton.java
+++ b/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/LinkButton.java
@@ -119,10 +119,10 @@ public class LinkButton extends JButton implements MouseListener, FocusListener 
     }
     
     public void setColors(Color linkColor, Color linkInFocusColor, Color mouseOverLinkColor, Color visitedLinkColor) {
-        this.linkInFocusColor = linkInFocusColor;
-        this.linkColor = linkColor;
-        this.mouseOverLinkColor = mouseOverLinkColor;
-        this.visitedLinkColor = visitedLinkColor;
+        LinkButton.linkInFocusColor = linkInFocusColor;
+        LinkButton.linkColor = linkColor;
+        LinkButton.mouseOverLinkColor = mouseOverLinkColor;
+        LinkButton.visitedLinkColor   = visitedLinkColor;
     }
 
     private void init() {

--- a/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/TermOptionsPanel.java
+++ b/ide/terminal.nb/src/org/netbeans/modules/terminal/nb/TermOptionsPanel.java
@@ -170,7 +170,7 @@ public final class TermOptionsPanel extends JPanel {
 
         org.openide.awt.Mnemonics.setLocalizedText(fontSizeLabel, org.openide.util.NbBundle.getMessage(TermOptionsPanel.class, "TermOptionsPanel.fontSizeLabel.text")); // NOI18N
 
-        fontSizeSpinner.setModel(new SpinnerNumberModel(12, termOptions.MIN_FONT_SIZE, termOptions.MAX_FONT_SIZE, 1));
+        fontSizeSpinner.setModel(new SpinnerNumberModel(12, TermOptions.MIN_FONT_SIZE, TermOptions.MAX_FONT_SIZE, 1));
         fontSizeSpinner.addChangeListener(new javax.swing.event.ChangeListener() {
             public void stateChanged(javax.swing.event.ChangeEvent evt) {
                 fontSizeSpinnerStateChanged(evt);

--- a/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
@@ -126,7 +126,7 @@ public abstract class GrammarQueryManager {
                     GrammarQuery query = g.getGrammar(ctx);
                     if (query == null) {
                         ErrorManager err = ErrorManager.getDefault();
-                        err.log(err.WARNING, "Broken contract: " + g.getClass());
+                        err.log(ErrorManager.WARNING, "Broken contract: " + g.getClass());
                     }
                     return query;
                 } else {
@@ -136,7 +136,7 @@ public abstract class GrammarQueryManager {
                     PrintWriter writer = new PrintWriter(stringWriter);
                     ex.printStackTrace(writer);
                     writer.flush();
-                    err.log(err.WARNING, stringWriter.getBuffer().toString());
+                    err.log(ErrorManager.WARNING, stringWriter.getBuffer().toString());
                     return null;
                 }
             } finally {

--- a/ide/xml.core/src/org/netbeans/modules/xml/core/lib/XSLT10PseudoDTDGrammarQueryProvider.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/core/lib/XSLT10PseudoDTDGrammarQueryProvider.java
@@ -42,7 +42,7 @@ public class XSLT10PseudoDTDGrammarQueryProvider extends GrammarQueryManager {
         Enumeration en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
             Node next = (Node) en.nextElement();
-            if (next.getNodeType() == next.ELEMENT_NODE) {
+            if (next.getNodeType() == Node.ELEMENT_NODE) {
                 boolean xslt = false;
                 boolean version1x = false;
                 NamedNodeMap attrs = next.getAttributes();

--- a/java/ant.grammar/src/org/netbeans/modules/ant/grammar/AntGrammarQueryProvider.java
+++ b/java/ant.grammar/src/org/netbeans/modules/ant/grammar/AntGrammarQueryProvider.java
@@ -46,7 +46,7 @@ public final class AntGrammarQueryProvider extends GrammarQueryManager {
         Enumeration en = ctx.getDocumentChildren();
         while (en.hasMoreElements()) {
             Node next = (Node) en.nextElement();
-            if (next.getNodeType() == next.ELEMENT_NODE) {
+            if (next.getNodeType() == Node.ELEMENT_NODE) {
                 Element root = (Element) next;                
                 if ("project".equals(root.getNodeName())) { // NOI18N
                     return Enumerations.singleton (next);

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ConfigurationsComboModel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ConfigurationsComboModel.java
@@ -172,7 +172,7 @@ public class ConfigurationsComboModel extends AbstractListModel implements Combo
 
         @Override
         public void keyPressed(KeyEvent ke) {
-            if (ke.getKeyCode() == ke.VK_ENTER || ke.getKeyCode() == ke.VK_ESCAPE) {
+            if (ke.getKeyCode() == KeyEvent.VK_ENTER || ke.getKeyCode() == KeyEvent.VK_ESCAPE) {
                 confirm(ke);
             }
         }

--- a/platform/openide.actions/src/org/openide/actions/HeapView.java
+++ b/platform/openide.actions/src/org/openide/actions/HeapView.java
@@ -471,11 +471,11 @@ class HeapView extends JComponent {
             if (e.isPopupTrigger()) {
                 // Show a popup allowing to configure the various options
                 showPopup(e.getX(), e.getY());
-            }  else if (e.getID() == e.MOUSE_ENTERED) {
+            }  else if (e.getID() == MouseEvent.MOUSE_ENTERED) {
                 containsMouse = true;
                 cachedBorderVaild = false;
                 repaint();
-            } else if (e.getID() == e.MOUSE_EXITED) {
+            } else if (e.getID() == MouseEvent.MOUSE_EXITED) {
                 containsMouse = false;
                 cachedBorderVaild = false;
                 repaint();

--- a/platform/openide.actions/src/org/openide/actions/PasteAction.java
+++ b/platform/openide.actions/src/org/openide/actions/PasteAction.java
@@ -497,7 +497,7 @@ public final class PasteAction extends CallbackSystemAction {
             } else {
                 // is action
                 Action a = (Action) arr[index];
-                a.actionPerformed(new ActionEvent(a, ActionEvent.ACTION_PERFORMED, a.NAME));
+                a.actionPerformed(new ActionEvent(a, ActionEvent.ACTION_PERFORMED, Action.NAME));
 
                 return;
             }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/BaseTable.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/BaseTable.java
@@ -778,7 +778,7 @@ abstract class BaseTable extends JTable implements FocusListener {
         }
 
         if (!isAncestorOf(fe.getOppositeComponent()) || (fe.getOppositeComponent() == null)) {
-            if (isEditing() && (fe.getID() == fe.FOCUS_LOST)) {
+            if (isEditing() && (fe.getID() == FocusEvent.FOCUS_LOST)) {
                 if (PropUtils.isLoggable(BaseTable.class)) {
                     PropUtils.log(
                         BaseTable.class, "ProcessFocusEvent got focus lost to unknown component, removing editor"
@@ -791,7 +791,7 @@ abstract class BaseTable extends JTable implements FocusListener {
 
         if (!inEditorRemoveRequest() && !inEditRequest()) { //XXX inEditRequest probably shouldn't be here
 
-            if ((fe.getOppositeComponent() == null) && (fe.getID() == fe.FOCUS_LOST)) {
+            if ((fe.getOppositeComponent() == null) && (fe.getID() == FocusEvent.FOCUS_LOST)) {
                 //ignore the strange focus to null stuff NetBeans does
                 return;
             }
@@ -842,7 +842,7 @@ abstract class BaseTable extends JTable implements FocusListener {
 
         //Manually hook in the bindings for tab - does not seem to get called
         //automatically
-        if (e.getKeyCode() != e.VK_TAB) {
+        if (e.getKeyCode() != KeyEvent.VK_TAB) {
             if (!suppressDefaultHandling) {
                 //Either the search field or the table should handle up/down, not both
                 super.processKeyEvent(e);

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/ComboInplaceEditor.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/ComboInplaceEditor.java
@@ -455,7 +455,7 @@ class ComboInplaceEditor extends JComboBox implements InplaceEditor, FocusListen
      * by the look and feel */
     @Override
     public void processFocusEvent(FocusEvent fe) {
-        if ((fe.getID() == fe.FOCUS_LOST) &&
+        if ((fe.getID() == FocusEvent.FOCUS_LOST) &&
             fe.getOppositeComponent() == getEditor().getEditorComponent() &&
             isPopupVisible()) {
 
@@ -471,7 +471,7 @@ class ComboInplaceEditor extends JComboBox implements InplaceEditor, FocusListen
 
         Component focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
 
-        if (isDisplayable() && (fe.getID() == fe.FOCUS_GAINED) && (focusOwner == this) && !isPopupVisible()) {
+        if (isDisplayable() && (fe.getID() == FocusEvent.FOCUS_GAINED) && (focusOwner == this) && !isPopupVisible()) {
             if (isEditable()) {
                 prepareEditor();
 
@@ -489,7 +489,7 @@ class ComboInplaceEditor extends JComboBox implements InplaceEditor, FocusListen
             }
 
             repaint();
-        } else if ((fe.getID() == fe.FOCUS_LOST) && isPopupVisible() && !isDisplayable()) {
+        } else if ((fe.getID() == FocusEvent.FOCUS_LOST) && isPopupVisible() && !isDisplayable()) {
             if (!PropUtils.psCommitOnFocusLoss) {
                 setActionCommand(COMMAND_FAILURE);
                 fireActionEvent();
@@ -603,7 +603,7 @@ class ComboInplaceEditor extends JComboBox implements InplaceEditor, FocusListen
     public void processKeyEvent(KeyEvent ke) {
         super.processKeyEvent(ke);
 
-        if ((ke.getID() == ke.KEY_PRESSED) && (ke.getKeyCode() == ke.VK_ESCAPE)) {
+        if ((ke.getID() == KeyEvent.KEY_PRESSED) && (ke.getKeyCode() == KeyEvent.VK_ESCAPE)) {
             setActionCommand(COMMAND_FAILURE);
             fireActionEvent();
         }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/IconPanel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/IconPanel.java
@@ -177,7 +177,7 @@ class IconPanel extends JComponent implements InplaceEditor {
             Icon ic = null;
             FeatureDescriptor fd = env.getFeatureDescriptor();
 
-            if (env.getState() == env.STATE_INVALID) {
+            if (env.getState() == PropertyEnv.STATE_INVALID) {
                 ic = ImageUtilities.loadImageIcon("org/openide/resources/propertysheet/invalid.gif", false); //NOI18N
             } else if (fd != null) {
                 ic = (Icon) fd.getValue("valueIcon"); //NOI18N

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertyPanel.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/PropertyPanel.java
@@ -686,7 +686,7 @@ public class PropertyPanel extends JComponent implements javax.accessibility.Acc
     protected void processFocusEvent(FocusEvent fe) {
         super.processFocusEvent(fe);
 
-        if (fe.getID() == fe.FOCUS_GAINED) {
+        if (fe.getID() == FocusEvent.FOCUS_GAINED) {
             if ((inner != null) && inner.isEnabled() && inner.isFocusTraversable()) {
                 inner.requestFocus();
             }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/RadioInplaceEditor.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/RadioInplaceEditor.java
@@ -37,6 +37,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
+import java.awt.event.KeyEvent;
 
 import java.beans.PropertyEditor;
 
@@ -478,17 +479,17 @@ class RadioInplaceEditor extends JPanel implements InplaceEditor, ActionListener
             return "InvRadioButton - " + getText(); //NOI18N
         }
 
-        public void processKeyEvent(java.awt.event.KeyEvent ke) {
+        public void processKeyEvent(KeyEvent ke) {
             super.processKeyEvent(ke);
 
             if (
-                ((ke.getKeyCode() == ke.VK_ENTER) || (ke.getKeyCode() == ke.VK_ESCAPE)) &&
-                    (ke.getID() == ke.KEY_PRESSED)
+                ((ke.getKeyCode() == KeyEvent.VK_ENTER) || (ke.getKeyCode() == KeyEvent.VK_ESCAPE)) &&
+                    (ke.getID() == KeyEvent.KEY_PRESSED)
             ) {
                 RadioInplaceEditor.this.fireActionPerformed(
                     new ActionEvent(
                         this, ActionEvent.ACTION_PERFORMED,
-                        (ke.getKeyCode() == ke.VK_ENTER) ? COMMAND_SUCCESS : COMMAND_FAILURE
+                        (ke.getKeyCode() == KeyEvent.VK_ENTER) ? COMMAND_SUCCESS : COMMAND_FAILURE
                     )
                 );
             }

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/RendererFactory.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/RendererFactory.java
@@ -242,7 +242,7 @@ final class RendererFactory {
 
         if (
             !(result instanceof JLabel) &&
-                ((env.getState() == env.STATE_INVALID) || (prop.getValue("valueIcon") != null))
+                ((env.getState() == ReusablePropertyEnv.STATE_INVALID) || (prop.getValue("valueIcon") != null))
         ) { //NOI18N
             result = prepareIconPanel(editor, env, (InplaceEditor) result);
         }

--- a/profiler/profiler.options/src/org/netbeans/modules/profiler/options/ui/ProfilerOptionsPanel.java
+++ b/profiler/profiler.options/src/org/netbeans/modules/profiler/options/ui/ProfilerOptionsPanel.java
@@ -237,13 +237,13 @@ public final class ProfilerOptionsPanel extends JPanel implements ActionListener
         Object oomeSelected = oomeCombo.getSelectedItem();
 
         if (Bundle.ProfilerOptionsPanel_OomeNothingText().equals(oomeSelected)) {
-            pis.setOOMDetectionMode(pis.OOME_DETECTION_NONE);
+            pis.setOOMDetectionMode(ProfilerIDESettings.OOME_DETECTION_NONE);
         } else if (Bundle.ProfilerOptionsPanel_OomeProjectText().equals(oomeSelected)) {
-            pis.setOOMDetectionMode(pis.OOME_DETECTION_PROJECTDIR);
+            pis.setOOMDetectionMode(ProfilerIDESettings.OOME_DETECTION_PROJECTDIR);
         } else if (Bundle.ProfilerOptionsPanel_OomeTempText().equals(oomeSelected)) {
-            pis.setOOMDetectionMode(pis.OOME_DETECTION_TEMPDIR);
+            pis.setOOMDetectionMode(ProfilerIDESettings.OOME_DETECTION_TEMPDIR);
         } else if (Bundle.ProfilerOptionsPanel_OomeCustomText().equals(oomeSelected)) {
-            pis.setOOMDetectionMode(pis.OOME_DETECTION_CUSTOMDIR);
+            pis.setOOMDetectionMode(ProfilerIDESettings.OOME_DETECTION_CUSTOMDIR);
         }
 
         pis.setCustomHeapdumpPath(oomeDetectionDirTextField.getText());
@@ -301,22 +301,22 @@ public final class ProfilerOptionsPanel extends JPanel implements ActionListener
             return false;
         }
 
-        if ((settings.getOOMDetectionMode() == settings.OOME_DETECTION_NONE)
+        if ((settings.getOOMDetectionMode() == ProfilerIDESettings.OOME_DETECTION_NONE)
                 && (!Bundle.ProfilerOptionsPanel_OomeNothingText().equals(oomeCombo.getSelectedItem()))) {
             return false;
         }
 
-        if ((settings.getOOMDetectionMode() == settings.OOME_DETECTION_PROJECTDIR)
+        if ((settings.getOOMDetectionMode() == ProfilerIDESettings.OOME_DETECTION_PROJECTDIR)
                 && (!Bundle.ProfilerOptionsPanel_OomeProjectText().equals(oomeCombo.getSelectedItem()))) {
             return false;
         }
 
-        if ((settings.getOOMDetectionMode() == settings.OOME_DETECTION_TEMPDIR)
+        if ((settings.getOOMDetectionMode() == ProfilerIDESettings.OOME_DETECTION_TEMPDIR)
                 && (!Bundle.ProfilerOptionsPanel_OomeTempText().equals(oomeCombo.getSelectedItem()))) {
             return false;
         }
 
-        if ((settings.getOOMDetectionMode() == settings.OOME_DETECTION_CUSTOMDIR)
+        if ((settings.getOOMDetectionMode() == ProfilerIDESettings.OOME_DETECTION_CUSTOMDIR)
                 && (!Bundle.ProfilerOptionsPanel_OomeCustomText().equals(oomeCombo.getSelectedItem()))) {
             return false;
         }
@@ -411,13 +411,13 @@ public final class ProfilerOptionsPanel extends JPanel implements ActionListener
             takingSnapshotCombo.setSelectedItem(Bundle.ProfilerOptionsPanel_SaveSnapshotRadioText());
         }
 
-        if (pis.getOOMDetectionMode() == pis.OOME_DETECTION_NONE) {
+        if (pis.getOOMDetectionMode() == ProfilerIDESettings.OOME_DETECTION_NONE) {
             oomeCombo.setSelectedItem(Bundle.ProfilerOptionsPanel_OomeNothingText());
-        } else if (pis.getOOMDetectionMode() == pis.OOME_DETECTION_PROJECTDIR) {
+        } else if (pis.getOOMDetectionMode() == ProfilerIDESettings.OOME_DETECTION_PROJECTDIR) {
             oomeCombo.setSelectedItem(Bundle.ProfilerOptionsPanel_OomeProjectText());
-        } else if (pis.getOOMDetectionMode() == pis.OOME_DETECTION_TEMPDIR) {
+        } else if (pis.getOOMDetectionMode() == ProfilerIDESettings.OOME_DETECTION_TEMPDIR) {
             oomeCombo.setSelectedItem(Bundle.ProfilerOptionsPanel_OomeTempText());
-        } else if (pis.getOOMDetectionMode() == pis.OOME_DETECTION_CUSTOMDIR) {
+        } else if (pis.getOOMDetectionMode() == ProfilerIDESettings.OOME_DETECTION_CUSTOMDIR) {
             oomeCombo.setSelectedItem(Bundle.ProfilerOptionsPanel_OomeCustomText());
         }
 

--- a/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AndroidDevice.java
+++ b/webcommon/cordova.platforms.android/src/org/netbeans/modules/cordova/platforms/android/AndroidDevice.java
@@ -70,7 +70,7 @@ public class AndroidDevice implements Device {
     @Override
     public void openUrl(String url) {
         try {
-            if (browser == browser.DEFAULT) {
+            if (browser == Browser.DEFAULT) {
             ProcessUtilities.callProcess(
                     ((AndroidPlatform) getPlatform()).getAdbCommand(), 
                     true,

--- a/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsonLexer.java
+++ b/webcommon/javascript2.lexer/src/org/netbeans/modules/javascript2/lexer/JsonLexer.java
@@ -64,7 +64,7 @@ public class JsonLexer implements Lexer<JsTokenId> {
     public Token<JsTokenId> nextToken() {
         org.antlr.v4.runtime.Token nextToken = scanner.nextToken();
         Token<JsTokenId> token = null;
-        if (nextToken.getType() != scanner.EOF) {            
+        if (nextToken.getType() != org.netbeans.modules.javascript2.json.parser.JsonLexer.EOF) {            
             token = tokenFactory.createToken(tokenId(nextToken.getType()));
             LOGGER.log(Level.FINEST, "Lexed token is {0}", token.id());
             return token;

--- a/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/html/RequireJsHtmlExtension.java
+++ b/webcommon/javascript2.requirejs/src/org/netbeans/modules/javascript2/requirejs/html/RequireJsHtmlExtension.java
@@ -177,7 +177,7 @@ public class RequireJsHtmlExtension extends HtmlExtension {
             HTMLTokenId tokenId = token.id();
             if (tokenId == HTMLTokenId.VALUE) {
                 String value = token.text().toString();
-                token = LexerUtils.followsToken(ts, Arrays.asList(HTMLTokenId.ARGUMENT), true, false, HTMLTokenId.OPERATOR, HTMLTokenId.ARGUMENT.WS, HTMLTokenId.BLOCK_COMMENT);
+                token = LexerUtils.followsToken(ts, Arrays.asList(HTMLTokenId.ARGUMENT), true, false, HTMLTokenId.OPERATOR, HTMLTokenId.WS, HTMLTokenId.BLOCK_COMMENT);
                 if (token != null && token.id() == HTMLTokenId.ARGUMENT && DATAMAIN.equals(token.text().toString())) {
                     return value.substring(1, value.length() - 1);
                 }


### PR DESCRIPTION
…ence

It's really not proper to use a static variable through a reference because they can't be derived. The proper thing to do is use them with a Class name..

   [repeat] /home/bwalker/src/netbeans/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ConfigurationsComboModel.java:175: warning: [static] static variable should be qualified by type name, KeyEvent, instead of by an expression
   [repeat]             if (ke.getKeyCode() == ke.VK_ENTER || ke.getKeyCode() == ke.VK_ESCAPE) {
   [repeat]                                      ^
   [repeat] /home/bwalker/src/netbeans/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/ConfigurationsComboModel.java:175: warning: [static] static variable should be qualified by type name, KeyEvent, instead of by an expression
   [repeat]             if (ke.getKeyCode() == ke.VK_ENTER || ke.getKeyCode() == ke.VK_ESCAPE) {
   [repeat]

This change fixes that..