### PR TITLE
[NETBEANS-3922] - Update maven-dependency-tree & maven-archetype-plugin

### DIFF
--- a/java/maven.embedder/external/binaries-list
+++ b/java/maven.embedder/external/binaries-list
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 A2AC1CD690AB4C80DEFE7F9BCE14D35934C35CEC jdom:jdom:1.0
-BF206C4AA93C74A739FBAF1F1C78E3AD5F167245 org.apache.maven.shared:maven-dependency-tree:2.0
+5D9CE6ADD7B714B8095F0E3E396C5E9F8C5DCFEF org.apache.maven.shared:maven-dependency-tree:2.2
 2DDF9BB8C3B41BC2891832A6D6FC25F8BF41D77F org.apache.maven:apache-maven:3.3.9:bin@zip

--- a/java/maven.embedder/external/maven-dependency-tree-2.2-license.txt
+++ b/java/maven.embedder/external/maven-dependency-tree-2.2-license.txt
@@ -1,7 +1,7 @@
 Name: Maven Dependency Tree
 Version: 2.2
 Description: Maven Dependency Tree
-License: Apache-2.2
+License: Apache-2.0
 Origin: Apache Software Foundation
 URL: https://maven.apache.org/
 

--- a/java/maven.embedder/external/maven-dependency-tree-2.2-license.txt
+++ b/java/maven.embedder/external/maven-dependency-tree-2.2-license.txt
@@ -1,9 +1,9 @@
 Name: Maven Dependency Tree
-Version: 2.0
+Version: 2.2
 Description: Maven Dependency Tree
-License: Apache-2.0
+License: Apache-2.2
 Origin: Apache Software Foundation
-URL: http://maven.apache.org/
+URL: https://maven.apache.org/
 
                                  Apache License
                            Version 2.0, January 2004

--- a/java/maven.embedder/manifest.mf
+++ b/java/maven.embedder/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven.embedder/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/embedder/Bundle.properties
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Specification-Version: 2.60
+OpenIDE-Module-Specification-Version: 2.61

--- a/java/maven.embedder/nbproject/project.properties
+++ b/java/maven.embedder/nbproject/project.properties
@@ -16,10 +16,10 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 release.external/jdom-1.0.jar=modules/ext/maven/jdom-1.0.jar
-release.external/maven-dependency-tree-2.0.jar=modules/ext/maven/maven-dependency-tree-2.0.jar
+release.external/maven-dependency-tree-2.2.jar=modules/ext/maven/maven-dependency-tree-2.2.jar
 bundled.maven=apache-maven-3.3.9
 extra.module.files=maven/
 nbm.executable.files=maven/bin/mvn,maven/bin/mvnDebug,maven/bin/mvnyjp

--- a/java/maven.embedder/nbproject/project.xml
+++ b/java/maven.embedder/nbproject/project.xml
@@ -265,8 +265,8 @@
                 <package>org.apache.maven.wagon.shared.http4</package>
             </friend-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/maven/maven-dependency-tree-2.0.jar</runtime-relative-path>
-                <binary-origin>external/maven-dependency-tree-2.0.jar</binary-origin>
+                <runtime-relative-path>ext/maven/maven-dependency-tree-2.2.jar</runtime-relative-path>
+                <binary-origin>external/maven-dependency-tree-2.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/maven/jdom-1.0.jar</runtime-relative-path>

--- a/java/maven/manifest.mf
+++ b/java/maven/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven/2
-OpenIDE-Module-Specification-Version: 2.136
+OpenIDE-Module-Specification-Version: 2.137
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/maven/layer.xml
 AutoUpdate-Show-In-Client: false

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenCommandSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenCommandSettings.java
@@ -65,7 +65,7 @@ public final class MavenCommandSettings {
                 toRet = "install:install-file";//NOI18N
             }
             else if (COMMAND_CREATE_ARCHETYPENG.equals(command)) {
-                toRet = "org.apache.maven.plugins:maven-archetype-plugin:2.4:generate"; // NOI18N
+                toRet = "org.apache.maven.plugins:maven-archetype-plugin:3.1.2:generate"; // NOI18N
             }
             else if (COMMAND_SCM_CHECKOUT.equals(command)) {
                 toRet = "scm:checkout";//NOI18N


### PR DESCRIPTION
Notes:

- maven-dependency-tree from 2.0 to 2.2
-- 2 Bugs Fixes
-- 1 Improvement
-- Build with java 7 instead of java 6
-- 2 New Features

[Maven Dependency Tree Release Notes](https://mail-archives.apache.org/mod_mbox/maven-announce/201409.mbox/%3C20140917202446.ED25A11952%40minotaur.apache.org%3E)
[Maven Dependency Tree Source Code](https://github.com/apache/maven-dependency-tree)
[Maven Dependency Tree apidocs](http://maven.apache.org/shared-archives/maven-dependency-tree-2.2/apidocs/)

- maven-archetype-plugin from 2.4 to 3.1.2
-- 29 Bugs Fixes
-- 23 Improvements
-- 2 New Features

[Release Notes 3.0.0](https://mail-archives.apache.org/mod_mbox/maven-announce/201702.mbox/%3Cop.yvj3qdiqkdkhrr%40desktop-2khsk44%3E)
[Release Notes 3.0.1](https://mail-archives.apache.org/mod_mbox/maven-announce/201704.mbox/%3Cop.yyjpvbcmkdkhrr%40desktop-2khsk44%3E)
[Release Notes 3.1.0](https://mail-archives.apache.org/mod_mbox/maven-announce/201904.mbox/%3Cop.z02rfzybkdkhrr%40desktop-2khsk44.dynamic.ziggo.nl%3E)
[Release Notes 3.1.1](https://mail-archives.apache.org/mod_mbox/maven-announce/201906.mbox/%3CCAKuVzBTycH4BiqgbPVmy-qgxmA8%2Bjf39y8R-oz%2BUU-Kqht3-dA%40mail.gmail.com%3E)
[Release Notes 3.1.2](https://mail-archives.apache.org/mod_mbox/maven-announce/201908.mbox/%3CCAKuVzBQLYGnTTGOS2v5d55YWPU-c5sdTpKC-yzn2QoaPfivZ3g%40mail.gmail.com%3E)

I test this updates by creating and deleting many random maven archetypes and with personal maven projects.