### PR TITLE
[NETBEANS-3317]: field TypeVar.bound has been encapsulated and rename…

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/SourceUtils.java
@@ -196,7 +196,11 @@ public class SourceUtils {
     
     public static TypeMirror getBound(WildcardType wildcardType) {
         Type.TypeVar bound = ((Type.WildcardType)wildcardType).bound;
-        return bound != null ? bound.bound : null;
+        try {
+            return bound != null ? bound.bound : null;
+        } catch (NoSuchFieldError err) {
+            return bound != null ? bound.getUpperBound() : null;
+        }
     }
 
     /**

--- a/java/java.source.base/test/unit/data/sourceutils/TestGetBound.java
+++ b/java/java.source.base/test/unit/data/sourceutils/TestGetBound.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package sourceutils;
+
+public class TestGetBound<T extends TestGetBoundExtra<? extends String>> {
+}
+class TestGetBoundExtra<T extends CharSequence> {}

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/SourceUtilsTest.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.api.java.source;
 
+import com.sun.source.tree.Tree;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -38,7 +39,12 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.ElementFilter;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -426,6 +432,21 @@ public class SourceUtilsTest extends ClassIndexTestCase {
         test = info.getElements().getTypeElement("sourceutils.TestDollarSourceName$dollar.InnerClass");
         f = SourceUtils.getFile(ElementHandle.create(test), info.getClasspathInfo());
         assertEquals("TestDollarSourceName.java", f.getNameExt());
+    }
+
+    public void testGetBound() throws Exception {
+        //only a scatch of the test, add testcases as needed:
+        prepareTest();
+
+        TypeElement test = info.getElements().getTypeElement("sourceutils.TestGetBound");
+
+        assertNotNull(test);
+
+        TypeParameterElement typeParam = test.getTypeParameters().get(0);
+        TypeMirror outerBound = ((TypeVariable) typeParam.asType()).getUpperBound();
+
+        TypeMirror bound = SourceUtils.getBound((WildcardType) ((DeclaredType) outerBound).getTypeArguments().get(0));
+        assertEquals("java.lang.CharSequence", String.valueOf(bound));
     }
 
     //<editor-fold defaultstate="collapsed" desc="Helper methods & Mock services">


### PR DESCRIPTION
…d to _bound - should use getUpperBound() instead.

Might be reasonable to do for 11.3, if there's time. If not, then it will need to wait for 12.0.