### PR TITLE
[NETBEANS-3790] - eliminate all StringBufferInputStream deprecations

### DIFF
--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringPanel.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringPanel.java
@@ -27,7 +27,7 @@ import java.awt.event.ActionListener;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.StringBufferInputStream;
+import java.io.StringReader;
 import java.io.StringReader;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
@@ -1543,7 +1543,7 @@ public class RefactoringPanel extends JPanel implements FiltersManagerImpl.Filte
                     return new StringReader(html);
                 } else if (InputStream.class.equals(flavor.getRepresentationClass())) {
                     // XXX should this enforce UTF-8 encoding?
-                    return new StringBufferInputStream(html);
+                    return new StringReader(html);
                 }
                 // fall through to unsupported
             } else if (isPlainFlavor(flavor)) {
@@ -1555,7 +1555,7 @@ public class RefactoringPanel extends JPanel implements FiltersManagerImpl.Filte
                     return new StringReader(data);
                 } else if (InputStream.class.equals(flavor.getRepresentationClass())) {
                     // XXX should this enforce UTF-8 encoding?
-                    return new StringBufferInputStream(data);
+                    return new StringReader(data);
                 }
                 // fall through to unsupported
             } else if (isStringFlavor(flavor)) {

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/SheetTable.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/SheetTable.java
@@ -47,7 +47,7 @@ import java.beans.PropertyEditor;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.StringBufferInputStream;
+import java.io.StringReader;
 import java.io.StringReader;
 import java.util.EventObject;
 import java.util.logging.Level;
@@ -1834,7 +1834,7 @@ final class SheetTable extends BaseTable implements PropertySetModelListener, Cu
                     return new StringReader(data);
                 } else if (InputStream.class.equals(flavor.getRepresentationClass())) {
                     // XXX should this enforce UTF-8 encoding?
-                    return new StringBufferInputStream(data);
+                    return new StringReader(data);
                 }
 
                 // fall through to unsupported


### PR DESCRIPTION
eliminate all references to the following deprecation:

   [repeat] /home/bwalker/src/netbeans/platform/openide.explorer/src/org/openide/explorer/propertysheet/SheetTable.java:50: warning: [deprecation] StringBufferInputStream in java.io has been deprecated
   [repeat] import java.io.StringBufferInputStream;
   [repeat]