### PR TITLE
[NETBEANS-4037] Don't invalidate global classpath on JAR content change.

### DIFF
--- a/ide/api.java.classpath/src/org/netbeans/api/java/classpath/ClassPath.java
+++ b/ide/api.java.classpath/src/org/netbeans/api/java/classpath/ClassPath.java
@@ -1415,7 +1415,9 @@ public final class ClassPath {
 
         @Override
         public void fileChanged(FileEvent fe) {
-            processEvent(fe);
+            if (!fe.getFile().isValid()) {
+                processEvent(fe);
+            }
         }
 
         @Override

--- a/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/ClassPathTest.java
+++ b/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/classpath/ClassPathTest.java
@@ -238,7 +238,7 @@ public class ClassPathTest extends NbTestCase {
             out.close ();
         }
         archiveFile.refresh();
-        impl.assertEvents(ClassPath.PROP_ROOTS);
+        impl.assertEvents();
         root_1.delete();
         root_2.delete();
         root_3.delete();

--- a/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/queries/BinaryForSourceQuery2Test.java
+++ b/ide/api.java.classpath/test/unit/src/org/netbeans/api/java/queries/BinaryForSourceQuery2Test.java
@@ -30,13 +30,22 @@ import org.netbeans.spi.java.queries.BinaryForSourceQueryImplementation2;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileSystem;
 import org.openide.filesystems.FileUtil;
-import org.openide.filesystems.URLMapper;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.ServiceProvider;
 
 public class BinaryForSourceQuery2Test extends NbTestCase {
     public BinaryForSourceQuery2Test (String n) {
         super(n);
+    }
+
+    @Override
+    public void setUp() {
+        URLMapper = org.openide.filesystems.URLMapper::findFileObject;
+    }
+
+    @Override
+    public void tearDown() {
+        URLMapper = (__) -> null;
     }
 
     public void testQuery2() throws Exception {
@@ -71,6 +80,12 @@ public class BinaryForSourceQuery2Test extends NbTestCase {
         assertSame("The result should be cached", result, result2);
     }
 
+    private static interface Find {
+        FileObject findFileObject(URL u);
+    }
+
+    private static Find URLMapper = (__) -> null;
+
     @SuppressWarnings("PackageVisibleField")
     // BEGIN: org.netbeans.api.java.queries.BinaryForSourceQuery2Test.SampleQuery
     @ServiceProvider(service = BinaryForSourceQueryImplementation.class)
@@ -82,8 +97,7 @@ public class BinaryForSourceQuery2Test extends NbTestCase {
         @Override
         public PrivateData findBinaryRoots2(URL sourceRoot) {
             final FileObject fo = URLMapper.findFileObject(sourceRoot);
-            assertNotNull("FileObject found", fo);
-            return new PrivateData(sourceRoot, fo);
+            return fo != null ? new PrivateData(sourceRoot, fo) : null;
         }
 
         @Override


### PR DESCRIPTION
One of the identified reasons for [debugger slowness](https://issues.apache.org/jira/browse/NETBEANS-4037) was the fact that GlobalClassPath registry is invalidated everytime a JAR file is changed. Hence, when you make a change and want to debug, you compile, change the JAR and then the debugger has to wait. Needlessly. I'd like to fix that by not invalidating the global classpath on JAR content change, when the JAR file still exists.