### PR TITLE
Fix startup warnings from netbeans 11.3

### DIFF
--- a/enterprise/servletjspapi/nbproject/project.properties
+++ b/enterprise/servletjspapi/nbproject/project.properties
@@ -16,7 +16,9 @@
 # under the License.
 
 is.autoload=true
-release.external/generated-servlet-jsp-api-3.1_2.3.jar=modules/ext/servlet3.1-jsp2.3-api.jar
 javac.compilerargs=-Xlint:unchecked
 javac.source=1.6
 spec.version.base=1.37.0
+
+release.external/generated-servlet-jsp-api-3.1_2.3.jar=modules/ext/servlet3.1-jsp2.3-api.jar
+extra.module.files=modules/ext/servlet3.1-jsp2.3-api.jar

--- a/enterprise/web.jspparser/nbproject/project.properties
+++ b/enterprise/web.jspparser/nbproject/project.properties
@@ -24,6 +24,7 @@ extsrc.cp.extra=external/generated-glassfish-jspparser-4.0.jar
 extra.module.files=modules/ext/jsp-parser-ext.jar
 
 release.external/generated-glassfish-jspparser-4.0.jar=modules/ext/glassfish-jspparser-4.0.jar
+extra.module.files=modules/ext/glassfish-jspparser-4.0.jar
 
 javadoc.arch=${basedir}/arch.xml
 

--- a/enterprise/web.struts/nbproject/project.properties
+++ b/enterprise/web.struts/nbproject/project.properties
@@ -39,7 +39,8 @@ extra.module.files=\
     modules/ext/struts/struts-mailreader-dao-1.3.10.jar,\
     modules/ext/struts/struts-scripting-1.3.10.jar,\
     modules/ext/struts/struts-taglib-1.3.10.jar,\
-    modules/ext/struts/struts-tiles-1.3.10.jar
+    modules/ext/struts/struts-tiles-1.3.10.jar,\
+    docs/struts-1.3.10-javadoc.zip
 
 release.external/generated-struts-1.3.10-javadoc.zip=docs/struts-1.3.10-javadoc.zip
 release.external/antlr-2.7.2.jar=modules/ext/struts/antlr-2.7.2.jar

--- a/enterprise/websvc.restlib/src/org/netbeans/modules/websvc/swdp/swdp.xml
+++ b/enterprise/websvc.restlib/src/org/netbeans/modules/websvc/swdp/swdp.xml
@@ -48,7 +48,12 @@
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/jersey-container-servlet.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/jersey-container-servlet-core.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/jersey-server.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/eclipselink.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.5.2.jar!/</resource>
     </volume>
     <properties>
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->

--- a/groovy/gradle/nbproject/project.properties
+++ b/groovy/gradle/nbproject/project.properties
@@ -29,3 +29,7 @@ test-unit-sys-prop.java.awt.headless=true
 release.external/gradle-tooling-api-6.0.jar=modules/gradle/gradle-tooling-api.jar
 release.build/tooling/netbeans-gradle-tooling.jar=modules/gradle/netbeans-gradle-tooling.jar
 release.build/tooling/nb-tooling.gradle=modules/gradle/nb-tooling.gradle
+
+extra.module.files=\
+    modules/gradle/netbeans-gradle-tooling.jar,\
+    modules/gradle/nb-tooling.gradle

--- a/groovy/gradle/src/org/netbeans/modules/gradle/GradleDataObject.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/GradleDataObject.java
@@ -58,7 +58,7 @@ import org.openide.windows.CloneableOpenSupport;
 @MIMEResolver.Registration(
         displayName="#LBL_GradleFile_LOADER",
         resource="gradle-mime-resolver.xml",
-        position = 300
+        position = 290
 )
 @ActionReferences({
     @ActionReference(

--- a/ide/libs.jaxb/nbproject/project.properties
+++ b/ide/libs.jaxb/nbproject/project.properties
@@ -18,19 +18,19 @@
 is.autoload=true
 
 jnlp.indirect.jars=\
-    modules/ext/jaxb/jaxb-impl-2.2.5-2.jar,\
-    modules/ext/jaxb/jaxb1-impl-2.2.5-2.jar,\
-    modules/ext/jaxb/jaxb-xjc-2.2.5-2.jar,\
-    docs/jaxb-api-2.2.5-javadoc.jar
+    modules/ext/jaxb/jaxb-impl.jar,\
+    modules/ext/jaxb/jaxb1-impl.jar,\
+    modules/ext/jaxb/jaxb-xjc.jar,\
+    docs/jaxb-api-javadoc.jar
 
 # pack200 bug in JDK 7 (#7131266)
-pack200.excludes=modules/ext/jaxb/jaxb-xjc-2.2.5-2.jar
+pack200.excludes=modules/ext/jaxb/jaxb-xjc.jar
 
-release.external/jaxb-impl-2.2.5-2.jar=modules/ext/jaxb/jaxb-impl-2.2.5-2.jar
-release.external/jaxb1-impl-2.2.5-2.jar=modules/ext/jaxb/jaxb1-impl-2.2.5-2.jar
-release.external/jaxb-xjc-2.2.5-2.jar=modules/ext/jaxb/jaxb-xjc-2.2.5-2.jar
+release.external/jaxb-impl-2.2.5-2.jar=modules/ext/jaxb/jaxb-impl.jar
+release.external/jaxb1-impl-2.2.5-2.jar=modules/ext/jaxb/jaxb1-impl.jar
+release.external/jaxb-xjc-2.2.5-2.jar=modules/ext/jaxb/jaxb-xjc.jar
 
 # JAXB Javadoc
-release.external/jaxb-api-2.2.5-javadoc.jar=docs/jaxb-api-2.2.5-javadoc.jar
+release.external/jaxb-api-2.2.5-javadoc.jar=docs/jaxb-api-doc.jar
 
 sigtest.gen.fail.on.error=false

--- a/ide/libs.jaxb/nbproject/project.xml
+++ b/ide/libs.jaxb/nbproject/project.xml
@@ -113,13 +113,13 @@
                 <package>com.sun.tools.xjc</package>
             </friend-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/jaxb/jaxb-impl-2.2.5-2.jar</runtime-relative-path>
+                <runtime-relative-path>ext/jaxb/jaxb-impl.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/jaxb/jaxb1-impl-2.2.5-2.jar</runtime-relative-path>
+                <runtime-relative-path>ext/jaxb/jaxb1-impl.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/jaxb/jaxb-xjc-2.2.5-2.jar</runtime-relative-path>
+                <runtime-relative-path>ext/jaxb/jaxb-xjc.jar</runtime-relative-path>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/libs.jaxb/src/org/netbeans/libs/jaxb/jaxb.xml
+++ b/ide/libs.jaxb/src/org/netbeans/libs/jaxb/jaxb.xml
@@ -27,15 +27,15 @@
     <localizing-bundle>org/netbeans/libs/jaxb/Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.libs.jaxb/modules/ext/jaxb/jaxb-impl-2.2.5-2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.libs.jaxb/modules/ext/jaxb/jaxb-xjc-2.2.5-2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.libs.jaxb/modules/ext/jaxb/jaxb1-impl-2.2.5-2.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.jaxb/modules/ext/jaxb/jaxb-impl.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.jaxb/modules/ext/jaxb/jaxb-xjc.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.jaxb/modules/ext/jaxb/jaxb1-impl.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.xml.jaxb.api/modules/ext/jaxb/activation.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.xml.jaxb.api/modules/ext/jaxb/api/jaxb-api.jar!/</resource>
     </volume>
     <volume>
         <type>javadoc</type>
-        <resource>jar:nbinst://org.netbeans.libs.jaxb/docs/jaxb-api-2.2.5-javadoc.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.jaxb/docs/jaxb-api-doc.jar!/</resource>
     </volume>
     <properties>
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->

--- a/java/j2ee.eclipselink/external/binaries-list
+++ b/java/j2ee.eclipselink/external/binaries-list
@@ -19,5 +19,6 @@
 189DB51E5A42710F16B5CF880AECC19B2820B0F9 org.eclipse.persistence:org.eclipse.persistence.antlr:2.5.2
 2A54E88F70B488381F837D644A16A2219FB4FD64 org.eclipse.persistence:org.eclipse.persistence.jpa:2.5.2
 29AF1D338CBB76290D1A96F5A6610F1E8C319AE5 org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.5.2
+AF39466383E372E3AB4737F6014ABE0D69470675 org.eclipse.persistence:org.eclipse.persistence.moxy:2.5.2
 5BAB675816DBE0F64BB86004B108BF2A00292358 org.eclipse.persistence:javax.persistence:2.1.0
 DA95A959929234C57B988644696C065D79774FC4 org.eclipse.persistence:javax.persistence:2.1.0:sources

--- a/java/j2ee.eclipselink/external/eclipselink-2.5.2-license.txt
+++ b/java/j2ee.eclipselink/external/eclipselink-2.5.2-license.txt
@@ -4,7 +4,7 @@ Version: 2.5.2
 Description: The Eclipse Persistence Services Project ( EclipseLink) project.
 License: EPL-v10-eclipselink
 Origin: http://www.eclipse.org/eclipselink/
-Files: javax.persistence-2.1.0-sources.jar, javax.persistence-2.1.0.jar, org.eclipse.persistence.core-2.5.2.jar, org.eclipse.persistence.asm-2.5.2.jar, org.eclipse.persistence.antlr-2.5.2.jar, org.eclipse.persistence.jpa-2.5.2.jar, org.eclipse.persistence.jpa.jpql-2.5.2.jar
+Files: javax.persistence-2.1.0-sources.jar, javax.persistence-2.1.0.jar, org.eclipse.persistence.core-2.5.2.jar, org.eclipse.persistence.asm-2.5.2.jar, org.eclipse.persistence.antlr-2.5.2.jar, org.eclipse.persistence.jpa-2.5.2.jar, org.eclipse.persistence.jpa.jpql-2.5.2.jar,org.eclipse.persistence.moxy-2.5.2.jar
 
 Use of EclipseLink version 2.5.2 is governed by the terms of the license below:
 

--- a/java/j2ee.eclipselink/nbproject/project.properties
+++ b/java/j2ee.eclipselink/nbproject/project.properties
@@ -33,6 +33,6 @@ release.external/org.eclipse.persistence.antlr-2.5.2.jar=modules/ext/eclipselink
 release.external/org.eclipse.persistence.jpa-2.5.2.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar
 release.external/org.eclipse.persistence.jpa.jpql-2.5.2.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar
 release.external/javax.persistence-2.1.0.jar=modules/ext/eclipselink/javax.persistence-2.1.0.jar
-release.build/javax.persistence-2.1.0-doc.zip=modules/ext/docs
+release.build/javax.persistence-2.1.0-doc.zip=modules/ext/docs/javax.persistence-2.1.0-doc.zip
 
 extra.module.files=modules/ext/docs/javax.persistence-2.1.0-doc.zip

--- a/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/eclipselink_lib.xml
+++ b/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/eclipselink_lib.xml
@@ -30,6 +30,7 @@
         <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.5.2.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/javax.persistence-2.1.0.jar!/</resource>
     </volume>
     <volume>
@@ -46,6 +47,7 @@
                 org.eclipse.persistence:org.eclipse.persistence.antlr:2.5.2:jar
                 org.eclipse.persistence:org.eclipse.persistence.jpa:2.5.2:jar
                 org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.5.2:jar
+                org.eclipse.persistence:org.eclipse.persistence.moxy:2.5.2
                 org.eclipse.persistence:javax.persistence:2.1.0:jar
             </value>
         </property>

--- a/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/jpa20-persistence.xml
+++ b/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/jpa20-persistence.xml
@@ -37,5 +37,5 @@
             <name>maven-dependencies</name>
             <value>org.eclipse.persistence:javax.persistence:2.1.0:jar</value>
         </property>
-    </properties>    
+    </properties>
 </library>

--- a/java/j2ee.persistence/nbproject/project.properties
+++ b/java/j2ee.persistence/nbproject/project.properties
@@ -18,7 +18,15 @@
 javac.source=1.8
 spec.version.base=1.61.0
 
-test.unit.run.cp.extra=${j2eeserver.dir}/modules/ext/jsr88javax.jar:${j2ee.persistence.dir}/modules/ext/eclipselink/eclipselink.jar:${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence_2.1.0.201304241213.jar:${masterfs.dir}/modules/org-netbeans-modules-masterfs.jar
+test.unit.run.cp.extra=\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.1.0.jar:\
+    ${j2eeserver.dir}/modules/ext/jsr88javax.jar:\
+    ${masterfs.dir}/modules/org-netbeans-modules-masterfs.jar
 
 sigtest.gen.fail.on.error=false
 requires.nb.javac=true

--- a/java/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
+++ b/java/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
@@ -21,17 +21,14 @@ package org.netbeans.modules.java.source;
 
 import java.awt.Dialog;
 import java.awt.GraphicsEnvironment;
-import java.awt.Toolkit;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.prefs.Preferences;
+import org.netbeans.api.annotations.common.StaticResource;
 import org.netbeans.modules.autoupdate.ui.api.PluginManager;
 import org.netbeans.modules.java.source.usages.ClassIndexManager;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
 import org.openide.awt.NotificationDisplayer;
 import org.openide.awt.NotificationDisplayer.Priority;
-import org.openide.awt.StatusDisplayer;
 import org.openide.modules.ModuleInstall;
 import org.openide.util.HelpCtx;
 import org.openide.util.ImageUtilities;
@@ -45,6 +42,9 @@ import org.openide.windows.WindowManager;
  * @author Tomas Zezula
  */
 public class JBrowseModule extends ModuleInstall {
+
+    @StaticResource
+    private static final String WARNING_ICON = "org/netbeans/modules/java/source/resources/icons/warning.png"; //NOI18N
 
     private static volatile boolean closed;
         
@@ -92,7 +92,7 @@ public class JBrowseModule extends ModuleInstall {
                 }
 
                 if (!NoJavacHelper.hasNbJavac()) {
-                    NotificationDisplayer.getDefault().notify("Install nb-javac Library", ImageUtilities.loadImageIcon("/org/netbeans/modules/java/source/resources/icons/warning.png", false), Bundle.DESC_InstallNbJavac(), evt -> {
+                    NotificationDisplayer.getDefault().notify("Install nb-javac Library", ImageUtilities.loadImageIcon(WARNING_ICON, false), Bundle.DESC_InstallNbJavac(), evt -> {
                         PluginManager.installSingle("org.netbeans.modules.nbjavac", Bundle.DN_nbjavac());
                     }, prefs.getBoolean(KEY_WARNING_SHOWN, false) ? Priority.SILENT : Priority.HIGH);
                     prefs.putBoolean(KEY_WARNING_SHOWN, true);

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTopComponent.form
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTopComponent.form
@@ -128,7 +128,7 @@
         <Component class="javax.swing.JButton" name="jBtnCancel">
           <Properties>
             <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-              <Connection code="org.openide.util.ImageUtilities.loadImageIcon(&quot;/org/netbeans/modules/refactoring/java/resources/cancel.png&quot;, false)" type="code"/>
+              <Connection code="org.openide.util.ImageUtilities.loadImageIcon(&quot;org/netbeans/modules/refactoring/java/resources/cancel.png&quot;, false)" type="code"/>
             </Property>
             <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
               <ResourceString bundle="org/netbeans/modules/refactoring/java/callhierarchy/Bundle.properties" key="CallHierarchyTopComponent.jBtnCancel.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
@@ -147,7 +147,7 @@
         <Component class="javax.swing.JToggleButton" name="jTogBtnCaller">
           <Properties>
             <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-              <Connection code="org.openide.util.ImageUtilities.loadImageIcon(&quot;/org/netbeans/modules/refactoring/java/resources/who_is_called.png&quot;, false)" type="code"/>
+              <Connection code="org.openide.util.ImageUtilities.loadImageIcon(&quot;org/netbeans/modules/refactoring/java/resources/who_is_called.png&quot;, false)" type="code"/>
             </Property>
             <Property name="selected" type="boolean" value="true"/>
             <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
@@ -162,7 +162,7 @@
         <Component class="javax.swing.JToggleButton" name="jTogBtnCallee">
           <Properties>
             <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-              <Connection code="org.openide.util.ImageUtilities.loadImageIcon(&quot;/org/netbeans/modules/refactoring/java/resources/who_calls.png&quot;, false)" type="code"/>
+              <Connection code="org.openide.util.ImageUtilities.loadImageIcon(&quot;org/netbeans/modules/refactoring/java/resources/who_calls.png&quot;, false)" type="code"/>
             </Property>
             <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
               <ResourceString bundle="org/netbeans/modules/refactoring/java/callhierarchy/Bundle.properties" key="CallHierarchyTopComponent.jTogBtnCallee.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
@@ -178,7 +178,7 @@
         <Component class="javax.swing.JToggleButton" name="jTogBtnScope">
           <Properties>
             <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-              <Connection code="org.openide.util.ImageUtilities.loadImageIcon(&quot;/org/netbeans/modules/refactoring/java/resources/filter.png&quot;, false)" type="code"/>
+              <Connection code="org.openide.util.ImageUtilities.loadImageIcon(&quot;org/netbeans/modules/refactoring/java/resources/filter.png&quot;, false)" type="code"/>
             </Property>
             <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
               <ResourceString bundle="org/netbeans/modules/refactoring/java/callhierarchy/Bundle.properties" key="CallHierarchyTopComponent.jTogBtnScope.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTopComponent.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/callhierarchy/CallHierarchyTopComponent.java
@@ -183,7 +183,7 @@ final class CallHierarchyTopComponent extends TopComponent implements ExplorerMa
         jBtnRefresh.addActionListener(formListener);
         jToolBar.add(jBtnRefresh);
 
-        jBtnCancel.setIcon(org.openide.util.ImageUtilities.loadImageIcon("/org/netbeans/modules/refactoring/java/resources/cancel.png", false)); // NOI18N
+        jBtnCancel.setIcon(org.openide.util.ImageUtilities.loadImageIcon("org/netbeans/modules/refactoring/java/resources/cancel.png", false));
         jBtnCancel.setToolTipText(org.openide.util.NbBundle.getMessage(CallHierarchyTopComponent.class, "CallHierarchyTopComponent.jBtnCancel.toolTipText")); // NOI18N
         jBtnCancel.setEnabled(false);
         jBtnCancel.setFocusable(false);
@@ -193,21 +193,21 @@ final class CallHierarchyTopComponent extends TopComponent implements ExplorerMa
         jToolBar.add(jBtnCancel);
         jToolBar.add(jSeparator1);
 
-        jTogBtnCaller.setIcon(org.openide.util.ImageUtilities.loadImageIcon("/org/netbeans/modules/refactoring/java/resources/who_is_called.png", false)); // NOI18N
+        jTogBtnCaller.setIcon(org.openide.util.ImageUtilities.loadImageIcon("org/netbeans/modules/refactoring/java/resources/who_is_called.png", false));
         jTogBtnCaller.setSelected(true);
         jTogBtnCaller.setToolTipText(org.openide.util.NbBundle.getMessage(CallHierarchyTopComponent.class, "CallHierarchyTopComponent.jTogBtnCaller.toolTipText")); // NOI18N
         jTogBtnCaller.setFocusable(false);
         jTogBtnCaller.addActionListener(formListener);
         jToolBar.add(jTogBtnCaller);
 
-        jTogBtnCallee.setIcon(org.openide.util.ImageUtilities.loadImageIcon("/org/netbeans/modules/refactoring/java/resources/who_calls.png", false)); // NOI18N
+        jTogBtnCallee.setIcon(org.openide.util.ImageUtilities.loadImageIcon("org/netbeans/modules/refactoring/java/resources/who_calls.png", false));
         jTogBtnCallee.setToolTipText(org.openide.util.NbBundle.getMessage(CallHierarchyTopComponent.class, "CallHierarchyTopComponent.jTogBtnCallee.toolTipText")); // NOI18N
         jTogBtnCallee.setFocusable(false);
         jTogBtnCallee.addActionListener(formListener);
         jToolBar.add(jTogBtnCallee);
         jToolBar.add(jSeparator2);
 
-        jTogBtnScope.setIcon(org.openide.util.ImageUtilities.loadImageIcon("/org/netbeans/modules/refactoring/java/resources/filter.png", false)); // NOI18N
+        jTogBtnScope.setIcon(org.openide.util.ImageUtilities.loadImageIcon("org/netbeans/modules/refactoring/java/resources/filter.png", false));
         jTogBtnScope.setToolTipText(org.openide.util.NbBundle.getMessage(CallHierarchyTopComponent.class, "CallHierarchyTopComponent.jTogBtnScope.toolTipText")); // NOI18N
         jTogBtnScope.setFocusable(false);
         jTogBtnScope.addItemListener(formListener);

--- a/java/websvc.jaxws21/src/org/netbeans/modules/websvc/jaxws21/jaxws21.xml
+++ b/java/websvc.jaxws21/src/org/netbeans/modules/websvc/jaxws21/jaxws21.xml
@@ -49,7 +49,6 @@
         <resource>jar:nbinst://org.netbeans.modules.websvc.jaxws21api/modules/ext/jaxws22/api/saaj-api.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.xml.jaxb.api/modules/ext/jaxb/activation.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.xml.jaxb.api/modules/ext/jaxb/api/jaxb-api.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.xml.jaxb.api/modules/ext/jaxb/api/jsr173_1.0_api.jar!/</resource>
     </volume>
     <volume>
         <type>javadoc</type>

--- a/php/php.project/src/org/netbeans/modules/php/project/api/PhpSourcePath.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/api/PhpSourcePath.java
@@ -106,7 +106,7 @@ public final class PhpSourcePath {
     public static synchronized List<FileObject> getPreindexedFolders() {
         if (phpStubsFolder == null) {
             // Core classes: Stubs generated for the "builtin" php runtime and extenstions.
-            File clusterFile = InstalledFileLocator.getDefault().locate("docs/phpsigfiles.zip", null, true); //NOI18N
+            File clusterFile = InstalledFileLocator.getDefault().locate("docs/phpsigfiles.zip", "org.netbeans.modules.php.project", true); //NOI18N
 
             if (clusterFile != null) {
                 FileObject root = FileUtil.getArchiveRoot(FileUtil.toFileObject(clusterFile));

--- a/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/file/NpmDebugLogDataObject.java
+++ b/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/file/NpmDebugLogDataObject.java
@@ -33,7 +33,7 @@ import org.openide.util.NbBundle.Messages;
 @Messages({
     "LBL_NpmDebugLog_LOADER=npm-debug.log"
 })
-@MIMEResolver.Registration(displayName = "npm-debug.log", resource = "../resources/npm-resolver.xml", position = 127)
+@MIMEResolver.Registration(displayName = "npm-debug.log", resource = "../resources/npm-resolver.xml", position = 144)
 @Registration(displayName = "#LBL_NpmDebugLog_LOADER", iconBase = "org/netbeans/modules/javascript/nodejs/ui/resources/npm.png", mimeType = "text/npm-log")
 @ActionReferences({
     @ActionReference(

--- a/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/file/PackageLockJsonDataObject.java
+++ b/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/file/PackageLockJsonDataObject.java
@@ -33,7 +33,7 @@ import org.openide.util.NbBundle.Messages;
 @Messages({
     "LBL_PackageLockJson_LOADER=package-lock.json"
 })
-@MIMEResolver.Registration(displayName = "package-lock.json", resource = "../resources/npm-resolver.xml", position = 127)
+@MIMEResolver.Registration(displayName = "package-lock.json", resource = "../resources/npm-resolver.xml", position = 143)
 @Registration(displayName = "#LBL_PackageLockJson_LOADER", iconBase = "org/netbeans/modules/javascript/nodejs/ui/resources/npm.png", mimeType = "text/package-lock+x-json")
 @ActionReferences({
     @ActionReference(

--- a/webcommon/typescript.editor/src/org/netbeans/modules/typescript/editor/TypeScriptDataObjectDataObject.java
+++ b/webcommon/typescript.editor/src/org/netbeans/modules/typescript/editor/TypeScriptDataObjectDataObject.java
@@ -37,7 +37,8 @@ import org.openide.util.NbBundle.Messages;
 @MIMEResolver.ExtensionRegistration(
         displayName = "#LBL_TypeScriptDataObject_LOADER",
         mimeType = "application/x-typescript",
-        extension = {"ts"}
+        extension = {"ts"},
+        position = 600
 )
 @DataObject.Registration(
         mimeType = "application/x-typescript",


### PR DESCRIPTION
Analysing the startup warnings from netbeans 11.3 revealed some problems:

- we have colliding positions/missing positions in the config file system (mimetype registrations)
- missing code base passing to InstalledFileLocator
- missed updates for library definitions, that don't anymore match the included files

I think this is a candidate for 11.3 as it fixes real problems (broken library definitions) and in general I would expect a release to be as warning free as possible.

@lkishalmi @jlahoda @Chris2011 I'd like you to have a look at this as you worked in the area/authored the code
@ebarboni please see see if you aggree to consider this for 11.3