### PR TITLE
Do not blindly cast to IndexedClassDecl while reassigning anonymous c…

### DIFF
--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBParserFactory.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBParserFactory.java
@@ -275,7 +275,7 @@ public class NBParserFactory extends ParserFactory {
 
         @Override
         public void visitClassDef(JCClassDecl tree) {
-            if (tree.name == names.empty) {
+            if (tree.name == names.empty && tree instanceof IndexedClassDecl) {
                 ((IndexedClassDecl) tree).index = this.anonScopes.peek().assignNumber();
             }
             newAnonScope(tree.name);
@@ -284,7 +284,7 @@ public class NBParserFactory extends ParserFactory {
             } finally {
                 this.anonScopes.pop();
             }
-            if (!this.anonScopes.isEmpty() && this.anonScopes.peek().localClass && tree.name != names.empty) {
+            if (!this.anonScopes.isEmpty() && this.anonScopes.peek().localClass && tree.name != names.empty && tree instanceof IndexedClassDecl) {
                 ((IndexedClassDecl) tree).index = this.anonScopes.peek().assignLocalNumber(tree.name);
             }
         }


### PR DESCRIPTION
…lass numbers, as the class decl may not be IndexedClassDecl.

While running on current JDK 15 without nb-javac, the parser produces ordinary JCClassDecl, not IndexedClassDecl, and then the casts to IndexedClassDecl fail, and various tests (like code completion tests) fail due to this.

Eventually, we probably want to get rid of IndexedClassDecls altogether, but more testing will be needed for that.

Added also a related test to partial reparse test, to verify things work reasonably during partial reparse.
