### PR TITLE
[NETBEANS-3787] FlatLaf: fixed active tab painting if project tab colors enabled

### DIFF
--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectColorTabDecorator.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectColorTabDecorator.java
@@ -161,8 +161,16 @@ public class ProjectColorTabDecorator extends TabDecorator {
         }
         g.setColor( c );
         Rectangle rect = new Rectangle( tabRect );
-        rect.y += rect.height - 3;
-        rect.grow( -1, -1 );
+        int underlineHeight = UIManager.getInt("nb.multitabs.underlineHeight"); // NOI18N
+        if( underlineHeight > 0 ) {
+            // if the selected tab is highlighted with an "underline" (e.g. in FlatLaf)
+            // then paint the project color bar at the top of the tab
+            rect.height = underlineHeight;
+        } else {
+            // bottom project color bar
+            rect.y += rect.height - 3;
+            rect.grow( -1, -1 );
+        }
         g.fillRect( rect.x, rect.y, rect.width, rect.height );
     }
 


### PR DESCRIPTION
Fix for https://issues.apache.org/jira/browse/NETBEANS-3787

When project tab colors are enabled in Options dialog (Appearance > Document tabs), then it is painted over the blue "underline" that FlatLaf uses for active tabs. To avoid this I've moved the project color bar to the top of the tab.

Before:
![image](https://user-images.githubusercontent.com/5604048/77704257-f731eb00-6fbc-11ea-9379-999b3cf4bcd5.png)

After:
![image](https://user-images.githubusercontent.com/5604048/77704277-02851680-6fbd-11ea-9b4c-236ac07f75e1.png)

Other LaFs are not affected. E.g Windows:
![image](https://user-images.githubusercontent.com/5604048/77704549-9bb42d00-6fbd-11ea-86ef-d1a99b744817.png)
