### PR TITLE
[NETBEANS-4337] Code Sniffer standard is optional

### DIFF
--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/CodeSniffer.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/CodeSniffer.java
@@ -137,7 +137,7 @@ public final class CodeSniffer {
         assert file.isValid() : "Invalid file given: " + file;
         try {
             Integer result = getExecutable(Bundle.CodeSniffer_analyze(analyzeGroupCounter++), findWorkDir(file))
-                    .additionalParameters(getParameters(ensureStandard(standard), file, noRecursion))
+                    .additionalParameters(getParameters(standard, file, noRecursion))
                     .runAndWait(getDescriptor(), "Running code sniffer..."); // NOI18N
             if (result == null) {
                 return null;
@@ -239,7 +239,8 @@ public final class CodeSniffer {
         Charset encoding = FileEncodingQuery.getEncoding(file);
         List<String> params = new ArrayList<>();
         // NETBEANS-3243 the path of Code Sniffer may have --standard parameter
-        if (!codeSnifferPath.contains(STANDARD_PARAM + "=") // NOI18N
+        if (StringUtils.hasText(standard)
+                && !codeSnifferPath.contains(STANDARD_PARAM + "=") // NOI18N
                 && !codeSnifferPath.contains(STANDARD_PARAM + " ")) { // NOI18N
             // #270987 use --standard
             params.add(String.format(STANDARD_PARAM_FORMAT, standard));
@@ -253,18 +254,6 @@ public final class CodeSniffer {
         }
         params.add(FileUtil.toFile(file).getAbsolutePath());
         return params;
-    }
-
-    private String ensureStandard(String standard) {
-        if (standard != null) {
-            return standard;
-        }
-        List<String> standards = getStandards();
-        if (standards == null) {
-            // fallback
-            return "PEAR"; // NOI18N
-        }
-        return standards.get(0);
     }
 
     private void addIgnoredFiles(List<String> params, FileObject file) {

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/options/AnalysisOptionsValidator.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/options/AnalysisOptionsValidator.java
@@ -73,7 +73,7 @@ public final class AnalysisOptionsValidator {
 
     @NbBundle.Messages("AnalysisOptionsValidator.codeSniffer.standard.empty=Valid code sniffer standard must be set.")
     public AnalysisOptionsValidator validateCodeSnifferStandard(String codeSnifferStandard) {
-        if (!StringUtils.hasText(codeSnifferStandard)) {
+        if (codeSnifferStandard == null) {
             result.addWarning(new ValidationResult.Message("codeSniffer.standard", Bundle.AnalysisOptionsValidator_codeSniffer_standard_empty())); // NOI18N
         }
         return this;

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/CodeSnifferStandardsComboBoxModel.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/ui/CodeSnifferStandardsComboBoxModel.java
@@ -107,8 +107,7 @@ public final class CodeSnifferStandardsComboBoxModel extends AbstractListModel<S
     @CheckForNull
     public String getSelectedStandard() {
         if (selectedStandard == NO_STANDARDS_AVAILABLE
-                || selectedStandard == FETCHING_STANDARDS
-                || selectedStandard.isEmpty()) {
+                || selectedStandard == FETCHING_STANDARDS ) {
             return null;
         }
         return selectedStandard;


### PR DESCRIPTION
Code Sniffer can be run without parameter '--standard'. In that case it is
looking for configuration file in project root.