### PR TITLE
[NETBEANS-4444] The selected text is not removed in the Find Combobox when text is input via IME

### DIFF
--- a/ide/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
+++ b/ide/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
@@ -123,6 +123,25 @@ public class SearchComboBoxEditor implements ComboBoxEditor {
                         DocumentUtilities.addDocumentListener(newDoc, manageViewListener, DocumentListenerPriority.AFTER_CARET_UPDATE);
                     }
                 }
+                // NETBEANS-4444
+                // selection is not removed when text is input via IME
+                // so, just remove it when the caret is changed
+                if ("caret".equals(evt.getPropertyName())) { // NOI18N
+                    if (evt.getOldValue() instanceof Caret) {
+                        Caret oldCaret = (Caret) evt.getOldValue();
+                        if (oldCaret != null) {
+                            int dotPosition = oldCaret.getDot();
+                            int markPosition = oldCaret.getMark();
+                            if (dotPosition != markPosition) {
+                                try {
+                                    editorPane.getDocument().remove(Math.min(markPosition, dotPosition), Math.abs(markPosition - dotPosition));
+                                } catch (BadLocationException ex) {
+                                    LOG.log(Level.WARNING, "Invalid removal offset: {0}", ex.offsetRequested()); // NOI18N
+                                }
+                            }
+                        }
+                    }
+                }
             }
         });
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4444

Selection is not removed when text is input via IME. So, just remove it when the caret is changed.

#### Before

![find-combobox-with-ime](https://user-images.githubusercontent.com/738383/84592569-a2966180-ae81-11ea-813e-8ed8eee5cfa8.gif)

#### After

![find-combobox-without-ime-after](https://user-images.githubusercontent.com/738383/84592553-7d095800-ae81-11ea-86d5-2ac23137d23c.gif)
