### PR TITLE
[NETBEANS-3717] Allow LaF to change the color of the selected item in Code Completion

### DIFF
--- a/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionScrollPane.java
+++ b/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionScrollPane.java
@@ -37,6 +37,7 @@ import javax.swing.JLabel;
 import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.Keymap;
@@ -93,6 +94,17 @@ public class CompletionScrollPane extends JScrollPane {
 
         // Add the completion view
         view = new CompletionJList(maxVisibleRowCount, mouseListener, editorComponent);
+
+        // Apply selection colors as CompletionJList selecion also means focused
+        Color selBg = UIManager.getColor("nb.completion.selectedBackground"); //NOI18N
+        if (selBg != null) {
+            view.setSelectionBackground(selBg);
+        }
+        Color selFg = UIManager.getColor("nb.completion.selectedForeground"); //NOI18N
+        if (selFg != null) {
+            view.setSelectionForeground(selFg);
+        }
+
         if (listSelectionListener != null) {
             view.addListSelectionListener(listSelectionListener);
         }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -67,6 +67,9 @@ nb.multitabs.selectedForeground=$EditorTab.selectedForeground
 nb.multitabs.underlineColor=$TabbedPane.underlineColor
 nb.multitabs.inactiveUnderlineColor=$EditorTab.inactiveUnderlineColor
 
+#---- Code Completion ----
+nb.completion.selectedBackground=@selectionBackground
+nb.completion.selectedForeground=@selectionForeground
 
 #---- TabControlIcon ----
 


### PR DESCRIPTION
Some Look and Feels use different colors for displaying selected and focused list cells. FlatLaf is one of them. This little change allows the LaF to control the selected and by that focused item in the code completion list. It could be confusing to decide which item is selected, especially on two item lists.

Before:

![CompletionFlatLafBefore](https://user-images.githubusercontent.com/1381701/72742268-3b88b100-3b5e-11ea-9eeb-f71befe31de1.png)

After:
![CompletionFlatLafAfter](https://user-images.githubusercontent.com/1381701/72742313-4a6f6380-3b5e-11ea-8745-fbb0617d6eb2.png)

 