### PR TITLE
[NETBEANS-4050] - cleanup uses of EMPTY_LIST, EMPTY_SET, EMPTY_MAP

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ExamineManifest.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/ExamineManifest.java
@@ -51,7 +51,7 @@ public class ExamineManifest  {
     private String locBundle;
     private boolean publicPackages;
     private boolean populateDependencies = false;
-    private List dependencyTokens = Collections.EMPTY_LIST;
+    private List dependencyTokens = Collections.emptyList();
    
     
     public void checkFile() throws MojoExecutionException {

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDWizardIterator.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDWizardIterator.java
@@ -106,7 +106,7 @@ public final class PayaraDDWizardIterator implements WizardDescriptor.Instantiat
     
     @Override
     public Set instantiate() throws IOException {
-        Set result = Collections.EMPTY_SET;
+        Set result = Collections.emptySet();
         PayaraDDWizardPanel wizardPanel = (PayaraDDWizardPanel) panels[0];
         
         File configDir = wizardPanel.getSelectedLocation();

--- a/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/JspHyperlinkProvider.java
+++ b/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/JspHyperlinkProvider.java
@@ -408,7 +408,7 @@ public class JspHyperlinkProvider implements HyperlinkProvider {
 
                     //compute the type off awt
                     ClasspathInfo cpInfo = ClasspathInfo.create(jspSup.getFileObject());
-                    JavaSource source = JavaSource.create(cpInfo, Collections.EMPTY_LIST);
+                    JavaSource source = JavaSource.create(cpInfo, Collections.<FileObject>emptyList());
 
                     AtomicBoolean cancel = new AtomicBoolean();
                     Compute<TypeElement> compute = new Compute<TypeElement>(cancel,

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/HtmlSourceTask.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/HtmlSourceTask.java
@@ -57,7 +57,7 @@ public final class HtmlSourceTask extends ParserResultTask<HtmlParserResult> {
             if (mimeType.equals("text/html")) { //NOI18N
                 return Collections.singletonList(new HtmlSourceTask());
             } else {
-                return Collections.EMPTY_LIST;
+                return Collections.<SchedulerTask>emptyList();
             }
         }
     }

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigUtilities.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFConfigUtilities.java
@@ -206,7 +206,7 @@ public class JSFConfigUtilities {
         ClassPath bootCP = cpp.findClassPath(webModule.getDocumentBase(), ClassPath.BOOT);
         ClassPath compileCP = cpp.findClassPath(webModule.getDocumentBase(), ClassPath.COMPILE);
         ClassPath sourceCP = cpp.findClassPath(webModule.getDocumentBase(), ClassPath.SOURCE);
-        return JavaSource.create(ClasspathInfo.create(bootCP, compileCP, sourceCP), Collections.EMPTY_LIST);
+        return JavaSource.create(ClasspathInfo.create(bootCP, compileCP, sourceCP), Collections.<FileObject>emptyList());
     }
 
     private static boolean containsAnnotatedJsfResource(CompilationController parameter) {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/EjbsNodeFactory.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/EjbsNodeFactory.java
@@ -84,7 +84,7 @@ public class EjbsNodeFactory implements NodeFactory {
             if (!isViewEmpty){
                 return Collections.singletonList(KEY_EJBS);
             }else{
-                return Collections.EMPTY_LIST;
+                return Collections.emptyList();
             }
         }
 

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigUtilities.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigUtilities.java
@@ -243,7 +243,7 @@ public class StrutsConfigUtilities {
             }
             
             ClasspathInfo cpi = ClasspathInfo.create(dd);
-            JavaSource js = JavaSource.create(cpi, Collections.EMPTY_LIST);
+            JavaSource js = JavaSource.create(cpi, Collections.<FileObject>emptyList());
             final int[] index = new int[]{-1};
             js.runUserActionTask( new Task <CompilationController>(){
                 public void run(CompilationController  cc) throws Exception {                        

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/nodes/RestServiceChildren.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/nodes/RestServiceChildren.java
@@ -51,7 +51,7 @@ public class RestServiceChildren extends Children.Keys {
     protected void removeNotify() {
         super.removeNotify();
         
-        setKeys(Collections.EMPTY_SET);
+        setKeys(Collections.emptySet());
     }
     
     private void updateKeys() {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/ConstructorGenerationCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/ConstructorGenerationCompletion.java
@@ -62,7 +62,7 @@ public class ConstructorGenerationCompletion extends BaseCompletion {
         boolean camelCaseMatch = CamelCaseUtil.compareCamelCase(className, request.getPrefix());
         if (camelCaseMatch) {
             LOG.log(Level.FINEST, "Prefix matches Class's CamelCase signature. Adding."); // NOI18N
-            proposals.add(new CompletionItem.ConstructorItem(className, Collections.EMPTY_LIST, anchor, true));
+            proposals.add(new CompletionItem.ConstructorItem(className, Collections.emptyList(), anchor, true));
         }
 
         return camelCaseMatch;

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueTable.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueTable.java
@@ -413,7 +413,7 @@ public class IssueTable implements MouseListener, AncestorListener, KeyListener,
     private Map<Integer, Integer> getColumnSorting() {
         String sortingString = getColumnSorting(repositoryId);
         if(sortingString == null || sortingString.equals("")) {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         }
         Map<Integer, Integer> map = new HashMap<>();
         String[] sortingArray = sortingString.split(CONFIG_DELIMITER);
@@ -697,7 +697,7 @@ public class IssueTable implements MouseListener, AncestorListener, KeyListener,
         String columns = getColumns(repositoryId);
         String[] visibleColumns = columns.split(CONFIG_DELIMITER);                         // NOI18N
         if(visibleColumns.length <= 1) {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         }
         Map<String, Integer> ret = new HashMap<String, Integer>();
         for (int i = 0; i < visibleColumns.length; i=i+2) {

--- a/ide/docker.api/src/org/netbeans/modules/docker/api/DockerContainerDetail.java
+++ b/ide/docker.api/src/org/netbeans/modules/docker/api/DockerContainerDetail.java
@@ -42,7 +42,7 @@ public class DockerContainerDetail {
         this.status = status;
         this.stdin = stdin;
         this.tty = tty;
-        this.portMappings = Collections.EMPTY_LIST;
+        this.portMappings = Collections.emptyList();
     }
     
     public DockerContainerDetail(String name, DockerContainer.Status status, boolean stdin, boolean tty, List<PortMapping> portMappings) {

--- a/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionJList.java
+++ b/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionJList.java
@@ -62,7 +62,7 @@ public class CompletionJList extends JList {
         setFont(editorComponent.getFont());
         setLayoutOrientation(JList.VERTICAL);
         setFixedCellHeight(fixedItemHeight = Math.max(CompletionLayout.COMPLETION_ITEM_HEIGHT, getFontMetrics(getFont()).getHeight()));
-        setModel(new Model(Collections.EMPTY_LIST));
+        setModel(new Model(Collections.emptyList()));
         setFocusable(false);
 
         renderComponent = new RenderComponent();

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/hooks/VCSHooks.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/hooks/VCSHooks.java
@@ -63,7 +63,7 @@ public class VCSHooks {
             hooksResult = Lookup.getDefault().lookupResult(VCSHookFactory.class);
         }
         if(hooksResult == null) {
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
         }
         Collection<VCSHookFactory> c = (Collection<VCSHookFactory>) Lookup.getDefault().lookupAll(VCSHookFactory.class);
         return hooksResult.allInstances();

--- a/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/MatchedStyles.java
+++ b/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/MatchedStyles.java
@@ -52,7 +52,7 @@ public class MatchedStyles {
             }
             Collections.reverse(matchedRules);
         } else {
-            matchedRules = Collections.EMPTY_LIST;
+            matchedRules = Collections.emptyList();
         }
         /* TODO: After it's needed, follow the most recent spec.
         if (styles.containsKey("pseudoElements")) { // NOI18N

--- a/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/PropertyInfo.java
+++ b/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/PropertyInfo.java
@@ -43,7 +43,7 @@ public class PropertyInfo {
         name = (String)propertyInfo.get("name"); // NOI18N
         JSONArray longHandsArray = (JSONArray)propertyInfo.get("longhands"); // NOI18N
         if (longHandsArray == null) {
-            longhands = Collections.EMPTY_LIST;
+            longhands = Collections.emptyList();
         } else {
             longhands = (List<String>)longHandsArray;
         }
@@ -57,7 +57,7 @@ public class PropertyInfo {
      */
     PropertyInfo(String name) {
         this.name = name;
-        this.longhands = Collections.EMPTY_LIST;
+        this.longhands = Collections.emptyList();
     }
 
     /**

--- a/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Rule.java
+++ b/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/Rule.java
@@ -89,7 +89,7 @@ public class Rule {
                 media.add(new Media((JSONObject)o));
             }
         } else {
-            media = Collections.EMPTY_LIST;
+            media = Collections.emptyList();
         }
         if (rule.containsKey("selectorList")) { // NOI18N
             JSONObject selectorList = (JSONObject)rule.get("selectorList"); // NOI18N

--- a/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/StyleSheetBody.java
+++ b/ide/web.webkit.debugging/src/org/netbeans/modules/web/webkit/debugging/api/css/StyleSheetBody.java
@@ -69,7 +69,7 @@ public class StyleSheetBody {
         this.styleSheetHeader = header;
         this.styleSheetId = header.getStyleSheetId();
         this.text = text;
-        this.rules = Collections.EMPTY_LIST;
+        this.rules = Collections.emptyList();
     }
 
     /**

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetsAction.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetsAction.java
@@ -142,7 +142,7 @@ public final class RunTargetsAction extends AbstractAction implements ContextAwa
                 } catch (IOException e) {
                     DialogDisplayer.getDefault().notify(
                             new NotifyDescriptor.Message(e.getLocalizedMessage()));
-                    allTargets = Collections.EMPTY_SET;
+                    allTargets = Collections.emptySet();
                 }
                 String defaultTarget = null;
                 SortedSet<String> describedTargets = new TreeSet(Collator.getInstance());

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -741,13 +741,13 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                     " Setting recycle bin tables to an empty list.", 
                     exc); // NOI18N
 
-            result = Collections.EMPTY_LIST;
+            result = Collections.emptyList();
         } catch (AbstractMethodError ame) {
             LOGGER.log(Level.WARNING, "Some older versions of the Oracle " +
                     " driver do not support getDatabaseMajorVersion().  " +
                     " Setting recycle bin tables to an empty list.", 
                     ame); // NOI18N
-            result = Collections.EMPTY_LIST;
+            result = Collections.emptyList();
         }
         return result;
     }

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/focus/AWTGrabHandler.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/focus/AWTGrabHandler.java
@@ -309,7 +309,7 @@ class AWTGrabHandler {
                 logger.info("Unable to release X grab, method ungrabInput not found in target VM "+VirtualMachineWrapper.description(vm));
                 return false;
             }
-            XBaseWindowClass.invokeMethod(tr, ungrabInput, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            XBaseWindowClass.invokeMethod(tr, ungrabInput, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         } catch (VMDisconnectedExceptionWrapper vmdex) {
             return true; // Disconnected, all is good.
         } catch (Exception ex) {
@@ -338,7 +338,7 @@ class AWTGrabHandler {
                 logger.info("Unable to release FX X grab, no impl_getWindows() method in "+WindowClass);
                 return true; // We do not know whether there was any grab
             }
-            ObjectReference windowsIterator = (ObjectReference) WindowClass.invokeMethod(tr, getWindowsMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            ObjectReference windowsIterator = (ObjectReference) WindowClass.invokeMethod(tr, getWindowsMethod, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
             if (windowsIterator == null) {
                 return true; // We do not know whether there was any grab
             }
@@ -359,12 +359,12 @@ class AWTGrabHandler {
     }
     
     private boolean hasNext(Method hasNext, ThreadReference tr, ObjectReference iterator) throws Exception {
-        Value v = iterator.invokeMethod(tr, hasNext, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        Value v = iterator.invokeMethod(tr, hasNext, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         return (v instanceof BooleanValue) && ((BooleanValue) v).booleanValue();
     }
     
     private ObjectReference next(Method next, ThreadReference tr, ObjectReference iterator) throws Exception {
-        return (ObjectReference) iterator.invokeMethod(tr, next, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        return (ObjectReference) iterator.invokeMethod(tr, next, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
     }
     
     private void ungrabWindowFX(ClassType WindowClass, ObjectReference w, ThreadReference tr) throws Exception {
@@ -400,7 +400,7 @@ class AWTGrabHandler {
             }
             InterfaceType TKStageClass = (InterfaceType) w.virtualMachine().classesByName("com.sun.javafx.tk.TKStage").get(0);
             Method ungrabFocusMethod = TKStageClass.methodsByName("ungrabFocus", "()V").get(0);
-            impl_peer.invokeMethod(tr, ungrabFocusMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            impl_peer.invokeMethod(tr, ungrabFocusMethod, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
             if (logger.isLoggable(Level.FINE)) {
                 logger.fine("FX Window "+w+" was successfully ungrabbed.");
             }
@@ -547,7 +547,7 @@ class AWTGrabHandler {
             //writeLock.lock();
             ClassType ToolkitClass = (ClassType) toolkitClassesByName.get(0);
             Method getDefaultToolkit = ClassTypeWrapper.concreteMethodByName(ToolkitClass, "getDefaultToolkit", "()Ljava/awt/Toolkit;");
-            ObjectReference toolkit = (ObjectReference) ToolkitClass.invokeMethod(tr, getDefaultToolkit, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            ObjectReference toolkit = (ObjectReference) ToolkitClass.invokeMethod(tr, getDefaultToolkit, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
             
             ClassType XToolkitClass;
             switch (tkt) {
@@ -583,7 +583,7 @@ class AWTGrabHandler {
                 if (getSunAwtDisableGrab == null) {
                     logger.fine("XToolkit.getSunAwtDisableGrab() method not found in target VM "+VirtualMachineWrapper.description(virtualMachine));
                 } else {
-                    BooleanValue sunAwtDisableGrab = (BooleanValue) XToolkitClass.invokeMethod(tr, getSunAwtDisableGrab, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                    BooleanValue sunAwtDisableGrab = (BooleanValue) XToolkitClass.invokeMethod(tr, getSunAwtDisableGrab, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                     if (logger.isLoggable(Level.FINE)) {
                         logger.fine("sunAwtDisableGrab = "+sunAwtDisableGrab.value());
                     }
@@ -601,7 +601,7 @@ class AWTGrabHandler {
                 logger.fine("XToolkit.getDefaultRootWindow() method does not exist in the target VM "+VirtualMachineWrapper.description(virtualMachine));
                 return false;
             }
-            LongValue defaultRootWindowValue = (LongValue) XToolkitClass.invokeMethod(tr, getDefaultRootWindow, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            LongValue defaultRootWindowValue = (LongValue) XToolkitClass.invokeMethod(tr, getDefaultRootWindow, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
             
             // XAtom xa = new XAtom(grabCheckStr, true);
             List<ReferenceType> xatomClassesByName = VirtualMachineWrapper.classesByName(virtualMachine, "sun.awt.X11.XAtom");

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorVisitor.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/EvaluatorVisitor.java
@@ -1719,15 +1719,15 @@ public class EvaluatorVisitor extends ErrorAwareTreePathScanner<Mirror, Evaluati
             }
             Method iteratorMethod = null;
             try {
-                iteratorMethod = getConcreteMethod(objType, "iterator", Collections.EMPTY_LIST);
+                iteratorMethod = getConcreteMethod(objType, "iterator", Collections.<TypeMirror>emptyList());
             } catch (UnsuitableArgumentsException ex) {
             }
             iterator = (ObjectReference)invokeMethod(arg0, iteratorMethod, Boolean.FALSE, (ClassType)objRef.type(),
-                    objRef, Collections.EMPTY_LIST, evaluationContext, false);
+                    objRef, Collections.<Value>emptyList(), evaluationContext, false);
             try {
                 ReferenceType iteratorType = iterator.referenceType();
-                nextMethod = getConcreteMethod(iteratorType, "next", Collections.EMPTY_LIST);
-                hasNextMethod = getConcreteMethod(iteratorType, "hasNext", Collections.EMPTY_LIST);
+                nextMethod = getConcreteMethod(iteratorType, "next", Collections.<TypeMirror>emptyList());
+                hasNextMethod = getConcreteMethod(iteratorType, "hasNext", Collections.<TypeMirror>emptyList());
             } catch (UnsuitableArgumentsException ex) {
             }
         } else {
@@ -1752,12 +1752,12 @@ public class EvaluatorVisitor extends ErrorAwareTreePathScanner<Mirror, Evaluati
                     index++;
                 } else {
                     value = invokeMethod(arg0, hasNextMethod, Boolean.FALSE, (ClassType)iterator.type(),
-                        iterator, Collections.EMPTY_LIST, evaluationContext, false);
+                        iterator, Collections.<Value>emptyList(), evaluationContext, false);
                     if (!((BooleanValue)value).value()) {
                         break;
                     }
                     value = invokeMethod(arg0, nextMethod, Boolean.FALSE, (ClassType)iterator.type(),
-                        iterator, Collections.EMPTY_LIST, evaluationContext, false);
+                        iterator, Collections.<Value>emptyList(), evaluationContext, false);
                 }
                 scriptVar.setValue(value); // [TODO] check if value is assignable to variable
                 try {
@@ -5496,7 +5496,7 @@ public class EvaluatorVisitor extends ErrorAwareTreePathScanner<Mirror, Evaluati
 
         @Override
         public List<ReferenceType> nestedTypes() {
-            return Collections.EMPTY_LIST;
+            return Collections.<ReferenceType>emptyList();
         }
 
         @Override
@@ -5600,7 +5600,7 @@ public class EvaluatorVisitor extends ErrorAwareTreePathScanner<Mirror, Evaluati
 
         @Override
         public List<ObjectReference> instances(long l) {
-            return Collections.EMPTY_LIST;
+            return Collections.<ObjectReference>emptyList();
         }
 
         @Override

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/VariableMirrorTranslator.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/VariableMirrorTranslator.java
@@ -586,12 +586,12 @@ public class VariableMirrorTranslator {
             ObjectReference objectConstructor = (ObjectReference)
                     ObjectReferenceWrapper.invokeMethod(objectClass, thread,
                                                   getDeclaredConstructorMethod,
-                                                  Collections.EMPTY_LIST,
+                                                  Collections.<Value>emptyList(),
                                                   ClassType.INVOKE_SINGLE_THREADED);
             ObjectReference rf = (ObjectReference)
                     ClassTypeWrapper.invokeMethod(reflectionFactoryType, thread,
                                                   getReflectionFactoryMethod,
-                                                  Collections.EMPTY_LIST,
+                                                  Collections.<Value>emptyList(),
                                                   ClassType.INVOKE_SINGLE_THREADED);
             ObjectReference constructor = (ObjectReference)
                     ObjectReferenceWrapper.invokeMethod(rf, thread,
@@ -610,11 +610,11 @@ public class VariableMirrorTranslator {
             ObjectReference newInstance = (ObjectReference)
                     ObjectReferenceWrapper.invokeMethod(constructor, thread,
                                                         newInstanceMethod,
-                                                        Collections.EMPTY_LIST,
+                                                        Collections.<Value>emptyList(),
                                                         ClassType.INVOKE_SINGLE_THREADED);
             return newInstance;
         } else {
-            return ClassTypeWrapper.newInstance(type, thread, c, Collections.EMPTY_LIST, ClassType.INVOKE_SINGLE_THREADED);
+            return ClassTypeWrapper.newInstance(type, thread, c, Collections.<Value>emptyList(), ClassType.INVOKE_SINGLE_THREADED);
         }
     }
     

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/remote/RemoteServices.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/remote/RemoteServices.java
@@ -143,7 +143,7 @@ public final class RemoteServices {
                     ClassType theClass = getClass(vm, Class.class.getName());
                     // Call some method that will prepare the class:
                     Method aMethod = ClassTypeWrapper.concreteMethodByName(theClass, "getConstructors", "()[Ljava/lang/reflect/Constructor;");
-                    ObjectReferenceWrapper.invokeMethod(theUploadedClass, tr, aMethod, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+                    ObjectReferenceWrapper.invokeMethod(theUploadedClass, tr, aMethod, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
                 }
             }
         } finally {
@@ -167,12 +167,12 @@ public final class RemoteServices {
                                                                                                        ObjectCollectedExceptionWrapper {
         ReferenceType threadType = tr.referenceType();
         Method getContextCl = ClassTypeWrapper.concreteMethodByName((ClassType) threadType, "getContextClassLoader", "()Ljava/lang/ClassLoader;");
-        ObjectReference cl = (ObjectReference) ObjectReferenceWrapper.invokeMethod(tr, tr, getContextCl, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+        ObjectReference cl = (ObjectReference) ObjectReferenceWrapper.invokeMethod(tr, tr, getContextCl, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         ClassType classLoaderClass = null;
         if (cl == null) {
             classLoaderClass = getClass(vm, ClassLoader.class.getName());
             Method getSystemClassLoader = ClassTypeWrapper.concreteMethodByName(classLoaderClass, "getSystemClassLoader", "()Ljava/lang/ClassLoader;");
-            cl = (ObjectReference) ClassTypeWrapper.invokeMethod(classLoaderClass, tr, getSystemClassLoader, Collections.EMPTY_LIST, ObjectReference.INVOKE_SINGLE_THREADED);
+            cl = (ObjectReference) ClassTypeWrapper.invokeMethod(classLoaderClass, tr, getSystemClassLoader, Collections.<Value>emptyList(), ObjectReference.INVOKE_SINGLE_THREADED);
         }
         return cl;
     }

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceLevelQueryImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceLevelQueryImpl.java
@@ -195,8 +195,8 @@ public class DefaultSourceLevelQueryImpl implements SourceLevelQueryImplementati
                     null,
                     null,
                     null,
-                    Collections.EMPTY_LIST,
-                    Collections.EMPTY_LIST,
+                    Collections.<String>emptyList(),
+                    Collections.<String>emptyList(),
                     Collections.singleton(new JFO(javaFile)));
             final Iterator<? extends CompilationUnitTree> cus = jt.parse().iterator();
             if (cus.hasNext()) {

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/NullResultImpl.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/spi/NullResultImpl.java
@@ -41,7 +41,7 @@ public final class NullResultImpl<T> implements ResultImplementation<T> {
     
     @Override
     public List<T> getResults() {            
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override

--- a/java/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsComponentImpl.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/settings/impl/SettingsComponentImpl.java
@@ -172,7 +172,7 @@ public abstract class SettingsComponentImpl extends AbstractDocumentComponent<Se
         if (text != null) {
             SettingsExtensibilityElement el = getModel().getFactory().createSettingsExtensibilityElement(qname);
             el.setElementText(text);
-            addAfter(qname.getLocalPart(), el, Collections.EMPTY_LIST);
+            addAfter(qname.getLocalPart(), el, Collections.emptyList());
         }
     }
 

--- a/java/maven/src/org/netbeans/modules/maven/DependencyType.java
+++ b/java/maven/src/org/netbeans/modules/maven/DependencyType.java
@@ -36,7 +36,7 @@ public enum DependencyType {
     private final List<String> scopes;
 
     private DependencyType(String... artifactScopes) {
-        this.scopes = Collections.unmodifiableList(artifactScopes == null || artifactScopes.length == 0 ? Collections.EMPTY_LIST : Arrays.asList(artifactScopes));
+        this.scopes = Collections.unmodifiableList(artifactScopes == null || artifactScopes.length == 0 ? Collections.emptyList() : Arrays.asList(artifactScopes));
     }        
 
     public List<String> artifactScopes() {

--- a/java/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/Modifications.java
+++ b/java/spring.beans/src/org/netbeans/modules/spring/beans/refactoring/Modifications.java
@@ -225,7 +225,7 @@ public final class Modifications implements org.netbeans.modules.refactoring.spi
 
     @Override
     public Collection<? extends File> getNewFiles() {
-        return Collections.EMPTY_LIST;
+        return Collections.<File>emptyList();
     }
 
     public static final class Difference {

--- a/java/testng.ui/src/org/netbeans/modules/testng/ui/wizards/TestNGSuiteHyperlingProvider.java
+++ b/java/testng.ui/src/org/netbeans/modules/testng/ui/wizards/TestNGSuiteHyperlingProvider.java
@@ -268,7 +268,7 @@ public class TestNGSuiteHyperlingProvider implements HyperlinkProvider {
                 break;
             case JAVA_SOURCE:
                 final ClasspathInfo cp = ClasspathInfo.create(doc);
-                JavaSource js = JavaSource.create(cp, Collections.EMPTY_LIST);
+                JavaSource js = JavaSource.create(cp, Collections.<FileObject>emptyList());
                 try {
                     js.runUserActionTask(new Task<CompilationController>() {
 

--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddJavaFXPropertyCodeGenerator.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddJavaFXPropertyCodeGenerator.java
@@ -86,7 +86,7 @@ public class AddJavaFXPropertyCodeGenerator implements CodeGenerator {
                     Element e = javac.getTrees().getElement(path);
                     
                     if (e == null || !e.getKind().isClass()) {
-                        return Collections.EMPTY_LIST;
+                        return Collections.<CodeGenerator>emptyList();
                     }
                     
                     List<String> existingFields = new LinkedList<String>();

--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddJavaFXPropertyMaker.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/codegen/AddJavaFXPropertyMaker.java
@@ -72,7 +72,7 @@ public class AddJavaFXPropertyMaker {
     private MethodTree createGetter(ModifiersTree mods, TypeMirror valueType) {
         StringBuilder getterName = GeneratorUtils.getCapitalizedName(config.getName());
         getterName.insert(0, valueType.getKind() == TypeKind.BOOLEAN ? "is" : "get");
-        ReturnTree returnTree = make.Return(make.MethodInvocation(Collections.EMPTY_LIST, make.MemberSelect(make.Identifier(config.getName()), hasGet ? "get" : "getValue"), Collections.EMPTY_LIST));
+        ReturnTree returnTree = make.Return(make.MethodInvocation(Collections.emptyList(), make.MemberSelect(make.Identifier(config.getName()), hasGet ? "get" : "getValue"), Collections.emptyList()));
         BlockTree getterBody = make.Block(Collections.singletonList(returnTree), false);
         Tree valueTree;
         if (valueType.getKind() == TypeKind.DECLARED) {
@@ -82,7 +82,7 @@ public class AddJavaFXPropertyMaker {
         } else {
             valueTree = make.Identifier(valueType.toString());
         }
-        MethodTree getter = make.Method(mods, getterName, valueTree, Collections.EMPTY_LIST, Collections.EMPTY_LIST, Collections.EMPTY_LIST, getterBody, null);
+        MethodTree getter = make.Method(mods, getterName, valueTree, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), getterBody, null);
         return getter;
     }
 
@@ -97,10 +97,10 @@ public class AddJavaFXPropertyMaker {
         } else {
             valueTree = make.Identifier(valueType.toString());
         }
-        StatementTree statement = make.ExpressionStatement(make.MethodInvocation(Collections.EMPTY_LIST, make.MemberSelect(make.Identifier(config.getName()), hasGet ? "set" : "setValue"), Collections.singletonList(make.Identifier("value"))));
+        StatementTree statement = make.ExpressionStatement(make.MethodInvocation(Collections.emptyList(), make.MemberSelect(make.Identifier(config.getName()), hasGet ? "set" : "setValue"), Collections.singletonList(make.Identifier("value"))));
         BlockTree getterBody = make.Block(Collections.singletonList(statement), false);
         VariableTree var = make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), "value", valueTree, null);
-        MethodTree getter = make.Method(mods, getterName, make.PrimitiveType(TypeKind.VOID), Collections.EMPTY_LIST, Collections.singletonList(var), Collections.EMPTY_LIST, getterBody, null);
+        MethodTree getter = make.Method(mods, getterName, make.PrimitiveType(TypeKind.VOID), Collections.emptyList(), Collections.singletonList(var), Collections.emptyList(), getterBody, null);
         return getter;
     }
 
@@ -110,11 +110,11 @@ public class AddJavaFXPropertyMaker {
         if (wrapperMethod == null) {
             expression = make.Identifier(config.getName());
         } else {
-            expression = make.MethodInvocation(Collections.EMPTY_LIST, make.MemberSelect(make.Identifier(config.getName()), wrapperMethod.getSimpleName()), Collections.EMPTY_LIST);
+            expression = make.MethodInvocation(Collections.emptyList(), make.MemberSelect(make.Identifier(config.getName()), wrapperMethod.getSimpleName()), Collections.emptyList());
         }
         ReturnTree returnTree = make.Return(expression);
         BlockTree getterBody = make.Block(Collections.singletonList(returnTree), false);
-        MethodTree getter = make.Method(mods, getterName, selectedType == null ? make.Identifier(config.getPropertyType()) : make.QualIdent(selectedType.asElement()), Collections.EMPTY_LIST, Collections.EMPTY_LIST, Collections.EMPTY_LIST, getterBody, null);
+        MethodTree getter = make.Method(mods, getterName, selectedType == null ? make.Identifier(config.getPropertyType()) : make.QualIdent(selectedType.asElement()), Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), getterBody, null);
         return getter;
     }
 
@@ -191,7 +191,7 @@ public class AddJavaFXPropertyMaker {
     private VariableTree createField(DeclaredType selectedType, ExpressionTree implementationType) {
         String initializer = config.getInitializer();
         NewClassTree newClass = make.NewClass(null,
-                Collections.EMPTY_LIST,
+                Collections.emptyList(),
                 implementationType,
                 Collections.singletonList(make.Identifier(initializer)), null);
         VariableTree property = make.Variable(

--- a/platform/openide.windows/src/org/openide/windows/DelegateActionMap.java
+++ b/platform/openide.windows/src/org/openide/windows/DelegateActionMap.java
@@ -134,7 +134,7 @@ final class DelegateActionMap extends ActionMap {
             if (all) {
                 Object[] allKeys = m.allKeys();
                 if( null == allKeys ) {
-                    l = Collections.EMPTY_LIST;
+                    l = Collections.emptyList();
                 } else {
                     l = Arrays.asList(m.allKeys());
                 }

--- a/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
+++ b/webcommon/javascript2.model/src/org/netbeans/modules/javascript2/model/ModelVisitor.java
@@ -1400,7 +1400,7 @@ public class ModelVisitor extends PathNodeVisitor implements ModelResolver {
                 JsObject parentObject = parentFqn.isEmpty() ? getGlobalObject() : ModelUtils.getJsObject(modelBuilder, parentFqn, true);
                 JsFunctionImpl callBackFunction = new JsFunctionImpl(
                         parentObject instanceof DeclarationScope ? (DeclarationScope) parentObject : ModelUtils.getDeclarationScope(parentObject),
-                        parentObject, fqn.get(fqn.size() - 1), Collections.EMPTY_LIST,
+                        parentObject, fqn.get(fqn.size() - 1), Collections.emptyList(),
                         callBack.getOffset() > -1 ? new OffsetRange(callBack.getOffset(), callBack.getOffset() + callBack.getType().length()) : OffsetRange.NONE,
                         JsTokenId.JAVASCRIPT_MIME_TYPE, null);
                 parentObject.addProperty(callBackFunction.getName(), callBackFunction);

--- a/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/model/NodeJsObjectInterceptor.java
+++ b/webcommon/javascript2.nodejs/src/org/netbeans/modules/javascript2/nodejs/editor/model/NodeJsObjectInterceptor.java
@@ -80,7 +80,7 @@ public class NodeJsObjectInterceptor implements ObjectInterceptor {
             }
         }
         if (exports != null) {
-            JsFunction module = factory.newFunction((DeclarationScope) global, global, NodeJsUtils.FAKE_OBJECT_NAME_PREFIX + global.getName(), Collections.EMPTY_LIST, global.getOffsetRange(), null);
+            JsFunction module = factory.newFunction((DeclarationScope) global, global, NodeJsUtils.FAKE_OBJECT_NAME_PREFIX + global.getName(), Collections.<String>emptyList(), global.getOffsetRange(), null);
             module.setAnonymous(true);
             global.addProperty(module.getName(), module);
             ((DeclarationScope)global).addDeclaredScope(module);

--- a/webcommon/javascript2.source.query/src/org/netbeans/modules/javascript2/source/query/SourceElementsQueryImpl.java
+++ b/webcommon/javascript2.source.query/src/org/netbeans/modules/javascript2/source/query/SourceElementsQueryImpl.java
@@ -44,7 +44,7 @@ public class SourceElementsQueryImpl implements SourceElementsQuery {
 
     @Override
     public Collection<Var> getVarsAt(Source source, int offset) {
-        final Collection[] vars = new Collection[] { Collections.EMPTY_LIST };
+        final Collection[] vars = new Collection[] { Collections.emptyList()};
         try {
             ParserManager.parse(Collections.singleton(source), new UserTask() {
                 public @Override

--- a/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/JSONReader.java
+++ b/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/JSONReader.java
@@ -845,7 +845,7 @@ public class JSONReader {
             return null;
         }
         if (array.isEmpty()) {
-            return Collections.EMPTY_MAP;
+            return Collections.<String, V8Object.Property>emptyMap();
         }
         Map<String, V8Object.Property> properties = new LinkedHashMap<>();
         V8Object.Property.Type[] types = V8Object.Property.Type.values();

--- a/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/commands/Flags.java
+++ b/webcommon/lib.v8debug/src/org/netbeans/lib/v8debug/commands/Flags.java
@@ -75,7 +75,7 @@ public final class Flags {
         private final Map<String, Boolean> flags;
         
         public ResponseBody() {
-            this(Collections.EMPTY_MAP);
+            this(Collections.<String, Boolean>emptyMap());
         }
         
         public ResponseBody(Map<String, Boolean> flags) {

--- a/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WadlSaasNodeChildren.java
+++ b/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WadlSaasNodeChildren.java
@@ -63,7 +63,7 @@ public class WadlSaasNodeChildren extends SaasNodeChildren<Object> {
         } else if (state == Saas.State.INITIALIZING) {
             setKeys(WAIT_HOLDER);
         } else {
-            setKeys(Collections.EMPTY_LIST);
+            setKeys(Collections.emptyList());
         }
     }
     

--- a/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlSaasNodeChildren.java
+++ b/websvccommon/websvc.saas.ui/src/org/netbeans/modules/websvc/saas/ui/nodes/WsdlSaasNodeChildren.java
@@ -62,7 +62,7 @@ public class WsdlSaasNodeChildren extends SaasNodeChildren<Object> {
         } else if (state == Saas.State.INITIALIZING) {
             setKeys(WAIT_HOLDER);
         } else {
-            setKeys(Collections.EMPTY_LIST);
+            setKeys(Collections.emptyList());
         }
     }
 


### PR DESCRIPTION
    [NETBEANS-4050] - cleanup uses of EMPTY_LIST, EMPTY_SET, EMPTY_MAP
    
         Clean up a bunch of compiler warning messages related to the use of Collections.[EMPTY_LIST, EMPTY_SET, EMPTY_MAP]..
    
         [repeat] /home/bwalker/src/netbeans/java/ant.debugger/src/org/netbeans/modules/ant/debugger/RunTargetsAction.java:145: warning: [unchecked] unchecked conversion
         [repeat] allTargets = Collections.EMPTY_SET;
         [repeat] ^
         [repeat] required: Set<Target>
         [repeat] found: Set