### PR TITLE
[NETBEANS-3600] Use gradle-wrapper.properties to detect wrapper

### DIFF
--- a/groovy/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
+++ b/groovy/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
@@ -139,10 +139,10 @@ public final class GradleFiles implements Serializable {
     }
 
     private void searchWrapper() {
-        File w = new File(rootDir, Utilities.isWindows() ? "gradlew.bat" : "gradlew");
+        File w = new File(rootDir, WRAPPER_PROPERTIES);
         if (w.isFile()) {
-            gradlew = w;
-            wrapperProperties = new File(rootDir, WRAPPER_PROPERTIES);
+            gradlew = new File(rootDir, Utilities.isWindows() ? "gradlew.bat" : "gradlew");
+            wrapperProperties = w;
         }
     }
 


### PR DESCRIPTION
Well this change is pretty harmless, but might help someone. Can be pushed to 11.2 if you decide.