### PR TITLE
[NETBEANS-3558] Fix SpringFramework dispatcher servlet template

### DIFF
--- a/enterprise/spring.webmvc/licenseinfo.xml
+++ b/enterprise/spring.webmvc/licenseinfo.xml
@@ -24,10 +24,10 @@
     <fileset>
         <file>src/org/netbeans/modules/spring/webmvc/resources/templates/AbstractController.template</file>
         <file>src/org/netbeans/modules/spring/webmvc/resources/templates/SimpleFormController.template</file>
-        <file>src/org/netbeans/modules/spring/webmvc/resources/templates/applicationContext31.template</file>
-        <file>src/org/netbeans/modules/spring/webmvc/resources/templates/applicationContext40.template</file>
-        <file>src/org/netbeans/modules/spring/webmvc/resources/templates/dispatcher-servlet31.template</file>
-        <file>src/org/netbeans/modules/spring/webmvc/resources/templates/dispatcher-servlet40.template</file>
+        <file>src/org/netbeans/modules/spring/webmvc/resources/templates/applicationContext3.template</file>
+        <file>src/org/netbeans/modules/spring/webmvc/resources/templates/applicationContext4.template</file>
+        <file>src/org/netbeans/modules/spring/webmvc/resources/templates/dispatcher-servlet3.template</file>
+        <file>src/org/netbeans/modules/spring/webmvc/resources/templates/dispatcher-servlet4.template</file>
         <file>src/org/netbeans/modules/spring/webmvc/resources/templates/index.template</file>
         <file>src/org/netbeans/modules/spring/webmvc/resources/templates/redirect.template</file>
         <license ref="Apache-2.0-ASF" />

--- a/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/SpringConfigPanelVisual.java
+++ b/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/SpringConfigPanelVisual.java
@@ -23,9 +23,7 @@
 package org.netbeans.modules.spring.webmvc;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.ComboBoxModel;
@@ -50,7 +48,7 @@ public class SpringConfigPanelVisual extends javax.swing.JPanel {
     private static final Logger LOG = Logger.getLogger(SpringConfigPanelVisual.class.getName());
     private static final long serialVersionUID = 1L;
     private boolean libsInitialized = false;
-    private List<SpringLibrary> springLibs = new ArrayList<>();
+    private final List<SpringLibrary> springLibs = new ArrayList<>();
     private SpringLibrary springLibrary;
     private final SpringWebModuleExtender extender;
     private final ChangeSupport changeSupport = new ChangeSupport(this);

--- a/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/SpringWebModuleExtender.java
+++ b/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/SpringWebModuleExtender.java
@@ -339,15 +339,16 @@ public class SpringWebModuleExtender extends WebModuleExtender implements Change
             FileObject jsp = FileUtil.createFolder(webInf, "jsp");
             // COPY TEMPLATE SPRING RESOURCES (JSP, XML, PROPERTIES)
             DataFolder webInfDO = DataFolder.findFolder(webInf);
-            final List<File> newConfigFiles = new ArrayList<File>(2);
-            HashMap<String, Object> params = new HashMap<String, Object>();
-            String appContextTemplateName = "applicationContext-4.0.xml"; //NOI18N
-            String dispServletTemplateName = "dispatcher-servlet-4.0.xml"; //NOI18N
+            final List<File> newConfigFiles = new ArrayList<>(2);
+            HashMap<String, Object> params = new HashMap<>();
+            
+            String appContextTemplateName = "applicationContext-4.xml"; //NOI18N
+            String dispServletTemplateName = "dispatcher-servlet-4.xml"; //NOI18N
             if (version.startsWith("3.")) {    //NOI18N
-//                params.put("springVersion3", Boolean.TRUE); //NOI18N
-                appContextTemplateName = "applicationContext-3.1.xml"; //NOI18N
-                dispServletTemplateName = "dispatcher-servlet-3.1.xml"; //NOI18N
+                appContextTemplateName = "applicationContext-3.xml"; //NOI18N
+                dispServletTemplateName = "dispatcher-servlet-3.xml"; //NOI18N
             }
+            
             FileObject configFile = createFromTemplate(appContextTemplateName, webInfDO, "applicationContext",params); // NOI18N
             addFileToOpen(configFile);
             newConfigFiles.add(FileUtil.toFile(configFile));

--- a/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/WebProjectSpringConfigFileProvider.java
+++ b/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/WebProjectSpringConfigFileProvider.java
@@ -48,12 +48,13 @@ public class WebProjectSpringConfigFileProvider implements SpringConfigFileProvi
         this.project = project;
     }
 
+    @Override
     public Set<File> getConfigFiles() {
         FileObject webInf = getWebInf();
         if (webInf == null) {
             return Collections.emptySet();
         }
-        Set<File> result = new HashSet<File>();
+        Set<File> result = new HashSet<>();
         addFilesInWebInf(webInf, result);
         return Collections.unmodifiableSet(result);
     }
@@ -74,6 +75,7 @@ public class WebProjectSpringConfigFileProvider implements SpringConfigFileProvi
         }
     }
 
+    @Override
     public FileObject getLocation() {
         return getWebInf();
     }

--- a/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/resources/layer.xml
+++ b/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/resources/layer.xml
@@ -69,19 +69,19 @@
     </folder>
     <folder name="SpringFramework">
         <folder name="Templates">
-            <file name="applicationContext-3.1.xml" url="templates/applicationContext31.template">
+            <file name="applicationContext-3.xml" url="templates/applicationContext3.template">
                 <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                 <attr name="template" boolvalue="true"/>
             </file>
-            <file name="dispatcher-servlet-3.1.xml" url="templates/dispatcher-servlet31.template">
+            <file name="dispatcher-servlet-3.xml" url="templates/dispatcher-servlet3.template">
                 <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                 <attr name="template" boolvalue="true"/>
             </file>
-            <file name="applicationContext-4.0.xml" url="templates/applicationContext40.template">
+            <file name="applicationContext-4.xml" url="templates/applicationContext4.template">
                 <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                 <attr name="template" boolvalue="true"/>
             </file>
-            <file name="dispatcher-servlet-4.0.xml" url="templates/dispatcher-servlet40.template">
+            <file name="dispatcher-servlet-4.xml" url="templates/dispatcher-servlet4.template">
                 <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                 <attr name="template" boolvalue="true"/>
             </file>

--- a/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/resources/templates/applicationContext3.template
+++ b/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/resources/templates/applicationContext3.template
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="${project.encoding}"?>
+<?xml version='1.0' encoding='UTF-8' ?> 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.2.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.2.xsd">
 
     <!--bean id="propertyConfigurer"
           class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"

--- a/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/resources/templates/applicationContext4.template
+++ b/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/resources/templates/applicationContext4.template
@@ -1,13 +1,12 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!-- was: <?xml version="1.0" encoding="${project.encoding}"?> -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.3.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.3.xsd">
 
     <!--bean id="propertyConfigurer"
           class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"

--- a/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/resources/templates/dispatcher-servlet3.template
+++ b/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/resources/templates/dispatcher-servlet3.template
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="${project.encoding}"?>
+<?xml version='1.0' encoding='UTF-8' ?> 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.1.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.1.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.xsd
+       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-3.2.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-3.2.xsd">
 
     <bean class="org.springframework.web.servlet.mvc.support.ControllerClassNameHandlerMapping"/>
 

--- a/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/resources/templates/dispatcher-servlet4.template
+++ b/enterprise/spring.webmvc/src/org/netbeans/modules/spring/webmvc/resources/templates/dispatcher-servlet4.template
@@ -1,15 +1,12 @@
 <?xml version='1.0' encoding='UTF-8' ?>
-<!-- was: <?xml version="1.0" encoding="${project.encoding}"?> -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:p="http://www.springframework.org/schema/p"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.0.xsd
-       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
-
-    <bean class="org.springframework.web.servlet.mvc.support.ControllerClassNameHandlerMapping"/>
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+       http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-4.3.xsd
+       http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-4.3.xsd">
 
     <!--
     Most controllers will use the ControllerClassNameHandlerMapping above, but


### PR DESCRIPTION
Fixes issue related with introduction off SpringFramework 5: [NETBEANS-3558](https://issues.apache.org/jira/browse/NETBEANS-3558?focusedCommentId=17029730&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17029730)
- Remove `org.springframework.web.servlet.mvc.support.ControllerClassNameHandlerMapping` bean definition in `dispatcher-servlet.xml` for Spring 4 and Spring 5.
- Update XML Schema Definitions for the `dispatcher-servlet.xml` and `applicationContext.xml` templates to last version.
- Fix some warnings.