### PR TITLE
[NETBEANS-4066] Fix overshooting text in editor tabs on HiDPI displays

### DIFF
--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractWinEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractWinEditorTabDisplayerUI.java
@@ -48,7 +48,7 @@ abstract class AbstractWinEditorTabDisplayerUI extends BasicScrollingTabDisplaye
     @Override
     public Dimension getPreferredSize(JComponent c) {
         int prefHeight = 22;
-        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics(c);
         if (g != null) {
             FontMetrics fm = g.getFontMetrics(displayer.getFont());
             Insets ins = getTabAreaInsets();

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabDisplayerUI.java
@@ -100,7 +100,7 @@ public class AquaEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
         int prefHeight = 28;
         //Never call getGraphics() on the control, it resets in-process
         //painting on OS-X 1.4.1 and triggers gratuitous repaints
-        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics(c);
         if (g != null) {
             FontMetrics fm = g.getFontMetrics(displayer.getFont());
             Insets ins = getTabAreaInsets();

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GtkEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/GtkEditorTabDisplayerUI.java
@@ -76,7 +76,7 @@ public final class GtkEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI 
 
     public Dimension getPreferredSize(JComponent c) {
         int prefHeight = 28;
-        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics(c);
         if (g != null) {
             FontMetrics fm = g.getFontMetrics(displayer.getFont());
             Insets ins = getTabAreaInsets();

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/MetalEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/MetalEditorTabDisplayerUI.java
@@ -70,7 +70,7 @@ public final class MetalEditorTabDisplayerUI extends BasicScrollingTabDisplayerU
     
     public Dimension getPreferredSize(JComponent c) {
         int prefHeight = 28;
-        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics(c);
         if (g != null) {
             FontMetrics fm = g.getFontMetrics(displayer.getFont());
             Insets ins = getTabAreaInsets();

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NimbusEditorTabDisplayerUI.java
@@ -77,7 +77,7 @@ public final class NimbusEditorTabDisplayerUI extends BasicScrollingTabDisplayer
 
     public Dimension getPreferredSize(JComponent c) {
         int prefHeight = 28;
-        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics(c);
         if (g != null) {
             FontMetrics fm = g.getFontMetrics(displayer.getFont());
             Insets ins = getTabAreaInsets();

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NonStretchingViewTabLayoutModel.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/NonStretchingViewTabLayoutModel.java
@@ -166,7 +166,7 @@ final class NonStretchingViewTabLayoutModel implements TabLayoutModel {
         for (int i = 0; i < size; i++) {
             tabIndex = i;
             curText = model.getTab(tabIndex).getText();
-            curX += HtmlRenderer.renderString(curText, BasicScrollingTabDisplayerUI.getOffscreenGraphics(), 0, 0,
+            curX += HtmlRenderer.renderString(curText, BasicScrollingTabDisplayerUI.getOffscreenGraphics(tabDisplayer), 0, 0,
                                        Integer.MAX_VALUE,
                                        Integer.MAX_VALUE, tabDisplayer.getFont(),
                                        Color.BLACK, HtmlRenderer.STYLE_TRUNCATE,

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ToolbarTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ToolbarTabDisplayerUI.java
@@ -287,7 +287,7 @@ public class ToolbarTabDisplayerUI extends AbstractTabDisplayerUI {
         public Dimension getPreferredSize() {
             Dimension result = super.getPreferredSize();
             String s = doGetText();
-            int w = DefaultTabLayoutModel.textWidth(s, getFont());
+            int w = DefaultTabLayoutModel.textWidth(s, getFont(), this);
             result.width += w;
             // as we cannot get the button small enough using the margin and border...
             if (Utilities.isMac()) {
@@ -310,7 +310,7 @@ public class ToolbarTabDisplayerUI extends AbstractTabDisplayerUI {
             int w = getWidth() - (ins.left + ins.right);
             int h = getHeight();
             
-            int txtW = DefaultTabLayoutModel.textWidth(s, getFont());
+            int txtW = DefaultTabLayoutModel.textWidth(s, getFont(), this);
             if (txtW < w) {
                 x += (w / 2) - (txtW / 2);
             }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ViewTabLayoutModel2.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ViewTabLayoutModel2.java
@@ -178,7 +178,7 @@ final class ViewTabLayoutModel2 implements TabLayoutModel, ChangeListener {
         for (int i = 0; i < size; i++) {
             tabIndex = pos2Index.get(i);
             curText = model.getTab(tabIndex).getText();
-            curX += HtmlRenderer.renderString(curText, BasicScrollingTabDisplayerUI.getOffscreenGraphics(), 0, 0,
+            curX += HtmlRenderer.renderString(curText, BasicScrollingTabDisplayerUI.getOffscreenGraphics(displayer), 0, 0,
                                        Integer.MAX_VALUE,
                                        Integer.MAX_VALUE, displayer.getFont(),
                                        Color.BLACK, HtmlRenderer.STYLE_TRUNCATE,

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinClassicEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinClassicEditorTabDisplayerUI.java
@@ -85,7 +85,7 @@ public final class WinClassicEditorTabDisplayerUI extends BasicScrollingTabDispl
 
     public Dimension getPreferredSize(JComponent c) {
         int prefHeight = 28;
-        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics(c);
         if (g != null) {
             FontMetrics fm = g.getFontMetrics(displayer.getFont());
             Insets ins = getTabAreaInsets();

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinXPEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinXPEditorTabDisplayerUI.java
@@ -55,7 +55,7 @@ public final class WinXPEditorTabDisplayerUI extends BasicScrollingTabDisplayerU
     @Override
     public Dimension getPreferredSize(JComponent c) {
         int prefHeight = 24;
-        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics(c);
         if (g != null) {
             FontMetrics fm = g.getFontMetrics(displayer.getFont());
             Insets ins = getTabAreaInsets();


### PR DESCRIPTION
This PR fixes the problem shown in the editor tab in the screeenshot; on some HiDPI scaling factors (150% in this case), the text in the tab may be incorrectly measured. The bug is fixed by making sure that the right FontRenderContext, with HiDPI scaling taken into account, is used when painting on a particular monitor.

![Inaccurate tab text mesaurement](https://user-images.githubusercontent.com/886243/83835474-da055100-a6be-11ea-8d41-875410104823.png)

See also https://github.com/apache/netbeans/pull/2025 , which fixed a similar problem in the org.openide.awt.HtmlRenderer class.