### PR TITLE
[NETBEANS-3671] Fix two ImageUtilities issues

### DIFF
--- a/platform/openide.util.ui/src/org/openide/util/CachedHiDPIIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/CachedHiDPIIcon.java
@@ -78,6 +78,10 @@ public abstract class CachedHiDPIIcon implements Icon {
         this.height = height;
     }
 
+    /**
+     * Get a scaled bitmap image of this icon. This method may not be called if either of the icon's
+     * dimensions are zero.
+     */
     private synchronized Image getScaledImageCached(Component c, CachedImageKey key) {
         Image ret = cache.get(key);
         if (ret != null) {
@@ -106,6 +110,10 @@ public abstract class CachedHiDPIIcon implements Icon {
 
     @Override
     public final void paintIcon(Component c, Graphics g0, int x, int y) {
+        if (getIconWidth() == 0 || getIconHeight() == 0) {
+            // Special case: Avoid attempting to create a zero-width/height image.
+            return;
+        }
         final Graphics2D g = (Graphics2D) g0;
         CachedImageKey key = CachedImageKey.create(g);
         final AffineTransform oldTransform = g.getTransform();
@@ -155,8 +163,8 @@ public abstract class CachedHiDPIIcon implements Icon {
      * @param colorModel the {@link ColorModel} of the surface on which the image will be painted
      *        (may be passed to {@link #createBufferedImage(ColorModel, int, int)} in the common
      *        case)
-     * @param deviceWidth the required width of the image, in device pixels
-     * @param deviceHeight the required height of the image, in device pixels
+     * @param deviceWidth the required width of the image, in device pixels (>=1)
+     * @param deviceHeight the required height of the image, in device pixels (>=1)
      * @param scale the HiDPI scaling factor detected in {@code graphicsConfiguration}
      */
     protected abstract Image createAndPaintImage(Component c, ColorModel colorModel,
@@ -168,8 +176,8 @@ public abstract class CachedHiDPIIcon implements Icon {
      * implementors of the latter to create a surface to draw on and return.
      *
      * @param colorModel the required {@link ColorModel}
-     * @param deviceWidth the required width of the image, in device pixels
-     * @param deviceHeight the required height of the image, in device pixels
+     * @param deviceWidth the required width of the image, in device pixels (>=1)
+     * @param deviceHeight the required height of the image, in device pixels (>=1)
      * @return an image compatible with the given parameters
      */
     protected static final BufferedImage createBufferedImage(

--- a/platform/openide.util.ui/src/org/openide/util/FilteredIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/FilteredIcon.java
@@ -28,6 +28,8 @@ import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.FilteredImageSource;
 import java.awt.image.RGBImageFilter;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 
@@ -42,6 +44,7 @@ import javax.swing.ImageIcon;
  * icon is initially entered into the cache.
  */
 final class FilteredIcon extends CachedHiDPIIcon {
+    private static final Logger LOG = Logger.getLogger(FilteredIcon.class.getName());
     private final RGBImageFilter filter;
     private final Icon delegate;
 
@@ -54,6 +57,17 @@ final class FilteredIcon extends CachedHiDPIIcon {
     }
 
     public static Icon create(RGBImageFilter filter, Icon delegate) {
+        final int width = delegate.getIconWidth();
+        final int height = delegate.getIconHeight();
+        if (width < 0 || height < 0) {
+            /* This case was once observed in NETBEANS-3671. I'm not sure where the offending Icon
+            came from. Log some more information for future debugging, and fall back gracefully. */
+            Object url = ImageUtilities.icon2Image(delegate).getProperty("url", null);
+            LOG.log(Level.WARNING,
+                    "NETBEANS-3671: FilteredIcon.create got {0} of invalid dimensions {1}x{2} with URL={3}",
+                    new Object[] { delegate.getClass().getName(), width, height, url });
+            return delegate;
+        }
         return new FilteredIcon(filter, delegate);
     }
 

--- a/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
@@ -37,6 +37,9 @@ import java.awt.image.ImageObserver;
 import java.awt.image.RGBImageFilter;
 import java.awt.image.WritableRaster;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
 import java.lang.ref.SoftReference;
 import java.net.URL;
 import java.util.HashMap;
@@ -1001,7 +1004,9 @@ public final class ImageUtilities {
      * scalable icons from {@link #loadImageIcon(String,boolean)} without changing the API.
      */
     private static final class IconImageIcon extends ImageIcon {
-        private final Icon delegate;
+        /* I'd love to make this final, but the custom serialization handling precludes this. Make
+        it volatile instead, to be completely sure that the class is still thread-safe. */
+        private volatile Icon delegate;
 
         private IconImageIcon(Icon delegate) {
             super(icon2Image(delegate));
@@ -1021,6 +1026,24 @@ public final class ImageUtilities {
 
         public Icon getDelegateIcon() {
             return delegate;
+        }
+
+        /* NETBEANS-3769: Since ImageIcon implements Serializable, we must support serialization.
+        But there is no guarantee that the delegate implements Serializable, thus the default
+        serialization mechanism might throw a java.io.NotSerializableException when
+        ObjectOutputStream.writeObject gets recursively called on the delegate. Implement a custom
+        serialization mechanism based on ImageIcon instead. */
+
+        private void writeObject(ObjectOutputStream out) throws IOException {
+            out.writeObject(new ImageIcon(getImage()));
+        }
+
+        private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+            this.delegate = (ImageIcon) in.readObject();
+        }
+
+        private void readObjectNoData() throws ObjectStreamException {
+            this.delegate = new ImageIcon(new BufferedImage(1, 1, BufferedImage.TYPE_4BYTE_ABGR));
         }
     }
 


### PR DESCRIPTION
Fix two problems caused by the recent (HiDPI-related) ImageUtilities revamp ( https://github.com/apache/netbeans/pull/998 and https://github.com/apache/netbeans/pull/1273 ).

* Make the Icon instance returned by ImageUtilities.loadImageIcon properly serializable.
* Make FilteredIcon (used by ImageUtilities.createDisabledIcon) robust against icons with zero or negative dimensions. Add a log message for the negative dimension case (once observed in NETBEANS-3671).

See:
https://issues.apache.org/jira/browse/NETBEANS-3769 (though in this case the HiDPI-related exception turned out not to be the cause of the bug)
https://issues.apache.org/jira/browse/NETBEANS-3671
