### PR TITLE
[NETBEANS-3973] Fixed double space before lambda arrow

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/Reformatter.java
@@ -2864,6 +2864,7 @@ public class Reformatter implements ReformatTask {
             if(statements != null)
             accept(COLON);
             else {
+                space();
                 accept(ARROW);
                 caseBody = TreeShims.getBody(node);
                 if (caseBody instanceof StatementTree)
@@ -3468,8 +3469,6 @@ public class Reformatter implements ReformatTask {
                             ? getIndent()
                             : after == 2 //after javadoc comment
                             ? getNewlines(1) + getIndent()
-                            : id == ARROW
-                            ? SPACE
                             : null;
                     if (lastWSToken != null) {
                         if (spaces == null || !spaces.contentEquals(lastWSToken.text()))

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -46,6 +46,7 @@ import org.netbeans.junit.NbTestSuite;
 import org.netbeans.modules.java.JavaDataLoader;
 import org.netbeans.modules.java.source.BootClassPathUtil;
 import org.netbeans.modules.java.source.usages.IndexUtil;
+import org.netbeans.modules.java.ui.FmtOptions;
 import org.netbeans.spi.java.classpath.ClassPathProvider;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.cookies.EditorCookie;
@@ -4830,7 +4831,18 @@ public class FormatingTest extends NbTestCase {
                 + "        java.util.Arrays.asList(args).map((val) -> val.length());\n"
                 + "    }\n"
                 + "}\n";
+        // Testing with wrapping lambda arrow deactivated
         reformat(doc, content, golden);
+
+        final String wrapAfterLambdaArrow = FmtOptions.wrapAfterLambdaArrow;
+        Preferences preferences = MimeLookup.getLookup(JavaTokenId.language().mimeType()).lookup(Preferences.class);
+        preferences.putBoolean(wrapAfterLambdaArrow, true);
+
+        // Testing with wrapping lambda arrow activated
+        reformat(doc, content, golden);
+
+        // Returning the setting to the default value
+        preferences.putBoolean(wrapAfterLambdaArrow, FmtOptions.getDefaultAsBoolean(wrapAfterLambdaArrow));
     }
 
     public void testForNoCondition() throws Exception {


### PR DESCRIPTION
I have undone the change from NETBEANS-3204 and moved it to another visitor, mostly impacting switch case formatting now. All the original tests are green and I added a new test that cover this scenario.