### PR TITLE
[NETBEANS-4464] Fixed unit tests for Atoum on Windows

### DIFF
--- a/php/php.atoum/test/unit/data/coverage.xml
+++ b/php/php.atoum/test/unit/data/coverage.xml
@@ -23,7 +23,7 @@
 <coverage generated="1404809792" clover="53bbb240a1c72">
   <project timestamp="1404809792" name="atoum code coverage">
     <package name="atoumCodeCoverage">
-      <file name="Calculator.php" path="%WORKDIR%/testdata/Calculator.php">
+      <file name="Calculator.php" path="%WORKDIR%%SEP%testdata%SEP%Calculator.php">
         <line num="50" type="stmt" complexity="0" count="1" falsecount="0" truecount="0" signature="" testduration="0" testsuccess="0"/>
         <line num="51" type="stmt" complexity="0" count="0" falsecount="0" truecount="0" signature="" testduration="0" testsuccess="0"/>
         <line num="54" type="stmt" complexity="0" count="1" falsecount="0" truecount="0" signature="" testduration="0" testsuccess="0"/>
@@ -40,7 +40,7 @@
         </class>
         <metrics complexity="0" elements="6" coveredelements="6" conditionals="0" coveredconditionals="0" statements="6" coveredstatements="6" methods="4" coveredmethods="4" testduration="0" testfailures="0" testpasses="0" testruns="0" classes="1" loc="6" ncloc="6"/>
       </file>
-      <file name="Calculator2.php" path="%WORKDIR%/testdata/Calculator2.php">
+      <file name="Calculator2.php" path="%WORKDIR%%SEP%testdata%SEP%Calculator2.php">
         <line num="50" type="stmt" complexity="0" count="0" falsecount="0" truecount="0" signature="" testduration="0" testsuccess="0"/>
         <line num="51" type="stmt" complexity="0" count="0" falsecount="0" truecount="0" signature="" testduration="0" testsuccess="0"/>
         <line num="54" type="stmt" complexity="0" count="1" falsecount="0" truecount="0" signature="" testduration="0" testsuccess="0"/>

--- a/php/php.atoum/test/unit/src/org/netbeans/modules/php/atoum/coverage/CloverLogParserTest.java
+++ b/php/php.atoum/test/unit/src/org/netbeans/modules/php/atoum/coverage/CloverLogParserTest.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.regex.Matcher;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.php.spi.testing.coverage.Coverage;
 import org.netbeans.modules.php.spi.testing.coverage.FileMetrics;
@@ -35,6 +36,7 @@ import org.netbeans.modules.php.spi.testing.coverage.FileMetrics;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
+import org.openide.filesystems.FileUtil;
 
 public class CloverLogParserTest extends NbTestCase {
 
@@ -101,7 +103,10 @@ public class CloverLogParserTest extends NbTestCase {
         Path path = file.toPath();
         Charset charset = StandardCharsets.UTF_8;
         String content = new String(Files.readAllBytes(path), charset);
-        content = content.replaceAll("%WORKDIR%", getDataDir().getAbsolutePath());
+        String workdirReplacement = Matcher.quoteReplacement(getDataDir().getAbsolutePath());
+        content = content.replaceAll("%WORKDIR%", workdirReplacement);
+        String separatorReplacement = Matcher.quoteReplacement(File.separator);
+        content = content.replaceAll("%SEP%", separatorReplacement);
         Files.write(path, content.getBytes(charset));
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4464
Directory separators had to be replaced with system-dependent value.
Because Windows use `\` as separator, replacement text has to be quoted.