### PR TITLE
Allow explicit selection of JUnit4 test generator 

### DIFF
--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/CommonTestsCfgOfCreate.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/CommonTestsCfgOfCreate.java
@@ -511,7 +511,7 @@ public class CommonTestsCfgOfCreate extends SelfResizingPanel implements ChangeL
         setSelectedTestingFramework();
         Collection<? extends GuiUtilsProvider> providers = Lookup.getDefault().lookupAll(GuiUtilsProvider.class);
         for (GuiUtilsProvider provider : providers) {
-            if(selectedTestingFramework != null && selectedTestingFramework.equals(provider.getJunitFramework())) {
+            if(selectedTestingFramework != null && selectedTestingFramework.startsWith(provider.getJunitFramework())) {
                 chkIntegrationTests.setEnabled(true);
             } else {
                 chkIntegrationTests.setEnabled(false);

--- a/ide/gsf.testrunner/manifest.mf
+++ b/ide/gsf.testrunner/manifest.mf
@@ -3,5 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gsf.testrunner/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gsf/testrunner/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/gsf/testrunner/layer.xml
-OpenIDE-Module-Specification-Version: 2.17
+OpenIDE-Module-Specification-Version: 2.18
 

--- a/ide/gsf.testrunner/nbproject/org-netbeans-modules-gsf-testrunner.sig
+++ b/ide/gsf.testrunner/nbproject/org-netbeans-modules-gsf-testrunner.sig
@@ -159,8 +159,6 @@ meth public java.awt.im.InputMethodRequests getInputMethodRequests()
 meth public java.awt.image.ColorModel getColorModel()
 meth public java.awt.image.VolatileImage createVolatileImage(int,int)
 meth public java.awt.image.VolatileImage createVolatileImage(int,int,java.awt.ImageCapabilities) throws java.awt.AWTException
-meth public java.awt.peer.ComponentPeer getPeer()
- anno 0 java.lang.Deprecated()
 meth public java.beans.PropertyChangeListener[] getPropertyChangeListeners()
 meth public java.beans.PropertyChangeListener[] getPropertyChangeListeners(java.lang.String)
 meth public java.lang.String getName()

--- a/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/TestCreatorProviderProcessor.java
+++ b/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/TestCreatorProviderProcessor.java
@@ -51,6 +51,9 @@ public class TestCreatorProviderProcessor extends LayerGeneratingProcessor {
             f.stringvalue("instanceOf", TestCreatorProvider.class.getName());
             f.bundlevalue("displayName", registration.displayName());
             f.bundlevalue("identifier", registration.identifier());
+            if (registration.position() != -1) {
+                f.intvalue("position", registration.position());
+            }
             f.write();
         }
 

--- a/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/TestCreatorProvider.java
+++ b/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/api/TestCreatorProvider.java
@@ -69,6 +69,10 @@ public abstract class TestCreatorProvider {
     @Target(ElementType.TYPE)
     @Retention(RetentionPolicy.SOURCE)
     public @interface Registration {
+        /** Priority of the provider. The lower the higher priority it has.
+         * @since 2.18
+         */
+        int position() default Integer.MAX_VALUE;
 
         /**
          * Identifier of the TestCreatorProvider. 

--- a/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/JavaTestCreatorConfiguration.java
+++ b/java/java.testrunner.ui/src/org/netbeans/modules/java/testrunner/ui/JavaTestCreatorConfiguration.java
@@ -77,9 +77,8 @@ public class JavaTestCreatorConfiguration extends TestCreatorConfiguration {
     }
 
     @Override
-    public boolean canHandleProject(@NonNull
-            String framework) {
-        return GuiUtils.JUNIT_TEST_FRAMEWORK.equals(framework) || GuiUtils.TESTNG_TEST_FRAMEWORK.equals(framework);
+    public boolean canHandleProject(@NonNull String framework) {
+        return framework.startsWith("JUnit") || GuiUtils.TESTNG_TEST_FRAMEWORK.equals(framework);
     }
 
     @Override

--- a/java/junit.ui/nbproject/project.xml
+++ b/java/junit.ui/nbproject/project.xml
@@ -83,7 +83,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.6</specification-version>
+                        <specification-version>2.18</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -159,7 +159,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.76</specification-version>
+                        <specification-version>2.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/AbstractJUnitTestCreatorProvider.java
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/AbstractJUnitTestCreatorProvider.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.junit.ui;
+
+import java.awt.EventQueue;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.SourceGroup;
+import org.netbeans.modules.gsf.testrunner.api.TestCreatorProvider;
+import static org.netbeans.modules.gsf.testrunner.api.TestCreatorProvider.getSourceGroup;
+import org.netbeans.modules.gsf.testrunner.plugin.CommonPlugin;
+import org.netbeans.modules.gsf.testrunner.ui.api.UICommonUtils;
+import org.netbeans.modules.junit.api.JUnitVersion;
+import org.netbeans.modules.junit.api.JUnitTestUtil;
+import org.netbeans.modules.junit.plugin.JUnitPlugin;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
+import org.openide.cookies.EditorCookie;
+import org.openide.filesystems.FileObject;
+import org.openide.loaders.DataObject;
+import org.openide.loaders.DataObjectNotFoundException;
+import org.openide.nodes.Node;
+import org.openide.util.NbBundle;
+import org.openide.util.RequestProcessor;
+
+abstract class AbstractJUnitTestCreatorProvider extends TestCreatorProvider {
+    abstract JUnitVersion useVersion();
+
+    @Override
+    public boolean enable(FileObject[] activatedFOs) {
+        if (activatedFOs == null || activatedFOs.length == 0) {
+            return false;
+        }
+        /*
+         * In most cases, there is just one node selected - that is why
+         * this case is handled in a special, more effective way
+         * (no collections and iterators created).
+         */
+        if (activatedFOs.length == 1) {
+            FileObject fileObj = activatedFOs[0];
+
+            Project project;
+            if ((fileObj != null)
+                && fileObj.isValid()
+                // selected FO might be folder or java file
+                && (fileObj.isFolder() || JUnitTestUtil.isJavaFile(fileObj))
+                && ((project = FileOwnerQuery.getOwner(fileObj)) != null)
+                && (getSourceGroup(fileObj, project) != null)) {
+
+                JUnitPlugin plugin = JUnitTestUtil.getPluginForProject(project, useVersion());
+                return JUnitTestUtil.canCreateTests(plugin, fileObj);
+            } else {
+                return false;
+            }
+        }
+
+        final Collection<FileObject> fileObjs = new ArrayList<>(activatedFOs.length);
+        Project theProject = null;
+        boolean result = false;
+        for (FileObject fileObj : activatedFOs) {
+            if ((fileObj == null) || !fileObj.isValid()
+                // selected FO might be folder or java file
+                && (fileObj.isFolder() || JUnitTestUtil.isJavaFile(fileObj))) {
+                continue;
+            }
+
+            fileObjs.add(fileObj);
+
+            Project prj = FileOwnerQuery.getOwner(fileObj);
+            if (prj != null) {
+                if (theProject == null) {
+                    theProject = prj;
+                }
+                if (prj != theProject) {
+                    return false;        /* files from different projects */
+
+                }
+
+                if (getSourceGroup(fileObj, prj) != null) {
+                    result = true;
+                }
+            }
+        }
+
+        if (theProject != null) {
+            JUnitPlugin plugin = JUnitTestUtil.getPluginForProject(theProject);
+            result &= JUnitTestUtil.canCreateTests(
+                            plugin,
+                            fileObjs.toArray(new FileObject[fileObjs.size()]));
+        }
+
+        return result;
+    }
+
+    @Override
+    public void createTests(Context context) {
+        String problem;
+        if ((problem = checkNodesValidity(context.getActivatedFOs())) != null) {
+            // TODO report problem
+            NotifyDescriptor msg = new NotifyDescriptor.Message(
+                    problem, NotifyDescriptor.WARNING_MESSAGE);
+            DialogDisplayer.getDefault().notify(msg);
+            return;
+        }
+
+        final FileObject[] filesToTest = context.getActivatedFOs();
+        if (filesToTest == null) {
+            return;     //XXX: display some message
+        }
+
+        /*
+         * Determine the plugin to be used:
+         */
+        final JUnitPlugin plugin = JUnitTestUtil.getPluginForProject(
+            FileOwnerQuery.getOwner(filesToTest[0]), useVersion()
+        );
+
+        if (!JUnitTestUtil.createTestActionCalled(
+                plugin, filesToTest)) {
+            return;
+        }
+
+        /*
+         * Store the configuration data:
+         */
+        final boolean singleClass = context.isSingleClass();
+        final Map<CommonPlugin.CreateTestParam, Object> params = JUnitTestUtil.getSettingsMap(!singleClass);
+        if (singleClass) {
+            params.put(CommonPlugin.CreateTestParam.CLASS_NAME, context.getTestClassName());
+        }
+        final FileObject targetFolder = context.getTargetFolder();
+        if(context.isIntegrationTests()) {
+            params.put(CommonPlugin.CreateTestParam.INC_GENERATE_INTEGRATION_TEST, Boolean.TRUE);
+        } else {
+            params.put(CommonPlugin.CreateTestParam.INC_GENERATE_INTEGRATION_TEST, Boolean.FALSE);
+        }
+
+        RequestProcessor.getDefault().post(new Runnable() {
+
+            @Override
+            public void run() {
+                /*
+                 * Now create the tests:
+                 */
+                final FileObject[] testFileObjects = JUnitTestUtil.createTests(
+                        plugin,
+                        filesToTest,
+                        targetFolder,
+                        params);
+
+                /*
+                 * Open the created/updated test class if appropriate:
+                 */
+                if (testFileObjects.length == 1) {
+                    try {
+                        DataObject dobj = DataObject.find(testFileObjects[0]);
+                        final EditorCookie ec = dobj.getLookup().lookup(EditorCookie.class);
+                        if (ec != null) {
+                            EventQueue.invokeLater(new Runnable() {
+
+                                @Override
+                                public void run() {
+                                    ec.open();
+                                }
+                            });
+                        }
+                    } catch (DataObjectNotFoundException ex) {
+                        ex.printStackTrace();
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Checks that the selection of nodes the dialog is invoked on is valid.
+     * @return String message describing the problem found or null, if the
+     *         selection is ok
+     */
+    private static String checkNodesValidity(FileObject[] files) {
+
+        Project project = getProject(files);
+        if (project == null) {
+            return NbBundle.getMessage(JUnitTestCreatorProvider.class,
+                                       "MSG_multiproject_selection");   //NOI18N
+        }
+
+        if (!checkPackages(files)) {
+            return NbBundle.getMessage(JUnitTestCreatorProvider.class,
+                                       "MSG_invalid_packages");         //NOI18N
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts {@code FileObject}s from the given nodes.
+     * Nodes that have (direct or indirect) parent nodes among the given
+     * nodes are ignored.
+     *
+     * @return  a non-empty array of {@code FileObject}s
+     *          represented by the given nodes;
+     *          or {@code null} if no {@code FileObject} was found;
+     */
+    private static FileObject[] getFileObjectsFromNodes(final Node[] nodes){
+        FileObject[] fileObjects = new FileObject[nodes.length];
+        List<FileObject> fileObjectsList = null;
+
+        for (int i = 0; i < nodes.length; i++) {
+            final Node node = nodes[i];
+            final FileObject fo;
+            if (!hasParentAmongNodes(nodes, i)
+                    && ((fo = getTestFileObject(node)) != null)) {
+                if (fileObjects != null) {
+                    fileObjects[i] = fo;
+                } else {
+                    if (fileObjectsList == null) {
+                        fileObjectsList = new ArrayList<FileObject>(
+                                                        nodes.length - i);
+                    }
+                    fileObjectsList.add(fo);
+                }
+            } else {
+                fileObjects = null;     //signs that some FOs were skipped
+            }
+        }
+        if (fileObjects == null) {
+            if (fileObjectsList != null) {
+                fileObjects = fileObjectsList.toArray(
+                        new FileObject[fileObjectsList.size()]);
+                fileObjectsList = null;
+            }
+        }
+
+        return fileObjects;
+    }
+
+    /**
+     * Check that all the files (folders or java files) have correct java
+     * package names.
+     * @return true if all are fine
+     */
+    private static boolean checkPackages(FileObject[] files) {
+        if (files.length == 0) {
+            return true;
+        } else {
+            Project project = FileOwnerQuery.getOwner(files[0]);
+            for (int i = 0 ; i < files.length; i++) {
+                String packageName = getPackage(project, files[i]);
+                if ((packageName == null)
+                        || !JUnitTestUtil.isValidPackageName(packageName)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    /**
+     * Get the package name of <code>file</code>.
+     *
+     * @param project owner of the file (for performance reasons)
+     * @param file the FileObject whose packagename to get
+     * @return package name of the file or null if it cannot be retrieved
+     */
+    private static String getPackage(Project project, FileObject file) {
+        SourceGroup srcGrp = JUnitTestUtil.findSourceGroupOwner(project, file);
+        if (srcGrp!= null) {
+            ClassPath cp = ClassPathSupport.createClassPath(
+                    new FileObject [] {srcGrp.getRootFolder()});
+            return cp.getResourceName(file, '.', false);
+        } else {
+            return null;
+        }
+    }
+
+
+    private static FileObject[] getFiles(Node[] nodes) {
+        FileObject[] ret = new FileObject[nodes.length];
+        for (int i = 0 ; i < nodes.length ; i++) {
+            ret[i]  = UICommonUtils.getFileObjectFromNode(nodes[i]);
+        }
+        return ret;
+    }
+
+    /**
+     * Get the single project for <code>nodes</code> if there is such.
+     * If the nodes belong to different projects or some of the nodes doesn't
+     * have a project, return null.
+     */
+    private static Project getProject(FileObject[] files) {
+        Project project = null;
+        for (int i = 0 ; i < files.length; i++) {
+            Project nodeProject = FileOwnerQuery.getOwner(files[i]);
+            if (project == null) {
+                project = nodeProject;
+            } else if (project != nodeProject) {
+                return null;
+            }
+        }
+        return project;
+    }
+
+    /**
+     * Grabs and checks a <code>FileObject</code> from the given node.
+     * If either the file could not be grabbed or the file does not pertain
+     * to any project, a message is displayed.
+     *
+     * @param  node  node to get a <code>FileObject</code> from.
+     * @return  the grabbed <code>FileObject</code>,
+     *          or <code>null</code> in case of failure
+     */
+    private static FileObject getTestFileObject(final Node node) {
+        final FileObject fo = UICommonUtils.getFileObjectFromNode(node);
+        if (fo == null) {
+            JUnitTestUtil.notifyUser(NbBundle.getMessage(
+                    JUnitTestCreatorProvider.class,
+                    "MSG_file_from_node_failed"));                      //NOI18N
+            return null;
+        }
+        ClassPath cp = ClassPath.getClassPath(fo, ClassPath.SOURCE);
+        if (cp == null) {
+            JUnitTestUtil.notifyUser(NbBundle.getMessage(
+                    JUnitTestCreatorProvider.class,
+                    "MSG_no_project",                                   //NOI18N
+                    fo));
+            return null;
+        }
+        return fo;
+    }
+
+    private static boolean hasParentAmongNodes(final Node[] nodes,
+                                               final int idx) {
+        Node node;
+
+        node = nodes[idx].getParentNode();
+        while (null != node) {
+            for (int i = 0; i < nodes.length; i++) {
+                if (i == idx) {
+                    continue;
+                }
+                if (node == nodes[i]) {
+                    return true;
+                }
+            }
+            node = node.getParentNode();
+        }
+        return false;
+    }
+
+
+}

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/JUnit4TestCreatorProvider.java
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/JUnit4TestCreatorProvider.java
@@ -16,13 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.netbeans.modules.junit.ui;
 
-package org.netbeans.modules.junit;
+import org.netbeans.modules.gsf.testrunner.api.TestCreatorProvider.Registration;
+import org.netbeans.modules.java.testrunner.GuiUtils;
+import org.netbeans.modules.junit.api.JUnitVersion;
 
-/**
- */
-public enum JUnitVersion {
-    JUNIT3,
-    JUNIT4,
-    JUNIT5
+@Registration(displayName="JUnit4", identifier = GuiUtils.JUNIT_TEST_FRAMEWORK, position = 100000)
+public final class JUnit4TestCreatorProvider extends AbstractJUnitTestCreatorProvider {
+    @Override
+    JUnitVersion useVersion() {
+        return JUnitVersion.JUNIT4;
+    }
 }

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/JUnitTestCreatorProvider.java
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/JUnitTestCreatorProvider.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.junit.ui;
 import java.awt.EventQueue;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -76,15 +75,13 @@ public class JUnitTestCreatorProvider extends TestCreatorProvider {
                 && (getSourceGroup(fileObj, project) != null)) {
 
                 JUnitPlugin plugin = JUnitTestUtil.getPluginForProject(project);
-                return JUnitTestUtil.canCreateTests(plugin,
-                                                                    fileObj);
+                return JUnitTestUtil.canCreateTests(plugin, fileObj);
             } else {
                 return false;
             }
         }
 
-        final Collection<FileObject> fileObjs
-                = new ArrayList<FileObject>(activatedFOs.length);
+        final Collection<FileObject> fileObjs = new ArrayList<>(activatedFOs.length);
         Project theProject = null;
         boolean result = false;
         for (FileObject fileObj : activatedFOs) {

--- a/java/junit/manifest.mf
+++ b/java/junit/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.junit/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/junit/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/junit/resources/layer.xml
-OpenIDE-Module-Specification-Version: 2.81
+OpenIDE-Module-Specification-Version: 2.82
 OpenIDE-Module-Needs: javax.script.ScriptEngine.freemarker
 AutoUpdate-Show-In-Client: false

--- a/java/junit/src/org/netbeans/modules/junit/AbstractTestGenerator.java
+++ b/java/junit/src/org/netbeans/modules/junit/AbstractTestGenerator.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.junit;
 
+import org.netbeans.modules.junit.api.JUnitVersion;
 import org.netbeans.modules.junit.api.JUnitSettings;
 import org.netbeans.modules.junit.api.JUnitTestUtil;
 import org.netbeans.api.java.source.TreeUtilities;

--- a/java/junit/src/org/netbeans/modules/junit/DefaultPlugin.java
+++ b/java/junit/src/org/netbeans/modules/junit/DefaultPlugin.java
@@ -21,13 +21,11 @@ package org.netbeans.modules.junit;
 
 import org.netbeans.modules.junit.api.JUnitSettings;
 import org.netbeans.modules.junit.api.JUnitTestUtil;
-import java.awt.BorderLayout;
 import java.awt.GridLayout;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
@@ -45,11 +43,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.lang.model.element.TypeElement;
 import javax.swing.BorderFactory;
-import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.project.JavaProjectConstants;
 import org.netbeans.api.java.project.classpath.ProjectClassPathModifier;
@@ -128,7 +124,7 @@ public final class DefaultPlugin extends JUnitPlugin {
                                 = "org/junit/platform/commons/annotation/Testable.class";               //NOI18N
     
     /** */
-    private static JUnitVersion junitVer;
+    private JUnitVersion junitVer;
 
     /** name of FreeMarker template property - generate {@literal &#64;BeforeClass} method? */
     private static final String templatePropBeforeClass = "classSetUp"; //NOI18N
@@ -159,23 +155,23 @@ public final class DefaultPlugin extends JUnitPlugin {
     private static boolean generatingIntegrationTest = false;
     
     private static final String PROJECT_PROPERTIES_PATH = "nbproject/project.properties";
+
+    public DefaultPlugin(JUnitVersion v) {
+        junitVer = v;
+    }
     
     public static void logJUnitUsage(URI projectURI) {
         String version = "";
-        if (junitVer == null) {
-            Project project = FileOwnerQuery.getOwner(projectURI);
-            final ClassPath classPath = getTestClassPath(project);
-            if (classPath != null) {
-                if (classPath.findResource(JUNIT5_SPECIFIC) != null) {
-                    version = JUnitVersion.JUNIT5.toString();
-                } else if (classPath.findResource(JUNIT4_SPECIFIC) != null) {
-                    version = JUnitVersion.JUNIT4.toString();
-                } else if (classPath.findResource(JUNIT3_SPECIFIC) != null) {
-                    version = JUnitVersion.JUNIT3.toString();
-                }
+        Project project = FileOwnerQuery.getOwner(projectURI);
+        final ClassPath classPath = getTestClassPath(project);
+        if (classPath != null) {
+            if (classPath.findResource(JUNIT5_SPECIFIC) != null) {
+                version = JUnitVersion.JUNIT5.toString();
+            } else if (classPath.findResource(JUNIT4_SPECIFIC) != null) {
+                version = JUnitVersion.JUNIT4.toString();
+            } else if (classPath.findResource(JUNIT3_SPECIFIC) != null) {
+                version = JUnitVersion.JUNIT3.toString();
             }
-        } else {
-            version = junitVer.toString();
         }
         UnitTestsUsage.getInstance().logUnitTestUsage(projectURI, version);
     }

--- a/java/junit/src/org/netbeans/modules/junit/JUnit3TestGenerator.java
+++ b/java/junit/src/org/netbeans/modules/junit/JUnit3TestGenerator.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.junit;
 
+import org.netbeans.modules.junit.api.JUnitVersion;
 import org.netbeans.modules.junit.api.JUnitTestUtil;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;

--- a/java/junit/src/org/netbeans/modules/junit/JUnit4TestGenerator.java
+++ b/java/junit/src/org/netbeans/modules/junit/JUnit4TestGenerator.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.junit;
 
+import org.netbeans.modules.junit.api.JUnitVersion;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;

--- a/java/junit/src/org/netbeans/modules/junit/JUnit5TestGenerator.java
+++ b/java/junit/src/org/netbeans/modules/junit/JUnit5TestGenerator.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.junit;
 
+import org.netbeans.modules.junit.api.JUnitVersion;
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;

--- a/java/junit/src/org/netbeans/modules/junit/TestCreator.java
+++ b/java/junit/src/org/netbeans/modules/junit/TestCreator.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.junit;
 
+import org.netbeans.modules.junit.api.JUnitVersion;
 import org.netbeans.modules.junit.api.JUnitTestUtil;
 import java.io.IOException;
 import java.util.Collections;

--- a/java/junit/src/org/netbeans/modules/junit/api/JUnitSettings.java
+++ b/java/junit/src/org/netbeans/modules/junit/api/JUnitSettings.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.junit.api;
 
 import java.util.prefs.Preferences;
 import org.netbeans.modules.java.testrunner.CommonSettings;
-import org.netbeans.modules.junit.JUnitVersion;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;

--- a/java/junit/src/org/netbeans/modules/junit/api/JUnitTestUtil.java
+++ b/java/junit/src/org/netbeans/modules/junit/api/JUnitTestUtil.java
@@ -822,9 +822,8 @@ public class JUnitTestUtil extends CommonTestUtil {
      *
      */
     public static JUnitPlugin getPluginForProject(final Project project) {
-        Object pluginObj = project.getLookup().lookup(JUnitPlugin.class);
-        return (pluginObj != null) ? (JUnitPlugin) pluginObj
-                                   : new DefaultPlugin();
+        JUnitPlugin pluginObj = project.getLookup().lookup(JUnitPlugin.class);
+        return pluginObj != null ? pluginObj : new DefaultPlugin();
     }
     
     public static JUnitPlugin getITPluginForProject(final Project project) {

--- a/java/junit/src/org/netbeans/modules/junit/api/JUnitTestUtil.java
+++ b/java/junit/src/org/netbeans/modules/junit/api/JUnitTestUtil.java
@@ -823,7 +823,7 @@ public class JUnitTestUtil extends CommonTestUtil {
      */
     public static JUnitPlugin getPluginForProject(final Project project) {
         JUnitPlugin pluginObj = project.getLookup().lookup(JUnitPlugin.class);
-        return pluginObj != null ? pluginObj : new DefaultPlugin();
+        return pluginObj != null ? pluginObj : new DefaultPlugin(null);
     }
     
     public static JUnitPlugin getITPluginForProject(final Project project) {

--- a/java/junit/src/org/netbeans/modules/junit/api/JUnitTestUtil.java
+++ b/java/junit/src/org/netbeans/modules/junit/api/JUnitTestUtil.java
@@ -822,8 +822,19 @@ public class JUnitTestUtil extends CommonTestUtil {
      *
      */
     public static JUnitPlugin getPluginForProject(final Project project) {
+        return getPluginForProject(project, null);
+    }
+
+    /**
+     *
+     * @param project
+     * @param preferredVersion
+     * @return
+     * @since 2.82
+     */
+    public static JUnitPlugin getPluginForProject(Project project, JUnitVersion preferredVersion) {
         JUnitPlugin pluginObj = project.getLookup().lookup(JUnitPlugin.class);
-        return pluginObj != null ? pluginObj : new DefaultPlugin(null);
+        return pluginObj != null ? pluginObj : new DefaultPlugin(preferredVersion);
     }
     
     public static JUnitPlugin getITPluginForProject(final Project project) {

--- a/java/junit/src/org/netbeans/modules/junit/api/JUnitUtils.java
+++ b/java/junit/src/org/netbeans/modules/junit/api/JUnitUtils.java
@@ -109,7 +109,7 @@ public final class JUnitUtils {
     }
     
     public static DataObject createSuiteTest(FileObject targetRootFolder, FileObject targetFolder, String suiteName, Map<CommonPlugin.CreateTestParam, Object> params) {
-        DefaultPlugin defaultPlugin = new DefaultPlugin();
+        DefaultPlugin defaultPlugin = new DefaultPlugin(null);
         
         if (!defaultPlugin.setupJUnitVersionByProject(targetFolder)) {
             return null;

--- a/java/junit/src/org/netbeans/modules/junit/api/JUnitVersion.java
+++ b/java/junit/src/org/netbeans/modules/junit/api/JUnitVersion.java
@@ -16,21 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.junit.ui;
 
-import org.netbeans.modules.gsf.testrunner.api.TestCreatorProvider;
-import org.netbeans.modules.gsf.testrunner.api.TestCreatorProvider.Registration;
-import org.netbeans.modules.java.testrunner.GuiUtils;
-import org.netbeans.modules.junit.api.JUnitVersion;
+package org.netbeans.modules.junit.api;
 
-/**
- *
- * @author Theofanis Oikonomou
+/** Supported JUnit versions.
+ * @since 2.82
  */
-@Registration(displayName=GuiUtils.JUNIT_TEST_FRAMEWORK, identifier = TestCreatorProvider.IDENTIFIER_JUNIT, position = 100)
-public class JUnitTestCreatorProvider extends AbstractJUnitTestCreatorProvider {
-    @Override
-    JUnitVersion useVersion() {
-        return null;
-    }
+public enum JUnitVersion {
+    JUNIT3,
+    JUNIT4,
+    JUNIT5;
 }

--- a/java/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestNGTestCreatorProvider.java
+++ b/java/testng.ui/src/org/netbeans/modules/testng/ui/actions/TestNGTestCreatorProvider.java
@@ -38,7 +38,7 @@ import org.openide.util.RequestProcessor;
  *
  * @author Theofanis Oikonomou
  */
-@Registration(displayName=GuiUtils.TESTNG_TEST_FRAMEWORK, identifier = TestCreatorProvider.IDENTIFIER_TESTNG)
+@Registration(displayName=GuiUtils.TESTNG_TEST_FRAMEWORK, identifier = TestCreatorProvider.IDENTIFIER_TESTNG, position = 1000)
 public class TestNGTestCreatorProvider extends TestCreatorProvider {
 
     private static final Logger LOGGER = Logger.getLogger(TestNGTestCreatorProvider.class.getName());


### PR DESCRIPTION
JUnit5 and JUnit4 have little in common. In fact they are almost completely different frameworks. I am annoyed by the IDE pushing me to use JUnit5. Most of my projects use JUnit4 and I am happy with it. I want to continue to use JUnit4 coding style in my new projects as well.

This PR adds new testing framework JUnit4 (in addition to existing generic JUnit) and allows users that care select JUnit4 explicitly when generating tests for a class.