### PR TITLE
Introducing new Plugin Portal 3.0 update center in Apache NetBeans 12.0

### DIFF
--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
@@ -25,12 +25,15 @@ OpenIDE-Module-Short-Description=Declares NetBeans autoupdate centers.
 
 Services/AutoupdateType/distribution-update-provider.instance=NetBeans Distribution
 Services/AutoupdateType/pluginportal-update-provider.instance=NetBeans Plugin Portal
+Services/AutoupdateType/legacy-pluginportal-update-provider.instance=Legacy NetBeans Plugin Portal
 Services/AutoupdateType/82pluginportal-update-provider.instance=NetBeans 8.2 Plugin Portal
 
 #NOI18N
 URL_Distribution=@@metabuild.DistributionURL@@
 #NOI18N
 URL_PluginPortal=@@metabuild.PluginPortalURL@@
+#NOI18N
+URL_LegacyPluginPortal=@@metabuild.LegacyPluginPortalURL@@
 #NOI18N
 URL_82PluginPortal=http://updates.netbeans.org/netbeans/updates/8.2/uc/final/distribution/catalog.xml.gz
 

--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
@@ -46,6 +46,16 @@
          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
       </file>
       
+      <file name="legacy-pluginportal-update-provider.instance">
+         <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/pluginportal-update-provider.instance"/>
+         <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>
+         <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_LegacyPluginPortal"/>
+         <attr name="category" stringvalue="COMMUNITY"/>
+         <attr name="enabled" boolvalue="true"/>
+         <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider"/>
+         <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
+      </file>
+      
       <file name="82pluginportal-update-provider.instance">
           <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/82pluginportal-update-provider.instance"/>
           <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>


### PR DESCRIPTION
In order to motivate NetBeans plugin developers to start using the new **Plugin Portal 3.0** [1] we need to register its update center in the **Apache NetBeans IDE 12.0**. This pull request contains necessary changes in this direction. Once this is merged we will also have to modify the URL redirect rules [2] accordingly. This is a fix for #NETBEANSINFRA-185.

[1] [https://netbeans-vm.apache.org/pluginportal/](https://netbeans-vm.apache.org/pluginportal/)
[2] [https://github.com/apache/netbeans-website/blob/master/netbeans.apache.org/src/content/.htaccess](https://github.com/apache/netbeans-website/blob/master/netbeans.apache.org/src/content/.htaccess)
[3] [https://issues.apache.org/jira/browse/NETBEANSINFRA-185](https://issues.apache.org/jira/browse/NETBEANSINFRA-185)