### PR TITLE
[NETBEANS-4356] Code Completion must check also superclass/superinter…

### DIFF
--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -3691,7 +3691,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
                     et = (ExecutableType) asMemberOf(e, actualType, types);
                     if (addCast && itemFactory instanceof TypeCastableItemFactory
                             && !types.isSubtype(type, e.getEnclosingElement().asType())
-                            && type.getKind() == TypeKind.DECLARED && !eu.alreadyDefinedIn(e.getSimpleName(), et, (TypeElement)((DeclaredType)type).asElement())) {
+                            && type.getKind() == TypeKind.DECLARED && !hasBaseMethod(elements, (DeclaredType) type, (ExecutableElement) e)) {
                         results.add(((TypeCastableItemFactory<T>)itemFactory).createTypeCastableExecutableItem(env.getController(), (ExecutableElement) e, et, actualType, anchorOffset, autoImport ? env.getReferencesCount() : null, typeElem != e.getEnclosingElement(), elements.isDeprecated(e), inImport, env.addSemicolon(), isOfSmartType(env, getCorrectedReturnType(env, et, (ExecutableElement) e, actualType), smartTypes), env.assignToVarPos(), false));
                     } else {
                         results.add(itemFactory.createExecutableItem(env.getController(), (ExecutableElement) e, et, anchorOffset, autoImport ? env.getReferencesCount() : null, typeElem != e.getEnclosingElement(), elements.isDeprecated(e), inImport, env.addSemicolon(), isOfSmartType(env, getCorrectedReturnType(env, et, (ExecutableElement) e, actualType), smartTypes), env.assignToVarPos(), false));
@@ -3720,6 +3720,17 @@ public final class JavaCompletionTask<T> extends BaseTask {
         if (!isStatic && nestedClassSeen[0]) {
             addKeyword(env, NEW_KEYWORD, SPACE, false);
         }
+    }
+
+    private boolean hasBaseMethod(Elements elements, DeclaredType type, ExecutableElement invoked) {
+        TypeElement clazz = (TypeElement) type.asElement();
+        for (ExecutableElement existing : ElementFilter.methodsIn(elements.getAllMembers(clazz))) {
+            if (existing.getSimpleName().equals(invoked.getSimpleName()) &&
+                elements.overrides(invoked, existing, clazz)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void addThisOrSuperConstructor(final Env env, final TypeMirror type, final Element elem, final String name, final ExecutableElement toExclude) throws IOException {

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/completion/JavaCompletionProviderTest/1.8/testCast1.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/completion/JavaCompletionProviderTest/1.8/testCast1.pass
@@ -1,0 +1,5 @@
+package test;
+public class Test {
+    private t(Object o) {
+        if (o instanceof String) {
+            ((String) o).length()

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/completion/JavaCompletionProviderTest/1.8/testCast2.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/completion/JavaCompletionProviderTest/1.8/testCast2.pass
@@ -1,0 +1,5 @@
+package test;
+public class Test {
+    private t(Number n) {
+        if (n instanceof Integer) {
+            n.intValue()

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/completion/JavaCompletionProviderTest/1.8/testCast3.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/completion/JavaCompletionProviderTest/1.8/testCast3.pass
@@ -1,0 +1,13 @@
+package test;
+public class Test {
+    public interface Base {
+         public void test() { }
+    }
+    public interface Int extends Base {
+    }
+    public static class Impl implements Int {
+         public void test() { }
+    }
+    private t(Int b) {
+        if (b instanceof Impl) {
+            b.test();

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/completion/JavaCompletionProviderTest/1.8/testCast4.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/completion/JavaCompletionProviderTest/1.8/testCast4.pass
@@ -1,0 +1,13 @@
+package test;
+public class Test {
+    public interface Base {
+         public void test() { }
+    }
+    public interface Int extends Base {
+    }
+    public static class Impl implements Int {
+         public void test() { }
+    }
+    private t(Base b) {
+        if (b instanceof Impl) {
+            b.test();

--- a/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/completion/CompletionTestBase.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/completion/CompletionTestBase.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.editor.completion;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.Writer;
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +47,10 @@ import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.xml.EntityCatalog;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 /**
  *
@@ -118,4 +123,19 @@ public class CompletionTestBase extends CompletionTestBaseBase {
         LifecycleManager.getDefault().saveAll();
     }
 
+    @ServiceProvider(service=EntityCatalog.class)
+    public static final class TestEntityCatalogImpl extends EntityCatalog {
+
+        @Override
+        public InputSource resolveEntity(String publicID, String systemID) throws SAXException, IOException {
+            switch (publicID) {
+                case "-//NetBeans//DTD Editor Fonts and Colors settings 1.1//EN":
+                    return new InputSource(TestEntityCatalogImpl.class.getResourceAsStream("/org/netbeans/modules/editor/settings/storage/fontscolors/EditorFontsColors-1_1.dtd"));
+                case "-//NetBeans//DTD Editor Code Templates settings 1.0//EN":
+                    return new InputSource(TestEntityCatalogImpl.class.getResourceAsStream("/org/netbeans/lib/editor/codetemplates/storage/EditorCodeTemplates-1_0.dtd"));
+            }
+            return null;
+        }
+
+    }
 }

--- a/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/completion/JavaCompletionItemPerformTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/completion/JavaCompletionItemPerformTest.java
@@ -36,4 +36,66 @@ public class JavaCompletionItemPerformTest extends CompletionTestBase {
     public void testAnnotation() throws Exception {
         performTest("Annotation", 27, "Se", "Set", "testAnnotation.pass2");
     }
+
+    public void testCast1() throws Exception {
+        performTest("Empty", 0,
+                    "package test;\n" +
+                    "public class Test {\n" +
+                    "    private t(Object o) {\n" +
+                    "        if (o instanceof String) {\n" +
+                    "            o.len",
+                    "length",
+                    "testCast1.pass");
+    }
+
+    public void testCast2() throws Exception {
+        performTest("Empty", 0,
+                    "package test;\n" +
+                    "public class Test {\n" +
+                    "    private t(Number n) {\n" +
+                    "        if (n instanceof Integer) {\n" +
+                    "            n.in",
+                    "intValue",
+                    "testCast2.pass");
+    }
+
+    public void testCast3() throws Exception {
+        //calling an overridden method
+        performTest("Empty", 0,
+                    "package test;\n" +
+                    "public class Test {\n" +
+                    "    public interface Base {\n" +
+                    "         public void test() { }\n" +
+                    "    }\n" +
+                    "    public interface Int extends Base {\n" +
+                    "    }\n" +
+                    "    public static class Impl implements Int {\n" +
+                    "         public void test() { }\n" +
+                    "    }\n" +
+                    "    private t(Int b) {\n" +
+                    "        if (b instanceof Impl) {\n" +
+                    "            b.tes",
+                    "test",
+                    "testCast3.pass");
+    }
+
+    public void testCast4() throws Exception {
+        //calling an overridden method
+        performTest("Empty", 0,
+                    "package test;\n" +
+                    "public class Test {\n" +
+                    "    public interface Base {\n" +
+                    "         public void test() { }\n" +
+                    "    }\n" +
+                    "    public interface Int extends Base {\n" +
+                    "    }\n" +
+                    "    public static class Impl implements Int {\n" +
+                    "         public void test() { }\n" +
+                    "    }\n" +
+                    "    private t(Base b) {\n" +
+                    "        if (b instanceof Impl) {\n" +
+                    "            b.tes",
+                    "test",
+                    "testCast4.pass");
+    }
 }


### PR DESCRIPTION
…face methods when determining if cast is required.

Consider code like:
```package test;
public class Test {
    public interface Base {
        public void test() { }
    }
    public interface Int extends Base {
    }
    public static class Impl implements Int {
         public void test() { }
    }
    private t(Int b) {
        if (b instanceof Impl) {
            b.tes",
```

And invoke code completion, and choose "test()". The code completion then needs to determine if a cast of "b" to "Impl" is needed of not. So it will look into the type of "b", which is "Int", to see if "test()" is declared there. But it is not, and so the cast will be generated, despite the method being declared in a supertype.

I believe it should look not only at methods declared directly in "Int", but on all members of "Int", even those that are inherited. Which is what this patch tries to do.
