### PR TITLE
[NETBEANS-3769] Use WindowsNotifier not NIO2. Avoids dangling directo…

### DIFF
--- a/platform/masterfs.windows/src/org/netbeans/modules/masterfs/watcher/windows/WindowsNotifier.java
+++ b/platform/masterfs.windows/src/org/netbeans/modules/masterfs/watcher/windows/WindowsNotifier.java
@@ -50,7 +50,9 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @author nenik
  */
-@ServiceProvider(service=Notifier.class, position=400)
+// This must come before NioNotifier to avoid dangling directory references.
+// See [NETBEANS-2785], [NETBEANS-3769]
+@ServiceProvider(service=Notifier.class, position=150)
 public final class WindowsNotifier extends Notifier<Void> {
     static final Logger LOG = Logger.getLogger(WindowsNotifier.class.getName());
 


### PR DESCRIPTION
Revert to using the native Notifier,  WindowsNotifier.java, rather than NIO2. After open/close a project, use SysInternals to see active handles, owned by NetBeans, for the directories in a project. On windows, this prevents remove/rename so the associated NB actions fail. See [NETBEANS-2785], [NETBEANS-3769].

I looked through close and didn't see where the watch keys for the directories are removed, but it would have been very easy to miss; for that matter, I'm not sure how they are added.

This change may have performance implications; the change was made to  improve performance on linux. I didn't see specific comments about windows. But if Notifier.removeWatch is being skipped, this seems like a memory leak on all systems. Since the windows notifier has been used for 11.2, it can probably be re-enabled after fixing this watch key leak.