### PR TITLE
[NETBEANSINFRA-6] get latest archetype from maven repo

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardIterator.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardIterator.java
@@ -51,6 +51,8 @@ import org.openide.util.NbBundle.Messages;
 import static org.netbeans.modules.maven.apisupport.Bundle.*;
 import static org.netbeans.modules.maven.apisupport.MavenNbModuleImpl.APACHE_SNAPSHOT_REPO_ID;
 import org.netbeans.modules.maven.embedder.EmbedderFactory;
+import org.netbeans.modules.maven.indexer.api.NBVersionInfo;
+import org.netbeans.modules.maven.indexer.api.RepositoryQueries;
 import org.netbeans.spi.project.ui.support.CommonProjectActions;
 
 public class NbmWizardIterator implements WizardDescriptor.BackgroundInstantiatingIterator<WizardDescriptor> {
@@ -62,12 +64,12 @@ public class NbmWizardIterator implements WizardDescriptor.BackgroundInstantiati
     static {
         NB_MODULE_ARCH = new Archetype();
         NB_MODULE_ARCH.setGroupId("org.apache.netbeans.archetypes"); //NOI18N
-        NB_MODULE_ARCH.setVersion("1.17"); //NOI18N
+        NB_MODULE_ARCH.setVersion("1.18"); //NOI18N
         NB_MODULE_ARCH.setArtifactId("nbm-archetype"); //NOI18N
 
         NB_APP_ARCH = new Archetype();
         NB_APP_ARCH.setGroupId("org.apache.netbeans.archetypes"); //NOI18N
-        NB_APP_ARCH.setVersion("1.22"); //NOI18N
+        NB_APP_ARCH.setVersion("1.23"); //NOI18N
         NB_APP_ARCH.setArtifactId("netbeans-platform-app-archetype"); //NOI18N
 
     }
@@ -113,7 +115,21 @@ public class NbmWizardIterator implements WizardDescriptor.BackgroundInstantiati
                 LBL_CreateProjectStepNbm()
             };
     }
-    
+
+    private static void getLatestArchetypeVersion(Archetype archetype) {
+        RepositoryQueries.Result<NBVersionInfo> versionsResult = RepositoryQueries.getVersionsResult(archetype.getGroupId(), archetype.getArtifactId(), null);
+
+        if (versionsResult.isPartial()) {
+            versionsResult.waitForSkipped();
+        }
+
+        // Versions are sorted in descending order
+        List<NBVersionInfo> results = versionsResult.getResults();
+        if (!results.isEmpty()) {
+            archetype.setVersion(results.get(0).getVersion());
+        }
+    }
+
     @Override
     public Set<FileObject> instantiate() throws IOException {
         ProjectInfo vi = new ProjectInfo((String) wiz.getProperty("groupId"), (String) wiz.getProperty("artifactId"), (String) wiz.getProperty("version"), (String) wiz.getProperty("package")); //NOI18N
@@ -127,10 +143,11 @@ public class NbmWizardIterator implements WizardDescriptor.BackgroundInstantiati
             Map<String,String> additional = Collections.singletonMap("netbeansVersion", version); // NOI18N
             
             if (archetype == NB_MODULE_ARCH) {
+                getLatestArchetypeVersion(NB_MODULE_ARCH);
                 NBMNativeMWI.instantiate(vi, projFile, version, Boolean.TRUE.equals(wiz.getProperty(OSGIDEPENDENCIES)), null);
-                
+
             } else {
-            
+            getLatestArchetypeVersion(NB_APP_ARCH);
             ArchetypeWizards.createFromArchetype(projFile, vi, archetype, additional, true);
             List<ModelOperation<POMModel>> opers = new ArrayList<ModelOperation<POMModel>>();
             if (Boolean.TRUE.equals(wiz.getProperty(OSGIDEPENDENCIES))) {

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardIterator.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NbmWizardIterator.java
@@ -64,12 +64,12 @@ public class NbmWizardIterator implements WizardDescriptor.BackgroundInstantiati
     static {
         NB_MODULE_ARCH = new Archetype();
         NB_MODULE_ARCH.setGroupId("org.apache.netbeans.archetypes"); //NOI18N
-        NB_MODULE_ARCH.setVersion("1.18"); //NOI18N
+        NB_MODULE_ARCH.setVersion("1.17"); //NOI18N
         NB_MODULE_ARCH.setArtifactId("nbm-archetype"); //NOI18N
 
         NB_APP_ARCH = new Archetype();
         NB_APP_ARCH.setGroupId("org.apache.netbeans.archetypes"); //NOI18N
-        NB_APP_ARCH.setVersion("1.23"); //NOI18N
+        NB_APP_ARCH.setVersion("1.22"); //NOI18N
         NB_APP_ARCH.setArtifactId("netbeans-platform-app-archetype"); //NOI18N
 
     }


### PR DESCRIPTION
Query the maven repository to get the latest version of  nbm-archetype and netbeans-platform-app-archetype. If this fails for some reason it will use the hard coded version.

- nbm-archetype: 1.18 apache/netbeans-mavenutils-archetype-nbm-archetype#1
- netbeans-platform-app-archetype:  1.23 /apache/netbeans-mavenutils-archetype-netbeans-platform-app-archetype#2
