### PR TITLE
[NETBEANS-4280] - cleanup potential security breaches

### DIFF
--- a/webcommon/javascript.nodejs/samples_src/MessagesAngular/package.json
+++ b/webcommon/javascript.nodejs/samples_src/MessagesAngular/package.json
@@ -10,7 +10,7 @@
     "dependencies": {
         "express": "^4.10.1",
         "body-parser": "^1.4.3",
-        "bower": "~1.3.12"
+        "bower": "~1.8.8"
     },
     "devDependencies": {
         "gulp": "^3.8.10",

--- a/webcommon/javascript.nodejs/samples_src/MessagesExpress/package.json
+++ b/webcommon/javascript.nodejs/samples_src/MessagesExpress/package.json
@@ -11,11 +11,11 @@
     "dependencies": {
         "body-parser": "~1.10.2",
         "cookie-parser": "~1.3.3",
-        "debug": "~2.1.1",
+        "debug": "~2.6.9",
         "express": "~4.11.1",
         "jade": "~1.9.1",
-        "morgan": "~1.5.1",
-        "bower" : "~1.3.12"
+        "morgan": "~1.9.1",
+        "bower" : "~1.8.8"
     },
     "devDependencies": {
         "grunt": "^0.4.5",

--- a/webcommon/javascript.nodejs/samples_src/MessagesKnockout/package.json
+++ b/webcommon/javascript.nodejs/samples_src/MessagesKnockout/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "express": "^4.10.1",
         "body-parser": "^1.4.3",
-        "bower" : "~1.3.12"
+        "bower" : "~1.8.8"
     },
     "devDependencies": {
         "grunt": "^0.4.5",


### PR DESCRIPTION
There are a few known security breaches in the sample source..

Specifically the following alerts:

CVE-2019-5484
Bower before 1.8.8 has a path traversal vulnerability permitting file write in arbitrary locations via install command, which allows attackers to write arbitrary files when a malicious package is extracted.

CVE-2019-5413
An attacker can use the format parameter to inject arbitrary commands in the npm package morgan < 1.9.1.

CVE-2017-16137
The debug module is vulnerable to regular expression denial of service when untrusted user input is passed into the o formatter. It takes around 50k characters to block for 2 seconds making this a low severity issue.

I'm not saying these are critical. But, it's better we fix them to prevent any possibility of using Netbeans IDE to allow someone to exploit this. As well as set the proper example.