### PR TITLE
[NETBEANS-3918] defer creation of target folder until/if needed

### DIFF
--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -458,7 +458,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.61</specification-version>
+                        <specification-version>7.76</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
@@ -513,8 +513,10 @@ public class BasicPanelVisual extends JPanel implements DocumentListener, Window
         
         d.putProperty(CommonProjectActions.PROJECT_PARENT_FOLDER, parentFolder);
         if (d instanceof TemplateWizard) {
-            parentFolder.mkdirs();
-            ((TemplateWizard) d).setTargetFolder(DataFolder.findFolder(FileUtil.toFileObject(parentFolder)));
+            ((TemplateWizard) d).setTargetFolderLazy(() -> {
+                parentFolder.mkdirs();
+                return DataFolder.findFolder(FileUtil.toFileObject(parentFolder));
+            });
         }
         d.putProperty("name", name); //NOI18N
         if (d instanceof TemplateWizard) {

--- a/platform/openide.loaders/apichanges.xml
+++ b/platform/openide.loaders/apichanges.xml
@@ -85,6 +85,26 @@ is the proper place.
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
   <changes>
+      <change id="org.openide.loaders.TemplateWizard.setTargetFolderLazy">
+          <api name="loaders"/>
+          <summary>Support lazy creation of TargetFolder.</summary>
+          <version major="7" minor="76"/>
+          <date day="1" month="3" year="2020"/>
+          <author login="errael"/>
+          <compatibility addition="yes" binary="compatible" source="compatible"
+                         semantic="compatible" deprecation="no" deletion="no"
+                         modification="no"/>
+          <description>
+              <p>
+                  Creation of TargetFolder can be deferred by using
+                  <a href="@org-openide-loaders@/org/openide/loaders/TemplateWizard.html#setTargetFolderLazy-java.util.function.Supplier-">
+                  TemplateWizard.setTargetFolderLazy(Supplier&lt;DataFolder&gt;)
+                  </a>.
+              </p>
+          </description>
+          <class package="org.openide.loaders" name="TemplateWizard"/>
+          <issue number="NETBEANS-3918"/>
+      </change>
       <change id="org.openide.awt.Toolbar.toggle">
           <api name="awt"/>
           <summary>Separate template handling</summary>

--- a/platform/openide.loaders/manifest.mf
+++ b/platform/openide.loaders/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.loaders
-OpenIDE-Module-Specification-Version: 7.75
+OpenIDE-Module-Specification-Version: 7.76
 OpenIDE-Module-Localizing-Bundle: org/openide/loaders/Bundle.properties
 OpenIDE-Module-Provides: org.netbeans.modules.templates.v1_0
 OpenIDE-Module-Layer: org/netbeans/modules/openide/loaders/layer.xml

--- a/platform/openide.loaders/nbproject/project.properties
+++ b/platform/openide.loaders/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.main.page=org/openide/loaders/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml


### PR DESCRIPTION
Without this change, there is some directory creation in BasicPanelVisual.store, but that method is called in several situations where directory/DataFolder creation should not occur. This PR moves the creation code to TemplateWizard.getTargetFolder(), which defers the creation until needed. Unfortunately, with a breakpoint, I have not seen getTargetFolder() invoked when creating a maven project.

This PR is designed to preserve semantic; it is highly targeted and relatively simple. There may be better/simpler/more-direct fixes; but I am unfamiliar with the overall architecture; revset which introduced the spurious directory creation:

```
    changeset:   301468:76d9cafcee35
    branch:      ArchetypesUI268677
    parent:      299970:0c5aa5cdb86a
    user:        Jaroslav Tulach <jtulach@netbeans.org>
    date:        Tue Oct 25 21:52:49 2016 +0200
    summary:     #268677: Recognizing .archetype template files and using them to instantiate projects via mvn archetype
```

This simplest fix would be to simply remove the directory creation from BasicPanelVisual and not put it in getTargetFolder(). This would fix the cases I have seen; in those cases the directory is created by maven project instantiation and the data fold is not referenced. But this would not preserve semantics around TemplateWizard and DataFolder.

This PR also fixes [NETBEANS-3875] which is about failure of maven artifact creation.