### PR TITLE
[NETBEANS-3428] Update FlatLaf from 0.25.1 to 0.26

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-3E05CE2EA9ED771C2912DD0E15B8F965892D0B9B com.formdev:flatlaf:0.25.1
+2EF2AB1FF80098D83488A715AC708D60A2986A9B com.formdev:flatlaf:0.26

--- a/platform/libs.flatlaf/external/flatlaf-0.26-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-0.26-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 0.25.1
-Files: flatlaf-0.25.1.jar
+Version: 0.26
+Files: flatlaf-0.26.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-0.25.1.jar=modules/ext/flatlaf-0.25.1.jar
+release.external/flatlaf-0.26.jar=modules/ext/flatlaf-0.26.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-0.25.1.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-0.25.1.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-0.26.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-0.26.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -120,7 +120,8 @@ nb.core.ui.balloon.defaultGradientStartColor=$ToolTip.background
 nb.core.ui.balloon.defaultGradientFinishColor=$ToolTip.background
 
 # QuickSearch
-nb.quicksearch.border=1,1,1,1,@background
+nb.quicksearch.background=$MenuBar.background
+nb.quicksearch.border=1,1,1,1,$MenuBar.background
 
 # popup switcher
 nb.popupswitcher.border=1,1,1,1,$PopupMenu.borderColor

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
@@ -61,3 +61,7 @@ SlidingButton.attentionForeground=$ViewTab.attentionForeground
 
 PropSheet.setBackground=darken(@background,10%)
 PropSheet.setForeground=@foreground
+
+
+# QuickSearch
+nb.quicksearch.border=1,1,1,1,@background

--- a/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/QuickSearchComboBar.java
+++ b/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/QuickSearchComboBar.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.quicksearch;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -105,6 +106,10 @@ public class QuickSearchComboBar extends AbstractQuickSearchComboBar {
 
         setLayout(new java.awt.GridBagLayout());
 
+        Color background = UIManager.getColor("nb.quicksearch.background"); //NOI18N
+        if (background != null) {
+            jPanel1.setBackground(background);
+        }
         jPanel1.setBorder(getQuickSearchBorder());
         jPanel1.setName("jPanel1"); // NOI18N
         jPanel1.setLayout(new java.awt.GridBagLayout());


### PR DESCRIPTION
FlatLaf 0.26 brings new menu styling with new menu bar and popup background colors. Previously they had same background color as panels, which made popup menus hard to distinguish.

Before in FlatLaf Light:
![image](https://user-images.githubusercontent.com/5604048/72917460-2b322b00-3d44-11ea-8a60-85f61995e134.png)

After in FlatLaf Light:
![image](https://user-images.githubusercontent.com/5604048/72917491-39804700-3d44-11ea-855d-2983e64502fd.png)

Before in FlatLaf Dark:
![image](https://user-images.githubusercontent.com/5604048/72917529-4b61ea00-3d44-11ea-9865-9a4049b1f034.png)

After in FlatLaf Dark:
![image](https://user-images.githubusercontent.com/5604048/72917544-5452bb80-3d44-11ea-984d-65173dc8998b.png)

Highlight items in menu bar on mouse hover:
![image](https://user-images.githubusercontent.com/5604048/72917679-8f54ef00-3d44-11ea-857c-fa49b6c29a10.png)

FlatLaf 0.26 change log:
https://github.com/JFormDesigner/FlatLaf/releases/tag/0.26
