### PR TITLE
[NETBEANS-3792] No more hardcoded colors in Remove Surrounding Code action

### DIFF
--- a/ide/defaults/src/org/netbeans/modules/defaults/BlueTheme-editor.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/BlueTheme-editor.xml
@@ -67,4 +67,6 @@
     <fontcolor name="coverage-inferred" bgColor="1F4F40"/>
     <fontcolor name="coverage-partial" bgColor="909040"/>
 
+    <fontcolor name="remove-surround-code-delete" foreColor="ff32538C" bgColor="ff16253F"/>
+    <fontcolor name="remove-surround-code-remain" bgColor="ff0C3F33"/>
  </fontscolors>

--- a/ide/defaults/src/org/netbeans/modules/defaults/CityLights-editor.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/CityLights-editor.xml
@@ -48,4 +48,6 @@
     <fontcolor name="trailing-whitespace"/>
     <fontcolor name="nbeditor-bracesMatching-sidebar"/>
     <fontcolor name="indent-guide-lines" foreColor="white"/>
+    <fontcolor name="remove-surround-code-delete" foreColor="lightGray" bgColor="ff333333"/>
+    <fontcolor name="remove-surround-code-remain" bgColor="ff3E5431"/>
 </fontscolors>

--- a/ide/defaults/src/org/netbeans/modules/defaults/NetBeans55-editor.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/NetBeans55-editor.xml
@@ -47,4 +47,6 @@
     <fontcolor name="indent-whitespace"/>
     <fontcolor name="trailing-whitespace"/>
     <fontcolor name="nbeditor-bracesMatching-sidebar"/>
+    <fontcolor name="remove-surround-code-delete" foreColor="ffB4B4B4" bgColor="ffF5F5F5"/>
+    <fontcolor name="remove-surround-code-remain" bgColor="ffCCFFCC"/>
 </fontscolors>

--- a/ide/defaults/src/org/netbeans/modules/defaults/NetBeansEarth-editor.xml
+++ b/ide/defaults/src/org/netbeans/modules/defaults/NetBeansEarth-editor.xml
@@ -47,4 +47,6 @@
     <fontcolor name="indent-whitespace"/>
     <fontcolor name="trailing-whitespace"/>
     <fontcolor name="nbeditor-bracesMatching-sidebar"/>
+    <fontcolor name="remove-surround-code-delete" foreColor="ffB4B4B4" bgColor="ffF5F5F5"/>
+    <fontcolor name="remove-surround-code-remain" bgColor="ffCCFFCC"/>
 </fontscolors>

--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/Bundle.properties
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/Bundle.properties
@@ -82,6 +82,10 @@ mod-annotation-type-declaration=Annotation Declaration
 mod-enum-declaration=Enum Declaration
 mod-unindented-text-block=Text Block
 
+# Coloring names for remove surrounding code action highlighting
+remove-surround-code-delete=Remove Surrounding Code (part to delete)
+remove-surround-code-remain=Remove Surrounding Code (part to keep)
+
 # Code Templates
 CT_iff=if (<b>exp</b>) { ...| }
 CT_ifelse=if (<b>exp</b>) { ...| } else { ... }

--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/fontsColors-highlighting.xml
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/fontsColors-highlighting.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+
+<fontscolors>
+    <fontcolor name="remove-surround-code-delete" foreColor="ffB4B4B4" bgColor="ffF5F5F5"/>
+    <fontcolor name="remove-surround-code-remain" bgColor="ffCCFFCC"/>
+</fontscolors>

--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/layer.xml
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/layer.xml
@@ -41,16 +41,13 @@
 <!--            <file name="org-netbeans-modules-editor-java-JavaFastOpenAction.shadow">            
                 <attr name="originalFile" stringvalue="Actions/Edit/org-netbeans-modules-editor-java-JavaFastOpenAction.instance"/>            
             </file> -->
-
-                       
-
         </folder>
         <folder name="Source">
             <file name="org-netbeans-modules-editor-java-JavaKit$JavaFixImports$GlobalAction.shadow">
                 <attr name="originalFile" stringvalue="Actions/Source/org-netbeans-modules-editor-java-JavaKit$JavaFixImports$GlobalAction.instance"/>
                 <attr name="position" intvalue="2400"/>
             </file>
-            </folder>
+        </folder>
     </folder>
                 
     <folder name="Shortcuts">
@@ -60,6 +57,18 @@
     </folder>
 
     <folder name="Editors">
+
+        <folder name="FontsColors">
+            <folder name="NetBeans">
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-editor-java-highlighting-colorings.xml" url="fontsColors-highlighting.xml">
+                        <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.java.editor.resources.Bundle"/>
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
+                </folder>
+            </folder>
+        </folder>
+
         <folder name="text">
             <folder name="x-jsp">
                 <file name="org-netbeans-modules-java-editor-semantic-HighlightsLayerFactoryImpl.instance" />

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-highlights.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafDark-highlights.xml
@@ -53,4 +53,6 @@
     <fontcolor name="coverage-uncovered" bgColor="813438"/>
     <fontcolor name="coverage-inferred" bgColor="1c501c"/>
     <fontcolor name="coverage-partial" bgColor="707000"/>
+    <fontcolor name="remove-surround-code-delete" foreColor="ff5A5A5A" bgColor="ff323232"/>
+    <fontcolor name="remove-surround-code-remain" bgColor="ff143C00"/>
 </fontscolors>


### PR DESCRIPTION
Exposed remove surrounding code color codes in editor color profile (Highlighting section):
![options](https://user-images.githubusercontent.com/1875690/73889007-0030f680-486f-11ea-86a2-ddc0c926094c.png)

Added color definitions to _NetBeans_, _Norway Today_, _CityLights_, _NetBeans55_, _NetBeans Earth_ and _FlatLaf Dark_ color profiles.

FlatLaf Dark before:
![before-dark](https://user-images.githubusercontent.com/1875690/73889243-88af9700-486f-11ea-921f-59a85ad7938c.png)

FlatLafDark after:
![after-dark](https://user-images.githubusercontent.com/1875690/73889258-906f3b80-486f-11ea-9576-284f3d6cfc34.png)