### PR TITLE
[NETBEANS-4328] Make sure JavaFX is recommended but not required on JDK 11+.

### DIFF
--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/ConfigurationPanel.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/ConfigurationPanel.java
@@ -117,7 +117,7 @@ public class ConfigurationPanel extends JPanel {
             
             if (extraModule.isRequiredFor(jdk)) {
                 jCheckBox.setSelected(true);
-                jCheckBox.setEnabled(false);
+//                jCheckBox.setEnabled(false);
                 extrasFilter.add(extraModule);
             }
             jCheckBox.addActionListener(e -> {

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FindComponentModules.java
@@ -299,7 +299,7 @@ public final class FindComponentModules extends Task {
     private void registerExtraDownloadable(FeatureInfo fi, FeatureInfo.ExtraModuleInfo fmi) {
         boolean required = false;
         if (fmi.isRequiredFor(jdk)) {
-            required = true;
+//            required = true;
         }
         if (fi.getExtraModulesRequiredText() != null && fi.getExtraModulesRecommendedText() == null) {
             required = true;

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FoDUpdateUnitProvider.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FoDUpdateUnitProvider.java
@@ -103,7 +103,7 @@ public class FoDUpdateUnitProvider implements UpdateProvider {
                 boolean required = false;
 
                 if (mi.isRequiredFor(jdk)) {
-                    required = true;
+//                    required = true;
                 }
                 if (fi.getExtraModulesRequiredText() != null && fi.getExtraModulesRecommendedText() == null) {
                     required = true;


### PR DESCRIPTION
This is a bare minimum fix to ensure that the user can opt out of nb-javac and JavaFX installation when enabling Java support via Open Project or import settings. This is particularly bad in import settings as it causes a continuous cascade of dialogs on first run. See mention in https://issues.apache.org/jira/browse/NETBEANS-3810

Merging this would (partially?) break the fix for https://issues.apache.org/jira/browse/NETBEANS-2439 in #1612 IMO that triggered what should have been a blocker for 11.3 though.