### PR TITLE
Netbeans project proxy configuration

### DIFF
--- a/enterprise/web.core/build.xml
+++ b/enterprise/web.core/build.xml
@@ -21,7 +21,4 @@
 -->
 <project basedir="." default="build" name="enterprise/web.core">
     <import file="../../nbbuild/templates/projectized.xml"/>
-    <taskdef name="configureproxy" classname="org.netbeans.nbbuild.extlibs.ConfigureProxy" classpath="${nbantext.jar}"/>
-    <configureproxy connectTo="http://netbeans.apache.org" hostProperty="proxyHost" portProperty="proxyPort"/>
-    <setproxy proxyhost="${proxyHost}" proxyPort="${proxyPort}"/>
 </project>

--- a/groovy/gradle/build.xml
+++ b/groovy/gradle/build.xml
@@ -23,8 +23,6 @@
     <description>Builds, tests, and runs the project org.netbeans.modules.gradle</description>
     <import file="../../nbbuild/templates/projectized.xml"/>
 
-    <taskdef name="configureproxy" classname="org.netbeans.nbbuild.extlibs.ConfigureProxy" classpath="${nbantext.jar}"/>
-
     <property name="test-unit-sys-prop.test.data.dir" location="test/data"/>
     <property name="tooling" value="netbeans-gradle-tooling"/>
     <available property="have.gradle.wrapper" file="${tooling}/gradle/wrapper/gradle-wrapper.jar"/>
@@ -38,8 +36,7 @@
         <copy file="external/gradle-wrapper-4.10.2.jar" tofile="${tooling}/gradle/wrapper/gradle-wrapper.jar"/>
     </target>
 
-    <target name="build-tooling-lib" depends="-download.release.files,-copy-gradle-wrapper,-uptodate-tooling" unless="tooling.uptodate">
-        <configureproxy connectTo="http://netbeans.apache.org" hostProperty="proxyHost" portProperty="proxyPort"/>
+    <target name="build-tooling-lib" depends="-proxy-configuration,-download.release.files,-copy-gradle-wrapper,-uptodate-tooling" unless="tooling.uptodate">
         <condition property="gradle.proxy.args" value="-Dhttp.proxyHost=${proxyHost} -Dhttp.proxyPort=${proxyPort} -Dhttps.proxyHost=${proxyHost} -Dhttps.proxyPort=${proxyPort}">
             <not>
                 <equals arg1="${proxyHost}" arg2="" />

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ConfigureProxy.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ConfigureProxy.java
@@ -74,8 +74,8 @@ public final class ConfigureProxy extends Task {
                 getProject().setUserProperty(hostProperty, "");
                 getProject().setUserProperty(portProperty, "80");
             }
-        } catch (IOException exception) {
-            throw new BuildException(exception);
+        } catch (IOException ex) {
+            throw new BuildException(ex);
         }
     }
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ConfigureProxy.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ConfigureProxy.java
@@ -74,8 +74,8 @@ public final class ConfigureProxy extends Task {
                 getProject().setUserProperty(hostProperty, "");
                 getProject().setUserProperty(portProperty, "80");
             }
-        } catch (IOException ex) {
-            throw new BuildException(ex);
+        } catch (IOException exception) {
+            throw new BuildException(exception);
         }
     }
 

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -67,7 +67,6 @@
     <taskdef name="deregisterexternalhook" classname="org.netbeans.nbbuild.extlibs.DeregisterExternalHook" classpath="${build.ant.classes.dir}"/>
     <deregisterexternalhook root=".."/>
     <taskdef name="downloadbinaries" classname="org.netbeans.nbbuild.extlibs.DownloadBinaries" classpath="${build.ant.classes.dir}"/>
-    <taskdef name="configureproxy" classname="org.netbeans.nbbuild.extlibs.ConfigureProxy" classpath="${build.ant.classes.dir}"/>
     <property name="have-downloadbinaries-task" value="true" />
     <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
         <manifest dir="${nb_all}">
@@ -116,8 +115,10 @@
             <isset property="metabuild.jsonurl"/>
         </not>
     </condition>
-    <configureproxy connectTo="${metabuild.jsonurl}" hostProperty="proxyHost" portProperty="proxyPort"/>
-    <setproxy proxyhost="${proxyHost}" proxyPort="${proxyPort}"/>
+    
+    <!-- Proxy configuration for ant tasks-->
+    <antcall target="-proxy-configuration"/>
+
     <get dest="${metabuild.releasejson}" skipexisting="false" src="${metabuild.jsonurl}" />
     <!-- read info from gitinfo.properties , if present in source bundle copy gitinfo-->
     <copy file="${nb_all}/nbbuild/gitinfo.properties" tofile="${nb_all}/nbbuild/build/gitinfo.properties" failonerror="false"/>

--- a/nbbuild/default.xml
+++ b/nbbuild/default.xml
@@ -119,6 +119,31 @@
     <property name="tasks-already-set" value="true"/>
   </target>
 
+  <condition property="auto.proxy" value="true">
+    <not>  
+      <isset property="auto.proxy"/>
+    </not>
+  </condition>
+
+  <condition property="proxy.host+port">
+    <and>
+        <isset property="proxy.host"/>
+        <isset property="proxy.port"/>
+    </and>
+  </condition>
+  
+  <target name="-manual-proxy" if="proxy.host+port">
+    <setproxy proxyhost="${proxy.host}" proxyport="${proxy.port}"/>
+  </target>
+    
+  <target name="-auto-proxy" unless="proxy.host+port" if="auto.proxy">
+    <taskdef name="configureproxy" classname="org.netbeans.nbbuild.extlibs.ConfigureProxy" classpath="${nbantext.jar}"/>
+    <configureproxy connectTo="http://netbeans.apache.org" hostProperty="proxyHost" portProperty="proxyPort"/>
+    <setproxy proxyhost="${proxyHost}" proxyPort="${proxyPort}"/>
+  </target>
+  
+  <target name="-proxy-configuration" depends="-manual-proxy,-auto-proxy"/>
+
   <target name="init" depends="init-tasks,-define-cluster-path">
     <!-- Gets the module name -->
     <getmodulename name="module.name" id="module.id" root="${nb_all}"/>

--- a/nbbuild/nbproject/project.xml
+++ b/nbbuild/nbproject/project.xml
@@ -205,7 +205,7 @@
         <java-data xmlns="http://www.netbeans.org/ns/freeform-project-java/4">
             <compilation-unit>
                 <package-root>antsrc</package-root>
-                <classpath mode="compile">${ant.core.lib}:${nb_all}/platform/javahelp/external/jhall-2.0_05.jar</classpath>
+                <classpath mode="compile">${ant.core.lib}:${nb_all}/platform/javahelp/external/jhall-2.0_05.jar:${nb_all}/nbbild/external/json-simple-1.1.1.jar</classpath>
                 <classpath mode="boot">${nbjdk.bootclasspath}</classpath>
                 <built-to>${nb.build.dir}/antclasses</built-to>
                 <built-to>${nbantext.jar}</built-to>

--- a/nbbuild/nbproject/project.xml
+++ b/nbbuild/nbproject/project.xml
@@ -205,7 +205,7 @@
         <java-data xmlns="http://www.netbeans.org/ns/freeform-project-java/4">
             <compilation-unit>
                 <package-root>antsrc</package-root>
-                <classpath mode="compile">${ant.core.lib}:${nb_all}/platform/javahelp/external/jhall-2.0_05.jar:${nb_all}/nbbild/external/json-simple-1.1.1.jar</classpath>
+                <classpath mode="compile">${ant.core.lib}:${nb_all}/platform/javahelp/external/jhall-2.0_05.jar:${nb_all}/nbbuild/external/json-simple-1.1.1.jar</classpath>
                 <classpath mode="boot">${nbjdk.bootclasspath}</classpath>
                 <built-to>${nb.build.dir}/antclasses</built-to>
                 <built-to>${nbantext.jar}</built-to>

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -35,7 +35,7 @@
     </target>
 
     <target name="common-init" depends="default.init,-build-dir-init"/>
-    <target name="init" depends="basic-init,files-init,build-init,-javac-init,-init-proxy"/>
+    <target name="init" depends="basic-init,files-init,build-init,-javac-init,-proxy-configuration"/>
     
     <target name="files-init" depends="projectized-common.files-init">
         <property name="locales" value=""/>
@@ -46,13 +46,6 @@
             basefilesref="module.files"
         />
     </target>
-    
-    <condition property="proxy.host+port">
-        <and>
-            <isset property="proxy.host"/>
-            <isset property="proxy.port"/>
-        </and>
-    </condition>
 
     <property name="ant.file.1" location="${ant.file}"/>
     <property name="ant.file.2" location="${nb_all}/${ant.project.name}/build.xml"/>
@@ -63,10 +56,6 @@
             </not>
         </condition>
     </fail>
-    
-    <target name="-init-proxy" if="proxy.host+port">
-        <setproxy proxyhost="${proxy.host}" proxyport="${proxy.port}"/>
-    </target>
 
     <target name="jdk-8-check" depends="-jdk-init" if="have-jdk-1.9" unless="permit.jdk9.builds">
         <property name="user.build.properties" location="${nb_all}/nbbuild/user.build.properties"/>

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/extlibs/ConfigureProxyTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/extlibs/ConfigureProxyTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.nbbuild.extlibs;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.netbeans.junit.NbTestCase;
+
+/**
+ *
+ * @author Hector Espert
+ */
+public class ConfigureProxyTest extends NbTestCase {
+    
+    private ConfigureProxy configureProxy;
+
+    public ConfigureProxyTest(String name) {
+        super(name);
+    }
+    
+    @Override
+    public void setUp() {
+        configureProxy = new ConfigureProxy();
+        
+        Project project = new Project();
+        configureProxy.setProject(project);
+    }
+    
+    public void testExecute() throws MalformedURLException {
+        configureProxy.setConnectTo("http://netbeans.apache.org");
+        configureProxy.execute();
+
+        assertNotNull(configureProxy.getProject().getUserProperty("http.proxyHost"));
+        assertNotNull(configureProxy.getProject().getUserProperty("http.proxyPort"));
+    }
+    
+    public void testExecuteCustomProperties() throws MalformedURLException {
+        configureProxy.setConnectTo("http://netbeans.apache.org");
+        configureProxy.setHostProperty("proxyHost");
+        configureProxy.setPortProperty("proxyPort");
+        configureProxy.execute();
+
+        assertNotNull(configureProxy.getProject().getUserProperty("proxyHost"));
+        assertNotNull(configureProxy.getProject().getUserProperty("proxyPort"));
+    }
+    
+    public void testExecuteFailedConnection() throws MalformedURLException {
+        try {
+            configureProxy.setConnectTo("http://notfound.not");
+            configureProxy.execute();
+            fail("Exception is expected");
+        } catch (BuildException buildException) {
+            assertEquals(IOException.class, buildException.getCause().getClass());
+        }
+    }
+    
+}


### PR DESCRIPTION
Seems that part of the problems related with the Apache infrastructure on Travis builds or GitHub actions are related to the proxy configuration introduced in the Netbeans build system to work behind a proxy. https://github.com/apache/netbeans/pull/1092 

```
2020-06-13T17:01:33.9599330Z /Users/runner/runners/2.263.0/work/netbeans/netbeans/enterprise/web.core/build.xml:25: java.io.IOException: Cannot connect to http://netbeans.apache.org
2020-06-13T17:01:33.9599810Z 	at org.netbeans.nbbuild.extlibs.ConfigureProxy.openConnection(ConfigureProxy.java:145)
2020-06-13T17:01:33.9601430Z 	at org.netbeans.nbbuild.extlibs.ConfigureProxy.execute(ConfigureProxy.java:62)
2020-06-13T17:01:33.9608220Z 	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
2020-06-13T17:01:33.9608370Z 	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
2020-06-13T17:01:33.9608490Z 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2020-06-13T17:01:33.9608660Z 	at java.lang.reflect.Method.invoke(Method.java:498)
2020-06-13T17:01:33.9608780Z 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
2020-06-13T17:01:33.9608910Z 	at org.apache.tools.ant.Task.perform(Task.java:350)
2020-06-13T17:01:33.9609020Z 	at org.apache.tools.ant.Target.execute(Target.java:449)
2020-06-13T17:01:33.9609140Z 	at org.apache.tools.ant.helper.ProjectHelper2.parse(ProjectHelper2.java:184)
2020-06-13T17:01:33.9609270Z 	at org.apache.tools.ant.ProjectHelper.configureProject(ProjectHelper.java:93)
2020-06-13T17:01:33.9609400Z 	at org.apache.tools.ant.taskdefs.Ant.execute(Ant.java:393)
2020-06-13T17:01:33.9609510Z 	at sun.reflect.GeneratedMethodAccessor114.invoke(Unknown Source)
2020-06-13T17:01:33.9609630Z 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2020-06-13T17:01:33.9609750Z 	at java.lang.reflect.Method.invoke(Method.java:498)
2020-06-13T17:01:33.9609870Z 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
```
The ConfigureProxy custom task generates a request to the apache infra every time that an ant task needs to resolve the proxy configuration. This PR disables this behaivour when run the build system in CI environments.

Additionally the proxy configuration is moved to a common task to do it available in all of modules. 