### PR TITLE
[NETBEANS-3735] FlatLaf: repaint desktop after closing the last editor tab

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/view/EditorView.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/EditorView.java
@@ -278,6 +278,8 @@ public class EditorView extends ViewElement {
             if(this.areaComponent != null) {
                 add(this.areaComponent, BorderLayout.CENTER);
             }
+
+            repaint();
         }
         
         @Override


### PR DESCRIPTION
Now always do an explicit repaint of the editor area to fix issue NETBEANS-3735.
It is maybe pure chance that the effect does not occur in other LAFs because they change the border of the editor area, which does the repaint.