### PR TITLE
Use correct constant to fetch welcome screen topbar foreground

### DIFF
--- a/nb/welcome/src/org/netbeans/modules/welcome/content/Utils.java
+++ b/nb/welcome/src/org/netbeans/modules/welcome/content/Utils.java
@@ -149,7 +149,7 @@ public class Utils {
     public static Color getTopBarForeground() {
         Color res = UIManager.getColor("nb.startpage.topbar.foreground"); //NOI18N
         if( null == res )
-            res = getColor( Constants.COLOR_TAB_BACKGROUND );
+            res = getColor( Constants.COLOR_TAB_FOREGROUND );
         return res;
     }
 


### PR DESCRIPTION
Commit 5fb6012a7d2bfd233b4b9ba8b9b3fbc6d98e1171 moved the definition
of the foreground color into the resource bundle. Instead of the correct
constant COLOR_TAB_FOREGROUND COLOR_TAB_BACKGROUND is referenced.

The consequence of the wrong constant is an unreadable welcome screen
on LAFs, that don't override the colors.