### PR TITLE
[NETBEANS-1603] MySQL Procedures in DB Explorer

### DIFF
--- a/ide/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/mysql/MySQLSchema.java
+++ b/ide/db.metadata.model/src/org/netbeans/modules/db/metadata/model/jdbc/mysql/MySQLSchema.java
@@ -35,13 +35,12 @@ import org.netbeans.modules.db.metadata.model.jdbc.JDBCProcedure;
 import org.netbeans.modules.db.metadata.model.jdbc.JDBCSchema;
 
 /**
- *
- * @author David, Jiri Rechtacek
+ * @author David, Jiri Rechtacek, Stjepan Brbot
  */
 public class MySQLSchema extends JDBCSchema {
-    
+
     private static final Logger LOGGER = Logger.getLogger(MySQLSchema.class.getName());
-    
+
     public MySQLSchema(JDBCCatalog jdbcCatalog, String name, boolean _default, boolean synthetic) {
         super(jdbcCatalog, name, _default, synthetic);
     }
@@ -50,19 +49,20 @@ public class MySQLSchema extends JDBCSchema {
     protected void createProcedures() {
         LOGGER.log(Level.FINE, "Initializing MySQL procedures in {0}", this);
         Map<String, Procedure> newProcedures = new LinkedHashMap<String, Procedure>();
-        // routines
+        // information_schema.routines
         try {
             DatabaseMetaData dmd = jdbcCatalog.getJDBCMetadata().getDmd();
             Statement stmt = dmd.getConnection().createStatement();
-            ResultSet rs = stmt.executeQuery("SELECT NAME, TYPE" // NOI18N
-                                            + " FROM mysql.proc WHERE DB='" + jdbcCatalog.getName() + "'" // NOI18N
-                                            + " AND ( TYPE = 'PROCEDURE' OR TYPE = 'FUNCTION' )"); // NOI18N
+            ResultSet rs = stmt.executeQuery("SELECT routine_name,routine_type" // NOI18N
+                                           + " FROM information_schema.routines" // NOI18N
+                                           + " WHERE routine_type IN ('PROCEDURE','FUNCTION')" // NOI18N
+                                           + " AND routine_schema='" + jdbcCatalog.getName() + "'"); // NOI18N
             try {
                 while (rs.next()) {
-                    String procedureName = rs.getString("NAME"); // NOI18N
+                    String procedureName = rs.getString("routine_name"); // NOI18N
                     Procedure procedure = createJDBCProcedure(procedureName).getProcedure();
                     newProcedures.put(procedureName, procedure);
-                    LOGGER.log(Level.FINE, "Created MySQL procedure: {0}, type: {1}", new Object[]{procedure, rs.getString("TYPE")});
+                    LOGGER.log(Level.FINE, "Created MySQL procedure: {0}, type: {1}", new Object[]{procedure, rs.getString("routine_type")});
                 }
             } finally {
                 if (rs != null) {
@@ -77,11 +77,12 @@ public class MySQLSchema extends JDBCSchema {
         try {
             DatabaseMetaData dmd = jdbcCatalog.getJDBCMetadata().getDmd();
             Statement stmt = dmd.getConnection().createStatement();
-            ResultSet rs = stmt.executeQuery("SELECT TRIGGER_NAME" // NOI18N
-                                            + " FROM information_schema.triggers WHERE TRIGGER_SCHEMA='" + jdbcCatalog.getName() + "'"); // NOI18N
+            ResultSet rs = stmt.executeQuery("SELECT trigger_name" // NOI18N
+                                           + " FROM information_schema.triggers" // NOI18N
+                                           + " WHERE trigger_schema='" + jdbcCatalog.getName() + "'"); // NOI18N
             try {
                 while (rs.next()) {
-                    String procedureName = rs.getString("TRIGGER_NAME"); // NOI18N
+                    String procedureName = rs.getString("trigger_name"); // NOI18N
                     Procedure procedure = createJDBCProcedure(procedureName).getProcedure();
                     newProcedures.put(procedureName, procedure);
                     LOGGER.log(Level.FINE, "Created MySQL trigger: {0}", new Object[]{procedure});
@@ -97,7 +98,7 @@ public class MySQLSchema extends JDBCSchema {
         }
         procedures = Collections.unmodifiableMap(newProcedures);
     }
-    
+
     @Override
     protected JDBCProcedure createJDBCProcedure(String procedureName) {
         return new MySQLProcedure(this, procedureName);

--- a/ide/db/src/org/netbeans/modules/db/explorer/node/ProcedureParamNodeProvider.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/node/ProcedureParamNodeProvider.java
@@ -33,6 +33,7 @@ import org.netbeans.modules.db.metadata.model.api.MetadataModel;
 import org.netbeans.modules.db.metadata.model.api.MetadataModelException;
 import org.netbeans.modules.db.metadata.model.api.Parameter;
 import org.netbeans.modules.db.metadata.model.api.Procedure;
+import org.netbeans.modules.db.metadata.model.api.Value;
 import org.openide.nodes.Node;
 import org.openide.util.Lookup;
 
@@ -83,7 +84,7 @@ public class ProcedureParamNodeProvider extends NodeProvider {
                                 return ;
                             }
 
-                            /* TBD uncomment after issue 156304 is resolved.
+                            /* issue 156304 is resolved */
                             Value returnValue = procedure.getReturnValue();
                             if (returnValue != null) {
                                 MetadataElementHandle<Value> h = MetadataElementHandle.create(returnValue);
@@ -97,10 +98,8 @@ public class ProcedureParamNodeProvider extends NodeProvider {
                                     newList.add(ReturnValueNode.create(lookup, ProcedureParamNodeProvider.this));
                                 }
                             }
-                            */
 
                             Collection<Parameter> parameters = procedure.getParameters();
-
                             for (Parameter parameter : parameters) {
                                 MetadataElementHandle<Parameter> h = MetadataElementHandle.create(parameter);
                                 Collection<Node> matches = getNodes(h);


### PR DESCRIPTION
Changed the code inside NetBeans IDE module which was fetching mysql.proc table. The mysql.proc table does not exist in new MySQL databases any more and is replaced with several tables in INFORMATION_SCHEMA.

This code was successfully tested on old MySQL 5.1.5 database from 2010. and the current version MySQL 8.0.19. It was successfully tested on Oracle 11g too.

![MySQL-procedures-in-NetBeans-11 3](https://user-images.githubusercontent.com/1915443/76234593-34128980-622a-11ea-8727-129a7bc16632.png)
