### PR TITLE
[NETBEANS-3413] Implicit inheritance of PHPDoc descriptions

### DIFF
--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/DocRendererTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/DocRendererTest.java
@@ -258,7 +258,7 @@ public class DocRendererTest extends PHPTestBase {
 
     public void testReplaceInlineInheritdoc_04() {
         checkReplaceInlineInheritdoc(
-                null,
+                "Parent Description",
                 null,
                 "Parent Description"
         );


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-3413
Uses description of inherited element when no PHPDoc is present.