### PR TITLE
[NETBEANS-4465] - update RAT license exceptions

### DIFF
--- a/nbbuild/rat-exclusions.txt
+++ b/nbbuild/rat-exclusions.txt
@@ -23,9 +23,30 @@ nbbuild/licenses/**
 nbbuild/netbeans/**
 nbbuild/testuserdir/**
 nbbuild/user.build.properties
-###### generated build artefact
+###### generated build artifacts
 nbbuild/gitinfo.properties
 nbbuild/netbeansrelease.properties
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/model_1_4/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/model_5/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/model_6/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/model_7/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/model_8/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/client/model_1_4/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/client/model_5_0/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/client/model_6_0/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/client/model_7_0/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/model_2_1/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/model_3_0/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/model_3_1/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/ejb/model_3_2/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/model_2_4/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/model_2_5/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/model_3_0/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/model_3_1/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/model_4_0/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/model_3_0_frag/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/model_3_1_frag/*
+enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/web/model_4_0_frag/*
 
 ###### user-specific files  
 **/nbproject/private/**


### PR DESCRIPTION
When running the RAT report after a build has taken place, the report
picks up hundreds of build generated files. These files do not have a license
header and it's really not necessary as they are generated by the build process..