### PR TITLE
[NETBEANS-3795] Fix auto-importing non-resolvable classes.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/ImportAnalysis2.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/ImportAnalysis2.java
@@ -348,18 +348,20 @@ public class ImportAnalysis2 {
         TypeElement type = (TypeElement) element;
 
         Element parent = type.getEnclosingElement();
-        if ((parent.getKind().isClass() || parent.getKind().isInterface()) && !cs.importInnerClasses()) {
-            ExpressionTree clazz = orig.getExpression();
-            if (clazz.getKind() == Kind.MEMBER_SELECT) {
-                clazz = resolveImport((MemberSelectTree) clazz, overlay.wrap(model, elements, parent));
+        if (parent != null) {
+            if ((parent.getKind().isClass() || parent.getKind().isInterface()) && !cs.importInnerClasses()) {
+                ExpressionTree clazz = orig.getExpression();
+                if (clazz.getKind() == Kind.MEMBER_SELECT) {
+                    clazz = resolveImport((MemberSelectTree) clazz, overlay.wrap(model, elements, parent));
+                }
+                return make.MemberSelect(clazz, orig.getIdentifier());
             }
-            return make.MemberSelect(clazz, orig.getIdentifier());
-        }
 
-        //check for java.lang:
-        if (parent.getKind() == ElementKind.PACKAGE) {
-            if ("java.lang".equals(((PackageElement) parent).getQualifiedName().toString())) {
-                return make.Identifier(element.getSimpleName());
+            //check for java.lang:
+            if (parent.getKind() == ElementKind.PACKAGE) {
+                if ("java.lang".equals(((PackageElement) parent).getQualifiedName().toString())) {
+                    return make.Identifier(element.getSimpleName());
+                }
             }
         }
 


### PR DESCRIPTION
This one is a pretty simple fix. When the IDE needs to import a class which is not on the classpath (eg. developing a NetBeans module application and hit the implement abstract methods, when not all the dependencies specified yet).
Tested it with on-the-fly debugging. it works leaving a non resolved import statement behind, which is good.
This issue has been reported at least 1 time against 11.1