### PR TITLE
[NETBEANS-3923] - cleanup ThreadLocal rawtype warnings

### DIFF
--- a/ide/versioning.util/src/org/netbeans/modules/turbo/Memory.java
+++ b/ide/versioning.util/src/org/netbeans/modules/turbo/Memory.java
@@ -53,7 +53,7 @@ final class Memory {
     public static final Object NULL = new Object();
 
     /** Keep reference to last isPrepared result. */
-    public static final ThreadLocal prepared = new ThreadLocal();
+    public static final ThreadLocal<Entry> prepared = new ThreadLocal<>();
 
     private final Statistics statistics;
 
@@ -105,7 +105,7 @@ final class Memory {
         }
         putLive(key, attributes);
         minimalMap.put(key, attributes);
-        Entry entry = (Entry) prepared.get();
+        Entry entry = prepared.get();
         if (entry != null) {
             if (key.equals(entry.key) && name.equals(entry.name)) {
                 if (value != null) {
@@ -167,7 +167,7 @@ final class Memory {
         }
 
         // have not been promised by existsEntry but eliminated by GC?
-        Entry entry = (Entry) prepared.get();
+        Entry entry = prepared.get();
         if (entry != null) {
             if (key.equals(entry.key) && name.equals(entry.name)) {
                 prepared.set(null);  // here ends our promised contract
@@ -192,7 +192,7 @@ final class Memory {
         // keep promised value in tread local to survive paralell GC
         boolean isPrepared = attributes != null && attributes.keySet().contains(name);
         if (isPrepared) {
-            Entry entry = (Entry) prepared.get();
+            Entry entry = prepared.get();
             if (entry == null) {
                 entry = new Entry();
             }

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/ProvidedExtensionsProxy.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/ProvidedExtensionsProxy.java
@@ -41,7 +41,7 @@ import org.openide.filesystems.FileSystem;
  */
 public class ProvidedExtensionsProxy extends ProvidedExtensions {
     private Collection<BaseAnnotationProvider> annotationProviders;
-    private static ThreadLocal  reentrantCheck = new ThreadLocal();
+    private static ThreadLocal<Boolean>  reentrantCheck = new ThreadLocal<>();
     
     /** Creates a new instance of ProvidedExtensionsProxy */
     public ProvidedExtensionsProxy(Collection/*AnnotationProvider*/ annotationProviders) {

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/ProxyLookup.java
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/ProxyLookup.java
@@ -549,9 +549,9 @@ public class ProxyLookup extends Lookup {
             collectFires(null);
         }
         
-        private static ThreadLocal<R> IN = new ThreadLocal<R>();
+        private static ThreadLocal<R<?>> IN = new ThreadLocal<>();
         protected void collectFires(Collection<Object> evAndListeners) {
-            R prev = IN.get();
+            R<?> prev = IN.get();
             if (this == prev) {
 //                Thread.dumpStack();
                 return;

--- a/webcommon/javascript2.knockout/src/org/netbeans/modules/javascript2/knockout/index/KnockoutIndexer.java
+++ b/webcommon/javascript2.knockout/src/org/netbeans/modules/javascript2/knockout/index/KnockoutIndexer.java
@@ -55,7 +55,7 @@ public class KnockoutIndexer extends EmbeddingIndexer {
 
     private static final Logger LOG = Logger.getLogger(KnockoutIndexer.class.getName());
 
-    private static final ThreadLocal<Map<URI, Collection<KnockoutCustomElement>>> CUSTOM_ELEMENTS = new ThreadLocal();
+    private static final ThreadLocal<Map<URI, Collection<KnockoutCustomElement>>> CUSTOM_ELEMENTS = new ThreadLocal<>();
 
     @Override
     protected void index(Indexable indexable, Parser.Result parserResult, Context context) {


### PR DESCRIPTION
This removes all the ThreadLocal rawtype warnings..

   [repeat] /home/bwalker/src/netbeans/platform/masterfs/src/org/netbeans/modules/masterfs/ProvidedExtensionsProxy.java:44: warning: [rawtypes] found ra
w type: ThreadLocal
   [repeat]     private static ThreadLocal  reentrantCheck = new ThreadLocal();
   [repeat]                    ^
   [repeat]   missing type arguments for generic class ThreadLocal<T>
   [repeat]   where T is a type-variable:
   [repeat]     T extends Object declared in class ThreadLocal