### PR TITLE
[NETBEANS-3873] Fix project from maven archetype wizard

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/newproject/ChooseArchetypePanel.form
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/ChooseArchetypePanel.form
@@ -230,7 +230,7 @@
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
             <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
-              <Connection code="(java.awt.Color)(UIManager.get(&quot;textArea.background&quot;)!=null?&#xa;    UIManager.get(&quot;textArea.background&quot;):new java.awt.Color(238, 238, 238))" type="code"/>
+              <Connection code="(java.awt.Color)(UIManager.get(&quot;TextArea.background&quot;)!=null?&#xa;    UIManager.get(&quot;TextArea.background&quot;):new java.awt.Color(238, 238, 238))" type="code"/>
             </Property>
             <Property name="columns" type="int" value="20"/>
             <Property name="lineWrap" type="boolean" value="true"/>

--- a/java/maven/src/org/netbeans/modules/maven/newproject/ChooseArchetypePanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/ChooseArchetypePanel.java
@@ -245,8 +245,8 @@ public class ChooseArchetypePanel extends JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(labelDesc, org.openide.util.NbBundle.getMessage(ChooseArchetypePanel.class, "LBL_Description")); // NOI18N
 
         taDescription.setEditable(false);
-        taDescription.setBackground((java.awt.Color)(UIManager.get("textArea.background")!=null?
-            UIManager.get("textArea.background"):new java.awt.Color(238, 238, 238)));
+        taDescription.setBackground((java.awt.Color)(UIManager.get("TextArea.background")!=null?
+            UIManager.get("TextArea.background"):new java.awt.Color(238, 238, 238)));
     taDescription.setColumns(20);
     taDescription.setLineWrap(true);
     taDescription.setRows(5);


### PR DESCRIPTION
This fixes the description text area in the second step of the "Project from Maven Archetype" wizard having a light background on dark LAFs.

See bug on Jira for screenshot of problem. After fix:
![after-archetype-project](https://user-images.githubusercontent.com/1875690/74593427-81387c80-502b-11ea-9802-8a572f5c12b4.png)

The hardcoded color remains as a fallback but should be rarely used now.