### PR TITLE
[NETBEANS-4005] Update jgit to v5.5.1

### DIFF
--- a/ide/o.eclipse.jgit/external/binaries-list
+++ b/ide/o.eclipse.jgit/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-75C27F087134757A8AC335E637C117D68D41C773 org.eclipse.jgit:org.eclipse.jgit:5.5.0.201909110433-r
+E0BA7A468E8C62DA8521CA3A06A061D4DDE95223 org.eclipse.jgit:org.eclipse.jgit:5.5.1.201910021850-r

--- a/ide/o.eclipse.jgit/external/org.eclipse.jgit-5.5.1.201910021850-r-license.txt
+++ b/ide/o.eclipse.jgit/external/org.eclipse.jgit-5.5.1.201910021850-r-license.txt
@@ -1,6 +1,6 @@
 Name: JGit Library
 Origin: Eclipse
-Version: 5.5.0.201909110433-r
+Version: 5.5.1.201910021850-r
 Description: Integration library for Git client
 License: EDL-1.0
 URL: http://www.eclipse.org/jgit/download/

--- a/ide/o.eclipse.jgit/nbproject/project.properties
+++ b/ide/o.eclipse.jgit/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/org.eclipse.jgit-5.5.0.201909110433-r.jar=modules/org-eclipse-jgit.jar
+release.external/org.eclipse.jgit-5.5.1.201910021850-r.jar=modules/org-eclipse-jgit.jar
 is.autoload=true

--- a/ide/o.eclipse.jgit/nbproject/project.xml
+++ b/ide/o.eclipse.jgit/nbproject/project.xml
@@ -73,7 +73,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>org-eclipse-jgit.jar</runtime-relative-path>
-                <binary-origin>external/org.eclipse.jgit-5.5.0.201909110433-r.jar</binary-origin>
+                <binary-origin>external/org.eclipse.jgit-5.5.1.201910021850-r.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Currently v5.5.0

The jgit project has recently released v5.7.0 but this has some API changes and AFAICS no compelling reason to upgrade.