### PR TITLE
[NETBEANS-3428] Update FlatLaf from 0.24 to 0.25.1 and other fixes

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-EF5EAB402A08F24C69FDA036E8E38A3C10310FA6 com.formdev:flatlaf:0.24
+3E05CE2EA9ED771C2912DD0E15B8F965892D0B9B com.formdev:flatlaf:0.25.1

--- a/platform/libs.flatlaf/external/flatlaf-0.25.1-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-0.25.1-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 0.24
-Files: flatlaf-0.24.jar
+Version: 0.25.1
+Files: flatlaf-0.25.1.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-0.24.jar=modules/ext/flatlaf-0.24.jar
+release.external/flatlaf-0.25.1.jar=modules/ext/flatlaf-0.25.1.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-0.24.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-0.24.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-0.25.1.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-0.25.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -206,6 +206,3 @@ Nb.browser.picker.foreground.light=rgb(192,192,192)
 # search in projects
 nb.search.sandbox.highlight=@selectionBackground
 nb.search.sandbox.regexp.wrong=rgb(255, 71, 71)
-
-# Windows file chooser places bar (at left side; class sun.swing.WindowsPlacesBar)
-[win]ToolBar.shadow=@background

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -23,7 +23,6 @@ nb.explorer.unfocusedSelFg=@selectionInactiveForeground
 nb.explorer.noFocusSelectionBackground=@selectionInactiveBackground
 nb.explorer.noFocusSelectionForeground=@selectionInactiveForeground
 
-Tree.textBackground=$Tree.background
 controlShadow=$Component.borderColor
 
 
@@ -114,3 +113,9 @@ nb.core.ui.balloon.defaultGradientFinishColor=$ToolTip.background
 
 # QuickSearch
 nb.quicksearch.border=1,1,1,1,@background
+
+# popup switcher
+nb.popupswitcher.border=1,1,1,1,$PopupMenu.borderColor
+
+# Windows file chooser places bar (at left side; class sun.swing.WindowsPlacesBar)
+[win]ToolBar.shadow=@background


### PR DESCRIPTION
Improvements and fixes thru FlatLaf 0.25.1:
- [NETBEANS-3703] fixed broken tree node expand/collapse with right/left keys on macOS
- fixed broken combobox keyboard navigation and show/hide popup on macOS
- hide menu mnemonics by default and show them only when `Alt` key is pressed (same as in Windows LAF)
- option in progress bar to use always large height even if no text is painted (for [NETBEANS-3713])
- UI default value `Tree.textBackground` now has a valid color and is no
longer `null` (for [NETBEANS-3688])
- "Find in Project" dialog: removed empty space in "(    test    )" and "(    edit    )" links

Other fixes in NB code:
- fixed border color of tabs "open documents" popup
- "FlatLaf Light" on Windows: fixed background of "places" bar in file chooser

Windows file chooser:
![image](https://user-images.githubusercontent.com/5604048/72662401-fee67980-39e6-11ea-856c-334d64cb94f7.png)

"open documents" popup:
![image](https://user-images.githubusercontent.com/5604048/72663157-7fa97380-39ef-11ea-9da3-1f6af31c90aa.png)

![image](https://user-images.githubusercontent.com/5604048/72663158-846e2780-39ef-11ea-92ff-b2dcb0e82409.png)

"Find in Project" dialog:
![image](https://user-images.githubusercontent.com/5604048/72663211-3574c200-39f0-11ea-91ed-9fa63e7c66c1.png)