### PR TITLE
[NETBEANS-4239] Fixed NPE in GradleCompilerOptionsQuery

### DIFF
--- a/groovy/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
+++ b/groovy/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
@@ -233,6 +233,13 @@ public final class GradleJavaSourceSet implements Serializable {
         return runtimeClassPath != null ? runtimeClassPath : getCompileClassPath();
     }
 
+    /**
+     * Returns the {@link SourceType} of the given file or {@code null} if that
+     * file cannot be associated with one.
+     *
+     * @param f the file to check.
+     * @return the matching {@link SourceType} or {@code null}.
+     */
     public SourceType getSourceType(File f) {
         for (SourceType type : sources.keySet()) {
             Set<File> dirs = sources.get(type);

--- a/groovy/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleCompilerOptionsQuery.java
+++ b/groovy/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleCompilerOptionsQuery.java
@@ -69,7 +69,7 @@ public final class GradleCompilerOptionsQuery implements CompilerOptionsQueryImp
         ResultImpl ret = null;
         if (sourceSet != null) {
             GradleJavaSourceSet.SourceType sourceType = sourceSet.getSourceType(f);
-            if (sourceType != GradleJavaSourceSet.SourceType.RESOURCES) {
+            if ((sourceType != null) && (sourceType != GradleJavaSourceSet.SourceType.RESOURCES)) {
                 String key = sourceSet.getName() + "." + sourceType.name();
                 synchronized(this) {
                     ret = cache.get(key);


### PR DESCRIPTION
Trivial and safe fix for an NPE that prevents code assistance in JSP files.