### PR TITLE
[NETBEANS-3957] fixed "opened documents list" show HTML code instead of rich text

### DIFF
--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/popupswitcher/SwitcherTable.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/popupswitcher/SwitcherTable.java
@@ -161,7 +161,7 @@ public class SwitcherTable extends JTable {
         if (ren instanceof JLabel) {
             // #199007: Swing HTML renderer does a poor job of truncating long labels
             JLabel prototype = (JLabel) ren;
-            lbl = HtmlRenderer.createLabel();
+            lbl = (JLabel) HtmlRenderer.createRenderer();
             if( lbl instanceof HtmlRenderer.Renderer ) {
                 ((HtmlRenderer.Renderer)lbl).setRenderStyle( HtmlRenderer.STYLE_TRUNCATE );
             }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-3957

tested with FlatLaf light/dark, Windows, Nimbus and Metal LaFs