### PR TITLE
[NETBEANS-3909] SQL Execution should reuse Output Window if possible

### DIFF
--- a/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLEditorSupport.java
+++ b/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLEditorSupport.java
@@ -465,18 +465,19 @@ public class SQLEditorSupport extends DataEditorSupport
         ConnectionManager.getDefault().refreshConnectionInExplorer(dbconn);
     }
     
-    private SQLExecutionLoggerImpl createLogger() {
+    private SQLExecutionLoggerImpl getOrCreateLogger() {
         synchronized (loggerLock) {
-            closeLogger();
-
-            String loggerDisplayName;
-            if (isConsole()) {
-                loggerDisplayName = getDataObject().getName();
-            } else {
-                loggerDisplayName = getDataObject().getNodeDelegate().getDisplayName();
+            if (logger == null) {
+                String loggerDisplayName;
+                if (isConsole()) {
+                    loggerDisplayName = getDataObject().getName();
+                } else {
+                    loggerDisplayName = getDataObject().getNodeDelegate().getDisplayName();
+                }
+                logger = new SQLExecutionLoggerImpl(loggerDisplayName, this);
             }
 
-            return new SQLExecutionLoggerImpl(loggerDisplayName, this);
+            return logger;
         }
     }
     
@@ -484,6 +485,7 @@ public class SQLEditorSupport extends DataEditorSupport
         synchronized (loggerLock) {
             if (logger != null) {
                 logger.close();
+                logger = null;
             }
         }
     }
@@ -586,7 +588,7 @@ public class SQLEditorSupport extends DataEditorSupport
                     }
                     parent.closeExecutionResult();
 
-                    SQLExecutionLoggerImpl logger = parent.createLogger();
+                    SQLExecutionLoggerImpl logger = parent.getOrCreateLogger();
                     SQLExecutionResults executionResults = SQLExecuteHelper.execute(
                             sql, startOffset, endOffset, dbconn, logger, pageSize);
                     handleExecutionResults(executionResults, logger);

--- a/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLExecutionLoggerImpl.java
+++ b/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLExecutionLoggerImpl.java
@@ -47,7 +47,7 @@ public class SQLExecutionLoggerImpl implements SQLExecutionLogger {
     private int errorCount;
 
     @NbBundle.Messages({
-        "# {0} - the name of the executed SQL file", 
+        "# {0} - the name of the executed SQL file",
         "LBL_SQLFileExecution={0} execution"})
     public SQLExecutionLoggerImpl(String displayName, LineCookie lineCookie) {
         this.lineCookie = lineCookie;
@@ -81,6 +81,7 @@ public class SQLExecutionLoggerImpl implements SQLExecutionLogger {
             writer.println(LBL_ExecutionFinished(
                     executionTime / 1000d,
                     errorCount));
+            writer.println("");
         }
         inputOutput.select();
     }


### PR DESCRIPTION
When executing an SQL statement, each time a new exection is started by
the user a new output windows is created. This quickly clutters the
output window pane. Instead of this it would be better to reuse the
existings output window.