### PR TITLE
[NETBEANS-4030] FlatLaf and Nimbus: fixed selection not painted in libraries category in project dialog

### DIFF
--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/PathsCustomizer.form
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/PathsCustomizer.form
@@ -66,10 +66,10 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="cpTree" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Component id="mpTree" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="cpTree" alignment="0" max="32767" attributes="0"/>
+                  <Component id="mpTree" alignment="0" max="32767" attributes="0"/>
               </Group>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="cpAddButton" alignment="1" min="-2" max="-2" attributes="0"/>
                   <Component id="mpAddButton" alignment="1" min="-2" max="-2" attributes="0"/>

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/PathsCustomizer.java
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/PathsCustomizer.java
@@ -34,6 +34,7 @@ import javax.swing.JList;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;
+import javax.swing.UIManager;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
 import javax.swing.event.TreeSelectionEvent;
@@ -65,22 +66,30 @@ public final class PathsCustomizer extends javax.swing.JPanel {
      */
     public PathsCustomizer() {
         initComponents();
-        mpTree.setUI(new BasicTreeUI() {
-            @Override
-            protected void paintHorizontalLine(Graphics g, JComponent c, int y, int left, int right) {
-            }
-            @Override
-            protected void paintVerticalLine(Graphics g, JComponent c, int x, int top, int bottom) {
-            }
-        });
-        cpTree.setUI(new javax.swing.plaf.basic.BasicTreeUI() {
-            @Override
-            protected void paintHorizontalLine(Graphics g, JComponent c, int y, int left, int right) {
-            }
-            @Override
-            protected void paintVerticalLine(Graphics g, JComponent c, int x, int top, int bottom) {
-            }
-        });
+
+        // Disable tree line painting if enabled in current look and feel.
+        // Do not use BasicTreeUI for all look and feels because this would
+        // break selection painting in FlatLaf and Nimbus.
+        // https://issues.apache.org/jira/browse/NETBEANS-4030
+        if (UIManager.getBoolean("Tree.paintLines")) {
+            mpTree.setUI(new BasicTreeUI() {
+                @Override
+                protected void paintHorizontalLine(Graphics g, JComponent c, int y, int left, int right) {
+                }
+                @Override
+                protected void paintVerticalLine(Graphics g, JComponent c, int x, int top, int bottom) {
+                }
+            });
+            cpTree.setUI(new javax.swing.plaf.basic.BasicTreeUI() {
+                @Override
+                protected void paintHorizontalLine(Graphics g, JComponent c, int y, int left, int right) {
+                }
+                @Override
+                protected void paintVerticalLine(Graphics g, JComponent c, int x, int top, int bottom) {
+                }
+            });
+        }
+
         setBackground(mpTree.getBackground());
         Mnemonics.setLocalizedText(addProject, NbBundle.getMessage(PathsCustomizer.class, "LBL_CustomizeLibraries_AddProject_JButton"));
         Mnemonics.setLocalizedText(addLibrary, NbBundle.getMessage(PathsCustomizer.class, "LBL_CustomizeLibraries_AddLibary_JButton"));
@@ -602,9 +611,9 @@ public final class PathsCustomizer extends javax.swing.JPanel {
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(cpTree, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(mpTree, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(cpTree, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(mpTree, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(cpAddButton, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(mpAddButton, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/PathsCustomizer.form
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/PathsCustomizer.form
@@ -66,10 +66,10 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="cpTree" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Component id="mpTree" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="cpTree" alignment="0" max="32767" attributes="0"/>
+                  <Component id="mpTree" alignment="0" max="32767" attributes="0"/>
               </Group>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="cpAddButton" alignment="1" min="-2" max="-2" attributes="0"/>
                   <Component id="mpAddButton" alignment="1" min="-2" max="-2" attributes="0"/>

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/PathsCustomizer.java
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/PathsCustomizer.java
@@ -34,6 +34,7 @@ import javax.swing.JList;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import javax.swing.JTree;
+import javax.swing.UIManager;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
 import javax.swing.event.TreeSelectionEvent;
@@ -65,22 +66,30 @@ public final class PathsCustomizer extends javax.swing.JPanel {
      */
     public PathsCustomizer() {
         initComponents();
-        mpTree.setUI(new BasicTreeUI() {
-            @Override
-            protected void paintHorizontalLine(Graphics g, JComponent c, int y, int left, int right) {
-            }
-            @Override
-            protected void paintVerticalLine(Graphics g, JComponent c, int x, int top, int bottom) {
-            }
-        });
-        cpTree.setUI(new javax.swing.plaf.basic.BasicTreeUI() {
-            @Override
-            protected void paintHorizontalLine(Graphics g, JComponent c, int y, int left, int right) {
-            }
-            @Override
-            protected void paintVerticalLine(Graphics g, JComponent c, int x, int top, int bottom) {
-            }
-        });
+
+        // Disable tree line painting if enabled in current look and feel.
+        // Do not use BasicTreeUI for all look and feels because this would
+        // break selection painting in FlatLaf and Nimbus.
+        // https://issues.apache.org/jira/browse/NETBEANS-4030
+        if (UIManager.getBoolean("Tree.paintLines")) {
+            mpTree.setUI(new BasicTreeUI() {
+                @Override
+                protected void paintHorizontalLine(Graphics g, JComponent c, int y, int left, int right) {
+                }
+                @Override
+                protected void paintVerticalLine(Graphics g, JComponent c, int x, int top, int bottom) {
+                }
+            });
+            cpTree.setUI(new javax.swing.plaf.basic.BasicTreeUI() {
+                @Override
+                protected void paintHorizontalLine(Graphics g, JComponent c, int y, int left, int right) {
+                }
+                @Override
+                protected void paintVerticalLine(Graphics g, JComponent c, int x, int top, int bottom) {
+                }
+            });
+        }
+
         setBackground(mpTree.getBackground());
         Mnemonics.setLocalizedText(addProject, NbBundle.getMessage(PathsCustomizer.class, "LBL_CustomizeLibraries_AddProject_JButton"));
         Mnemonics.setLocalizedText(addLibrary, NbBundle.getMessage(PathsCustomizer.class, "LBL_CustomizeLibraries_AddLibary_JButton"));
@@ -602,9 +611,9 @@ public final class PathsCustomizer extends javax.swing.JPanel {
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(cpTree, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(mpTree, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(cpTree, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(mpTree, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(cpAddButton, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(mpAddButton, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))


### PR DESCRIPTION
fix for https://issues.apache.org/jira/browse/NETBEANS-4030

The two nested JTree's ("Modulepath" and "Classpath") now span the whole width, which looks better for FlatLaf and Nimbus wide selection. Also the white background in Nimbus looks better than before.

Also tested with Windows, Mac and Metal LaFs, which are unchanged.

After:
![image](https://user-images.githubusercontent.com/5604048/77756952-89270b80-7030-11ea-9f00-242d7431eeaa.png)

![image](https://user-images.githubusercontent.com/5604048/77756968-904e1980-7030-11ea-997b-4d1cd0e9e617.png)

Nimbus after:
![image](https://user-images.githubusercontent.com/5604048/77756978-97752780-7030-11ea-8a58-29693ad5c0bf.png)

Nimbus before:
![image](https://user-images.githubusercontent.com/5604048/77756996-9c39db80-7030-11ea-87dd-cf5651ddecfd.png)
