### PR TITLE
[NETBEANS-4038] - Add javadoc for JDK 14 General-Availability Release

### DIFF
--- a/java/java.j2seplatform/manifest.mf
+++ b/java/java.j2seplatform/manifest.mf
@@ -4,5 +4,5 @@ OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/j2seplatform/Bundle.
 OpenIDE-Module-Layer: org/netbeans/modules/java/j2seplatform/resources/layer.xml
 OpenIDE-Module-Install: org/netbeans/modules/java/j2seplatform/J2SEPlatformModule.class
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Specification-Version: 1.49
+OpenIDE-Module-Specification-Version: 1.50
 OpenIDE-Module-Provides: j2seplatform

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
@@ -62,7 +62,7 @@ public final class J2SEPlatformDefaultJavadocImpl implements J2SEPlatformDefault
         OFFICIAL_JAVADOC.put("11", "https://docs.oracle.com/en/java/javase/11/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("12", "https://docs.oracle.com/en/java/javase/12/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("13", "https://docs.oracle.com/en/java/javase/13/docs/api/"); // NOI18N
-        OFFICIAL_JAVADOC.put("14", "https://download.java.net/java/early_access/jdk14/docs/api/"); // NOI18N Early access
+        OFFICIAL_JAVADOC.put("14", "https://docs.oracle.com/en/java/javase/14/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("15", "https://download.java.net/java/early_access/jdk15/docs/api/"); // NOI18N Early access
     }
 


### PR DESCRIPTION
[JDK 14 Web Page](https://jdk.java.net/14/)
[API Javadoc](https://docs.oracle.com/en/java/javase/14/docs/api/index.html)