### PR TITLE
[NETBEANS-3727] FlatLaf: darker color for empty editor area

### DIFF
--- a/platform/core.windows/src/org/netbeans/core/windows/view/EditorView.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/EditorView.java
@@ -256,6 +256,18 @@ public class EditorView extends ViewElement {
                     || "Aqua".equals(UIManager.getLookAndFeel().getID()) ) //NOI18N
                 setOpaque( false);
         }
+
+        @Override
+        public void updateUI() {
+            super.updateUI();
+
+            Color background = UIManager.getColor("Nb.EmptyEditorArea.background");
+            if (background == null) {
+                // restore to default (on LaF switch)
+                background = UIManager.getColor("Panel.background");
+            }
+            setBackground(background);
+        }
         
         public void setAreaComponent(Component areaComponent) {
             if(this.areaComponent == areaComponent) {

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -23,6 +23,11 @@ nb.errorForeground=#DB5860
 nb.warningForeground=@foreground
 
 
+#---- EditorView ----
+
+Nb.EmptyEditorArea.background=darken(@background,5%)
+
+
 #---- EditorTab ----
 
 EditorTab.background=@background

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
@@ -17,6 +17,11 @@
 
 nb.preferred.color.profile=NetBeans
 
+#---- EditorView ----
+
+Nb.EmptyEditorArea.background=darken(@background,10%)
+
+
 #---- EditorTab ----
 
 EditorTab.background=@background


### PR DESCRIPTION
This changes the background color of empty editor area (no editor open) for FlatLaf Dark and Light.

Latest screenshots see https://issues.apache.org/jira/browse/NETBEANS-3727?focusedCommentId=17030045&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17030045

Other LAFs are not affected.
Tested with Nimbus, Metal and Window LAFs.