### PR TITLE
[NETBEANS-3657] FlatLaf: fix Conditional Breakpoint editor

### DIFF
--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ConditionsPanel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ConditionsPanel.java
@@ -26,12 +26,13 @@ import java.awt.event.ActionListener;
 
 import java.util.ArrayList;
 import java.util.StringTokenizer;
+import javax.swing.BorderFactory;
 import javax.swing.ComboBoxEditor;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JComponent;
 import javax.swing.JEditorPane;
 import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.border.Border;
 import org.netbeans.api.debugger.Breakpoint.HIT_COUNT_FILTERING_STYLE;
 import org.netbeans.api.debugger.Properties;
@@ -56,7 +57,14 @@ public class ConditionsPanel extends javax.swing.JPanel {
         tfConditionFieldForUI = new javax.swing.JTextField();
         tfConditionFieldForUI.setEnabled(false);
         tfConditionFieldForUI.setToolTipText(tfCondition.getToolTipText());
-        
+
+        // remove border from condition editor on some LAFs
+        String lafID = UIManager.getLookAndFeel().getID();
+        if (lafID.equals("Windows") || lafID.startsWith("FlatLaf")) { // NOI18N
+            tfConditionFieldForUI.setBorder(BorderFactory.createEmptyBorder());
+            spCondition.setBorder(BorderFactory.createEmptyBorder());
+        }
+
         classFilterCheckBoxActionPerformed(null);
         conditionCheckBoxActionPerformed(null);
         cbWhenHitCountActionPerformed(null);


### PR DESCRIPTION
This PR:
- fixes double border in conditional breakpoint editor (FlatLaf and Windows LAF)
- fixes displaced caret in single line editor
  (in FlatLaf caret was 6px to left; in other LAFs hardly noticeable 0-2px to left)

https://issues.apache.org/jira/browse/NETBEANS-3657

FlatLaf:
![image](https://user-images.githubusercontent.com/5604048/72652427-06763600-3987-11ea-9ec2-4d6f978245fb.png)

Windows:
![image](https://user-images.githubusercontent.com/5604048/72652786-7b963b00-3988-11ea-8a11-f87de70be284.png)
