### PR TITLE
[NETBEANS-3428] Remove experimental from FlatLafDark

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Installer.java
@@ -25,8 +25,8 @@ import org.openide.modules.ModuleInstall;
 import org.openide.util.*;
 
 @NbBundle.Messages({
-    "LBL_FLATLAF_LIGHT=FlatLaf Light (experimental)",
-    "LBL_FLATLAF_DARK=FlatLaf Dark (experimental)"
+    "LBL_FLATLAF_LIGHT=FlatLaf Light",
+    "LBL_FLATLAF_DARK=FlatLaf Dark"
 })
 public class Installer extends ModuleInstall {
 
@@ -34,8 +34,6 @@ public class Installer extends ModuleInstall {
     public void validate() throws IllegalStateException {
         UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_LIGHT(), FlatLightLaf.class.getName()));
         UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo(Bundle.LBL_FLATLAF_DARK(), FlatDarkLaf.class.getName()));
-//        UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo("Flat IntelliJ", FlatIntelliJLaf.class.getName()));
-//        UIManager.installLookAndFeel(new UIManager.LookAndFeelInfo("Flat Darcula", FlatDarculaLaf.class.getName()));
     }
 
 }

--- a/platform/o.n.swing.plaf/manifest.mf
+++ b/platform/o.n.swing.plaf/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Localizing-Bundle: org/netbeans/swing/plaf/Bundle.properties
 OpenIDE-Module: org.netbeans.swing.plaf
-OpenIDE-Module-Specification-Version: 1.48
+OpenIDE-Module-Specification-Version: 1.49
 AutoUpdate-Show-In-Client: false
 

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/LFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/LFCustoms.java
@@ -311,6 +311,9 @@ public abstract class LFCustoms {
     //custom fonts based on this value
     protected static final String DEFAULT_FONT_SIZE = "nbDefaultFontSize"; //NOI18N
 
+    //Color Profile
+    protected static final String EDITOR_PREFERRED_COLOR_PROFILE = "nb.preferred.color.profile"; //NOI18N
+
     //Editor
     protected static final String EDITOR_STATUS_LEFT_BORDER = "Nb.Editor.Status.leftBorder"; //NOI18N
     protected static final String EDITOR_STATUS_INNER_BORDER = "Nb.Editor.Status.innerBorder"; //NOI18N

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/AquaLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/aqua/AquaLFCustoms.java
@@ -95,6 +95,7 @@ public final class AquaLFCustoms extends LFCustoms {
             "org/netbeans/swing/plaf/resources/osx-folder.png"); //NOI18N
 
         Object[] result = {
+            EDITOR_PREFERRED_COLOR_PROFILE, "NetBeans", //NOI18N
             TOOLBAR_UI, "org.netbeans.swing.plaf.aqua.PlainAquaToolbarUI",
 
             // XXX  - EXPLORER_STATUS_BORDER,

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/GtkLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/GtkLFCustoms.java
@@ -74,6 +74,7 @@ public class GtkLFCustoms extends LFCustoms {
         }
         
         Object[] result = {
+            EDITOR_PREFERRED_COLOR_PROFILE, "NetBeans", //NOI18N
             PROPSHEET_SELECTION_BACKGROUND, selBg,
             PROPSHEET_SELECTION_FOREGROUND, selFg,
             PROPSHEET_SELECTED_SET_BACKGROUND, selBg,

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/MetalLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/MetalLFCustoms.java
@@ -50,6 +50,7 @@ public final class MetalLFCustoms extends LFCustoms {
         Font controlFont = new Font("Dialog", Font.PLAIN, fontsize); //NOI18N
         Object[] result = {
             //The assorted standard NetBeans metal font customizations
+            EDITOR_PREFERRED_COLOR_PROFILE, "NetBeans", //NOI18N
             CONTROLFONT, controlFont,
             SYSTEMFONT, controlFont,
             USERFONT, controlFont,

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/NimbusLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/NimbusLFCustoms.java
@@ -79,6 +79,7 @@ public final class NimbusLFCustoms extends LFCustoms {
         }*/
 
         Object[] result = {
+            EDITOR_PREFERRED_COLOR_PROFILE, "NetBeans", //NOI18N
             //UI Delegates for the tab control
             EDITOR_TAB_DISPLAYER_UI,
                 "org.netbeans.swing.tabcontrol.plaf.NimbusEditorTabDisplayerUI", //NOI18N

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/WindowsLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/winclassic/WindowsLFCustoms.java
@@ -63,6 +63,7 @@ public final class WindowsLFCustoms extends LFCustoms {
     public Object[] createApplicationSpecificKeysAndValues () {
         Object propertySheetColorings = new WinClassicPropertySheetColorings();
         Object[] result = {
+            EDITOR_PREFERRED_COLOR_PROFILE, "NetBeans", //NOI18N
             DESKTOP_BORDER, new EmptyBorder(4, 2, 1, 2),
             SCROLLPANE_BORDER, UIManager.get("ScrollPane.border"),
             EXPLORER_STATUS_BORDER, new StatusLineBorder(StatusLineBorder.TOP),

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
@@ -94,6 +94,7 @@ public final class Windows8LFCustoms extends LFCustoms {
         Object[] constants = new Object[] {
             "TextArea.font", textAreaFont, //NOI18N
 
+            EDITOR_PREFERRED_COLOR_PROFILE, "NetBeans", //NOI18N
             EDITOR_ERRORSTRIPE_SCROLLBAR_INSETS, new Insets(17, 0, 17, 0),
 
             /* NETBEANS-1249: Remove excessive spacing between menu items, which appeared going from

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/winvista/VistaLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/winvista/VistaLFCustoms.java
@@ -89,6 +89,7 @@ public final class VistaLFCustoms extends LFCustoms {
         Object propertySheetValues = new VistaPropertySheetColorings();
 
         Object[] uiDefaults = {
+            EDITOR_PREFERRED_COLOR_PROFILE, "NetBeans", //NOI18N
             EDITOR_TAB_DISPLAYER_UI, editorTabsUI,
             VIEW_TAB_DISPLAYER_UI, viewTabsUI,
             

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/winxp/XPLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/winxp/XPLFCustoms.java
@@ -88,6 +88,7 @@ public final class XPLFCustoms extends LFCustoms {
         Object propertySheetValues = new XPPropertySheetColorings();
 
         Object[] uiDefaults = {
+            EDITOR_PREFERRED_COLOR_PROFILE, "NetBeans", //NOI18N
             EDITOR_TAB_DISPLAYER_UI, editorTabsUI,
             VIEW_TAB_DISPLAYER_UI, viewTabsUI,
             


### PR DESCRIPTION
Also added the preferred color profile for standard supported LaF-s, so switching back some Dark to regular light LaF offers you changing the editor coloring back to default NetBeans as well.