### PR TITLE
FlatLaf Light editor color profile

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
@@ -22,3 +22,4 @@ OpenIDE-Module-Name=FlatLaf Look and Feel
 OpenIDE-Module-Short-Description=FlatLaf Look and Feels
 
 Editors/FontsColors/FlatLafDark=FlatLaf Dark
+Editors/FontsColors/FlatLafLight=FlatLaf Light

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-nb.preferred.color.profile=NetBeans
+nb.preferred.color.profile=FlatLaf Light
 
 #---- EditorView ----
 

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafLight-annotations.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafLight-annotations.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+<fontscolors>
+    <fontcolor name="Breakpoint_broken" bgColor="dcdcd8"/>
+    <fontcolor name="Breakpoint_stroke" bgColor="dcdcd8"/>
+    <fontcolor name="Breakpoint" bgColor="fc9d9f"/>
+    <fontcolor name="CallSite" bgColor="e7e1ef"/>
+    <fontcolor name="ClassBreakpoint_stroke"/>
+    <fontcolor name="ClassBreakpoint"/>
+    <fontcolor name="CondBreakpoint_broken" bgColor="dcdcd8"/>
+    <fontcolor name="CondBreakpoint_stroke" bgColor="dcdcd8"/>
+    <fontcolor name="CondBreakpoint" bgColor="fc9d9f"/>
+    <fontcolor name="CurrentExpression" bgColor="d1ffbc"/>
+    <fontcolor name="CurrentExpressionLine_BP" bgColor="e9ffe6"/>
+    <fontcolor name="CurrentExpressionLine_CBP" bgColor="e9ffe6"/>
+    <fontcolor name="CurrentExpressionLine_DBP" bgColor="e9ffe6"/>
+    <fontcolor name="CurrentExpressionLine_DCBP" bgColor="e9ffe6"/>
+    <fontcolor name="CurrentExpressionLine" bgColor="e9ffe6"/>
+    <fontcolor name="CurrentPC" bgColor="bde6aa"/>
+    <fontcolor name="CurrentPC2_BP" bgColor="fc9d9f"/>
+    <fontcolor name="CurrentPC2_DBP" bgColor="dcdcd8"/>
+    <fontcolor name="CurrentPC2" bgColor="bde6aa"/>
+    <fontcolor name="CurrentPC2LinePart" bgColor="bde6aa"/>
+    <fontcolor name="CurrentPCLinePart" bgColor="bde6aa"/>
+    <fontcolor name="debugger-mixed_BP_broken" bgColor="dcdcd8"/>
+    <fontcolor name="debugger-mixed_BP" bgColor="fc9d9f"/>
+    <fontcolor name="debugger-multi_BPCBP_broken" bgColor="dcdcd8"/>
+    <fontcolor name="debugger-multi_BPCBP" bgColor="fc9d9f"/>
+    <fontcolor name="debugger-multi_DBPCBP" bgColor="dcdcd8"/>
+    <fontcolor name="debugger-PC_BP_broken" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_BP_stroke" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_BP" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_CBP_broken" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_CBP_stroke" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_CBP" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_DBP_stroke" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_DBP" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_DCBP_stroke" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_DCBP" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_mixedBP_broken" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_mixedBP" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_multi_BPCBP_broken" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_multi_BPCBP" bgColor="bde6aa"/>
+    <fontcolor name="debugger-PC_multi_DBPCBP" bgColor="bde6aa"/>
+    <fontcolor name="DisabledBreakpoint_stroke" bgColor="dcdcd8"/>
+    <fontcolor name="DisabledBreakpoint" bgColor="dcdcd8"/>
+    <fontcolor name="DisabledClassBreakpoint_stroke"/>
+    <fontcolor name="DisabledClassBreakpoint"/>
+    <fontcolor name="DisabledCondBreakpoint_stroke" bgColor="dcdcd8"/>
+    <fontcolor name="DisabledCondBreakpoint" bgColor="dcdcd8"/>
+    <fontcolor name="DisabledFieldBreakpoint_stroke"/>
+    <fontcolor name="DisabledFieldBreakpoint"/>
+    <fontcolor name="DisabledMethodBreakpoint_stroke"/>
+    <fontcolor name="DisabledMethodBreakpoint"/>
+    <fontcolor name="editor-bookmark"/>
+    <fontcolor name="FieldBreakpoint_stroke"/>
+    <fontcolor name="FieldBreakpoint"/>
+    <fontcolor name="loadgenProfilingPoint" bgColor="b4e4fc"/>
+    <fontcolor name="loadgenProfilingPointD" bgColor="dcdcd8"/>
+    <fontcolor name="MethodBreakpoint_stroke"/>
+    <fontcolor name="MethodBreakpoint"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-has_implementations"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements-has-implementations-combined"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements-is-overridden-combined"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-implements"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-is_overridden"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-override-is-overridden-combined"/>
+    <fontcolor name="org-netbeans-modules-editor-annotations-overrides"/>
+    <fontcolor name="org-netbeans-modules-git-Annotation"/>
+    <fontcolor name="org-netbeans-modules-mercurial-Annotation"/>
+    <fontcolor name="org-netbeans-modules-subversion-Annotation"/>
+    <fontcolor name="org-netbeans-modules-versioning-annotate-Annotation"/>
+    <fontcolor name="org-netbeans-modules-xml-error" bgColor="ffa0a0"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_err"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_hint"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_todo"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_verifier"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn_fixable"/>
+    <fontcolor name="org-netbeans-spi-editor-hints-parser_annotation_warn"/>
+    <fontcolor name="OtherThread_BP_broken" bgColor="bde6aa"/>
+    <fontcolor name="OtherThread_BP" bgColor="fc9d9f"/>
+    <fontcolor name="OtherThread_DBP" bgColor="dcdcd8"/>
+    <fontcolor name="OtherThread_PC_BP" bgColor="bde6aa"/>
+    <fontcolor name="OtherThread_PC" bgColor="bde6aa"/>
+    <fontcolor name="OtherThread"/>
+    <fontcolor name="OtherThreads_BP_broken" bgColor="bde6aa"/>
+    <fontcolor name="OtherThreads_BP" bgColor="fc9d9f"/>
+    <fontcolor name="OtherThreads_DBP" bgColor="dcdcd8"/>
+    <fontcolor name="OtherThreads_PC_BP" bgColor="bde6aa"/>
+    <fontcolor name="OtherThreads"/>
+    <fontcolor name="resetResultsProfilingPoint" bgColor="b4e4fc"/>
+    <fontcolor name="resetResultsProfilingPointD" bgColor="dcdcd8"/>
+    <fontcolor name="stopwatchProfilingPoint" bgColor="b4e4fc"/>
+    <fontcolor name="stopwatchProfilingPointD" bgColor="dcdcd8"/>
+    <fontcolor name="takeSnapshotProfilingPoint" bgColor="b4e4fc"/>
+    <fontcolor name="takeSnapshotProfilingPointD" bgColor="dcdcd8"/>
+</fontscolors>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafLight-highlights.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafLight-highlights.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+<fontscolors>
+    <fontcolor name="block-search" foreColor="black" bgColor="E0E8F1"/>
+    <fontcolor name="caret-color-insert-mode" foreColor="black"/>
+    <fontcolor name="caret-color-overwrite-mode" foreColor="black"/>
+    <fontcolor name="code-folding-bar" foreColor="8C8C8C"/>
+    <fontcolor name="code-folding-border" foreColor="8C8C8C"/>
+    <fontcolor name="code-folding" foreColor="8C8C8C"/>
+    <fontcolor name="guarded" bgColor="DFDFDF"/>
+    <fontcolor name="highlight-caret-row" bgColor="F9F4E0"/>
+    <fontcolor name="highlight-search" foreColor="black" bgColor="FFB442"/>
+    <fontcolor name="hyperlinks" foreColor="185ADD" underline="185ADD"/>
+    <fontcolor name="inc-search" foreColor="black" bgColor="FFB442"/>
+    <fontcolor name="indent-guide-lines" foreColor="D3D3D3"/>
+    <fontcolor name="indent-whitespace" foreColor="lightGray"/>
+    <fontcolor name="line-number" foreColor="darkGray" bgColor="E9E8E2"/>
+    <fontcolor name="nbeditor-bracesMatching-match-multichar" bgColor="CCFFCC"/>
+    <fontcolor name="nbeditor-bracesMatching-match" bgColor="CCFFCC"/>
+    <fontcolor name="nbeditor-bracesMatching-mismatch-multichar" bgColor="D83636"/>
+    <fontcolor name="nbeditor-bracesMatching-mismatch" bgColor="D83636"/>
+    <fontcolor name="nbeditor-bracesMatching-sidebar" foreColor="6B8EB2"/>
+    <fontcolor name="readonly-files" bgColor="DFDFDF"/>
+    <fontcolor name="selection" bgColor="89BCED"/>
+    <fontcolor name="status-bar-bold" foreColor="DD2A2A"/>
+    <fontcolor name="status-bar"/>
+    <fontcolor name="synchronized-text-blocks-ext-slave" foreColor="996600"/>
+    <fontcolor name="synchronized-text-blocks-ext" foreColor="CC0099"/>
+    <fontcolor name="synchronized-text-blocks" bgColor="8AC0EC"/>
+    <fontcolor name="text-limit-line-color" foreColor="D2ACCB"/>
+    <fontcolor name="trailing-whitespace" foreColor="lightGray"/>
+    <fontcolor name="west-sidebars-color"/>
+    <!-- <fontcolor name="coverage-covered" bgColor="005000"/>
+    <fontcolor name="coverage-uncovered" bgColor="813438"/>
+    <fontcolor name="coverage-inferred" bgColor="1c501c"/>
+    <fontcolor name="coverage-partial" bgColor="707000"/>
+    <fontcolor name="remove-surround-code-delete" foreColor="ff5A5A5A" bgColor="ff323232"/>
+    <fontcolor name="remove-surround-code-remain" bgColor="ff143C00"/> -->
+</fontscolors>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafLight-tokenColorings.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/fontscolors/FlatLafLight-tokenColorings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE fontscolors PUBLIC "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN" "http://www.netbeans.org/dtds/EditorFontsColors-1_1.dtd">
+<fontscolors>
+    <fontcolor name="char" foreColor="1E9347"/>
+    <fontcolor name="comment" foreColor="969696"/>
+    <fontcolor name="default" foreColor="black" bgColor="white"/>
+    <fontcolor name="entity-reference" foreColor="black" default="default"><font style="bold"/></fontcolor>
+    <fontcolor name="error" waveUnderlined="red"/>
+    <fontcolor name="field" foreColor="CE54B8" default="identifier"/>
+    <fontcolor name="identifier"/>
+    <fontcolor name="keyword" foreColor="336BDD"/>
+    <fontcolor name="mark-occurrences" bgColor="D7E6CB"/>
+    <fontcolor name="markup-attribute" default="field"/>
+    <fontcolor name="markup-attribute-value" default="string"/>
+    <fontcolor name="markup-element" default="keyword"/>
+    <fontcolor name="method" default="identifier"/>
+    <fontcolor name="number" foreColor="black"/>
+    <fontcolor name="operator"/>
+    <fontcolor name="separator"/>
+    <fontcolor name="string" foreColor="1E9347"/>
+    <fontcolor name="url" foreColor="287BDE" underline="287BDE"/>
+    <fontcolor name="warning" waveUnderlined="FFA500"/>
+    <fontcolor name="whitespace" foreColor="black"/>
+</fontscolors>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/layer.xml
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/layer.xml
@@ -27,13 +27,27 @@
             <folder name="FlatLafDark">
                 <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.swing.laf.flatlaf.Bundle"/>
                 <folder name="Defaults">
-                    <file name="org-netbeans-modules-editor-annotations-colorings.xml" url="fontscolors/FlatLafDark-annotations.xml">
+                    <file name="org-netbeans-modules-editor-annotations-flatlafdark.xml" url="fontscolors/FlatLafDark-annotations.xml">
                         <attr name="nbeditor-settings-ColoringType" stringvalue="annotation"/>
                     </file>
-                    <file name="org-netbeans-modules-defaults-highlight-colorings.xml" url="fontscolors/FlatLafDark-highlights.xml"> 
+                    <file name="org-netbeans-modules-defaults-highlight-flatlafdark.xml" url="fontscolors/FlatLafDark-highlights.xml"> 
                         <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
                     </file>
-                    <file name="org-netbeans-modules-defaults-token-colorings.xml" url="fontscolors/FlatLafDark-tokenColorings.xml">
+                    <file name="org-netbeans-modules-defaults-token-flatlafdark.xml" url="fontscolors/FlatLafDark-tokenColorings.xml">
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="token"/>
+                    </file>
+                </folder>
+            </folder>
+            <folder name="FlatLafLight">
+                <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.swing.laf.flatlaf.Bundle"/>
+                <folder name="Defaults">
+                    <file name="org-netbeans-modules-editor-annotations-flatlaflight.xml" url="fontscolors/FlatLafLight-annotations.xml">
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="annotation"/>
+                    </file>
+                    <file name="org-netbeans-modules-defaults-highlight-flatlaflight.xml" url="fontscolors/FlatLafLight-highlights.xml"> 
+                        <attr name="nbeditor-settings-ColoringType" stringvalue="highlight"/>
+                    </file>
+                    <file name="org-netbeans-modules-defaults-token-flatlaflight.xml" url="fontscolors/FlatLafLight-tokenColorings.xml">
                         <attr name="nbeditor-settings-ColoringType" stringvalue="token"/>
                     </file>
                 </folder>


### PR DESCRIPTION
Initial attempt at an editor color profile that goes well with FlatLaf Light look and feel.

Still contains no syntax specific token colorings

Annotation colorings are those of default NetBeans color profile.