### PR TITLE
Fix member references in Jackpot scripts

### DIFF
--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintLexerTest.java
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintLexerTest.java
@@ -308,4 +308,47 @@ public class DeclarativeHintLexerTest {
         assertFalse(ts.moveNext());
     }
 
+    @Test
+    public void testDoubleColonDisamgibuation() {
+        {
+            String text = "System.err::println;;";
+            TokenHierarchy<?> hi = TokenHierarchy.create(text, language());
+            TokenSequence<?> ts = hi.tokenSequence();
+            TestUtils.assertNextTokenEquals(ts, JAVA_SNIPPET, "System.err::println");
+            TestUtils.assertNextTokenEquals(ts, DOUBLE_SEMICOLON, ";;");
+
+            assertFalse(ts.moveNext());
+        }
+        {
+            String text = "System.err::!println();;";
+            TokenHierarchy<?> hi = TokenHierarchy.create(text, language());
+            TokenSequence<?> ts = hi.tokenSequence();
+            TestUtils.assertNextTokenEquals(ts, JAVA_SNIPPET, "System.err");
+            TestUtils.assertNextTokenEquals(ts, DOUBLE_COLON, "::");
+            TestUtils.assertNextTokenEquals(ts, NOT, "!");
+            TestUtils.assertNextTokenEquals(ts, JAVA_SNIPPET, "println()");
+            TestUtils.assertNextTokenEquals(ts, DOUBLE_SEMICOLON, ";;");
+
+            assertFalse(ts.moveNext());
+        }
+        {
+            String text = "$1.isDirectory <!suppress-warnings=isDirectory> :: $1 instanceof java.io.File ;;";
+            TokenHierarchy<?> hi = TokenHierarchy.create(text, language());
+            TokenSequence<?> ts = hi.tokenSequence();
+            TestUtils.assertNextTokenEquals(ts, VARIABLE, "$1");
+            TestUtils.assertNextTokenEquals(ts, JAVA_SNIPPET, ".isDirectory ");
+            TestUtils.assertNextTokenEquals(ts, OPTIONS, "<!suppress-warnings=isDirectory>");
+            TestUtils.assertNextTokenEquals(ts, WHITESPACE, " ");
+            TestUtils.assertNextTokenEquals(ts, DOUBLE_COLON, "::");
+            TestUtils.assertNextTokenEquals(ts, WHITESPACE, " ");
+            TestUtils.assertNextTokenEquals(ts, VARIABLE, "$1");
+            TestUtils.assertNextTokenEquals(ts, WHITESPACE, " ");
+            TestUtils.assertNextTokenEquals(ts, INSTANCEOF, "instanceof");
+            TestUtils.assertNextTokenEquals(ts, JAVA_SNIPPET, " java.io.File ");
+            TestUtils.assertNextTokenEquals(ts, DOUBLE_SEMICOLON, ";;");
+
+            assertFalse(ts.moveNext());
+        }
+    }
+
 }

--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/use-member-ref.hint
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/use-member-ref.hint
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+    $test.method() :: $test instanceof Test
+ => $test.method(System.err::println)
+ ;;

--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/use-member-ref.test
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/use-member-ref.test
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+%%TestCase pos-1
+package test;
+public class Test {
+    public void method() {
+        method();
+    }
+}
+%%=>
+package test;
+public class Test {
+    public void method() {
+        method(System.err::println);
+    }
+}

--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/use-undeclared-lambda.hint
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/use-undeclared-lambda.hint
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+    $test.method() :: $test instanceof Test
+ => $test.method(t -> System.err.println(t))
+ ;;

--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/use-undeclared-lambda.test
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/use-undeclared-lambda.test
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+%%TestCase pos-1
+package test;
+public class Test {
+    public void method() {
+        method();
+    }
+}
+%%=>
+package test;
+public class Test {
+    public void method() {
+        method(System.err::println);
+    }
+}

--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/use-undeclared-lambda.test
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/use-undeclared-lambda.test
@@ -27,6 +27,6 @@ public class Test {
 package test;
 public class Test {
     public void method() {
-        method(System.err::println);
+        method(t -> System.err.println(t));
     }
 }

--- a/java/java.source.base/apichanges.xml
+++ b/java/java.source.base/apichanges.xml
@@ -25,6 +25,18 @@
     <apidef name="javasource_base">Java Source API</apidef>
 </apidefs>
 <changes>
+    <change id="CodeStyle.parensAroundSingularLambdaParam">
+        <api name="javasource_base" />
+        <summary>CodeStyle.parensAroundSingularLambdaParam() added</summary>
+        <version major="1" minor="2.45"/>
+        <date day="8" month="2" year="2020"/>
+        <author login="jlahoda"/>
+        <compatibility addition="yes" binary="compatible" source="compatible"/>
+        <description>
+                Method CodeStyle.parensAroundSingularLambdaParam() has been added.
+        </description>
+        <class name="CodeStyle" package="org.netbeans.api.java.source"/>
+    </change>
     <change id="TreeMaker.SwitchExpression">
         <api name="javasource_base" />
         <summary>Creates a new SwitchExpressionTree</summary>

--- a/java/java.source.base/nbproject/project.properties
+++ b/java/java.source.base/nbproject/project.properties
@@ -23,7 +23,7 @@ javadoc.name=Java Source Base
 javadoc.title=Java Source Base
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-spec.version.base=2.44.0
+spec.version.base=2.45.0
 test.qa-functional.cp.extra=${refactoring.java.dir}/modules/ext/nb-javac-api.jar
 test.unit.run.cp.extra=${o.n.core.dir}/core/core.jar:\
     ${o.n.core.dir}/lib/boot.jar:\

--- a/java/java.source.base/src/org/netbeans/api/java/source/CodeStyle.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/CodeStyle.java
@@ -944,6 +944,13 @@ public final class CodeStyle {
         return preferences.getBoolean(spaceWithinLambdaParens, getDefaultAsBoolean(spaceWithinLambdaParens));
     }
 
+    /**
+     * @since 2.45
+     */
+    public boolean parensAroundSingularLambdaParam() {
+        return preferences.getBoolean(parensAroundSingularLambdaParam, getDefaultAsBoolean(parensAroundSingularLambdaParam));
+    }
+
     public boolean spaceWithinMethodCallParens() {
         return preferences.getBoolean(spaceWithinMethodCallParens, getDefaultAsBoolean(spaceWithinMethodCallParens));
     }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
@@ -1212,7 +1212,10 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
 
     @Override
     public void visitLambda(JCLambda tree) {
-        print(cs.spaceWithinLambdaParens() && tree.params.nonEmpty() ? "( " : "(");
+        boolean useParens = cs.parensAroundSingularLambdaParam() || tree.params.size() != 1;
+        if (useParens) {
+            print(cs.spaceWithinLambdaParens() && tree.params.nonEmpty() ? "( " : "(");
+        }
         boolean oldPrintingMethodParams = printingMethodParams;
         printingMethodParams = true;
         suppressVariableType = tree.paramKind == JCLambda.ParameterKind.IMPLICIT;
@@ -1221,9 +1224,11 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
                   true);
         suppressVariableType = false;
         printingMethodParams = oldPrintingMethodParams;
-        if (cs.spaceWithinLambdaParens() && tree.params.nonEmpty())
-            needSpace();
-        print(')');
+        if (useParens) {
+            if (cs.spaceWithinLambdaParens() && tree.params.nonEmpty())
+                needSpace();
+            print(')');
+        }
         print(cs.spaceAroundLambdaArrow() ? " ->" : "->");
         if (tree.getBodyKind() == BodyKind.STATEMENT) {
             printBlock(tree.body, cs.getOtherBracePlacement(), cs.spaceAroundLambdaArrow());

--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
@@ -1212,7 +1212,9 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
 
     @Override
     public void visitLambda(JCLambda tree) {
-        boolean useParens = cs.parensAroundSingularLambdaParam() || tree.params.size() != 1;
+        boolean useParens = cs.parensAroundSingularLambdaParam() ||
+                            tree.params.size() != 1 ||
+                            tree.paramKind != JCLambda.ParameterKind.IMPLICIT;
         if (useParens) {
             print(cs.spaceWithinLambdaParens() && tree.params.nonEmpty() ? "( " : "(");
         }

--- a/java/java.source.base/src/org/netbeans/modules/java/ui/FmtOptions.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/ui/FmtOptions.java
@@ -201,6 +201,7 @@ public class FmtOptions {
     public static final String spaceWithinParens = "spaceWithinParens"; //NOI18N
     public static final String spaceWithinMethodDeclParens = "spaceWithinMethodDeclParens"; //NOI18N
     public static final String spaceWithinLambdaParens = "spaceWithinLambdaParens"; //NOI18N
+    public static final String parensAroundSingularLambdaParam = "parensAroundSingularLambdaParam"; //NOI18N
     public static final String spaceWithinMethodCallParens = "spaceWithinMethodCallParens"; //NOI18N
     public static final String spaceWithinIfParens = "spaceWithinIfParens"; //NOI18N
     public static final String spaceWithinForParens = "spaceWithinForParens"; //NOI18N
@@ -505,6 +506,7 @@ public class FmtOptions {
             { spaceWithinParens, FALSE}, //NOI18N
             { spaceWithinMethodDeclParens, FALSE}, //NOI18N
             { spaceWithinLambdaParens, FALSE}, //NOI18N
+            { parensAroundSingularLambdaParam, FALSE}, //NOI18N
             { spaceWithinMethodCallParens, FALSE}, //NOI18N
             { spaceWithinIfParens, FALSE}, //NOI18N
             { spaceWithinForParens, FALSE}, //NOI18N

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/LambdaTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/LambdaTest.java
@@ -21,6 +21,7 @@ package org.netbeans.api.java.source.gen;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.LiteralTree;
@@ -40,7 +41,11 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.prefs.Preferences;
 import javax.lang.model.element.Modifier;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.api.java.lexer.JavaTokenId;
+import org.netbeans.api.java.source.CodeStyle;
 import org.netbeans.api.java.source.GeneratorUtilities;
 import org.netbeans.api.java.source.Task;
 import org.netbeans.api.java.source.JavaSource;
@@ -49,6 +54,7 @@ import org.netbeans.api.java.source.TestUtilities;
 import org.netbeans.api.java.source.TreeMaker;
 import org.netbeans.api.java.source.WorkingCopy;
 import org.netbeans.junit.NbTestSuite;
+import org.netbeans.modules.java.ui.FmtOptions;
 
 /**
  * Tests correct adding cast to statement.
@@ -148,6 +154,59 @@ public class LambdaTest extends GeneratorTestMDRCompat {
         String res = TestUtilities.copyFileToString(testFile);
         //System.err.println(res);
         assertEquals(golden, res);
+    }
+    
+    public void testImplicitLambdaParam() throws Exception {
+        for (boolean parens : new boolean[] {false, true}) {
+            testFile = new File(getWorkDir(), "Test.java");
+            TestUtilities.copyStringToFile(testFile, 
+                "package hierbas.del.litoral;\n\n" +
+                "public class Test {\n" +
+                "    public static void taragui() {\n" +
+                "        ChangeListener l;\n" + 
+                "    }\n" +
+                "}\n"
+                );
+            String golden =
+                "package hierbas.del.litoral;\n\n" +
+                "public class Test {\n" +
+                "    public static void taragui() {\n" +
+                (parens ? "        ChangeListener l = (e) -> System.err.println();\n"
+                        : "        ChangeListener l = e -> System.err.println();\n") + 
+                "    }\n" +
+                "}\n";
+            JavaSource src = getJavaSource(testFile);
+
+            Preferences preferences = MimeLookup.getLookup(JavaTokenId.language().mimeType()).lookup(Preferences.class);
+
+            try {
+                preferences.putBoolean(FmtOptions.parensAroundSingularLambdaParam, parens);
+
+                Task<WorkingCopy> task = new Task<WorkingCopy>() {
+
+                    public void run(final WorkingCopy workingCopy) throws IOException {
+                        workingCopy.toPhase(Phase.RESOLVED);
+                        final TreeMaker make = workingCopy.getTreeMaker();
+                        new ErrorAwareTreeScanner<Void, Void>() {
+                            @Override
+                            public Void visitVariable(VariableTree node, Void p) {
+                                ExpressionTree stat = make.MethodInvocation(Collections.emptyList(), make.MemberSelect(make.MemberSelect(make.QualIdent("java.lang.System"), "err"), "println"), Collections.emptyList());
+                                LambdaExpressionTree lambda = make.LambdaExpression(Collections.singletonList(make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), "e", null, null)), stat);
+                                workingCopy.rewrite(node, make.Variable(node.getModifiers(), node.getName(), node.getType(), lambda));
+                                return super.visitVariable(node, p);
+                            }
+                        }.scan(workingCopy.getCompilationUnit(), null);
+                    }
+
+                };
+                src.runModificationTask(task).commit();
+                String res = TestUtilities.copyFileToString(testFile);
+                //System.err.println(res);
+                assertEquals(golden, res);
+            } finally {
+                preferences.remove(FmtOptions.parensAroundSingularLambdaParam);
+            }
+        }
     }
     
     public void testAddFirstLambdaParam() throws Exception {

--- a/java/java.source/src/org/netbeans/modules/java/ui/Bundle.properties
+++ b/java/java.source/src/org/netbeans/modules/java/ui/Bundle.properties
@@ -565,3 +565,5 @@ TITLE_LowMemory=Low Memory
 MSG_LowMemory=Not enough memory to compile: {0}.
 URL_LowMemory=http://wiki.netbeans.org/InsufficientMemoryToIndexRoot
 FmtCodeGeneration.sortUsesDependenciesCheckBox.text=Sort uses dependencies
+FmtBraces.jLabel1.text=Parenthesis
+FmtBraces.lambdaParensCheckBox.text=Always use parens around lambda parameters

--- a/java/java.source/src/org/netbeans/modules/java/ui/FmtBraces.form
+++ b/java/java.source/src/org/netbeans/modules/java/ui/FmtBraces.form
@@ -53,6 +53,11 @@
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jSeparator2" max="32767" attributes="0"/>
           </Group>
+          <Group type="102" alignment="0" attributes="0">
+              <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="jSeparator3" max="32767" attributes="0"/>
+          </Group>
           <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
@@ -82,8 +87,9 @@
                   <Component id="ifBracesLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="forBracesLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="moduleDeclLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="lambdaParensCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace min="-2" pref="16" max="-2" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -147,7 +153,14 @@
                   <Component id="doWhileBracesLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="doWhileBracesCombo" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="1" attributes="0">
+                  <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+                  <Component id="jSeparator3" min="-2" pref="8" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Component id="lambdaParensCheckBox" min="-2" max="-2" attributes="0"/>
+              <EmptySpace pref="30" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -368,6 +381,22 @@
       <AuxValues>
         <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
       </AuxValues>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel1">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/java/ui/Bundle.properties" key="FmtBraces.jLabel1.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JSeparator" name="jSeparator3">
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="lambdaParensCheckBox">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/java/ui/Bundle.properties" key="FmtBraces.lambdaParensCheckBox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
     </Component>
   </SubComponents>
 </Form>

--- a/java/java.source/src/org/netbeans/modules/java/ui/FmtBraces.java
+++ b/java/java.source/src/org/netbeans/modules/java/ui/FmtBraces.java
@@ -42,6 +42,7 @@ public class FmtBraces extends javax.swing.JPanel {
         forBracesCombo.putClientProperty(OPTION_ID, redundantForBraces);
         whileBracesCombo.putClientProperty(OPTION_ID, redundantWhileBraces);
         doWhileBracesCombo.putClientProperty(OPTION_ID, redundantDoWhileBraces);
+        lambdaParensCheckBox.putClientProperty(OPTION_ID, parensAroundSingularLambdaParam);
     }
     
     public static PreferencesCustomizer.Factory getController() {
@@ -79,6 +80,9 @@ public class FmtBraces extends javax.swing.JPanel {
         jSeparator2 = new javax.swing.JSeparator();
         moduleDeclLabel = new javax.swing.JLabel();
         moduleDeclCombo = new javax.swing.JComboBox<>();
+        jLabel1 = new javax.swing.JLabel();
+        jSeparator3 = new javax.swing.JSeparator();
+        lambdaParensCheckBox = new javax.swing.JCheckBox();
 
         setName(org.openide.util.NbBundle.getMessage(FmtBraces.class, "LBL_Braces")); // NOI18N
         setOpaque(false);
@@ -137,6 +141,10 @@ public class FmtBraces extends javax.swing.JPanel {
 
         moduleDeclCombo.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
 
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel1, org.openide.util.NbBundle.getMessage(FmtBraces.class, "FmtBraces.jLabel1.text")); // NOI18N
+
+        org.openide.awt.Mnemonics.setLocalizedText(lambdaParensCheckBox, org.openide.util.NbBundle.getMessage(FmtBraces.class, "FmtBraces.lambdaParensCheckBox.text")); // NOI18N
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -149,6 +157,10 @@ public class FmtBraces extends javax.swing.JPanel {
                 .addComponent(bracesGenerationLabel)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(jSeparator2))
+            .addGroup(layout.createSequentialGroup()
+                .addComponent(jLabel1)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jSeparator3))
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -173,8 +185,9 @@ public class FmtBraces extends javax.swing.JPanel {
                     .addComponent(specialElseIfCheckBox)
                     .addComponent(ifBracesLabel)
                     .addComponent(forBracesLabel)
-                    .addComponent(moduleDeclLabel))
-                .addGap(16, 16, 16))
+                    .addComponent(moduleDeclLabel)
+                    .addComponent(lambdaParensCheckBox))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         layout.linkSize(javax.swing.SwingConstants.HORIZONTAL, new java.awt.Component[] {classDeclCombo, doWhileBracesCombo, forBracesCombo, ifBracesCombo, methodDeclCombo, otherCombo, whileBracesCombo});
@@ -227,7 +240,13 @@ public class FmtBraces extends javax.swing.JPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(doWhileBracesLabel)
                     .addComponent(doWhileBracesCombo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                    .addComponent(jLabel1)
+                    .addComponent(jSeparator3, javax.swing.GroupLayout.PREFERRED_SIZE, 8, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(lambdaParensCheckBox)
+                .addContainerGap(30, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -247,8 +266,11 @@ public class FmtBraces extends javax.swing.JPanel {
     private javax.swing.JLabel forBracesLabel;
     private javax.swing.JComboBox ifBracesCombo;
     private javax.swing.JLabel ifBracesLabel;
+    private javax.swing.JLabel jLabel1;
     private javax.swing.JSeparator jSeparator1;
     private javax.swing.JSeparator jSeparator2;
+    private javax.swing.JSeparator jSeparator3;
+    private javax.swing.JCheckBox lambdaParensCheckBox;
     private javax.swing.JComboBox methodDeclCombo;
     private javax.swing.JLabel methodDeclLabel;
     private javax.swing.JComboBox<String> moduleDeclCombo;

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Hacks.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Hacks.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.hints.spiimpl;
 
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Scope;
 import com.sun.source.tree.Tree;
@@ -48,6 +49,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.tools.JavaFileObject;
 
 import com.sun.tools.javac.parser.ParserFactory;
+import com.sun.tools.javac.tree.JCTree.JCLambda;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.source.CompilationInfo;
@@ -100,6 +102,10 @@ public class Hacks {
             return null;
         } finally {
         }
+    }
+
+    public static void copyLambdaKind(LambdaExpressionTree node, LambdaExpressionTree nue) {
+        ((JCLambda) nue).paramKind = ((JCLambda) node).paramKind;
     }
 
     private static final class ScannerImpl extends ErrorAwareTreePathScanner<Scope, CompilationInfo> {

--- a/java/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFixUtilities.java
+++ b/java/spi.java.hints/src/org/netbeans/spi/java/hints/JavaFixUtilities.java
@@ -1285,6 +1285,8 @@ public class JavaFixUtilities {
             List<? extends VariableTree> args = resolveMultiParameters(node.getParameters());
             LambdaExpressionTree nue = make.LambdaExpression(args, node.getBody());
 
+            Hacks.copyLambdaKind(node, nue);
+
             rewrite(node, nue);
 
             return super.visitLambdaExpression(node, p);

--- a/java/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/JavaFixUtilitiesTest.java
+++ b/java/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/JavaFixUtilitiesTest.java
@@ -1323,6 +1323,22 @@ public class JavaFixUtilitiesTest extends TestBase {
 		           "}\n");
     }
 
+    public void testRewriteUndeclaredLambda() throws Exception {
+        performRewriteTest("package test;\n" +
+                           "public class Test {\n" +
+                           "    public void m() {\n" +
+                           "        m();\n" +
+                           "    }\n" +
+                           "}\n",
+                           "$0{test.Test}.m()=>$0.m(t -> System.err.println(t))",
+                           "package test;\n" +
+                           "public class Test {\n" +
+                           "    public void m() {\n" +
+                           "        m(t -> System.err.println(t));\n" +
+                           "    }\n" +
+		           "}\n");
+    }
+
     public void performRewriteTest(String code, String rule, String golden) throws Exception {
         performRewriteTest(code, rule, golden, null);
     }

--- a/java/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/JavaFixUtilitiesTest.java
+++ b/java/spi.java.hints/test/unit/src/org/netbeans/spi/java/hints/JavaFixUtilitiesTest.java
@@ -1339,6 +1339,22 @@ public class JavaFixUtilitiesTest extends TestBase {
 		           "}\n");
     }
 
+    public void testRewriteToExplicitLambda() throws Exception {
+        performRewriteTest("package test;\n" +
+                           "public class Test {\n" +
+                           "    public void m() {\n" +
+                           "        m();\n" +
+                           "    }\n" +
+                           "}\n",
+                           "$0{test.Test}.m()=>$0.m((String t) -> System.err.println(t))",
+                           "package test;\n" +
+                           "public class Test {\n" +
+                           "    public void m() {\n" +
+                           "        m((String t) -> System.err.println(t));\n" +
+                           "    }\n" +
+		           "}\n");
+    }
+
     public void performRewriteTest(String code, String rule, String golden) throws Exception {
         performRewriteTest(code, rule, golden, null);
     }


### PR DESCRIPTION
Fixing three problems related to the declarative Java hints:
-the declarative hints use :: as a separator between snippets and conditions - but :: is also used in meber references. So this patch is trying to disambiguate the two uses.
-implicit lambdas in the target snippets get erroneously explicit parameter handling (i.e. get types for the parameter names, often even wrong like "(ERROR)")
-for implicit lambdas with a single parameters, the parameter is still wrapped with parentheses
--added a configuration option for this; and this may be the most doubtful thing in the patch
