### PR TITLE
[NETBEANS-4173] Update FlatLaf from 0.30 to 0.31

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-1EBD625C1844170CEBC7BCF02856E5E2DD396070 com.formdev:flatlaf:0.30
+AFD85ED83238E56BD032FB05471781C6E54AD6F2 com.formdev:flatlaf:0.31

--- a/platform/libs.flatlaf/external/flatlaf-0.31-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-0.31-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 0.30
-Files: flatlaf-0.30.jar
+Version: 0.31
+Files: flatlaf-0.31.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-0.30.jar=modules/ext/flatlaf-0.30.jar
+release.external/flatlaf-0.31.jar=modules/ext/flatlaf-0.31.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-0.30.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-0.30.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-0.31.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-0.31.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
There is only one change in FlatLaf 0.31 (compared to 0.30), which makes updating uncomplicated.
It changes "has focus" checking in FlatLaf and fixes https://issues.apache.org/jira/browse/NETBEANS-4173

In FlatLaf 0.30 the "current focus owner" was used to paint focused borders and blue list/table/tree selection. But "current focus owner" temporary changes when opening a popup menu or main menu.

Since FlatLaf 0.31 the "permanent focus owner" is used and the focused border stays where it is.

Now FlatLaf focus indication behaves the same as in Windows, macOS, GNOME and KDE.

This PR supersedes PR #2079.

FlatLaf 0.31 change log:
https://github.com/JFormDesigner/FlatLaf/releases/tag/0.31