### PR TITLE
[NETBEANS-4291] Fix some classes not found from multi-release JARs in Java editor

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingFileManager.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingFileManager.java
@@ -247,6 +247,8 @@ public class CachingFileManager implements JavaFileManager, PropertyChangeListen
                 Archive archive = provider.getArchive( entry.getURL(), cacheFile );
                 if (archive != null) {
                     final Iterable<JavaFileObject> entries;
+                    // multi-release code here duplicated in ModuleFileManager
+                    // fixes should be ported across, or ideally this logic abstracted
                     if (supportsMultiRelease && archive.isMultiRelease()) {
                         if (prefixes == null) {
                             prefixes = multiReleaseRelocations();
@@ -267,11 +269,12 @@ public class CachingFileManager implements JavaFileManager, PropertyChangeListen
                                 }
                                 final String fqn = inferBinaryName(l, fo);
                                 final String pkg = FileObjects.getPackageAndName(fqn)[0];
+                                final String name = pkg + "/" + FileObjects.getName(fo, false);
                                 if (base) {
                                     seenPackages.add(pkg);
-                                    fqn2f.put(fqn, fo);
+                                    fqn2f.put(name, fo);
                                 } else if (seenPackages.contains(pkg)) {
-                                    fqn2f.put(fqn, fo);
+                                    fqn2f.put(name, fo);
                                 }
                             }
                         }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleFileManager.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ModuleFileManager.java
@@ -100,6 +100,8 @@ final class ModuleFileManager implements JavaFileManager {
                 final Archive archive = cap.getArchive(root, cacheFile);
                 if (archive != null) {
                     final Iterable<JavaFileObject> entries;
+                    // multi-release code here duplicated in CachingFileManager
+                    // fixes should be ported across, or ideally this logic abstracted
                     if (supportsMultiRelease && archive.isMultiRelease()) {
                         if (prefixes == null) {
                             prefixes = multiReleaseRelocations();
@@ -120,11 +122,12 @@ final class ModuleFileManager implements JavaFileManager {
                                 }
                                 final String fqn = inferBinaryName(l, fo);
                                 final String pkg = FileObjects.getPackageAndName(fqn)[0];
+                                final String name = pkg + "/" + FileObjects.getName(fo, false);
                                 if (base) {
                                     seenPackages.add(pkg);
-                                    fqn2f.put(fqn, fo);
+                                    fqn2f.put(name, fo);
                                 } else if (seenPackages.contains(pkg)) {
-                                    fqn2f.put(fqn, fo);
+                                    fqn2f.put(name, fo);
                                 }
                             }
                         }


### PR DESCRIPTION
If a multi-release JAR contains resources with the same name but a different extension, then only one of these resources is picked up.  This causes errors with projects using eg. FlatLaf where errors are seen in the code editor while compilation works fine.  Files such as `FlatLightLaf.properties` shadows `FlatLightLaf.class`.

This is caused by an error in CachingFileManager and ModuleFileManager using the file name and location without extension as a map key to look up multi-release files. Hopefully changes here fix this without causing problems elsewhere - better tests would be good in this area in future.

See also https://github.com/JFormDesigner/FlatLaf/issues/13

The projects attached to the JIRA issue demonstrate the issue on classpath and modulepath. Both show broken in NB 12.0-beta3. https://issues.apache.org/jira/browse/NETBEANS-4291
