### PR TITLE
[NETBEANS-4143] Dont quote args in common case; fixes terminal startu…

### DIFF
--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NativeProcessInfo.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/NativeProcessInfo.java
@@ -298,6 +298,12 @@ public final class NativeProcessInfo {
         boolean escape;
 
         for (String arg : arguments) {
+            if(!arg.contains(" ") && !arg.contains("$")) { // NOI18N
+                // This condition avoids quoting --login, [NETBEANS-4143]
+                sb.append(arg).append(' ');
+                continue;
+            }
+
             escape = false;
             sarg[0] = arg;
             arg = Utilities.escapeParameters(sarg);


### PR DESCRIPTION
…p in cygwin.

"Tools > Open in Terminal" was failing with
```
Malformed argument has embedded quote: exec /cygdrive/F/cygwin64/bin/bash.exe \"--login\"
```
This is a simple/trivial fix; it avoids touching/quoting arguments unless they have a space or contain a `$`; this is consistent with the rest of the code I've seen in dlight.