### PR TITLE
Removing legacy Update Center for NetBeans 8.2 hosted on Plugin Portal 2.0

### DIFF
--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/Bundle.properties
@@ -25,14 +25,11 @@ OpenIDE-Module-Short-Description=Declares NetBeans autoupdate centers.
 
 Services/AutoupdateType/distribution-update-provider.instance=NetBeans Distribution
 Services/AutoupdateType/pluginportal-update-provider.instance=NetBeans Plugin Portal
-Services/AutoupdateType/82pluginportal-update-provider.instance=NetBeans 8.2 Plugin Portal
 
 #NOI18N
 URL_Distribution=@@metabuild.DistributionURL@@
 #NOI18N
 URL_PluginPortal=@@metabuild.PluginPortalURL@@
-#NOI18N
-URL_82PluginPortal=http://updates.netbeans.org/netbeans/updates/8.2/uc/final/distribution/catalog.xml.gz
 
 3rdparty=Third Party Libraries
 #NOI18N

--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
@@ -46,16 +46,6 @@
          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
       </file>
       
-      <file name="82pluginportal-update-provider.instance">
-          <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#Services/AutoupdateType/82pluginportal-update-provider.instance"/>
-          <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>
-          <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_82PluginPortal"/>
-          <attr name="category" stringvalue="STANDARD"/>
-          <attr name="enabled" boolvalue="false"/>
-          <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider"/>
-          <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
-      </file>
-
       <file name="3rdparty.instance">
           <attr name="displayName" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#3rdparty"/>
           <attr name="iconBase" stringvalue="org/netbeans/modules/updatecenters/resources/updateAction.gif"/>


### PR DESCRIPTION
As discussed in PR #2056 [1] Apache NetBeans IDE 12.0 will not rely on Oracle hosted infrastructure so here we remove old update center for NetBeans 8.2. If someone still needs old plugins, s/he can still register copy of legacy update centers hosted on Emilian's box as described in [2] and install the plugins like CND.

[1] https://github.com/apache/netbeans/pull/2056
[2] https://cwiki.apache.org/confluence/display/NETBEANS/Where+to+download+plugins+for+NetBeans+10.0+and+earlier