### PR TITLE
[NETBEANS-2446] Use *parent* of saved projectFolder as projectLocation

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
@@ -509,13 +509,14 @@ public class BasicPanelVisual extends JPanel implements DocumentListener, Window
         }
         String name = projectNameTextField.getText().trim();
         String folder = createdFolderTextField.getText().trim();
-        final File parentFolder = new File(folder);
+        final File projectFolder = new File(folder);
         
-        d.putProperty(CommonProjectActions.PROJECT_PARENT_FOLDER, parentFolder);
+        // PROJECT_PARENT_FOLDER confusing, better name is PROJECT_BASE_FOLDER
+        d.putProperty(CommonProjectActions.PROJECT_PARENT_FOLDER, projectFolder);
         if (d instanceof TemplateWizard) {
             ((TemplateWizard) d).setTargetFolderLazy(() -> {
-                parentFolder.mkdirs();
-                return DataFolder.findFolder(FileUtil.toFileObject(parentFolder));
+                projectFolder.mkdirs();
+                return DataFolder.findFolder(FileUtil.toFileObject(projectFolder));
             });
         }
         d.putProperty("name", name); //NOI18N
@@ -561,10 +562,14 @@ public class BasicPanelVisual extends JPanel implements DocumentListener, Window
                 handle = null;
             }
         }        
-        File projectLocation = (File) settings.getProperty(CommonProjectActions.PROJECT_PARENT_FOLDER); //NOI18N
-        if (projectLocation == null || projectLocation.getParentFile() == null || !projectLocation.getParentFile().isDirectory()) {
+        // PROJECT_PARENT_FOLDER confusing, better name is PROJECT_BASE_FOLDER
+        File projectFolder = (File) settings.getProperty(CommonProjectActions.PROJECT_PARENT_FOLDER); //NOI18N
+        File projectLocation;
+        if (projectFolder == null || projectFolder.getParentFile() == null || !projectFolder.getParentFile().isDirectory()) {
             projectLocation = ProjectChooser.getProjectsFolder();
-        } 
+        } else {
+            projectLocation = projectFolder.getParentFile();
+        }
         this.projectLocationTextField.setText(projectLocation.getAbsolutePath());
         
         String projectName = (String) settings.getProperty("name"); //NOI18N


### PR DESCRIPTION
NOTE: this PR only addresses the problem caused by the first changeset listed. I'm filing a 2nd issue for the spurious directory creation which is the 2nd changeset. But I'm including it here for reference/completeness since it is in the issue report.

NETBEANS-2446 problem comes from two commits (seen in main-silver)
```
    changeset:   244321:021157efa98e
    parent:      244318:5036dc46020f
    user:        Milos Kleint <mkleint@netbeans.org>
    date:        Thu Jan 24 15:12:37 2013 +0100
    summary:     #217087 new wizard able to pick up the parent directory from Action's properties as initial value
```
and
```
    changeset:   301468:76d9cafcee35
    branch:      ArchetypesUI268677
    parent:      299970:0c5aa5cdb86a
    user:        Jaroslav Tulach <jtulach@netbeans.org>
    date:        Tue Oct 25 21:52:49 2016 +0200
    summary:     #268677: Recognizing .archetype template files and using them to instantiate projects via mvn archetype
```
The first change took out these two lines near the start of java/maven/.../BasicPanelVisual.read(WizardDescriptor settings)
```
        } else {
            projectLocation = projectLocation.getParentFile();
```
This is really unrelated to the overall changeset, except that PROJECT_PARENT_FOLDER is nearby.

Without these two lines, in NewProject > JavaWithMaven > JavaApplication, if you alternately click "next"/"back" you'll see
>    F:\tmp\proj1\proj1\proj1\proj1\

adding another "proj1" with each "next". Putting back these two lines fixes it.

The 2nd changeset problem (not addressed by this PR), "Recognizing .archetype template ...", causes spurious directory creation and makes the overall problem highly visible. This problem creates this deep directory tree even though finish is not pushed. Pushing cancel still creates directories.

The directory creation comes from java/maven/.../BasicPanelVisual.store(WizardDescriptor d)
```
    void store(WizardDescriptor d) {
        ...
        d.putProperty(CommonProjectActions.PROJECT_PARENT_FOLDER, parentFolder);
        if (d instanceof TemplateWizard) {
            parentFolder.mkdirs();
            ((TemplateWizard) d).setTargetFolder(DataFolder.findFolder(FileUtil.toFileObject(parentFolder)));
        }
```
The store method is called to save panel settings; it could be for cancel, finish, back, next.

I don't know if this code is for convenience, to avoid later calculations, or if it's required. I'll file a 2nd issue for this.
