### PR TITLE
[NETBEANS-3972] Draft implementation of GIT GPG signing

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/client/GitClient.java
+++ b/ide/git/src/org/netbeans/modules/git/client/GitClient.java
@@ -285,16 +285,16 @@ public final class GitClient {
         }, "clean", roots); //NOI18N
     }
     
-    public GitRevisionInfo commit (final File[] roots, final String commitMessage, final GitUser author, final GitUser commiter, final ProgressMonitor monitor) throws GitException {
-        return commit(roots, commitMessage, author, commiter, false, monitor);
+    public GitRevisionInfo commit (final File[] roots, final String commitMessage, final GitUser author, final GitUser commiter, final String gpgPrivateKeyPassphase, final ProgressMonitor monitor) throws GitException {
+        return commit(roots, commitMessage, author, commiter, false, gpgPrivateKeyPassphase, monitor);
     }
     
-    public GitRevisionInfo commit (final File[] roots, final String commitMessage, final GitUser author, final GitUser commiter, final boolean amend, final ProgressMonitor monitor) throws GitException {
+    public GitRevisionInfo commit (final File[] roots, final String commitMessage, final GitUser author, final GitUser commiter, final boolean amend, final String gpgPrivateKeyPassphase, final ProgressMonitor monitor) throws GitException {
         return new CommandInvoker().runMethod(new Callable<GitRevisionInfo>() {
 
             @Override
             public GitRevisionInfo call () throws Exception {
-                return delegate.commit(roots, commitMessage, author, commiter, amend, monitor);
+                return delegate.commit(roots, commitMessage, author, commiter, amend, gpgPrivateKeyPassphase, monitor);
             }
         }, "commit", roots); //NOI18N
     }

--- a/ide/git/src/org/netbeans/modules/git/utils/JGitUtils.java
+++ b/ide/git/src/org/netbeans/modules/git/utils/JGitUtils.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.git.utils;
 
 import java.io.File;
 import java.io.IOException;
+import org.eclipse.jgit.lib.ConfigConstants;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
@@ -71,6 +72,14 @@ public class JGitUtils {
             }
         }
         return userExists;
+    }
+    
+    public static boolean isGPGSignEnabled (File root) {
+        Repository repository = getRepository(root);
+        boolean gpgSigningEnabled = false;
+        
+        gpgSigningEnabled = repository.getConfig().getBoolean(ConfigConstants.CONFIG_COMMIT_SECTION, null, ConfigConstants.CONFIG_KEY_GPGSIGN, false);
+        return gpgSigningEnabled;
     }
 
     public static void persistUser (File root, GitUser author) throws GitException {

--- a/ide/libs.git/src/org/netbeans/libs/git/GitClient.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/GitClient.java
@@ -460,8 +460,8 @@ public final class GitClient {
      * @param monitor progress monitor
      * @throws GitException an unexpected error occurs
      */
-    public GitRevisionInfo commit(File[] roots, String commitMessage, GitUser author, GitUser commiter, ProgressMonitor monitor) throws GitException {
-        return commit(roots, commitMessage, author, commiter, false, monitor);
+    public GitRevisionInfo commit(File[] roots, String commitMessage, GitUser author, GitUser commiter, String gpgPrivateKeyPassphase, ProgressMonitor monitor) throws GitException {
+        return commit(roots, commitMessage, author, commiter, false, gpgPrivateKeyPassphase, monitor);
     }
     
     /**
@@ -474,9 +474,9 @@ public final class GitClient {
      * @param monitor progress monitor
      * @throws GitException an unexpected error occurs
      */
-    public GitRevisionInfo commit(File[] roots, String commitMessage, GitUser author, GitUser commiter, boolean amend, ProgressMonitor monitor) throws GitException {
+    public GitRevisionInfo commit(File[] roots, String commitMessage, GitUser author, GitUser commiter, boolean amend, String gpgPrivateKeyPassphase, ProgressMonitor monitor) throws GitException {
         Repository repository = gitRepository.getRepository();
-        CommitCommand cmd = new CommitCommand(repository, getClassFactory(), roots, commitMessage, author, commiter, amend, monitor);
+        CommitCommand cmd = new CommitCommand(repository, getClassFactory(), roots, commitMessage, author, commiter, amend, gpgPrivateKeyPassphase, monitor);
         cmd.execute();
         return cmd.revision;
     }

--- a/ide/libs.git/src/org/netbeans/libs/git/jgit/JGitCommitCredentialsProvider.java
+++ b/ide/libs.git/src/org/netbeans/libs/git/jgit/JGitCommitCredentialsProvider.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.git.jgit;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.eclipse.jgit.errors.UnsupportedCredentialItem;
+import org.eclipse.jgit.transport.CredentialItem;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.URIish;
+import org.netbeans.libs.git.GitClientCallback;
+
+/**
+ *
+ * @author kevin
+ */
+public class JGitCommitCredentialsProvider extends CredentialsProvider {
+    private final String gpgPrivateKeyPassphase;
+    private static final Logger LOG = Logger.getLogger(JGitCredentialsProvider.class.getName());
+
+    public JGitCommitCredentialsProvider (String gpgPrivateKeyPassphase) {
+        this.gpgPrivateKeyPassphase = gpgPrivateKeyPassphase;
+    }
+    
+    @Override
+    public boolean isInteractive() {
+        return false;
+    }
+
+    @Override
+    public boolean supports(CredentialItem... items) {
+        for (CredentialItem i : items) {
+            if (!(i instanceof CredentialItem.Username
+                    || i instanceof CredentialItem.Password || i instanceof CredentialItem.InformationalMessage || i instanceof CredentialItem.CharArrayType)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean get(URIish uriish, CredentialItem... items) throws UnsupportedCredentialItem {
+        String uri = uriish.toString();
+        String user = uriish.getUser();
+        if (user == null) {
+            user = "";
+        }
+        String password = uriish.getPass();
+        if (password == null) {
+            password = "";
+        }
+        for (CredentialItem item : items) {
+            if (item instanceof CredentialItem.InformationalMessage) {
+                continue;
+            }
+            if (item instanceof CredentialItem.CharArrayType) {
+                ((CredentialItem.CharArrayType) item).setValue(gpgPrivateKeyPassphase.toCharArray());
+                continue;
+            }
+            
+            LOG.log(Level.WARNING, "Unknown credential item: {0} - {1}:{2}", new Object[] { uri, item.getClass().getName(), item.getPromptText() });
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Initial draft of GIT GPG commit signing, I'm not happy with this implementation and need some guidance on how to improve this implementation.

1. Alteration of the commit() command construct signature breaks a lot of tests and doesn't feel like the right way to pass through the GPG passphrase to jgit/bouncycastle.
2. GPG Passphrase popup doesn't obfuscate the input and isn't a great UX being separate and before the commit window for file selection/author/committer etc
3. Override checkbox on the commit window to enable/disable signing like author/committer would also be useful.

I've built this on the 11.3 stable release of netbeans but will follow guidance on how to raise a new pull request as needed. To build/run at the moment all tests in Git and Git Client Library need disabling for now due to the commit command construct change.

I'm happy to continue attempting to implement this, but Java isn't my primary language (so please go easy).

Calling for suggestions and guidance on implementation.

