### PR TITLE
[NETBEANS-4100] - Update asm from 7.2 to 8.0

### DIFF
--- a/harness/apisupport.harness/build.xml
+++ b/harness/apisupport.harness/build.xml
@@ -39,13 +39,13 @@
                 <pathelement location="${cluster}/tasks.jar"></pathelement>
             </classpath>
         </taskdef>
-        <echo file="build/binaries-list">FA637EB67EB7628C915D73762B681AE7FF0B9731 org.ow2.asm:asm:7.2</echo>
+        <echo file="build/binaries-list">D1A17D07C60E9E82C8B31B1D8F9CA98726418DB4 org.ow2.asm:asm:8.0</echo>
         <TestDownload>
             <manifest dir="build">
                 <include name="binaries-list"/>
             </manifest>
         </TestDownload>
-        <delete file="build/asm-7.2.jar"/>
+        <delete file="build/asm-8.0.jar"/>
     </target>
 
     <target name="compile-jnlp-launcher" depends="init,compile">

--- a/java/lib.jshell.agent/manifest.mf
+++ b/java/lib.jshell.agent/manifest.mf
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.lib.jshell.agent
 OpenIDE-Module-Localizing-Bundle: org/netbeans/lib/jshell/agent/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.7
+OpenIDE-Module-Specification-Version: 1.8
 Premain-class: org.netbeans.lib.jshell.agent.NbJShellAgent
 Can-Redefine-Classes: true
 Can-Retransform-Classes: true

--- a/java/lib.jshell.agent/nbproject/project.properties
+++ b/java/lib.jshell.agent/nbproject/project.properties
@@ -21,5 +21,5 @@ javac.compilerargs=-Xlint -Xlint:-serial
 extra.module.files=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 jnlp.indirect.jars=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 
-agentsrc.asm.cp=${libs.asm.dir}/core/asm-7.2.jar
+agentsrc.asm.cp=${libs.asm.dir}/core/asm-8.0.jar
 agentsrc.jshell.cp=${nb_all}/java/libs.jshell.compile/external/jshell-9.jar

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -78,10 +78,10 @@
         <tstamp>
             <format property="module.build.started.time" pattern="yyyy-MM-dd'T'HH:mm:ss.SSSZ"/>
         </tstamp>
-        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-7.2.jar">
-            <available file="${nbplatform.active.dir}/platform/core/asm-7.2.jar"/>
+        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-8.0.jar">
+            <available file="${nbplatform.active.dir}/platform/core/asm-8.0.jar"/>
         </condition>
-        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-7.2.jar"/>
+        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-8.0.jar"/>
     </target>
 
     <target name="-release.dir">

--- a/platform/libs.asm/external/asm-8.0-license.txt
+++ b/platform/libs.asm/external/asm-8.0-license.txt
@@ -1,6 +1,6 @@
 Name: OW2 ASM
-Version: 7.2
-Files: asm-tree-7.2.jar asm-commons-7.2.jar asm-7.2.jar
+Version: 8.0
+Files: asm-tree-8.0.jar asm-commons-8.0.jar asm-8.0.jar
 License: BSD-INRIA
 Origin: OW2 Consortium
 URL: https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/

--- a/platform/libs.asm/external/binaries-list
+++ b/platform/libs.asm/external/binaries-list
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-FA637EB67EB7628C915D73762B681AE7FF0B9731 org.ow2.asm:asm:7.2
-3A23CC36EDAF8FC5A89CB100182758CCB5991487 org.ow2.asm:asm-tree:7.2
-CA2954E8D92A05BACC28FF465B25C70E0F512497 org.ow2.asm:asm-commons:7.2
+D1A17D07C60E9E82C8B31B1D8F9CA98726418DB4 org.ow2.asm:asm:8.0
+7B31CA94DA9F57334A5AED79B40F2B88C5EE9F4F org.ow2.asm:asm-tree:8.0
+EA2231BDB3394BCCA5989DB7F7586F743829A9CB org.ow2.asm:asm-commons:8.0

--- a/platform/libs.asm/manifest.mf
+++ b/platform/libs.asm/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.libs.asm
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/asm/Bundle.properties
-OpenIDE-Module-Specification-Version: 5.11
+OpenIDE-Module-Specification-Version: 5.12

--- a/platform/libs.asm/nbproject/project.properties
+++ b/platform/libs.asm/nbproject/project.properties
@@ -19,7 +19,7 @@ javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 module.jar.dir=core
 
-release.external/asm-7.2.jar=core/asm-7.2.jar
-release.external/asm-tree-7.2.jar=core/asm-tree-7.2.jar
-release.external/asm-commons-7.2.jar=core/asm-commons-7.2.jar
-license.file=../external/asm-7.2-license.txt
+release.external/asm-8.0.jar=core/asm-8.0.jar
+release.external/asm-tree-8.0.jar=core/asm-tree-8.0.jar
+release.external/asm-commons-8.0.jar=core/asm-commons-8.0.jar
+license.file=../external/asm-8.0-license.txt

--- a/platform/libs.asm/nbproject/project.xml
+++ b/platform/libs.asm/nbproject/project.xml
@@ -29,16 +29,16 @@
                 <subpackages>org</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>asm-7.2.jar</runtime-relative-path>
-                <binary-origin>external/asm-7.2.jar</binary-origin>
+                <runtime-relative-path>asm-8.0.jar</runtime-relative-path>
+                <binary-origin>external/asm-8.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>asm-tree-7.2.jar</runtime-relative-path>
-                <binary-origin>external/asm-tree-7.2.jar</binary-origin>
+                <runtime-relative-path>asm-tree-8.0.jar</runtime-relative-path>
+                <binary-origin>external/asm-tree-8.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>asm-commons-7.2.jar</runtime-relative-path>
-                <binary-origin>external/asm-commons-7.2.jar</binary-origin>
+                <runtime-relative-path>asm-commons-8.0.jar</runtime-relative-path>
+                <binary-origin>external/asm-commons-8.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Notes:
- New V15 constant
- Experimental support for PermittedSubtypes and RecordComponent
- Bug fixes (317885): SKIP_DEBUG now skips MethodParameters attributes
- Java 14 support (RecordComponent)
- Bug fixes (317896): Performance degradation when using dynamic constants as a static paramet to another InDy/ConDy


[ASM Web Page](https://asm.ow2.io/index.html)
[Release Notes](https://asm.ow2.io/versions.html)