### PR TITLE
Only initialize the LSP server once; prevent NPE in LSP code completion.

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.WeakHashMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -203,9 +204,10 @@ public class LSPBindings {
        wcc.getWorkspaceEdit().setDocumentChanges(true);
        wcc.getWorkspaceEdit().setResourceOperations(Arrays.asList(ResourceOperationKind.Create, ResourceOperationKind.Delete, ResourceOperationKind.Rename));
        initParams.setCapabilities(new ClientCapabilities(wcc, tdcc, null));
+       CompletableFuture<InitializeResult> initResult = server.initialize(initParams);
        while (true) {
            try {
-               return server.initialize(initParams).get(100, TimeUnit.MILLISECONDS);
+               return initResult.get(100, TimeUnit.MILLISECONDS);
            } catch (TimeoutException ex) {
                if (p != null && !p.isAlive()) {
                    InitializeResult emptyResult = new InitializeResult();

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
@@ -388,6 +388,8 @@ public class CompletionProviderImpl implements CompletionProvider {
         if (capabilities == null) return false;
         CompletionOptions completionOptions = capabilities.getCompletionProvider();
         if (completionOptions == null) return false;
-        return completionOptions.getTriggerCharacters().stream().anyMatch(trigger -> text.endsWith(trigger));
+        List<String> triggerCharacters = completionOptions.getTriggerCharacters();
+        if (triggerCharacters == null) return false;
+        return triggerCharacters.stream().anyMatch(trigger -> text.endsWith(trigger));
     }
 }


### PR DESCRIPTION
Two small (in size)/big (in effect) fixes for the LSP client - avoid duplicate initialization (while waiting for the server to come up), and prevent NPE in code completion when no trigger characters are specified. These were unfortunate oversights/mistakes.

If there's any chance on putting this into 11.3, that would be absolutely awesome.
