### PR TITLE
Ensure a clean license stub is used for source config builds

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -203,6 +203,6 @@
 
 ********************************************************************************
 Apache NetBeans repository includes a number of source files that are not
-covered by the apache license. These files are refered to by licenseinfo.xml
+covered by the Apache license. These files are refered to by licenseinfo.xml
 files which hold the license information.
 ********************************************************************************

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1619,7 +1619,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
         <delete dir="${netbeans.dest.dir}/licenses" />
         <mkdir dir="${netbeans.dest.dir}/licenses" />
 
-        <createlicensesummary licenseStub="${nb_all}/LICENSE" 
+        <createlicensesummary licenseStub="license-stub.txt"
                               noticeStub="notice-stub.txt" 
                               report="${nb.build.dir}/createlicensesummary.xml" 
                               nball=".." 
@@ -1678,7 +1678,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
             <include name="libs.antlr3.devel/external/binaries-list"/>
         </manifest>
     </downloadbinaries>
-    <createlicensesummary licenseStub="${nb_all}/LICENSE"
+    <createlicensesummary licenseStub="license-stub.txt"
                           noticeStub="notice-stub.txt"
                           report="${nb.build.dir}/createlicensesummary.xml"
                           nball=".."

--- a/nbbuild/license-stub.txt
+++ b/nbbuild/license-stub.txt
@@ -201,8 +201,3 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-********************************************************************************
-Apache NetBeans repository includes a number of source files that are not
-covered by the apache license. These files are refered to by licenseinfo.xml
-files which hold the license information.
-********************************************************************************


### PR DESCRIPTION
Before this changeset the LICENSE file from the root of the
repository/source directory was used to create the LICENSE file of the
binary build. This worked correctly for the repository because there
only the ALv2 is present, but a source config build in the LICENSE file
also the references to the license files for the embedded source files
with foreign licenses are included.

A binary build from a source config thus contains the license info of
the source config _and_ the binary build. This is not correct, as the
binary config can contains less source only files because they are only
required at build time.

To fix this, a new license-stub.txt is introduced, that only contains
the ALv2 regardless whether it comes from the repository or from a
source config build.