### PR TITLE
Fix macOS QuickSearch toolbar position

### DIFF
--- a/platform/applemenu/src/org/netbeans/modules/applemenu/layer.xml
+++ b/platform/applemenu/src/org/netbeans/modules/applemenu/layer.xml
@@ -98,7 +98,7 @@
     <!-- quick search enabled for ide in toolbar by default -->
         <folder name="QuickSearch">
             <attr name="displayName" bundlevalue="org.netbeans.modules.applemenu.Bundle#Toolbars/QuickSearch"/>
-            <attr name="position" intvalue="700"/>
+            <attr name="position" intvalue="710"/>
             <file name="org-netbeans-modules-quicksearch-QuickSearchAction.shadow">
                 <attr name="originalFile" stringvalue="Actions/Edit/org-netbeans-modules-quicksearch-QuickSearchAction.instance"/>
                 <attr name="position" intvalue="250"/>


### PR DESCRIPTION
When Netbeans projects is running in macOS using `ant tryme` command, this `WARN` message is logged: `WARNING [org.openide.filesystems.Ordering]: Found same position 700 for both Toolbars/Git and Toolbars/QuickSearch`
Git Toolbar has the same position than QuickSearch toolbar.