### PR TITLE
[NETBEANS-3903] - Netbeans 11.2 fails to detect startup of Tomcat

### DIFF
--- a/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/Utils.java
+++ b/enterprise/tomcat5/src/org/netbeans/modules/tomcat5/util/Utils.java
@@ -78,7 +78,7 @@ public final class Utils {
                     BufferedReader in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
                     try {
                         // request
-                        out.println("HEAD /netbeans-tomcat-status-test HTTP/1.1\r\nHost: localhost:" + port + "\r\n"); // NOI18N
+                        out.println("HEAD /netbeans-tomcat-status-test HTTP/1.1\r\nHost: localhost:" + port + "\r\n\r\n"); // NOI18N
                         out.flush();
 
                         // response


### PR DESCRIPTION

+ Added new line to the HTTP head request to the Tomcat so it would 
    return successfully (according to HTTP specs)