### PR TITLE
[NETBEANS-2623] Added Composer actions to update autoloader and run script

### DIFF
--- a/php/php.composer/src/org/netbeans/modules/php/composer/commands/Composer.java
+++ b/php/php.composer/src/org/netbeans/modules/php/composer/commands/Composer.java
@@ -72,7 +72,9 @@ public final class Composer {
     private static final String INIT_COMMAND = "init"; // NOI18N
     private static final String INSTALL_COMMAND = "install"; // NOI18N
     private static final String UPDATE_COMMAND = "update"; // NOI18N
+    private static final String UPDATE_AUTOLOADER_COMMAND = "dump-autoload"; // NOI18N
     private static final String REQUIRE_COMMAND = "require"; // NOI18N
+    private static final String RUN_SCRIPT_COMMAND = "run-script"; // NOI18N
     private static final String VALIDATE_COMMAND = "validate"; // NOI18N
     private static final String SELF_UPDATE_COMMAND = "self-update"; // NOI18N
     private static final String SEARCH_COMMAND = "search"; // NOI18N
@@ -221,6 +223,20 @@ public final class Composer {
         return runCommand(phpModule, UPDATE_COMMAND, Collections.singletonList(NO_DEV_PARAM));
     }
 
+    public Future<Integer> updateAutoloader(PhpModule phpModule) {
+        assert phpModule != null;
+        return runCommand(phpModule, UPDATE_AUTOLOADER_COMMAND);
+    }
+
+    public Future<Integer> updateAutoloaderDev(PhpModule phpModule) {
+        return updateAutoloader(phpModule);
+    }
+
+    public Future<Integer> updateAutoloaderNoDev(PhpModule phpModule) {
+        assert phpModule != null;
+        return runCommand(phpModule, UPDATE_AUTOLOADER_COMMAND, Collections.singletonList(NO_DEV_PARAM));
+    }
+
     public Future<Integer> require(PhpModule phpModule, String... packages) {
         assert phpModule != null;
         return runCommand(phpModule, REQUIRE_COMMAND, Arrays.asList(packages));
@@ -232,6 +248,11 @@ public final class Composer {
         params.add(DEV_PARAM);
         params.addAll(Arrays.asList(packages));
         return runCommand(phpModule, REQUIRE_COMMAND, params);
+    }
+
+    public Future<Integer> runScript(PhpModule phpModule, String scriptName) {
+        assert phpModule != null;
+        return runCommand(phpModule, RUN_SCRIPT_COMMAND, Collections.singletonList(scriptName));
     }
 
     public Future<Integer> validate(PhpModule phpModule) {

--- a/php/php.composer/src/org/netbeans/modules/php/composer/files/ComposerJson.java
+++ b/php/php.composer/src/org/netbeans/modules/php/composer/files/ComposerJson.java
@@ -20,8 +20,10 @@ package org.netbeans.modules.php.composer.files;
 
 import java.beans.PropertyChangeListener;
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NullAllowed;
@@ -39,6 +41,7 @@ public final class ComposerJson {
     private static final String FIELD_REQUIRE_DEV = "require-dev"; // NOI18N
     private static final String FIELD_CONFIG = "config"; // NOI18N
     private static final String FIELD_VENDOR_DIR = "vendor-dir"; // NOI18N
+    private static final String FIELD_SCRIPTS = "scripts"; // NOI18N
     // default values
     static final String DEFAULT_VENDOR_DIR = "vendor"; // NOI18N
 
@@ -73,6 +76,14 @@ public final class ComposerJson {
             vendorDir = DEFAULT_VENDOR_DIR;
         }
         return new File(getFile().getParentFile(), vendorDir);
+    }
+
+    public Set<String> getScripts() {
+        Map<String, Object> scripts = composerJson.getContentValue(Map.class, FIELD_SCRIPTS);
+        if (scripts == null) {
+            return Collections.emptySet();
+        }
+        return scripts.keySet();
     }
 
     public void addPropertyChangeListener(PropertyChangeListener composerJsonListener) {

--- a/php/php.composer/src/org/netbeans/modules/php/composer/ui/actions/ComposerActionsFactory.java
+++ b/php/php.composer/src/org/netbeans/modules/php/composer/ui/actions/ComposerActionsFactory.java
@@ -75,6 +75,8 @@ public final class ComposerActionsFactory extends AbstractAction implements Pres
             add(new InstallNoDevAction());
             add(new UpdateDevAction());
             add(new UpdateNoDevAction());
+            add(new UpdateAutoloaderDevAction());
+            add(new UpdateAutoloaderNoDevAction());
             add(new ValidateAction());
             addSeparator();
             add(new SelfUpdateAction());

--- a/php/php.composer/src/org/netbeans/modules/php/composer/ui/actions/ComposerScriptsAction.java
+++ b/php/php.composer/src/org/netbeans/modules/php/composer/ui/actions/ComposerScriptsAction.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.composer.ui.actions;
+
+import java.awt.event.ActionEvent;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.php.api.executable.InvalidPhpExecutableException;
+import org.netbeans.modules.php.api.phpmodule.PhpModule;
+import org.netbeans.modules.php.composer.commands.Composer;
+import org.netbeans.modules.php.composer.files.ComposerJson;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.awt.Actions;
+import org.openide.awt.DynamicMenuContent;
+import org.openide.util.ContextAwareAction;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
+import org.openide.util.actions.Presenter;
+
+@ActionID(id = "org.netbeans.modules.php.composer.ui.actions.ComposerScriptsAction", category = "Project")
+@ActionRegistration(displayName = "#ComposerScriptsAction.name", lazy = false)
+@ActionReference(path = "Projects/org-netbeans-modules-php-project/Actions", position = 1051)
+@NbBundle.Messages("ComposerScriptsAction.name=Composer Scripts")
+public class ComposerScriptsAction extends AbstractAction implements ContextAwareAction, Presenter.Popup {
+
+    private static final long serialVersionUID = -5103436278063173440L;
+
+    @NullAllowed
+    final Project project;
+    final List<String> scripts = new CopyOnWriteArrayList<>();
+
+    public ComposerScriptsAction() {
+        this(null, null);
+    }
+
+    public ComposerScriptsAction(Project project, Collection<String> scripts) {
+        this.project = project;
+        if (scripts != null) {
+            this.scripts.addAll(scripts);
+        }
+        setEnabled(project != null);
+        putValue(DynamicMenuContent.HIDE_WHEN_DISABLED, true);
+        // hide this action from Tools > Keymap
+        putValue(Action.NAME, ""); // NOI18N
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        assert false;
+    }
+
+    @Override
+    public Action createContextAwareInstance(Lookup context) {
+        Project contextProject = context.lookup(Project.class);
+        if (contextProject == null) {
+            return this;
+        }
+        PhpModule phpModule = PhpModule.Factory.lookupPhpModule(context);
+        if (phpModule == null) {
+            return this;
+        }
+        ComposerJson composerJson = new ComposerJson(phpModule.getProjectDirectory());
+        Set<String> allScripts = composerJson.getScripts();
+        if (allScripts.isEmpty()) {
+            return this;
+        }
+        List<String> orderedScripts = new ArrayList<>(allScripts);
+        Collections.sort(orderedScripts);
+        return new ComposerScriptsAction(contextProject, orderedScripts);
+    }
+
+    @Override
+    public JMenuItem getPopupPresenter() {
+        if (project == null) {
+            return new Actions.MenuItem(this, false);
+        }
+        return createScriptsMenu();
+    }
+
+    private JMenuItem createScriptsMenu() {
+        assert project != null;
+        assert !scripts.isEmpty();
+        JMenu menu = new JMenu(Bundle.ComposerScriptsAction_name());
+        for (final String command : scripts) {
+            RunScriptAction scriptAction = new RunScriptAction(command);
+            menu.add(scriptAction);
+        }
+        return menu;
+    }
+
+    //~ Inner classes
+    private static class RunScriptAction extends BaseComposerAction {
+
+        private final String script;
+
+        public RunScriptAction(String script) {
+            this.script = script;
+            putValue("noIconInMenu", true); // NOI18N
+            putValue(NAME, script);
+            putValue(SHORT_DESCRIPTION, script);
+            putValue("menuText", script); // NOI18N
+        }
+
+        @Override
+        protected String getName() {
+            return script;
+        }
+
+        @Override
+        protected void runCommand(PhpModule phpModule) throws InvalidPhpExecutableException {
+            Composer.getDefault().runScript(phpModule, script);
+        }
+
+    }
+
+}

--- a/php/php.composer/src/org/netbeans/modules/php/composer/ui/actions/UpdateAutoloaderDevAction.java
+++ b/php/php.composer/src/org/netbeans/modules/php/composer/ui/actions/UpdateAutoloaderDevAction.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.composer.ui.actions;
+
+import org.netbeans.modules.php.api.executable.InvalidPhpExecutableException;
+import org.netbeans.modules.php.api.phpmodule.PhpModule;
+import org.netbeans.modules.php.composer.commands.Composer;
+import org.openide.util.NbBundle;
+
+public class UpdateAutoloaderDevAction extends BaseComposerAction {
+
+    private static final long serialVersionUID = -1069248481245729168L;
+
+    @NbBundle.Messages("UpdateAutoloaderDevAction.name=Update Autoloader (dev)")
+    @Override
+    protected String getName() {
+        return Bundle.UpdateAutoloaderDevAction_name();
+    }
+
+    @Override
+    protected void runCommand(PhpModule phpModule) throws InvalidPhpExecutableException {
+        Composer.getDefault().updateAutoloaderDev(phpModule);
+    }
+
+}

--- a/php/php.composer/src/org/netbeans/modules/php/composer/ui/actions/UpdateAutoloaderNoDevAction.java
+++ b/php/php.composer/src/org/netbeans/modules/php/composer/ui/actions/UpdateAutoloaderNoDevAction.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.composer.ui.actions;
+
+import org.netbeans.modules.php.api.executable.InvalidPhpExecutableException;
+import org.netbeans.modules.php.api.phpmodule.PhpModule;
+import org.netbeans.modules.php.composer.commands.Composer;
+import org.openide.util.NbBundle;
+
+public class UpdateAutoloaderNoDevAction extends BaseComposerAction {
+
+    private static final long serialVersionUID = 1440742493215481033L;
+
+    @NbBundle.Messages("UpdateAutoloaderNoDevAction.name=Update Autoloader (no-dev)")
+    @Override
+    protected String getName() {
+        return Bundle.UpdateAutoloaderNoDevAction_name();
+    }
+
+    @Override
+    protected void runCommand(PhpModule phpModule) throws InvalidPhpExecutableException {
+        Composer.getDefault().updateAutoloaderNoDev(phpModule);
+    }
+
+}

--- a/php/php.composer/test/unit/data/composer-scripts.json
+++ b/php/php.composer/test/unit/data/composer-scripts.json
@@ -1,0 +1,11 @@
+{
+    "name": "me/project",
+    "scripts": {
+        "ci": [
+            "@analyze",
+            "@test"
+        ],
+        "analyze": "phpstan analyze",
+        "test": "codecept run"
+    }
+}

--- a/php/php.composer/test/unit/src/org/netbeans/modules/php/composer/files/ComposerJsonTest.java
+++ b/php/php.composer/test/unit/src/org/netbeans/modules/php/composer/files/ComposerJsonTest.java
@@ -21,6 +21,8 @@ package org.netbeans.modules.php.composer.files;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.FileUtil;
 
@@ -73,6 +75,25 @@ public class ComposerJsonTest extends NbTestCase {
         ComposerJson composerJson = new ComposerJson(FileUtil.toFileObject(getDataDir()), "nonexisting-composer.json");
         assertFalse(composerJson.getFile().getAbsolutePath(), composerJson.exists());
         assertEquals(new File(getDataDir(), ComposerJson.DEFAULT_VENDOR_DIR), composerJson.getVendorDir());
+    }
+
+    public void testScripts() {
+        ComposerJson composerJson = new ComposerJson(FileUtil.toFileObject(getDataDir()), "composer-scripts.json");
+        assertTrue(composerJson.getFile().getAbsolutePath(), composerJson.exists());
+        Set<String> scripts = composerJson.getScripts();
+        assertEquals(3, scripts.size());
+        Set<String> expectedScripts = new TreeSet<>();
+        expectedScripts.add("ci");
+        expectedScripts.add("analyze");
+        expectedScripts.add("test");
+        assertEquals(expectedScripts, scripts);
+    }
+
+    public void testNoScripts() {
+        ComposerJson composerJson = new ComposerJson(FileUtil.toFileObject(getDataDir()), "composer-vendor.json");
+        assertTrue(composerJson.getFile().getAbsolutePath(), composerJson.exists());
+        Set<String> scripts = composerJson.getScripts();
+        assertTrue(scripts.isEmpty());
     }
 
 }


### PR DESCRIPTION
This PR adds actions into Composer menu to update autoloader (dump-autoload) and also submenu with scripts from composer.json.

https://issues.apache.org/jira/browse/NETBEANS-2623

New actions:
![autoloader](https://user-images.githubusercontent.com/4249184/84081093-a20f4e00-a9dd-11ea-9328-f08a5cfa5220.png)

New submenu for scripts:
![scripts](https://user-images.githubusercontent.com/4249184/84081102-a5a2d500-a9dd-11ea-948a-27ef2ae0532c.png)

Implementation was inspired by "npm Scripts" menu.