### PR TITLE
[NETBEANS-4108] fixed git -> ignore should add a new line at the end …

### DIFF
--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/IgnoreUnignoreCommand.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/commands/IgnoreUnignoreCommand.java
@@ -137,9 +137,7 @@ public abstract class IgnoreUnignoreCommand extends GitCommand {
             for (ListIterator<IgnoreRule> it = ignoreRules.listIterator(); it.hasNext(); ) {
                 String s = it.next().getPattern(false);
                 bw.write(s, 0, s.length());
-                if (it.hasNext()) {
-                    bw.newLine();
-                }
+                bw.newLine();
             }
         } finally {
             if (bw != null) {

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/AbstractGitTestCase.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/AbstractGitTestCase.java
@@ -98,23 +98,15 @@ public class AbstractGitTestCase extends NbTestCase {
     }
 
     protected void write(File file, String str) throws IOException {
-        FileWriter w = null;
-        try {
-            w = new FileWriter(file);
+        try (FileWriter w = new FileWriter(file)) {
             w.write(str);
             w.flush();
-        } finally {
-            if (w != null) {
-                w.close();
-            }
         }
     }
 
     protected String read(File file) throws IOException {
         StringBuilder sb = new StringBuilder();
-        BufferedReader r = null;
-        try {
-            r = new BufferedReader(new FileReader(file));
+        try (BufferedReader r = new BufferedReader(new FileReader(file))) {
             String s = r.readLine();
             if (s != null) {
                 while( true ) {
@@ -124,27 +116,17 @@ public class AbstractGitTestCase extends NbTestCase {
                     sb.append('\n');
                 }
             }
-        } finally {
-            if (r != null) {
-                r.close();
-            }
         }
         return sb.toString();
     }
 
     protected boolean containsCRorLF(File file) throws IOException {
-        BufferedReader r = null;
-        try {
-            r = new BufferedReader(new FileReader(file));
+        try (BufferedReader r = new BufferedReader(new FileReader(file))) {
             int i;
-            while((i = r.read()) >-1)
-            {
-                if( i=='\n' || i=='\r')
+            while ((i = r.read()) > -1) {
+                if (i == '\n' || i == '\r') {
                     return true;
-            }
-        } finally {
-            if (r != null) {
-                r.close();
+                }
             }
         }
         return false;

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/AbstractGitTestCase.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/AbstractGitTestCase.java
@@ -132,6 +132,24 @@ public class AbstractGitTestCase extends NbTestCase {
         return sb.toString();
     }
 
+    protected boolean containsCRorLF(File file) throws IOException {
+        BufferedReader r = null;
+        try {
+            r = new BufferedReader(new FileReader(file));
+            int i;
+            while((i = r.read()) >-1)
+            {
+                if( i=='\n' || i=='\r')
+                    return true;
+            }
+        } finally {
+            if (r != null) {
+                r.close();
+            }
+        }
+        return false;
+    }
+
     protected static void assertStatus (Map<File, GitStatus> statuses, File workDir, File file, boolean tracked, Status headVsIndex, Status indexVsWorking, Status headVsWorking, boolean conflict) {
         GitStatus status = statuses.get(file);
         assertNotNull(file.getAbsolutePath() + " not in " + statuses.keySet(), status);

--- a/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/IgnoreTest.java
+++ b/ide/libs.git/test/unit/src/org/netbeans/libs/git/jgit/commands/IgnoreTest.java
@@ -589,4 +589,13 @@ public class IgnoreTest extends AbstractGitTestCase {
         statuses = client.getStatus(new File[0], NULL_PROGRESS_MONITOR);
         assertEquals(Status.STATUS_IGNORED, statuses.get(f).getStatusIndexWC());
     }
+
+    public void testGitIgnoreEndsWithNewLine () throws Exception {
+        File f = new File(workDir, "file");
+        f.createNewFile();
+        File gitIgnore = new File(workDir, Constants.DOT_GIT_IGNORE);
+        File[] ignores = getClient(workDir).ignore(new File[] { f }, NULL_PROGRESS_MONITOR);
+        assertTrue(gitIgnore.exists());
+        assertTrue("The .gitignore file should ends with an empty new line.",containsCRorLF(gitIgnore));
+    }
 }


### PR DESCRIPTION
…of .gitignore file

Simple two line changes and added auto test for that. For more information see the [issue](https://issues.apache.org/jira/browse/NETBEANS-4108) and recommendations on [SO](https://stackoverflow.com/questions/5813311/no-newline-at-end-of-file)

The GitHub native client handles the new line correctly.