### PR TITLE
[NETBEANS-3929] Adding the ability to delete a tag from a remote repo.

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/ui/push/PushAction.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/push/PushAction.java
@@ -159,8 +159,11 @@ public class PushAction extends SingleRepositoryAction {
         "# {0} - branch name", "MSG_PushAction.branchDeleted=Branch {0} deleted in the local repository.",
         "# {0} - branch name", "# {1} - branch head id", "# {2} - result of the update",
         "MSG_PushAction.updates.deleteBranch=Branch Delete : {0}\n"
-            + "Id            : {1}\n"
-            + "Result        : {2}\n",
+        + "Id            : {1}\n"
+        + "Result        : {2}\n",
+        "MSG_PushAction.updates.deleteTag=Tag Delete    : {0}\n"
+        + "Id            : {1}\n"
+        + "Result        : {2}\n",
         "# {0} - branch name", "# {1} - branch head id", "# {2} - result of the update",
         "MSG_PushAction.updates.addBranch=Branch Add : {0}\n"
             + "Id         : {1}\n"
@@ -341,10 +344,20 @@ public class PushAction extends SingleRepositoryAction {
                                 }
                             }
                         } else {
-                            logger.outputLine(NbBundle.getMessage(PushAction.class, "MSG_PushAction.updates.updateTag", new Object[] { //NOI18N
-                                update.getLocalName(), 
-                                update.getResult(),
-                            }));
+                            //tag deleting or updating
+                            if (update.getNewObjectId() == null && update.getOldObjectId() != null) {
+                                //deleting tag from remote
+                                logger.outputLine(NbBundle.getMessage(PushAction.class, "MSG_PushAction.updates.deleteTag", new Object[]{ //NOI18N
+                                    update.getRemoteName(),
+                                    update.getOldObjectId(),
+                                    update.getResult(),}));
+                            } else {
+                                //updating or adding tag to the remoteё
+                                logger.outputLine(NbBundle.getMessage(PushAction.class, "MSG_PushAction.updates.updateTag", new Object[]{ //NOI18N
+                                    update.getLocalName(),
+                                    update.getResult(),}));
+                            }
+
                         }
                     }
                 }

--- a/ide/git/src/org/netbeans/modules/git/ui/push/PushAction.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/push/PushAction.java
@@ -352,7 +352,7 @@ public class PushAction extends SingleRepositoryAction {
                                     update.getOldObjectId(),
                                     update.getResult(),}));
                             } else {
-                                //updating or adding tag to the remoteё
+                                //updating or adding tag to the remote
                                 logger.outputLine(NbBundle.getMessage(PushAction.class, "MSG_PushAction.updates.updateTag", new Object[]{ //NOI18N
                                     update.getLocalName(),
                                     update.getResult(),}));

--- a/ide/git/src/org/netbeans/modules/git/ui/push/PushBranchesStep.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/push/PushBranchesStep.java
@@ -99,10 +99,9 @@ public class PushBranchesStep extends AbstractWizardPanel implements WizardDescr
     }
 
     /**
-     * *
-     * @param cfg Congiruration of the remote repository including urls of
-     * remote
-     * @param branches list of all brances in the remote repo
+     *
+     * @param cfg configuration of the remote repository including URLs of remote
+     * @param branches list of all branches in the remote repo
      * @param tags list of all tags in the remote repo
      */
     public void fillRemoteBranches (final GitRemoteConfig cfg, final Map<String, GitBranch> branches,
@@ -163,7 +162,7 @@ public class PushBranchesStep extends AbstractWizardPanel implements WizardDescr
                         }
                         boolean preselected = !conflicted && updateNeeded;
 
-                        //add current brunch in the list for update or for adding
+                        //add current branch in the list for update or for adding
                         l.add(new PushMapping.PushBranchMapping(remoteBranch == null ? null : remoteBranch.getName(),
                                 remoteBranch == null ? null : remoteBranch.getId(),
                                 branch, conflicted, preselected, updateNeeded));

--- a/ide/git/src/org/netbeans/modules/git/ui/push/PushMapping.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/push/PushMapping.java
@@ -229,7 +229,6 @@ public abstract class PushMapping extends ItemSelector.Item {
         private final String remoteTagName;
 
         /**
-         * *
          * Tag that we need to delete in the remote repository
          *
          * @param remoteName remote tag name
@@ -245,8 +244,7 @@ public abstract class PushMapping extends ItemSelector.Item {
          * Adding or updating tag in the remote repository
          *
          * @param tag representation of a local tag
-         * @param remoteName remote tag name, can be null. If null than we crate
-         * tag.
+         * @param remoteName remote tag name, can be null. If null than we create tag.
          */
         public PushTagMapping (GitTag tag, String remoteName) {
             super("tags/" + tag.getTagName(), tag.getTaggedObjectId(), remoteName, false, false, remoteName != null); //NOI18N

--- a/ide/git/src/org/netbeans/modules/git/utils/GitUtils.java
+++ b/ide/git/src/org/netbeans/modules/git/utils/GitUtils.java
@@ -836,6 +836,7 @@ public final class GitUtils {
     public static final String REF_SPEC_DEL_PREFIX = ":refs/remotes/"; //NOI18N
     private static final String REF_PUSHSPEC_PATTERN = "refs/heads/{0}:refs/heads/{1}"; //NOI18N
     public static final String REF_PUSHSPEC_DEL_PREFIX = ":refs/heads/"; //NOI18N
+    public static final String REF_PUSHSPEC_DEL_TAG_PREFIX = ":refs/tags/"; //NOI18N
     private static final String REF_TAG_PUSHSPEC_PATTERN = "refs/tags/{0}:refs/tags/{0}"; //NOI18N
     private static final String REF_TAG_PUSHSPEC_PATTERN_FORCE = "+" + REF_TAG_PUSHSPEC_PATTERN; //NOI18N
 
@@ -861,6 +862,10 @@ public final class GitUtils {
 
     public static String getPushDeletedRefSpec (String remoteRepositoryBranchName) {
         return REF_PUSHSPEC_DEL_PREFIX + remoteRepositoryBranchName;
+    }
+
+    public static String getPushDeletedTagRefSpec(String remoteRepositoryBranchName) {
+        return REF_PUSHSPEC_DEL_TAG_PREFIX + remoteRepositoryBranchName;
     }
 
     public static String getPushTagRefSpec (String tagName, boolean forceUpdate) {

--- a/ide/libs.git/src/org/netbeans/libs/git/GitClassFactoryImpl.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/GitClassFactoryImpl.java
@@ -148,8 +148,8 @@ final class GitClassFactoryImpl extends GitClassFactory {
     }
 
     @Override
-    public GitTransportUpdate createTransportUpdate (URIish urI, RemoteRefUpdate update, Map<String, GitBranch> remoteBranches) {
-        return new GitTransportUpdate(urI, update, remoteBranches);
+    public GitTransportUpdate createTransportUpdate(URIish urI, RemoteRefUpdate update, Map<String, GitBranch> remoteBranches, Map<String, String> remoteTags) {
+        return new GitTransportUpdate(urI, update, remoteBranches, remoteTags);
     }
 
     @Override

--- a/ide/libs.git/src/org/netbeans/libs/git/GitTransportUpdate.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/GitTransportUpdate.java
@@ -74,14 +74,29 @@ public final class GitTransportUpdate {
         this.type = getType(update.getLocalName());
     }
 
-    GitTransportUpdate (URIish uri, RemoteRefUpdate update, Map<String, GitBranch> remoteBranches) {
+    /**
+     * *
+     *
+     * @param uri uri of the repo.
+     * @param update
+     * @param remoteBranches key value list of remote branches.
+     * @param remoteTags key value list of remote tags. Key - name of the tag,
+     * value - id (hash) of the tag.
+     */
+    GitTransportUpdate(URIish uri, RemoteRefUpdate update, Map<String, GitBranch> remoteBranches, Map<String, String> remoteTags) {
         this.localName = stripRefs(update.getSrcRef());
         this.remoteName = stripRefs(update.getRemoteName());
-        this.oldObjectId = getOldRevisionId(remoteBranches.get(remoteName));
+        this.type = getType(update.getRemoteName());
+        if (type == type.TAG) {
+            //get object id for deleted tag.
+            this.oldObjectId = remoteTags.get(remoteName);
+        } else {
+            this.oldObjectId = getOldRevisionId(remoteBranches.get(remoteName));
+        }
+
         this.newObjectId = update.getNewObjectId() == null || ObjectId.zeroId().equals(update.getNewObjectId()) ? null : update.getNewObjectId().getName();
         this.result = GitRefUpdateResult.valueOf(update.getStatus().name());
         this.uri = uri.toString();
-        this.type = getType(update.getRemoteName());
     }
     
     /**

--- a/ide/libs.git/src/org/netbeans/libs/git/GitTransportUpdate.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/GitTransportUpdate.java
@@ -75,13 +75,11 @@ public final class GitTransportUpdate {
     }
 
     /**
-     * *
      *
      * @param uri uri of the repo.
      * @param update
      * @param remoteBranches key value list of remote branches.
-     * @param remoteTags key value list of remote tags. Key - name of the tag,
-     * value - id (hash) of the tag.
+     * @param remoteTags key value list of remote tags. Key - name of the tag, value - id (hash) of the tag.
      */
     GitTransportUpdate(URIish uri, RemoteRefUpdate update, Map<String, GitBranch> remoteBranches, Map<String, String> remoteTags) {
         this.localName = stripRefs(update.getSrcRef());

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/GitClassFactory.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/GitClassFactory.java
@@ -109,7 +109,7 @@ public abstract class GitClassFactory {
 
     public abstract GitTransportUpdate createTransportUpdate (URIish urI, TrackingRefUpdate update);
 
-    public abstract GitTransportUpdate createTransportUpdate (URIish urI, RemoteRefUpdate update, Map<String, GitBranch> remoteBranches);
+    public abstract GitTransportUpdate createTransportUpdate(URIish urI, RemoteRefUpdate update, Map<String, GitBranch> remoteBranches, Map<String, String> remoteTags);
 
     public abstract GitUser createUser (PersonIdent personIdent);
 

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/PushCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/PushCommand.java
@@ -96,10 +96,11 @@ public class PushCommand extends TransportCommand {
             transport.setTagOpt(TagOpt.AUTO_FOLLOW);
             PushResult pushResult = transport.push(new DelegatingProgressMonitor(monitor), fetchSpecs.isEmpty() ? transport.findRemoteRefUpdatesFor(specs) : Transport.findRemoteRefUpdatesFor(getRepository(), specs, fetchSpecs));
             Map<String, GitBranch> remoteBranches = Utils.refsToBranches(pushResult.getAdvertisedRefs(), Constants.R_HEADS, getClassFactory());
+            Map<String, String> remoteTags = Utils.refsToTags(pushResult.getAdvertisedRefs());
             processMessages(pushResult.getMessages());
             Map<String, GitTransportUpdate> remoteRepositoryUpdates = new HashMap<String, GitTransportUpdate>(pushResult.getRemoteUpdates().size());
             for (RemoteRefUpdate update : pushResult.getRemoteUpdates()) {
-                GitTransportUpdate upd = getClassFactory().createTransportUpdate(transport.getURI(), update, remoteBranches);
+                GitTransportUpdate upd = getClassFactory().createTransportUpdate(transport.getURI(), update, remoteBranches, remoteTags);
                 remoteRepositoryUpdates.put(upd.getRemoteName(), upd);
             }
             Map<String, GitTransportUpdate> localRepositoryUpdates = new HashMap<String, GitTransportUpdate>(pushResult.getTrackingRefUpdates().size());


### PR DESCRIPTION
Adding the ability to delete a tag from a remote repository using integrated Git Client. Before a user could delete a branch but could not delete a tag. Now, when performing git push... a user can select locally deleted tag and Git Client will perform git push :refs/tags/{tag_name_to_delete}
I tested the implementation locally using GitHub. It looks like this:


![image](https://user-images.githubusercontent.com/1295142/75629689-1bd0b800-5bf5-11ea-84d0-0d744a5c2463.png)



It's my first PR so any feedback would be highly appreciated. 

