### PR TITLE
[NETBEANS-3807] - cleanup ArrayList rawtype warnings..

### DIFF
--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/ui/branding/InternationalizationResourceBundleBrandingPanel.java
@@ -537,7 +537,7 @@ public class InternationalizationResourceBundleBrandingPanel extends AbstractBra
         }
 
         private void refreshList() {
-            List keys = new ArrayList();
+            List<Node> keys = new ArrayList<>();
             Node[] origChildren = original.getChildren().getNodes();
             for (Node node : origChildren) {
                 keys.add(node);

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/RunnerRestFetchLogData.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/RunnerRestFetchLogData.java
@@ -221,7 +221,7 @@ public class RunnerRestFetchLogData extends RunnerRest {
     protected boolean processResponse() {
         // Make ArrayList copy of stored lines. ArrayList allows better access
         // to log values.
-        List logLines = new ArrayList(lines.size());
+        List<String> logLines = new ArrayList<>(lines.size());
         for (String line : lines) {
             logLines.add(line);
         }

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java
@@ -192,7 +192,7 @@ public class SourceGroupSupport {
     private static List<SourceGroup> getTestTargets(SourceGroup sourceGroup, Map foldersToSourceGroupsMap) {
         final URL[] rootURLs = UnitTestForSourceQuery.findUnitTests(sourceGroup.getRootFolder());
         if (rootURLs.length == 0) {
-            return new ArrayList();
+            return new ArrayList<SourceGroup>();
         }
         List<SourceGroup> result = new ArrayList<>();
         List<FileObject> sourceRoots = getFileObjects(rootURLs, true);

--- a/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatter.java
+++ b/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatter.java
@@ -79,7 +79,7 @@ import org.openide.util.WeakListeners;
 public class ExtFormatter extends Formatter implements FormatLayer {
 
     /** List holding the format layers */
-    private List formatLayerList = new ArrayList();
+    private List<FormatLayer> formatLayerList = new ArrayList<>();
 
     /** Use this instead of testing by containsKey() */
     private static final Object NULL_VALUE = new Object();

--- a/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatTokenPositionSupport.java
+++ b/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/FormatTokenPositionSupport.java
@@ -20,6 +20,7 @@
 package org.netbeans.editor.ext;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.ArrayList;
 import javax.swing.text.Position;
 import org.netbeans.editor.TokenItem;
@@ -43,16 +44,16 @@ class FormatTokenPositionSupport {
     private SaveSet lastSet;
 
     /** Map holding the [token, token-position-list] pairs. */
-    private final HashMap<TokenItem, ArrayList> tokens2positionLists = new HashMap<>();
+    private final HashMap<TokenItem, List<ExtTokenPosition>> tokens2positionLists = new HashMap<>();
 
     FormatTokenPositionSupport(FormatWriter formatWriter) {
         this.formatWriter = formatWriter;
     }
 
-    private ArrayList getPosList(TokenItem token) {
-        ArrayList ret = (ArrayList)tokens2positionLists.get(token);
+    private List<ExtTokenPosition> getPosList(TokenItem token) {
+        List<ExtTokenPosition> ret = tokens2positionLists.get(token);
         if (ret == null) {
-            ret = new ArrayList(3);
+            ret = new ArrayList<>(3);
             tokens2positionLists.put(token, ret);
         }
         return ret;
@@ -77,7 +78,7 @@ class FormatTokenPositionSupport {
                     + " >= tokenLength=" + token.getImage().length()); // NOI18N
         }
 
-        ArrayList posList = getPosList(token);
+        List<ExtTokenPosition> posList = getPosList(token);
         int cnt = posList.size();
         ExtTokenPosition etp;
         for (int i = 0; i < cnt; i++) {
@@ -105,9 +106,9 @@ class FormatTokenPositionSupport {
         if (prevToken != null) {
             prevToken = formatWriter.findNonEmptyToken(prevToken, true);
         }
-        ArrayList posList = getPosList(token);
+        List<ExtTokenPosition> posList = getPosList(token);
         int len = posList.size();
-        ArrayList prevPosList = getPosList(prevToken);
+        List<ExtTokenPosition> prevPosList = getPosList(prevToken);
         for (int i = 0; i < len; i++) {
             ExtTokenPosition etp = (ExtTokenPosition)posList.get(i);
             if (etp.offset < startLength) { // move to prevToken
@@ -133,9 +134,9 @@ class FormatTokenPositionSupport {
         if (nextToken != null) {
             nextToken = formatWriter.findNonEmptyToken(nextToken, false);
         }
-        ArrayList nextPosList = getPosList(nextToken);
+        List<ExtTokenPosition> nextPosList = getPosList(nextToken);
 
-        ArrayList posList = getPosList(token);
+        List<ExtTokenPosition> posList = getPosList(token);
         int len = posList.size();
         int offset = token.getImage().length() - endLength;
         for (int i = 0; i < len; i++) {
@@ -153,7 +154,7 @@ class FormatTokenPositionSupport {
 
     /** Text in the token will be inserted. */
     synchronized void tokenTextInsert(TokenItem token, int offset, int length) {
-        ArrayList posList = getPosList(token);
+        List<ExtTokenPosition> posList = getPosList(token);
         int len = posList.size();
         // Add length to all positions after insertion point
         for (int i = 0; i < len; i++) {
@@ -186,10 +187,10 @@ class FormatTokenPositionSupport {
 
     /** Text in the token will be removed. */
     synchronized void tokenTextRemove(TokenItem token, int offset, int length) {
-        ArrayList posList = getPosList(token);
+        List<ExtTokenPosition> posList = getPosList(token);
         int len = posList.size();
         int newLen = token.getImage().length() - length;
-        ArrayList nextList = getPosList(token.getNext());
+        List<ExtTokenPosition> nextList = getPosList(token.getNext());
         for (int i = 0; i < len; i++) {
             ExtTokenPosition etp = (ExtTokenPosition)posList.get(i);
             if (etp.offset >= offset + length) { // move to nextToken
@@ -217,9 +218,9 @@ class FormatTokenPositionSupport {
         if (nextToken != null) {
             nextToken = formatWriter.findNonEmptyToken(nextToken, false);
         }
-        ArrayList nextPosList = getPosList(nextToken);
+        List<ExtTokenPosition> nextPosList = getPosList(nextToken);
 
-        ArrayList posList = getPosList(token);
+        List<ExtTokenPosition> posList = getPosList(token);
         int len = posList.size();
         for (int i = 0; i < len; i++) {
             ExtTokenPosition etp = (ExtTokenPosition)posList.get(i);
@@ -236,13 +237,13 @@ class FormatTokenPositionSupport {
     /** Given token was inserted into the chain */
     synchronized void tokenInsert(TokenItem token) {
         if (token.getImage().length() > 0) { // only for non-zero size
-            ArrayList posList = getPosList(token);
+            List<ExtTokenPosition> posList = getPosList(token);
 
             TokenItem nextToken = token.getNext();
             if (nextToken != null) {
                 nextToken = formatWriter.findNonEmptyToken(nextToken, false);
             }
-            ArrayList nextPosList = getPosList(nextToken);
+            List<ExtTokenPosition> nextPosList = getPosList(nextToken);
 
             int nextLen = nextPosList.size();
             for (int i = 0; i < nextLen; i++) {

--- a/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/CaretFoldExpanderImpl.java
+++ b/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/CaretFoldExpanderImpl.java
@@ -55,12 +55,12 @@ public final class CaretFoldExpanderImpl extends CaretFoldExpander {
                         endOffset = offset;
                     }
                     Iterator collapsedFoldIterator = FoldUtilities.collapsedFoldIterator(foldHierarchy, offset, endOffset);
-                    List foldsToExpand;
+                    List<Fold> foldsToExpand;
                     Fold lastFold;
                     boolean lastFoldExpandAdded = false;
                     if (collapsedFoldIterator.hasNext()) {
                         lastFold = (Fold) collapsedFoldIterator.next();
-                        foldsToExpand = new ArrayList(2);
+                        foldsToExpand = new ArrayList<>(2);
                     } else {
                         lastFold = null;
                         foldsToExpand = null;

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ViewModelListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ViewModelListener.java
@@ -551,7 +551,7 @@ public class ViewModelListener extends DebuggerManagerAdapter {
             models.add(joinLists(treeModelFilters));
         }
         synchronized (treeExpansionModels) {
-            models.add(new ArrayList(treeExpansionModels));
+            models.add(new ArrayList<Object>(treeExpansionModels));
         }
         synchronized (nodeModels) {
             models.add(joinLists(nodeModels));
@@ -563,25 +563,25 @@ public class ViewModelListener extends DebuggerManagerAdapter {
             models.add(joinLists(tableModels));
         }
         synchronized (tableModelFilters) {
-            models.add(new ArrayList(tableModelFilters));
+            models.add(new ArrayList<Object>(tableModelFilters));
         }
         synchronized (nodeActionsProviders) {
-            models.add(new ArrayList(nodeActionsProviders));
+            models.add(new ArrayList<Object>(nodeActionsProviders));
         }
         synchronized (nodeActionsProviderFilters) {
-            models.add(new ArrayList(nodeActionsProviderFilters));
+            models.add(new ArrayList<Object>(nodeActionsProviderFilters));
         }
         synchronized (columnModels) {
-            models.add(new ArrayList(columnModels));
+            models.add(new ArrayList<Object>(columnModels));
         }
         synchronized (mm) {
-            models.add(new ArrayList(mm));
+            models.add(new ArrayList<Object>(mm));
         }
         synchronized (treeExpansionModelFilters) {
-            models.add(new ArrayList(treeExpansionModelFilters));
+            models.add(new ArrayList<Object>(treeExpansionModelFilters));
         }
         synchronized (asynchModelFilters) {
-            models.add(new ArrayList(asynchModelFilters));
+            models.add(new ArrayList<Object>(asynchModelFilters));
         }
         synchronized (tableRenderers) {
             models.add(new ArrayList(tableRenderers));

--- a/ide/target.iterator/nbproject/project.properties
+++ b/ide/target.iterator/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/ide/target.iterator/src/org/netbeans/modules/target/iterator/api/BrowseFolders.java
+++ b/ide/target.iterator/src/org/netbeans/modules/target/iterator/api/BrowseFolders.java
@@ -25,6 +25,7 @@ import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyVetoException;
+import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -346,7 +347,7 @@ public class BrowseFolders extends JPanel implements ExplorerManager.Provider, L
             else {
                 FileObject files[] = fo.getChildren();
                 Arrays.sort(files,new BrowseFolders.FileObjectComparator());
-                ArrayList children = new ArrayList( files.length );
+                List<Key> children = new ArrayList<>(files.length);
                 
                 if (BrowseFolders.this.target==DataFolder.class)
                     for( int i = 0; i < files.length; i++ ) {

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogMounterModel.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogMounterModel.java
@@ -43,7 +43,7 @@ final class CatalogMounterModel extends Object {
     
     private ComboBoxModel cxModel = null;  // model containig CatalogMounterModel.Entries
     
-    private List changeListeners = new ArrayList(2);
+    private List<ChangeListener> changeListeners = new ArrayList<>(2);
         
     
     /** Creates new CatalogMounterModel */

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/PersistenceManager.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/PersistenceManager.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.ant.debugger.breakpoints;
 
 import java.beans.PropertyChangeEvent;
+import java.util.List;
 import java.util.ArrayList;
 import org.netbeans.api.debugger.Breakpoint;
 import org.netbeans.api.debugger.DebuggerEngine;
@@ -134,7 +135,7 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
         Breakpoint[] bs = DebuggerManager.getDebuggerManager ().
             getBreakpoints ();
         int i, k = bs.length;
-        ArrayList bb = new ArrayList ();
+        List<Breakpoint> bb = new ArrayList<>();
         for (i = 0; i < k; i++)
             // Don't store hidden breakpoints
             if (bs[i] instanceof AntBreakpoint)

--- a/java/dbschema/src/org/netbeans/modules/dbschema/DBMemoryCollection.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/DBMemoryCollection.java
@@ -70,7 +70,7 @@ class DBMemoryCollection {
             DBElement[] oldElements = getElements();
             int oldLength = (oldElements == null) ? 0 : oldElements.length;
             int newLength = (c == null) ? 0 : c.size();
-            List list = null;
+            List<DBElement> list = null;
 
             switch (action) {
                 case DBElement.Impl.ADD:
@@ -86,7 +86,7 @@ class DBMemoryCollection {
                     break;
                 case TableElement.Impl.REMOVE:
                     if (newLength > 0 && oldLength > 0) {
-                        list = new ArrayList(Arrays.asList(oldElements));
+                        list = new ArrayList<>(Arrays.asList(oldElements));
                         list.removeAll(c);
                         hasChange = true;
                     }

--- a/java/dbschema/src/org/netbeans/modules/dbschema/TableElement.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/TableElement.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.dbschema;
 
+import java.util.List;
 import java.util.ArrayList;
 import java.util.ResourceBundle;
 import java.text.MessageFormat;
@@ -367,14 +368,14 @@ public final class TableElement extends DBElement implements ColumnElementHolder
      * @param subtype the type of the key classes
 	 * @return the keys of the given subtype or <code>null</code> if not found
 	 */
-	private ArrayList getKeys(Class subtype) {
+	private List<KeyElement> getKeys(Class subtype) {
 		KeyElement[] keys = getKeys();
 
         if (keys == null)
             return null;
 
 		int i, count = keys.length;
-		ArrayList subKeys = new ArrayList(count);
+		List<KeyElement> subKeys = new ArrayList<>(count);
 
 		for (i = 0; i < count; i++) {
 			KeyElement key = keys[i];
@@ -390,7 +391,7 @@ public final class TableElement extends DBElement implements ColumnElementHolder
 	 * @return the foreign keys or <code>null</code> if not found
 	 */
 	public ForeignKeyElement[] getForeignKeys() {
-		ArrayList keys = getKeys(ForeignKeyElement.class);
+		List<KeyElement> keys = getKeys(ForeignKeyElement.class);
         
         if (keys == null)
             return null;
@@ -422,7 +423,7 @@ public final class TableElement extends DBElement implements ColumnElementHolder
 	 * @return the unique keys or <code>null</code> if not found
 	 */
 	public UniqueKeyElement[] getUniqueKeys() {
-		ArrayList keys = getKeys(UniqueKeyElement.class);
+		List<KeyElement> keys = getKeys(UniqueKeyElement.class);
 
 		if (keys == null)
             return null;

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementsCollection.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/DBElementsCollection.java
@@ -69,12 +69,12 @@ public class DBElementsCollection implements DBElementProperties {
         DBElement[] oldElements = getElements();
         int oldLength = (oldElements == null) ? 0 : oldElements.length;
         int newLength = (elems == null) ? 0 : elems.size();
-        List list = null;
+        List<DBElement> list = null;
             
         switch (action) {
             case DBElement.Impl.ADD:
                 if (newLength > 0) {
-                    list = ((oldLength == 0) ? new ArrayList() : new ArrayList(Arrays.asList(oldElements)));
+                    list = ((oldLength == 0) ? new ArrayList<DBElement>() : new ArrayList<DBElement>(Arrays.asList(oldElements)));
                     list.addAll(elems);
                     changed = true;
                 }

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -712,7 +712,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
     }
     
     private List getOracleRecycleBinTables() {
-        List result = new ArrayList();
+        List<String> result = new ArrayList<>();
         try {
             if ( dmd.getDatabaseMajorVersion() < 10 ) {
                 return Collections.EMPTY_LIST;

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/JavaProjectGenerator.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/JavaProjectGenerator.java
@@ -284,7 +284,6 @@ public class JavaProjectGenerator {
      */
     public static void putSourceViews(AntProjectHelper helper, List<SourceFolder> sources, String style) {
         //assert ProjectManager.mutex().isWriteAccess();
-        ArrayList list = new ArrayList();
         Element data = Util.getPrimaryConfigurationData(helper);
         Document doc = data.getOwnerDocument();
         Element viewEl = XMLUtil.findElement(data, "view", Util.NAMESPACE); // NOI18N
@@ -686,7 +685,6 @@ public class JavaProjectGenerator {
      */
     public static void putExports(AntProjectHelper helper, List<Export> exports) {
         //assert ProjectManager.mutex().isWriteAccess();
-        ArrayList list = new ArrayList();
         Element data = Util.getPrimaryConfigurationData(helper);
         Document doc = data.getOwnerDocument();
         
@@ -764,7 +762,6 @@ public class JavaProjectGenerator {
      */
     public static void putSubprojects(AntProjectHelper helper, List<String> subprojects) {
         //assert ProjectManager.mutex().isWriteAccess();
-        ArrayList list = new ArrayList();
         Element data = Util.getPrimaryConfigurationData(helper);
         Document doc = data.getOwnerDocument();
         Element subproject = XMLUtil.findElement(data, "subprojects", Util.NAMESPACE); // NOI18N

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
@@ -235,7 +235,7 @@ public class InspectAndRefactorPanel extends javax.swing.JPanel implements Popup
     }
     
     private static Object[] createArray(Object ... items) {
-        ArrayList a = new ArrayList();
+        List<Object> a = new ArrayList<>();
         for (Object o:items) {
             if (o!=null)
                 a.add(o);

--- a/java/jshell.support/src/org/netbeans/modules/jshell/project/JShellOptions2.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/project/JShellOptions2.java
@@ -79,7 +79,7 @@ public class JShellOptions2 extends javax.swing.JPanel implements ItemListener {
     private J2SECategoryExtensionProvider.ConfigChangeListener listener;
     private ChangeListener  changeListener;
     private Map<String, String> changedOptions = new HashMap<>();
-    private List<JComponent> hideControls = new ArrayList();
+    private List<JComponent> hideControls = new ArrayList<>();
     private ElementHandle<TypeElement> targetClass;
     private String oldText;
     private ClasspathInfo cpi;

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
@@ -66,7 +66,7 @@ public class SourceGroupSupport {
         SourceGroup[] sourceGroups = ProjectUtils.getSources(project).getSourceGroups(
                 JavaProjectConstants.SOURCES_TYPE_JAVA);
         Set testGroups = getTestSourceGroups(sourceGroups);
-        List result = new ArrayList();
+        List<SourceGroup> result = new ArrayList<>();
         for (int i = 0; i < sourceGroups.length; i++) {
             if (!testGroups.contains(sourceGroups[i])) {
                 result.add(sourceGroups[i]);

--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/ControllerGenerator.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/actions/ControllerGenerator.java
@@ -238,7 +238,7 @@ public class ControllerGenerator implements Task<WorkingCopy> {
             if (old instanceof Collection) {
                 c = (Collection)old;
             } else {
-                methods.put(key, c = new ArrayList());
+                methods.put(key, c = new ArrayList<Object>());
                 c.add(old);
             }
             c.add(mt);

--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxBean.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxBean.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.javafx2.editor.completion.beans;
 
+import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -454,7 +455,7 @@ public final class FxBean extends FxDefinition {
     
     @SuppressWarnings("unchecked")
     private void appendMap(StringBuilder sb, Map m) {
-        ArrayList al = new ArrayList(m.keySet());
+        List al = new ArrayList(m.keySet());
         Collections.sort(al);
         
         for (Object o : al) {

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabLayoutManager.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabLayoutManager.java
@@ -242,7 +242,7 @@ abstract class TabLayoutManager {
 
             final int tabCount = tabModel.size();
             final int rowCount = rows.size();
-            ArrayList<Integer>[] rowIndexes = new ArrayList[rowCount];
+            List<Integer>[] rowIndexes = new ArrayList[rowCount];
             for( int i=0; i<rowCount; i++ ) {
                 rowIndexes[i] = new ArrayList<Integer>( tabCount );
             }

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
@@ -803,7 +803,7 @@ public final class MultiViewPeer implements PropertyChangeListener {
     boolean canClose() {
         Collection col = model.getCreatedElements();
         Iterator it = col.iterator();
-        Collection badOnes = new ArrayList();
+        Collection<CloseOperationState> badOnes = new ArrayList<>();
         while (it.hasNext()) {
            MultiViewElement el = (MultiViewElement)it.next();
            CloseOperationState state = el.canCloseElement();
@@ -1067,7 +1067,7 @@ public final class MultiViewPeer implements PropertyChangeListener {
     
     private class DelegateUndoRedo implements UndoRedo {
         
-        private List listeners = new ArrayList();
+        private List<ChangeListener> listeners = new ArrayList<>();
         
         public boolean canUndo() {
             return privateGetUndoRedo().canUndo();
@@ -1104,7 +1104,7 @@ public final class MultiViewPeer implements PropertyChangeListener {
         }
         
         private void fireElementChange() {
-            Iterator it = new ArrayList(listeners).iterator();
+            Iterator it = new ArrayList<ChangeListener>(listeners).iterator();
             while (it.hasNext()) {
                 ChangeListener elem = (ChangeListener) it.next();
                 ChangeEvent event = new ChangeEvent(this);

--- a/platform/core.startup/src/org/netbeans/core/startup/layers/SessionManager.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/layers/SessionManager.java
@@ -19,6 +19,8 @@
 
 package org.netbeans.core.startup.layers;
 
+import java.util.List;
+import java.util.ArrayList;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
@@ -48,7 +50,7 @@ public final class SessionManager {
     private HashMap<String,FileSystem> layers = new HashMap<String,FileSystem>(); //<layer_key, fs>
     
     /** Utility field holding list of PropertyChangeListeners. */
-    private transient java.util.ArrayList<PropertyChangeListener> propertyChangeListeners;
+    private transient List<PropertyChangeListener> propertyChangeListeners;
     
     /** Creates new SessionManager */
     private SessionManager() {
@@ -98,7 +100,7 @@ public final class SessionManager {
      */
     public synchronized void addPropertyChangeListener(PropertyChangeListener listener) {
         if (propertyChangeListeners == null ) {
-            propertyChangeListeners = new java.util.ArrayList<PropertyChangeListener>();
+            propertyChangeListeners = new ArrayList<>();
         }
         propertyChangeListeners.add(listener);
     }
@@ -116,10 +118,10 @@ public final class SessionManager {
      * @param name the name to be fired
      */
     private void firePropertyChange(String name) {
-        java.util.ArrayList list;
+        List<PropertyChangeListener> list;
         synchronized (this) {
             if (propertyChangeListeners == null || propertyChangeListeners.size() == 0) return;
-            list = (java.util.ArrayList)propertyChangeListeners.clone();
+            list = new ArrayList<>(propertyChangeListeners);
         }
         java.beans.PropertyChangeEvent event = new java.beans.PropertyChangeEvent(this, name, null, null);
         for (int i = 0; i < list.size(); i++) {

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerNode.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerNode.java
@@ -90,7 +90,7 @@ public abstract class HeapWalkerNode extends CCTNode {
     }
     
     public static TreePath fromNode(TreeNode node, TreeNode root) {
-        List l = new ArrayList();
+        List<TreeNode> l = new ArrayList<>();
         while (node != root) {
             l.add(0, node);
             node = node.getParent();

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -980,7 +980,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
                     if (fncScope.isAnonymous()) {
                         // TODO we probably should not move the properties, or at least increase offset range
                         // of the singleton to fit offsets of these methods in the singleton object
-                        List<JsObject> properties = new ArrayList(fncScope.getProperties().values());
+                        List<JsObject> properties = new ArrayList<>(fncScope.getProperties().values());
                         for (JsObject property : properties) {
                             ModelUtils.moveProperty(singleton, property);
                         }
@@ -1450,11 +1450,9 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
             
             DeclarationScopeImpl currentBlockScope = parentFn;
             private boolean isParameterBlock = false;
-            private List<FunctionNode> declaredFunctions = new ArrayList();
-            private List<VarNode> declaredVars = new ArrayList();
-            
-            
-            
+            private List<FunctionNode> declaredFunctions = new ArrayList<>();
+            private List<VarNode> declaredVars = new ArrayList<>();
+
             private void handleDeclarations() {
                 if (!declaredFunctions.isEmpty() || !declaredVars.isEmpty()) {
                     for (FunctionNode fnNode : declaredFunctions) {
@@ -1568,7 +1566,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
             return;
         }
         // process parameters
-        List<Identifier> parameters = new ArrayList(fnNode.getParameters().size());
+        List<Identifier> parameters = new ArrayList<>(fnNode.getParameters().size());
         for(IdentNode node: fnNode.getParameters()) {
             Identifier param = create(parserResult, node);
             if (param != null && !node.isDestructuredParameter()) {
@@ -1850,7 +1848,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
         } else if (previousVisited instanceof ExportNode && ((ExportNode)previousVisited).isDefault()) { 
             // we are handling case: export default {}
             // the node should be visible in navigator
-            List<Identifier> fqName = new ArrayList(1);
+            List<Identifier> fqName = new ArrayList<>(1);
             fqName.add(new Identifier("default", OffsetRange.NONE)); // NOI18N
             JsObjectImpl objectScope = ModelElementFactory.create(parserResult, objectNode, fqName, modelBuilder, true); //ModelElementFactory.createAnonymousObject(parserResult, objectNode, modelBuilder);
             modelBuilder.setCurrentObject(objectScope);
@@ -2607,7 +2605,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
     }
 
     private List<Identifier> getName(PropertyNode propertyNode) {
-        List<Identifier> name = new ArrayList(1);
+        List<Identifier> name = new ArrayList<>(1);
         if (propertyNode.getGetter() != null || propertyNode.getSetter() != null) {
             // check whether this is not defining getter or setter of a property.
             Node previousNode = getPreviousFromPath(1);
@@ -2625,7 +2623,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
     }
 
     private static List<Identifier> getName(PropertyNode propertyNode, ParserResult parserResult) {
-        List<Identifier> name = new ArrayList(1);
+        List<Identifier> name = new ArrayList<>(1);
         if (propertyNode.getKey() instanceof IdentNode) {
             IdentNode ident = (IdentNode) propertyNode.getKey();
             name.add(new Identifier(ident.getName(), getOffsetRange(ident)));
@@ -2638,14 +2636,14 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
     }
 
     private static List<Identifier> getName(VarNode varNode, ParserResult parserResult) {
-        List<Identifier> name = new ArrayList();
+        List<Identifier> name = new ArrayList<>();
         name.add(new Identifier(varNode.getName().getName(),
                 new OffsetRange(varNode.getName().getStart(), varNode.getName().getFinish())));
         return name;
     }
 
     private static List<Identifier> getName(BinaryNode binaryNode, ParserResult parserResult) {
-        List<Identifier> name = new ArrayList();
+        List<Identifier> name = new ArrayList<>();
         Node lhs = binaryNode.lhs();
         if (lhs instanceof AccessNode) {
             name = getName((AccessNode)lhs, parserResult);
@@ -2678,7 +2676,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
     }
 
     private static List<Identifier> getName(AccessNode aNode, ParserResult parserResult) {
-        List<Identifier> name = new ArrayList();
+        List<Identifier> name = new ArrayList<>();
         name.add(new Identifier(aNode.getProperty(),
                 new OffsetRange(aNode.getFinish() - aNode.getProperty().length(), aNode.getFinish())));
         Node base = aNode.getBase();


### PR DESCRIPTION
This code was previously reverted because it was checked in by accident during the release window..
It's been re-based and tested.

This change cleans up the following warning..

  [repeat] /home/bwalker/src/netbeans/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java:1454: warning: [rawt
ypes] found raw type: ArrayList
  [repeat]             private List<VarNode> declaredVars = new ArrayList();
  [repeat]                                                      ^
  [repeat]   missing type arguments for generic class ArrayList<E>
  [repeat]   where E is a type-variable:
  [repeat]     E extends Object declared in class ArrayList