### PR TITLE
With Java 11.0.6 AntiAlias fix available on Ubuntu get rid of the suboptimal AA rendering

### DIFF
--- a/nbbuild/packaging/netbeans-dev_snap/snap/snapcraft.yaml
+++ b/nbbuild/packaging/netbeans-dev_snap/snap/snapcraft.yaml
@@ -65,7 +65,7 @@ parts:
         # Make the default cache and data directory relative to Snap user directory
         sed -i 's/${HOME}\/.netbeans/${SNAP_USER_COMMON}\/data/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
         sed -i 's/${HOME}\/.cache\/netbeans/${SNAP_USER_COMMON}\/cache/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
-        sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dplugin.manager.install.global=false -J-Dawt.useSystemAAFontSettings=on/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
+        sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dplugin.manager.install.global=false/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
     stage:
         - $netbeans
 

--- a/nbbuild/packaging/netbeans_snap/snap/snapcraft.yaml
+++ b/nbbuild/packaging/netbeans_snap/snap/snapcraft.yaml
@@ -58,7 +58,7 @@ parts:
         # Make the default cache and data directory relative to Snap user directory
         sed -i 's/${HOME}\/.netbeans/${SNAP_USER_COMMON}\/data/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
         sed -i 's/${HOME}\/.cache\/netbeans/${SNAP_USER_COMMON}\/cache/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
-        sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dplugin.manager.install.global=false -J-Dawt.useSystemAAFontSettings=on/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
+        sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dplugin.manager.install.global=false/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
     stage:
         - $netbeans
 


### PR DESCRIPTION
This is a trivial fix affecting Snap packages only. Java 11.0.6 just came out 2 days ago on Ubuntu.