### PR TITLE
[NETBEANS-3999] - Upgrade GraalVM from 19.3.0 to 19.3.1

### DIFF
--- a/ide/libs.graalsdk/external/binaries-list
+++ b/ide/libs.graalsdk/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-3821A19AF32F12D794E77762BE0F18D9BEC9A9C3 org.graalvm.sdk:graal-sdk:19.3.0
+8C28D9270C22D533149801D9262C64BE40F25601 org.graalvm.sdk:graal-sdk:19.3.1

--- a/ide/libs.graalsdk/external/graal-sdk-19.3.1-license.txt
+++ b/ide/libs.graalsdk/external/graal-sdk-19.3.1-license.txt
@@ -2,8 +2,8 @@ Name: Graal SDK and Truffle API
 Description: Graal SDK and Truffle API
 License: UPL
 Origin: https://github.com/oracle/graal
-Version: 19.3.0
-Files: truffle-api-19.3.0.jar
+Version: 19.3.1
+Files: graal-sdk-19.3.1.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/ide/libs.graalsdk/manifest.mf
+++ b/ide/libs.graalsdk/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.libs.graalsdk
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/graalsdk/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.5
+OpenIDE-Module-Specification-Version: 1.6
 OpenIDE-Module-Provides: org.netbeans.spi.scripting.EngineProvider
 OpenIDE-Module-Recommends: com.oracle.truffle.polyglot.PolyglotImpl

--- a/ide/libs.graalsdk/nbproject/project.properties
+++ b/ide/libs.graalsdk/nbproject/project.properties
@@ -19,7 +19,7 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/graal-sdk-19.3.0.jar=modules/ext/graal-sdk-19.3.0.jar
+release.external/graal-sdk-19.3.1.jar=modules/ext/graal-sdk-19.3.1.jar
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/libs.graalsdk/nbproject/project.xml
+++ b/ide/libs.graalsdk/nbproject/project.xml
@@ -80,8 +80,8 @@
                 <package>org.netbeans.libs.graalsdk</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/graal-sdk-19.3.0.jar</runtime-relative-path>
-                <binary-origin>external/graal-sdk-19.3.0.jar</binary-origin>
+                <runtime-relative-path>ext/graal-sdk-19.3.1.jar</runtime-relative-path>
+                <binary-origin>external/graal-sdk-19.3.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/webcommon/libs.graaljs/external/binaries-list
+++ b/webcommon/libs.graaljs/external/binaries-list
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-65984134F43A3A54FA9CB12577737E231E5DF360 org.graalvm.js:js:19.3.0
-1488B638A846E38BB87AD691037DD8D2347E22E1 org.graalvm.regex:regex:19.3.0
+F8459CE16538F099701EE8E6C88F73A38D7A0FEB org.graalvm.js:js:19.3.1
+6C66647CF105EB33BB225BF626229BF6279F79F1 org.graalvm.regex:regex:19.3.1
 00B56801548AEB2F75EE3FBB42B11790F07F7D0F com.ibm.icu:icu4j:65.1

--- a/webcommon/libs.graaljs/external/js-19.3.1-license.txt
+++ b/webcommon/libs.graaljs/external/js-19.3.1-license.txt
@@ -2,8 +2,8 @@ Name: Graal SDK and Truffle API
 Description: Graal SDK and Truffle API
 License: UPL
 Origin: https://github.com/oracle/graal
-Version: 19.3.0
-Files: graal-sdk-19.3.0.jar
+Version: 19.3.1
+Files: js-19.3.1.jar regex-19.3.1.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/webcommon/libs.graaljs/manifest.mf
+++ b/webcommon/libs.graaljs/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.libs.graaljs/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/graaljs/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.5
+OpenIDE-Module-Specification-Version: 1.6
 OpenIDE-Module-Provides: javax.script.ScriptEngine.js

--- a/webcommon/libs.graaljs/nbproject/project.properties
+++ b/webcommon/libs.graaljs/nbproject/project.properties
@@ -19,6 +19,6 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/js-19.3.0.jar=modules/ext/js-19.3.0.jar
-release.external/regex-19.3.0.jar=modules/ext/regex-19.3.0.jar
+release.external/js-19.3.1.jar=modules/ext/js-19.3.1.jar
+release.external/regex-19.3.1.jar=modules/ext/regex-19.3.1.jar
 release.external/icu4j-65.1.jar=modules/ext/icu4j-65.1.jar

--- a/webcommon/libs.graaljs/nbproject/project.xml
+++ b/webcommon/libs.graaljs/nbproject/project.xml
@@ -71,12 +71,12 @@
                 <package>com.oracle.js.parser.ir</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/js-19.3.0.jar</runtime-relative-path>
-                <binary-origin>external/js-19.3.0.jar</binary-origin>
+                <runtime-relative-path>ext/js-19.3.1.jar</runtime-relative-path>
+                <binary-origin>external/js-19.3.1.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/regex-19.3.0.jar</runtime-relative-path>
-                <binary-origin>external/regex-19.3.0.jar</binary-origin>
+                <runtime-relative-path>ext/regex-19.3.1.jar</runtime-relative-path>
+                <binary-origin>external/regex-19.3.1.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/icu4j-65.1.jar</runtime-relative-path>

--- a/webcommon/libs.truffleapi/external/binaries-list
+++ b/webcommon/libs.truffleapi/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-3DC77031E53473954C8DA0895F45A7449B07B021 org.graalvm.truffle:truffle-api:19.3.0
+F11E9FA49DF40AB8963000260E8DA989C88CF8D9 org.graalvm.truffle:truffle-api:19.3.1

--- a/webcommon/libs.truffleapi/external/truffle-api-19.3.1-license.txt
+++ b/webcommon/libs.truffleapi/external/truffle-api-19.3.1-license.txt
@@ -2,8 +2,8 @@ Name: Graal SDK and Truffle API
 Description: Graal SDK and Truffle API
 License: UPL
 Origin: https://github.com/oracle/graal
-Version: 19.3.0
-Files: js-19.3.0.jar regex-19.3.0.jar
+Version: 19.3.1
+Files: truffle-api-19.3.1.jar
 
 Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
 

--- a/webcommon/libs.truffleapi/manifest.mf
+++ b/webcommon/libs.truffleapi/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.libs.truffleapi
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/truffle/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.6
+OpenIDE-Module-Specification-Version: 1.7
 OpenIDE-Module-Provides: com.oracle.truffle.polyglot.PolyglotImpl

--- a/webcommon/libs.truffleapi/nbproject/project.properties
+++ b/webcommon/libs.truffleapi/nbproject/project.properties
@@ -19,4 +19,4 @@ javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 is.autoload=true
 
-release.external/truffle-api-19.3.0.jar=modules/ext/truffle-api-19.3.0.jar
+release.external/truffle-api-19.3.1.jar=modules/ext/truffle-api-19.3.1.jar

--- a/webcommon/libs.truffleapi/nbproject/project.xml
+++ b/webcommon/libs.truffleapi/nbproject/project.xml
@@ -50,8 +50,8 @@
                 <package>com.oracle.truffle.api.utilities</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/truffle-api-19.3.0.jar</runtime-relative-path>
-                <binary-origin>external/truffle-api-19.3.0.jar</binary-origin>
+                <runtime-relative-path>ext/truffle-api-19.3.1.jar</runtime-relative-path>
+                <binary-origin>external/truffle-api-19.3.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Notes:
- 13 Fixed Bugs
- 7 Improvements
- Update Java to 8u241 for Java 8 based GraalVM
- Update Ruby to 2.6.5
- Update Node.js to 12.14.0

[GraalVM Web Page](https://www.graalvm.org/)
[GraalVM Release Notes](https://www.graalvm.org/docs/release-notes/19_3/)