### PR TITLE
[NETBEANS-3428] FlatLaf: improving editor and view tabs in main window

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -35,16 +35,20 @@ TabbedContainer.view.contentBorderColor=$Component.borderColor
 
 #---- EditorTab ----
 
-EditorTab.tabInsets=6,8,6,8
+EditorTab.tabInsets=5,6,7,6
 EditorTab.underlineHeight=3
 #EditorTab.underlineAtTop=true
+EditorTab.tabSeparatorColor=$Component.borderColor
+EditorTab.showTabSeparators=true
 
 
 #---- ViewTab ----
 
-ViewTab.tabInsets=6,8,6,8
+ViewTab.tabInsets=5,6,7,0
 ViewTab.underlineHeight=3
 #ViewTab.underlineAtTop=true
+ViewTab.tabSeparatorColor=$Component.borderColor
+ViewTab.showTabSeparators=true
 
 
 #---- Multi-tabs ----

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
@@ -58,13 +58,17 @@ public class FlatEditorTabCellRenderer extends AbstractTabCellRenderer {
 
     private static final Color underlineColor = UIManager.getColor("EditorTab.underlineColor"); // NOI18N
     private static final Color inactiveUnderlineColor = UIManager.getColor("EditorTab.inactiveUnderlineColor"); // NOI18N
+    private static final Color tabSeparatorColor = UIManager.getColor("EditorTab.tabSeparatorColor"); // NOI18N
     private static final Color contentBorderColor = UIManager.getColor("TabbedContainer.editor.contentBorderColor"); // NOI18N
 
     private static final Insets tabInsets = UIScale.scale(UIManager.getInsets("EditorTab.tabInsets")); // NOI18N
     private static final int underlineHeight = UIScale.scale(UIManager.getInt("EditorTab.underlineHeight")); // NOI18N
     private static final boolean underlineAtTop = UIManager.getBoolean("EditorTab.underlineAtTop"); // NOI18N
+    private static boolean showTabSeparators = UIManager.getBoolean("EditorTab.showTabSeparators"); // NOI18N
 
     private static final FlatTabPainter painter = new FlatTabPainter();
+
+    boolean nextTabSelected;
 
     public FlatEditorTabCellRenderer() {
         super(painter, new Dimension(tabInsets.left + tabInsets.right, tabInsets.top + tabInsets.bottom));
@@ -198,24 +202,39 @@ public class FlatEditorTabCellRenderer extends AbstractTabCellRenderer {
             FlatEditorTabCellRenderer ren = (FlatEditorTabCellRenderer) c;
             boolean selected = ren.isSelected();
 
+            // get background color
+            Color bg = ren.colorForState(
+                    background, activeBackground, selectedBackground,
+                    hoverBackground, attentionBackground);
+
+            boolean showSeparator = showTabSeparators && !selected && !ren.nextTabSelected;
+
+            // do not round tab separator width to get nice small lines at 125%, 150% and 175%
+            int tabSeparatorWidth = showSeparator ? (int) (1 * scale) : 0;
+
             // paint background
-            g.setColor(ren.colorForState(background, activeBackground, selectedBackground,
-                    hoverBackground, attentionBackground));
-            g.fillRect(0, 0, width, height);
+            g.setColor(bg);
+            g.fillRect(0, 0, width - (bg != background ? tabSeparatorWidth : 0), height);
 
             if (selected && underlineHeight > 0) {
                 // paint underline if tab is selected
                 int underlineHeight = (int) Math.round(FlatEditorTabCellRenderer.underlineHeight * scale);
                 g.setColor(ren.isActive() ? underlineColor : inactiveUnderlineColor);
                 if (underlineAtTop)
-                    g.fillRect(0, 0, width, underlineHeight);
+                    g.fillRect(0, 0, width - tabSeparatorWidth, underlineHeight);
                 else
-                    g.fillRect(0, height - underlineHeight, width, underlineHeight);
+                    g.fillRect(0, height - underlineHeight, width - tabSeparatorWidth, underlineHeight);
             } else {
                 // paint bottom border
                 int contentBorderWidth = HiDPIUtils.deviceBorderWidth(scale, 1);
                 g.setColor(contentBorderColor);
                 g.fillRect(0, height - contentBorderWidth, width, contentBorderWidth);
+            }
+
+            if (showSeparator) {
+                int offset = (int) (4 * scale);
+                g.setColor(tabSeparatorColor);
+                g.fillRect(width - tabSeparatorWidth, offset, tabSeparatorWidth, height - (offset * 2) - 1);
             }
         }
 

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabDisplayerUI.java
@@ -36,6 +36,7 @@ import org.netbeans.swing.laf.flatlaf.HiDPIUtils;
 import org.netbeans.swing.tabcontrol.TabDisplayer;
 import org.netbeans.swing.tabcontrol.plaf.BasicScrollingTabDisplayerUI;
 import org.netbeans.swing.tabcontrol.plaf.TabCellRenderer;
+import org.netbeans.swing.tabcontrol.plaf.TabState;
 
 /**
  * Tab displayer UI for FlatLaf look and feel
@@ -74,6 +75,15 @@ public class FlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
         } else
             prefHeight = UIScale.scale(28);
         return new Dimension(displayer.getWidth(), prefHeight);
+    }
+
+    @Override
+    public TabCellRenderer getTabCellRenderer(int tab) {
+        TabCellRenderer ren = super.getTabCellRenderer(tab);
+        if (ren instanceof FlatEditorTabCellRenderer && tab + 1 < displayer.getModel().size()) {
+            ((FlatEditorTabCellRenderer)ren).nextTabSelected = (tabState.getState(tab + 1) & TabState.SELECTED) != 0;
+        }
+        return ren;
     }
 
     @Override

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatTabControlIcon.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatTabControlIcon.java
@@ -220,17 +220,17 @@ public final class FlatTabControlIcon extends VectorIcon {
             g.fill(win1);
             g.fill(win2);
         } else if (buttonId == TabControlButton.ID_MAXIMIZE_BUTTON) {
-            int xy = round(3 * scaling);
-            int wh = round(10 * scaling);
+            int xy = (int) (3 * scaling);
+            int wh = width - (2 * xy);
             /* Draw one larger window. The getWindowSymbol method ensures we are using the same
             window border thickness as for ID_RESTORE_BUTTON. */
             g.fill(getWindowSymbol(scaling, xy, xy, wh, wh));
         } else if (buttonId == TabControlButton.ID_SLIDE_GROUP_BUTTON) {
             // Draw a simple bar towards the bottom of the icon.
-            int barX = round(3 * scaling);
-            int barY = round(7 * scaling);
-            int barWidth = round(10 * scaling);
-            int barThickness = round(2 * scaling);
+            int barX = (int) (3 * scaling);
+            int barY = round(11 * scaling);
+            int barWidth = width - (2 * barX);
+            int barThickness = (int) (1 * scaling);
             g.fill(new Rectangle2D.Double(barX, barY, barWidth, barThickness));
         } else if (buttonId == TabControlButton.ID_DROP_DOWN_BUTTON ||
                    buttonId == TabControlButton.ID_SCROLL_LEFT_BUTTON ||


### PR DESCRIPTION
This PR improves PR #1771

Editor and View tabs:
- tab separators
- tab text moved up 1px
- smaller tab insets
- minimize icon improved

View tabs only:
- minimized space between tab text and close button
- center tab text if close button is hidden
- make sure that as much tab text as possible is shown by dynamically reducing left/right margins
- avoid empty tabs (truncate text if necessary)

New:

![image](https://user-images.githubusercontent.com/5604048/72667386-bf865000-3a1b-11ea-93b1-34b3119285fe.png)

Old (from PR #1771):

![image](https://user-images.githubusercontent.com/5604048/70626237-59402d80-1c24-11ea-93d0-c6ccabcc9d54.png)

The tab text in views is now centered (was left aligned) because left aligned text looks horrible with tab separators.
![image](https://user-images.githubusercontent.com/5604048/72667964-d62fa580-3a21-11ea-837f-cede937574ab.png)

When horizontal space becomes rare, the left/right tab margins are reduced.
Empty tabs (no tab text painted) does no longer occur.
![image](https://user-images.githubusercontent.com/5604048/72668035-bba9fc00-3a22-11ea-9119-b0b9e6621e05.png)
