### PR TITLE
[NETBEANS-4463] Fixed unit tests for Codeception on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,9 @@ jobs:
         
       - name: Test
         run: ant -f platform/core.network test
+
+      - name: Codeception test
+        run: ant -f php/php.codeception test
         
   linux:
     name: Check Build System

--- a/php/php.codeception/test/unit/src/org/netbeans/modules/php/codeception/coverage/CodeceptionCoverageLogParserTest.java
+++ b/php/php.codeception/test/unit/src/org/netbeans/modules/php/codeception/coverage/CodeceptionCoverageLogParserTest.java
@@ -24,6 +24,7 @@ import java.io.FileReader;
 import java.io.Reader;
 import org.junit.Test;
 import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileUtil;
 
 public class CodeceptionCoverageLogParserTest extends NbTestCase {
 
@@ -45,7 +46,7 @@ public class CodeceptionCoverageLogParserTest extends NbTestCase {
 
         // 1st file
         CoverageImpl.FileImpl file = (CoverageImpl.FileImpl) coverage.getFiles().get(0);
-        assertEquals("/home/junichi11/NetBeansProjects/codeception/src/FizzBuzz.php", file.getPath());
+        assertEquals(FileUtil.normalizePath("/home/junichi11/NetBeansProjects/codeception/src/FizzBuzz.php"), file.getPath());
         assertEquals(1, file.getClasses().size());
 
         // class
@@ -98,7 +99,7 @@ public class CodeceptionCoverageLogParserTest extends NbTestCase {
 
         // 2nd file
         file = (CoverageImpl.FileImpl) coverage.getFiles().get(1);
-        assertEquals("/home/junichi11/NetBeansProjects/codeception/tests/_support/UnitTester.php", file.getPath());
+        assertEquals(FileUtil.normalizePath("/home/junichi11/NetBeansProjects/codeception/tests/_support/UnitTester.php"), file.getPath());
         assertEquals(1, file.getClasses().size());
 
         // class
@@ -138,7 +139,7 @@ public class CodeceptionCoverageLogParserTest extends NbTestCase {
 
         // 3rd file
         file = (CoverageImpl.FileImpl) coverage.getFiles().get(2);
-        assertEquals("/home/junichi11/NetBeansProjects/codeception/tests/_support/_generated/UnitTesterActions.php", file.getPath());
+        assertEquals(FileUtil.normalizePath("/home/junichi11/NetBeansProjects/codeception/tests/_support/_generated/UnitTesterActions.php"), file.getPath());
         assertEquals(1, file.getClasses().size());
 
         // class


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4463

Expected file paths are normalized to match paths parsed from log file.