### PR TITLE
[NETBEANS-3858] Checking if the iterator has a next element, before m…

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ParameterNameProviderImpl.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/ParameterNameProviderImpl.java
@@ -208,7 +208,7 @@ public class ParameterNameProviderImpl {
 
     static void capCache(LinkedHashMap<String, ?> map) {
         Iterator<String> it = map.keySet().iterator();
-        while (map.size() > MAX_CACHE_SIZE) {
+        while (map.size() > MAX_CACHE_SIZE && it.hasNext()) {
             it.next();
             it.remove();
         }


### PR DESCRIPTION
…oving to it.

This is an attempt to alleviate https://issues.apache.org/jira/browse/NETBEANS-3858. I am not sure what is causing the issue there, but this patch will simply call hasNext() before calling next().

I guess the issue (as some other issues with the class) is that it was not expected the class would be used from multiple threads, but it is. So, for the next version, I'll try to rewrite the cache to be thread safe. But this is a safe approach, which is likely to help, which we can use for NetBeans 12.0, if the RM decides so.