### PR TITLE
[NETBEANS-346] Tabs, characters, and the right Margin don't line up

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/FontInfo.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/FontInfo.java
@@ -91,8 +91,18 @@ final class FontInfo {
         TextLayout rowHeightTextLayout = new TextLayout("A_|B", renderFont, frc);
         // Round the ascent to eliminate long mantissa without any visible effect on rendering.
         updateRowHeight(rowHeightTextLayout, rowHeightCorrection);
-        // Ceil fractions to whole numbers since this measure may be used for background rendering
-        charWidth = (float) Math.ceil(defaultCharTextLayout.getAdvance());
+        /* We originally did Math.ceil() when setting charWidth, but this was the cause of NETBEANS-346,
+        where the end-of-line marker (SimpleValueNames.TEXT_LIMIT_WIDTH) would appear in the wrong
+        position due to rounding errors, and similar misalignments in tabs vs. spaces, on certain editor
+        zoom levels. This was observed on Java 9 or above on both Windows and MacOS. Java 9 saw many
+        changes in font metrics implementations, including a new font shaping engine (HarfBuzz) and
+        fractional HiDPI support. Avoiding Math.ceil fixes the problem. The original Math.ceil was
+        introduced by Miloslav Metelka on 2011-08-18, with a comment "Ceil fractions to whole numbers
+        since this measure may be used for background rendering" in the commit titled "Improve
+        AnnotationView performance" for the similarly titled BugZilla bug #201102. So the Math.ceil was
+        intended to be an optimization rather than fixing a correctness bug, and it seems safe to remove
+        it. */
+        charWidth = defaultCharTextLayout.getAdvance();
         LineMetrics lineMetrics = renderFont.getLineMetrics(defaultCharText, frc);
         underlineAndStrike[0] = lineMetrics.getUnderlineOffset() * rowHeightCorrection;
         underlineAndStrike[1] = lineMetrics.getUnderlineThickness();


### PR DESCRIPTION
Fix a problem that caused the end-of-line marker (e.g. at 80 chars) to be displayed at an incorrect position (e.g. at 82 chars) on certain zoom levels, on Java 9 or above. This problem stems from rounding error caused by assuming that the width of each (monotype font) character is an integral number of logical pixels wide. The latter is not the case on HiDPI screens (e.g. where 10 device pixels may map to 6.67 logical pixels at 150% scaling), nor on Windows with subpixel antialiasing, and probably some other situations as well.

This also fixes less prominent problems with visual alignment of tabs vs. spaces (e.g. 8-space tabs will get the wrong width due to the same rounding error).

While looking at the related code, I discovered various other places where the same kind of rounding error is likely to cause problem; I created NETBEANS-4166 for these.