### PR TITLE
Default JavaFX archetypes to javafx 1.8 when running on jdk1.8

### DIFF
--- a/java/api.maven/src/org/netbeans/api/maven/archetype/ArchetypeWizards.java
+++ b/java/api.maven/src/org/netbeans/api/maven/archetype/ArchetypeWizards.java
@@ -88,6 +88,10 @@ public class ArchetypeWizards {
         return org.netbeans.modules.maven.api.archetype.ArchetypeWizards.definedArchetype(groupId, artifactId, version, repository, title);
     }
 
+    // possiblly expose the new method with Map<String, String> defaultProps here
+    // and an API for others to consume
+    // alas, with all the versioning stuff...
+
     private static org.netbeans.modules.maven.api.archetype.ProjectInfo convertProjectInfo(ProjectInfo pi) {
         return new org.netbeans.modules.maven.api.archetype.ProjectInfo(pi.getGroupId(), pi.getArtifactId(), pi.getVersion(), pi.getPackageName());
     }

--- a/java/maven/manifest.mf
+++ b/java/maven/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven/2
-OpenIDE-Module-Specification-Version: 2.137
+OpenIDE-Module-Specification-Version: 2.138
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/maven/layer.xml
 AutoUpdate-Show-In-Client: false

--- a/java/maven/src/org/netbeans/modules/maven/api/archetype/ArchetypeWizards.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/archetype/ArchetypeWizards.java
@@ -83,7 +83,7 @@ public class ArchetypeWizards {
     }
 
     public static WizardDescriptor.Panel<WizardDescriptor> basicWizardPanel(ValidationGroup vg, boolean isFinish, @NullAllowed Archetype archetype) {
-        return new BasicWizardPanel(vg, archetype, isFinish, false);
+        return new BasicWizardPanel(vg, archetype, isFinish, false, null);
     }
 
     static WizardDescriptor.Panel<WizardDescriptor> basicWizardPanel(Object p, String type) {
@@ -109,12 +109,21 @@ public class ArchetypeWizards {
      * @see #TEMPLATE_FOLDER
      */
     public static WizardDescriptor.InstantiatingIterator<?> definedArchetype(String groupId, String artifactId, String version, @NullAllowed String repository, String title) {
+        return definedArchetype(groupId, artifactId, version, repository, title, null);
+    }
+    /** 
+     * @sinced 2.138
+     */
+    public static WizardDescriptor.InstantiatingIterator<?> definedArchetype(
+        String groupId, String artifactId, String version, @NullAllowed String repository, String title,
+        Map<String,String> defaultProps
+    ) {
         Archetype arch = new Archetype();
         arch.setGroupId(groupId);
         arch.setArtifactId(artifactId);
         arch.setVersion(version);
         arch.setRepository(repository);
-        return new MavenWizardIterator(arch, title);
+        return new MavenWizardIterator(arch, title, defaultProps);
     }
 
 }

--- a/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.form
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.form
@@ -73,7 +73,7 @@
           </Group>
           <Group type="102" alignment="0" attributes="0">
               <Component id="pnlAdditionals" max="32767" attributes="0"/>
-              <EmptySpace pref="12" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/BasicPanelVisual.java
@@ -555,7 +555,7 @@ public class BasicPanelVisual extends JPanel implements DocumentListener, Window
         "# {0} - project count", "TXT_MavenProjectName=mavenproject{0}",
         "TXT_Checking1=Checking additional creation properties..."
     })
-    void read(WizardDescriptor settings) {
+    void read(WizardDescriptor settings, Map<String,String> defaultProps) {
         synchronized (HANDLE_LOCK) {
             if (handle != null) {
                 handle.finish();
@@ -603,7 +603,7 @@ public class BasicPanelVisual extends JPanel implements DocumentListener, Window
             RPprep.post(new Runnable() {
                 @Override
                 public void run() {
-                    prepareAdditionalProperties(archet);
+                    prepareAdditionalProperties(archet, defaultProps);
                 }
             });
         }
@@ -620,7 +620,7 @@ public class BasicPanelVisual extends JPanel implements DocumentListener, Window
         "COL_Value=Value",
         "TXT_Checking2=A&dditional Creation Properties:"
     })
-    private void prepareAdditionalProperties(Archetype arch) {
+    private void prepareAdditionalProperties(Archetype arch, Map<String, String> defaultProps) {
         final DefaultTableModel dtm = new DefaultTableModel();
         dtm.addColumn(COL_Key());
         dtm.addColumn(COL_Value());
@@ -634,7 +634,13 @@ public class BasicPanelVisual extends JPanel implements DocumentListener, Window
                     if ("groupId".equals(key) || "artifactId".equals(key) || "version".equals(key)) {
                         continue; //don't show the basic props as additionals..
                     }
-                    dtm.addRow(new Object[] {key, defVal == null ? "" : defVal });
+                    if (defaultProps != null && defaultProps.containsKey(key)) {
+                        defVal = defaultProps.get(key);
+                    }
+                    if (defVal == null) {
+                        defVal = "";
+                    }
+                    dtm.addRow(new Object[] {key, defVal });
                 }
             }
         } catch (ArtifactResolutionException ex) {

--- a/java/maven/src/org/netbeans/modules/maven/newproject/BasicWizardPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/BasicWizardPanel.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.maven.newproject;
 
+import java.util.Map;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.modules.maven.api.archetype.Archetype;
@@ -38,12 +39,16 @@ public class BasicWizardPanel implements WizardDescriptor.FinishablePanel<Wizard
     private final boolean additional;
     private final ValidationGroup validationGroup;
     private final Archetype arch;
+    private final Map<String, String> defaultProps;
     
-    public BasicWizardPanel(ValidationGroup vg, @NullAllowed Archetype arch, boolean isFinish, boolean additional) {
+    public BasicWizardPanel(ValidationGroup vg, @NullAllowed
+            Archetype arch, boolean isFinish, boolean additional, Map<String,String> defaultArgs
+    ) {
         this.isFinish = isFinish;
         this.additional = additional;
         this.validationGroup = vg;
         this.arch = arch;
+        this.defaultProps = defaultArgs;
     }
 
     ValidationGroup getValidationGroup() {
@@ -81,7 +86,7 @@ public class BasicWizardPanel implements WizardDescriptor.FinishablePanel<Wizard
     
     public @Override void readSettings(WizardDescriptor settings) {
         wizardDescriptor = settings;
-        getComponent().read(wizardDescriptor);
+        getComponent().read(wizardDescriptor, defaultProps);
         // XXX hack, TemplateWizard in final setTemplateImpl() forces new wizard's title
         // this name is used in NewProjectWizard to modify the title
 //        Object substitute = getComponent().getClientProperty ("NewProjectWizard_Title"); // NOI18N

--- a/java/maven/src/org/netbeans/modules/maven/newproject/MavenWizardIterator.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/MavenWizardIterator.java
@@ -22,7 +22,9 @@ package org.netbeans.modules.maven.newproject;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,6 +35,7 @@ import org.netbeans.api.validation.adapters.WizardDescriptorAdapter;
 import org.netbeans.modules.maven.api.archetype.Archetype;
 import org.netbeans.modules.maven.api.archetype.ArchetypeWizards;
 import static org.netbeans.modules.maven.newproject.Bundle.*;
+import org.netbeans.modules.maven.options.MavenSettings;
 import org.netbeans.spi.project.ui.support.CommonProjectActions;
 import org.netbeans.validation.api.ui.ValidationGroup;
 import org.openide.WizardDescriptor;
@@ -57,14 +60,16 @@ public class MavenWizardIterator implements WizardDescriptor.BackgroundInstantia
     private final Archetype archetype;
     private final AtomicBoolean hasNextCalled = new AtomicBoolean(); //#216236
     private final String titlename;
+    private final Map<String, String> defaultProps;
 
     public MavenWizardIterator() {
-        this(null, null);
+        this(null, null, null);
     }
     
-    public MavenWizardIterator(Archetype archetype, String titleName) {
+    public MavenWizardIterator(Archetype archetype, String titleName, Map<String,String> defaultProps) {
         this.archetype = archetype;
         this.titlename = titleName;
+        this.defaultProps = defaultProps;
     }
 
 //    @TemplateRegistration(folder=ArchetypeWizards.TEMPLATE_FOLDER, position=100, displayName="#LBL_Maven_Quickstart_Archetype", iconBase="org/netbeans/modules/maven/resources/jaricon.png", description="quickstart.html")
@@ -88,14 +93,23 @@ public class MavenWizardIterator implements WizardDescriptor.BackgroundInstantia
     @TemplateRegistration(folder=ArchetypeWizards.TEMPLATE_FOLDER, position = 925, displayName = "#LBL_Maven_FXML_Archetype", iconBase = "org/netbeans/modules/maven/resources/jaricon.png", description = "javafx.html")
     @Messages("LBL_Maven_FXML_Archetype=FXML JavaFX Maven Archetype (Gluon)")
     public static WizardDescriptor.InstantiatingIterator<?> openJFXFML() {
-       return ArchetypeWizards.definedArchetype("com.raelity.jfx", "javafx-archetype-fxml-netbeans", "0.0.1", null, LBL_Maven_FXML_Archetype());
+       return definedFXArchetype("com.raelity.jfx", "javafx-archetype-fxml-netbeans", "0.0.1", LBL_Maven_FXML_Archetype());
     }
 
     @TemplateRegistration(folder=ArchetypeWizards.TEMPLATE_FOLDER, position = 926, displayName = "#LBL_Maven_Simple_Archetype", iconBase = "org/netbeans/modules/maven/resources/jaricon.png", description = "javafx.html")
     @Messages("LBL_Maven_Simple_Archetype=Simple JavaFX Maven Archetype (Gluon)")
     public static WizardDescriptor.InstantiatingIterator<?> openJFXSimple() {
-       return ArchetypeWizards.definedArchetype("com.raelity.jfx", "javafx-archetype-simple-netbeans", "0.0.1", null, LBL_Maven_Simple_Archetype());
+       return definedFXArchetype("com.raelity.jfx", "javafx-archetype-simple-netbeans", "0.0.1", LBL_Maven_Simple_Archetype());
     }
+
+    private static WizardDescriptor.InstantiatingIterator<?> definedFXArchetype(String g, String a, String v, String name) {
+        Map<String,String> props = new HashMap<>();
+        if (System.getProperty("java.version").startsWith("1.8")) {
+            props.put("javafx-version", "1.8");
+        }
+        return ArchetypeWizards.definedArchetype(g, a, v, null, name, props);
+    }
+
 //    @TemplateRegistration(folder=ArchetypeWizards.TEMPLATE_FOLDER, position=980, displayName="#LBL_Maven_POM_Archetype", iconBase="org/netbeans/modules/maven/resources/Maven2Icon.gif", description="pom-root.html")
 //    @Messages("LBL_Maven_POM_Archetype=POM Project")
 //    public static WizardDescriptor.InstantiatingIterator<?> pomRoot() {
@@ -120,7 +134,7 @@ public class MavenWizardIterator implements WizardDescriptor.BackgroundInstantia
             panels.add(new ChooseWizardPanel());
             steps.add(LBL_CreateProjectStep());
         }
-        panels.add(new BasicWizardPanel(vg, null, true, true)); //only download archetype (for additional props) when unknown archetype is used.
+        panels.add(new BasicWizardPanel(vg, null, true, true, defaultProps)); //only download archetype (for additional props) when unknown archetype is used.
         steps.add(LBL_CreateProjectStep2());
         for (int i = 0; i < panels.size(); i++) {
             JComponent c = (JComponent) panels.get(i).getComponent();

--- a/java/maven/src/org/netbeans/modules/maven/newproject/idenative/IDENativeMavenWizardIterator.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/idenative/IDENativeMavenWizardIterator.java
@@ -116,7 +116,7 @@ public abstract class IDENativeMavenWizardIterator implements WizardDescriptor.I
         panels = new ArrayList<WizardDescriptor.Panel<WizardDescriptor>>();
         List<String> steps = new ArrayList<String>();
         
-        panels.add(new BasicWizardPanel(vg, null, true, false)); //only download archetype (for additional props) when unknown archetype is used.
+        panels.add(new BasicWizardPanel(vg, null, true, false, null)); //only download archetype (for additional props) when unknown archetype is used.
         steps.add(LBL_CreateProjectStep2());
         for (int i = 0; i < panels.size(); i++) {
             JComponent c = (JComponent) panels.get(i).getComponent();


### PR DESCRIPTION
This PR detects NetBeans running on JDK8 and uses "javafx-version=1.8" in such situation. Once the project is created, it is going to be full of bugs shown in editor. There is `module-info.java` in the project and it confuses the Java parser. A PR for this is forthcoming.