### PR TITLE
[NETBEANS-3332] Use the latest maven-nbm-plugin 4.4

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenNbModuleImpl.java
@@ -107,7 +107,7 @@ public class MavenNbModuleImpl implements NbModuleProvider {
     public static final String GROUPID_MOJO = "org.codehaus.mojo";
     public static final String GROUPID_APACHE = "org.apache.netbeans.utilities";
     public static final String NBM_PLUGIN = "nbm-maven-plugin";
-    public static final String LATEST_NBM_PLUGIN_VERSION = "4.3";
+    public static final String LATEST_NBM_PLUGIN_VERSION = "4.4";
     
     public static final String NETBEANSAPI_GROUPID = "org.netbeans.api";  
     

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardIterator.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardIterator.java
@@ -62,12 +62,12 @@ public class NbmWizardIterator implements WizardDescriptor.BackgroundInstantiati
     static {
         NB_MODULE_ARCH = new Archetype();
         NB_MODULE_ARCH.setGroupId("org.apache.netbeans.archetypes"); //NOI18N
-        NB_MODULE_ARCH.setVersion("1.17"); //NOI18N
+        NB_MODULE_ARCH.setVersion("1.18"); //NOI18N
         NB_MODULE_ARCH.setArtifactId("nbm-archetype"); //NOI18N
 
         NB_APP_ARCH = new Archetype();
         NB_APP_ARCH.setGroupId("org.apache.netbeans.archetypes"); //NOI18N
-        NB_APP_ARCH.setVersion("1.22"); //NOI18N
+        NB_APP_ARCH.setVersion("1.23"); //NOI18N
         NB_APP_ARCH.setArtifactId("netbeans-platform-app-archetype"); //NOI18N
 
     }


### PR DESCRIPTION
This PR updates the maven-nbm-plugin version to 4.4 when a user creates a new Maven based NetBeans project from the wizard. 

 **This PR requires that  nbm-archetype and netbeans-platform-app-archetype are updated, voted on, and published.** 

https://github.com/apache/netbeans-mavenutils-archetype-nbm-archetype/pull/1
https://github.com/apache/netbeans-mavenutils-archetype-nbm-suite-root/pull/1
https://github.com/apache/netbeans-mavenutils-archetype-netbeans-platform-app-archetype/pull/2