### PR TITLE
Fix ant property to exclude tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ matrix:
             - hide-logs.sh ant $OPTS -f platform/libs.javafx test
             - travis_retry hide-logs.sh ant $OPTS -f platform/masterfs test
             - hide-logs.sh ant $OPTS -f platform/masterfs.linux test
-            #- hide-logs.sh ant $OPTS -f platform/netbinox test
+            - hide-logs.sh ant $OPTS -f platform/netbinox test  -Dtest.config=stableBTD
             - hide-logs.sh ant $OPTS -f platform/o.n.bootstrap test
             - hide-logs.sh ant $OPTS -f platform/o.n.core test-unit
             - hide-logs.sh ant $OPTS -f platform/o.n.swing.outline test

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -621,7 +621,6 @@
             <depend srcdir="${test.@{test.type}.src.dir}" destdir="${build.test.@{test.type}.classes.dir}" cache="${build.test.@{test.type}.dir}/depcache">
                 <classpath refid="test.@{test.type}.cp"/>
             </depend>
-            <property name="test.excludes" value=""/> <!-- # 113770 -->
             <nb-javac srcdir="${test.@{test.type}.src.dir}" destdir="${build.test.@{test.type}.classes.dir}" excludes="${test.excludes}"
                       debug="true" deprecation="${build.compiler.deprecation}" encoding="UTF-8"
                       source="${javac.source}" target="${javac.target}" optimize="${build.compiler.optimize}" includeantruntime="false">

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -621,7 +621,8 @@
             <depend srcdir="${test.@{test.type}.src.dir}" destdir="${build.test.@{test.type}.classes.dir}" cache="${build.test.@{test.type}.dir}/depcache">
                 <classpath refid="test.@{test.type}.cp"/>
             </depend>
-            <nb-javac srcdir="${test.@{test.type}.src.dir}" destdir="${build.test.@{test.type}.classes.dir}" excludes="${test.excludes}"
+            <property name="test.javac.excludes" value=""/> <!-- # 113770 -->
+            <nb-javac srcdir="${test.@{test.type}.src.dir}" destdir="${build.test.@{test.type}.classes.dir}" excludes="${test.javac.excludes}"
                       debug="true" deprecation="${build.compiler.deprecation}" encoding="UTF-8"
                       source="${javac.source}" target="${javac.target}" optimize="${build.compiler.optimize}" includeantruntime="false">
                 <classpath refid="test.@{test.type}.cp"/>

--- a/platform/netbinox/nbproject/project.properties
+++ b/platform/netbinox/nbproject/project.properties
@@ -23,8 +23,8 @@ javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\
-    **/BundleURLConnectionTest.class,\
     **/CachingAndExternalPathsTest.class,\
     **/CachingAndExternalURLTest.class,\
     **/CachingPreventsFileTouchesTest.class,\
-    **/NetigsoTest.class
+    **/LogReaderServiceTest.class,\
+    **/NetigsoHasSAXParserTest.class


### PR DESCRIPTION
Netbeans build system has a project property to define a list of classes/packages to be excluded when run tests in a module. 
```java
test.config.stableBTD.includes=**/*Test.class

test.config.stableBTD.excludes=\
    **/CachingAndExternalPathsTest.class,\
    **/CachingAndExternalURLTest.class,\
    **/CachingPreventsFileTouchesTest.class,\
    **/LogReaderServiceTest.class,\
    **/NetigsoHasSAXParserTest.class
```
This PR removes the hardcoded value from the property to allow us to exclude tests again.