### PR TITLE
Heapview FlatLaF alternative colors

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -97,19 +97,6 @@ nb.formdesigner.gap.min.color=darken(@background,5%)
 nb.formdesigner.gap.border.color=lighten(@background,10%)
 nb.formdesigner.saw.color=lighten(@background,15%)
 
-
-#---- HeapView ----
-
-# text
-nb.heapview.foreground=#ddd
-
-# grid
-nb.heapview.background=#4e4e4e
-
-# heap
-nb.heapview.chart=#958f17
-
-
 # startpage
 nb.startpage.defaultbackground=true
 # Darkred and darkblue from NB Icon palette

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -119,6 +119,10 @@ nb.core.ui.balloon.mouseOverGradientFinishColor=$ToolTip.background
 nb.core.ui.balloon.defaultGradientStartColor=$ToolTip.background
 nb.core.ui.balloon.defaultGradientFinishColor=$ToolTip.background
 
+#---- HeapView ----
+nb.heapview.background=@background
+nb.heapview.foreground=lighten(@foreground,15%)
+
 # QuickSearch
 nb.quicksearch.background=$MenuBar.background
 nb.quicksearch.border=1,1,1,1,$MenuBar.background


### PR DESCRIPTION
Well, this is just an alternative coloring of the HeapView on FlatLaF. Personally I think the yellow draws more attention to the eye than it should be. I also changed the view background color match the toolbar so it is more flat that way. If agreed it is trivial to merge for 11.3.
See the samples:
![HeapViewDark](https://user-images.githubusercontent.com/1381701/74091477-d2b19c00-4a6c-11ea-9e51-534c17874f9b.png)

![HeapView2](https://user-images.githubusercontent.com/1381701/74091479-d7765000-4a6c-11ea-92fc-041930b72844.png)

@DevCharly, @pedro-w  ?