### PR TITLE
[NETBEANS-4343] - remove unused MacroExpanderFactory methods

### DIFF
--- a/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/MacroExpanderFactory.java
+++ b/ide/dlight.nativeexecution/src/org/netbeans/modules/nativeexecution/api/util/MacroExpanderFactory.java
@@ -48,15 +48,6 @@ public final class MacroExpanderFactory {
         return getExpander(execEnv, ExpanderStyle.DEFAULT_STYLE, true);
     }
 
-    public static MacroExpander getExpander(ExecutionEnvironment execEnv, boolean connectIfNeed) {
-        return getExpander(execEnv, ExpanderStyle.DEFAULT_STYLE, connectIfNeed);
-    }
-
-    public static MacroExpander getExpander(
-            ExecutionEnvironment execEnv, ExpanderStyle style) {        
-        return getExpander(execEnv, style, true);
-    }
-
     public static MacroExpander getExpander(
             ExecutionEnvironment execEnv, ExpanderStyle style, boolean connectIfNeed) {
 


### PR DESCRIPTION
I'm trying to cleanup some of the code that deals with native execution. This will be helpful to the CND module code that I'm working on..

Removing these two unused & old methods as there are no consumers and leads to API bloat..

public static MacroExpander getExpander(ExecutionEnvironment execEnv, boolean connectIfNeed)

public static MacroExpander getExpander(ExecutionEnvironment execEnv, ExpanderStyle style)