### PR TITLE
[NETBEANS-4329] - Update eclipselink from 2.5.2 to 2.7.7

### DIFF
--- a/enterprise/websvc.restlib/manifest.mf
+++ b/enterprise/websvc.restlib/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.websvc.restlib/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/websvc/swdp/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.16
+OpenIDE-Module-Specification-Version: 2.17
 OpenIDE-Module-Layer: org/netbeans/modules/websvc/swdp/layer.xml
 AutoUpdate-Show-In-Client: false
 

--- a/enterprise/websvc.restlib/src/org/netbeans/modules/websvc/swdp/swdp.xml
+++ b/enterprise/websvc.restlib/src/org/netbeans/modules/websvc/swdp/swdp.xml
@@ -48,12 +48,12 @@
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/jersey-container-servlet.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/jersey-container-servlet-core.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/jersey-server.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.5.2.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.7.jar!/</resource>
     </volume>
     <properties>
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->

--- a/java/j2ee.eclipselink/build.xml
+++ b/java/j2ee.eclipselink/build.xml
@@ -24,22 +24,22 @@
     <import file="../../nbbuild/templates/projectized.xml"/>
 
     <target name="-check-jpa-doc" depends="projectized.build-init">
-        <available file="build/javax.persistence-2.1.0-doc.zip" property="jpa-doc-available"/>
+        <available file="build/javax.persistence-2.2.1-doc.zip" property="jpa-doc-available"/>
     </target>
 
     <target name="-build-jpa-doc" depends="-check-jpa-doc" unless="jpa-doc-available">
-       <delete dir="build/javax.persistence-2.1.0-sources" />
-       <delete dir="build/javax.persistence-2.1.0-doc" />
-       <delete file="build/javax.persistence-2.1.0-doc.zip" />
-       <unzip dest="build/javax.persistence-2.1.0-sources"
-              src="external/javax.persistence-2.1.0-sources.jar" />
-       <javadoc destdir="build/javax.persistence-2.1.0-doc">
-           <packageset dir="build/javax.persistence-2.1.0-sources" defaultexcludes="yes">
+       <delete dir="build/javax.persistence-2.2.1-sources" />
+       <delete dir="build/javax.persistence-2.2.1-doc" />
+       <delete file="build/javax.persistence-2.2.1-doc.zip" />
+       <unzip dest="build/javax.persistence-2.2.1-sources"
+              src="external/javax.persistence-2.2.1-sources.jar" />
+       <javadoc destdir="build/javax.persistence-2.2.1-doc">
+           <packageset dir="build/javax.persistence-2.2.1-sources" defaultexcludes="yes">
                <include name="javax/persistence/**" />
            </packageset>
        </javadoc>
-       <zip destfile="build/javax.persistence-2.1.0-doc.zip">
-           <zipfileset dir="build/javax.persistence-2.1.0-doc" prefix="docs/"/>
+       <zip destfile="build/javax.persistence-2.2.1-doc.zip">
+           <zipfileset dir="build/javax.persistence-2.2.1-doc" prefix="docs/"/>
        </zip>
     </target>
 

--- a/java/j2ee.eclipselink/external/binaries-list
+++ b/java/j2ee.eclipselink/external/binaries-list
@@ -14,11 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-04C4E53577658440409783942AEE0D37DA0A67F9 org.eclipse.persistence:org.eclipse.persistence.core:2.5.2
-83298D74D26BDDD95C5025AB2A1E545BB5424739 org.eclipse.persistence:org.eclipse.persistence.asm:2.5.2
-189DB51E5A42710F16B5CF880AECC19B2820B0F9 org.eclipse.persistence:org.eclipse.persistence.antlr:2.5.2
-2A54E88F70B488381F837D644A16A2219FB4FD64 org.eclipse.persistence:org.eclipse.persistence.jpa:2.5.2
-29AF1D338CBB76290D1A96F5A6610F1E8C319AE5 org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.5.2
-AF39466383E372E3AB4737F6014ABE0D69470675 org.eclipse.persistence:org.eclipse.persistence.moxy:2.5.2
-5BAB675816DBE0F64BB86004B108BF2A00292358 org.eclipse.persistence:javax.persistence:2.1.0
-DA95A959929234C57B988644696C065D79774FC4 org.eclipse.persistence:javax.persistence:2.1.0:sources
+165FF90EF6904E7A14F84C2C921C4109558C676D org.eclipse.persistence:org.eclipse.persistence.core:2.7.7
+EEA79261168918E4638D11DAC47C80557473F56A org.eclipse.persistence:org.eclipse.persistence.asm:2.7.7
+78712ED5187194106A5563F3DE0539BED69ED8E5 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.7
+CEEA5C43E5A92585846CC7A6F5D9F1E67FAC6B84 org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.7
+B4BCDECDC32C907D04108FE2E39F1CAB3AAAF186 org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.7
+8DED6B5CD72F934DD643A89C1CC792FC4079CAB8 org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.7
+7EA990B062655A52CA5010CF8716FB3FBDE46D2E org.eclipse.persistence:javax.persistence:2.2.1
+865540770A6BB480AFA34A785F765B567D14909B org.eclipse.persistence:javax.persistence:2.2.1:sources

--- a/java/j2ee.eclipselink/external/eclipselink-2.7.7-license.txt
+++ b/java/j2ee.eclipselink/external/eclipselink-2.7.7-license.txt
@@ -1,12 +1,12 @@
 Name: EclipseLink
 Origin: Eclipse
-Version: 2.5.2
+Version: 2.7.7
 Description: The Eclipse Persistence Services Project ( EclipseLink) project.
 License: EPL-v10-eclipselink
 Origin: http://www.eclipse.org/eclipselink/
-Files: org.eclipse.persistence.jpa.modelgen.processor-2.5.2.jar
+Files: javax.persistence-2.2.1-sources.jar, javax.persistence-2.2.1.jar, org.eclipse.persistence.core-2.7.7.jar, org.eclipse.persistence.asm-2.7.7.jar, org.eclipse.persistence.antlr-2.7.7.jar, org.eclipse.persistence.jpa-2.7.7.jar, org.eclipse.persistence.jpa.jpql-2.7.7.jar,org.eclipse.persistence.moxy-2.7.7.jar
 
-Use of EclipseLink version 2.5.2 is governed by the terms of the license below:
+Use of EclipseLink version 2.7.7 is governed by the terms of the license below:
 
 License
 

--- a/java/j2ee.eclipselink/manifest.mf
+++ b/java/j2ee.eclipselink/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module: org.netbeans.modules.j2ee.eclipselink/1
 OpenIDE-Module-Layer: org/netbeans/modules/j2ee/eclipselink/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/j2ee/eclipselink/Bundle.properties
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Specification-Version: 1.40
+OpenIDE-Module-Specification-Version: 1.41

--- a/java/j2ee.eclipselink/nbproject/project.properties
+++ b/java/j2ee.eclipselink/nbproject/project.properties
@@ -17,22 +17,24 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 jnlp.indirect.jars=\
-    modules/ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar,\
-    modules/ext/eclipselink/javax.persistence-2.1.0.jar,\
-    modules/ext/docs/javax.persistence-2.1.0-doc.zip
+    modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.7.jar,\
+    modules/ext/eclipselink/javax.persistence-2.2.1.jar,\
+    modules/ext/docs/javax.persistence-2.2.1-doc.zip
 
-release.external/org.eclipse.persistence.core-2.5.2.jar=modules/ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar
-release.external/org.eclipse.persistence.asm-2.5.2.jar=modules/ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar
-release.external/org.eclipse.persistence.antlr-2.5.2.jar=modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar
-release.external/org.eclipse.persistence.jpa-2.5.2.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar
-release.external/org.eclipse.persistence.jpa.jpql-2.5.2.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar
-release.external/javax.persistence-2.1.0.jar=modules/ext/eclipselink/javax.persistence-2.1.0.jar
-release.build/javax.persistence-2.1.0-doc.zip=modules/ext/docs/javax.persistence-2.1.0-doc.zip
+release.external/org.eclipse.persistence.core-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar
+release.external/org.eclipse.persistence.asm-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar
+release.external/org.eclipse.persistence.antlr-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar
+release.external/org.eclipse.persistence.jpa-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar
+release.external/org.eclipse.persistence.jpa.jpql-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar
+release.external/org.eclipse.persistence.moxy-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.7.jar
+release.external/javax.persistence-2.2.1.jar=modules/ext/eclipselink/javax.persistence-2.2.1.jar
+release.build/javax.persistence-2.2.1-doc.zip=modules/ext/docs/javax.persistence-2.2.1-doc.zip
 
-extra.module.files=modules/ext/docs/javax.persistence-2.1.0-doc.zip
+extra.module.files=modules/ext/docs/javax.persistence-2.2.1-doc.zip

--- a/java/j2ee.eclipselink/nbproject/project.xml
+++ b/java/j2ee.eclipselink/nbproject/project.xml
@@ -30,22 +30,25 @@
                 <subpackages>javax.persistence</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/javax.persistence-2.1.0.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.moxy-2.7.7.jar</runtime-relative-path>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/eclipselink/javax.persistence-2.2.1.jar</runtime-relative-path>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/eclipselink_lib.xml
+++ b/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/eclipselink_lib.xml
@@ -25,30 +25,30 @@
     <localizing-bundle>org.netbeans.modules.j2ee.eclipselink.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.5.2.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/javax.persistence-2.1.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/javax.persistence-2.2.1.jar!/</resource>
     </volume>
     <volume>
         <type>javadoc</type>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/docs/javax.persistence-2.1.0-doc.zip!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/docs/javax.persistence-2.2.1-doc.zip!/</resource>
     </volume>
     <properties>
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->
         <property>
             <name>maven-dependencies</name>
             <value>
-                org.eclipse.persistence:org.eclipse.persistence.core:2.5.2:jar
-                org.eclipse.persistence:org.eclipse.persistence.asm:2.5.2:jar
-                org.eclipse.persistence:org.eclipse.persistence.antlr:2.5.2:jar
-                org.eclipse.persistence:org.eclipse.persistence.jpa:2.5.2:jar
-                org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.5.2:jar
-                org.eclipse.persistence:org.eclipse.persistence.moxy:2.5.2
-                org.eclipse.persistence:javax.persistence:2.1.0:jar
+                org.eclipse.persistence:org.eclipse.persistence.core:2.7.7:jar
+                org.eclipse.persistence:org.eclipse.persistence.asm:2.7.7:jar
+                org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.7:jar
+                org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.7:jar
+                org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.7:jar
+                org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.7:jar
+                org.eclipse.persistence:javax.persistence:2.2.1:jar
             </value>
         </property>
     </properties>

--- a/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/jpa20-persistence.xml
+++ b/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/jpa20-persistence.xml
@@ -25,17 +25,17 @@
     <localizing-bundle>org.netbeans.modules.j2ee.eclipselink.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/javax.persistence-2.1.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/javax.persistence-2.2.1.jar!/</resource>
     </volume>
     <volume>
         <type>javadoc</type>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/docs/javax.persistence-2.1.0-doc.zip!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/docs/javax.persistence-2.2.1-doc.zip!/</resource>
     </volume>
     <properties>
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->
         <property>
             <name>maven-dependencies</name>
-            <value>org.eclipse.persistence:javax.persistence:2.1.0:jar</value>
+            <value>org.eclipse.persistence:javax.persistence:2.2.1:jar</value>
         </property>
     </properties>
 </library>

--- a/java/j2ee.eclipselinkmodelgen/external/binaries-list
+++ b/java/j2ee.eclipselinkmodelgen/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-85A0C541AFE89159B3DD6BC213D8CB95E6FE911B org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.5.2
+B04976CFF167CC9FF4EB84BCEA663CED9477959B org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.7

--- a/java/j2ee.eclipselinkmodelgen/external/eclipselink-2.7.7-license.txt
+++ b/java/j2ee.eclipselinkmodelgen/external/eclipselink-2.7.7-license.txt
@@ -1,12 +1,12 @@
 Name: EclipseLink
 Origin: Eclipse
-Version: 2.5.2
+Version: 2.7.7
 Description: The Eclipse Persistence Services Project ( EclipseLink) project.
 License: EPL-v10-eclipselink
 Origin: http://www.eclipse.org/eclipselink/
-Files: javax.persistence-2.1.0-sources.jar, javax.persistence-2.1.0.jar, org.eclipse.persistence.core-2.5.2.jar, org.eclipse.persistence.asm-2.5.2.jar, org.eclipse.persistence.antlr-2.5.2.jar, org.eclipse.persistence.jpa-2.5.2.jar, org.eclipse.persistence.jpa.jpql-2.5.2.jar,org.eclipse.persistence.moxy-2.5.2.jar
+Files: org.eclipse.persistence.jpa.modelgen.processor-2.7.7.jar
 
-Use of EclipseLink version 2.5.2 is governed by the terms of the license below:
+Use of EclipseLink version 2.7.7 is governed by the terms of the license below:
 
 License
 

--- a/java/j2ee.eclipselinkmodelgen/manifest.mf
+++ b/java/j2ee.eclipselinkmodelgen/manifest.mf
@@ -3,5 +3,5 @@ OpenIDE-Module: org.netbeans.modules.j2ee.eclipselinkmodelgen/1
 OpenIDE-Module-Layer: org/netbeans/modules/j2ee/eclipselinkmodelgen/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/j2ee/eclipselinkmodelgen/Bundle.properties
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Specification-Version: 1.40
+OpenIDE-Module-Specification-Version: 1.41
 

--- a/java/j2ee.eclipselinkmodelgen/nbproject/project.properties
+++ b/java/j2ee.eclipselinkmodelgen/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 jnlp.indirect.jars=\
-    modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.5.2.jar
+    modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.7.jar
 
-release.external/org.eclipse.persistence.jpa.modelgen.processor-2.5.2.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.5.2.jar
+release.external/org.eclipse.persistence.jpa.modelgen.processor-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.7.jar

--- a/java/j2ee.eclipselinkmodelgen/src/org/netbeans/modules/j2ee/eclipselinkmodelgen/eclipselinkmodelgen_lib.xml
+++ b/java/j2ee.eclipselinkmodelgen/src/org/netbeans/modules/j2ee/eclipselinkmodelgen/eclipselinkmodelgen_lib.xml
@@ -25,7 +25,7 @@
     <localizing-bundle>org.netbeans.modules.j2ee.eclipselinkmodelgen.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselinkmodelgen/modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.5.2.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselinkmodelgen/modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.7.jar!/</resource>
     </volume>
     <volume>
         <type>javadoc</type>
@@ -37,7 +37,7 @@
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->
         <property>
             <name>maven-dependencies</name>
-            <value>org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.5.2:jar</value>
+            <value>org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.7:jar</value>
         </property>
     </properties> 
 </library>

--- a/java/j2ee.jpa.refactoring/manifest.mf
+++ b/java/j2ee.jpa.refactoring/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.j2ee.jpa.refactoring
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/j2ee/jpa/refactoring/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.39
+OpenIDE-Module-Specification-Version: 1.40
 AutoUpdate-Show-In-Client: false

--- a/java/j2ee.jpa.refactoring/nbproject/project.properties
+++ b/java/j2ee.jpa.refactoring/nbproject/project.properties
@@ -16,16 +16,16 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 requires.nb.javac=true
 
 test.unit.run.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.1.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.2.1.jar:\
     ${j2eeserver.dir}/modules/ext/jsr88javax.jar:\
     ${masterfs.dir}/modules/org-netbeans-modules-masterfs.jar
 

--- a/java/j2ee.jpa.verification/nbproject/project.properties
+++ b/java/j2ee.jpa.verification/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 requires.nb.javac=true

--- a/java/j2ee.metadata.model.support/manifest.mf
+++ b/java/j2ee.metadata.model.support/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.j2ee.metadata.model.support/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/j2ee/metadata/model/support/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.39
+OpenIDE-Module-Specification-Version: 1.40
 AutoUpdate-Show-In-Client: false

--- a/java/j2ee.metadata.model.support/nbproject/project.properties
+++ b/java/j2ee.metadata.model.support/nbproject/project.properties
@@ -16,14 +16,14 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 requires.nb.javac=true
 
 test.unit.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.1.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.2.1.jar:\
     ${j2ee.core.dir}/modules/ext/javaee6-endorsed/javax.annotation.jar

--- a/java/j2ee.persistence/nbproject/project.properties
+++ b/java/j2ee.persistence/nbproject/project.properties
@@ -16,15 +16,15 @@
 # under the License.
 
 javac.source=1.8
-spec.version.base=1.62.0
+spec.version.base=1.63.0
 
 test.unit.run.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.1.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.2.1.jar:\
     ${j2eeserver.dir}/modules/ext/jsr88javax.jar:\
     ${masterfs.dir}/modules/org-netbeans-modules-masterfs.jar
 

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceCfgProperties.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceCfgProperties.java
@@ -50,7 +50,7 @@ public class PersistenceCfgProperties {
     private final static String[] EL_LOGGER = new String[]{"DefaultLogger", "JavaLogger", "ServerLogger"};//NOI18N
     private final static String[] EL_LOGGER_LEVEL = new String[]{"OFF", "SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", "FINEST", "ALL"};//NOI18N
     private final static String[] EL_TARGET_DATABASE = new String[]{"Access", "Attunity", "Auto", "Cloudscape", "Database", "DB2Mainframe", "DB2", "DB2Z", "DBase", "Derby", "Firebird", "H2", "HANA", "HSQL", "Informix11", "Informix", "JavaDB", "MaxDB", "MySQL", "Oracle10", "Oracle11", "Oracle12", "Oracle18", "Oracle19", "Oracle8", "Oracle9", "Oracle", "Pervasive", "PointBase", "PostgreSQL", "SQLAnywhere", "SQLServer", "Sybase", "Symfoware", "TimesTen7", "TimesTen"};//NOI18N
-    private final static String[] EL_TARGET_SERVER = new String[]{"None", "Glassfish", "JBoss", "Oc4j", "SAPNetWeaver_7_1", "SunAS9Server", "WebLogic_10_", "WebLogic_12", "WebLogic_9", "WebLogic", "WebSphere_6_1", "WebSphere_7", "WebSphere_EJBEmbeddable", "WebSphere_Liberty", "WebSphere"};//NOI18N
+    private final static String[] EL_TARGET_SERVER = new String[]{"None", "Glassfish", "JBoss", "Oc4j", "SAPNetWeaver_7_1", "SunAS9Server", "WebLogic_10", "WebLogic_12", "WebLogic_9", "WebLogic", "WebSphere_6_1", "WebSphere_7", "WebSphere_EJBEmbeddable", "WebSphere_Liberty", "WebSphere"};//NOI18N
     private final static String[] EL_DDL_GEN_MODE = new String[]{"both", "database", "sql-script"};//NOI18N
     
     private static final Map<Provider, Map<String, String[]>> possiblePropertyValues = new HashMap<Provider, Map<String, String[]>>();

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceCfgProperties.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/unit/PersistenceCfgProperties.java
@@ -49,8 +49,8 @@ public class PersistenceCfgProperties {
     private final static String[] EL_EXCLUSIVE_CON_MODE = new String[]{"Transactional", "Isolated", "Always"};//NOI18N
     private final static String[] EL_LOGGER = new String[]{"DefaultLogger", "JavaLogger", "ServerLogger"};//NOI18N
     private final static String[] EL_LOGGER_LEVEL = new String[]{"OFF", "SEVERE", "WARNING", "INFO", "CONFIG", "FINE", "FINER", "FINEST", "ALL"};//NOI18N
-    private final static String[] EL_TARGET_DATABASE = new String[]{"Attunity", "Auto", "Cloudscape", "Database", "DB2", "DB2Mainframe", "DBase", "Derby", "HSQL", "Informix", "JavaDB", "MySQL", "Oracle", "PointBase", "PostgreSQL", "SQLAnywhere", "SQLServer", "Sybase", "TimesTen"};//NOI18N
-    private final static String[] EL_TARGET_SERVER = new String[]{"None", "WebLogic", "Note", "WebLogic_9", "WebLogic_10", "OC4J", "SunAS9", "Note", "WebSphere", "WebSphere_6_1", "JBoss", "NetWeaver_7_1"};//NOI18N
+    private final static String[] EL_TARGET_DATABASE = new String[]{"Access", "Attunity", "Auto", "Cloudscape", "Database", "DB2Mainframe", "DB2", "DB2Z", "DBase", "Derby", "Firebird", "H2", "HANA", "HSQL", "Informix11", "Informix", "JavaDB", "MaxDB", "MySQL", "Oracle10", "Oracle11", "Oracle12", "Oracle18", "Oracle19", "Oracle8", "Oracle9", "Oracle", "Pervasive", "PointBase", "PostgreSQL", "SQLAnywhere", "SQLServer", "Sybase", "Symfoware", "TimesTen7", "TimesTen"};//NOI18N
+    private final static String[] EL_TARGET_SERVER = new String[]{"None", "Glassfish", "JBoss", "Oc4j", "SAPNetWeaver_7_1", "SunAS9Server", "WebLogic_10_", "WebLogic_12", "WebLogic_9", "WebLogic", "WebSphere_6_1", "WebSphere_7", "WebSphere_EJBEmbeddable", "WebSphere_Liberty", "WebSphere"};//NOI18N
     private final static String[] EL_DDL_GEN_MODE = new String[]{"both", "database", "sql-script"};//NOI18N
     
     private static final Map<Provider, Map<String, String[]>> possiblePropertyValues = new HashMap<Provider, Map<String, String[]>>();

--- a/java/j2ee.persistenceapi/nbproject/project.properties
+++ b/java/j2ee.persistenceapi/nbproject/project.properties
@@ -22,14 +22,14 @@ javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 requires.nb.javac=true
 
-spec.version.base=1.44.0
+spec.version.base=1.45.0
 test.unit.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.5.2.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.1.0.jar
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.2.1.jar
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/nbbuild/licenses/EPL-v10-eclipselink
+++ b/nbbuild/licenses/EPL-v10-eclipselink
@@ -1,4 +1,4 @@
-Use of EclipseLink version 2.5.2 is governed by the terms of the license below:
+Use of EclipseLink version 2.7.7 is governed by the terms of the license below:
 
 License
 


### PR DESCRIPTION
Notes for NetBeans:
- Add 17 entries to 'eclipselink.target-database' as per [documentation](https://www.eclipse.org/eclipselink/api/2.7/org/eclipse/persistence/platform/database/package-summary.html)
- Add 3 entries to 'eclipselink.target-server' as per [documentation](https://www.eclipse.org/eclipselink/api/2.7/org/eclipse/persistence/platform/server/ServerPlatform.html)

This is just an update to the eclipselink library, this will not provide support for JPA 2.2, I am working on a different Issue/PR for that matter.

Notes for the library:
- Java EE 8 integration
- Bean Validation support in MOXy
- Java API for JSON Processing (JSR-353) support in MOXy
- JPA-RS Enhancements (Pagination, Options, Versions, ...)
- Redesign of type property in JSON processing
- Pluggable Serializers
- JGroups Support
- Substantial number of bug fixes and enhancements
- Certified support for:
  - Java Persistence (JPA) 2.2 - JSR 338
  - Java Architecture for XML Binding (JAXB) 2.3 - JSR 222
  - Service Data Objects (SDO) 2.1.1 - JSR 235
  - Java API for JSON Processing (JSON-P) 1.0 - JSR 353
- Deprecated Functionality: None
- Known Issues
  - When running EclipseLink 2.7 in Glassfish 4.0, you must specify a valid datasource 
    in the persistence.xml through either the jta-data-source or non-jta-data-source tags.
  - Java hotspot compiler may crash when compiling 
    org.eclipse.persistence.internal.sessions.CommitManager::commitChangedObjectsForClassWithChangeSet 
    As a workaround, execute java with 
    -XX:CompileCommand=exclude,org/eclipse/persistence/internal/sessions/CommitManager,commitChangedObjectsForClassWithChangeSet 
    command line option for JIT compiler.


[EclipseLink Web Page](https://www.eclipse.org/eclipselink/)
[EclipseLink Release Notes](https://www.eclipse.org/eclipselink/releases/2.7.php)