### PR TITLE
[NETBEANS-2543] File names clipped in Files and Projects tabs

### DIFF
--- a/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
@@ -339,7 +339,7 @@ public final class HtmlRenderer {
             // #54257 - on macosx + chinese/japanese fonts, the getStringBounds() method returns bad value
             wid = fm.stringWidth(s);
         } else {
-            wid = (int)fm.getStringBounds(s, g).getWidth();
+            wid = (int) Math.ceil(fm.getStringBounds(s, g).getWidth());
         }
 
         if (paint) {


### PR DESCRIPTION
This patch fixes a bug where some file names in the "Projects" and "Files" tabs would appear truncated on fractional HiDPI scalings (e.g. 150%) on Windows. It probably also improves text measurement on an integral 200% scaling as well, possibly on MacOS as well.

The problem was in org.openide.awt.HtmlRenderer and the associated HtmlRendererImpl class, which creates a fake Graphics2D object for the purposes of calculating text dimensions in getPreferredWidth. This Graphics2D object was not properly prepared with a HiDPI transform for its FontRenderContext, leading to inaccurate text measurement. Moreover, the GraphicsConfiguration was not retrieved for the correct monitor (in multi-monitor setups). These problems have been fixed.

Since the scratch Graphics2D object is now specific to each monitor (each can have a different HiDPI scaling), it is now cached at the HtmlRenderer level rather than at the previous global (static) level.

An alternative approach would have been to pass a FontRenderContext instead of a full Graphics2D during off-screen text measurements. This would complicate the HtmlRenderer._renderHTML method too much, however.

![truncated](https://user-images.githubusercontent.com/886243/76836061-8c3b2400-6806-11ea-99de-63511884fdf9.png)