### PR TITLE
[NETBEANS-4002] - clean Iterator raw types

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ImportantFilesNodeFactory.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/ImportantFilesNodeFactory.java
@@ -342,10 +342,10 @@ public class ImportantFilesNodeFactory implements NodeFactory {
         
         private void refreshKeys() {
             List<String> newVisibleFiles = new ArrayList<String>();
-            Iterator it = FILES.keySet().iterator();
+            Iterator<String> it = FILES.keySet().iterator();
             Set<FileObject> files = new HashSet<FileObject>();
             while (it.hasNext()) {
-                String loc = (String) it.next();
+                String loc = it.next();
                 String locEval = project.getEvaluator().evaluate(loc);
                 if (locEval == null) {
                     continue;

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/PlatformNode.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/PlatformNode.java
@@ -296,8 +296,8 @@ final class PlatformNode extends AbstractNode implements ChangeListener {
         private static URL[]  getJavadocRoots(JavaPlatform platform) {
             Set<URL> result = new HashSet<URL>();
             List<ClassPath.Entry> l = platform.getBootstrapLibraries().entries();
-            for (Iterator it = l.iterator(); it.hasNext();) {
-                ClassPath.Entry e = (ClassPath.Entry) it.next();
+            for (Iterator<ClassPath.Entry> it = l.iterator(); it.hasNext();) {
+                ClassPath.Entry e = it.next();
                 result.addAll(Arrays.asList(JavadocForBinaryQuery.findJavadoc(e.getURL()).getRoots()));
             }
             return result.toArray(new URL[result.size()]);

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SingleModuleProperties.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/SingleModuleProperties.java
@@ -429,8 +429,8 @@ public final class SingleModuleProperties extends ModuleProperties {
             return false;
         }
         Set<ModuleDependency> deps = depsModel.getDependencies();
-        for (Iterator it = deps.iterator(); it.hasNext();) {
-            ModuleDependency dep = (ModuleDependency) it.next();
+        for (Iterator<ModuleDependency> it = deps.iterator(); it.hasNext();) {
+            ModuleDependency dep = it.next();
             if (dep.hasImplementationDependency()) {
                 return true;
             }
@@ -741,8 +741,8 @@ public final class SingleModuleProperties extends ModuleProperties {
     String[] getAvailableFriends() {
         SortedSet<String> set = new TreeSet<String>();
         if (isSuiteComponent()) {
-            for (Iterator it = SuiteUtils.getSubProjects(getSuite()).iterator(); it.hasNext();) {
-                Project prj = (Project) it.next();
+            for (Iterator<NbModuleProject> it = SuiteUtils.getSubProjects(getSuite()).iterator(); it.hasNext();) {
+                Project prj = it.next();
                 String cnb = ProjectUtils.getInformation(prj).getName();
                 if (!getCodeNameBase().equals(cnb)) {
                     set.add(cnb);
@@ -750,8 +750,8 @@ public final class SingleModuleProperties extends ModuleProperties {
             }
         } else if (isNetBeansOrg()) {
             Set<ModuleDependency> deps = getUniverseDependencies(false);
-            for (Iterator it = deps.iterator(); it.hasNext();) {
-                ModuleDependency dep = (ModuleDependency) it.next();
+            for (Iterator<ModuleDependency> it = deps.iterator(); it.hasNext();) {
+                ModuleDependency dep = it.next();
                 set.add(dep.getModuleEntry().getCodeNameBase());
             }
         } // else standalone module - leave empty (see the UI spec)
@@ -901,8 +901,8 @@ public final class SingleModuleProperties extends ModuleProperties {
         for (int i = 0; i < pexports.length; i++) {
             ManifestManager.PackageExport pexport = pexports[i];
             if (pexport.isRecursive()) {
-                for (Iterator it = getAvailablePublicPackages().iterator(); it.hasNext(); ) {
-                    String p = (String) it.next();
+                for (Iterator<String> it = getAvailablePublicPackages().iterator(); it.hasNext(); ) {
+                    String p = it.next();
                     if (p.startsWith(pexport.getPackage())) {
                         sPackages.add(p);
                     }

--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractEntry.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/universe/AbstractEntry.java
@@ -128,9 +128,9 @@ abstract class AbstractEntry implements ModuleEntry {
                 String pkg = path.substring(0, slash + 1);
                 if (!publicPackagesSlashNonRec.contains(pkg)) {
                     boolean pub = false;
-                    Iterator it = publicPackagesSlashRec.iterator();
+                    Iterator<String> it = publicPackagesSlashRec.iterator();
                     while (it.hasNext()) {
-                        if (pkg.startsWith((String) it.next())) {
+                        if (pkg.startsWith(it.next())) {
                             pub = true;
                             break;
                         }

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/api/EditableManifest.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/api/EditableManifest.java
@@ -455,9 +455,9 @@ public final class EditableManifest {
         }
         
         public void write(Writer w, boolean forceBlankLine) throws IOException {
-            Iterator it = lines.iterator();
+            Iterator<Line> it = lines.iterator();
             while (it.hasNext()) {
-                Line line = (Line) it.next();
+                Line line = it.next();
                 line.write(w);
             }
             for (int i = 0; i < blankLinesAfter; i++) {

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/WritableXMLFileSystem.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/layers/WritableXMLFileSystem.java
@@ -162,7 +162,7 @@ public final class WritableXMLFileSystem extends AbstractFileSystem
         if (doc == null) {
             return null;
         }
-        Iterator it;
+        Iterator<?> it;
         it = doc.getChildNodes().iterator();
         while (it.hasNext()) {
             Object next = it.next();
@@ -195,9 +195,9 @@ public final class WritableXMLFileSystem extends AbstractFileSystem
                 remainder = name.substring(idx + 1);
             }
             TreeElement subel = null;
-            Iterator it = el.getChildNodes(TreeElement.class).iterator();
+            Iterator<TreeElement> it = el.getChildNodes(TreeElement.class).iterator();
             while (it.hasNext()) {
-                TreeElement e = (TreeElement) it.next();
+                TreeElement e = it.next();
                 if (e.getLocalName().equals("file") || // NOI18N
                         e.getLocalName().equals("folder")) { // NOI18N
                     TreeAttribute nameAttr = e.getAttribute("name"); // NOI18N
@@ -233,9 +233,9 @@ public final class WritableXMLFileSystem extends AbstractFileSystem
         }
         ArrayList<String> kids = new ArrayList<String>();
         Set<String> allNames = new HashSet<String>();
-        Iterator it = el.getChildNodes(TreeElement.class).iterator();
+        Iterator<TreeElement> it = el.getChildNodes(TreeElement.class).iterator();
         while (it.hasNext()) {
-            TreeElement sub = (TreeElement) it.next();
+            TreeElement sub = it.next();
             if (sub.getLocalName().equals("file") || // NOI18N
                     sub.getLocalName().equals("folder")) { // NOI18N
                 TreeAttribute childName = sub.getAttribute("name"); // NOI18N
@@ -296,7 +296,7 @@ public final class WritableXMLFileSystem extends AbstractFileSystem
             }
         } else {
             StringBuffer buf = new StringBuffer();
-            Iterator it = el.getChildNodes().iterator();
+            Iterator<?> it = el.getChildNodes().iterator();
             while (it.hasNext()) {
                 Object o = it.next();
                 if (o instanceof TreeCDATASection) {
@@ -560,9 +560,9 @@ public final class WritableXMLFileSystem extends AbstractFileSystem
             return Enumerations.empty();
         }
         java.util.List<String> l = new ArrayList<String>(10);
-        Iterator it = el.getChildNodes(TreeElement.class).iterator();
+        Iterator<TreeElement> it = el.getChildNodes(TreeElement.class).iterator();
         while (it.hasNext()) {
-            TreeElement sub = (TreeElement) it.next();
+            TreeElement sub = it.next();
             if (sub.getLocalName().equals("attr")) { // NOI18N
                 TreeAttribute nameAttr = sub.getAttribute("name"); // NOI18N
                 if (nameAttr == null) {
@@ -836,9 +836,9 @@ public final class WritableXMLFileSystem extends AbstractFileSystem
         }
         // Find any existing <attr>.
         TreeChild existingAttr = null;
-        Iterator it = el.getChildNodes(TreeElement.class).iterator();
+        Iterator<TreeElement> it = el.getChildNodes(TreeElement.class).iterator();
         while (it.hasNext()) {
-            TreeElement sub = (TreeElement) it.next();
+            TreeElement sub = it.next();
             if (sub.getLocalName().equals("attr")) { // NOI18N
                 TreeAttribute attr = sub.getAttribute("name"); // NOI18N
                 if (attr == null) {
@@ -1150,9 +1150,9 @@ public final class WritableXMLFileSystem extends AbstractFileSystem
         TreeElement childe = (TreeElement) child;
         if (childe.getQName().equals("file") || childe.getQName().equals("folder")) { // NOI18N
             String name = childe.getAttribute("name").getValue(); // NOI18N
-            Iterator it = parent.getChildNodes(TreeElement.class).iterator();
+            Iterator<TreeElement> it = parent.getChildNodes(TreeElement.class).iterator();
             while (it.hasNext()) {
-                TreeElement kid = (TreeElement) it.next();
+                TreeElement kid = it.next();
                 if (kid.getQName().equals("file") || kid.getQName().equals("folder")) { // NOI18N
                     TreeAttribute attr = kid.getAttribute("name"); // NOI18N
                     if (attr != null) { // #66816 - layer might be malformed
@@ -1166,9 +1166,9 @@ public final class WritableXMLFileSystem extends AbstractFileSystem
             return null;
         } else if (childe.getQName().equals("attr")) { // NOI18N
             String name = childe.getAttribute("name").getValue(); // NOI18N
-                Iterator it = parent.getChildNodes(TreeElement.class).iterator();
+                Iterator<TreeElement> it = parent.getChildNodes(TreeElement.class).iterator();
                 while (it.hasNext()) {
-                    TreeElement kid = (TreeElement) it.next();
+                    TreeElement kid = it.next();
                     if (kid.getQName().equals("file") || kid.getQName().equals("folder")) { // NOI18N
                         return kid;
                     } else if (kid.getQName().equals("attr")) { // NOI18N
@@ -1337,7 +1337,7 @@ public final class WritableXMLFileSystem extends AbstractFileSystem
         TreeElement parent = (TreeElement) child.getParentNode();
         TreeObjectList list = parent.getChildNodes();
         boolean kill = true;
-        Iterator it = list.iterator();
+        Iterator<?> it = list.iterator();
         while (it.hasNext()) {
             Object o = it.next();
             if (o == child) {

--- a/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingSupport.java
+++ b/apisupport/apisupport.project/src/org/netbeans/modules/apisupport/project/spi/BrandingSupport.java
@@ -209,8 +209,8 @@ public abstract class BrandingSupport {
         BrandedFile retval = null;
         try {
             retval = new BrandedFile(moduleEntry, entryPath);
-            for (Iterator it = getBrandedFiles().iterator();it.hasNext() ;) {
-                BrandedFile bFile = (BrandedFile)it.next();
+            for (Iterator<BrandedFile> it = getBrandedFiles().iterator();it.hasNext() ;) {
+                BrandedFile bFile = it.next();
                 
                 if (retval.equals(bFile)) {
                     retval = bFile;

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/nodes/Hk2InstanceChildren.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/nodes/Hk2InstanceChildren.java
@@ -75,8 +75,8 @@ public class Hk2InstanceChildren extends Children.Keys<Node> implements Refresha
                         Hk2ItemNode.WS_FOLDER));
             }
             List<Node> pluggableNodes = getExtensionNodes();
-            for (Iterator itr = pluggableNodes.iterator(); itr.hasNext();) {
-                keys.add((Node)itr.next());
+            for (Iterator<Node> itr = pluggableNodes.iterator(); itr.hasNext();) {
+                keys.add(itr.next());
             }
         }
         setKeys(keys);

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/HttpMonitorHelper.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/HttpMonitorHelper.java
@@ -32,6 +32,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.modules.j2ee.dd.api.web.DDProvider;
@@ -442,11 +443,11 @@ public class HttpMonitorHelper {
     private static void startModuleSpy (final ModuleSpy spy) {
         // trying to hang a listener on monitor module 
         res = Lookup.getDefault().lookup(new Lookup.Template<ModuleInfo>(ModuleInfo.class));
-        java.util.Iterator it = res.allInstances ().iterator ();
+        Iterator<ModuleInfo> it = res.allInstances ().iterator ();
         final String moduleId = spy.getModuleId();        
        // boolean found = false;
         while (it.hasNext ()) {
-            org.openide.modules.ModuleInfo mi = (ModuleInfo)it.next ();
+            org.openide.modules.ModuleInfo mi = it.next();
             if (mi.getCodeName ().startsWith(moduleId)) {
                 httpMonitorInfo=mi;
                 spy.setEnabled(mi.isEnabled());
@@ -525,10 +526,10 @@ public class HttpMonitorHelper {
         
         @Override
         public void resultChanged(LookupEvent lookupEvent) {
-            java.util.Iterator it = res.allInstances ().iterator ();
+            Iterator<ModuleInfo> it = res.allInstances().iterator();
             boolean moduleFound=false;
             while (it.hasNext ()) {
-                ModuleInfo mi = (ModuleInfo)it.next ();
+                ModuleInfo mi = it.next();
                 if (mi.getCodeName ().startsWith(spy.getModuleId())) {
                     spy.setEnabled(mi.isEnabled());
                     if (httpMonitorInfo==null) {

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/ResourceRegistrationHelper.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/ResourceRegistrationHelper.java
@@ -149,9 +149,9 @@ public class ResourceRegistrationHelper {
             Map<String, String> localData = resourceFinder.getResourceData().get(jndiName);
             String remoteKey = prefix + jndiName + "."; // NOI18N
             Map<String, String> remoteData = new HashMap<String, String>();
-            Iterator itr = allRemoteData.keySet().iterator();
+            Iterator<String> itr = allRemoteData.keySet().iterator();
             while (itr.hasNext()) {
-                String key = (String) itr.next();
+                String key = itr.next();
                 if(key.startsWith(remoteKey)){
                     remoteData.put(key, allRemoteData.get(key));
                 }

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/nodes/Hk2InstanceChildren.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/nodes/Hk2InstanceChildren.java
@@ -75,8 +75,8 @@ public class Hk2InstanceChildren extends Children.Keys<Node> implements Refresha
                         Hk2ItemNode.WS_FOLDER));
             }
             List<Node> pluggableNodes = getExtensionNodes();
-            for (Iterator itr = pluggableNodes.iterator(); itr.hasNext();) {
-                keys.add((Node)itr.next());
+            for (Iterator<Node> itr = pluggableNodes.iterator(); itr.hasNext();) {
+                keys.add(itr.next());
             }
         }
         setKeys(keys);

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/HttpMonitorHelper.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/HttpMonitorHelper.java
@@ -32,6 +32,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.util.Iterator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.modules.j2ee.dd.api.web.DDProvider;
@@ -442,11 +443,11 @@ public class HttpMonitorHelper {
     private static void startModuleSpy (final ModuleSpy spy) {
         // trying to hang a listener on monitor module 
         res = Lookup.getDefault().lookup(new Lookup.Template<ModuleInfo>(ModuleInfo.class));
-        java.util.Iterator it = res.allInstances ().iterator ();
+        Iterator<ModuleInfo> it = res.allInstances().iterator();
         final String moduleId = spy.getModuleId();        
        // boolean found = false;
         while (it.hasNext ()) {
-            org.openide.modules.ModuleInfo mi = (ModuleInfo)it.next ();
+            org.openide.modules.ModuleInfo mi = it.next();
             if (mi.getCodeName ().startsWith(moduleId)) {
                 httpMonitorInfo=mi;
                 spy.setEnabled(mi.isEnabled());
@@ -525,10 +526,10 @@ public class HttpMonitorHelper {
         
         @Override
         public void resultChanged(LookupEvent lookupEvent) {
-            java.util.Iterator it = res.allInstances ().iterator ();
+            Iterator<ModuleInfo> it = res.allInstances().iterator();
             boolean moduleFound=false;
             while (it.hasNext ()) {
-                ModuleInfo mi = (ModuleInfo)it.next ();
+                ModuleInfo mi = it.next();
                 if (mi.getCodeName ().startsWith(spy.getModuleId())) {
                     spy.setEnabled(mi.isEnabled());
                     if (httpMonitorInfo==null) {

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/ResourceRegistrationHelper.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/ResourceRegistrationHelper.java
@@ -149,9 +149,9 @@ public class ResourceRegistrationHelper {
             Map<String, String> localData = resourceFinder.getResourceData().get(jndiName);
             String remoteKey = prefix + jndiName + "."; // NOI18N
             Map<String, String> remoteData = new HashMap<String, String>();
-            Iterator itr = allRemoteData.keySet().iterator();
+            Iterator<String> itr = allRemoteData.keySet().iterator();
             while (itr.hasNext()) {
-                String key = (String) itr.next();
+                String key = itr.next();
                 if(key.startsWith(remoteKey)){
                     remoteData.put(key, allRemoteData.get(key));
                 }

--- a/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/RunTimeDDCatalog.java
+++ b/enterprise/payara.jakartaee/src/org/netbeans/modules/payara/jakartaee/RunTimeDDCatalog.java
@@ -362,9 +362,9 @@ public class RunTimeDDCatalog extends GrammarQueryManager implements CatalogRead
     }
     
     public  void fireCatalogListeners() {
-        Iterator iter = catalogListeners.iterator();
+        Iterator<CatalogListener> iter = catalogListeners.iterator();
         while (iter.hasNext()) {
-            CatalogListener l = (CatalogListener) iter.next();
+            CatalogListener l = iter.next();
             l.notifyInvalidate();
         }
     }

--- a/enterprise/projectimport.eclipse.web/src/org/netbeans/modules/projectimport/eclipse/web/ServerSelectionWizardPanel.java
+++ b/enterprise/projectimport.eclipse.web/src/org/netbeans/modules/projectimport/eclipse/web/ServerSelectionWizardPanel.java
@@ -88,8 +88,8 @@ public class ServerSelectionWizardPanel implements WizardDescriptor.Panel<Wizard
     private void fireChange() {
         if (changeListeners != null) {
             ChangeEvent e = new ChangeEvent(this);
-            for (Iterator i = changeListeners.iterator(); i.hasNext(); ) {
-                ((ChangeListener) i.next()).stateChanged(e);
+            for (Iterator<ChangeListener> i = changeListeners.iterator(); i.hasNext(); ) {
+                i.next().stateChanged(e);
             }
         }
     }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceGroup.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceGroup.java
@@ -140,9 +140,9 @@ public class WebServiceGroup {
     
     public void setWebServiceIds(Set ids){
         webserviceIds = ids;
-        Iterator iter = webserviceIds.iterator();
+        Iterator<String> iter = webserviceIds.iterator();
         while(iter.hasNext()) {
-            WebServiceData wsData = WebServiceListModel.getInstance().getWebService((String)iter.next());
+            WebServiceData wsData = WebServiceListModel.getInstance().getWebService(iter.next());
             wsData.setGroupId(getId());
         }
     }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceListModel.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceListModel.java
@@ -236,10 +236,10 @@ public class WebServiceListModel {
                 WebServiceManager.getInstance().removeWebService(getWebService(webserviceIds[ii]));
             }
             webServiceGroups.remove(group);
-            Iterator iter = listeners.iterator();
+            Iterator<WebServiceListModelListener> iter = listeners.iterator();
             while (iter.hasNext()) {
                 WebServiceListModelEvent evt = new WebServiceListModelEvent(groupId);
-                ((WebServiceListModelListener) iter.next()).webServiceGroupRemoved(evt);
+                iter.next().webServiceGroupRemoved(evt);
             }
         }
     }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/TestWebServiceMethodDlg.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/TestWebServiceMethodDlg.java
@@ -696,9 +696,9 @@ public class TestWebServiceMethodDlg extends JPanel implements ActionListener, M
         }
 
         private void notifyListeners(Object returnedObject) {
-            Iterator listenerIterator = listeners.iterator();
+            Iterator<MethodTaskListener> listenerIterator = listeners.iterator();
             while(listenerIterator.hasNext()) {
-                MethodTaskListener currentListener = (MethodTaskListener)listenerIterator.next();
+                MethodTaskListener currentListener = listenerIterator.next();
                 currentListener.methodFinished(returnedObject, paramList);
             }
         }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyVirtualSourceProvider.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyVirtualSourceProvider.java
@@ -392,8 +392,8 @@ public class GroovyVirtualSourceProvider implements VirtualSourceProvider {
             }
             boolean first = true;
             
-            for (Iterator iterator = fields.iterator(); iterator.hasNext();) {
-                FieldNode fieldNode = (FieldNode) iterator.next();
+            for (Iterator<FieldNode> iterator = fields.iterator(); iterator.hasNext();) {
+                FieldNode fieldNode = iterator.next();
                 if (!first) {
                     out.print(", ");
                 } else {

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/debug/GroovyBreakpointAnnotationListener.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/debug/GroovyBreakpointAnnotationListener.java
@@ -108,9 +108,9 @@ public class GroovyBreakpointAnnotationListener extends DebuggerManagerAdapter {
     }
 
     public void updateGroovyLineBreakpoints () {
-        Iterator it = breakpointToAnnotation.keySet ().iterator (); 
+        Iterator<LineBreakpoint> it = breakpointToAnnotation.keySet ().iterator (); 
         while (it.hasNext ()) {
-            LineBreakpoint lb = (LineBreakpoint) it.next ();
+            LineBreakpoint lb = it.next();
             update (lb, null);
         }
     }

--- a/harness/o.n.insane/src/org/netbeans/insane/impl/LiveEngine.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/impl/LiveEngine.java
@@ -126,7 +126,7 @@ public class LiveEngine implements ObjectMap, Visitor {
         objects.put(to, entry);
     }
 
-    private Iterator/*<Object>*/ getIncomingRefs(Object to) {
+    private Iterator<Object> getIncomingRefs(Object to) {
         Object oo = objects.get(to);
         if (oo instanceof Object[]) {
             return Arrays.asList((Object[])oo).iterator();
@@ -181,7 +181,7 @@ public class LiveEngine implements ObjectMap, Visitor {
         int base = objExpected;
         int step = found > 0 ? objExpected/9/found : 0;
         
-        for (Iterator it = objs.iterator(); it.hasNext(); ) {
+        for (Iterator<Object> it = objs.iterator(); it.hasNext(); ) {
             Object obj = it.next();
             if (rest.containsKey(obj)) continue; // not found
             Path toObj = findRoots(obj, s.keySet());
@@ -212,7 +212,7 @@ public class LiveEngine implements ObjectMap, Visitor {
             }
 
             // follow incomming
-            Iterator it = getIncomingRefs(item);
+            Iterator<Object> it = getIncomingRefs(item);
             while(it.hasNext()) {
                 Object o = it.next();
                 Path prev = Utils.createPath(o, act);

--- a/harness/o.n.insane/src/org/netbeans/insane/model/InsaneConverter.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/model/InsaneConverter.java
@@ -351,8 +351,8 @@ final class InsaneConverter {
         objsOffset = currentOffset;
         
         // compute offsets of instances
-        for (Iterator it = instanceInfo.iterator(); it.hasNext(); ) {
-            InstanceInfo info = (InstanceInfo)it.next();
+        for (Iterator<InstanceInfo> it = instanceInfo.iterator(); it.hasNext(); ) {
+            InstanceInfo info = it.next();
             currentOffset = info.computeNextOffset(currentOffset);
         }
         totalOffset = currentOffset;

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/NodeTableModel.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/NodeTableModel.java
@@ -208,10 +208,10 @@ class NodeTableModel extends AbstractTableModel {
         propertyColumns = new int[visibleCount];
 
         int j = 0;
-        Iterator it = sort.values().iterator();
+        Iterator<Integer> it = sort.values().iterator();
 
         while (it.hasNext()) {
-            i = ((Integer) it.next()).intValue();
+            i = it.next().intValue();
             allPropertyColumns[i].setVisibleIndex(j);
             propertyColumns[j] = i;
             j++;

--- a/ide/db.mysql/src/org/netbeans/modules/db/mysql/impl/InstallationManager.java
+++ b/ide/db.mysql/src/org/netbeans/modules/db/mysql/impl/InstallationManager.java
@@ -68,8 +68,8 @@ public class InstallationManager {
             ArrayList<Installation> stackInstalls = new ArrayList<Installation>();
             ArrayList<Installation> stdInstalls = new ArrayList<Installation>();
 
-            for ( Iterator it = loadedInstallations.iterator() ; it.hasNext() ; ) {
-                Installation installation = (Installation)it.next();
+            for ( Iterator<Installation> it = loadedInstallations.iterator() ; it.hasNext() ; ) {
+                Installation installation = it.next();
 
                 if ( installation.isStackInstall() ) {
                     stackInstalls.add(installation);                

--- a/ide/db/src/org/netbeans/modules/db/explorer/DbActionLoaderSupport.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/DbActionLoaderSupport.java
@@ -39,8 +39,8 @@ public class DbActionLoaderSupport {
     public static List<Action> getAllActions() {
         List<Action> actions = new ArrayList<Action>();
         Collection loaders = Lookup.getDefault().lookupAll(DbActionLoader.class);
-        for (Iterator i = loaders.iterator(); i.hasNext();) {
-            actions.addAll(((DbActionLoader)i.next()).getAllActions());
+        for (Iterator<DbActionLoader> i = loaders.iterator(); i.hasNext();) {
+            actions.addAll(i.next().getAllActions());
         }
         
         return actions;

--- a/ide/db/src/org/netbeans/modules/db/explorer/DbDriverManager.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/DbDriverManager.java
@@ -223,8 +223,8 @@ public class DbDriverManager {
         // try the registered drivers first
         synchronized (this) {
             if (registeredDrivers != null) {
-                for (Iterator i = registeredDrivers.iterator(); i.hasNext();) {
-                    Driver d = (Driver)i.next();
+                for (Iterator<Driver> i = registeredDrivers.iterator(); i.hasNext();) {
+                    Driver d = i.next();
                     try {
                         if (d.acceptsURL(databaseURL)) {
                             return d;

--- a/ide/db/src/org/netbeans/modules/db/explorer/DbMetaDataListenerSupport.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/DbMetaDataListenerSupport.java
@@ -35,14 +35,14 @@ public class DbMetaDataListenerSupport {
     }
 
     public static void fireTablesChanged(DatabaseConnection dbconn) {
-        for (Iterator i = listeners.allInstances().iterator(); i.hasNext();) {
-            ((DbMetaDataListener)i.next()).tablesChanged(dbconn);
+        for (Iterator<DbMetaDataListener> i = listeners.allInstances().iterator(); i.hasNext();) {
+            i.next().tablesChanged(dbconn);
         }
     }
 
     public static void fireTableChanged(DatabaseConnection dbconn, String tableName) {
-        for (Iterator i = listeners.allInstances().iterator(); i.hasNext();) {
-            ((DbMetaDataListener)i.next()).tableChanged(dbconn, tableName);
+        for (Iterator<DbMetaDataListener> i = listeners.allInstances().iterator(); i.hasNext();) {
+            i.next().tableChanged(dbconn, tableName);
         }
     }
 }

--- a/ide/dbapi/src/org/netbeans/modules/dbapi/DbActionLoaderImpl.java
+++ b/ide/dbapi/src/org/netbeans/modules/dbapi/DbActionLoaderImpl.java
@@ -47,8 +47,8 @@ public class DbActionLoaderImpl implements DbActionLoader {
         Collection providers = Lookups.forPath(ACTION_PROVIDER_PATH).
                 lookupAll(ActionProvider.class);
         
-        for (Iterator i = providers.iterator(); i.hasNext();) {
-            ActionProvider provider = (ActionProvider)i.next();
+        for (Iterator<ActionProvider> i = providers.iterator(); i.hasNext();) {
+            ActionProvider provider = i.next();
             List<Action> actionList = provider.getActions();
             if (actionList != null) {
                 actions.addAll(actionList);

--- a/ide/dbapi/src/org/netbeans/modules/dbapi/DbMetaDataListenerImpl.java
+++ b/ide/dbapi/src/org/netbeans/modules/dbapi/DbMetaDataListenerImpl.java
@@ -41,14 +41,14 @@ public class DbMetaDataListenerImpl implements DbMetaDataListener {
     private final Lookup.Result listeners = getListeners();
 
     public void tablesChanged(DatabaseConnection dbconn) {
-        for (Iterator i = listeners.allInstances().iterator(); i.hasNext();) {
-            ((MetaDataListener)i.next()).tablesChanged(dbconn);
+        for (Iterator<MetaDataListener> i = listeners.allInstances().iterator(); i.hasNext();) {
+            i.next().tablesChanged(dbconn);
         }
     }
 
     public void tableChanged(DatabaseConnection dbconn, String tableName) {
-        for (Iterator i = listeners.allInstances().iterator(); i.hasNext();) {
-            ((MetaDataListener)i.next()).tableChanged(dbconn, tableName);
+        for (Iterator<MetaDataListener> i = listeners.allInstances().iterator(); i.hasNext();) {
+            i.next().tableChanged(dbconn, tableName);
         }
     }
 

--- a/ide/dbapi/src/org/netbeans/modules/dbapi/DbNodeLoaderImpl.java
+++ b/ide/dbapi/src/org/netbeans/modules/dbapi/DbNodeLoaderImpl.java
@@ -56,8 +56,8 @@ public class DbNodeLoaderImpl implements DbNodeLoader, ChangeListener {
             providers = Lookups.forPath(NODE_PROVIDER_PATH).lookupAll(NodeProvider.class);    
         }
         
-        for (Iterator i = providers.iterator(); i.hasNext();) {
-            NodeProvider provider = (NodeProvider)i.next();
+        for (Iterator<NodeProvider> i = providers.iterator(); i.hasNext();) {
+            NodeProvider provider = i.next();
             List<Node> nodeList = provider.getNodes();
             if (nodeList != null) {
                 nodes.addAll(nodeList);

--- a/ide/docker.api/src/org/netbeans/modules/docker/DockerConfig.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/DockerConfig.java
@@ -91,8 +91,8 @@ public final class DockerConfig {
         }
 
         List<Credentials> ret = new ArrayList<>(currentAuths.size());
-        for (Iterator it = currentAuths.entrySet().iterator(); it.hasNext();) {
-            Map.Entry e = (Map.Entry) it.next();
+        for (Iterator<Map.Entry> it = currentAuths.entrySet().iterator(); it.hasNext();) {
+            Map.Entry e = it.next();
             if (!(e.getKey() instanceof String)) {
                 continue;
             }
@@ -251,8 +251,8 @@ public final class DockerConfig {
                     currentHeaders = new JSONObject();
                 }
                 httpHeaders = new HashMap<>();
-                for (Iterator it = currentHeaders.entrySet().iterator(); it.hasNext(); ) {
-                    Map.Entry e = (Map.Entry) it.next();
+                for (Iterator<Map.Entry> it = currentHeaders.entrySet().iterator(); it.hasNext(); ) {
+                    Map.Entry e = it.next();
                     httpHeaders.put((String) e.getKey(), (String) e.getValue());
                 }
             }

--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateCompletionProvider.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateCompletionProvider.java
@@ -209,8 +209,8 @@ public final class CodeTemplateCompletionProvider implements CompletionProvider 
         }
         
         private static boolean accept(CodeTemplate template, Collection/*<CodeTemplateFilter>*/ filters) {
-            for(Iterator it = filters.iterator(); it.hasNext();) {
-                CodeTemplateFilter filter = (CodeTemplateFilter)it.next();
+            for(Iterator<CodeTemplateFilter> it = filters.iterator(); it.hasNext();) {
+                CodeTemplateFilter filter = it.next();
                 if (!filter.accept(template))
                     return false;                
             }

--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/ParametrizedTextParser.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/ParametrizedTextParser.java
@@ -120,9 +120,8 @@ public final class ParametrizedTextParser {
         StringBuffer insertTextBuffer = new StringBuffer(parametrizedText.length());
         insertTextBuffer.append(parametrizedTextFragments.get(0));
         int fragIndex = 1;
-        for (Iterator it = allParameters.iterator(); it.hasNext();) {
-            CodeTemplateParameterImpl param = CodeTemplateParameterImpl.get(
-                    (CodeTemplateParameter)it.next());
+        for (Iterator<CodeTemplateParameter> it = allParameters.iterator(); it.hasNext();) {
+            CodeTemplateParameterImpl param = CodeTemplateParameterImpl.get(it.next());
             int startOffset = insertTextBuffer.length();
             insertTextBuffer.append(param.getValue());
             param.resetPositions(

--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateInsertRequest.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/spi/CodeTemplateInsertRequest.java
@@ -103,8 +103,8 @@ public final class CodeTemplateInsertRequest {
      *  parameter exists.
      */
     public CodeTemplateParameter getMasterParameter(String name) {
-        for (Iterator it = getMasterParameters().iterator(); it.hasNext();) {
-            CodeTemplateParameter master = (CodeTemplateParameter)it.next();
+        for (Iterator<? extends CodeTemplateParameter> it = getMasterParameters().iterator(); it.hasNext();) {
+            CodeTemplateParameter master = it.next();
             if (name.equals(master.getName())) {
                 return master;
             }

--- a/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatter.java
+++ b/ide/editor.deprecated.pre65formatting/src/org/netbeans/editor/ext/ExtFormatter.java
@@ -187,9 +187,9 @@ public class ExtFormatter extends Formatter implements FormatLayer {
     /** Remove the first layer which has the same name as the given one.
     */
     public synchronized void removeFormatLayer(String layerName) {
-        Iterator it = formatLayerIterator();
+        Iterator<FormatLayer> it = formatLayerIterator();
         while (it.hasNext()) {
-            if (layerName.equals(((FormatLayer)it.next()).getName())) {
+            if (layerName.equals(it.next().getName())) {
                 it.remove();
                 return;
             }

--- a/ide/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/TableSorter.java
+++ b/ide/editor.macros/src/org/netbeans/modules/editor/macros/storage/ui/TableSorter.java
@@ -283,8 +283,8 @@ public class TableSorter extends AbstractTableModel {
         public int compareTo(Object o) {
             int row1 = modelIndex;
             int row2 = ((Row) o).modelIndex;
-            for (Iterator it = sortingColumns.iterator(); it.hasNext();) {
-                Directive directive = (Directive) it.next();
+            for (Iterator<Directive> it = sortingColumns.iterator(); it.hasNext();) {
+                Directive directive = it.next();
                 int column = directive.column;
                 Object o1 = tableModel.getValueAt(row1, column);
                 Object o2 = tableModel.getValueAt(row2, column);

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/CommonTestsCfgOfCreate.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/CommonTestsCfgOfCreate.java
@@ -1173,8 +1173,8 @@ public class CommonTestsCfgOfCreate extends SelfResizingPanel implements ChangeL
     private void fireStateChange() {
         if (changeListeners != null) {
             ChangeEvent e = new ChangeEvent(this);
-            for (Iterator i = changeListeners.iterator(); i.hasNext(); ) {
-                ((ChangeListener) i.next()).stateChanged(e);
+            for (Iterator<ChangeListener> i = changeListeners.iterator(); i.hasNext(); ) {
+                i.next().stateChanged(e);
             }
         }
     }

--- a/ide/image/src/org/netbeans/modules/image/navigation/ImageNavigatorPanel.java
+++ b/ide/image/src/org/netbeans/modules/image/navigation/ImageNavigatorPanel.java
@@ -178,7 +178,7 @@ public class ImageNavigatorPanel implements NavigatorPanel {
 
     private DataObject getDataObject(Collection data) {
         DataObject dataObject = null;
-        Iterator it = data.iterator();
+        Iterator<?> it = data.iterator();
         while (it.hasNext()) {
             Object o = it.next();
             if (o instanceof DataObject) {

--- a/ide/jellytools.ide/src/org/netbeans/jellytools/EditorWindowOperator.java
+++ b/ide/jellytools.ide/src/org/netbeans/jellytools/EditorWindowOperator.java
@@ -123,9 +123,9 @@ public class EditorWindowOperator {
             SwingUtilities.invokeAndWait(new Runnable() {
 
                 public void run() {
-                    Iterator iter = Arrays.asList(mode.getTopComponents()).iterator();
+                    Iterator<TopComponent> iter = Arrays.asList(mode.getTopComponents()).iterator();
                     while (iter.hasNext()) {
-                        EditorOperator.close((TopComponent) iter.next(), false);
+                        EditorOperator.close(iter.next(), false);
                     }
                 }
             });

--- a/ide/notifications/src/org/netbeans/modules/notifications/filter/FilterEditor.java
+++ b/ide/notifications/src/org/netbeans/modules/notifications/filter/FilterEditor.java
@@ -216,9 +216,9 @@ public class FilterEditor extends JPanel implements PropertyChangeListener {
     void updateFilters() {
         filterRepository.clear();             // throw away all original filters
 
-        Iterator filterIt = filterModel.iterator();
+        Iterator<NotificationFilter> filterIt = filterModel.iterator();
         while (filterIt.hasNext()) {
-            NotificationFilter f = (NotificationFilter) filterIt.next();
+            NotificationFilter f = filterIt.next();
             if (filter2types.get(f.getCategoryFilter()) != null) {
                 f.setCategoryFilter(filter2types.get(f.getCategoryFilter()).getFilter()); // has panel, was touched
             }

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/LogContext.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/LogContext.java
@@ -1344,8 +1344,8 @@ import org.openide.util.BaseUtilities;
         private void expireRoots() {
             long l = System.currentTimeMillis();
             
-            for (Iterator mapIt = rootHistory.values().iterator(); mapIt.hasNext(); ) {
-                Map<EventType, RingTimeBuffer> map = (Map<EventType, RingTimeBuffer>)mapIt.next();
+            for (Iterator<Map<EventType, RingTimeBuffer>> mapIt = rootHistory.values().iterator(); mapIt.hasNext(); ) {
+                Map<EventType, RingTimeBuffer> map = mapIt.next();
                 for (Iterator<Map.Entry<EventType, RingTimeBuffer>> it = map.entrySet().iterator(); it.hasNext(); ) {
                     Map.Entry<EventType, RingTimeBuffer> entry = it.next();
                     EventType et = entry.getKey();

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogMounterModel.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogMounterModel.java
@@ -118,8 +118,8 @@ final class CatalogMounterModel extends Object {
 
     private void fireStateChanged() {
 
-        for (Iterator it = changeListeners.iterator(); it.hasNext();) {
-            ChangeListener next = (ChangeListener) it.next();
+        for (Iterator<ChangeListener> it = changeListeners.iterator(); it.hasNext();) {
+            ChangeListener next = it.next();
             next.stateChanged(new ChangeEvent(this));
         }
     }

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/CatalogNode.java
@@ -274,10 +274,10 @@ final class CatalogNode extends BeanNode implements Refreshable, PropertyChangeL
 
             Set<String> previous = new HashSet<>(keys);
             keys.clear();
-            Iterator it = peer.getPublicIDs();
+            Iterator<String> it = peer.getPublicIDs();
             if (it != null) {
                 while (it.hasNext()) {
-                    String publicID = (String) it.next();
+                    String publicID = it.next();
                     keys.add(publicID);
                     if (previous.contains(publicID)) {
                         refreshKey(publicID);  // recreate node, the systemId may have changed

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/user/UserXMLCatalog.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/user/UserXMLCatalog.java
@@ -123,25 +123,25 @@ public class UserXMLCatalog implements CatalogReader, CatalogWriter, CatalogDesc
     }
     
     protected void fireEntryAdded(String publicId) {
-        Iterator it = catalogListeners.iterator();
+        Iterator<CatalogListener> it = catalogListeners.iterator();
         while (it.hasNext()) {
-            CatalogListener listener = (CatalogListener)it.next();
+            CatalogListener listener = it.next();
             listener.notifyNew(publicId);
         }
     }
     
     protected void fireEntryRemoved(String publicId) {
-        Iterator it = catalogListeners.iterator();
+        Iterator<CatalogListener> it = catalogListeners.iterator();
         while (it.hasNext()) {
-            CatalogListener listener = (CatalogListener)it.next();
+            CatalogListener listener = it.next();
             listener.notifyRemoved(publicId);
         }
     }
     
     protected void fireEntryUpdated(String publicId) {
-        Iterator it = catalogListeners.iterator();
+        Iterator<CatalogListener> it = catalogListeners.iterator();
         while (it.hasNext()) {
-            CatalogListener listener = (CatalogListener)it.next();
+            CatalogListener listener = it.next();
             listener.notifyUpdate(publicId);
         }
     }
@@ -151,9 +151,9 @@ public class UserXMLCatalog implements CatalogReader, CatalogWriter, CatalogDesc
     }
 
     public void refresh() {
-        Iterator it = catalogListeners.iterator();
+        Iterator<CatalogListener> it = catalogListeners.iterator();
         while (it.hasNext()) {
-            CatalogListener listener = (CatalogListener)it.next();
+            CatalogListener listener = it.next();
             listener.notifyInvalidate();
         }
         FileObject userCatalog = FileUtil.getConfigFile(catalogResource);

--- a/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
@@ -145,7 +145,7 @@ public abstract class GrammarQueryManager {
         }
         
         public Enumeration enabled(GrammarEnvironment ctx) {
-            Iterator it = getRegistrations();
+            Iterator<GrammarQueryManager> it = getRegistrations();
             transaction.set(null);
             ArrayList list = new ArrayList(5);
             {
@@ -156,7 +156,7 @@ public abstract class GrammarQueryManager {
             }
             Object[] array = list.toArray();
             while (it.hasNext()) {
-                GrammarQueryManager next = (GrammarQueryManager) it.next();
+                GrammarQueryManager next = it.next();
                 GrammarEnvironment env = new GrammarEnvironment(
                     org.openide.util.Enumerations.array (array), 
                     ctx.getInputSource(),

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
@@ -86,9 +86,9 @@ class DTDGrammar implements ExtendedGrammarQuery {
         if (entities == null) return org.openide.util.Enumerations.empty();
         
         List<MyEntityReference> list = new LinkedList<>();
-        Iterator it = entities.iterator();
+        Iterator<String> it = entities.iterator();
         while ( it.hasNext()) {
-            String next = (String) it.next();
+            String next = it.next();
             if (next.startsWith(prefix)) {
                 list.add (new MyEntityReference(next));
             }
@@ -144,9 +144,9 @@ class DTDGrammar implements ExtendedGrammarQuery {
         String prefix = ctx.getCurrentPrefix();
         
         LinkedList list = new LinkedList ();
-        Iterator it = possibleAttributes.iterator();
+        Iterator<String> it = possibleAttributes.iterator();
         while ( it.hasNext()) {
-            String next = (String) it.next();
+            String next = it.next();
             if (next.startsWith(prefix)) {
                 if (existingAttributes.getNamedItem(next) == null ||
                         next.equals(currentAttrName)) {
@@ -217,9 +217,9 @@ class DTDGrammar implements ExtendedGrammarQuery {
         String prefix = ctx.getCurrentPrefix();
         
         LinkedList list = new LinkedList ();
-        Iterator it = elements.iterator();
+        Iterator<String> it = elements.iterator();
         while ( it.hasNext()) {
-            String next = (String) it.next();
+            String next = it.next();
             if (next.startsWith(prefix)) {
                 boolean empty = emptyElements.contains(next);
                 list.add(new MyElement(next, empty));
@@ -237,9 +237,9 @@ class DTDGrammar implements ExtendedGrammarQuery {
         if (notations == null) return org.openide.util.Enumerations.empty();;
         
         LinkedList list = new LinkedList ();
-        Iterator it = notations.iterator();
+        Iterator<String> it = notations.iterator();
         while ( it.hasNext()) {
-            String next = (String) it.next();
+            String next = it.next();
             if (next.startsWith(prefix)) {
                 list.add (new MyNotation(next));
             }

--- a/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionInnerPanel.java
+++ b/ide/xml.multiview/src/org/netbeans/modules/xml/multiview/ui/SectionInnerPanel.java
@@ -265,8 +265,8 @@ public abstract class SectionInnerPanel extends javax.swing.JPanel implements Li
      * Reloads data from data model
      */
     public void refreshView() {
-        for (Iterator it = refreshableList.iterator(); it.hasNext();) {
-            ((Refreshable) it.next()).refresh();
+        for (Iterator<Refreshable> it = refreshableList.iterator(); it.hasNext();) {
+            it.next().refresh();
         }
     }
     

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/TreeObjectListProxyListener.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/TreeObjectListProxyListener.java
@@ -45,8 +45,8 @@ public class TreeObjectListProxyListener implements PropertyChangeListener {
     public TreeObjectListProxyListener(TreeObjectList list) {
         this.list = list;
         list.addPropertyChangeListener(this);
-        for (Iterator it = list.iterator(); it.hasNext();) {
-            TreeObject next = (TreeObject) it.next();
+        for (Iterator<TreeObject> it = list.iterator(); it.hasNext();) {
+            TreeObject next = it.next();
             if (next != null) next.addPropertyChangeListener(this);
         }
     }

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
@@ -556,9 +556,9 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
     /**
      */
     private static void fillPublicNodeTypesInheritanceTree (Set layer, String prefix) {
-        Iterator it = layer.iterator();
+        Iterator<Item> it = layer.iterator();
         while ( it.hasNext() ) {
-            Item item = (Item) it.next();
+            Item item = it.next();
             String itemPrefix = ""; // NOI18N
             if ( prefix.length() != 0 ) {
                 if ( it.hasNext() ) {

--- a/ide/xml/src/org/netbeans/modules/xml/sync/DataObjectSyncSupport.java
+++ b/ide/xml/src/org/netbeans/modules/xml/sync/DataObjectSyncSupport.java
@@ -115,8 +115,8 @@ public class DataObjectSyncSupport extends SyncSupport implements Synchronizator
 
         if (rep.represents(Document.class)) {
             synchronized (reps) {
-                for (Iterator it = reps.iterator(); it.hasNext();) {
-                    Representation next = (Representation) it.next();
+                for (Iterator<Representation> it = reps.iterator(); it.hasNext();) {
+                    Representation next = it.next();
                     if (next.represents(FileObject.class)) {
                         it.remove();
                     }                               

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AdvancedActionPanel.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AdvancedActionPanel.java
@@ -96,9 +96,9 @@ final class AdvancedActionPanel extends javax.swing.JPanel {
         assert script != null : "No file found for " + project;
         String initialTargets = (String) script.getAttribute(ATTR_TARGETS);
         SortedSet<String> relevantTargets = new TreeSet<>(Collator.getInstance());
-        Iterator it = allTargets.iterator();
+        Iterator<TargetLister.Target> it = allTargets.iterator();
         while (it.hasNext()) {
-            TargetLister.Target target = (TargetLister.Target) it.next();
+            TargetLister.Target target = it.next();
             if (!target.isOverridden() && !target.isInternal()) {
                 relevantTargets.add(target.getName());
                 if (defaultTarget == null && target.isDefault()) {
@@ -253,9 +253,9 @@ final class AdvancedActionPanel extends javax.swing.JPanel {
         String description = "";
         if (targetsL.size() == 1) {
             String targetName = (String) targetsL.get(0);
-            Iterator it = allTargets.iterator();
+            Iterator<TargetLister.Target> it = allTargets.iterator();
             while (it.hasNext()) {
-                TargetLister.Target target = (TargetLister.Target) it.next();
+                TargetLister.Target target = it.next();
                 if (!target.isOverridden() && target.getName().equals(targetName)) {
                     description = target.getElement().getAttribute("description"); // NOI18N
                     // may still be "" if not defined

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
@@ -895,9 +895,9 @@ public class AntDebugger extends ActionsProviderSupport {
                 }
                 try {
                     Set targets = TargetLister.getTargets (ant);
-                    Iterator it = targets.iterator ();
+                    Iterator<TargetLister.Target> it = targets.iterator ();
                     while (it.hasNext ()) {
-                        TargetLister.Target t = (TargetLister.Target) it.next ();
+                        TargetLister.Target t = it.next();
                         nameToTarget.put (t.getName (), t);
                     }
                 } catch (IOException ioex) {

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
@@ -60,9 +60,9 @@ public class DebuggerAntLogger extends AntLogger {
     
     
     static DebuggerAntLogger getDefault () {
-        Iterator it = Lookup.getDefault ().lookupAll (AntLogger.class).iterator ();
+        Iterator<? extends AntLogger> it = Lookup.getDefault().lookupAll(AntLogger.class).iterator();
         while (it.hasNext ()) {
-            AntLogger al = (AntLogger) it.next ();
+            AntLogger al = it.next();
             if (al instanceof DebuggerAntLogger) {
                 return (DebuggerAntLogger) al;
             }

--- a/java/beans/src/org/netbeans/modules/beans/beaninfo/BIEditorSupport.java
+++ b/java/beans/src/org/netbeans/modules/beans/beaninfo/BIEditorSupport.java
@@ -266,11 +266,11 @@ public final class BIEditorSupport extends DataEditorSupport
     }
     
     private static void detachStatusListeners() {
-        Iterator iter = fsToStatusListener.entrySet().iterator();
+        Iterator<Map.Entry<FileSystem, FileStatusListener>> iter = fsToStatusListener.entrySet().iterator();
         while (iter.hasNext()) {
-            Map.Entry entry = (Map.Entry)iter.next();
-            FileSystem fs = (FileSystem)entry.getKey();
-            FileStatusListener fsl = (FileStatusListener)entry.getValue();
+            Map.Entry<FileSystem, FileStatusListener> entry = iter.next();
+            FileSystem fs = entry.getKey();
+            FileStatusListener fsl = entry.getValue();
             fs.removeFileStatusListener(fsl);
         }
         fsToStatusListener.clear();

--- a/java/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupport.java
+++ b/java/j2ee.core.utilities/src/org/netbeans/modules/j2ee/core/api/support/java/method/MethodModelSupport.java
@@ -213,9 +213,9 @@ public final class MethodModelSupport {
                     annotationTree = genUtils.createAnnotation(annotation.getType());
                 } else {
                     List<ExpressionTree> annotationArgs = new ArrayList<ExpressionTree>();
-                    Iterator it = annotation.getArguments().entrySet().iterator();
+                    Iterator<Map.Entry<String, Object>> it = annotation.getArguments().entrySet().iterator();
                     while (it.hasNext()) {
-                        Map.Entry pairs = (Map.Entry)it.next();
+                        Map.Entry<String, Object> pairs = it.next();
                         annotationArgs.add(genUtils.createAnnotationArgument((String) pairs.getKey(),pairs.getValue()));
                     }
                     annotationTree = genUtils.createAnnotation(annotation.getType(), annotationArgs);

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ActionFilterNode.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/project/ui/ActionFilterNode.java
@@ -534,8 +534,8 @@ final class ActionFilterNode extends FilterNode implements NodeListener {
            // and ensures the project will be saved.
             boolean found = false;
             final List<ClassPathSupport.Item> resources = getClassPathItems();
-            for (Iterator i = resources.iterator(); i.hasNext();) {
-                ClassPathSupport.Item item = (ClassPathSupport.Item)i.next();
+            for (Iterator<ClassPathSupport.Item> i = resources.iterator(); i.hasNext();) {
+                ClassPathSupport.Item item = i.next();
                 if (entryId.equals(CommonProjectUtils.getAntPropertyName(item.getReference()))) {
                     lastRef.set(item.getReference());
                     i.remove();

--- a/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/SourceFoldersWizardPanel.java
+++ b/java/java.freeform/src/org/netbeans/modules/java/freeform/ui/SourceFoldersWizardPanel.java
@@ -108,9 +108,9 @@ public class SourceFoldersWizardPanel implements WizardDescriptor.Panel, ChangeL
         }
         List l = (List)wizardDescriptor.getProperty(NewJavaFreeformProjectSupport.PROP_EXTRA_JAVA_SOURCE_FOLDERS);
         if (l != null) {
-            Iterator it = l.iterator();
+            Iterator<String> it = l.iterator();
             while (it.hasNext()) {
-                String path = (String)it.next();
+                String path = it.next();
                 assert it.hasNext();
                 String label = (String)it.next();
                 // try to find if the model already contains this source folder

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerLibraries.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/CustomizerLibraries.java
@@ -250,8 +250,8 @@ public class CustomizerLibraries extends JPanel implements HelpCtx.Provider, Lis
             uiProperties.RUN_TEST_CLASSPATH_MODEL
            };
         for (int i = 0; i < models.length; i++) {
-            for (Iterator it = ClassPathUiSupport.getIterator(models[i]); it.hasNext();) {
-                ClassPathSupport.Item itm = (ClassPathSupport.Item) it.next();
+            for (Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator(models[i]); it.hasNext();) {
+                ClassPathSupport.Item itm = it.next();
                 if (itm.getType() == ClassPathSupport.Item.TYPE_LIBRARY) {
                     itm.reassignLibraryManager(man);
                 }
@@ -277,8 +277,8 @@ public class CustomizerLibraries extends JPanel implements HelpCtx.Provider, Lis
         boolean broken = false;
         
         for( int i = 0; i < models.length; i++ ) {
-            for( Iterator it = ClassPathUiSupport.getIterator( models[i] ); it.hasNext(); ) {
-                if ( ((ClassPathSupport.Item)it.next()).isBroken() ) {
+            for( Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator( models[i] ); it.hasNext(); ) {
+                if ( it.next().isBroken() ) {
                     broken = true;
                     break;
                 }

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceLevelQueryImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceLevelQueryImpl.java
@@ -138,8 +138,8 @@ public class J2SELibrarySourceLevelQueryImpl implements SourceLevelQueryImplemen
     }
     
     private FileObject getClassFile (List cpRoots) {
-        for (Iterator it = cpRoots.iterator(); it.hasNext();) {
-            FileObject root = URLMapper.findFileObject((URL)it.next());
+        for (Iterator<URL> it = cpRoots.iterator(); it.hasNext();) {
+            FileObject root = URLMapper.findFileObject(it.next());
             if (root == null) {
                 continue;
             }

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/FileObjectPropertyEditor.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/FileObjectPropertyEditor.java
@@ -35,8 +35,8 @@ public class FileObjectPropertyEditor extends PropertyEditorSupport {
             List fileobjs = (List) this.getValue();
             StringBuffer result = new StringBuffer ();
             boolean first = true;
-            for (Iterator it = fileobjs.iterator(); it.hasNext();) {
-                FileObject fo = (FileObject) it.next ();
+            for (Iterator<FileObject> it = fileobjs.iterator(); it.hasNext();) {
+                FileObject fo = it.next();
                 File f = FileUtil.toFile(fo);
                 if (f != null) {
                     if (!first) {

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerLibraries.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/CustomizerLibraries.java
@@ -250,8 +250,8 @@ public class CustomizerLibraries extends JPanel implements HelpCtx.Provider, Lis
             uiProperties.RUN_TEST_CLASSPATH_MODEL
            };
         for (int i = 0; i < models.length; i++) {
-            for (Iterator it = ClassPathUiSupport.getIterator(models[i]); it.hasNext();) {
-                ClassPathSupport.Item itm = (ClassPathSupport.Item) it.next();
+            for (Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator(models[i]); it.hasNext();) {
+                ClassPathSupport.Item itm = it.next();
                 if (itm.getType() == ClassPathSupport.Item.TYPE_LIBRARY) {
                     itm.reassignLibraryManager(man);
                 }
@@ -277,8 +277,8 @@ public class CustomizerLibraries extends JPanel implements HelpCtx.Provider, Lis
         boolean broken = false;
         
         for( int i = 0; i < models.length; i++ ) {
-            for( Iterator it = ClassPathUiSupport.getIterator( models[i] ); it.hasNext(); ) {
-                if ( ((ClassPathSupport.Item)it.next()).isBroken() ) {
+            for (Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator( models[i] ); it.hasNext(); ) {
+                if ( it.next().isBroken() ) {
                     broken = true;
                     break;
                 }

--- a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/JavaTargetChooserPanel.java
+++ b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/JavaTargetChooserPanel.java
@@ -219,9 +219,9 @@ public final class JavaTargetChooserPanel implements WizardDescriptor.Panel<Wiza
 
     private void fireChange() {
         ChangeEvent e = new ChangeEvent(this);
-        Iterator it = listeners.iterator();
+        Iterator<ChangeListener> it = listeners.iterator();
         while (it.hasNext()) {
-            ((ChangeListener)it.next()).stateChanged(e);
+            it.next().stateChanged(e);
         }
     }
 

--- a/java/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/LocationAwareMavenXpp3Writer.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/LocationAwareMavenXpp3Writer.java
@@ -270,8 +270,8 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((build.getExtensions() != null) && (build.getExtensions().size() > 0)) {
             serializer.startTag(NAMESPACE, "extensions");
-            for (Iterator iter = build.getExtensions().iterator(); iter.hasNext();) {
-                Extension o = (Extension) iter.next();
+            for (Iterator<Extension> iter = build.getExtensions().iterator(); iter.hasNext();) {
+                Extension o = iter.next();
                 writeExtension(o, "extension", serializer);
             }
             serializer.endTag(NAMESPACE, "extensions");
@@ -281,16 +281,16 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((build.getResources() != null) && (build.getResources().size() > 0)) {
             serializer.startTag(NAMESPACE, "resources");
-            for (Iterator iter = build.getResources().iterator(); iter.hasNext();) {
-                Resource o = (Resource) iter.next();
+            for (Iterator<Resource> iter = build.getResources().iterator(); iter.hasNext();) {
+                Resource o = iter.next();
                 writeResource(o, "resource", serializer);
             }
             serializer.endTag(NAMESPACE, "resources");
         }
         if ((build.getTestResources() != null) && (build.getTestResources().size() > 0)) {
             serializer.startTag(NAMESPACE, "testResources");
-            for (Iterator iter = build.getTestResources().iterator(); iter.hasNext();) {
-                Resource o = (Resource) iter.next();
+            for (Iterator<Resource> iter = build.getTestResources().iterator(); iter.hasNext();) {
+                Resource o = iter.next();
                 writeResource(o, "testResource", serializer);
             }
             serializer.endTag(NAMESPACE, "testResources");
@@ -307,8 +307,8 @@ public class LocationAwareMavenXpp3Writer {
             int start2 = b.length();
             InputLocationTracker filtersTracker = build.getLocation("filters");
             int index = 0;
-            for (Iterator iter = build.getFilters().iterator(); iter.hasNext();) {
-                String filter = (String) iter.next();
+            for (Iterator<String> iter = build.getFilters().iterator(); iter.hasNext();) {
+                String filter = iter.next();
                 writeValue(serializer, "filter", filter, filtersTracker, index);
                 index = index + 1;
             }
@@ -320,8 +320,8 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((build.getPlugins() != null) && (build.getPlugins().size() > 0)) {
             serializer.startTag(NAMESPACE, "plugins");
-            for (Iterator iter = build.getPlugins().iterator(); iter.hasNext();) {
-                Plugin o = (Plugin) iter.next();
+            for (Iterator<Plugin> iter = build.getPlugins().iterator(); iter.hasNext();) {
+                Plugin o = iter.next();
                 writePlugin(o, "plugin", serializer);
             }
             serializer.endTag(NAMESPACE, "plugins");
@@ -341,16 +341,16 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((buildBase.getResources() != null) && (buildBase.getResources().size() > 0)) {
             serializer.startTag(NAMESPACE, "resources");
-            for (Iterator iter = buildBase.getResources().iterator(); iter.hasNext();) {
-                Resource o = (Resource) iter.next();
+            for (Iterator<Resource> iter = buildBase.getResources().iterator(); iter.hasNext();) {
+                Resource o = iter.next();
                 writeResource(o, "resource", serializer);
             }
             serializer.endTag(NAMESPACE, "resources");
         }
         if ((buildBase.getTestResources() != null) && (buildBase.getTestResources().size() > 0)) {
             serializer.startTag(NAMESPACE, "testResources");
-            for (Iterator iter = buildBase.getTestResources().iterator(); iter.hasNext();) {
-                Resource o = (Resource) iter.next();
+            for (Iterator<Resource> iter = buildBase.getTestResources().iterator(); iter.hasNext();) {
+                Resource o = iter.next();
                 writeResource(o, "testResource", serializer);
             }
             serializer.endTag(NAMESPACE, "testResources");
@@ -367,8 +367,8 @@ public class LocationAwareMavenXpp3Writer {
             int start2 = b.length();
             InputLocationTracker filtersTracker = buildBase.getLocation("filters");
             int index = 0;
-            for (Iterator iter = buildBase.getFilters().iterator(); iter.hasNext();) {
-                String filter = (String) iter.next();
+            for (Iterator<String> iter = buildBase.getFilters().iterator(); iter.hasNext();) {
+                String filter = iter.next();
                 writeValue(serializer, "filter", filter, filtersTracker, index);
                 index = index + 1;
             }
@@ -380,8 +380,8 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((buildBase.getPlugins() != null) && (buildBase.getPlugins().size() > 0)) {
             serializer.startTag(NAMESPACE, "plugins");
-            for (Iterator iter = buildBase.getPlugins().iterator(); iter.hasNext();) {
-                Plugin o = (Plugin) iter.next();
+            for (Iterator<Plugin> iter = buildBase.getPlugins().iterator(); iter.hasNext();) {
+                Plugin o = iter.next();
                 writePlugin(o, "plugin", serializer);
             }
             serializer.endTag(NAMESPACE, "plugins");
@@ -404,8 +404,8 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((ciManagement.getNotifiers() != null) && (ciManagement.getNotifiers().size() > 0)) {
             serializer.startTag(NAMESPACE, "notifiers");
-            for (Iterator iter = ciManagement.getNotifiers().iterator(); iter.hasNext();) {
-                Notifier o = (Notifier) iter.next();
+            for (Iterator<Notifier> iter = ciManagement.getNotifiers().iterator(); iter.hasNext();) {
+                Notifier o = iter.next();
                 writeNotifier(o, "notifier", serializer);
             }
             serializer.endTag(NAMESPACE, "notifiers");
@@ -441,8 +441,8 @@ public class LocationAwareMavenXpp3Writer {
             int start2 = b.length();
             InputLocationTracker rolesTracker = contributor.getLocation("roles");
             int index = 0;
-            for (Iterator iter = contributor.getRoles().iterator(); iter.hasNext();) {
-                String role = (String) iter.next();
+            for (Iterator<String> iter = contributor.getRoles().iterator(); iter.hasNext();) {
+                String role = iter.next();
                 writeValue(serializer, "role", role, rolesTracker, index);
                 index = index + 1;
             }
@@ -499,8 +499,8 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((dependency.getExclusions() != null) && (dependency.getExclusions().size() > 0)) {
             serializer.startTag(NAMESPACE, "exclusions");
-            for (Iterator iter = dependency.getExclusions().iterator(); iter.hasNext();) {
-                Exclusion o = (Exclusion) iter.next();
+            for (Iterator<Exclusion> iter = dependency.getExclusions().iterator(); iter.hasNext();) {
+                Exclusion o = iter.next();
                 writeExclusion(o, "exclusion", serializer);
             }
             serializer.endTag(NAMESPACE, "exclusions");
@@ -517,8 +517,8 @@ public class LocationAwareMavenXpp3Writer {
         serializer.startTag(NAMESPACE, tagName);
         if ((dependencyManagement.getDependencies() != null) && (dependencyManagement.getDependencies().size() > 0)) {
             serializer.startTag(NAMESPACE, "dependencies");
-            for (Iterator iter = dependencyManagement.getDependencies().iterator(); iter.hasNext();) {
-                Dependency o = (Dependency) iter.next();
+            for (Iterator<Dependency> iter = dependencyManagement.getDependencies().iterator(); iter.hasNext();) {
+                Dependency o = iter.next();
                 writeDependency(o, "dependency", serializer);
             }
             serializer.endTag(NAMESPACE, "dependencies");
@@ -587,8 +587,8 @@ public class LocationAwareMavenXpp3Writer {
             int start2 = b.length();
             InputLocationTracker rolesTracker = developer.getLocation("roles");
             int index = 0;
-            for (Iterator iter = developer.getRoles().iterator(); iter.hasNext();) {
-                String role = (String) iter.next();
+            for (Iterator<String> iter = developer.getRoles().iterator(); iter.hasNext();) {
+                String role = iter.next();
                 writeValue(serializer, "role", role, rolesTracker, index);
                 index = index + 1;
             }
@@ -604,7 +604,7 @@ public class LocationAwareMavenXpp3Writer {
             int start2 = b.length();
             InputLocationTracker propTracker = developer.getLocation("properties");
             for (Iterator iter = developer.getProperties().keySet().iterator(); iter.hasNext();) {
-                String key = (String) iter.next();
+                String key = (String)iter.next();
                 String value = (String) developer.getProperties().get(key);
                 writeValue(serializer, key, value, propTracker);
             }
@@ -744,8 +744,8 @@ public class LocationAwareMavenXpp3Writer {
             flush(serializer);
             InputLocation otherLoc = mailingList.getLocation("otherArchives");
             int index = 0;
-            for (Iterator iter = mailingList.getOtherArchives().iterator(); iter.hasNext();) {
-                String otherArchive = (String) iter.next();
+            for (Iterator<String> iter = mailingList.getOtherArchives().iterator(); iter.hasNext();) {
+                String otherArchive = iter.next();
                 writeValue(serializer, "otherArchive", otherArchive, otherLoc, index);
                 index = index + 1;
             }
@@ -798,32 +798,32 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((model.getLicenses() != null) && (model.getLicenses().size() > 0)) {
             serializer.startTag(NAMESPACE, "licenses");
-            for (Iterator iter = model.getLicenses().iterator(); iter.hasNext();) {
-                License o = (License) iter.next();
+            for (Iterator<License> iter = model.getLicenses().iterator(); iter.hasNext();) {
+                License o = iter.next();
                 writeLicense(o, "license", serializer);
             }
             serializer.endTag(NAMESPACE, "licenses");
         }
         if ((model.getDevelopers() != null) && (model.getDevelopers().size() > 0)) {
             serializer.startTag(NAMESPACE, "developers");
-            for (Iterator iter = model.getDevelopers().iterator(); iter.hasNext();) {
-                Developer o = (Developer) iter.next();
+            for (Iterator<Developer> iter = model.getDevelopers().iterator(); iter.hasNext();) {
+                Developer o = iter.next();
                 writeDeveloper(o, "developer", serializer);
             }
             serializer.endTag(NAMESPACE, "developers");
         }
         if ((model.getContributors() != null) && (model.getContributors().size() > 0)) {
             serializer.startTag(NAMESPACE, "contributors");
-            for (Iterator iter = model.getContributors().iterator(); iter.hasNext();) {
-                Contributor o = (Contributor) iter.next();
+            for (Iterator<Contributor> iter = model.getContributors().iterator(); iter.hasNext();) {
+                Contributor o = iter.next();
                 writeContributor(o, "contributor", serializer);
             }
             serializer.endTag(NAMESPACE, "contributors");
         }
         if ((model.getMailingLists() != null) && (model.getMailingLists().size() > 0)) {
             serializer.startTag(NAMESPACE, "mailingLists");
-            for (Iterator iter = model.getMailingLists().iterator(); iter.hasNext();) {
-                MailingList o = (MailingList) iter.next();
+            for (Iterator<MailingList> iter = model.getMailingLists().iterator(); iter.hasNext();) {
+                MailingList o = iter.next();
                 writeMailingList(o, "mailingList", serializer);
             }
             serializer.endTag(NAMESPACE, "mailingLists");
@@ -837,8 +837,8 @@ public class LocationAwareMavenXpp3Writer {
             int start2 = b.length();
             int index = 0;
             InputLocation tracker = model.getLocation("modules");
-            for (Iterator iter = model.getModules().iterator(); iter.hasNext();) {
-                String module = (String) iter.next();
+            for (Iterator<String> iter = model.getModules().iterator(); iter.hasNext();) {
+                String module = iter.next();
                 writeValue(serializer, "module", module, tracker, index);
                 index = index + 1;
             }
@@ -875,24 +875,24 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((model.getDependencies() != null) && (model.getDependencies().size() > 0)) {
             serializer.startTag(NAMESPACE, "dependencies");
-            for (Iterator iter = model.getDependencies().iterator(); iter.hasNext();) {
-                Dependency o = (Dependency) iter.next();
+            for (Iterator<Dependency> iter = model.getDependencies().iterator(); iter.hasNext();) {
+                Dependency o = iter.next();
                 writeDependency(o, "dependency", serializer);
             }
             serializer.endTag(NAMESPACE, "dependencies");
         }
         if ((model.getRepositories() != null) && (model.getRepositories().size() > 0)) {
             serializer.startTag(NAMESPACE, "repositories");
-            for (Iterator iter = model.getRepositories().iterator(); iter.hasNext();) {
-                Repository o = (Repository) iter.next();
+            for (Iterator<Repository> iter = model.getRepositories().iterator(); iter.hasNext();) {
+                Repository o = iter.next();
                 writeRepository(o, "repository", serializer);
             }
             serializer.endTag(NAMESPACE, "repositories");
         }
         if ((model.getPluginRepositories() != null) && (model.getPluginRepositories().size() > 0)) {
             serializer.startTag(NAMESPACE, "pluginRepositories");
-            for (Iterator iter = model.getPluginRepositories().iterator(); iter.hasNext();) {
-                Repository o = (Repository) iter.next();
+            for (Iterator<Repository> iter = model.getPluginRepositories().iterator(); iter.hasNext();) {
+                Repository o = iter.next();
                 writeRepository(o, "pluginRepository", serializer);
             }
             serializer.endTag(NAMESPACE, "pluginRepositories");
@@ -908,8 +908,8 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((model.getProfiles() != null) && (model.getProfiles().size() > 0)) {
             serializer.startTag(NAMESPACE, "profiles");
-            for (Iterator iter = model.getProfiles().iterator(); iter.hasNext();) {
-                Profile o = (Profile) iter.next();
+            for (Iterator<Profile> iter = model.getProfiles().iterator(); iter.hasNext();) {
+                Profile o = iter.next();
                 writeProfile(o, "profile", serializer);
             }
             serializer.endTag(NAMESPACE, "profiles");

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/ElementBindings.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/ElementBindings.java
@@ -104,9 +104,9 @@ public class ElementBindings extends HashMap {
         
         if (name == null) return false;
         
-        Iterator it = values().iterator();
+        Iterator<Entry> it = values().iterator();
         while (it.hasNext()) {
-            Entry next = (Entry) it.next();
+            Entry next = it.next();
             if (name.equals(next.parslet)) return true;
         }
         
@@ -118,10 +118,10 @@ public class ElementBindings extends HashMap {
      */
     public int getParsletUsageCount(String parslet) {
         int toret = 0;
-        Iterator it = values().iterator();
+        Iterator<Entry> it = values().iterator();
         
         while (it.hasNext()) {
-            Entry next = (Entry) it.next();
+            Entry next = it.next();
             if (parslet != null && parslet.equals(next.parslet)) {            
                 toret++;
             }
@@ -143,9 +143,9 @@ public class ElementBindings extends HashMap {
      */
     public final Entry getEntry(final int index) {
         int myindex = index;
-        Iterator it = values().iterator();
+        Iterator<Entry> it = values().iterator();
         while (it.hasNext()) {
-            Entry next = (Entry) it.next();
+            Entry next = it.next();
             if (myindex-- == 0) 
                 return next;
         }

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerateDOMScannerSupport.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerateDOMScannerSupport.java
@@ -220,9 +220,9 @@ public class GenerateDOMScannerSupport implements XMLGenerateCookie {
         
                         // no root element is obvious, go over all declated elements.
         
-                       Iterator it = dtd.getElementDeclarations().iterator();
+                       Iterator<TreeElementDecl> it = dtd.getElementDeclarations().iterator();
                        while (it.hasNext()) {
-                           String tagName = ((TreeElementDecl)it.next()).getName();
+                           String tagName = it.next().getName();
                            sb.append ("if ((").append (VARIABLE_ELEMENT).append (" != null) && "). // NOI18N
                            append (VARIABLE_ELEMENT).append (".getTagName().equals (\"").append (tagName).append ("\")) {\n"); // NOI18N
                            sb.append (METHOD_SCAN_ELEMENT).append ("_").append (GenerateSupportUtils.getJavaName (tagName)).append (" (").append (VARIABLE_ELEMENT). // NOI18N
@@ -263,14 +263,14 @@ public class GenerateDOMScannerSupport implements XMLGenerateCookie {
                             sb = new StringBuffer ();
                             sb.append("{");
                             sb.append (" // <").append (tagName).append (">\n// element.getValue();\n"); // NOI18N
-                            Iterator it2;
+                            Iterator<TreeAttlistDeclAttributeDef> it2;
                             if ((it2 = dtd.getAttributeDeclarations (tagName).iterator()).hasNext()) {
                                 sb.append (DOM_NAMED_NODE_MAP).append (" ").append (VARIABLE_ATTRS).append (" = "). // NOI18N
                                 append (VARIABLE_ELEMENT).append (".getAttributes();\n"); // NOI18N
                                 sb.append ("for (int i = 0; i < ").append (VARIABLE_ATTRS).append (".getLength(); i++) {\n"); // NOI18N
                                 sb.append ("org.w3c.dom.Attr attr = (org.w3c.dom.Attr)attrs.item(i);\n"); // NOI18N
                                 while (it2.hasNext()) {
-                                    TreeAttlistDeclAttributeDef attr = (TreeAttlistDeclAttributeDef)it2.next();
+                                    TreeAttlistDeclAttributeDef attr = it2.next();
                                     sb.append ("if (attr.getName().equals (\"").append (attr.getName()).append ("\")) { // <"). // NOI18N
                                     append (tagName).append (" ").append (attr.getName()).append ("=\"???\">\n"); // NOI18N
                                     sb.append ("// attr.getValue();\n}\n"); // NOI18N
@@ -310,7 +310,7 @@ public class GenerateDOMScannerSupport implements XMLGenerateCookie {
      */
     private String generateElementScanner(TreeElementDecl element) {
         
-        Iterator it;
+        Iterator<TreeElementDecl> it;
         Set<String> elements = new HashSet<>();
         
         TreeElementDecl.ContentType type = element.getContentType();
@@ -318,7 +318,7 @@ public class GenerateDOMScannerSupport implements XMLGenerateCookie {
         if (type instanceof ANYType) {
             it = dtd.getElementDeclarations().iterator();
             while (it.hasNext()) {
-                String tagName = ((TreeElementDecl)it.next()).getName();
+                String tagName = it.next().getName();
                 elements.add(tagName);
             }
             
@@ -365,8 +365,8 @@ public class GenerateDOMScannerSupport implements XMLGenerateCookie {
     private void addElements(TreeElementDecl.ContentType type, Set elements) {
         
         if (type instanceof ChildrenType) {
-            for (Iterator it = ((ChildrenType)type).getTypes().iterator(); it.hasNext(); ) {
-                TreeElementDecl.ContentType next = (TreeElementDecl.ContentType) it.next();
+            for (Iterator<TreeElementDecl.ContentType> it = ((ChildrenType)type).getTypes().iterator(); it.hasNext(); ) {
+                TreeElementDecl.ContentType next = it.next();
                 if (next instanceof ChildrenType) {
                     addElements(next, elements);
                 } else if ( next instanceof NameType) {

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerationUtils.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerationUtils.java
@@ -394,8 +394,8 @@ public final class GenerationUtils {
         Parameters.notNull("fieldTrees", fieldTrees); // NOI18N
 
         int firstNonFieldIndex = 0;
-        Iterator memberTrees = classTree.getMembers().iterator();
-        while (memberTrees.hasNext() && ((Tree)memberTrees.next()).getKind() == Tree.Kind.VARIABLE) {
+        Iterator<? extends Tree> memberTrees = classTree.getMembers().iterator();
+        while (memberTrees.hasNext() && memberTrees.next().getKind() == Tree.Kind.VARIABLE) {
             firstNonFieldIndex++;
         }
         TreeMaker make = getTreeMaker();

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsGenerator.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXBindingsGenerator.java
@@ -47,9 +47,9 @@ final class SAXBindingsGenerator {
     private static String elementBindings(SAXGeneratorModel model) {
         StringBuffer s = new StringBuffer();
         
-        Iterator it = model.getElementBindings().values().iterator();
+        Iterator<ElementBindings.Entry> it = model.getElementBindings().values().iterator();
         while (it.hasNext()) {
-            ElementBindings.Entry next = (ElementBindings.Entry) it.next();
+            ElementBindings.Entry next = it.next();
             s.append("\t<bind element='" + next.getElement() + "' method='" + next.getMethod() + "' "); // NOI18N
             s.append("type='" + next.getType() + "' "); // NOI18N
             if (next.getParslet() != null) {
@@ -64,9 +64,9 @@ final class SAXBindingsGenerator {
         
         StringBuffer s = new StringBuffer();
         
-        Iterator it = model.getParsletBindings().values().iterator();
+        Iterator<ParsletBindings.Entry> it = model.getParsletBindings().values().iterator();
         while (it.hasNext()) {
-            ParsletBindings.Entry next = (ParsletBindings.Entry) it.next();
+            ParsletBindings.Entry next = it.next();
             s.append("\t<parslet parslet='" + next.getId() + "' return='" + next.getType() + "' />\n"); // NOI18N
         }
         

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorAbstractPanel.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorAbstractPanel.java
@@ -138,9 +138,9 @@ public abstract class SAXGeneratorAbstractPanel extends JPanel implements Custom
             this.valid = valid;
 
             synchronized (listeners) {
-                Iterator it = listeners.iterator();
+                Iterator<ChangeListener> it = listeners.iterator();
                 while (it.hasNext()) {
-                    ChangeListener next = (ChangeListener) it.next();
+                    ChangeListener next = it.next();
                     next.stateChanged(EVENT);
                 }
             }

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorModel.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorModel.java
@@ -294,9 +294,9 @@ public class SAXGeneratorModel implements java.io.Serializable {
     public void loadElementBindings(ElementBindings bindings) {
         if (bindings == null) return;
         
-        Iterator it = bindings.values().iterator();
+        Iterator<ElementBindings.Entry> it = bindings.values().iterator();
         while (it.hasNext()) {
-            ElementBindings.Entry next = (ElementBindings.Entry) it.next();
+            ElementBindings.Entry next = it.next();
             
             if (elementDeclarations.getEntry(next.getElement()) != null) {
                 elementBindings.put(next.getElement(), next);
@@ -312,9 +312,9 @@ public class SAXGeneratorModel implements java.io.Serializable {
        
         if (parslets == null) return;
         
-        Iterator it = parslets.values().iterator();
+        Iterator<ParsletBindings.Entry> it = parslets.values().iterator();
         while (it.hasNext()) {
-            ParsletBindings.Entry next = (ParsletBindings.Entry) it.next();
+            ParsletBindings.Entry next = it.next();
             
             if (elementBindings.containsParslet(next.getId())) {
                 parsletBindings.put(next.getId(), next);

--- a/javafx/javafx2.samples/src/org/netbeans/modules/javafx2/samples/PanelConfigureProject.java
+++ b/javafx/javafx2.samples/src/org/netbeans/modules/javafx2/samples/PanelConfigureProject.java
@@ -86,13 +86,13 @@ final class PanelConfigureProject implements WizardDescriptor.Panel, WizardDescr
     }
 
     protected final void fireChangeEvent() {
-        Iterator it;
+        Iterator<ChangeListener> it;
         synchronized (listeners) {
             it = new HashSet<ChangeListener>(listeners).iterator();
         }
         ChangeEvent ev = new ChangeEvent(this);
         while (it.hasNext()) {
-            ((ChangeListener) it.next()).stateChanged(ev);
+            it.next().stateChanged(ev);
         }
     }
 

--- a/php/php.smarty/src/org/netbeans/modules/php/smarty/editor/completion/TplCompletionQuery.java
+++ b/php/php.smarty/src/org/netbeans/modules/php/smarty/editor/completion/TplCompletionQuery.java
@@ -91,9 +91,9 @@ public class TplCompletionQuery extends UserTask {
             // first command contain main keyword
             ArrayList<TplCompletionItem> availableItems = new ArrayList<TplCompletionItem>(functionParams.get(commands.get(0)));
             // rest of them is just removed from codecompletion
-            Iterator it = availableItems.iterator();
+            Iterator<TplCompletionItem> it = availableItems.iterator();
             while (it.hasNext()) {
-                TplCompletionItem tplCompletionItem = (TplCompletionItem)it.next();
+                TplCompletionItem tplCompletionItem = it.next();
                 for (String command : commands) {
                     if (tplCompletionItem.getItemText().equals(command)) {
                         it.remove();

--- a/platform/autoupdate.services/libsrc/org/netbeans/updater/Localization.java
+++ b/platform/autoupdate.services/libsrc/org/netbeans/updater/Localization.java
@@ -152,9 +152,9 @@ class Localization {
             for( LocaleIterator li = new LocaleIterator( Locale.getDefault() ); li.hasNext(); ) {
                 String localeName = li.next().toString ();
                 // loop for clusters
-                Iterator it = UpdateTracking.clusters (true).iterator ();
+                Iterator<File> it = UpdateTracking.clusters (true).iterator ();
                 while (it.hasNext ()) {
-                    File cluster = (File)it.next ();
+                    File cluster = it.next();
                     File locJar = new File( cluster.getPath () + FILE_SEPARATOR + LOCALE_DIR + FILE_SEPARATOR + UPDATER_JAR + localeName + UPDATER_JAR_EXT );
                     if ( locJar.exists() ) {  // File exists
                         try {

--- a/platform/autoupdate.services/libsrc/org/netbeans/updater/UpdateTracking.java
+++ b/platform/autoupdate.services/libsrc/org/netbeans/updater/UpdateTracking.java
@@ -854,10 +854,10 @@ public final class UpdateTracking {
             config.getParentFile().mkdirs();
             Boolean isAutoload = null;
             Boolean isEager = null;
-            java.util.Iterator it = newVersion.getFiles().iterator();
+            Iterator<ModuleFile> it = newVersion.getFiles().iterator();
             boolean needToWrite = false;
             while (it.hasNext()) {
-                ModuleFile f = (ModuleFile) it.next ();
+                ModuleFile f = it.next();
                 String n = f.getName();
                 String parentDir;
                 {

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewCloneableTopComponent.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewCloneableTopComponent.java
@@ -286,9 +286,9 @@ public final class MultiViewCloneableTopComponent extends CloneableTopComponent
         // now try a best guess.. iterate the already created elements and check if any of
         // them is a Pane
         Collection col = peer.model.getCreatedElements();
-        Iterator it = col.iterator();
+        Iterator<MultiViewElement> it = col.iterator();
         while (it.hasNext()) {
-            el = (MultiViewElement)it.next();
+            el = it.next();
             if (el.getVisualRepresentation() instanceof CloneableEditorSupport.Pane) {
                 // fingers crossed and hope for the best... could result in bad results once
                 // we have multiple editors in the multiview component.

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewPeer.java
@@ -297,9 +297,9 @@ public final class MultiViewPeer implements PropertyChangeListener {
     }        
     
     void peerComponentClosed() {
-        Iterator it = model.getCreatedElements().iterator();
+        Iterator<MultiViewElement> it = model.getCreatedElements().iterator();
         while (it.hasNext()) {
-            MultiViewElement el = (MultiViewElement)it.next();
+            MultiViewElement el = it.next();
             model.markAsHidden(el);
             el.componentClosed();
         }
@@ -802,10 +802,10 @@ public final class MultiViewPeer implements PropertyChangeListener {
      */
     boolean canClose() {
         Collection col = model.getCreatedElements();
-        Iterator it = col.iterator();
+        Iterator<MultiViewElement> it = col.iterator();
         Collection<CloseOperationState> badOnes = new ArrayList<>();
         while (it.hasNext()) {
-           MultiViewElement el = (MultiViewElement)it.next();
+           MultiViewElement el = it.next();
            CloseOperationState state = el.canCloseElement();
            if (!state.canClose()) {
                badOnes.add(state);
@@ -1104,9 +1104,9 @@ public final class MultiViewPeer implements PropertyChangeListener {
         }
         
         private void fireElementChange() {
-            Iterator it = new ArrayList<ChangeListener>(listeners).iterator();
+            Iterator<ChangeListener> it = new ArrayList<ChangeListener>(listeners).iterator();
             while (it.hasNext()) {
-                ChangeListener elem = (ChangeListener) it.next();
+                ChangeListener elem = it.next();
                 ChangeEvent event = new ChangeEvent(this);
                 elem.stateChanged(event);
             }
@@ -1114,9 +1114,9 @@ public final class MultiViewPeer implements PropertyChangeListener {
         }
         
         void updateListeners(MultiViewElement old, MultiViewElement fresh) {
-            Iterator it = listeners.iterator();
+            Iterator<ChangeListener> it = listeners.iterator();
             while (it.hasNext()) {
-                ChangeListener elem = (ChangeListener) it.next();
+                ChangeListener elem = it.next();
                 if (old.getUndoRedo() != null) {
                     old.getUndoRedo().removeChangeListener(elem);
                 }

--- a/platform/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewFactory.java
+++ b/platform/core.multiview/src/org/netbeans/core/spi/multiview/MultiViewFactory.java
@@ -309,9 +309,9 @@ public final class MultiViewFactory {
             }
             
             StringBuilder sb = new StringBuilder();
-            Iterator it = elems.values().iterator();
+            Iterator<CloseOperationState> it = elems.values().iterator();
             while (it.hasNext()) {
-                CloseOperationState state = (CloseOperationState)it.next();
+                CloseOperationState state = it.next();
                 if (sb.length() > 0) {
                     sb.append(" ");
                 }

--- a/platform/core.startup/src/org/netbeans/core/startup/Asm.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Asm.java
@@ -127,8 +127,8 @@ final class Asm {
      * @param mn method to process
      */
     private static void replaceSuperCtorCalls(final ClassNode theClass, final ClassNode extenderClass, MethodNode mn) {
-        for (Iterator it = mn.instructions.iterator(); it.hasNext(); ) {
-            AbstractInsnNode aIns = (AbstractInsnNode)it.next();
+        for (Iterator<AbstractInsnNode> it = mn.instructions.iterator(); it.hasNext(); ) {
+            AbstractInsnNode aIns = it.next();
             if (aIns.getOpcode() == Opcodes.INVOKESPECIAL) {
                 MethodInsnNode mins = (MethodInsnNode)aIns;
                 if (CONSTRUCTOR_NAME.equals(mins.name) && mins.owner.equals(extenderClass.superName)) {

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ColumnSelectionPanel.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ColumnSelectionPanel.java
@@ -226,8 +226,8 @@ class ColumnSelectionPanel extends JPanel {
         if (columnModel == null) {
             return;
         }
-        for (Iterator it = checkBoxes.keySet().iterator(); it.hasNext(); ) {
-            ETableColumn etc = (ETableColumn) it.next();
+        for (Iterator<ETableColumn> it = checkBoxes.keySet().iterator(); it.hasNext(); ) {
+            ETableColumn etc = it.next();
             JCheckBox checkBox = checkBoxes.get (etc);
             columnModel.setColumnHidden(etc,! checkBox.isSelected());
         }

--- a/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
+++ b/platform/o.n.swing.outline/src/org/netbeans/swing/etable/ETable.java
@@ -2225,8 +2225,8 @@ public class ETable extends JTable {
                 int rows[] = getSelectedRows();
                 int selectedRowIndex = (rows == null || rows.length == 0) ? 0 : rows[0];
                 int r = 0;
-                for (Iterator it = results.iterator(); it.hasNext(); r++) {
-                    int curResult = ((Integer)it.next()).intValue();
+                for (Iterator<Integer> it = results.iterator(); it.hasNext(); r++) {
+                    int curResult = it.next().intValue();
                     if (selectedRowIndex <= curResult) {
                         currentSelectionIndex = r;
                         break;

--- a/platform/openide.actions/src/org/openide/actions/NewAction.java
+++ b/platform/openide.actions/src/org/openide/actions/NewAction.java
@@ -19,6 +19,7 @@
 
 package org.openide.actions;
 
+import java.util.Iterator;
 import java.beans.PropertyChangeListener;
 import javax.swing.event.ChangeListener;
 import org.openide.awt.Actions;
@@ -159,10 +160,10 @@ public final class NewAction extends NodeAction {
                 java.util.Collection c = lookup.lookupResult(Node.class).allItems();
 
                 if (c.size() == 1) {
-                    java.util.Iterator it = c.iterator();
+                    Iterator<Lookup.Item> it = c.iterator();
 
                     while (it.hasNext()) {
-                        Lookup.Item item = (Lookup.Item) it.next();
+                        Lookup.Item item = it.next();
                         Node n = (Node) item.getInstance();
 
                         if (n != null) {

--- a/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
@@ -204,9 +204,9 @@ final class MultiFileObject extends AbstractFolder implements FileObject.Priorit
             }
         }
 
-        Iterator it = now.iterator();
+        Iterator<FileObject> it = now.iterator();
         while (it.hasNext()) {
-            FileObject fo = (FileObject) it.next();
+            FileObject fo = it.next();
             fo.removeFileChangeListener(weakL);
         }
 

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLFileSystem.java
@@ -861,10 +861,10 @@ public final class XMLFileSystem extends AbstractFileSystem {
                 foAttrs = new XMLMapAttr();
             }
 
-            Iterator it = attrs.entrySet().iterator();
+            Iterator<Map.Entry> it = attrs.entrySet().iterator();
             boolean ch = false;
             while (it.hasNext()) {
-                Map.Entry attrEntry = (Map.Entry) it.next();
+                Map.Entry attrEntry = it.next();
                 Object prev = foAttrs.put(attrEntry.getKey(), attrEntry.getValue());
                 
                 ch |= (prev == null && attrEntry.getValue() != null) || !prev.equals(attrEntry.getValue());

--- a/platform/openide.loaders/src/org/openide/loaders/DataLoaderPool.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataLoaderPool.java
@@ -570,10 +570,10 @@ implements java.io.Serializable {
                 // [PENDING] in the future a more efficient API may be introduced
                 // (actually currently you can look up with a template giving the name
                 // as part of the lookup item ID but this is not an official API)
-                Iterator modules = Lookup.getDefault().lookupAll(ModuleInfo.class).iterator();
+                Iterator<? extends ModuleInfo> modules = Lookup.getDefault().lookupAll(ModuleInfo.class).iterator();
                 boolean ok = false;
                 while (modules.hasNext()) {
-                    ModuleInfo module = (ModuleInfo)modules.next();
+                    ModuleInfo module = modules.next();
                     if (module.getCodeNameBase().equals(modulename)) {
                         if (module.isEnabled()) {
                             // Carry on.

--- a/platform/openide.loaders/src/org/openide/loaders/DataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataObject.java
@@ -274,9 +274,9 @@ implements Node.Cookie, Serializable, HelpCtx.Provider, Lookup.Provider {
      * If the files are rescanned (e.g. after a disposal), the current data loader will be given preference.
     */
     protected final void markFiles () throws IOException {
-        Iterator en = files ().iterator ();
+        Iterator<FileObject> en = files ().iterator ();
         while (en.hasNext ()) {
-            FileObject fo = (FileObject)en.next ();
+            FileObject fo = en.next ();
             loader.markFile (fo);
         }
     }

--- a/platform/openide.loaders/src/org/openide/loaders/MultiDataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/MultiDataObject.java
@@ -385,10 +385,10 @@ public class MultiDataObject extends DataObject {
      */
     private void removeAllInvalid () {
         ERR.log(Level.FINE, "removeAllInvalid, started {0}", this); // NOI18N
-        Iterator it = checkSecondary ().entrySet ().iterator ();
+        Iterator<Map.Entry<FileObject, MultiDataObject.Entry>> it = checkSecondary().entrySet().iterator();
         boolean fire = false;
         while (it.hasNext ()) {
-            Map.Entry e = (Map.Entry)it.next ();
+            Map.Entry e = it.next();
             FileObject fo = (FileObject)e.getKey ();
             if (fo == null || !fo.isValid ()) {
                 it.remove ();

--- a/platform/openide.loaders/src/org/openide/loaders/XMLEntityResolverChain.java
+++ b/platform/openide.loaders/src/org/openide/loaders/XMLEntityResolverChain.java
@@ -99,9 +99,9 @@ final class XMLEntityResolverChain implements EntityResolver {
         IOException lioex = null;
         
         synchronized (resolverChain) {
-            Iterator it = resolverChain.iterator();
+            Iterator<EntityResolver> it = resolverChain.iterator();
             while (it.hasNext()) {
-                EntityResolver resolver = (EntityResolver) it.next();
+                EntityResolver resolver = it.next();
                 try {
                     InputSource test = resolver.resolveEntity(publicID, systemID);
                     if (test == null) continue;

--- a/platform/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesRegistrationSupport.java
+++ b/platform/openide.nodes/src/org/netbeans/modules/openide/nodes/NodesRegistrationSupport.java
@@ -60,8 +60,8 @@ public final class NodesRegistrationSupport {
                 @Override
                 void register() {
                     ClassLoader clsLoader = findClsLoader();
-                    for (Iterator it = lookupResult.allInstances().iterator(); it.hasNext();) {
-                        PEClassRegistration clsReg = (PEClassRegistration) it.next();
+                    for (Iterator<PEClassRegistration> it = lookupResult.allInstances().iterator(); it.hasNext();) {
+                        PEClassRegistration clsReg = it.next();
                         for (String type : clsReg.targetTypes) {
                             try {
                                 Class<?> cls = getClassFromCanonicalName(type);
@@ -88,8 +88,8 @@ public final class NodesRegistrationSupport {
                 @Override
                 void register() {
                     Set<String> newPath = new LinkedHashSet<String> ();
-                    for (Iterator it = lookupResult.allInstances().iterator(); it.hasNext();) {
-                        PEPackageRegistration pkgReg = (PEPackageRegistration) it.next();
+                    for (Iterator<PEPackageRegistration> it = lookupResult.allInstances().iterator(); it.hasNext();) {
+                        PEPackageRegistration pkgReg = it.next();
                         newPath.add(pkgReg.pkg);
                     }
                     newPath.addAll(originalPath);
@@ -113,8 +113,8 @@ public final class NodesRegistrationSupport {
                 @Override
                 void register() {
                     Set<String> newPath = new LinkedHashSet<String> ();
-                    for (Iterator it = lookupResult.allInstances().iterator(); it.hasNext();) {
-                        BeanInfoRegistration biReg = (BeanInfoRegistration) it.next();
+                    for (Iterator<BeanInfoRegistration> it = lookupResult.allInstances().iterator(); it.hasNext();) {
+                        BeanInfoRegistration biReg = it.next();
                         newPath.add(biReg.searchPath);
                     }
                     newPath.addAll(originalBeanInfoSearchPath);

--- a/platform/openide.nodes/src/org/openide/nodes/EntrySupportDefault.java
+++ b/platform/openide.nodes/src/org/openide/nodes/EntrySupportDefault.java
@@ -546,9 +546,9 @@ class EntrySupportDefault extends EntrySupport {
                 children.parent.fireSubNodesChange(false, arr, current);
             }
             // fire change of parent
-            Iterator it = nodes.iterator();
+            Iterator<Node> it = nodes.iterator();
             while (it.hasNext()) {
-                Node n = (Node) it.next();
+                Node n = it.next();
                 n.deassignFrom(children);
                 n.fireParentNodeChange(children.parent, null);
             }

--- a/platform/openide.nodes/src/org/openide/nodes/NodeLookup.java
+++ b/platform/openide.nodes/src/org/openide/nodes/NodeLookup.java
@@ -133,10 +133,10 @@ final class NodeLookup extends AbstractLookup {
                 all = CookieSet.exitAllClassesMode(prev);
             }
 
-            Iterator it = all.iterator();
+            Iterator<Class> it = all.iterator();
 
             while (it.hasNext()) {
-                Class c = (Class) it.next();
+                Class c = it.next();
                 updateLookupAsCookiesAreChanged(c);
             }
 

--- a/platform/openide.options/src/org/openide/options/SystemOption.java
+++ b/platform/openide.options/src/org/openide/options/SystemOption.java
@@ -33,6 +33,7 @@ import java.io.ObjectOutput;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import java.util.Iterator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -137,10 +138,10 @@ public abstract class SystemOption extends SharedClassObject implements HelpCtx.
                 return;
             }
 
-            java.util.Iterator it = m.entrySet().iterator();
+            Iterator<Map.Entry> it = m.entrySet().iterator();
 WHILE: 
             while (it.hasNext()) {
-                Map.Entry e = (Map.Entry) it.next();
+                Map.Entry e = it.next();
 
                 if (e.getValue() instanceof Box) {
                     Object value = ((Box) e.getValue()).value;

--- a/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
+++ b/platform/openide.util.ui/src/org/openide/util/ImageUtilities.java
@@ -528,8 +528,9 @@ public final class ImageUtilities {
                 }
                 useLoaderQuery = loaderQuery;
             }
-            Iterator it = useLoaderQuery.allInstances().iterator();
-            toReturn = Optional.ofNullable(it.hasNext() ? (T) it.next() : null);
+
+            Iterator<? extends T> it = useLoaderQuery.allInstances().iterator();
+            toReturn = Optional.ofNullable(it.hasNext() ? it.next() : null);
             if (!toReturn.isPresent()) {
                 if (!noLoaderWarned.getAndSet(true)) {
                     ERR.log(Level.WARNING, "No {0} instance found in {1}", // NOI18N

--- a/platform/openide.util/src/org/openide/util/MapFormat.java
+++ b/platform/openide.util/src/org/openide/util/MapFormat.java
@@ -310,13 +310,13 @@ public class MapFormat extends Format {
     */
     public String parse(String source) {
         StringBuffer sbuf = new StringBuffer(source);
-        Iterator key_it = argmap.keySet().iterator();
+        Iterator<String> key_it = argmap.keySet().iterator();
 
         //skipped = new RangeList();
         // What was this for??
         //process(source, "\"", "\""); // NOI18N
         while (key_it.hasNext()) {
-            String it_key = (String) key_it.next();
+            String it_key = key_it.next();
             String it_obj = formatObject(argmap.get(it_key));
             int it_idx = -1;
 

--- a/platform/openide.util/src/org/openide/util/NbCollections.java
+++ b/platform/openide.util/src/org/openide/util/NbCollections.java
@@ -65,7 +65,7 @@ public class NbCollections {
      */
     public static <E> Set<E> checkedSetByCopy(Set rawSet, Class<E> type, boolean strict) throws ClassCastException {
         Set<E> s = new HashSet<E>(rawSet.size() * 4 / 3 + 1);
-        Iterator it = rawSet.iterator();
+        Iterator<?> it = rawSet.iterator();
         while (it.hasNext()) {
             Object e = it.next();
             try {
@@ -93,7 +93,7 @@ public class NbCollections {
      */
     public static <E> List<E> checkedListByCopy(List rawList, Class<E> type, boolean strict) throws ClassCastException {
         List<E> l = (rawList instanceof RandomAccess) ? new ArrayList<E>(rawList.size()) : new LinkedList<E>();
-        Iterator it = rawList.iterator();
+        Iterator<?> it = rawList.iterator();
         while (it.hasNext()) {
             Object e = it.next();
             try {
@@ -122,9 +122,9 @@ public class NbCollections {
      */
     public static <K,V> Map<K,V> checkedMapByCopy(Map rawMap, Class<K> keyType, Class<V> valueType, boolean strict) throws ClassCastException {
         Map<K,V> m2 = new HashMap<K,V>(rawMap.size() * 4 / 3 + 1);
-        Iterator it = rawMap.entrySet().iterator();
+        Iterator<Map.Entry> it = rawMap.entrySet().iterator();
         while (it.hasNext()) {
-            Map.Entry e = (Map.Entry) it.next();
+            Map.Entry e = it.next();
             try {
                 m2.put(keyType.cast(e.getKey()), valueType.cast(e.getValue()));
             } catch (ClassCastException x) {
@@ -142,7 +142,7 @@ public class NbCollections {
 
         private static final Object WAITING = new Object();
 
-        private final Iterator it;
+        private final Iterator<?> it;
         private Object next = WAITING;
 
         public CheckedIterator(Iterator it) {
@@ -264,7 +264,7 @@ public class NbCollections {
         @Override
         public int size() {
             int c = 0;
-            Iterator it = rawSet.iterator();
+            Iterator<?> it = rawSet.iterator();
             while (it.hasNext()) {
                 if (acceptEntry(it.next())) {
                     c++;
@@ -365,9 +365,9 @@ public class NbCollections {
             @Override
             public int size() {
                 int c = 0;
-                Iterator it = rawMap.entrySet().iterator();
+                Iterator<Map.Entry> it = rawMap.entrySet().iterator();
                 while (it.hasNext()) {
-                    if (acceptEntry((Map.Entry) it.next())) {
+                    if (acceptEntry(it.next())) {
                         c++;
                     }
                 }
@@ -430,9 +430,9 @@ public class NbCollections {
         @Override
         public int size() {
             int c = 0;
-            Iterator it = rawMap.entrySet().iterator();
+            Iterator<Map.Entry> it = rawMap.entrySet().iterator();
             while (it.hasNext()) {
-                if (acceptEntry((Map.Entry) it.next())) {
+                if (acceptEntry(it.next())) {
                     c++;
                 }
             }

--- a/platform/openide.util/src/org/openide/util/RE13.java
+++ b/platform/openide.util/src/org/openide/util/RE13.java
@@ -219,7 +219,7 @@ ALL:
 
         Integer last = null;
 
-        Iterator it = item.iterator();
+        Iterator<?> it = item.iterator();
         int i = 0;
 
         while (it.hasNext()) {

--- a/platform/openide.util/src/org/openide/util/Task.java
+++ b/platform/openide.util/src/org/openide/util/Task.java
@@ -195,7 +195,7 @@ public class Task extends Object implements Runnable {
     * @see #run
     */
     protected final void notifyFinished() {
-        Iterator it;
+        Iterator<TaskListener> it;
 
         synchronized (this) {
             finished = true;
@@ -211,7 +211,7 @@ public class Task extends Object implements Runnable {
         }
 
         while (it.hasNext()) {
-            TaskListener l = (TaskListener) it.next();
+            TaskListener l = it.next();
             l.taskFinished(this);
         }
     }

--- a/platform/openide.util/src/org/openide/util/TopologicalSortException.java
+++ b/platform/openide.util/src/org/openide/util/TopologicalSortException.java
@@ -316,10 +316,10 @@ public final class TopologicalSortException extends Exception {
         visited.add(vertex.object);
         vertex.visited = true;
 
-        Iterator it = vertex.edges();
+        Iterator<Vertex> it = vertex.edges();
 
         while (it.hasNext()) {
-            Vertex v = (Vertex) it.next();
+            Vertex v = it.next();
             visitDualGraph(v, visited);
         }
     }

--- a/platform/openide.util/src/org/openide/util/io/NbObjectOutputStream.java
+++ b/platform/openide.util/src/org/openide/util/io/NbObjectOutputStream.java
@@ -145,11 +145,11 @@ public class NbObjectOutputStream extends ObjectOutputStream {
             b.append(classname);
             b.append(" does not declare serialVersionUID field. Encountered while storing: ["); // NOI18N
 
-            Iterator it = serializing.iterator();
+            Iterator<Class> it = serializing.iterator();
             boolean first = true;
 
             while (it.hasNext()) {
-                Class c = (Class) it.next();
+                Class c = it.next();
 
                 if ((c != cl) && serializingUniq.add(c)) {
                     if (first) {

--- a/profiler/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLCompletionProvider.java
+++ b/profiler/profiler.oql.language/src/org/netbeans/modules/profiler/oql/language/OQLCompletionProvider.java
@@ -237,9 +237,9 @@ public class OQLCompletionProvider implements CompletionProvider {
                         Set<String> pkgCompletions = new HashSet<String>();
                         Set<String> completions = new HashSet<String>();
 
-                        Iterator clzs = e.getHeap().getJavaClassesByRegExp(regex).iterator();
+                        Iterator<JavaClass> clzs = e.getHeap().getJavaClassesByRegExp(regex).iterator();
                         while(clzs.hasNext()) {
-                            String className = ((JavaClass)clzs.next()).getName();
+                            String className = clzs.next().getName();
                             String[] sig = splitClassName(className);
                             if (sig[1].startsWith(tokentext)) {
                                 completions.add("00 " + className); // NOI18N

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
@@ -167,7 +167,7 @@ public class Snapshot {
     }
 
     public Iterator getClassNames(String regex)  {
-        final Iterator delegated = delegate.getJavaClassesByRegExp(regex).iterator();
+        final Iterator<JavaClass> delegated = delegate.getJavaClassesByRegExp(regex).iterator();
         return new Iterator() {
 
             public boolean hasNext() {
@@ -175,7 +175,7 @@ public class Snapshot {
             }
 
             public Object next() {
-                return ((JavaClass)delegated.next()).getName();
+                return delegated.next().getName();
             }
 
             public void remove() {

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/Util.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/Util.java
@@ -188,9 +188,9 @@ public class Util {
     public static JLabel findLabel(JComponent comp, String labelText) {
         Vector allComponents = new Vector();
         getAllComponents(comp.getComponents(), allComponents);
-        Iterator iterator = allComponents.iterator();
+        Iterator<Component> iterator = allComponents.iterator();
         while (iterator.hasNext()) {
-            Component c = (Component) iterator.next();
+            Component c = iterator.next();
             if (c instanceof JLabel) {
                 JLabel label = (JLabel) c;
                 if (label.getText().equals(labelText)) {

--- a/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlMethodNode.java
+++ b/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlMethodNode.java
@@ -190,11 +190,11 @@ public class WsdlMethodNode extends AbstractNode {
 
             signature += ")";
 
-            Iterator excpIterator = javaMethod.getExceptions();
+            Iterator<String> excpIterator = javaMethod.getExceptions();
             if (excpIterator.hasNext()) {
                 signature += " throws";
                 while (excpIterator.hasNext()) {
-                    String currentExcp = (String) excpIterator.next();
+                    String currentExcp = excpIterator.next();
                     signature += " " + currentExcp;
                     if (excpIterator.hasNext()) {
                         signature += ",";
@@ -257,9 +257,9 @@ public class WsdlMethodNode extends AbstractNode {
                 sheet.put(exceptionSet);
             }
 
-            Iterator exceptionIterator = javaMethod.getExceptions();
+            Iterator<String> exceptionIterator = javaMethod.getExceptions();
             for (int ii = 0; exceptionIterator.hasNext(); ii++) {
-                String currentException = (String) exceptionIterator.next();
+                String currentException = exceptionIterator.next();
                 p = new Reflection(currentException, String.class, "toString", null); // NOI18N
                 p.setName("exception" + ii); // NOI18N
                 p.setDisplayName(NbBundle.getMessage(WsdlMethodNode.class, "METHOD_PARAMTYPE")); // NOI18N


### PR DESCRIPTION
This change removes the majority of these warnings..

This bug implements changes that clean a whole lot of Iterator raw type warning messages from the compiler..

   [repeat] /home/bwalker/src/netbeans/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/ElementBindings.java:156: warning: [rawtypes] found
 raw type: Iterator
   [repeat]         Iterator it = values().iterator();
   [repeat]         ^
   [repeat]   missing type arguments for generic class Iterator<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in interface Iterator

This change removes the majority of these warnings..