### PR TITLE
Added property to allow the user to specify the max number of objects and details in search:

### DIFF
--- a/platform/api.search/src/org/netbeans/modules/search/Constants.java
+++ b/platform/api.search/src/org/netbeans/modules/search/Constants.java
@@ -29,11 +29,11 @@ public final class Constants {
     /**
      * maximum number of found objects
      */
-    public static final int COUNT_LIMIT = 500;
+    public static final int COUNT_LIMIT = Integer.getInteger("netbeans.search.count.limit", 500);
     /**
      * maximum total number of detail entries for found objects
      */
-    public static final int DETAILS_COUNT_LIMIT = 5000;
+    public static final int DETAILS_COUNT_LIMIT = Integer.getInteger("netbeans.search.details.count.limit", 5000);
 
     public enum Limit {
 


### PR DESCRIPTION
Some clients of ours had this problem, they had a lot of files to search inside, but NetBeans limited the maximum number of results to 500.