### PR TITLE
Get a file of all libraries during download

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
@@ -33,6 +33,8 @@ import java.math.BigInteger;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -91,6 +93,12 @@ public class DownloadBinaries extends Task {
      */
     public void setRepos(String repos) {
         this.repos = repos;
+    }
+    
+    private File report = null;
+    
+    public void setReportToFile(File file) {
+        this.report = file;
     }
     
     private final List<FileSet> manifests = new ArrayList<>();
@@ -161,6 +169,13 @@ public class DownloadBinaries extends Task {
                             } else {
                                 success &= fillInFile(hashAndFile[0], hashAndFile[1], manifest, () -> legacyDownload(hashAndFile[0] + "-" + hashAndFile[1]));
                             }
+                            if (report != null) {
+                                Files.write(
+                                        report.toPath(),
+                                        (hashAndFile[0] + ";" + hashAndFile[1] + ";" + include + "\n").getBytes(),
+                                        StandardOpenOption.APPEND);
+                            }
+                            
                         }
                     }
                 } catch (IOException x) {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java
@@ -141,6 +141,14 @@ public class DownloadBinaries extends Task {
     @Override
     public void execute() throws BuildException {
         boolean success = true;
+        if (report != null) {
+            try {
+                Files.deleteIfExists(report.toPath());
+                Files.createFile(report.toPath());
+            } catch (IOException x) {
+                throw new BuildException("Cannot create report file at : " + report + x, getLocation());
+            }
+        }
         for (FileSet fs : manifests) {
             DirectoryScanner scanner = fs.getDirectoryScanner(getProject());
             File basedir = scanner.getBasedir();
@@ -170,10 +178,7 @@ public class DownloadBinaries extends Task {
                                 success &= fillInFile(hashAndFile[0], hashAndFile[1], manifest, () -> legacyDownload(hashAndFile[0] + "-" + hashAndFile[1]));
                             }
                             if (report != null) {
-                                Files.write(
-                                        report.toPath(),
-                                        (hashAndFile[0] + ";" + hashAndFile[1] + ";" + include + "\n").getBytes(),
-                                        StandardOpenOption.APPEND);
+                                Files.write(report.toPath(), (hashAndFile[0] + ";" + hashAndFile[1] + ";" + include + "\n").getBytes("UTF-8"),StandardOpenOption.APPEND);
                             }
                             
                         }

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -197,8 +197,7 @@ metabuild.hash=${metabuild.hash}</echo>
   <target name="getgitinformation" depends="-git.up,-git.down" />
   <target name="download-all-extbins" unless="ext.binaries.downloaded" depends="bootstrap">
     <echo>Downloading external binaries (*/external/ directories)...</echo>
-    <delete file="${nb_all}/nbbuild/build/external.info" />
-    <touch file="${nb_all}/nbbuild/build/external.info" />
+    <!-- optionnal reporttofile used to speed resolving artefacts resolution for maven artefacts -->
     <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" reporttofile="${nb_all}/nbbuild/build/external.info" >
         <manifest dir="${nb_all}">
             <include name="**/external/binaries-list"/>

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -197,7 +197,9 @@ metabuild.hash=${metabuild.hash}</echo>
   <target name="getgitinformation" depends="-git.up,-git.down" />
   <target name="download-all-extbins" unless="ext.binaries.downloaded" depends="bootstrap">
     <echo>Downloading external binaries (*/external/ directories)...</echo>
-    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
+    <delete file="${nb_all}/nbbuild/build/external.info" />
+    <touch file="${nb_all}/nbbuild/build/external.info" />
+    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" reporttofile="${nb_all}/nbbuild/build/external.info" >
         <manifest dir="${nb_all}">
             <include name="**/external/binaries-list"/>
         </manifest>


### PR DESCRIPTION
little file generation to get all binaries-list in one file.
May save lots of time (15 per build) for Maven artefacts generation

related to: https://github.com/apache/netbeans-mavenutils-nb-repository-plugin/pull/2