### PR TITLE
[NETBEANS-4367] Properly handle default_cachedir in platform application launcher script

### DIFF
--- a/harness/apisupport.harness/release/launchers/app.sh
+++ b/harness/apisupport.harness/release/launchers/app.sh
@@ -77,6 +77,8 @@ while [ $# -gt 0 ] ; do
     shift
 done
 
+cachedir="${default_cachedir}"
+
 if [ -f "${userdir}/etc/$APPNAME".conf ] ; then
     . "${userdir}/etc/$APPNAME".conf
 fi
@@ -125,6 +127,7 @@ case "`uname`" in
             '"-J-Xdock:icon=$progdir/../../$APPNAME.icns"' \
             --clusters '"$clusters"' \
             --userdir '"${userdir}"' \
+            --cachedir '"${cachedir}"' \
             ${default_options} \
             "$args"
         ;;
@@ -139,6 +142,7 @@ case "`uname`" in
             --jdkhome '"$jdkhome"' \
             --clusters '"$clusters"' \
             --userdir '"${userdir}"' \
+            --cachedir '"${cachedir}"' \
             ${default_options} \
             "$args"
        exit 1


### PR DESCRIPTION
Fix the platform application launcher script (for MasOS/Linux) to properly take the default_cachedir setting into account.

I encountered this problem while working on my own NetBeans Platform application, and fixed it a while back with the patch in this PR. Today, another NetBeans Platform developer reported the same problem on the mailing list.

One downside of this patch is that platform applications which encountered the problem before may now have their cache directory changed upon upgrade. Since the cache directory is considered a temporary directory which can be freely deleted at any time, this should not cause problems, other than the fact that the old cache directory may now linger around and take up disk space.

This patch does not impact the launcher script for the IDE (where the bug is not present), only that of NetBeans platform applications which use the default launcher script which is included in the "bin" directory upon build. Also note that the launcher script is used only on MacOS and Linux, but not on Windows (where a separate .exe launcher is used instead).