### PR TITLE
[NETBEANS-3428] FlatLaf Dark: fix text color when using project colored tab

### DIFF
--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectColorTabDecorator.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectColorTabDecorator.java
@@ -52,6 +52,7 @@ public class ProjectColorTabDecorator extends TabDecorator {
     private static final Map<Object, Color> project2color = new WeakHashMap<Object, Color>(10);
     private static final Map<TabData, Color> tab2color = new WeakHashMap<TabData, Color>(10);
     private static final List<Color> backGroundColors;
+    private static Color foregroundColor;
     private final static ChangeListener projectsListener = new ChangeListener() {
 
         @Override
@@ -82,6 +83,11 @@ public class ProjectColorTabDecorator extends TabDecorator {
             backGroundColors.add( new Color( 228, 255, 216 ) );
             backGroundColors.add( new Color( 227, 255, 158 ) );
             backGroundColors.add( new Color( 238, 209, 255 ) );
+        }
+
+        foregroundColor = UIManager.getColor("nb.multitabs.project.foreground");
+        if (foregroundColor == null) {
+            foregroundColor = Color.BLACK;
         }
 
         ProjectSupport projects = ProjectSupport.getDefault();
@@ -136,7 +142,7 @@ public class ProjectColorTabDecorator extends TabDecorator {
     public Color getForeground( TabData tab, boolean selected ) {
         if( selected || !Settings.getDefault().isSameProjectSameColor() )
             return null;
-        return null == getBackground( tab, selected ) ? null : Color.black;
+        return null == getBackground( tab, selected ) ? null : foregroundColor;
     }
 
     @Override

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -74,6 +74,7 @@ nb.multitabs.project.6.background=rgb(135, 105, 89)
 nb.multitabs.project.7.background=rgb(108, 135, 96)
 nb.multitabs.project.8.background=rgb(107, 135, 38)
 nb.multitabs.project.9.background=rgb(118, 89, 135)
+nb.multitabs.project.foreground=#f0f0f0
 
 
 #---- PropSheet ----

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -53,7 +53,7 @@ ViewTab.showTabSeparators=true
 #---- Multi-tabs ----
 
 nb.multitabs.tabInsets=5,2,7,2
-nb.multitabs.underlineHeight=3
+nb.multitabs.underlineHeight={scaledInteger}3
 nb.multitabs.showVerticalLines=true
 nb.multitabs.showHorizontalLines=false
 nb.multitabs.gridColor=$Component.borderColor


### PR DESCRIPTION
If option "same background color for files from the same project" (Options > Appearance > Document Tabs) is enabled, editor tabs have different background colors, but the text color was always black. This PR changes the text color for FlatLaf Dark to (nearly) white to make it consistent with other text and maybe easier to read. Other LAFs are not affected.

Before (3 files from 3 projects):
![image](https://user-images.githubusercontent.com/5604048/73983546-fb377a00-4936-11ea-9c57-c4b4436b6570.png)

After:
![image](https://user-images.githubusercontent.com/5604048/73983564-012d5b00-4937-11ea-9eac-26510bf4eb55.png)

The change in `FlatLaf.properties` scales the "underline" height of selected editor tab (in multi-tabs) in Java 8 on HiDPI screens.

Before (Java 8 at 150%):
![image](https://user-images.githubusercontent.com/5604048/73983836-a6483380-4937-11ea-8066-403d10a49b3c.png)

After:
![image](https://user-images.githubusercontent.com/5604048/73983851-ac3e1480-4937-11ea-850c-2600c2adc279.png)
