### PR TITLE
NETBEANS-2082: do not scroll to caret after fold collapse, if caret is s off-screen.

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
@@ -1999,6 +1999,9 @@ public final class EditorCaret implements Caret {
                 if (cbounds != null) {
                     // save relative position of the main caret
                     maybeSaveCaretOffset(cbounds);
+                    if (log) {
+                        LOG.fine("EditorCaret.update: forced:true, savedBounds=" + cbounds + ", relativeOffset=" + lastCaretVisualOffset + "\n"); // NOI18N
+                    }
                 }
             }
             if (!calledFromPaint && !c.isValid() /* && maintainVisible == null */) {
@@ -2025,6 +2028,11 @@ public final class EditorCaret implements Caret {
                         scroll = scrollToLastCaret;
                         scrollToLastCaret = false;
                     }
+                    if (lastCaretVisualOffset == -1) {
+                        // wasn't able to save the visual offset, the caret was already off screen. Do not scroll just because of fold updates.
+                        forceUpdate = false;
+                        c.putClientProperty("editorcaret.updateRetainsVisibleOnce", null); // NOI18N
+                    }
                     if (scroll || forceUpdate) {
                         Rectangle caretBounds;
                         Rectangle oldCaretBounds;
@@ -2034,6 +2042,10 @@ public final class EditorCaret implements Caret {
                         } else {
                             caretBounds = lastCaretItem.getCaretBounds();
                             oldCaretBounds = caretBounds;
+                        }
+                        if (log) {
+                            LOG.fine("EditorCaret.update: caretBounds=" + caretBounds + "\n"); // NOI18N
+                            LOG.fine("EditorCaret.update: oldCaretBounds=" + oldCaretBounds + "\n"); // NOI18N
                         }
                         if (caretBounds != null) {
                             Rectangle scrollBounds = new Rectangle(caretBounds); // Must possibly be cloned upon change


### PR DESCRIPTION
(sorry, hit ENTER prematurely)
This tries to fix [NETBEANS-2082](https://issues.apache.org/jira/browse/NETBEANS-2082), and older [Bugzilla-270972](https://bz.apache.org/netbeans/show_bug.cgi?id=270972) while retaining fix for [Bugzilla-270172](https://bz.apache.org/netbeans/show_bug.cgi?id=270172).

The original fix attempted to provide hint to the Editor infrastructure, to **save caret position** when the fold was collapsed, so it could scroll back the caret into the view, when the caret went off the screen as a result of the view hierarchy redraw.

But there were two issues: 
-  the instruction to `forceUpdate` was sent on **every** fold change, not just the initial one (e.g. on fold expand, too).  This is fixed in `FoldViewFactory.java`.
- And even though it was meant as an instruction to *maintain* the caret visible, the scroll code triggered even though the caret was already off the screen when the folding happened. This is now checked in `EditorCaret.java`.

I retained a few additional LOGs.
