### PR TITLE
[NETBEANS-4127] Adjust maven profiler to provide jvmargs as separate …

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/newproject/MavenWizardIterator.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/MavenWizardIterator.java
@@ -93,13 +93,13 @@ public class MavenWizardIterator implements WizardDescriptor.BackgroundInstantia
     @TemplateRegistration(folder=ArchetypeWizards.TEMPLATE_FOLDER, position = 925, displayName = "#LBL_Maven_FXML_Archetype", iconBase = "org/netbeans/modules/maven/resources/jaricon.png", description = "javafx.html")
     @Messages("LBL_Maven_FXML_Archetype=FXML JavaFX Maven Archetype (Gluon)")
     public static WizardDescriptor.InstantiatingIterator<?> openJFXFML() {
-       return definedFXArchetype("com.raelity.jfx", "javafx-archetype-fxml-netbeans", "0.0.3", LBL_Maven_FXML_Archetype());
+       return definedFXArchetype("com.raelity.jfx", "javafx-archetype-fxml-netbeans", "0.0.4", LBL_Maven_FXML_Archetype());
     }
 
     @TemplateRegistration(folder=ArchetypeWizards.TEMPLATE_FOLDER, position = 926, displayName = "#LBL_Maven_Simple_Archetype", iconBase = "org/netbeans/modules/maven/resources/jaricon.png", description = "javafx.html")
     @Messages("LBL_Maven_Simple_Archetype=Simple JavaFX Maven Archetype (Gluon)")
     public static WizardDescriptor.InstantiatingIterator<?> openJFXSimple() {
-       return definedFXArchetype("com.raelity.jfx", "javafx-archetype-simple-netbeans", "0.0.3", LBL_Maven_Simple_Archetype());
+       return definedFXArchetype("com.raelity.jfx", "javafx-archetype-simple-netbeans", "0.0.4", LBL_Maven_Simple_Archetype());
     }
 
     private static WizardDescriptor.InstantiatingIterator<?> definedFXArchetype(String g, String a, String v, String name) {

--- a/profiler/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfilerLauncher.java
+++ b/profiler/profiler.nbimpl/src/org/netbeans/modules/profiler/nbimpl/actions/ProfilerLauncher.java
@@ -69,6 +69,7 @@ public class ProfilerLauncher {
     
     final private static String AGENT_ARGS = "agent.jvmargs"; // NOI18N
     final private static String LINUX_THREAD_TIMER_KEY = "-XX:+UseLinuxPosixThreadCPUClocks"; // NOI18N
+    final private static String ARGS_PREFIX = "profiler.netbeansBindings.jvmarg"; // NOI18N
     
     public static final class Command {
         private final String command;
@@ -541,6 +542,7 @@ public class ProfilerLauncher {
         }
         assert agentArgs != null;
         props.put(AGENT_ARGS, agentArgs);
+        props.put(ARGS_PREFIX + ".agent", agentArgs); // NOI18N
 
         if (Platform.isLinux() && javaVersion.equals(CommonConstants.JDK_16_STRING)) {
             activateLinuxPosixThreadTime(pSettings, props);
@@ -608,8 +610,12 @@ public class ProfilerLauncher {
                     heapDumpPath = "\"" + heapDumpPath + "\"";//NOI18N
                 }
 
-                oomArgsBuffer.append(" -XX:+HeapDumpOnOutOfMemoryError"); // NOI18N
-                oomArgsBuffer.append(" -XX:HeapDumpPath=").append(heapDumpPath).append(" "); // NOI18N
+                final String oom = "-XX:+HeapDumpOnOutOfMemoryError";
+                final String path = "-XX:HeapDumpPath=" + heapDumpPath;
+                oomArgsBuffer.append(" ").append(oom); // NOI18N
+                oomArgsBuffer.append(" ").append(path).append(" "); // NOI18N
+                props.put(ARGS_PREFIX + ".outOfMemory", oom); // NOI18N
+                props.put(ARGS_PREFIX + ".heapDumpPath", path); // NOI18N
 
                 ProfilerLogger.log("Profiler.OutOfMemoryDetection: Enabled"); // NOI18N
             }


### PR DESCRIPTION
…options

This change is structured to add some new properties for use in pom.xml. It does not change any existing stuff, either internal to NB or available to the pom.

This change makes the profiling jvmargs available as individual properties. This is required for the javafx-maven-plugin.

The PR also uses updated javafx archetypes which include a profile nbactions and pom execution.