### PR TITLE
[NETBEANS-3713] FlatLaf: progress bar improvements

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
@@ -72,6 +72,11 @@ public class FlatLFCustoms extends LFCustoms {
             "nb.multitabs.button.right.icon", FlatTabControlIcon.get(TabControlButton.ID_SCROLL_RIGHT_BUTTON), // NOI18N
             "nb.multitabs.button.rollover", true, // NOI18N
 
+            // for module progress.ui
+            "nb.progress.cancel.icon", FlatTabControlIcon.get(TabControlButton.ID_CLOSE_BUTTON, TabControlButton.STATE_DEFAULT), // NOI18N
+            "nb.progress.cancel.icon.pressed", FlatTabControlIcon.get(TabControlButton.ID_CLOSE_BUTTON, TabControlButton.STATE_PRESSED), // NOI18N
+            "nb.progress.cancel.icon.mouseover", FlatTabControlIcon.get(TabControlButton.ID_CLOSE_BUTTON, TabControlButton.STATE_ROLLOVER), // NOI18N
+
             // Change some colors from ColorUIResource to Color because they are used as
             // background colors for checkboxes (e.g. in org.netbeans.modules.palette.ui.CategoryButton),
             // which in FlatLaf paint background only if background color is not a UIResource.

--- a/platform/progress.ui/nbproject/project.properties
+++ b/platform/progress.ui/nbproject/project.properties
@@ -18,7 +18,7 @@
 # Sample ResourceBundle properties file
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 
 test.config.stableBTD.includes=**/*Test.class

--- a/platform/progress.ui/src/org/netbeans/modules/progress/ui/AbstractWindowRunner.java
+++ b/platform/progress.ui/src/org/netbeans/modules/progress/ui/AbstractWindowRunner.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
+import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
@@ -252,21 +253,21 @@ abstract class AbstractWindowRunner<T> extends WindowAdapter implements Runnable
             closeButton.setOpaque(false);
             closeButton.setContentAreaFilled(false);
 
-            Image img = (Image)UIManager.get("nb.progress.cancel.icon"); //NOI18N
+            Object img = UIManager.get("nb.progress.cancel.icon"); //NOI18N
             if( null != img ) {
-                closeButton.setIcon( ImageUtilities.image2Icon( img ) );
+                closeButton.setIcon( (img instanceof Icon) ? (Icon) img : ImageUtilities.image2Icon( (Image) img ) );
             } else {
                 closeButton.setText ( NbBundle.getMessage(AbstractWindowRunner.class,
                         "ModalDialog.btnClose.text")); //NOI18N
             }
-            img = (Image)UIManager.get("nb.progress.cancel.icon.mouseover"); //NOI18N
+            img = UIManager.get("nb.progress.cancel.icon.mouseover"); //NOI18N
             if( null != img ) {
                 closeButton.setRolloverEnabled(true);
-                closeButton.setRolloverIcon( ImageUtilities.image2Icon( img ) );
+                closeButton.setRolloverIcon( (img instanceof Icon) ? (Icon) img : ImageUtilities.image2Icon( (Image) img ) );
             }
-            img = (Image)UIManager.get("nb.progress.cancel.icon.pressed"); //NOI18N
+            img = UIManager.get("nb.progress.cancel.icon.pressed"); //NOI18N
             if( null != img ) {
-                closeButton.setPressedIcon( ImageUtilities.image2Icon( img ) ); //NOI18N
+                closeButton.setPressedIcon( (img instanceof Icon) ? (Icon) img : ImageUtilities.image2Icon( (Image) img ) );
             }
             closeButton.setToolTipText(NbBundle.getMessage(AbstractWindowRunner.class,
                     "ModalDialog.btnClose.tooltip")); //NOI18N

--- a/platform/progress.ui/src/org/netbeans/modules/progress/ui/ListComponent.java
+++ b/platform/progress.ui/src/org/netbeans/modules/progress/ui/ListComponent.java
@@ -34,6 +34,7 @@ import java.awt.event.MouseEvent;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
+import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -130,18 +131,18 @@ public class ListComponent extends JPanel {
             closeButton.setContentAreaFilled(false);
             closeButton.setFocusable(false);
             
-            Image img = (Image)UIManager.get("nb.progress.cancel.icon");
+            Object img = UIManager.get("nb.progress.cancel.icon");
             if( null != img ) {
-                closeButton.setIcon( new ImageIcon( img ) );
+                closeButton.setIcon( iconOrImage2icon( img ) );
             }
-            img = (Image)UIManager.get("nb.progress.cancel.icon.mouseover");
+            img = UIManager.get("nb.progress.cancel.icon.mouseover");
             if( null != img ) {
                 closeButton.setRolloverEnabled(true);
-                closeButton.setRolloverIcon( new ImageIcon( img ) );
+                closeButton.setRolloverIcon( iconOrImage2icon( img ) );
             }
-            img = (Image)UIManager.get("nb.progress.cancel.icon.pressed");
+            img = UIManager.get("nb.progress.cancel.icon.pressed");
             if( null != img ) {
-                closeButton.setPressedIcon( new ImageIcon( img ) );
+                closeButton.setPressedIcon( iconOrImage2icon( img ) );
             }
             
             closeButton.setToolTipText(NbBundle.getMessage(ListComponent.class, "ListComponent.btnClose.tooltip"));
@@ -190,6 +191,12 @@ public class ListComponent extends JPanel {
             
         });
         
+    }
+
+    static Icon iconOrImage2icon( Object iconOrImage ) {
+        return (iconOrImage instanceof Icon)
+                ? (Icon) iconOrImage
+                : new ImageIcon( (Image) iconOrImage );
     }
     
     
@@ -296,12 +303,12 @@ public class ListComponent extends JPanel {
                putValue(Action.NAME, NbBundle.getMessage(ListComponent.class, "StatusLineComponent.Cancel"));
                putValue(Action.ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0));
            } else {
-               Image icon = (Image)UIManager.get("nb.progress.cancel.icon");
+               Object icon = UIManager.get("nb.progress.cancel.icon");
                if (icon == null) {
                    // for custom L&F?
                    icon = ImageUtilities.loadImage("org/netbeans/progress/module/resources/buton.png");
                }
-               putValue(Action.SMALL_ICON, new ImageIcon(icon));
+               putValue(Action.SMALL_ICON, iconOrImage2icon(icon));
            }
             setEnabled(handle == null ? false : handle.isAllowCancel());
        }
@@ -395,7 +402,14 @@ public class ListComponent extends JPanel {
             }
             // have the bar approx 30 percent of the width
             int barOffset = offset - (ITEM_WIDTH / 3);
-            bar.setBounds(barOffset, UPPERMARGIN, offset - barOffset, mainHeight);
+            int barY = UPPERMARGIN;
+            int barHeight = mainHeight;
+            if (UIManager.getLookAndFeel().getID().startsWith("FlatLaf")) {
+                // use smaller (preferred) height
+                barHeight = bar.getPreferredSize().height;
+                barY += (mainHeight - barHeight) / 2;
+            }
+            bar.setBounds(barOffset, barY, offset - barOffset, barHeight);
             mainLabel.setBounds(LEFTMARGIN, UPPERMARGIN, barOffset - LEFTMARGIN, mainHeight);
             dynaLabel.setBounds(LEFTMARGIN, mainHeight + UPPERMARGIN + BETWEENTEXTMARGIN, 
                                 parentWidth - LEFTMARGIN, dynaHeight);

--- a/platform/progress.ui/src/org/netbeans/modules/progress/ui/NbProgressBar.java
+++ b/platform/progress.ui/src/org/netbeans/modules/progress/ui/NbProgressBar.java
@@ -62,6 +62,10 @@ public class NbProgressBar extends JProgressBar implements ExtractedProgressUIWo
     
     public void setUseInStatusBar(boolean use) {
         usedInStatusBar = use;
+
+        if (UIManager.getLookAndFeel().getID().startsWith("FlatLaf")) { //NOI18N
+            putClientProperty("JProgressBar.largeHeight", use ? true : null); //NOI18N
+        }
     }
     
     public Dimension getPreferredSize() {

--- a/platform/progress.ui/src/org/netbeans/modules/progress/ui/PopupPane.java
+++ b/platform/progress.ui/src/org/netbeans/modules/progress/ui/PopupPane.java
@@ -38,9 +38,9 @@ import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
+import javax.swing.UIManager;
 import javax.swing.border.Border;
 import org.netbeans.modules.progress.spi.InternalHandle;
-import org.netbeans.modules.progress.spi.UIInternalHandle;
 import org.openide.util.Mutex;
 
 /**
@@ -119,6 +119,11 @@ public class PopupPane extends JScrollPane {
                         break;
                     }
                 }
+                if (view.getComponentCount() > 0) {
+                    // remove bottom border from last component
+                    JComponent last = (JComponent)view.getComponent(view.getComponentCount() - 1);
+                    last.setBorder(null);
+                }
                 if (listComponents.size() > 3) {
                     setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
                 } else {
@@ -155,9 +160,14 @@ public class PopupPane extends JScrollPane {
     
     private static class BottomLineBorder implements Border {
         private Insets ins = new Insets(0, 0, 1, 0);
-        private Color col = new Color(221, 229, 248);
+        private Color col;
         
-        public BottomLineBorder () {}
+        public BottomLineBorder () {
+            col = UIManager.getColor("Separator.foreground"); // NOI18N
+            if (col == null) {
+                col = new Color(221, 229, 248);
+            }
+        }
         
         public @Override Insets getBorderInsets(Component c) {
             return ins;

--- a/platform/progress.ui/src/org/netbeans/modules/progress/ui/StatusLineComponent.java
+++ b/platform/progress.ui/src/org/netbeans/modules/progress/ui/StatusLineComponent.java
@@ -28,7 +28,6 @@ import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.GraphicsEnvironment;
-import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
@@ -48,7 +47,6 @@ import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.Icon;
-import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -191,18 +189,18 @@ public class StatusLineComponent extends JPanel implements ProgressUIWorkerWithM
         closeButton.setOpaque(false);
         closeButton.setContentAreaFilled(false);
         
-        Image img = (Image)UIManager.get("nb.progress.cancel.icon");
+        Object img = UIManager.get("nb.progress.cancel.icon");
         if( null != img ) {
-            closeButton.setIcon( new ImageIcon( img ) );
+            closeButton.setIcon( ListComponent.iconOrImage2icon( img ) );
         }
-        img = (Image)UIManager.get("nb.progress.cancel.icon.mouseover");
+        img = UIManager.get("nb.progress.cancel.icon.mouseover");
         if( null != img ) {
             closeButton.setRolloverEnabled(true);
-            closeButton.setRolloverIcon( new ImageIcon( img ) );
+            closeButton.setRolloverIcon( ListComponent.iconOrImage2icon( img ) );
         }
-        img = (Image)UIManager.get("nb.progress.cancel.icon.pressed");
+        img = UIManager.get("nb.progress.cancel.icon.pressed");
         if( null != img ) {
-            closeButton.setPressedIcon( new ImageIcon( img ) );
+            closeButton.setPressedIcon( ListComponent.iconOrImage2icon( img ) );
         }
     }
     
@@ -620,12 +618,12 @@ public class StatusLineComponent extends JPanel implements ProgressUIWorkerWithM
             if (text) {
                 putValue(Action.NAME, NbBundle.getMessage(StatusLineComponent.class, "StatusLineComponent.Cancel"));
             } else {
-                Image icon = (Image)UIManager.get("nb.progress.cancel.icon");
+                Object icon = UIManager.get("nb.progress.cancel.icon");
                 if (icon == null) {
                        // for custom L&F?
                     putValue(Action.SMALL_ICON, ImageUtilities.loadImageIcon("org/netbeans/progress/module/resources/buton.png", true));
                 } else {
-                    putValue(Action.SMALL_ICON, new ImageIcon(icon));
+                    putValue(Action.SMALL_ICON, ListComponent.iconOrImage2icon(icon));
                 }
             }
             setEnabled(handle == null ? false : handle.isAllowCancel());


### PR DESCRIPTION
- progress bar in status bar now always has large height (has changed height before depending on whether text is painted in progress bar)
- cancel button replaced with vector icon
- fixed color of separator in "Processes" popup
- remove separator of last row in "Processes" popup if process was removed
- use preferred height for progress bars in "Processes" popup

Before ("Processes" popup shown):
![image](https://user-images.githubusercontent.com/5604048/72671659-de9dd580-3a4d-11ea-97b2-cce5d1761bd8.png)

Before, separator was not removed after background scanning finished:
![image](https://user-images.githubusercontent.com/5604048/72671534-510db600-3a4c-11ea-9dd2-67508d461328.png)

After:
![image](https://user-images.githubusercontent.com/5604048/72671638-9e3e5780-3a4d-11ea-8e7d-b1dbb0eed684.png)

"Processes" popup:
![image](https://user-images.githubusercontent.com/5604048/72671549-7bf80a00-3a4c-11ea-92ca-29e4d76c3dbe.png)
