### PR TITLE
[NETBEANS-4458] - enable use of generics

### DIFF
--- a/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ui/customizer/EarProjectProperties.java
+++ b/enterprise/j2ee.earproject/src/org/netbeans/modules/j2ee/earproject/ui/customizer/EarProjectProperties.java
@@ -844,7 +844,7 @@ public final class EarProjectProperties {
             return;
         }
         
-        for( Iterator/*<Project>*/ it = spp.getSubprojects().iterator(); it.hasNext(); ) {
+        for( Iterator<? extends Project> it = spp.getSubprojects().iterator(); it.hasNext(); ) {
             Project sp = (Project) it.next();
             if (ProjectUtils.hasSubprojectCycles(project, sp)) {
                 Logger.getLogger("global").log(Level.WARNING, "There would be cyclic " + // NOI18N

--- a/enterprise/j2ee.genericserver/nbproject/project.properties
+++ b/enterprise/j2ee.genericserver/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/ManagedBeanPanel.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/ManagedBeanPanel.java
@@ -123,7 +123,8 @@ final class ManagedBeanPanel implements WizardDescriptor.Panel, WizardDescriptor
         }
         return component.isAddBeanToConfig();
     }
-    private final Set/*<ChangeListener>*/ listeners = new HashSet(1);
+
+    private final Set<ChangeListener> listeners = new HashSet<>(1);
 
     @Override
     public final void addChangeListener(ChangeListener l) {

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/PersistenceClientSetupPanel.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/PersistenceClientSetupPanel.java
@@ -72,7 +72,7 @@ final class PersistenceClientSetupPanel implements WizardDescriptor.Panel, Wizar
         return component.valid(wizardDescriptor);
     }
     
-    private final Set/*<ChangeListener>*/ listeners = new HashSet(1);
+    private final Set<ChangeListener> listeners = new HashSet<>(1);
     
     public final void addChangeListener(ChangeListener l) {
         synchronized (listeners) {

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/TemplateClientPanelVisual.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/TemplateClientPanelVisual.java
@@ -75,7 +75,7 @@ public class TemplateClientPanelVisual extends javax.swing.JPanel implements Hel
 
     private WizardDescriptor wizardDescriptor;
 
-    private final Set/*<ChangeListener>*/ listeners = new HashSet(1);
+    private final Set<ChangeListener> listeners = new HashSet<>(1);
 
     private final static String VALUE_NAME = "name";    //NOI18N
 

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDParser.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDParser.java
@@ -243,7 +243,7 @@ public class DTDParser {
     private class EntityResolverWrapper implements EntityResolver {
         
         private EntityResolver resolver;
-        private ArrayList/*<String>*/ resolvedSystemIds = new ArrayList(3);
+        private ArrayList<String> resolvedSystemIds = new ArrayList(3);
         
         public EntityResolverWrapper(EntityResolver resolver) {
             this.resolver = resolver;

--- a/ide/xml.text/src/org/netbeans/modules/xml/text/structure/XMLDocumentModelProvider.java
+++ b/ide/xml.text/src/org/netbeans/modules/xml/text/structure/XMLDocumentModelProvider.java
@@ -476,7 +476,7 @@ public class XMLDocumentModelProvider implements DocumentModelProvider {
     }
     
     
-    private List/*<DocumentElement>*/ getDescendantsOfNotSkippedElements(DocumentElement de, List/*<DocumentElement>*/ skippedElements) {
+    private List<DocumentElement> getDescendantsOfNotSkippedElements(DocumentElement de, List<DocumentElement> skippedElements) {
         ArrayList desc = new ArrayList();
         Iterator children = de.getChildren().iterator();
         while(children.hasNext()) {

--- a/java/i18n.form/nbproject/project.properties
+++ b/java/i18n.form/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 spec.version.base=1.61.0
 
 test.config.stableBTD.includes=**/*Test.class

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerSetupPanel.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/wizard/jpacontroller/JpaControllerSetupPanel.java
@@ -67,7 +67,7 @@ final class JpaControllerSetupPanel implements WizardDescriptor.Panel, WizardDes
         return component.valid(wizardDescriptor);
     }
     
-    private final Set/*<ChangeListener>*/ listeners = new HashSet(1);
+    private final Set<ChangeListener> listeners = new HashSet(1);
     
     public final void addChangeListener(ChangeListener l) {
         synchronized (listeners) {

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapperTestHidden.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/URLMapperTestHidden.java
@@ -165,7 +165,7 @@ public class URLMapperTestHidden extends TestBaseHid {
         assertNotNull(urlFromMapper);
 
         FileObject[] all = URLMapper.findFileObjects(urlFromMapper);
-        List/*<FileObject>*/ allList = Arrays.asList(all);
+        List<FileObject> allList = Arrays.asList(all);
         assertTrue("found " + fo + " in " + allList + " from " + urlFromMapper, allList.contains(fo));
         assertEquals("findFileObject works too", fo, URLMapper.findFileObject(urlFromMapper));
     }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDumpSegment.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDumpSegment.java
@@ -59,7 +59,7 @@ class ClassDumpSegment extends TagBounds {
     final int superClassIDOffset;
     ClassDump java_lang_Class;
     boolean newSize;
-    Map /*<JavaClass,List<Field>>*/ fieldsCache;
+    Map<JavaClass,List<Field>> fieldsCache;
     private List<JavaClass> classes;
     private Map /*<Byte,JavaClass>*/ primitiveArrayMap;
 
@@ -202,12 +202,12 @@ class ClassDumpSegment extends TagBounds {
         }
     }
 
-    synchronized List /*<JavaClass>*/ createClassCollection() {
+    synchronized List<JavaClass> createClassCollection() {
         if (classes != null) {
             return classes;
         }
 
-        List cls = new ArrayList /*<JavaClass>*/(1000);
+        List<JavaClass> cls = new ArrayList<>(1000);
 
         long[] offset = new long[] { startOffset };
 


### PR DESCRIPTION
A lot of places in the code has generic use commented out.. For example, the following in
LayoutModel.java

     public void unsetSameSize(List/*<String>*/ components, int dimension) {
        Iterator i = components.iterator();
        while (i.hasNext()) {
            String cid = (String)i.next();
            LayoutComponent lc = getLayoutComponent(cid);
            removeComponentFromLinkSizedGroup(lc, dimension);
        }
    }

All I've done here is enable it to reduce the warnings and test out the code to make sure it works correctly.