### PR TITLE
[NETBEANS-3915] - Update JUnit from 5.5.2 to 5.6.0

### DIFF
--- a/java/maven/test/unit/src/org/netbeans/modules/maven/ActionProviderImplTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/ActionProviderImplTest.java
@@ -107,7 +107,7 @@ public class ActionProviderImplTest extends NbTestCase {
                 + "<groupId>test</groupId><artifactId>prj</artifactId>"
                 + "<version>1.0</version>"
                 + "<build><plugins><plugin><groupId>org.apache.maven.plugins</groupId><artifactId>maven-surefire-plugin</artifactId><version>2.22.2</version></plugin></plugins></build>"
-                + "<dependencies><dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-api</artifactId><version>5.5.2</version><scope>test</scope></dependency><dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-params</artifactId><version>5.5.2</version><scope>test</scope></dependency><dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-engine</artifactId><version>5.5.2</version><scope>test</scope></dependency></dependencies>"
+                + "<dependencies><dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-api</artifactId><version>5.6.0</version><scope>test</scope></dependency><dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-params</artifactId><version>5.6.0</version><scope>test</scope></dependency><dependency><groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-engine</artifactId><version>5.6.0</version><scope>test</scope></dependency></dependencies>"
                 + "<properties><netbeans.compile.on.save>none</netbeans.compile.on.save></properties>"
                 + "</project>");
         assertSupportsRunSingleMethod(ProjectManager.getDefault().findProject(FileUtil.toFileObject(getWorkDir())), true);

--- a/platform/junitlib/external/binaries-list
+++ b/platform/junitlib/external/binaries-list
@@ -16,9 +16,9 @@
 # under the License.
 A6C32B40BF3D76ECA54E3C601E5D1470C86FCDFA junit:junit:4.12:sources
 941A8BE4506C65F0A9001C08812FB7DA1E505E21 junit:junit:4.12:javadoc
-22B57242E953BF2DE96FD5A122BD697F18B2FCD2 org.junit.jupiter:junit-jupiter-api:5.5.2:sources
-D24A5A6853030EBB11DACE58BD5FA49F0BCE4D58 org.junit.jupiter:junit-jupiter-api:5.5.2:javadoc
-F68669855D3DCFD6F6087FAF53A5A503DEF5D09B org.junit.jupiter:junit-jupiter-params:5.5.2:sources
-E94D6EA9D7460B9460114A009857D5588F8DC1BA org.junit.jupiter:junit-jupiter-params:5.5.2:javadoc
-44D1543A802A072D87CC146D9D96223D61683617 org.junit.jupiter:junit-jupiter-engine:5.5.2:sources
-EEAA786F518DDE7B0298A08426A349B55728D7D9 org.junit.jupiter:junit-jupiter-engine:5.5.2:javadoc
+EECCE5DA465F85A39FDD55F39A55591290170FAE org.junit.jupiter:junit-jupiter-api:5.6.0:sources
+9FF3C4B16802300C00C765F5D134D22291C98B34 org.junit.jupiter:junit-jupiter-api:5.6.0:javadoc
+6F38FDB1F7E00CEB6AA6F7DB54B1EE92CB196257 org.junit.jupiter:junit-jupiter-params:5.6.0:sources
+82B86EA526559DD1C1E2D7BD748CEA63AA7D067D org.junit.jupiter:junit-jupiter-params:5.6.0:javadoc
+9001C3C1E19E10FD2D0CF3C0E9CD9EAE96A6666E org.junit.jupiter:junit-jupiter-engine:5.6.0:sources
+2960C0C3D45F9F0078E75549C2FB479A73AF8BE4 org.junit.jupiter:junit-jupiter-engine:5.6.0:javadoc

--- a/platform/junitlib/external/junit-jupiter-api-5.6.0-license.txt
+++ b/platform/junitlib/external/junit-jupiter-api-5.6.0-license.txt
@@ -1,9 +1,9 @@
 Name: JUnit Jupiter API
-Version: 5.5.2
+Version: 5.6.0
 License: EPL-v20
 Description: JUnit Jupiter API
 Origin: JUnit
-Files: junit-jupiter-api-5.5.2-sources.jar junit-jupiter-api-5.5.2-javadoc.jar
+Files: junit-jupiter-api-5.6.0-sources.jar junit-jupiter-api-5.6.0-javadoc.jar
 
 
 Eclipse Public License - v 2.0

--- a/platform/junitlib/external/junit-jupiter-engine-5.6.0-license.txt
+++ b/platform/junitlib/external/junit-jupiter-engine-5.6.0-license.txt
@@ -1,10 +1,9 @@
-Name: JUnit Jupiter
-Version: 5.5.2
-Files: junit-jupiter-api-5.5.2.jar junit-jupiter-params-5.5.2.jar junit-jupiter-engine-5.5.2.jar
+Name: JUnit Jupiter Engine
+Version: 5.6.0
 License: EPL-v20
-Description: JUnit Jupiter
+Description: JUnit Jupiter Engine
 Origin: JUnit
-URL: https://search.maven.org/search?q=g:org.junit.jupiter%20AND%20v:5.5.2
+Files: junit-jupiter-engine-5.6.0-sources.jar junit-jupiter-engine-5.6.0-javadoc.jar
 
 Eclipse Public License - v 2.0
 THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.

--- a/platform/junitlib/external/junit-jupiter-params-5.6.0-license.txt
+++ b/platform/junitlib/external/junit-jupiter-params-5.6.0-license.txt
@@ -1,9 +1,9 @@
-Name: JUnit Jupiter Engine
-Version: 5.5.2
+Name: JUnit Jupiter Params
+Version: 5.6.0
 License: EPL-v20
-Description: JUnit Jupiter Engine
+Description: JUnit Jupiter Params
 Origin: JUnit
-Files: junit-jupiter-engine-5.5.2-sources.jar junit-jupiter-engine-5.5.2-javadoc.jar
+Files: junit-jupiter-params-5.6.0-sources.jar junit-jupiter-params-5.6.0-javadoc.jar
 
 Eclipse Public License - v 2.0
 THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.

--- a/platform/junitlib/nbproject/project.properties
+++ b/platform/junitlib/nbproject/project.properties
@@ -19,20 +19,20 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 release.external/junit-4.12-sources.jar=docs/junit-4.12-sources.jar
 release.external/junit-4.12-javadoc.jar=docs/junit-4.12-javadoc.jar
-release.external/junit-jupiter-api-5.5.2-sources.jar=docs/junit-jupiter-api-5.5.2-sources.jar
-release.external/junit-jupiter-api-5.5.2-javadoc.jar=docs/junit-jupiter-api-5.5.2-javadoc.jar
-release.external/junit-jupiter-params-5.5.2-sources.jar=docs/junit-jupiter-params-5.5.2-sources.jar
-release.external/junit-jupiter-params-5.5.2-javadoc.jar=docs/junit-jupiter-params-5.5.2-javadoc.jar
-release.external/junit-jupiter-engine-5.5.2-sources.jar=docs/junit-jupiter-engine-5.5.2-sources.jar
-release.external/junit-jupiter-engine-5.5.2-javadoc.jar=docs/junit-jupiter-engine-5.5.2-javadoc.jar
+release.external/junit-jupiter-api-5.6.0-sources.jar=docs/junit-jupiter-api-5.6.0-sources.jar
+release.external/junit-jupiter-api-5.6.0-javadoc.jar=docs/junit-jupiter-api-5.6.0-javadoc.jar
+release.external/junit-jupiter-params-5.6.0-sources.jar=docs/junit-jupiter-params-5.6.0-sources.jar
+release.external/junit-jupiter-params-5.6.0-javadoc.jar=docs/junit-jupiter-params-5.6.0-javadoc.jar
+release.external/junit-jupiter-engine-5.6.0-sources.jar=docs/junit-jupiter-engine-5.6.0-sources.jar
+release.external/junit-jupiter-engine-5.6.0-javadoc.jar=docs/junit-jupiter-engine-5.6.0-javadoc.jar
 nbm.target.cluster=java
 nbm.is.global=false
 jnlp.indirect.jars=\
     docs/junit-4.12-sources.jar,\
     docs/junit-4.12-javadoc.jar,\
-    docs/junit-jupiter-api-5.5.2-sources.jar,\
-    docs/junit-jupiter-api-5.5.2-javadoc.jar,\
-    docs/junit-jupiter-params-5.5.2-sources.jar,\
-    docs/junit-jupiter-params-5.5.2-javadoc.jar,\
-    docs/junit-jupiter-engine-5.5.2-sources.jar,\
-    docs/junit-jupiter-engine-5.5.2-javadoc.jar
+    docs/junit-jupiter-api-5.6.0-sources.jar,\
+    docs/junit-jupiter-api-5.6.0-javadoc.jar,\
+    docs/junit-jupiter-params-5.6.0-sources.jar,\
+    docs/junit-jupiter-params-5.6.0-javadoc.jar,\
+    docs/junit-jupiter-engine-5.6.0-sources.jar,\
+    docs/junit-jupiter-engine-5.6.0-javadoc.jar

--- a/platform/junitlib/src/org/netbeans/modules/junitlib/Bundle.properties
+++ b/platform/junitlib/src/org/netbeans/modules/junitlib/Bundle.properties
@@ -20,5 +20,5 @@ OpenIDE-Module-Short-Description=Bundles the JUnit testing library.
 OpenIDE-Module-Long-Description=\
     Includes the JUnit unit testing library and corresponding library definition. Versions 4.x/5.x are included.
 junit_4=JUnit 4.12
-junit_5=JUnit 5.5.2
+junit_5=JUnit 5.6.0
 hamcrest=Hamcrest 1.3

--- a/platform/junitlib/src/org/netbeans/modules/junitlib/junit_5.xml
+++ b/platform/junitlib/src/org/netbeans/modules/junitlib/junit_5.xml
@@ -25,29 +25,29 @@
     <localizing-bundle>org.netbeans.modules.junitlib.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.libs.junit5/modules/ext/junit-jupiter-api-5.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.libs.junit5/modules/ext/junit-jupiter-params-5.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.libs.junit5/modules/ext/junit-jupiter-engine-5.5.2.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.junit5/modules/ext/junit-jupiter-api-5.6.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.junit5/modules/ext/junit-jupiter-params-5.6.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.libs.junit5/modules/ext/junit-jupiter-engine-5.6.0.jar!/</resource>
     </volume>
     <volume>
         <type>javadoc</type>
-        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-api-5.5.2-javadoc.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-params-5.5.2-javadoc.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-engine-5.5.2-javadoc.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-api-5.6.0-javadoc.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-params-5.6.0-javadoc.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-engine-5.6.0-javadoc.jar!/</resource>
     </volume>
     <volume>
         <type>src</type>
-        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-api-5.5.2-sources.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-params-5.5.2-sources.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-engine-5.5.2-sources.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-api-5.6.0-sources.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-params-5.6.0-sources.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.junitlib/docs/junit-jupiter-engine-5.6.0-sources.jar!/</resource>
     </volume>
     <properties>
         <property>
             <name>maven-dependencies</name>
             <value>
-                org.junit.jupiter:junit-jupiter-api:5.5.2:jar
-                org.junit.jupiter:junit-jupiter-params:5.5.2:jar
-                org.junit.jupiter:junit-jupiter-engine:5.5.2:jar
+                org.junit.jupiter:junit-jupiter-api:5.6.0:jar
+                org.junit.jupiter:junit-jupiter-params:5.6.0:jar
+                org.junit.jupiter:junit-jupiter-engine:5.6.0:jar
             </value>
         </property>
     </properties>

--- a/platform/libs.junit5/external/binaries-list
+++ b/platform/libs.junit5/external/binaries-list
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-6393DB7E4C0265152D8FC4FF146633D1A7D36C47 org.junit.jupiter:junit-jupiter-api:5.5.2
-E0659722923BD9FDFA08602E2DA22BD5A9D354E8 org.junit.jupiter:junit-jupiter-params:5.5.2
-F597408BDE45371548F9E9791DA7981A1134328D org.junit.jupiter:junit-jupiter-engine:5.5.2
+F29E6318333D2303CE4965C9819CFAD08DE7D1E5 org.junit.jupiter:junit-jupiter-api:5.6.0
+B28E078D4E8424DE01DF02EC92410D225E5D6444 org.junit.jupiter:junit-jupiter-params:5.6.0
+83C9E737F6015D9E00029B9B1D51E952A884B8F9 org.junit.jupiter:junit-jupiter-engine:5.6.0

--- a/platform/libs.junit5/external/junit-jupiter-5.6.0-license.txt
+++ b/platform/libs.junit5/external/junit-jupiter-5.6.0-license.txt
@@ -1,9 +1,10 @@
-Name: JUnit Jupiter Params
-Version: 5.5.2
+Name: JUnit Jupiter
+Version: 5.6.0
+Files: junit-jupiter-api-5.6.0.jar junit-jupiter-params-5.6.0.jar junit-jupiter-engine-5.6.0.jar
 License: EPL-v20
-Description: JUnit Jupiter Params
+Description: JUnit Jupiter
 Origin: JUnit
-Files: junit-jupiter-params-5.5.2-sources.jar junit-jupiter-params-5.5.2-javadoc.jar
+URL: https://search.maven.org/search?q=g:org.junit.jupiter%20AND%20v:5.6.0
 
 Eclipse Public License - v 2.0
 THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (“AGREEMENT”). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.

--- a/platform/libs.junit5/nbproject/project.properties
+++ b/platform/libs.junit5/nbproject/project.properties
@@ -16,9 +16,9 @@
 # under the License.
 
 is.autoload=true
-release.external/junit-jupiter-api-5.5.2.jar=modules/ext/junit-jupiter-api-5.5.2.jar
-release.external/junit-jupiter-params-5.5.2.jar=modules/ext/junit-jupiter-params-5.5.2.jar
-release.external/junit-jupiter-engine-5.5.2.jar=modules/ext/junit-jupiter-engine-5.5.2.jar
+release.external/junit-jupiter-api-5.6.0.jar=modules/ext/junit-jupiter-api-5.6.0.jar
+release.external/junit-jupiter-params-5.6.0.jar=modules/ext/junit-jupiter-params-5.6.0.jar
+release.external/junit-jupiter-engine-5.6.0.jar=modules/ext/junit-jupiter-engine-5.6.0.jar
 nbm.target.cluster=platform
 sigtest.skip.check=true
 sigtest.fail.on.error=false

--- a/platform/libs.junit5/nbproject/project.xml
+++ b/platform/libs.junit5/nbproject/project.xml
@@ -43,16 +43,16 @@
                 <package>org.junit.jupiter.engine.script</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/junit-jupiter-api-5.5.2.jar</runtime-relative-path>
-                <binary-origin>external/junit-jupiter-api-5.5.2.jar</binary-origin>
+                <runtime-relative-path>ext/junit-jupiter-api-5.6.0.jar</runtime-relative-path>
+                <binary-origin>external/junit-jupiter-api-5.6.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/junit-jupiter-params-5.5.2.jar</runtime-relative-path>
-                <binary-origin>external/junit-jupiter-params-5.5.2.jar</binary-origin>
+                <runtime-relative-path>ext/junit-jupiter-params-5.6.0.jar</runtime-relative-path>
+                <binary-origin>external/junit-jupiter-params-5.6.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/junit-jupiter-engine-5.5.2.jar</runtime-relative-path>
-                <binary-origin>external/junit-jupiter-engine-5.5.2.jar</binary-origin>
+                <runtime-relative-path>ext/junit-jupiter-engine-5.6.0.jar</runtime-relative-path>
+                <binary-origin>external/junit-jupiter-engine-5.6.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Notes:
- Improved reporting for failures during test discovery/execution
- Modular Javadoc
- OSGi metadata is now published in all binary JARs
- Gradle Module Metadata is now published for all artifacts
- Performance improvements and bug fixes for the Vintage engine
- Minor bug fixes and improvements

[JUnit Web Page](https://junit.org)
[Release Notes](https://junit.org/junit5/docs/5.6.0/release-notes/)