### PR TITLE
NETBEANS-4209: Update Truffle debugging for GraalVM 20.1.0

### DIFF
--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/LanguageName.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/LanguageName.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.debugger.jpda.truffle;
+
+import java.util.Objects;
+
+/**
+ *
+ * @author Martin
+ */
+public final class LanguageName {
+
+    public static final LanguageName NONE = new LanguageName("", "");
+
+    private final String id;
+    private final String name;
+
+    private LanguageName(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public static LanguageName parse(String string) {
+        string = string.trim();
+        if (string.isEmpty()) {
+            return NONE;
+        }
+        int i = string.indexOf(" ");
+        assert i > 0 : string;
+        return new LanguageName(string.substring(0, i), string.substring(i + 1));
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(this.id);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final LanguageName other = (LanguageName) obj;
+        return this.id.equals(other.id);
+    }
+
+}

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleStrataProvider.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleStrataProvider.java
@@ -60,10 +60,10 @@ public class TruffleStrataProvider implements StrataProvider {
 
     @Override
     public int getStrataLineNumber(CallStackFrameImpl csf, String stratum) {
-        if (TRUFFLE_STRATUM.equals(stratum)) {
+        if (TRUFFLE_STRATUM.equals(stratum) && isInTruffleAccessPoint(csf)) {
             CurrentPCInfo currentPCInfo = TruffleAccess.getCurrentPCInfo(csf.getThread());
             if (currentPCInfo != null) {
-                return currentPCInfo.getSourcePosition().getLine();
+                return currentPCInfo.getSourcePosition().getStartLine();
             }
         }
         return csf.getLineNumber(stratum);

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/ast/model/ASTNodeModel.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/ast/model/ASTNodeModel.java
@@ -46,19 +46,17 @@ public class ASTNodeModel implements NodeModel {
             String label = ast.getClassSimpleName();
             String tags = ast.getTags();
             if (!tags.isEmpty()) {
-                label = '[' + tags + "] " + label;
+                label = '(' + tags + ") " + label;
             }
             int l1 = ast.getStartLine();
             if (l1 >= 0) {
                 int c1 = ast.getStartColumn();
                 int l2 = ast.getEndLine();
                 int c2 = ast.getEndColumn();
-                label += " <"+l1+":"+c1+"-"+l2+":"+c2+">";
+                label += " ["+l1+":"+c1+"-"+l2+":"+c2+"]";
             }
-            if (ast.getChildren().length == 0) {
-                if (ast.isCurrent()) {
-                    label = "<html><b>" + label + "</b></html>";
-                }
+            if (ast.isCurrent()) {
+                label = "<html><b>" + label + "</b></html>";
             }
             return label;
         } else {

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/ast/model/ASTTreeExpansionModel.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/ast/model/ASTTreeExpansionModel.java
@@ -42,7 +42,7 @@ public class ASTTreeExpansionModel implements TreeExpansionModel {
     public boolean isExpanded(Object node) throws UnknownTypeException {
         if (node instanceof TruffleNode) {
             TruffleNode ast = (TruffleNode) node;
-            return ast.isCurrent();
+            return ast.isCurrentEncapsulating() || ast.isCurrent();
         } else {
             return false;
         }

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/breakpoints/TruffleBreakpointsHandler.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/breakpoints/TruffleBreakpointsHandler.java
@@ -245,11 +245,14 @@ public class TruffleBreakpointsHandler {
             }
         }
         bp.addPropertyChangeListener(breakpointsChangeListener);
-        List<Value> values = bpRef[0].getValues();
         Set<ObjectReference> breakpoints = new HashSet<>();
-        for (Value v : values) {
-            if (v instanceof ObjectReference) {
-                breakpoints.add((ObjectReference) v);
+        ArrayReference bpArray = bpRef[0];
+        if (bpArray != null) {
+            List<Value> values = bpArray.getValues();
+            for (Value v : values) {
+                if (v instanceof ObjectReference) {
+                    breakpoints.add((ObjectReference) v);
+                }
             }
         }
         if (!breakpoints.isEmpty()) {

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/TruffleStackFrame.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/TruffleStackFrame.java
@@ -30,9 +30,9 @@ import org.netbeans.api.debugger.jpda.InvalidExpressionException;
 import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.debugger.jpda.JPDAThread;
 import org.netbeans.api.debugger.jpda.ObjectVariable;
+import org.netbeans.modules.debugger.jpda.truffle.LanguageName;
 import org.netbeans.modules.debugger.jpda.truffle.access.CurrentPCInfo;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleAccess;
-import org.netbeans.modules.debugger.jpda.truffle.actions.StepActionProvider;
 import org.netbeans.modules.debugger.jpda.truffle.source.Source;
 import org.netbeans.modules.debugger.jpda.truffle.source.SourcePosition;
 import org.netbeans.modules.debugger.jpda.truffle.vars.TruffleScope;
@@ -51,13 +51,14 @@ public final class TruffleStackFrame {
     private final int depth;
     private final ObjectVariable frameInstance;
     private final String methodName;
+    private final LanguageName language;
     private final String sourceLocation;
     
     private final int    sourceId;
     private final String sourceName;
     private final String sourcePath;
     private final URI    sourceURI;
-    private final int    sourceLine;
+    private final String sourceSection;
     private final StringReference codeRef;
     private TruffleScope[] scopes;
     private final ObjectVariable thisObject;
@@ -89,6 +90,9 @@ public final class TruffleStackFrame {
             methodName = frameDefinition.substring(i1, i2);
             i1 = i2 + 1;
             i2 = frameDefinition.indexOf('\n', i1);
+            language = LanguageName.parse(frameDefinition.substring(i1, i2));
+            i1 = i2 + 1;
+            i2 = frameDefinition.indexOf('\n', i1);
             sourceLocation = frameDefinition.substring(i1, i2);
             i1 = i2 + 1;
             i2 = frameDefinition.indexOf('\n', i1);
@@ -109,11 +113,11 @@ public final class TruffleStackFrame {
             i1 = i2 + 1;
             if (includeInternal) {
                 i2 = frameDefinition.indexOf('\n', i1);
-                sourceLine = Integer.parseInt(frameDefinition.substring(i1, i2));
+                sourceSection = frameDefinition.substring(i1, i2);
                 i1 = i2 + 1;
                 internalFrame = Boolean.valueOf(frameDefinition.substring(i1));
             } else {
-                sourceLine = Integer.parseInt(frameDefinition.substring(i1));
+                sourceSection = frameDefinition.substring(i1);
             }
         } catch (IndexOutOfBoundsException ioob) {
             throw new IllegalStateException("frameDefinition='"+frameDefinition+"'", ioob);
@@ -140,6 +144,10 @@ public final class TruffleStackFrame {
         return methodName;
     }
 
+    public LanguageName getLanguage() {
+        return language;
+    }
+
     public String getSourceLocation() {
         return sourceLocation;
     }
@@ -157,7 +165,7 @@ public final class TruffleStackFrame {
         if (src == null) {
             src = Source.getSource(debugger, sourceId, sourceName, sourcePath, sourceURI, codeRef);
         }
-        SourcePosition sp = new SourcePosition(debugger, sourceId, src, sourceLine);
+        SourcePosition sp = new SourcePosition(debugger, sourceId, src, sourceSection);
         return sp;
     }
     

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleActionsProvider.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleActionsProvider.java
@@ -107,7 +107,7 @@ public class DebuggingTruffleActionsProvider implements NodeActionsProviderFilte
             public void run () {
                 EditorContextBridge.getContext().showSource (
                     sourcePosition.getSource().getUrl().toExternalForm(),
-                    sourcePosition.getLine(),
+                    sourcePosition.getStartLine(),
                     f.getDebugger()
                 );
             }

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleTreeModel.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleTreeModel.java
@@ -47,7 +47,7 @@ import org.netbeans.spi.viewmodel.UnknownTypeException;
                              types={ TreeModelFilter.class })
 public class DebuggingTruffleTreeModel implements TreeModelFilter {
     
-    private static final Predicate<String> PREDICATE1 = Pattern.compile("^((com|org)\\.\\p{Alpha}*\\.truffle|(com|org)\\.graalvm)\\..*$").asPredicate();
+    private static final Predicate<String> PREDICATE1 = Pattern.compile("^((com|org)\\.\\p{Alpha}*\\.truffle|(com|org)(\\.graalvm|\\.truffleruby))\\..*$").asPredicate();
     private static final String FILTER1 = "com.[A-z]*.truffle.";                     // NOI18N
     private static final String FILTER2 = "com.oracle.graal.";                  // NOI18N
     private static final String FILTER3 = "org.netbeans.modules.debugger.jpda.backend.";    // NOI18N

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/SourcePosition.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/SourcePosition.java
@@ -28,20 +28,44 @@ public class SourcePosition {
 
     private final long id;
     private final Source src;
-    private final int line;
+    private final int startLine;
+    private final int startColumn;
+    private final int endLine;
+    private final int endColumn;
     
-    public SourcePosition(JPDADebugger debugger, long id, Source src, int line) {
+    public SourcePosition(JPDADebugger debugger, long id, Source src, String sourceSection) {
         this.id = id;
         this.src = src;
-        this.line = line;
+        int i1 = 0, i2 = sourceSection.indexOf(',');
+        this.startLine = Integer.parseInt(sourceSection.substring(i1, i2));
+        i1 = i2 + 1;
+        i2 = sourceSection.indexOf(',', i1);
+        this.startColumn = Integer.parseInt(sourceSection.substring(i1, i2));
+        i1 = i2 + 1;
+        i2 = sourceSection.indexOf(',', i1);
+        this.endLine = Integer.parseInt(sourceSection.substring(i1, i2));
+        i1 = i2 + 1;
+        this.endColumn = Integer.parseInt(sourceSection.substring(i1));
     }
 
     public Source getSource() {
         return src;
     }
-    
-    public int getLine() {
-        return line;
+
+    public int getStartLine() {
+        return startLine;
     }
 
+    public int getStartColumn() {
+        return startColumn;
+    }
+
+    public int getEndLine() {
+        return endLine;
+    }
+
+    public int getEndColumn() {
+        return endColumn;
+    }
+    
 }

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/vars/TruffleVariable.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/vars/TruffleVariable.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.debugger.jpda.truffle.vars;
 
 import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.debugger.jpda.ObjectVariable;
+import org.netbeans.modules.debugger.jpda.truffle.LanguageName;
 import org.netbeans.modules.debugger.jpda.truffle.source.SourcePosition;
 
 /**
@@ -29,7 +30,9 @@ import org.netbeans.modules.debugger.jpda.truffle.source.SourcePosition;
 public interface TruffleVariable {
     
     String getName();
-    
+
+    LanguageName getLanguage();
+
     String getType();
 
     boolean isReadable();
@@ -40,7 +43,11 @@ public interface TruffleVariable {
     
     Object getValue();
     
+    boolean hasValueSource();
+    
     SourcePosition getValueSource();
+    
+    boolean hasTypeSource();
     
     SourcePosition getTypeSource();
     

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/vars/models/TruffleVariablesActionsProviderFilter.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/vars/models/TruffleVariablesActionsProviderFilter.java
@@ -23,7 +23,9 @@ import java.net.URL;
 import javax.swing.Action;
 import javax.swing.SwingUtilities;
 
+import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.modules.debugger.jpda.EditorContextBridge;
+import org.netbeans.modules.debugger.jpda.JPDADebuggerImpl;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleStrataProvider;
 import org.netbeans.modules.debugger.jpda.truffle.source.SourcePosition;
 import org.netbeans.modules.debugger.jpda.truffle.vars.TruffleVariable;
@@ -37,6 +39,7 @@ import org.netbeans.spi.viewmodel.UnknownTypeException;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.util.NbBundle;
+import org.openide.util.RequestProcessor;
 
 @DebuggerServiceRegistrations({
     @DebuggerServiceRegistration(path="netbeans-JPDASession/"+TruffleStrataProvider.TRUFFLE_STRATUM+"/LocalsView",  types=NodeActionsProviderFilter.class),
@@ -45,9 +48,11 @@ import org.openide.util.NbBundle;
     @DebuggerServiceRegistration(path="netbeans-JPDASession/"+TruffleStrataProvider.TRUFFLE_STRATUM+"/WatchesView", types=NodeActionsProviderFilter.class),
 })
 public class TruffleVariablesActionsProviderFilter implements NodeActionsProviderFilter {
-    
+
+    private final RequestProcessor rp;
+
     public TruffleVariablesActionsProviderFilter(ContextProvider contextProvider) {
-        System.err.println("new TruffleVariablesActionsProviderFilter()");
+        this.rp = ((JPDADebuggerImpl) contextProvider.lookupFirst(null, JPDADebugger.class)).getRequestProcessor();
     }
 
     @NbBundle.Messages("CTL_GoToSource=Go to source")
@@ -61,7 +66,7 @@ public class TruffleVariablesActionsProviderFilter implements NodeActionsProvide
             @Override
             public void perform (final Object[] nodes) {
                 TruffleVariable var = (TruffleVariable) nodes[0];
-                showSource(var.getValueSource());
+                rp.post(() -> showSource(var.getValueSource()));
             }
         },
         Models.MULTISELECTION_TYPE_EXACTLY_ONE
@@ -78,7 +83,7 @@ public class TruffleVariablesActionsProviderFilter implements NodeActionsProvide
             @Override
             public void perform (final Object[] nodes) {
                 TruffleVariable var = (TruffleVariable) nodes[0];
-                showSource(var.getTypeSource());
+                rp.post(() -> showSource(var.getTypeSource()));
             }
         },
         Models.MULTISELECTION_TYPE_EXACTLY_ONE
@@ -86,19 +91,18 @@ public class TruffleVariablesActionsProviderFilter implements NodeActionsProvide
 
     @Override
     public void performDefaultAction(NodeActionsProvider original, Object node) throws UnknownTypeException {
-        boolean shown = false;
         if (node instanceof TruffleVariable) {
             TruffleVariable var = (TruffleVariable) node;
-            SourcePosition source = var.getValueSource();
-            if (source == null) {
-                source = var.getTypeSource();
-            }
-            if (source != null) {
-                showSource(source);
-                shown = true;
-            }
-        }
-        if (!shown) {
+            rp.post(() -> {
+                SourcePosition source = var.getValueSource();
+                if (source == null) {
+                    source = var.getTypeSource();
+                }
+                if (source != null) {
+                    showSource(source);
+                }
+            });
+        } else {
             original.performDefaultAction(node);
         }
     }
@@ -115,23 +119,23 @@ public class TruffleVariablesActionsProviderFilter implements NodeActionsProvide
         }
         if (node instanceof TruffleVariable) {
             TruffleVariable var = (TruffleVariable) node;
-            SourcePosition valueSource = var.getValueSource();
-            SourcePosition typeSource = var.getTypeSource();
-            if (valueSource != null || typeSource != null) {
+            boolean hasValueSource = var.hasValueSource();
+            boolean hasTypeSource = var.hasTypeSource();
+            if (hasValueSource || hasTypeSource) {
                 int l = actions.length;
-                if (valueSource != null) {
+                if (hasValueSource) {
                     l++;
                 }
-                if (typeSource != null) {
+                if (hasTypeSource) {
                     l++;
                 }
                 Action[] newActions = new Action[l];
                 System.arraycopy(actions, 0, newActions, 0, actions.length);
                 l = actions.length;
-                if (valueSource != null) {
+                if (hasValueSource) {
                     newActions[l++] = GO_TO_VALUE_SOURCE_ACTION;
                 }
-                if (typeSource != null) {
+                if (hasTypeSource) {
                     newActions[l++] = GO_TO_TYPE_SOURCE_ACTION;
                 }
                 actions = newActions;
@@ -145,7 +149,7 @@ public class TruffleVariablesActionsProviderFilter implements NodeActionsProvide
     @NbBundle.Messages({"# {0} - The file path", "MSG_NoSourceFile=Cannot find source file {0}."})
     private void showSource(SourcePosition source) {
         URL url = source.getSource().getUrl();
-        int lineNumber = source.getLine();
+        int lineNumber = source.getStartLine();
         SwingUtilities.invokeLater (() -> {
             boolean success = EditorContextBridge.getContext().showSource(url.toExternalForm(), lineNumber, null);
             if (!success) {

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/vars/models/TruffleVariablesTreeModel.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/vars/models/TruffleVariablesTreeModel.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.netbeans.api.debugger.jpda.JPDADebugger;
-import org.netbeans.api.debugger.jpda.JPDAWatch;
 import org.netbeans.api.debugger.jpda.Variable;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleStrataProvider;
 import org.netbeans.modules.debugger.jpda.truffle.vars.TruffleScope;
@@ -62,7 +61,7 @@ public class TruffleVariablesTreeModel implements TreeModelFilter {
 
     @Override
     public Object[] getChildren(TreeModel original, Object parent, int from, int to) throws UnknownTypeException {
-        if (parent instanceof JPDAWatch) {
+        if (parent instanceof Variable) {
             TruffleVariable tv = TruffleVariableImpl.get((Variable) parent);
             if (tv != null) {
                 parent = tv;

--- a/java/debugger.jpda.truffle/test/unit/src/org/netbeans/modules/debugger/jpda/truffle/DebugSLTest.java
+++ b/java/debugger.jpda.truffle/test/unit/src/org/netbeans/modules/debugger/jpda/truffle/DebugSLTest.java
@@ -130,7 +130,7 @@ public class DebugSLTest extends NbTestCase {
             assertNotNull("No top frame", topFrame);
             SourcePosition sourcePosition = topFrame.getSourcePosition();
             assertEquals("Bad source", "Meaning of world.sl", sourcePosition.getSource().getName());
-            assertEquals("Bad line", lineNo, sourcePosition.getLine());
+            assertEquals("Bad line", lineNo, sourcePosition.getStartLine());
             assertEquals("Bad method name", methodName, topFrame.getMethodName());
             
             support.doContinue();
@@ -178,7 +178,7 @@ public class DebugSLTest extends NbTestCase {
             assertNotNull("No top frame", topFrame);
             SourcePosition sourcePosition = topFrame.getSourcePosition();
             assertEquals("Bad source", "TestApp.sl", sourcePosition.getSource().getName());
-            assertEquals("Bad line", lb.getLineNumber(), sourcePosition.getLine());
+            assertEquals("Bad line", lb.getLineNumber(), sourcePosition.getStartLine());
             assertEquals("Bad method name", "main", topFrame.getMethodName());
             
             support.doContinue();

--- a/java/debugger.jpda.truffle/test/unit/src/org/netbeans/modules/debugger/jpda/truffle/testapps/SLApp.java
+++ b/java/debugger.jpda.truffle/test/unit/src/org/netbeans/modules/debugger/jpda/truffle/testapps/SLApp.java
@@ -44,7 +44,7 @@ public class SLApp {
             "}\n",
             "Meaning of world.sl").build();
         
-        Context context = Context.newBuilder().out(os).build();
+        Context context = Context.newBuilder().allowAllAccess(true).out(os).build();
         Value result = context.eval(src);                           // LBREAKPOINT
 
         assertEquals("Expected result", 42L, result.asLong());

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/FrameInfo.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/FrameInfo.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.debugger.jpda.backend.truffle;
 
 import com.oracle.truffle.api.debug.DebugStackFrame;
+import com.oracle.truffle.api.nodes.LanguageInfo;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.SourceSection;
 import java.lang.reflect.InvocationTargetException;
@@ -40,7 +41,7 @@ final class FrameInfo {
 
     FrameInfo(DebugStackFrame topStackFrame, Iterable<DebugStackFrame> stackFrames) {
         SourceSection topSS = topStackFrame.getSourceSection();
-        SourcePosition position = JPDATruffleDebugManager.getPosition(topSS);
+        SourcePosition position = new SourcePosition(topSS);
         ArrayList<DebugStackFrame> stackFramesArray = new ArrayList<>();
         for (DebugStackFrame sf : stackFrames) {
             if (sf == topStackFrame) {
@@ -55,10 +56,13 @@ final class FrameInfo {
         }
         frame = topStackFrame;
         stackTrace = stackFramesArray.toArray(new DebugStackFrame[stackFramesArray.size()]);
+        LanguageInfo sfLang = topStackFrame.getLanguage();
         topFrame = topStackFrame.getName() + "\n" +
+                   ((sfLang != null) ? sfLang.getId() + " " + sfLang.getName() : "") + "\n" +
                    DebuggerVisualizer.getSourceLocation(topSS) + "\n" +
                    position.id + "\n" + position.name + "\n" + position.path + "\n" +
-                   position.uri.toString() + "\n" + position.line + "\n" + isInternal(topStackFrame);
+                   position.uri.toString() + "\n" + position.sourceSection +/* "," + position.startColumn + "," +
+                   position.endLine + "," + position.endColumn +*/ "\n" + isInternal(topStackFrame);
         topVariables = JPDATruffleAccessor.getVariables(topStackFrame);
     }
     

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/GuestObject.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/GuestObject.java
@@ -21,12 +21,11 @@ package org.netbeans.modules.debugger.jpda.backend.truffle;
 
 import com.oracle.truffle.api.debug.DebugStackFrame;
 import com.oracle.truffle.api.debug.DebugValue;
+import com.oracle.truffle.api.nodes.LanguageInfo;
 import com.oracle.truffle.api.source.SourceSection;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * A guest language object.
@@ -37,6 +36,7 @@ public final class GuestObject {
 
     final DebugValue value;
     final String name;
+    final String language;
     final String type;
     final String displayValue;
     final boolean readable;
@@ -50,6 +50,14 @@ public final class GuestObject {
     final SourcePosition typeSourcePosition;
 
     GuestObject(DebugValue value) {
+        LanguageInfo originalLanguage = value.getOriginalLanguage();
+        // Setup the object with a language-specific value
+        if (originalLanguage != null) {
+            value = value.asInLanguage(originalLanguage);
+            this.language = originalLanguage.getId() + " " + originalLanguage.getName();
+        } else {
+            this.language = "";
+        }
         this.value = value;
         this.name = value.getName();
         //System.err.println("new GuestObject("+name+")");
@@ -62,36 +70,34 @@ public final class GuestObject {
             LangErrors.exception("Value "+name+" .getMetaObject()", ex);
         }
         String typeStr = "";
-        if (metaObject != null) {
-            try {
-                typeStr = metaObject.as(String.class);
-            } catch (ThreadDeath td) {
-                throw td;
-            } catch (Throwable ex) {
-                LangErrors.exception("Meta object of "+name+" .as(String.class)", ex);
+        try {
+            // New in GraalVM 20.1.0
+            typeStr = (String) DebugValue.class.getMethod("getMetaSimpleName").invoke(value);
+        } catch (ReflectiveOperationException | IllegalArgumentException | SecurityException exc) {
+            if (metaObject != null) {
+                try {
+                    typeStr = metaObject.as(String.class);
+                } catch (ThreadDeath td) {
+                    throw td;
+                } catch (Throwable ex) {
+                    LangErrors.exception("Meta object of "+name+" .as(String.class)", ex);
+                }
             }
         }
         this.type = typeStr;
         //this.object = value;
         String valueStr = null;
         try {
-            valueStr = value.as(String.class);
+            try {
+                // New in GraalVM 20.1.0
+                valueStr = (String) DebugValue.class.getMethod("toDisplayString").invoke(value);
+            } catch (ReflectiveOperationException | IllegalArgumentException | SecurityException exc) {
+                valueStr = value.as(String.class);
+            }
         } catch (ThreadDeath td) {
             throw td;
         } catch (Throwable ex) {
-            LangErrors.exception("Value "+name+" .as(String.class)", ex);
-        }
-        if (valueStr == null) {
-            // Hack for R:
-            try {
-                Method getMethod = DebugValue.class.getDeclaredMethod("get");
-                getMethod.setAccessible(true);
-                Object realValue = getMethod.invoke(value);
-                valueStr = Objects.toString(realValue);
-            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException |
-                     NoSuchMethodException | SecurityException ex) {
-                LangErrors.exception("Value "+name+" get() invocation", ex);
-            }
+            LangErrors.exception("Value "+name+" .toDisplayString", ex);
         }
         this.displayValue = valueStr;
         //System.err.println("  have display value "+valueStr);
@@ -138,8 +144,8 @@ public final class GuestObject {
         try {
             SourceSection sourceLocation = value.getSourceLocation();
             //System.err.println("\nSOURCE of "+value.getName()+" is: "+sourceLocation);
-            if (sourceLocation != null) {
-                sp = JPDATruffleDebugManager.getPosition(sourceLocation);
+            if (sourceLocation != null && sourceLocation.isAvailable()) {
+                sp = new SourcePosition(sourceLocation);
             }
         } catch (ThreadDeath td) {
             throw td;
@@ -152,8 +158,8 @@ public final class GuestObject {
             try {
                 SourceSection sourceLocation = metaObject.getSourceLocation();
                 //System.err.println("\nSOURCE of metaobject "+metaObject+" is: "+sourceLocation);
-                if (sourceLocation != null) {
-                    sp = JPDATruffleDebugManager.getPosition(sourceLocation);
+                if (sourceLocation != null && sourceLocation.isAvailable()) {
+                    sp = new SourcePosition(sourceLocation);
                 }
             } catch (ThreadDeath td) {
                 throw td;

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/JPDATruffleAccessor.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/JPDATruffleAccessor.java
@@ -26,7 +26,8 @@ import com.oracle.truffle.api.debug.DebugValue;
 import com.oracle.truffle.api.debug.Debugger;
 import com.oracle.truffle.api.debug.DebuggerSession;
 import com.oracle.truffle.api.debug.SuspendedEvent;
-//import com.oracle.truffle.api.vm.PolyglotEngine;
+import com.oracle.truffle.api.nodes.LanguageInfo;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -111,7 +112,7 @@ public class JPDATruffleAccessor extends Object {
         }
     }
     
-    static JPDATruffleDebugManager setUpDebugManagerFor(/*Engine*/Object engineObj, boolean doStepInto) {
+    static JPDATruffleDebugManager setUpDebugManagerFor(/*Engine*/Object engineObj, boolean includeInternal, boolean doStepInto) {
         trace("setUpDebugManagerFor("+engineObj+", "+doStepInto+")");
         Engine engine = (Engine) engineObj;
         Debugger debugger;
@@ -126,13 +127,24 @@ public class JPDATruffleAccessor extends Object {
                 return null;
             }
         }
-        JPDATruffleDebugManager tdm = new JPDATruffleDebugManager(debugger, doStepInto);
+        JPDATruffleDebugManager tdm = new JPDATruffleDebugManager(debugger, includeInternal, doStepInto);
         synchronized (debugManagers) {
             debugManagers.put(debugger, tdm);
         }
         return tdm;
     }
     
+    static void setIncludeInternal(boolean includeInternal) {
+        synchronized (debugManagers) {
+            for (JPDATruffleDebugManager tdm : debugManagers.values()) {
+                DebuggerSession debuggerSession = tdm.getDebuggerSession();
+                if (debuggerSession != null) {
+                    debuggerSession.setSteppingFilter(JPDATruffleDebugManager.createSteppingFilter(includeInternal));
+                }
+            }
+        }
+    }
+
     static int executionHalted(JPDATruffleDebugManager tdm,
                                SourcePosition position,
                                boolean haltedBefore,
@@ -200,6 +212,10 @@ public class JPDATruffleAccessor extends Object {
             }
             frameInfos.append(sfName);
             frameInfos.append('\n');
+            LanguageInfo sfLang = sf.getLanguage();
+            String sfLangId = (sfLang != null) ? sfLang.getId() + " " + sfLang.getName() : "";
+            frameInfos.append(sfLangId);
+            frameInfos.append('\n');
             frameInfos.append(DebuggerVisualizer.getSourceLocation(sf.getSourceSection()));
             frameInfos.append('\n');
             /*if (fi.getCallNode() == null) {
@@ -210,7 +226,7 @@ public class JPDATruffleAccessor extends Object {
                 System.err.println("frameInfos = "+frameInfos);
                 *//*
             }*/
-            SourcePosition position = JPDATruffleDebugManager.getPosition(sf.getSourceSection());
+            SourcePosition position = new SourcePosition(sf.getSourceSection());
             frameInfos.append(createPositionIdentificationString(position));
             if (includeInternal) {
                 frameInfos.append('\n');
@@ -220,12 +236,6 @@ public class JPDATruffleAccessor extends Object {
             frameInfos.append("\n\n");
             
             codes[j] = position.code;
-            /*
-             TODO Find "this"
-            Frame f = fi.getFrame(FrameInstance.FrameAccess.READ_ONLY, false);
-            if (f instanceof VirtualFrame) {
-                thiss[i] = JSFrameUtil.getThisObj((VirtualFrame) f);
-            }*/
             j++;
         }
         if (j < n) {
@@ -246,7 +256,7 @@ public class JPDATruffleAccessor extends Object {
         str.append('\n');
         str.append(position.uri.toString());
         str.append('\n');
-        str.append(position.line);
+        str.append(position.sourceSection);
         return str.toString();
     }
 
@@ -293,7 +303,8 @@ public class JPDATruffleAccessor extends Object {
                 }
                 Iterable<DebugValue> varsIt = scope.getDeclaredValues();
                 Iterator<DebugValue> vars = varsIt.iterator();
-                if ((args == null || !args.hasNext()) && !vars.hasNext()) {
+                DebugValue receiver = scope.isFunctionScope() ? scope.getReceiver() : null;
+                if ((args == null || !args.hasNext()) && !vars.hasNext() && receiver == null) {
                     // An empty scope, skip it
                     scope = scope.getParent();
                     continue;
@@ -313,6 +324,9 @@ public class JPDATruffleAccessor extends Object {
                 List<DebugValue> variables = new ArrayList<>();
                 while (vars.hasNext()) {
                     variables.add(vars.next());
+                }
+                if (receiver != null) {
+                    variables.add(receiver);
                 }
                 elements.add(variables.size());
                 if (arguments != null) {
@@ -377,6 +391,12 @@ public class JPDATruffleAccessor extends Object {
             while (vars.hasNext()) {
                 variables.add(vars.next());
             }
+            if (scope.isFunctionScope()) {
+                DebugValue receiver = scope.getReceiver();
+                if (receiver != null) {
+                    variables.add(receiver);
+                }
+            }
             elements.add(variables.size());
             if (arguments != null) {
                 for (DebugValue v : arguments) {
@@ -394,11 +414,12 @@ public class JPDATruffleAccessor extends Object {
         return elements.toArray();
     }
 
-    // Store 11 elements: <name>, <type>, <readable>, <writable>, <internal>, <String value>,
+    // Store 12 elements: <name>, <language>, <type>, <readable>, <writable>, <internal>, <String value>,
     //                    <var source>, <VS code>, <type source>, <TS code>, <DebugValue>
     static void addValueElement(DebugValue value, List<Object> elements) {
         GuestObject tobj = new GuestObject(value);
         elements.add(tobj.name);
+        elements.add(tobj.language);
         elements.add(tobj.type);
         elements.add(tobj.readable);
         elements.add(tobj.writable);

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/SourcePosition.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/SourcePosition.java
@@ -20,6 +20,8 @@
 package org.netbeans.modules.debugger.jpda.backend.truffle;
 
 import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
+
 import java.net.URI;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -36,16 +38,21 @@ final class SourcePosition {
     final long id;
     final String name;
     final String path;
-    final int line;
+    final String sourceSection;
     final String code;
     final URI uri;
 
-    public SourcePosition(Source source, String name, String path, int line, String code) {
+    public SourcePosition(SourceSection sourceSection) {
+        Source source = sourceSection.getSource();
         this.id = getId(source);
-        this.name = name;
-        this.path = path;
-        this.line = line;
-        this.code = code;
+        this.name = source.getName();
+        String sourcePath = source.getPath();
+        if (sourcePath == null) {
+            sourcePath = name;
+        }
+        this.path = sourcePath;
+        this.sourceSection = sourceSection.getStartLine() + "," + sourceSection.getStartColumn() + "," + sourceSection.getEndLine() + "," + sourceSection.getEndColumn();
+        this.code = source.getCharacters().toString();
         this.uri = source.getURI();
     }
 


### PR DESCRIPTION
* Resolved issues NETBEANS-4208 and NETBEANS-4209,
* several more fixes and corrections,
* receiver object is displayed (this),
* [lang-name] is added to types of foreign objects for better usability,
* when "Language Developer Mode" option is on debugger steps into internal sources
* corrected tags in "Truffle AST view" (displayed in dev mode only).