### PR TITLE
[NETBEANS-3870] FlatLaf and Windows LaF: fix smooth scrolling

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/DocumentViewOp.java
@@ -1510,7 +1510,7 @@ public final class DocumentViewOp
        
         JTextComponent textComponent = docView.getTextComponent();
         Keymap keymap = textComponent.getKeymap();
-        int wheelRotation = evt.getWheelRotation();
+        double wheelRotation = evt.getPreciseWheelRotation();
         if (wheelRotation < 0) {
             Action action = keymap.getAction(KeyStroke.getKeyStroke(0x290, modifiers)); //WHEEL_UP constant
             if (action != null) {

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebuggingViewComponent.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebuggingViewComponent.java
@@ -873,7 +873,7 @@ public class DebuggingViewComponent extends TopComponent implements org.openide.
     public void mouseWheelMoved(MouseWheelEvent e) {
         JScrollBar scrollBar = mainScrollPane.getVerticalScrollBar();
         if (e.getScrollType() == MouseWheelEvent.WHEEL_UNIT_SCROLL) {
-            int totalScrollAmount = e.getUnitsToScroll() * scrollBar.getUnitIncrement();
+            int totalScrollAmount = (int) (e.getPreciseWheelRotation() * e.getScrollAmount() * scrollBar.getUnitIncrement());
             scrollBar.setValue(scrollBar.getValue() + totalScrollAmount);
         }
     }

--- a/platform/core.output2/src/org/netbeans/core/output2/ui/AbstractOutputPane.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/ui/AbstractOutputPane.java
@@ -822,7 +822,8 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
         } else if (e.isShiftDown()) { // horizontal scrolling
             BoundedRangeModel sbmodel = getHorizontalScrollBar().getModel();
             int currPosition = sbmodel.getValue();
-            int newPosition = Math.max(0, Math.min(sbmodel.getMaximum(), currPosition + (e.getUnitsToScroll()) * fontWidth));
+            int newPosition = Math.max(0, Math.min(sbmodel.getMaximum(), currPosition
+                    + (int) (e.getPreciseWheelRotation() * e.getScrollAmount() * fontWidth)));
             sbmodel.setValue (newPosition);
             return;
         }
@@ -832,7 +833,8 @@ public abstract class AbstractOutputPane extends JScrollPane implements Document
 
         int currPosition = sbmodel.getValue();
         if (e.getSource() == textView) {
-            int newPosition = Math.max(0, Math.min(sbmodel.getMaximum(), currPosition + (e.getUnitsToScroll() * fontHeight)));
+            int newPosition = Math.max(0, Math.min(sbmodel.getMaximum(), currPosition
+                    + (int) (e.getPreciseWheelRotation() * e.getScrollAmount() * fontHeight)));
             // height is a magic constant because of #57532
             sbmodel.setValue (newPosition);
             if (newPosition + range >= max) {


### PR DESCRIPTION
This fixes smooth scrolling in **editors**,  **Output** view and **Debugging** view for FlatLaf and Windows LaF.

Smooth scrolling requires a "precise" trackpad our mouse wheel (e.g. Macs or Surface Books) and allows scrolling by fraction of lines.

Smooth scrolling worked before fine in many views where FlatLaf or Windows LaF does the scrolling. But there are some places in NB where scrolling is done in NB, but precise rotation values are not used.

The problem is that `MouseWheelEvent.getWheelRotation()` or `MouseWheelEvent.getUnitsToScroll()` return zero when a precise trackpad/wheel is moved slowly. So the events are ignored.

Solution is to use `MouseWheelEvent.getPreciseWheelRotation()` instead.

On not precise wheels, `getPreciseWheelRotation()` returns the same value as `getWheelRotation()`.