### PR TITLE
[NETBEANS-4270] account for doc.insertString changing length of inser…

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
@@ -400,11 +400,14 @@ public final class ModificationResult {
                 // first insert the new content, THEN remove the old one. In situations where the content AFTER the
                 // change is not writable this ordering allows to replace the content, but if we first delete, 
                 // replacement cannot be inserted into the nonwritable area.
-                int delta = diff.getNewText().length();
                 int offs = diff.getStartPosition().getOffset();
                 int removeLen = diff.getEndPosition().getOffset() - offs;
                 
+                // [NETBEANS-4270] Can't use "delta = diff.getNewText().length()".
+                // doc.insertString may filter chars, e.g. '\r', and change length.
+                int initialLength = doc.getLength();
                 doc.insertString(offs, diff.getNewText(), null);
+                int delta = doc.getLength() - initialLength;
                 doc.remove(delta + offs, removeLen);
                 break;
             }


### PR DESCRIPTION
…tion

Simple fix. The problem occurs when a hint changes Bundle.properties. Hint processing wants to change a line: delete some content, insert "\r\n". The code assumes that 2 characters are inserted, but the "\r" is filtered out. So the delete, after the insert, corrupts the properties file.

The bug report includes a small project to reproduce the problem.

The bug was introduced by the following change (for a different issue). Before this change, the last step was to insert the "\r\n" so the difference in length didn't matter.
```
/f/repos/main-silver/java.source.base
$ hg log -r 095e4043efa0 src/org/netbeans/api/java/source/ModificationResult.java
changeset:   279147:095e4043efa0
branch:      server_split
parent:      279146:6e4b43cb7725
parent:      277049:d05de673f3a8
user:        Svata Dedic <sdedic@netbeans.org>
date:        Wed Aug 27 15:42:57 2014 +0200
summary:     Manual merge of jet-main/trunk since approx 22 Apr


/f/repos/main-silver/java.source.base
$ hg diff -c 095e4043efa0 src/org/netbeans/api/java/source/ModificationResult.java
diff --git a/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java b/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
--- a/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
+++ b/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
@@ -428,10 +428,18 @@
             case REMOVE:
                 doc.remove(diff.getStartPosition().getOffset(), diff.getEndPosition().getOffset() - diff.getStartPosition().getOffset());
                 break;
-            case CHANGE:
-                doc.remove(diff.getStartPosition().getOffset(), diff.getEndPosition().getOffset() - diff.getStartPosition().getOffset());
-                doc.insertString(diff.getStartPosition().getOffset(), diff.getNewText(), null);
+            case CHANGE: {
+                // first insert the new content, THEN remove the old one. In situations where the content AFTER the
+                // change is not writable this ordering allows to replace the content, but if we first delete,
+                // replacement cannot be inserted into the nonwritable area.
+                int delta = diff.getNewText().length();
+                int offs = diff.getStartPosition().getOffset();
+                int removeLen = diff.getEndPosition().getOffset() - offs;
+
+                doc.insertString(offs, diff.getNewText(), null);
+                doc.remove(delta + offs, removeLen);
                 break;
+            }
         }
     }
```

