### PR TITLE
[NETBEANS-4281] Fix ConvertToPatternInstanceOf hint always showing.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToPatternInstanceOf.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToPatternInstanceOf.java
@@ -64,7 +64,8 @@ import org.openide.util.NbBundle;
     "ERR_ConvertToPatternInstanceOf=instanceof <pattern> can be used here",
     "FIX_ConvertToPatternInstanceOf=Use instanceof <pattern>"
 })
-@Hint(displayName="#DN_ConvertToPatternInstanceOf", description="#DESC_ConvertToPatternInstanceOf", category="rules15")
+@Hint(displayName="#DN_ConvertToPatternInstanceOf", description="#DESC_ConvertToPatternInstanceOf", category="rules15",
+        minSourceVersion = "14")
 public class ConvertToPatternInstanceOf {
     
     @TriggerPatterns({

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintMetadata.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/providers/spi/HintMetadata.java
@@ -175,6 +175,7 @@ public class HintMetadata {
                     this.sourceVersion = SourceVersion.valueOf("RELEASE_" + version);
                 } catch (IllegalArgumentException ex) {
                     this.sourceVersion = SourceVersion.RELEASE_3;
+                    setEnabled(false);
                 }
             }
             return this;


### PR DESCRIPTION
Add minSourceVersion = 14 to ConvertToPatternInstanceOf hint.
Disable hint in HintMetadata if lookup of SourceVersion by name fails.

The change to HintMetadata handles the problem with hints requiring a higher minimum version of SourceVersion than exists on the running machine. With move away from nb-javac, hints should perhaps use an integer value rather than SourceVersion here in the longer term?