### PR TITLE
[NETBEANS-4459] - remove use of deprecated field in Logger

### DIFF
--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/web/multiview/AbsoluteOrderingPanel.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/web/multiview/AbsoluteOrderingPanel.java
@@ -254,7 +254,7 @@ public class AbsoluteOrderingPanel extends SectionInnerPanel implements java.awt
             dObj.modelUpdatedFromUI();
         }
         catch (VersionNotSupportedException e) {
-            Logger.global.log(Level.SEVERE, "refresh of DD model failed", e);
+            Logger.getGlobal().log(Level.SEVERE, "refresh of DD model failed", e);
         }
     }
     

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/web/multiview/RelativeOrderingPanel.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/web/multiview/RelativeOrderingPanel.java
@@ -421,7 +421,7 @@ public class RelativeOrderingPanel extends SectionInnerPanel implements java.awt
     
     private void refreshDdModel() {
         if (!(webApp instanceof WebFragment)) {
-            Logger.global.log(Level.SEVERE, "refreshDdModel failed, not a WebFragment instance of DD passed!");
+            Logger.getGlobal().log(Level.SEVERE, "refreshDdModel failed, not a WebFragment instance of DD passed!");
             return;
         }
         WebFragment webFrag = (WebFragment)webApp;

--- a/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/TagLibParseSupport.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/core/jsploader/TagLibParseSupport.java
@@ -411,7 +411,7 @@ public class TagLibParseSupport implements org.openide.nodes.Node.Cookie, TagLib
         
         private boolean checkError(JspParserAPI.ErrorDescriptor err) {
             if(err.getErrorMessage() == null) {
-                Logger.global.log(Level.INFO, null, 
+                Logger.getGlobal().log(Level.INFO, null, 
                         new IllegalStateException("Invalid JspParserAPI.ErrorDescription from jsp parser - null error message: " + err.toString()));
                 return false;
             }

--- a/enterprise/web.core/src/org/netbeans/modules/web/wizards/ServletPanel.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/wizards/ServletPanel.java
@@ -166,10 +166,10 @@ public class ServletPanel implements WizardDescriptor.FinishablePanel {
             return servlets;
         }
         catch (MetadataModelException e) {
-            Logger.global.log(Level.WARNING, "getServlets failed", e);
+            Logger.getGlobal().log(Level.WARNING, "getServlets failed", e);
         }
         catch (IOException e) {
-            Logger.global.log(Level.WARNING, "getServlets failed", e);
+            Logger.getGlobal().log(Level.WARNING, "getServlets failed", e);
         }
         return Collections.emptyList();
     }
@@ -184,10 +184,10 @@ public class ServletPanel implements WizardDescriptor.FinishablePanel {
             return filters;
         }
         catch (MetadataModelException e) {
-            Logger.global.log(Level.WARNING, "getFilters failed", e);
+            Logger.getGlobal().log(Level.WARNING, "getFilters failed", e);
         }
         catch (IOException e) {
-            Logger.global.log(Level.WARNING, "getFilters failed", e);
+            Logger.getGlobal().log(Level.WARNING, "getFilters failed", e);
         }
         return Collections.emptyList();
     }

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/JaxWsUtils.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/JaxWsUtils.java
@@ -1884,7 +1884,7 @@ public class JaxWsUtils {
                 }
             }
         } catch (CatalogModelException ex) {
-            Logger.global.log(Level.INFO, "", ex);
+            Logger.getGlobal().log(Level.INFO, "", ex);
         }
 
         return false;

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/saas/RestWrapperForSoapGenerator.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/saas/RestWrapperForSoapGenerator.java
@@ -315,7 +315,7 @@ public class RestWrapperForSoapGenerator {
         try {
             return loader.loadClass(raw);
         } catch (ClassNotFoundException ex) {
-            Logger.global.log(Level.INFO, "", ex);
+            Logger.getGlobal().log(Level.INFO, "", ex);
             return null;
         }
     }

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/WebServiceManager.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/WebServiceManager.java
@@ -518,7 +518,7 @@ public final class WebServiceManager {
                 wsData.setCompiled(true);
             }
         } catch (IOException ex) {
-            Logger.global.log(Level.INFO, ex.getLocalizedMessage(), ex);
+            Logger.getGlobal().log(Level.INFO, ex.getLocalizedMessage(), ex);
         } finally {
             if (!wsData.getState().equals(WebServiceData.State.WSDL_SERVICE_COMPILED) && compileAttempted) {
                 wsData.setState(WebServiceData.State.WSDL_SERVICE_COMPILE_FAILED);

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/WebServicePersistenceManager.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/WebServicePersistenceManager.java
@@ -142,7 +142,7 @@ public class WebServicePersistenceManager implements ExceptionListener {
                             WsdlModel wsdlModel = WebServiceManager.getInstance().getWsdlModel(wsData);
                             wsData.setWsdlService(wsdlModel.getServiceByName(wsData.getName()));
                         } catch (IOException ex) {
-                            Logger.global.log(Level.INFO, ex.getLocalizedMessage(), ex);
+                            Logger.getGlobal().log(Level.INFO, ex.getLocalizedMessage(), ex);
                         }
                     } else {
                         wsData.reset();

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceListModel.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceListModel.java
@@ -304,7 +304,7 @@ public class WebServiceListModel {
                     try {
                         WebServiceManager.getInstance().addWebService(target, true);
                     } catch (IOException ex) {
-                        Logger.global.log(Level.INFO, ex.getLocalizedMessage(), ex);
+                        Logger.getGlobal().log(Level.INFO, ex.getLocalizedMessage(), ex);
                     }
                 }
             };

--- a/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/AbstractRefactoring.java
+++ b/ide/refactoring.api/src/org/netbeans/modules/refactoring/api/AbstractRefactoring.java
@@ -387,7 +387,7 @@ public abstract class AbstractRefactoring {
         if (cause != null && (cause.getClass().getName().equals("org.netbeans.api.java.source.JavaSource$InsufficientMemoryException") ||  //NOI18N
             (cause.getCause()!=null ) && cause.getCause().getClass().getName().equals("org.netbeans.api.java.source.JavaSource$InsufficientMemoryException"))) { //NOI18N
             newProblem = new Problem(true, NbBundle.getMessage(Util.class, "ERR_OutOfMemory"));
-            Logger.global.log(Level.INFO, "There is not enough memory to complete this task.", t);
+            Logger.getGlobal().log(Level.INFO, "There is not enough memory to complete this task.", t);
         } else {
             newProblem = new Problem(false, createMessage(source, t));
             Exceptions.printStackTrace(t);

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SoapClientOperationInfo.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/model/SoapClientOperationInfo.java
@@ -246,7 +246,7 @@ public class SoapClientOperationInfo {
             ;
             return WSDLModelFactory.getDefault().getModel(Utilities.createModelSource(wsdlFO, true));
         } catch (CatalogModelException ex) {
-            Logger.global.log(Level.INFO, "", ex);
+            Logger.getGlobal().log(Level.INFO, "", ex);
         }
         return null;
     }

--- a/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/Util.java
+++ b/websvccommon/websvc.saas.codegen/src/org/netbeans/modules/websvc/saas/codegen/util/Util.java
@@ -457,7 +457,7 @@ public class Util {
         try {
             return loader.loadClass(raw);
         } catch (ClassNotFoundException ex) {
-            Logger.global.log(Level.INFO, "", ex);
+            Logger.getGlobal().log(Level.INFO, "", ex);
             return null;
         }
     }


### PR DESCRIPTION
Remove use of the deprecated Logger.global field..

   [repeat] /home/bwalker/src/netbeans/enterprise/web.core/src/org/netbeans/modules/web/wizards/ServletPanel.java:169: warning: [deprecation] global in Logger has been deprecated
   [repeat]             Logger.global.log(Level.WARNING, "getServlets failed", e);
   [repeat]                   ^
   [repeat] /home/bwalker/src/netbeans/enterprise/web.core/src/org/netbeans/modules/web/wizards/ServletPanel.java:172: warning: [deprecation] global in Logger has been deprecated
   [repeat]             Logger.global.log(Level.WARNING, "getServlets failed", e);
   [repeat]                   ^
   [repeat] Note: Some input files additionally use or override a deprecated API.