### PR TITLE
[NETBEANS-3647] Update FtpClient.java - compatibility with IIS

### DIFF
--- a/php/php.project/src/org/netbeans/modules/php/project/connections/ftp/FtpClient.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/connections/ftp/FtpClient.java
@@ -158,7 +158,7 @@ public class FtpClient implements RemoteClient {
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "Connecting to {0} [timeout: {1} ms]", new Object[] {configuration.getHost(), timeout});
             }
-            ftpClient.setStrictReplyParsing(false);
+            ftpClient.setStrictReplyParsing(false); // NETBEANS-3647
             ftpClient.setDefaultTimeout(timeout);
             ftpClient.setControlKeepAliveReplyTimeout(keepAliveInterval);
             if (LOGGER.isLoggable(Level.FINE)) {

--- a/php/php.project/src/org/netbeans/modules/php/project/connections/ftp/FtpClient.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/connections/ftp/FtpClient.java
@@ -158,6 +158,7 @@ public class FtpClient implements RemoteClient {
             if (LOGGER.isLoggable(Level.FINE)) {
                 LOGGER.log(Level.FINE, "Connecting to {0} [timeout: {1} ms]", new Object[] {configuration.getHost(), timeout});
             }
+            ftpClient.setStrictReplyParsing(false);
             ftpClient.setDefaultTimeout(timeout);
             ftpClient.setControlKeepAliveReplyTimeout(keepAliveInterval);
             if (LOGGER.isLoggable(Level.FINE)) {


### PR DESCRIPTION
Allow non-strict interpretation of RFC 959 to enhance compatibility with some FTP servers (e.g. Microsoft IIS FTP).

cf. https://issues.apache.org/jira/browse/NETBEANS-3647