### PR TITLE
Let Lookup and NbBundle be usable in a sandbox

### DIFF
--- a/platform/openide.util.lookup/src/org/openide/util/lookup/implspi/ActiveQueue.java
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/implspi/ActiveQueue.java
@@ -72,6 +72,7 @@ public final class ActiveQueue {
     }
 
     private static final class Daemon extends Thread {
+        private static boolean initialized;
         private static Daemon running;
         
         public Daemon() {
@@ -79,17 +80,19 @@ public final class ActiveQueue {
         }
         
         static synchronized void ping() {
-            if (running == null) {
-                Daemon t = new Daemon();
+            if (!initialized) {
                 try {
+                    Daemon t = new Daemon();
                     t.setPriority(Thread.MIN_PRIORITY);
                     t.setDaemon(true);
                     t.start();
                     LOGGER.fine("starting thread");
+                    running = t;
                 } catch (SecurityException ex) {
                     LOGGER.log(Level.FINE, "cannot start thread", ex);
+                } finally {
+                    initialized = true;
                 }
-                running = t;
             }
         }
         

--- a/platform/openide.util.lookup/src/org/openide/util/lookup/implspi/ActiveQueue.java
+++ b/platform/openide.util.lookup/src/org/openide/util/lookup/implspi/ActiveQueue.java
@@ -81,10 +81,14 @@ public final class ActiveQueue {
         static synchronized void ping() {
             if (running == null) {
                 Daemon t = new Daemon();
-                t.setPriority(Thread.MIN_PRIORITY);
-                t.setDaemon(true);
-                t.start();
-                LOGGER.fine("starting thread");
+                try {
+                    t.setPriority(Thread.MIN_PRIORITY);
+                    t.setDaemon(true);
+                    t.start();
+                    LOGGER.fine("starting thread");
+                } catch (SecurityException ex) {
+                    LOGGER.log(Level.FINE, "cannot start thread", ex);
+                }
                 running = t;
             }
         }

--- a/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/implspi/ActiveQueueWithSecurityManagerTest.java
+++ b/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/implspi/ActiveQueueWithSecurityManagerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.util.lookup.implspi;
+
+import java.lang.ref.ReferenceQueue;
+import java.security.Permission;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ActiveQueueWithSecurityManagerTest {
+
+    public ActiveQueueWithSecurityManagerTest() {
+    }
+
+    @Test
+    public void testQueue() {
+        final Thread[] raised = { null };
+        System.setSecurityManager(new SecurityManager() {
+            @Override
+            public void checkAccess(Thread t) {
+                if (t.getName().startsWith("Active")) {
+                    raised[0] = t;
+                    throw new SecurityException();
+                }
+            }
+
+            @Override
+            public void checkPermission(Permission perm) {
+            }
+        });
+        ReferenceQueue<Object> result = ActiveQueue.queue();
+        System.setSecurityManager(null);
+        assertNotNull("The thread has been prevented from being started", raised[0]);
+        assertEquals("Active Reference Queue Daemon", raised[0].getName());
+        assertNotNull("ActiveQueue can be created in spite of that", result);
+    }
+
+}

--- a/platform/openide.util/src/org/openide/util/TimedSoftReference.java
+++ b/platform/openide.util/src/org/openide/util/TimedSoftReference.java
@@ -67,8 +67,14 @@ final class TimedSoftReference<T> extends SoftReference<T> implements Runnable {
         this.o = o;
         this.m = m;
         this.k = k;
-        task = RP.create(this);
-        task.schedule(TIMEOUT);
+        try {
+            this.task = RP.create(this);
+            this.task.schedule(TIMEOUT);
+        } catch (SecurityException ex) {
+            // behave as regular SoftReference
+            this.o = null;
+            this.task = null;
+        }
     }
 
     public void run() {
@@ -102,7 +108,9 @@ final class TimedSoftReference<T> extends SoftReference<T> implements Runnable {
                 // touch me
                 //System.err.println("Touch " + k);
                 if (touched == 0) {
-                    task.schedule(TIMEOUT);
+                    if (task != null) {
+                        task.schedule(TIMEOUT);
+                    }
                 }
 
                 touched = System.currentTimeMillis();

--- a/platform/openide.util/src/org/openide/util/TimedSoftReference.java
+++ b/platform/openide.util/src/org/openide/util/TimedSoftReference.java
@@ -62,7 +62,7 @@ final class TimedSoftReference<T> extends SoftReference<T> implements Runnable {
      * @param m a map in which this reference may serve as a value
      * @param k the key whose value in <code>m</code> may be this reference
      */
-    public TimedSoftReference(T o, Map m, Object k) {
+    TimedSoftReference(T o, Map m, Object k) {
         super(o, BaseUtilities.activeReferenceQueue());
         this.o = o;
         this.m = m;

--- a/platform/openide.util/test/unit/src/org/openide/util/NbBundleWithSecurityManager.properties
+++ b/platform/openide.util/test/unit/src/org/openide/util/NbBundleWithSecurityManager.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+HELLO=World

--- a/platform/openide.util/test/unit/src/org/openide/util/NbBundleWithSecurityManagerTest.java
+++ b/platform/openide.util/test/unit/src/org/openide/util/NbBundleWithSecurityManagerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.util;
+
+import java.security.Permission;
+import java.util.ResourceBundle;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+public class NbBundleWithSecurityManagerTest {
+    @Test
+    public void testQueue() {
+        final Thread[] raised = { null };
+        System.setSecurityManager(new SecurityManager() {
+            @Override
+            public void checkAccess(Thread t) {
+                if (t.getClass().getName().startsWith("java.util.logging")) {
+                    return;
+                }
+                raised[0] = t;
+                throw new SecurityException();
+            }
+
+            @Override
+            public void checkPermission(Permission perm) {
+            }
+        });
+        ResourceBundle bundle = NbBundle.getBundle("org.openide.util.NbBundleWithSecurityManager");
+        assertNotNull("Bundle found", bundle);
+        assertEquals("World", bundle.getString("HELLO"));
+
+        System.setSecurityManager(null);
+        assertNotNull("The thread has been prevented from being started", raised[0]);
+    }
+}


### PR DESCRIPTION
I am trying to execute application that uses `NbBundle` and `Lookup.allInstances` in a [browser](https://github.com/jtulach/bck2brwsr/commit/c79a4f5e725c79d22ebb3f714faa09271678161b) which supports only single-threaded Java.

Alas, `NbBundle` is using `TimedReference` and `AbstractLookup` is using `ActiveQueue` - both try to launch a thread. 

This change adds two tests that simulate such restricted environment by using `SecurityManager` and throwing a `SecurityException` whenever a thread is started. This change then modifies the code to catch the exception and go on.

With changes like this I managed to get an application using `NbBundle` and `Lookup` running.