### PR TITLE
[NETBEANS-4203] for InputOutput.reset() do NbWriter.reset() as needed

### DIFF
--- a/platform/core.output2/src/org/netbeans/core/output2/NbIOProvider.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/NbIOProvider.java
@@ -25,6 +25,7 @@ import java.io.Reader;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.logging.Level;
 import javax.swing.Action;
 import org.netbeans.api.io.Hyperlink;
 import org.netbeans.api.io.OutputColor;
@@ -214,7 +215,14 @@ public final class NbIOProvider extends IOProvider implements
     @Override
     public void resetIO(InputOutput io) {
         if (io instanceof NbIO) {
-            ((NbIO) io).reset();
+            try {
+                // ((NbWriter)io.getOut).reset() does OutWriter fixup,
+                // then NbWriter invokes ((NbIO) io).reset()
+                io.getOut().reset();
+            } catch (IOException ex) {
+                Exceptions.attachSeverity(ex, Level.WARNING);
+                Exceptions.printStackTrace(ex);
+            }
         } else {
             throw new IllegalArgumentException();
         }


### PR DESCRIPTION
The new `I/O API and SPI`, introduced around 2014, has never had a working "reset()" to clear the output window, AFAICT. 

It looks like this new interface delegates to platform/core.output2 and this in turn is based on the old stuff in platform/openide.windows. The new interface gave us the long promised InputOutput.reset() and hid the older OutputWriter.reset(). The older OutputWriter.reset has some essential code that the newer InputOutput.reset() never invokes.

This PR makes sure there's a full reset and the output window is cleared when using the default api implementation.

Testing is tricky. The tests for the new stuff test that delegation occurs. It never actually tests a real output window. Based on the tests for the old api I've put together some tests as a module that uses reflection for verification. I don't know if there's any way to incorporate these tests into netbeans. I'm cleaning them up and will attach them to the issue.