### PR TITLE
[NETBEANS-4299] find endPos for synthetic annotation attribute

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
@@ -535,8 +535,14 @@ public class CasualDiff {
             VariableTree vt = fgt.getVariables().get(fgt.getVariables().size() - 1);
             return TreeInfo.getEndPos((JCTree)vt, oldTopLevel.endPositions);
         }
-        return TreeInfo.getEndPos(t, oldTopLevel.endPositions);
+        int endPos = TreeInfo.getEndPos(t, oldTopLevel.endPositions);
+
+        // [NETBEANS-4299], might be a synthetic annotation attribute, try rhs
+        if (endPos == Position.NOPOS && t instanceof JCAssign) {
+            endPos = TreeInfo.getEndPos(((JCAssign)t).rhs, oldTopLevel.endPositions);
         }
+        return endPos;
+    }
 
     private int endPos(com.sun.tools.javac.util.List<? extends JCTree> trees) {
         int result = -1;


### PR DESCRIPTION
Fixes 12.0 regression from 11.3. (might be nb-javac to jdk14 issue)

This fixes "Use @NbBundle.messages" adding a message to
``` 
@Messages("OptionsCategory_Name_OptionsPlayHack=any old")
```
and also adding a message to
```
@Messages({"OptionsCategory_Name_OptionsPlayHack=any old", "OptionsCategory_Keywords_OptionsPlayHack=keyw1"})
```
Not sure it's the best fix, it seems safe; needs review.

Questions about the fix:
- I don't understand getKind() vs instanceof (if/when it matters)
- Not sure if this check fully qualifies "assignment as annotation", but don't think that matters.
