### PR TITLE
[NETBEANS-3806] - cleanup hashcode in DBElementsCollection

### DIFF
--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementsCollection.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementsCollection.java
@@ -28,19 +28,23 @@ import org.netbeans.modules.dbschema.*;
  */
 public class DBElementsCollection implements DBElementProperties {
 
-    /** Object to fire info about changes to */
+    /**
+     * Object to fire info about changes to
+     */
     DBElementImpl owner;
-
     DBElement[] _elms;
 
-    /** Array template for typed returns */
+    /**
+     * Array template for typed returns
+     */
     private Object[] _template;
 
-    //workaround for bug #4396371
-    //http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
-    protected static transient HashSet instances = new HashSet();
-    
-	public DBElementsCollection () {
+    // NOTE - After doing research, not sure this comment still applys? Remove it?
+    // workaround for bug #4396371
+    // http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
+    protected static transient Set<String> instances = new HashSet<>();
+
+    public DBElementsCollection() {
         this(null, null);
     }
 

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/IndexElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/IndexElementImpl.java
@@ -37,20 +37,22 @@ public class IndexElementImpl extends DBMemberElementImpl implements IndexElemen
     }
 
     public IndexElementImpl(TableElementImpl tei, String name, boolean unique) {
-		super(name);
-		columns = new DBElementsCollection(tei, new ColumnElement[0]);
+        super(name);
+        columns = new DBElementsCollection(tei, new ColumnElement[0]);
+
+        // NOTE - After doing research, not sure this comment still applys? Remove it?
+        // workaround for bug #4396371
+        // http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
+        String hc = String.valueOf(columns.hashCode());
         
-        //workaround for bug #4396371
-        //http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
-        Object hc = String.valueOf(columns.hashCode());
         while (DBElementsCollection.instances.contains(hc)) {
-    		columns = new DBElementsCollection(tei, new ColumnElement[0]);
+            columns = new DBElementsCollection(tei, new ColumnElement[0]);
             hc = String.valueOf(columns.hashCode());
         }
         DBElementsCollection.instances.add(hc);
 
-		this.tei = tei;
-		_unique = unique;
+        this.tei = tei;
+        _unique = unique;
     }
   
     /** Get the unique flag of the index.

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/KeyElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/KeyElementImpl.java
@@ -33,17 +33,19 @@ public abstract class KeyElementImpl extends DBMemberElementImpl implements KeyE
 	/** Creates new KeyElementImpl with the specified name */
     public KeyElementImpl (String name) {
         super(name);
-		columns = initializeCollection();
+        columns = initializeCollection();
 
-        //workaround for bug #4396371
-        //http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
-        Object hc = String.valueOf(columns.hashCode());
+        // NOTE - After doing research, not sure this comment still applys? Remove it?
+        // workaround for bug #4396371
+        // http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
+        String hc = String.valueOf(columns.hashCode());
+
         while (DBElementsCollection.instances.contains(hc)) {
-    		columns = initializeCollection();
+            columns = initializeCollection();
             hc = String.valueOf(columns.hashCode());
         }
         DBElementsCollection.instances.add(hc);
-	}
+    }
 
     protected DBElementsCollection initializeCollection() {
         return new DBElementsCollection(this, new ColumnElement[0]);

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -62,39 +62,41 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
   
     public SchemaElementImpl(ConnectionProvider cp) {
         tables = new DBElementsCollection(this, new TableElement[0]);
-        
-        //workaround for bug #4396371
-        //http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
-        Object hc = String.valueOf(tables.hashCode());
+
+        // NOTE - After doing research, not sure this comment still applys? Remove it?
+        // workaround for bug #4396371
+        // http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
+        String hc = String.valueOf(tables.hashCode());
+
         while (DBElementsCollection.instances.contains(hc)) {
             tables = new DBElementsCollection(this, new TableElement[0]);
             hc = String.valueOf(tables.hashCode());
         }
         DBElementsCollection.instances.add(hc);
-        
-		if (cp != null) {
-			try {
-				String schema;
 
-				dmd = cp.getDatabaseMetaData();
+        if (cp != null) {
+            try {
+                String schema;
 
-				_url = dmd.getURL();
-				_username = dmd.getUserName();
-//				schema = dmd.getUserName();
-				schema = cp.getSchema();
-				_schema = schema == null ? DBIdentifier.create("") : DBIdentifier.create(schema); //NOI18N
-				catalog = cp.getConnection().getCatalog();
-				_catalog = catalog == null ? DBIdentifier.create("") : DBIdentifier.create(catalog); //NOI18N
-				_driver = cp.getDriver();
-				_databaseProductName = dmd.getDatabaseProductName().trim();
-				_databaseProductVersion = dmd.getDatabaseProductVersion();
-				_driverName = dmd.getDriverName();
-				_driverVersion = dmd.getDriverVersion();
-			} catch (Exception exc) {
-				exc.printStackTrace();
-			}
-		}
-        
+                dmd = cp.getDatabaseMetaData();
+
+                _url = dmd.getURL();
+                _username = dmd.getUserName();
+//		schema = dmd.getUserName();
+                schema = cp.getSchema();
+                _schema = schema == null ? DBIdentifier.create("") : DBIdentifier.create(schema); //NOI18N
+                catalog = cp.getConnection().getCatalog();
+                _catalog = catalog == null ? DBIdentifier.create("") : DBIdentifier.create(catalog); //NOI18N
+                _driver = cp.getDriver();
+                _databaseProductName = dmd.getDatabaseProductName().trim();
+                _databaseProductVersion = dmd.getDatabaseProductVersion();
+                _driverName = dmd.getDriverName();
+                _driverVersion = dmd.getDriverVersion();
+            } catch (Exception exc) {
+                exc.printStackTrace();
+            }
+        }
+
         stop = false;
     }
   

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
@@ -45,48 +45,50 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
 
     /** Creates new TableElementImpl */
     public TableElementImpl(String table) {
-		super(table);
-		columns = new DBElementsCollection(this, new ColumnElement[0]);
-        //workaround for bug #4396371
-        //http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
-        Object hc = String.valueOf(columns.hashCode());
+        super(table);
+        columns = new DBElementsCollection(this, new ColumnElement[0]);
+
+        // NOTE - After doing research, not sure this comment still applys? Remove it?
+        // workaround for bug #4396371
+        // http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
+        String hc = String.valueOf(columns.hashCode());
         while (DBElementsCollection.instances.contains(hc)) {
-    		columns = new DBElementsCollection(this, new ColumnElement[0]);
+            columns = new DBElementsCollection(this, new ColumnElement[0]);
             hc = String.valueOf(columns.hashCode());
         }
         DBElementsCollection.instances.add(hc);
-        
-		indexes = new DBElementsCollection(this, new IndexElement[0]);
+
+        indexes = new DBElementsCollection(this, new IndexElement[0]);
         //workaround for bug #4396371
         //http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
         hc = String.valueOf(indexes.hashCode());
         while (DBElementsCollection.instances.contains(hc)) {
-    		indexes = new DBElementsCollection(this, new IndexElement[0]);
+            indexes = new DBElementsCollection(this, new IndexElement[0]);
             hc = String.valueOf(indexes.hashCode());
         }
         DBElementsCollection.instances.add(hc);
-        
-		keys = new DBElementsCollection(this, new KeyElement[0]);
+
+        keys = new DBElementsCollection(this, new KeyElement[0]);
         //workaround for bug #4396371
         //http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
         hc = String.valueOf(keys.hashCode());
         while (DBElementsCollection.instances.contains(hc)) {
-    		keys = new DBElementsCollection(this, new KeyElement[0]);
+            keys = new DBElementsCollection(this, new KeyElement[0]);
             hc = String.valueOf(keys.hashCode());
         }
         DBElementsCollection.instances.add(hc);
-        
-		columnPairs = new DBElementsCollection(this, new ColumnPairElement[0]);
+
+        columnPairs = new DBElementsCollection(this, new ColumnPairElement[0]);
         //workaround for bug #4396371
         //http://andorra.eng:8080/cgi-bin/ws.exe/bugtraq/bug.hts?where=bugid_value%3D4396371
         hc = String.valueOf(columnPairs.hashCode());
         while (DBElementsCollection.instances.contains(hc)) {
-    		columnPairs = new DBElementsCollection(this, new ColumnPairElement[0]);
+            columnPairs = new DBElementsCollection(this, new ColumnPairElement[0]);
             hc = String.valueOf(columnPairs.hashCode());
         }
         DBElementsCollection.instances.add(hc);
         
-		this.table = table;
+        this.table = table;
     }
     
     /** Get the name of this element.


### PR DESCRIPTION
I came across this issue in Netbeans with the DBElementsCollection class.

Basically the hascode is being returned as a String but the code removes checking for type by treating the hashcode as an object.

This change keeps it as a String and removes the folloiwng warning..

[repeat] /home/bwalker/src/netbeans/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementsCollection.java:41: warning: [rawtypes] found raw type: HashSet
 [repeat] protected static transient HashSet instances = new HashSet();
 [repeat] ^
 [repeat] missing type arguments for generic class HashSet<E>
 [repeat] where E is a type-variable:
 [repeat] E extends Object declared in class HashSet