### PR TITLE
[NETBEANS-3700] No more harcoding for Code Coverage Highlights.

### DIFF
--- a/ide/defaults/src/org/netbeans/modules/defaults/BlueTheme-editor.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/BlueTheme-editor.xml
@@ -62,4 +62,9 @@
     <fontcolor name="LastOperation" bgColor="6f9f5a"/>
     <fontcolor name="StepOutOperation" bgColor="2D6035"/>
 
+    <fontcolor name="coverage-covered" bgColor="0F4F40"/>
+    <fontcolor name="coverage-uncovered" bgColor="4F0F40"/>
+    <fontcolor name="coverage-inferred" bgColor="1F4F40"/>
+    <fontcolor name="coverage-partial" bgColor="909040"/>
+
  </fontscolors>

--- a/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/Bundle.properties
+++ b/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/Bundle.properties
@@ -51,3 +51,9 @@ CoverageReportTopComponent.allTestsButton.text=Run Al&l Tests
 
 CoverageAction.MenuName=Code Covera&ge
 CoverageSideBar.label.toolTipText=Use Ctrl-Shift-F11 to focus
+
+# Coloring names
+coverage-covered=Code Coverage (covered)
+coverage-uncovered=Code Coverage (not covered)
+coverage-inferred=Code Coverage (inferred)
+coverage-partial=Code Coverage (partial)

--- a/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageHighlightsContainer.java
+++ b/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageHighlightsContainer.java
@@ -70,6 +70,11 @@ public class CoverageHighlightsContainer extends AbstractHighlightsContainer imp
     private FileObject fileObject;
     private Project project;
 
+    private static final String COLORING_COVERED   = "coverage-covered"; //NOI18N
+    private static final String COLORING_UNCOVERED = "coverage-uncovered"; //NOI18N
+    private static final String COLORING_INFERRED  = "coverage-inferred"; //NOI18N
+    private static final String COLORING_PARTIAL   = "coverage-partial"; //NOI18N
+
     CoverageHighlightsContainer(JTextComponent component) {
         this.component = component;
         Document document = component.getDocument();
@@ -118,7 +123,7 @@ public class CoverageHighlightsContainer extends AbstractHighlightsContainer imp
     }
 
     private static Color getColoring(FontColorSettings fcs, String tokenName) {
-        AttributeSet as = fcs.getTokenFontColors(tokenName);
+        AttributeSet as = fcs.getFontColors(tokenName);
         if (as != null) {
             return (Color) as.getAttribute(StyleConstants.Background); //NOI18N
         }
@@ -136,10 +141,10 @@ public class CoverageHighlightsContainer extends AbstractHighlightsContainer imp
         Color partialBc = null;
         FontColorSettings fcs = MimeLookup.getLookup(mimeType).lookup(FontColorSettings.class);
         if (fcs != null) {
-            coveredBc = getColoring(fcs, "covered"); // NOI18N
-            uncoveredBc = getColoring(fcs, "uncovered"); // NOI18N
-            inferredBc = getColoring(fcs, "inferred"); // NOI18N
-            partialBc = getColoring(fcs, "partial"); // NOI18N
+            coveredBc = getColoring(fcs, COLORING_COVERED);
+            uncoveredBc = getColoring(fcs, COLORING_UNCOVERED);
+            inferredBc = getColoring(fcs, COLORING_INFERRED);
+            partialBc = getColoring(fcs, COLORING_PARTIAL);
         }
         if (coveredBc == null) {
             coveredBc = new Color(0xCC, 0xFF, 0xCC);

--- a/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/fontsColors.xml
+++ b/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/fontsColors.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+
+<fontscolors>
+    <fontcolor name="coverage-covered" bgColor="CCFFCC"/>
+    <fontcolor name="coverage-uncovered" bgColor="FFCCCC"/>
+    <fontcolor name="coverage-inferred" bgColor="E0FFE0"/>
+    <fontcolor name="coverage-partial" bgColor="FFFFE0"/>
+</fontscolors>
+

--- a/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/layer.xml
+++ b/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/layer.xml
@@ -21,6 +21,18 @@
 -->
 <!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
 <filesystem>
+    <folder name="Editors">
+        <folder name="FontsColors">
+            <folder name="NetBeans">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-gsf-codecoverage-fontsColors.xml" url="fontsColors.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.gsf.codecoverage.Bundle"/>
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
+                </folder>
+            </folder>
+        </folder>        
+    </folder>
     <folder name="Windows2">
         <folder name="Modes">
             <folder name="editor">

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-highlights.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-highlights.xml
@@ -49,4 +49,8 @@
     <fontcolor name="text-limit-line-color" foreColor="ff555555"/>
     <fontcolor name="trailing-whitespace"/>
     <fontcolor name="west-sidebars-color"/>
+    <fontcolor name="coverage-covered" bgColor="005000"/>
+    <fontcolor name="coverage-uncovered" bgColor="813438"/>
+    <fontcolor name="coverage-inferred" bgColor="1c501c"/>
+    <fontcolor name="coverage-partial" bgColor="707000"/>
 </fontscolors>


### PR DESCRIPTION
The Options Panel:
![CodeCoverahe-Highlights](https://user-images.githubusercontent.com/1381701/72487329-899a5f00-37c2-11ea-9925-07c44dce78d9.png)

The default colors:
![CodeCoverage-NetBeans](https://user-images.githubusercontent.com/1381701/72487337-91f29a00-37c2-11ea-9d2c-6c47a141e479.png)

Norway Today:
![CodeCoverage-NorwayToday](https://user-images.githubusercontent.com/1381701/72487370-a767c400-37c2-11ea-9569-32e492b4292b.png)

FlatLaf Dark:
![CodeCoverage-FlatlafDark](https://user-images.githubusercontent.com/1381701/72487378-aafb4b00-37c2-11ea-8022-15616917c666.png)

Well these are the colors I could came up with, I guess they could be improved by someone more artistic than me.