### PR TITLE
[NETBEANS-3799] Improve extracting types from PHP annotations

### DIFF
--- a/php/php.api.annotation/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtils.java
+++ b/php/php.api.annotation/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtils.java
@@ -35,7 +35,7 @@ import org.openide.util.Parameters;
  */
 public class AnnotationUtils {
 
-    private static final String PARAM_TYPE_PATTERN = "\\s*=\\s*(\\\"?)\\s*([\\w\\\\]+)\\s*\\1"; //NOI18N
+    private static final String PARAM_TYPE_PATTERN = "\\s*=\\s*(\\\"?)\\s*([\\w\\\\]+)(?:::class)?\\s*\\1"; //NOI18N
 
     private static final Pattern INLINE_TYPE_PATTERN = Pattern.compile("@([\\w\\\\]+)"); //NOI18N
 

--- a/php/php.api.annotation/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtils.java
+++ b/php/php.api.annotation/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtils.java
@@ -35,7 +35,7 @@ import org.openide.util.Parameters;
  */
 public class AnnotationUtils {
 
-    private static final String PARAM_TYPE_PATTERN = "\\s*=\\s*\\\"\\s*([\\w\\\\]+)\\s*\\\""; //NOI18N
+    private static final String PARAM_TYPE_PATTERN = "\\s*=\\s*(\\\"?)\\s*([\\w\\\\]+)\\s*\\1"; //NOI18N
 
     private static final Pattern INLINE_TYPE_PATTERN = Pattern.compile("@([\\w\\\\]+)"); //NOI18N
 

--- a/php/php.api.annotation/test/unit/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtilsTest.java
+++ b/php/php.api.annotation/test/unit/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtilsTest.java
@@ -91,28 +91,24 @@ public class AnnotationUtilsTest extends NbTestCase {
         assertTrue(types.containsKey(new OffsetRange(59, 75)));
     }
 
-    public void extractJustSomeParamTypes_01() throws Exception {
+    public void testExtractJustSomeParamTypes_01() throws Exception {
         Set<String> manyToOneRegexs = new HashSet<String>();
         manyToOneRegexs.add("targetEntity"); //NOI18N
         Map<OffsetRange, String> types = AnnotationUtils.extractTypesFromParameters("ManyToOne(targetEntity=\"Cart\", cascade={\"all\"}, fetch=\"EAGER\")", manyToOneRegexs);
         assertNotNull(types);
-        assertEquals(2, types.size());
-        String type1 = types.get(new OffsetRange(0, 9));
-        assertEquals("ManyToOne", type1);
-        String type2 = types.get(new OffsetRange(24, 28));
-        assertEquals("Cart", type2);
+        assertEquals(1, types.size());
+        String type1 = types.get(new OffsetRange(24, 28));
+        assertEquals("Cart", type1);
     }
 
-    public void extractJustSomeParamTypes_02() throws Exception {
+    public void testExtractJustSomeParamTypes_02() throws Exception {
         Set<String> manyToOneRegexs = new HashSet<String>();
         manyToOneRegexs.add("targetEntity"); //NOI18N
         Map<OffsetRange, String> types = AnnotationUtils.extractTypesFromParameters("ManyToOne(targetEntity=\"\\Foo\\Cart\", cascade={\"all\"}, fetch=\"EAGER\")", manyToOneRegexs);
         assertNotNull(types);
-        assertEquals(2, types.size());
-        String type1 = types.get(new OffsetRange(0, 9));
-        assertEquals("ManyToOne", type1);
-        String type2 = types.get(new OffsetRange(24, 33));
-        assertEquals("\\Foo\\Cart", type2);
+        assertEquals(1, types.size());
+        String type1 = types.get(new OffsetRange(24, 33));
+        assertEquals("\\Foo\\Cart", type1);
     }
 
     public void testNotNullTypeAnnotation_01() throws Exception {

--- a/php/php.api.annotation/test/unit/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtilsTest.java
+++ b/php/php.api.annotation/test/unit/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtilsTest.java
@@ -139,6 +139,16 @@ public class AnnotationUtilsTest {
                     }},
                 },
                 {
+                    "DiscriminatorMap({\"person\" = Person, \"employee\" = Employee })",
+                    new HashSet<String>() {{
+                        add("");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(29, 35), "Person");
+                        put(new OffsetRange(50, 58), "Employee");
+                    }},
+                },
+                {
                     "DiscriminatorMap({\"person\" = \" My\\Person \", \"employee\" = \" \\Full\\Q\\Employee \"})",
                     new HashSet<String>() {{
                         add("");
@@ -146,6 +156,16 @@ public class AnnotationUtilsTest {
                     new HashMap<OffsetRange, String>() {{
                         put(new OffsetRange(31, 40), "My\\Person");
                         put(new OffsetRange(59, 75), "\\Full\\Q\\Employee");
+                    }},
+                },
+                {
+                    "DiscriminatorMap({person = My\\Person, employee=\\Full\\Q\\Employee})",
+                    new HashSet<String>() {{
+                        add("");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(27, 36), "My\\Person");
+                        put(new OffsetRange(47, 63), "\\Full\\Q\\Employee");
                     }},
                 },
                 {
@@ -158,6 +178,15 @@ public class AnnotationUtilsTest {
                     }},
                 },
                 {
+                    "ManyToOne(targetEntity=Cart, cascade={\"all\"}, fetch=\"EAGER\")",
+                    new HashSet<String>() {{
+                        add("targetEntity");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(23, 27), "Cart");
+                    }},
+                },
+                {
                     "ManyToOne(targetEntity=\"\\Foo\\Cart\", cascade={\"all\"}, fetch=\"EAGER\")",
                     new HashSet<String>() {{
                         add("targetEntity");
@@ -165,6 +194,32 @@ public class AnnotationUtilsTest {
                     new HashMap<OffsetRange, String>() {{
                         put(new OffsetRange(24, 33), "\\Foo\\Cart");
                     }},
+                },
+                {
+                    "ManyToOne(targetEntity = \\Foo\\Cart, cascade={\"all\"}, fetch=\"EAGER\")",
+                    new HashSet<String>() {{
+                        add("targetEntity");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(25, 34), "\\Foo\\Cart");
+                    }},
+                },
+                {
+                    "@Enum(class=\"Visibility\")",
+                    new HashSet<String>() {{
+                        add("class");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(13, 23), "Visibility");
+                    }},
+                },
+                {
+                    // If there's a leading quote, then there must be a trailing quote as well. The other way around would work though.
+                    "@Enum(class=\"Visibility)",
+                    new HashSet<String>() {{
+                        add("class");
+                    }},
+                    new HashMap<OffsetRange, String>(),
                 },
             });
         }

--- a/php/php.api.annotation/test/unit/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtilsTest.java
+++ b/php/php.api.annotation/test/unit/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtilsTest.java
@@ -149,6 +149,16 @@ public class AnnotationUtilsTest {
                     }},
                 },
                 {
+                    "DiscriminatorMap({\"person\" = Person::class, \"employee\" = \"Employee\" })",
+                    new HashSet<String>() {{
+                        add("");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(29, 35), "Person");
+                        put(new OffsetRange(58, 66), "Employee");
+                    }},
+                },
+                {
                     "DiscriminatorMap({\"person\" = \" My\\Person \", \"employee\" = \" \\Full\\Q\\Employee \"})",
                     new HashSet<String>() {{
                         add("");
@@ -196,6 +206,15 @@ public class AnnotationUtilsTest {
                     }},
                 },
                 {
+                    "ManyToOne(targetEntity=\"\\Foo\\Cart::class \" , cascade={\"all\"}, fetch=\"EAGER\")",
+                    new HashSet<String>() {{
+                        add("targetEntity");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(24, 33), "\\Foo\\Cart");
+                    }},
+                },
+                {
                     "ManyToOne(targetEntity = \\Foo\\Cart, cascade={\"all\"}, fetch=\"EAGER\")",
                     new HashSet<String>() {{
                         add("targetEntity");
@@ -211,6 +230,24 @@ public class AnnotationUtilsTest {
                     }},
                     new HashMap<OffsetRange, String>() {{
                         put(new OffsetRange(13, 23), "Visibility");
+                    }},
+                },
+                {
+                    "@Enum(class=\"Visibility::class\")",
+                    new HashSet<String>() {{
+                        add("class");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(13, 23), "Visibility");
+                    }},
+                },
+                {
+                    "@Enum(class=Visibility::class)",
+                    new HashSet<String>() {{
+                        add("class");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(12, 22), "Visibility");
                     }},
                 },
                 {

--- a/php/php.api.annotation/test/unit/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtilsTest.java
+++ b/php/php.api.annotation/test/unit/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtilsTest.java
@@ -18,125 +18,198 @@
  */
 package org.netbeans.modules.php.api.annotation.util;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.netbeans.junit.NbTestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.netbeans.modules.csl.api.OffsetRange;
 
 /**
  *
  * @author Ondrej Brejla <obrejla@netbeans.org>
  */
-public class AnnotationUtilsTest extends NbTestCase {
+@RunWith(Enclosed.class)
+public class AnnotationUtilsTest {
 
     private static final String ANNOTATION_NAME = "Annotation";
 
-    public AnnotationUtilsTest(String name) {
-        super(name);
+    @RunWith(Parameterized.class)
+    public static class IsTypeAnnotationValidTest {
+
+        @Parameters(name = "{index}: {0} is a type annotation of {1}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                {"\\Foo\\Bar\\Baz\\" + ANNOTATION_NAME, ANNOTATION_NAME},
+                {"Foo\\Bar\\Baz\\" + ANNOTATION_NAME, ANNOTATION_NAME},
+                {ANNOTATION_NAME, ANNOTATION_NAME},
+                {ANNOTATION_NAME.toLowerCase(), ANNOTATION_NAME},
+                {"Foo\\Bar\\Baz\\" + ANNOTATION_NAME.toLowerCase(), ANNOTATION_NAME},
+            });
+        }
+
+        @Parameter(0)
+        public String lineToCheck;
+
+        @Parameter(1)
+        public String annotationName;
+
+        @Test
+        public void test() throws Exception {
+            assertTrue(AnnotationUtils.isTypeAnnotation(lineToCheck, annotationName));
+        }
     }
 
-    public void testValidUseCase_01() throws Exception {
-        assertTrue(AnnotationUtils.isTypeAnnotation("\\Foo\\Bar\\Baz\\" + ANNOTATION_NAME, ANNOTATION_NAME));
+    @RunWith(Parameterized.class)
+    public static class IsTypeAnnotationInvalidTest {
+
+        @Parameters(name = "{index}: {0} is not a type annotation of {1}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                {ANNOTATION_NAME + "\\Foo\\Bar\\Baz\\", ANNOTATION_NAME},
+                {"\\Foo\\Bar" + ANNOTATION_NAME + "\\Baz\\", ANNOTATION_NAME},
+            });
+        }
+
+        @Parameter(0)
+        public String lineToCheck;
+
+        @Parameter(1)
+        public String annotationName;
+
+        @Test
+        public void test() throws Exception {
+            assertFalse(AnnotationUtils.isTypeAnnotation(lineToCheck, annotationName));
+        }
     }
 
-    public void testValidUseCase_02() throws Exception {
-        assertTrue(AnnotationUtils.isTypeAnnotation("Foo\\Bar\\Baz\\" + ANNOTATION_NAME, ANNOTATION_NAME));
+    @RunWith(Parameterized.class)
+    public static class IsTypeAnnotationNotNullableTest {
+
+        @Parameters(name = "{index}: invoking isTypeAnnotation with [{0}, {1}] throws NullPointerException")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                {null, ""},
+                {"", null},
+            });
+        }
+
+        @Parameter(0)
+        public String lineToCheck;
+
+        @Parameter(1)
+        public String annotationName;
+
+        @Test
+        public void test() throws Exception {
+            try {
+                AnnotationUtils.isTypeAnnotation(lineToCheck, annotationName);
+                fail();
+            } catch (NullPointerException ex) {}
+        }
     }
 
-    public void testValidUseCase_03() throws Exception {
-        assertTrue(AnnotationUtils.isTypeAnnotation(ANNOTATION_NAME, ANNOTATION_NAME));
+    @RunWith(Parameterized.class)
+    public static class ExtractTypesFromParametersTest {
+
+        @Parameters(name = "{index}: extracting types from {0}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                {
+                    "DiscriminatorMap({\"person\" = \" Person \", \"employee\" = \" Employee \"})",
+                    new HashSet<String>() {{
+                        add("");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(31, 37), "Person");
+                        put(new OffsetRange(56, 64), "Employee");
+                    }},
+                },
+                {
+                    "DiscriminatorMap({\"person\" = \" My\\Person \", \"employee\" = \" \\Full\\Q\\Employee \"})",
+                    new HashSet<String>() {{
+                        add("");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(31, 40), "My\\Person");
+                        put(new OffsetRange(59, 75), "\\Full\\Q\\Employee");
+                    }},
+                },
+                {
+                    "ManyToOne(targetEntity=\"Cart\", cascade={\"all\"}, fetch=\"EAGER\")",
+                    new HashSet<String>() {{
+                        add("targetEntity");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(24, 28), "Cart");
+                    }},
+                },
+                {
+                    "ManyToOne(targetEntity=\"\\Foo\\Cart\", cascade={\"all\"}, fetch=\"EAGER\")",
+                    new HashSet<String>() {{
+                        add("targetEntity");
+                    }},
+                    new HashMap<OffsetRange, String>() {{
+                        put(new OffsetRange(24, 33), "\\Foo\\Cart");
+                    }},
+                },
+            });
+        }
+
+        @Parameter(0)
+        public String line;
+
+        @Parameter(1)
+        public Set<String> parameterNameRegexs;
+
+        @Parameter(2)
+        public Map<OffsetRange, String> expected;
+
+        @Test
+        public void test() throws Exception {
+            Map<OffsetRange, String> actual = AnnotationUtils.extractTypesFromParameters(line, parameterNameRegexs);
+            assertNotNull(actual);
+            assertEquals(expected, actual);
+        }
     }
 
-    public void testValidUseCase_04() throws Exception {
-        assertTrue(AnnotationUtils.isTypeAnnotation(ANNOTATION_NAME.toLowerCase(), ANNOTATION_NAME));
-    }
+    @RunWith(Parameterized.class)
+    public static class ExtractTypesFromParametersNotNullableTest {
 
-    public void testValidUseCase_05() throws Exception {
-        assertTrue(AnnotationUtils.isTypeAnnotation("Foo\\Bar\\Baz\\" + ANNOTATION_NAME.toLowerCase(), ANNOTATION_NAME));
-    }
+        @Parameters(name = "{index}: invoking extractTypesFromParameters with [{0}, {1}] throws NullPointerException")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                {null, Collections.EMPTY_SET},
+                {"", null},
+            });
+        }
 
-    public void testInvalidUseCase_01() throws Exception {
-        assertFalse(AnnotationUtils.isTypeAnnotation(ANNOTATION_NAME + "\\Foo\\Bar\\Baz\\", ANNOTATION_NAME));
-    }
+        @Parameter(0)
+        public String line;
 
-    public void testInvalidUseCase_02() throws Exception {
-        assertFalse(AnnotationUtils.isTypeAnnotation("\\Foo\\Bar" + ANNOTATION_NAME + "\\Baz\\", ANNOTATION_NAME));
-    }
+        @Parameter(1)
+        public Set<String> parameterNameRegexs;
 
-    public void testExtractParamTypes() throws Exception {
-        Set<String> discriminatorMapRegexs = new HashSet<String>();
-        discriminatorMapRegexs.add(""); //NOI18N
-        Map<OffsetRange, String> types = AnnotationUtils.extractTypesFromParameters("DiscriminatorMap({\"person\" = \" Person \", \"employee\" = \" Employee \"})", discriminatorMapRegexs);
-        assertNotNull(types);
-        assertTrue(!types.isEmpty());
-        assertEquals(2, types.size());
-        assertTrue(types.containsValue("Person"));
-        assertTrue(types.containsValue("Employee"));
-        assertTrue(types.containsKey(new OffsetRange(31, 37)));
-        assertTrue(types.containsKey(new OffsetRange(56, 64)));
-    }
-
-    public void testQualifiedExtractParamTypes() throws Exception {
-        Set<String> discriminatorMapRegexs = new HashSet<String>();
-        discriminatorMapRegexs.add(""); //NOI18N
-        Map<OffsetRange, String> types = AnnotationUtils.extractTypesFromParameters("DiscriminatorMap({\"person\" = \" My\\Person \", \"employee\" = \" \\Full\\Q\\Employee \"})", discriminatorMapRegexs);
-        assertNotNull(types);
-        assertTrue(!types.isEmpty());
-        assertEquals(2, types.size());
-        assertTrue(types.containsValue("My\\Person"));
-        assertTrue(types.containsValue("\\Full\\Q\\Employee"));
-        assertTrue(types.containsKey(new OffsetRange(31, 40)));
-        assertTrue(types.containsKey(new OffsetRange(59, 75)));
-    }
-
-    public void testExtractJustSomeParamTypes_01() throws Exception {
-        Set<String> manyToOneRegexs = new HashSet<String>();
-        manyToOneRegexs.add("targetEntity"); //NOI18N
-        Map<OffsetRange, String> types = AnnotationUtils.extractTypesFromParameters("ManyToOne(targetEntity=\"Cart\", cascade={\"all\"}, fetch=\"EAGER\")", manyToOneRegexs);
-        assertNotNull(types);
-        assertEquals(1, types.size());
-        String type1 = types.get(new OffsetRange(24, 28));
-        assertEquals("Cart", type1);
-    }
-
-    public void testExtractJustSomeParamTypes_02() throws Exception {
-        Set<String> manyToOneRegexs = new HashSet<String>();
-        manyToOneRegexs.add("targetEntity"); //NOI18N
-        Map<OffsetRange, String> types = AnnotationUtils.extractTypesFromParameters("ManyToOne(targetEntity=\"\\Foo\\Cart\", cascade={\"all\"}, fetch=\"EAGER\")", manyToOneRegexs);
-        assertNotNull(types);
-        assertEquals(1, types.size());
-        String type1 = types.get(new OffsetRange(24, 33));
-        assertEquals("\\Foo\\Cart", type1);
-    }
-
-    public void testNotNullTypeAnnotation_01() throws Exception {
-        try {
-            AnnotationUtils.isTypeAnnotation(null, "");
-            fail();
-        } catch (NullPointerException ex) {}
-    }
-
-    public void testNotNullTypeAnnotation_02() throws Exception {
-        try {
-            AnnotationUtils.isTypeAnnotation("", null);
-            fail();
-        } catch (NullPointerException ex) {}
-    }
-
-    public void testNotNullExtracParamTypes() throws Exception {
-        try {
-            AnnotationUtils.extractTypesFromParameters(null, Collections.EMPTY_SET);
-            fail();
-        } catch (NullPointerException ex) {}
-    }
-
-    public void testNotNullExtracParamTypesRegexs() throws Exception {
-        try {
-            AnnotationUtils.extractTypesFromParameters("", null);
-            fail();
-        } catch (NullPointerException ex) {}
+        @Test
+        public void test() throws Exception {
+            try {
+                AnnotationUtils.extractTypesFromParameters(line, parameterNameRegexs);
+                fail();
+            } catch (NullPointerException ex) {}
+        }
     }
 
 }

--- a/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/DiscriminatorMapLineParserTest.java
+++ b/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/DiscriminatorMapLineParserTest.java
@@ -170,4 +170,19 @@ public class DiscriminatorMapLineParserTest extends NbTestCase {
         assertEquals("Employee", type3);
     }
 
+    public void testValidUseCase_09() throws Exception {
+        AnnotationParsedLine parsedLine = parser.parse("\\Foo\\Bar\\discriminatormap({\"person\" = Person::class, \"employee\" = \"Employee::class\"})  \t");
+        assertEquals("DiscriminatorMap", parsedLine.getName());
+        assertEquals("({\"person\" = Person::class, \"employee\" = \"Employee::class\"})", parsedLine.getDescription());
+        Map<OffsetRange, String> types = parsedLine.getTypes();
+        assertNotNull(types);
+        assertEquals(3, types.size());
+        String type1 = types.get(new OffsetRange(0, 25));
+        assertEquals("\\Foo\\Bar\\discriminatormap", type1);
+        String type2 = types.get(new OffsetRange(38, 44));
+        assertEquals("Person", type2);
+        String type3 = types.get(new OffsetRange(67, 75));
+        assertEquals("Employee", type3);
+    }
+
 }

--- a/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/EntityLineParserTest.java
+++ b/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/EntityLineParserTest.java
@@ -162,4 +162,17 @@ public class EntityLineParserTest extends NbTestCase {
         assertEquals("MyProject\\UserRepository", type2);
     }
 
+    public void testValidUseCase_09() throws Exception {
+        AnnotationParsedLine parsedLine = parser.parse("\\Foo\\Bar\\entity(repositoryClass=\"MyProject\\UserRepository::class\")  \t");
+        assertEquals("Entity", parsedLine.getName());
+        assertEquals("(repositoryClass=\"MyProject\\UserRepository::class\")", parsedLine.getDescription());
+        Map<OffsetRange, String> types = parsedLine.getTypes();
+        assertNotNull(types);
+        assertEquals(2, types.size());
+        String type1 = types.get(new OffsetRange(0, 15));
+        assertEquals("\\Foo\\Bar\\entity", type1);
+        String type2 = types.get(new OffsetRange(33, 57));
+        assertEquals("MyProject\\UserRepository", type2);
+    }
+
 }

--- a/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/ManyToManyLineParserTest.java
+++ b/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/ManyToManyLineParserTest.java
@@ -161,4 +161,17 @@ public class ManyToManyLineParserTest extends NbTestCase {
         assertEquals("Group", type2);
     }
 
+    public void testValidUseCase_09() throws Exception {
+        AnnotationParsedLine parsedLine = parser.parse("\\Foo\\Bar\\manytomany(targetEntity=\"\\Foo\\Bar\\Group::class\", inversedBy=\"features\")  \t");
+        assertEquals("ManyToMany", parsedLine.getName());
+        assertEquals("(targetEntity=\"\\Foo\\Bar\\Group::class\", inversedBy=\"features\")", parsedLine.getDescription());
+        Map<OffsetRange, String> types = parsedLine.getTypes();
+        assertNotNull(types);
+        assertEquals(2, types.size());
+        String type1 = types.get(new OffsetRange(0, 19));
+        assertEquals("\\Foo\\Bar\\manytomany", type1);
+        String type2 = types.get(new OffsetRange(34, 48));
+        assertEquals("\\Foo\\Bar\\Group", type2);
+    }
+
 }

--- a/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/ManyToOneLineParserTest.java
+++ b/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/ManyToOneLineParserTest.java
@@ -161,4 +161,17 @@ public class ManyToOneLineParserTest extends NbTestCase {
         assertEquals("Cart", type2);
     }
 
+    public void testValidUseCase_09() throws Exception {
+        AnnotationParsedLine parsedLine = parser.parse("\\Foo\\Bar\\manytoone(targetEntity=\"Cart::class\", cascade={\"all\"}, fetch=\"EAGER\")  \t");
+        assertEquals("ManyToOne", parsedLine.getName());
+        assertEquals("(targetEntity=\"Cart::class\", cascade={\"all\"}, fetch=\"EAGER\")", parsedLine.getDescription());
+        Map<OffsetRange, String> types = parsedLine.getTypes();
+        assertNotNull(types);
+        assertEquals(2, types.size());
+        String type1 = types.get(new OffsetRange(0, 18));
+        assertEquals("\\Foo\\Bar\\manytoone", type1);
+        String type2 = types.get(new OffsetRange(33, 37));
+        assertEquals("Cart", type2);
+    }
+
 }

--- a/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/OneToManyLineParserTest.java
+++ b/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/OneToManyLineParserTest.java
@@ -161,4 +161,17 @@ public class OneToManyLineParserTest extends NbTestCase {
         assertEquals("Phonenumber", type2);
     }
 
+    public void testValidUseCase_09() throws Exception {
+        AnnotationParsedLine parsedLine = parser.parse("\\Foo\\Bar\\onetomany(targetEntity=\\Foo\\Bar\\Phonenumber::class, mappedBy=\"user\", cascade={\"persist\", \"remove\", \"merge\"}, orphanRemoval=true)  \t");
+        assertEquals("OneToMany", parsedLine.getName());
+        assertEquals("(targetEntity=\\Foo\\Bar\\Phonenumber::class, mappedBy=\"user\", cascade={\"persist\", \"remove\", \"merge\"}, orphanRemoval=true)", parsedLine.getDescription());
+        Map<OffsetRange, String> types = parsedLine.getTypes();
+        assertNotNull(types);
+        assertEquals(2, types.size());
+        String type1 = types.get(new OffsetRange(0, 18));
+        assertEquals("\\Foo\\Bar\\onetomany", type1);
+        String type2 = types.get(new OffsetRange(32, 52));
+        assertEquals("\\Foo\\Bar\\Phonenumber", type2);
+    }
+
 }

--- a/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/OneToOneLineParserTest.java
+++ b/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/orm/parser/OneToOneLineParserTest.java
@@ -161,4 +161,30 @@ public class OneToOneLineParserTest extends NbTestCase {
         assertEquals("Customer", type2);
     }
 
+    public void testValidUseCase_09() throws Exception {
+        AnnotationParsedLine parsedLine = parser.parse("\\Foo\\Bar\\onetoone(targetEntity=\"Customer::class\")  \t");
+        assertEquals("OneToOne", parsedLine.getName());
+        assertEquals("(targetEntity=\"Customer::class\")", parsedLine.getDescription());
+        Map<OffsetRange, String> types = parsedLine.getTypes();
+        assertNotNull(types);
+        assertEquals(2, types.size());
+        String type1 = types.get(new OffsetRange(0, 17));
+        assertEquals("\\Foo\\Bar\\onetoone", type1);
+        String type2 = types.get(new OffsetRange(32, 40));
+        assertEquals("Customer", type2);
+    }
+
+    public void testValidUseCase_10() throws Exception {
+        AnnotationParsedLine parsedLine = parser.parse("\\Foo\\Bar\\onetoone(targetEntity=Customer::class)  \t");
+        assertEquals("OneToOne", parsedLine.getName());
+        assertEquals("(targetEntity=Customer::class)", parsedLine.getDescription());
+        Map<OffsetRange, String> types = parsedLine.getTypes();
+        assertNotNull(types);
+        assertEquals(2, types.size());
+        String type1 = types.get(new OffsetRange(0, 17));
+        assertEquals("\\Foo\\Bar\\onetoone", type1);
+        String type2 = types.get(new OffsetRange(31, 39));
+        assertEquals("Customer", type2);
+    }
+
 }

--- a/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/parser/Doctrine2CommonLineAnnotationLineParserTest.java
+++ b/php/php.doctrine2/test/unit/src/org/netbeans/modules/php/doctrine2/annotations/parser/Doctrine2CommonLineAnnotationLineParserTest.java
@@ -160,4 +160,18 @@ public class Doctrine2CommonLineAnnotationLineParserTest extends NbTestCase {
         assertEquals("Index", type2);
     }
 
+    public void testWithTypedParam_04() throws Exception {
+        AnnotationParsedLine parsedLine = parser.parse("    targetEntity=MyProject\\UserRepository::class, indexes={ @Index(keys={\"username\"=\"desc\"}, options={\"unique\"=true}) }, ");
+        assertNotNull(parsedLine);
+        assertEquals("", parsedLine.getName());
+        assertEquals("targetEntity=MyProject\\UserRepository::class, indexes={ @Index(keys={\"username\"=\"desc\"}, options={\"unique\"=true}) },", parsedLine.getDescription());
+        assertFalse(parsedLine.startsWithAnnotation());
+        Map<OffsetRange, String> types = parsedLine.getTypes();
+        assertEquals(2, types.size());
+        String type1 = types.get(new OffsetRange(17, 41));
+        assertEquals("MyProject\\UserRepository", type1);
+        String type2 = types.get(new OffsetRange(61, 66));
+        assertEquals("Index", type2);
+    }
+
 }


### PR DESCRIPTION
See Jira for details: https://issues.apache.org/jira/browse/NETBEANS-3799

There were some unused test methods for the class I've modified (and failing if renamed to be included when running tests), according to git history, they were just added and never actually tested:

https://github.com/emilianbold/netbeans-releases/blame/d5e07b7d6c95bf5342eb8bc351e2d09b88d5e0ad/php.api.annotation/test/unit/src/org/netbeans/modules/php/api/annotation/util/AnnotationUtilsTest.java

I've included these test cases to run and modified the expected values so that they don't fail, specifically not to expect `ManyToOne` type.