### PR TITLE
[NETBEANS-4368] Fix test file navigation dialog

### DIFF
--- a/php/php.project/src/org/netbeans/modules/php/project/ui/actions/tests/GoToTest.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/actions/tests/GoToTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.php.project.ui.actions.tests;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +54,14 @@ import org.openide.util.RequestProcessor;
 public class GoToTest implements TestLocator {
     private static final Logger LOGGER = Logger.getLogger(GoToTest.class.getName());
     private static final RequestProcessor RP = new RequestProcessor(GoToTest.class.getName(), 2);
+
+    private static class FileObjectComparator implements Comparator<FileObject> {
+        @Override
+        public int compare(FileObject fo1, FileObject fo2) {
+            return fo1.getPath().compareTo(fo2.getPath());
+        }
+    }
+    static final Comparator<FileObject> FILE_OBJECT_COMAPARTOR = new FileObjectComparator();
 
     public GoToTest() {
     }
@@ -174,6 +183,7 @@ public class GoToTest implements TestLocator {
         for (Locations.Offset location : phpFiles.values()) {
             files.add(location.getFile());
         }
+        files.sort(FILE_OBJECT_COMAPARTOR);
         final List<FileObject> sourceRootsCopy = new CopyOnWriteArrayList<>(sourceRoots);
         final List<FileObject> filesCopy = new CopyOnWriteArrayList<>(files);
         FileObject selected = Mutex.EVENT.readAccess(new Mutex.Action<FileObject>() {

--- a/php/php.project/src/org/netbeans/modules/php/project/ui/actions/tests/SelectFilePanel.form
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/actions/tests/SelectFilePanel.form
@@ -50,10 +50,10 @@
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Component id="selectFileLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="selectFileScrollPane" min="-2" pref="85" max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <Component id="selectFileScrollPane" pref="85" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/php/php.project/src/org/netbeans/modules/php/project/ui/actions/tests/SelectFilePanel.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/actions/tests/SelectFilePanel.java
@@ -133,7 +133,7 @@ public final class SelectFilePanel extends JPanel {
 
         selectFileLabel = new JLabel();
         selectFileScrollPane = new JScrollPane();
-        selectFileList = new JList<FileObject>();
+        selectFileList = new JList<>();
 
         selectFileLabel.setLabelFor(selectFileList);
         Mnemonics.setLocalizedText(selectFileLabel, NbBundle.getMessage(SelectFilePanel.class, "SelectFilePanel.selectFileLabel.text")); // NOI18N
@@ -143,8 +143,7 @@ public final class SelectFilePanel extends JPanel {
 
         GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(Alignment.LEADING)
@@ -152,13 +151,12 @@ public final class SelectFilePanel extends JPanel {
                     .addComponent(selectFileLabel))
                 .addContainerGap())
         );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setVerticalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                .addContainerGap()
                 .addComponent(selectFileLabel)
                 .addPreferredGap(ComponentPlacement.RELATED)
-                .addComponent(selectFileScrollPane, GroupLayout.PREFERRED_SIZE, 85, GroupLayout.PREFERRED_SIZE))
+                .addComponent(selectFileScrollPane, GroupLayout.DEFAULT_SIZE, 85, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 


### PR DESCRIPTION
Fixes resizing of test file selection when navigating to test file.
Files are sorted by path.

Before:
![before](https://user-images.githubusercontent.com/4249184/82832837-97709700-9ebc-11ea-91ed-e30af476643c.png)

After:
![after](https://user-images.githubusercontent.com/4249184/82832851-9f303b80-9ebc-11ea-9305-57941ec2ca3f.png)
