### PR TITLE
NETBEANS-4176-Unescape javadoc title after parsing

### DIFF
--- a/java/javadoc/nbproject/project.xml
+++ b/java/javadoc/nbproject/project.xml
@@ -246,6 +246,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.editor.util</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.73</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/javadoc/src/org/netbeans/modules/javadoc/search/IndexBuilder.java
+++ b/java/javadoc/src/org/netbeans/modules/javadoc/search/IndexBuilder.java
@@ -34,6 +34,7 @@ import java.util.StringTokenizer;
 import java.util.WeakHashMap;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import org.netbeans.lib.editor.util.StringEscapeUtils;
 import org.openide.ErrorManager;
 import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
@@ -70,12 +71,12 @@ public class IndexBuilder implements Runnable, ChangeListener {
         /**
          * Display name / title of the helpset
          */
-        String      title;
+        String title;
 
         /**
          * Name of the index/overview file
          */
-        String      indexFileName;
+        String indexFileName;
     }
 
     @SuppressWarnings("LeakingThisInConstructor")
@@ -157,8 +158,8 @@ public class IndexBuilder implements Runnable, ChangeListener {
         }
         URL[] docRoots = jdocRegs.getDocRoots();
         // XXX needs to be able to listen to result; when it changes, call scheduleTask()
-        Map<URL,Info> m = new WeakHashMap<URL,Info>();
-//        long startTime = System.nanoTime();
+        Map<URL,Info> m = new WeakHashMap<>();
+        // long startTime = System.nanoTime();
 
         for ( int ifCount = 0; ifCount < docRoots.length; ifCount++ ) {
             URL fo = docRoots[ifCount];
@@ -230,7 +231,7 @@ public class IndexBuilder implements Runnable, ChangeListener {
                 this.filesystemInfo = m;
             }
         }
-        List<Index> data = new ArrayList<Index>();
+        List<Index> data = new ArrayList<>();
         for (Map.Entry<URL,Info> entry : filesystemInfo.entrySet()) {
             Info info = entry.getValue();
             URL fo = URLUtils.findOpenable(entry.getKey(), info.indexFileName);
@@ -242,8 +243,8 @@ public class IndexBuilder implements Runnable, ChangeListener {
         Collections.sort(data);
         cachedData = data;
 
-//        long elapsedTime = System.nanoTime() - startTime;
-//        System.out.println("\nElapsed time[nano]: " + elapsedTime);
+        // long elapsedTime = System.nanoTime() - startTime;
+        // System.out.println("\nElapsed time[nano]: " + elapsedTime);
     }
     
     /**
@@ -252,20 +253,15 @@ public class IndexBuilder implements Runnable, ChangeListener {
      */
     private String parseTitle(URL html) {
         String title = null;
-        try {
+        try (InputStream is = new BufferedInputStream(URLUtils.openStream(html), 1024)) {
             // #71979: html parser used again to fix encoding issues.
             // I have measured no difference if the parser or plain file reading
             // is used (#32551).
             // In case the parser is stopped as soon as it finds the title it is
             // even faster than the previous fix.
-            InputStream is = new BufferedInputStream(URLUtils.openStream(html), 1024);
             SimpleTitleParser tp = new SimpleTitleParser(is);
-            try {
-                tp.parse();
-                title = tp.getTitle();
-            } finally {
-                is.close();
-            }
+            tp.parse();
+            title = tp.getTitle();
         } catch (IOException ioe) {
             ErrorManager.getDefault().notify(ErrorManager.INFORMATIONAL, ioe);
         }
@@ -417,6 +413,11 @@ public class IndexBuilder implements Runnable, ChangeListener {
                             } else {
                                 title = new String(buf, 0, offset - 7, charset).trim();
                             }
+                            
+                            // Unescape the title, done for JDK 11.
+                            // JDK 11 title contains &amp; (NETBEANS-4176)
+                            title = StringEscapeUtils.unescapeHtml(title);
+                            
                             return;
                         }
                     default:

--- a/java/javadoc/test/unit/src/org/netbeans/modules/javadoc/search/IndexBuilderTest.java
+++ b/java/javadoc/test/unit/src/org/netbeans/modules/javadoc/search/IndexBuilderTest.java
@@ -59,82 +59,77 @@ public class IndexBuilderTest extends NbTestCase {
     public void testTitleInJDK14() throws Exception {
         FileObject html = fs.findResource(JDK14_INDEX_PATH + "/index-4.html");
 
-        InputStream is = new BufferedInputStream(html.getInputStream(), 1024);
-        SimpleTitleParser tp = new SimpleTitleParser(is);
-        try {
+        try (InputStream is = new BufferedInputStream(html.getInputStream(), 1024)) {
+            SimpleTitleParser tp = new SimpleTitleParser(is);
             tp.parse();
             String titlestr = tp.getTitle();
             assertEquals("wrong title", "D-Index (Java 2 Platform SE v1.4.2)", titlestr);
-        } finally {
-            is.close();
         }
     }
 
     public void testTitleInJDK15() throws Exception {
         FileObject html = fs.findResource(JDK15_INDEX_PATH + "/index-4.html");
 
-        InputStream is = new BufferedInputStream(html.getInputStream(), 1024);
-        SimpleTitleParser tp = new SimpleTitleParser(is);
-        try {
+        try (InputStream is = new BufferedInputStream(html.getInputStream(), 1024)) {
+            SimpleTitleParser tp = new SimpleTitleParser(is);
             tp.parse();
             String titlestr = tp.getTitle();
             assertEquals("wrong title", "D-Index (Java 2 Platform SE 5.0)", titlestr);
-        } finally {
-            is.close();
         }
     }
     
     public void testTitleInJDK7() throws Exception {
         FileObject html = fs.findResource(JDK7_INDEX_PATH + "/index-4.html");
 
-        InputStream is = new BufferedInputStream(html.getInputStream(), 1024);
-        SimpleTitleParser tp = new SimpleTitleParser(is);
-        try {
+        try (InputStream is = new BufferedInputStream(html.getInputStream(), 1024)) {
+            SimpleTitleParser tp = new SimpleTitleParser(is);
             tp.parse();
             String titlestr = tp.getTitle();
             assertEquals("wrong title", "D-Index (Java Platform SE 7 )", titlestr);
-        } finally {
-            is.close();
         }
     }
     
     public void testTitleInJDK8() throws Exception {
         FileObject html = fs.findResource(JDK8_INDEX_PATH + "/index-4.html");
 
-        InputStream is = new BufferedInputStream(html.getInputStream(), 1024);
-        SimpleTitleParser tp = new SimpleTitleParser(is);
-        try {
+        try (InputStream is = new BufferedInputStream(html.getInputStream(), 1024)) {
+            SimpleTitleParser tp = new SimpleTitleParser(is);
             tp.parse();
             String titlestr = tp.getTitle();
             assertEquals("wrong title", "D-Index (Java Platform SE 8 )", titlestr);
-        } finally {
-            is.close();
         }
     }
 
     public void testEmptyTitle() throws Exception {
         String content = "<HTML><HEAD><TITLE></TITLE></HEAD></HTML>";
-        InputStream is = new ByteArrayInputStream(content.getBytes());
-        SimpleTitleParser tp = new SimpleTitleParser(is);
-        try {
+        
+        try (InputStream is = new ByteArrayInputStream(content.getBytes())) {
+            SimpleTitleParser tp = new SimpleTitleParser(is);
             tp.parse();
             String titlestr = tp.getTitle();
             assertEquals("wrong title", "", titlestr);
-        } finally {
-            is.close();
         }
     }
 
     public void testMissingTitle() throws Exception {
         String content = "<HTML><HEAD></HEAD></HTML>";
-        InputStream is = new ByteArrayInputStream(content.getBytes());
-        SimpleTitleParser tp = new SimpleTitleParser(is);
-        try {
+        
+        try (InputStream is = new ByteArrayInputStream(content.getBytes())) {
+            SimpleTitleParser tp = new SimpleTitleParser(is);
             tp.parse();
             String titlestr = tp.getTitle();
             assertNull("wrong title", titlestr);
-        } finally {
-            is.close();
+        }
+    }
+    
+    public void testEscapedHtmlTitle() throws Exception {
+        String content = "<HTML><HEAD><TITLE>Overview (Java SE 11 &amp; JDK 11 )</TITLE></HEAD></HTML>";
+        
+        try (InputStream is = new ByteArrayInputStream(content.getBytes())) {
+            SimpleTitleParser tp = new SimpleTitleParser(is);
+            tp.parse();
+            String titlestr = tp.getTitle();
+            assertEquals("wrong title", "Java SE 11 & JDK 11", titlestr);
         }
     }
 
@@ -166,14 +161,11 @@ public class IndexBuilderTest extends NbTestCase {
             r.close();
         }
 
-        InputStream is = new BufferedInputStream(html.getInputStream(), 1024);
-        SimpleTitleParser tp = new SimpleTitleParser(is);
-        try {
+        try (InputStream is = new BufferedInputStream(html.getInputStream(), 1024)) {
+            SimpleTitleParser tp = new SimpleTitleParser(is);
             tp.parse();
             String titlestr = tp.getTitle();
             assertEquals("wrong title", sb.toString(), titlestr);
-        } finally {
-            is.close();
         }
     }
 }


### PR DESCRIPTION
This is my first contribution and is trivial.
Javadoc title is being unescaped after parsing.

Before fix - 
![BeforeFix](https://user-images.githubusercontent.com/22575469/79359036-b0059d00-7f5f-11ea-89cf-6886e978ab47.png)

After fix -
![AfterFix](https://user-images.githubusercontent.com/22575469/79359109-c7448a80-7f5f-11ea-9cbc-cb200f3f3959.png)

