### PR TITLE
Mark included 3rd-party update centre as trusted.

### DIFF
--- a/nb/updatecenters/build.xml
+++ b/nb/updatecenters/build.xml
@@ -41,8 +41,6 @@
       />
       <subant  target="nbm" inheritall="false">
           <property name="build.dir" location="build/3rdparty-nbms"/>
-          <property name="keystore" location="${netbeans.bundled.ks}"/>
-          <property name="storepass" value="${netbeans.bundled.ks}"/>
           <property name="nbm_alias" value="netbeans-bundled"/>
           <fileset dir="${nb_all}/extra" includes="libs.javafx.*/build.xml"/>
       </subant>
@@ -56,8 +54,6 @@
       </subant>
       <subant target="nbm" inheritall="false">
           <property name="build.dir" location="build/3rdparty-nbms"/>
-          <property name="keystore" location="${netbeans.bundled.ks}"/>
-          <property name="storepass" value="${netbeans.bundled.ks}"/>
           <property name="nbm_alias" value="netbeans-bundled"/>
           <property name="nb_all" location="${nb_all}"/>
           <property name="nbplatform.default.netbeans.dest.dir" location="${netbeans.dest.dir}"/>

--- a/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
+++ b/nb/updatecenters/src/org/netbeans/modules/updatecenters/resources/mf-layer.xml
@@ -62,6 +62,7 @@
           <attr name="url" bundlevalue="org.netbeans.modules.updatecenters.resources.Bundle#URL_3rdparty"/>
           <attr name="category" stringvalue="STANDARD"/>
           <attr name="enabled" boolvalue="true"/>
+          <attr name="trusted" boolvalue="true"/>
           <attr name="instanceOf" stringvalue="org.netbeans.spi.autoupdate.UpdateProvider"/>
           <attr name="instanceCreate" methodvalue="org.netbeans.modules.autoupdate.updateprovider.AutoupdateCatalogFactory.createUpdateProvider"/>
       </file>


### PR DESCRIPTION
Mark included 3rd-party update centre as trusted and don't sign bundled nbms. This should fix the issue with the signature of the bundled nbms not matching the keystore in the updatecenter nbm - a problem for anyone using the distribution nbms, and for pushing updates to nb-javac or JavaFX to the IDE after release.

Deliberately kept light touch for 12.0.  We can probably drop all the `ide.ks` and `NetBeansKeyStoreProvider` stuff for 12.1?