### PR TITLE
JUnit Ignore annotation support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,12 +97,11 @@ matrix:
         - name: Test harness modules
           jdk: openjdk8
           env:
-            - OPTS="-silent -Dcluster.config=platform -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true -Dvanilla.javac.exists=true"
+            - OPTS="-quiet -Dcluster.config=platform -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true -Dvanilla.javac.exists=true"
           before_script:
             - ant $OPTS clean
             - ant $OPTS build
           script:
-            - OPTS="-quiet -Dcluster.config=platform -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true -Dvanilla.javac.exists=true"
             - ant $OPTS -f harness/o.n.insane test
             - ant $OPTS -f harness/apisupport.harness test
             - ant $OPTS -f harness/nbjunit test
@@ -149,6 +148,7 @@ matrix:
             - hide-logs.sh ant $OPTS -f platform/keyring.impl test
             - hide-logs.sh ant $OPTS -f platform/lib.uihandler test
             - hide-logs.sh ant $OPTS -f platform/libs.javafx test
+            - hide-logs.sh ant $OPTS -f platform/libs.junit4 test
             - travis_retry hide-logs.sh ant $OPTS -f platform/masterfs test
             - hide-logs.sh ant $OPTS -f platform/masterfs.linux test
             - hide-logs.sh ant $OPTS -f platform/netbinox test  -Dtest.config=stableBTD

--- a/harness/nbjunit/apichanges.xml
+++ b/harness/nbjunit/apichanges.xml
@@ -34,6 +34,20 @@
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="ignore.support">
+        <api name="nbjunit"/>
+        <summary>JUnit ignore annotation</summary>
+        <version major="1" minor="98"/>
+        <date day="21" month="6" year="2020"/>
+        <author login="hectorespert"/>
+        <compatibility addition="yes"/>
+        <description>
+            <p>
+                Add support for JUnit <a href="http://junit.sourceforge.net/javadoc/org/junit/Ignore.html">@Ignore</a> annotation on NbTestCase test case extension.
+            </p>
+        </description>
+        <class package="org.netbeans.junit" name="NbTestCase"/>
+    </change>
     <change id="NbModuleSuite.Configuration.parentClassLoader">
         <api name="nbjunit"/>
         <summary>NbModuleSuite.Configuration.parentClassLoader()</summary>

--- a/harness/nbjunit/manifest.mf
+++ b/harness/nbjunit/manifest.mf
@@ -1,5 +1,4 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.nbjunit/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/junit/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.97
-
+OpenIDE-Module-Specification-Version: 1.98

--- a/harness/nbjunit/nbproject/project.properties
+++ b/harness/nbjunit/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/harness/nbjunit/src/org/netbeans/junit/NbTestCase.java
+++ b/harness/nbjunit/src/org/netbeans/junit/NbTestCase.java
@@ -34,7 +34,6 @@ import java.io.PrintStream;
 import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
-import java.lang.management.PlatformLoggingMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -62,6 +61,7 @@ import java.util.regex.Pattern;
 import junit.framework.AssertionFailedError;
 import junit.framework.TestCase;
 import junit.framework.TestResult;
+import org.junit.Ignore;
 import org.netbeans.insane.live.LiveReferences;
 import org.netbeans.insane.live.Path;
 import org.netbeans.insane.scanner.CountingVisitor;
@@ -129,6 +129,22 @@ public abstract class NbTestCase extends TestCase implements NbTest {
      * @return true if the test can run
      */
     public @Override boolean canRun() {
+        if (getClass().isAnnotationPresent(Ignore.class)) {
+            String message = getClass().getAnnotation(Ignore.class).value();
+            System.err.println("Skipping " + getClass().getName() + (message.isEmpty() ? "" : ": " + message));
+            return false;
+        }
+        
+        try {
+            if (getClass().getMethod(getName()).isAnnotationPresent(Ignore.class)) {
+                String message = getClass().getMethod(getName()).getAnnotation(Ignore.class).value();
+                System.err.println("Skipping " + getClass().getName() + "." + getName() + (message.isEmpty() ? "" : ": " + message));
+                return false;
+            }
+        } catch (NoSuchMethodException x) {
+            // Specially named methods; let it pass.
+        }
+        
         if (NbTestSuite.ignoreRandomFailures()) {
             if (getClass().isAnnotationPresent(RandomlyFails.class)) {
                 System.err.println("Skipping " + getClass().getName());

--- a/harness/nbjunit/src/org/netbeans/junit/RandomlyFails.java
+++ b/harness/nbjunit/src/org/netbeans/junit/RandomlyFails.java
@@ -36,6 +36,10 @@ import java.lang.annotation.Target;
  * <p>Test runs which must be reliable should define the system property.
  * (E.g. for NetBeans modules: <code>ant -Dtest-unit-sys-prop.ignore.random.failures=true test</code>)
  * Developers running tests interactively should not.
+ * 
+ * JUnit {@literal @}Ignore annotation is supported.
+ * {@literal @}Ignore annotation is recommended to mark tests that are broken instead this annotation.
+ * 
  * @since 1.51
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/harness/nbjunit/test/unit/src/org/netbeans/junit/IgnoreTest.java
+++ b/harness/nbjunit/test/unit/src/org/netbeans/junit/IgnoreTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.junit;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import static junit.framework.TestCase.assertEquals;
+import junit.framework.TestResult;
+import junit.runner.BaseTestRunner;
+import junit.textui.TestRunner;
+import org.junit.Ignore;
+
+/**
+ * Test JUnit @Ignore annotation support 
+ * @author Hector Espert
+ */
+public class IgnoreTest extends TestCase {
+
+    public void testNbTestCase() throws Exception {
+        assertTestClass(BasicTestCase.class, 3, 1, 1);
+        assertTestClass(IgnoredTestCase.class, 0, 0, 0);
+        assertTestClass(IgnoredTestCaseWithMessage.class, 0, 0, 0);
+        assertTestClass(IgnoredMethodTestCase.class, 2, 1, 0);
+        assertTestClass(IgnoredMethodTestCaseWithMessage.class, 1, 0, 0);
+    }
+    
+    public void testNbTestSuite() throws Exception {
+        assertTestClass(BasicTestSuite.class, 3, 1, 1);
+        assertTestClass(IgnoredTestSuite.class, 0, 0, 0);
+        assertTestClass(IgnoredMethodTestSuite.class, 3, 1, 0);
+    }
+    
+    private void assertTestClass(Class testClass, int runCount, int failures, int errors) {
+        BaseTestRunner runner = new TestRunner();
+        TestResult result = new TestResult();
+        runner.getTest(testClass.getName()).run(result);
+        assertEquals(runCount, result.runCount());
+        assertEquals(failures, result.failureCount());
+        assertEquals(errors, result.errorCount());
+    }
+    
+    public static class BasicTestCase extends NbTestCase {
+        
+        public BasicTestCase(String n) {
+            super(n);
+        }
+        
+        public void testSuccesful() {
+            assertTrue(true);
+        }
+        
+        public void testFailed() {
+            fail();
+        }
+        
+        public void testError() {
+            throw new RuntimeException();
+        }
+        
+    }
+    
+    @Ignore
+    public static class IgnoredTestCase extends NbTestCase {
+        
+        public IgnoredTestCase(String n) {
+            super(n);
+        }
+        
+        public void testSuccesful() {
+            assertTrue(true);
+        }
+        
+        public void testFailed() {
+            fail();
+        }
+        
+        public void testError() {
+            throw new RuntimeException();
+        }
+        
+    }
+    
+    @Ignore("Ignored test case")
+    public static class IgnoredTestCaseWithMessage extends NbTestCase {
+        
+        public IgnoredTestCaseWithMessage(String n) {
+            super(n);
+        }
+        
+        public void testFailed() {
+            fail();
+        }
+
+    }
+    
+    public static class IgnoredMethodTestCase extends NbTestCase {
+        
+        public IgnoredMethodTestCase(String n) {
+            super(n);
+        }
+        
+        public void testSuccesful() {
+            assertTrue(true);
+        }
+        
+        public void testFailed() {
+            fail();
+        }
+        
+        @Ignore
+        public void testIgnored() {
+            fail("Test method should be ignored");
+        }
+        
+    }
+    
+    public static class IgnoredMethodTestCaseWithMessage extends NbTestCase {
+        
+        public IgnoredMethodTestCaseWithMessage(String n) {
+            super(n);
+        }
+        
+        public void testSuccesful() {
+            assertTrue(true);
+        }
+
+        @Ignore("Ignored method with message")
+        public void testIgnored() {
+            fail("Test method should be ignored");
+        }
+        
+    }
+    
+    public static class BasicTestSuite extends TestCase {
+        public static Test suite() {
+            return new NbTestSuite(BasicTestCase.class);
+        }
+    }
+    
+    public static class IgnoredTestSuite extends TestCase {
+        public static Test suite() {
+            NbTestSuite suite = new NbTestSuite();
+            suite.addTestSuite(IgnoredTestCase.class);
+            suite.addTestSuite(IgnoredTestCaseWithMessage.class);
+            return suite;
+        }
+    }
+    
+    public static class IgnoredMethodTestSuite extends TestCase {
+        public static Test suite() {
+            NbTestSuite suite = new NbTestSuite();
+            suite.addTestSuite(IgnoredMethodTestCase.class);
+            suite.addTestSuite(IgnoredMethodTestCaseWithMessage.class);
+            return suite;
+        }
+    }
+    
+}

--- a/harness/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteContextClassLoaderTest.java
+++ b/harness/nbjunit/test/unit/src/org/netbeans/junit/NbModuleSuiteContextClassLoaderTest.java
@@ -26,7 +26,8 @@ import test.pkg.not.in.junit.NbModuleSuiteT;
  * @author Jaroslav Tulach <jtulach@netbeans.org>
  */
 public class NbModuleSuiteContextClassLoaderTest extends NbTestCase {
-    static ClassLoader before;
+    
+    private static ClassLoader before;
     
     public NbModuleSuiteContextClassLoaderTest(String name) {
         super(name);

--- a/harness/nbjunit/test/unit/src/org/netbeans/junit/RandomlyFailsTest.java
+++ b/harness/nbjunit/test/unit/src/org/netbeans/junit/RandomlyFailsTest.java
@@ -83,7 +83,7 @@ public class RandomlyFailsTest extends TestCase {
     }
 
     private void run(Class... tests) {
-        runs = new ArrayList<Integer>();
+        runs = new ArrayList<>();
         BaseTestRunner runner = new TestRunner();
         for (Class test : tests) {
             TestResult result = new TestResult();

--- a/platform/libs.junit4/test/unit/src/org/netbeans/libs/junit4/JunitTest.java
+++ b/platform/libs.junit4/test/unit/src/org/netbeans/libs/junit4/JunitTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.junit4;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author Hector Espert
+ */
+public class JunitTest {
+    
+    @Test
+    public void assertObject() {
+        Object object = new Object();
+        assertNotNull("Object shouldn't be null", object);
+    }
+    
+    @Test
+    @Ignore
+    public void ignoreTestMethod() {
+        fail("This method should be ignored");
+    }
+    
+}


### PR DESCRIPTION
Add support for JUnit [@Ignore annotation](http://junit.sourceforge.net/javadoc/org/junit/Ignore.html)  on [NbTestCase](https://bits.netbeans.org/dev/javadoc/org-netbeans-modules-nbjunit/org/netbeans/junit/NbTestCase.html) test case extension.

```java
    @Ignore("Ignored test case")
    public static class IgnoredTestCase extends NbTestCase {

        public IgnoredTestCase(String n) {
            super(n);
        }

        public void testFailed() {
            fail();
        }

    }
```