### PR TITLE
[NETBEANS-3428] FlatLaf: optimized editor and view tabs in main window

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -34,7 +34,7 @@ TabbedContainer.view.contentBorderColor=$Component.borderColor
 
 #---- EditorTab ----
 
-EditorTab.tabInsets=5,6,7,6
+EditorTab.tabInsets=5,6,7,8
 EditorTab.underlineHeight=3
 #EditorTab.underlineAtTop=true
 EditorTab.tabSeparatorColor=$Component.borderColor
@@ -43,7 +43,7 @@ EditorTab.showTabSeparators=true
 
 #---- ViewTab ----
 
-ViewTab.tabInsets=5,6,7,0
+ViewTab.tabInsets=5,6,7,2
 ViewTab.underlineHeight=3
 #ViewTab.underlineAtTop=true
 ViewTab.tabSeparatorColor=$Component.borderColor
@@ -52,7 +52,7 @@ ViewTab.showTabSeparators=true
 
 #---- Multi-tabs ----
 
-nb.multitabs.tabInsets=6,2,6,2
+nb.multitabs.tabInsets=5,2,7,2
 nb.multitabs.underlineHeight=3
 nb.multitabs.showVerticalLines=true
 nb.multitabs.showHorizontalLines=false

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
@@ -100,7 +100,7 @@ public class FlatEditorTabCellRenderer extends AbstractTabCellRenderer {
         int txtH = fm.getHeight();
         Insets ins = getInsets();
         int availH = getHeight() - (ins.top + ins.bottom);
-        return (availH <= txtH) ? -fm.getDescent() : 0;
+        return (availH <= txtH) ? -fm.getDescent() : -1;
     }
 
     @Override
@@ -151,7 +151,7 @@ public class FlatEditorTabCellRenderer extends AbstractTabCellRenderer {
             int iconWidth = icon.getIconWidth();
             int iconHeight = icon.getIconHeight();
             rect.x = bounds.x + bounds.width - iconWidth - UIScale.scale(CLOSE_ICON_RIGHT_PAD);
-            rect.y = bounds.y + (Math.max(0, bounds.height / 2 - iconHeight / 2));
+            rect.y = bounds.y + (Math.max(0, bounds.height / 2 - iconHeight / 2)) - 1;
             rect.width = iconWidth;
             rect.height = iconHeight;
         }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatViewTabDisplayerUI.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatViewTabDisplayerUI.java
@@ -128,7 +128,7 @@ public class FlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
                 } else {
                     buttons.setVisible(true);
                     availTxtWidth -= (buttonsSize.width + ICON_X_PAD);
-                    buttons.setLocation(x + width - buttonsSize.width - ICON_X_PAD, y + (height - buttonsSize.height) / 2);
+                    buttons.setLocation(x + width - buttonsSize.width - ICON_X_PAD, y + ((height - buttonsSize.height) / 2) - 1);
                 }
             }
         }


### PR DESCRIPTION
Fix for this: https://github.com/apache/netbeans/pull/1883#issuecomment-576024263

Editor and View tabs:
- 2px larger space between tab text and close icon
- close icon moved up 1px so that it is not on the same baseline as the tab text

Multi-tabs:
- tab text moved up 1px so that it is at the same baseline as View tabs
