### PR TITLE
[NETBEANS-4173] FlatLaf: Partial render selected BeanTreeView element

### DIFF
--- a/platform/openide.awt/src/org/openide/awt/HtmlRendererImpl.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlRendererImpl.java
@@ -182,7 +182,7 @@ class HtmlRendererImpl extends JLabel implements HtmlRenderer.Renderer {
 
         setSelected(selected);
 
-        if (selected) {
+        if (selected && leadSelection) {
             setParentFocused(checkFocused(target));
         } else {
             setParentFocused(false);


### PR DESCRIPTION
When using FlatLaf Look and Feel, incorrect rendering of tree item under the context menu in the BeanTreeView component occurs. This problem can be easily reproduced by the following simple example.

```
import com.formdev.flatlaf.FlatLightLaf;
import org.openide.explorer.ExplorerManager;
import org.openide.explorer.view.BeanTreeView;
import org.openide.nodes.AbstractNode;
import org.openide.nodes.Children;

import javax.swing.*;
import java.awt.*;
import java.awt.event.ActionEvent;

public class SampleFrame extends JFrame implements ExplorerManager.Provider {
    private final ExplorerManager explorerManager = new ExplorerManager();

    public SampleFrame() throws HeadlessException {
        setSize(300, 400);
        explorerManager.setRootContext(new SampleNode());
        BeanTreeView beanTreeView = new BeanTreeView();
        getContentPane().add(beanTreeView, BorderLayout.CENTER);
    }

    @Override
    public ExplorerManager getExplorerManager() {
        return explorerManager;
    }


    private static class SampleNode extends AbstractNode {
        public SampleNode() {
            super(Children.LEAF);
            setName("SampleNode");
        }

        @Override
        public Action[] getActions(boolean context) {
            AbstractAction action = new AbstractAction() {
                @Override
                public void actionPerformed(ActionEvent e) {

                }
            };
            action.putValue(Action.NAME, "Sample");
            return new Action[]{action};
        }
    }

    public static void main(String[] args) {
        SwingUtilities.invokeLater(() -> {
            FlatLightLaf.install();

            SampleFrame frame = new SampleFrame();
            frame.setDefaultCloseOperation(EXIT_ON_CLOSE);
            frame.setVisible(true);
        });
    }
}
```


The result will be the following
<img width="304" alt="FlatLaf_before_fix" src="https://user-images.githubusercontent.com/1597289/79316587-2fb64c00-7f0d-11ea-852b-7e55a6cfa61b.png">

and in Netbeans Services Window

<img width="359" alt="Netbeans Services Windows before fix_FlatLaf" src="https://user-images.githubusercontent.com/1597289/79427493-72d7f400-7fcd-11ea-9f0a-277a8c3d3a22.png">

After my fix, the render of the tree item becomes correct

<img width="304" alt="FlatLaf" src="https://user-images.githubusercontent.com/1597289/79316682-54122880-7f0d-11ea-9dd0-565c4a616c51.png">

and in Netbeans Services Window

<img width="346" alt="Netbeans Services Windows after fix_FlatLaf" src="https://user-images.githubusercontent.com/1597289/79427516-7ec3b600-7fcd-11ea-875f-47970f9e3166.png">

Additionally, I checked the fix in Metal and Aqua LAF

Metal:
<img width="354" alt="Netbeans Services Windows after fix_Metal" src="https://user-images.githubusercontent.com/1597289/79427536-871bf100-7fcd-11ea-9ddb-19a10a5d255a.png">

Aqua:
<img width="346" alt="Netbeans Services Windows after fix_Aqua" src="https://user-images.githubusercontent.com/1597289/79427547-8aaf7800-7fcd-11ea-969b-0df3b8b12dab.png">



