### PR TITLE
[NETBEANS-2613] Enable fetching schemas for urn schema

### DIFF
--- a/ide/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogModelImpl.java
+++ b/ide/xml.retriever/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogModelImpl.java
@@ -89,8 +89,8 @@ public class CatalogModelImpl implements CatalogModel {
     protected FileObject catalogFileObject = null;
     NbCatalogResolver catalogResolver;
     Catalog apacheCatalogResolverObj;
-    private boolean doFetch = true;
-    private boolean fetchSynchronous = false;
+    boolean doFetch = true;
+    boolean fetchSynchronous = false;
     private boolean registerInCatalog = true;
     
     /**
@@ -129,12 +129,21 @@ public class CatalogModelImpl implements CatalogModel {
      * Check if the URI conveys control information.
      * CC adds special query strings into the URI that must be cleared.
      */
-    private URI extractRealURI(URI locationURI) throws URISyntaxException {
+    URI extractRealURI(URI locationURI) throws URISyntaxException {
         URI realURI = locationURI;
-        String queryString = locationURI.getQuery();
+        // URI parsing is parsing broken on JDK and fails to parse URNs
+        // literal question marks should only be present in URIs when
+        // used as separators, so splitting at "?" should extract the
+        // queryString
+        String literalUri = locationURI.toString();
+        int questionMarkPos = literalUri.indexOf("?"); //NOI18N
+        String queryString = null;
+        if(questionMarkPos >= 0) {
+            queryString = literalUri.substring(questionMarkPos);
+        }
         if(queryString != null &&
-           queryString.indexOf("fetch=") != -1 && //NOI18N
-           queryString.indexOf("sync=") != -1) { //NOI18N
+           queryString.contains("fetch=") && //NOI18N
+           queryString.contains("sync=")) { //NOI18N
             int index = queryString.indexOf("fetch="); //NOI18N
             String temp = queryString.substring(index);
             String queries[] = temp.split("&"); //NOI18N

--- a/ide/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogModelImplTest.java
+++ b/ide/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/catalog/impl/CatalogModelImplTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.xml.retriever.catalog.impl;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CatalogModelImplTest {
+
+    public CatalogModelImplTest() {
+    }
+
+    @Test
+    public void testUriDecoding() throws URISyntaxException {
+        URI[] inputUri = new URI[] {
+            new URI("http://netbeans.apache.org/dummy?queryString=1"),
+            new URI("http://netbeans.apache.org/dummy?queryString=1&fetch=false&sync=true"),
+            new URI("file:///localfile"),
+            new URI("file:///localfile?fetch=false&sync=true"),
+            new URI("urn:demo:urn"),
+            new URI("urn:demo:urn?fetch=false&sync=false"),
+        };
+        URI[] outputURI = new URI[] {
+            new URI("http://netbeans.apache.org/dummy?queryString=1"),
+            new URI("http://netbeans.apache.org/dummy?queryString=1"),
+            new URI("file:///localfile"),
+            new URI("file:///localfile"),
+            new URI("urn:demo:urn"),
+            new URI("urn:demo:urn"),
+        };
+        boolean[] doFetch = new boolean[]{
+            true,
+            false,
+            true,
+            false,
+            true,
+            false
+        };
+        boolean[] fetchSynchronous = new boolean[] {
+            false,
+            true,
+            false,
+            true,
+            false,
+            false
+        };
+        for (int i = 0; i < inputUri.length; i++) {
+            CatalogModelImpl cmi = new CatalogModelImpl();
+            URI extractedURI = cmi.extractRealURI(inputUri[i]);
+            Assert.assertEquals("Entry " + i + " (URI)", outputURI[i], extractedURI);
+            Assert.assertEquals("Entry " + i + " (doFetch)", doFetch[i], cmi.doFetch);
+            Assert.assertEquals("Entry " + i + " (fetchSynchronous)", fetchSynchronous[i], cmi.fetchSynchronous);
+        }
+    }
+
+}


### PR DESCRIPTION
urn URIs are not correctly decoded by the JDK java.net.URI class.
It is expected that urn:xyz?fetch=true would result in an URI
reporting xyz as path and ?fetch=true as query string, but the
JDK reports null for both parts.

Instead of relying on URI class, acknowledge, that the extraction
of the relevant parts of the query string rely on direct manipulation
of the querystring, so getting the query string can take the same
code path.