### PR TITLE
Custom ant task to download release properties

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/DownloadReleaseJsonProperties.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/DownloadReleaseJsonProperties.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.nbbuild;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Project;
+import org.apache.tools.ant.taskdefs.Get;
+
+/**
+ *
+ * @author Hector Espert
+ */
+public class DownloadReleaseJsonProperties extends Get {
+
+    private File dest;
+
+    private File cache;
+
+    private long refresh = 86400;
+
+    private boolean force = false;
+
+    @Override
+    public void setDest(File dest) {
+        this.dest = dest;
+    }
+
+    public void setCache(File cache) {
+        this.cache = cache;
+    }
+
+    public void setRefresh(long refresh) {
+        this.refresh = refresh;
+    }
+
+    public void setForce(boolean force) {
+        this.force = force;
+    }
+
+    @Override
+    public void execute() throws BuildException {
+        log("Cached release properties file path: " + cache.getAbsolutePath() + ", file exists: " + cache.exists(), Project.MSG_INFO);
+
+        // Download file if cache file doesn't exists.
+        boolean downloadFile = !cache.exists() || force;
+
+        // Force download if file is older
+        if (cache.exists()) {
+            try {
+                BasicFileAttributes attr = Files.readAttributes(cache.toPath(), BasicFileAttributes.class);
+                Instant fileInstant = attr.creationTime().toInstant();
+                if (Instant.now().minusSeconds(refresh).isAfter(fileInstant)) {
+                    downloadFile = true;
+                }
+            } catch (IOException ex) {
+                throw new BuildException(ex);
+            }
+        }
+
+        log("Download release properties file: " + downloadFile, Project.MSG_INFO);
+        if (downloadFile) {
+            super.setDest(cache);
+            super.execute();
+        }
+
+        if (cache.exists()) {
+            try {
+                Files.copy(cache.toPath(), dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException ex) {
+                throw new BuildException(ex);
+            }
+        } else {
+            throw new BuildException("Unable to obtain the release properties file");
+        }
+
+    }
+
+}

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -118,7 +118,13 @@
     </condition>
     <configureproxy connectTo="${metabuild.jsonurl}" hostProperty="proxyHost" portProperty="proxyPort"/>
     <setproxy proxyhost="${proxyHost}" proxyPort="${proxyPort}"/>
-    <get dest="${metabuild.releasejson}" skipexisting="false" src="${metabuild.jsonurl}" />
+    
+    <!-- Download release json properties -->
+    <taskdef name="downloadreleasejson" classname="org.netbeans.nbbuild.DownloadReleaseJsonProperties" classpath="${nbantext.jar}" />
+    <property name="metabuild.releasejson.cache" value="${binaries.cache}/netbeansrelease.json"/>
+    <property name="metabuild.releasejson.cache.refresh" value="86400"/>
+    <downloadreleasejson dest="${metabuild.releasejson}" src="${metabuild.jsonurl}" cache="${metabuild.releasejson.cache}" refresh="${metabuild.releasejson.cache.refresh}" ignoreerrors="true"/>
+
     <!-- read info from gitinfo.properties , if present in source bundle copy gitinfo-->
     <copy file="${nb_all}/nbbuild/gitinfo.properties" tofile="${nb_all}/nbbuild/build/gitinfo.properties" failonerror="false"/>
     <copy file="${nb_all}/nbbuild/netbeansrelease.properties" tofile="${nb_all}/nbbuild/build/netbeansrelease.properties" failonerror="false"/>

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/DownloadReleaseJsonPropertiesTest.java
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/DownloadReleaseJsonPropertiesTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.nbbuild;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.apache.tools.ant.Project;
+import org.junit.Test;
+import org.netbeans.junit.NbTestCase;
+
+/**
+ *
+ * @author Hector Espert
+ */
+public class DownloadReleaseJsonPropertiesTest extends NbTestCase {
+    
+    private final DownloadReleaseJsonProperties downloadTask = new DownloadReleaseJsonProperties();
+
+    public DownloadReleaseJsonPropertiesTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        clearWorkDir();
+    }
+
+    public void testExecute() throws MalformedURLException, IOException {
+        Project project = new Project();
+        downloadTask.setProject(project);
+
+        URL src = new URL("https://gitbox.apache.org/repos/asf?p=netbeans-jenkins-lib.git;a=blob_plain;f=meta/netbeansrelease.json");
+        downloadTask.setSrc(src);
+        
+        File destFolder = new File(getWorkDir().getAbsolutePath() + File.separator + "dest" + File.separator + "netbeansrelease.json");
+        destFolder.mkdirs();
+        
+        File dest = new File(destFolder.getAbsolutePath() + File.separator + "netbeansrelease.json");
+        assertFalse(dest.exists());
+        downloadTask.setDest(dest);
+        
+        File cacheFolder = new File(getWorkDir().getAbsolutePath() + File.separator + "cache");
+        cacheFolder.mkdirs();
+        
+        File cache = new File(cacheFolder.getAbsolutePath() + File.separator + "netbeansrelease.json");
+        assertFalse(cache.exists());
+        downloadTask.setCache(cache);
+        
+        downloadTask.execute();
+        
+        assertTrue(dest.exists());
+        assertTrue(cache.exists());
+        
+    }
+    
+}


### PR DESCRIPTION
Add custom ant task to download and cache the release json properties file to prevent send a request to the Apache gitbox every time that an ant command is executed in the root project.

This PR is related to this other to prevent requests in the proxy configuration: https://github.com/apache/netbeans/pull/2192