### PR TITLE
If cancel happens while Analyzer is running, AssertionError is thrown…

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -709,9 +709,14 @@ public class JavacParser extends Parser {
         } catch (Abort abort) {
             parserError = currentPhase;
         } catch (RuntimeException | Error ex) {
-            parserError = currentPhase;
-            dumpSource(currentInfo, ex);
-            throw ex;
+            if (cancellable && parserCanceled.get()) {
+                currentPhase = Phase.MODIFIED;
+                invalidate(false);
+            } else {
+                parserError = currentPhase;
+                dumpSource(currentInfo, ex);
+                throw ex;
+            }
         } finally {
             currentInfo.setPhase(currentPhase);
             currentInfo.parserCrashed = parserError;


### PR DESCRIPTION
…. Rather ignore all exception happening while the parser is cancelled.

While running without nb-javac, the AssertionErrors from Analyzer due to cancellation are about 1/2 of javac-related exceptions I see. So feels like something worthy to solve. Theoretically, this can lead to ignored exceptions - but I don't think we really care about anything if the parser is cancelled.
