### PR TITLE
[NETBEANS-4483] Fixed unit tests for Nette Tester

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
           ant -f php/php.doctrine2 test
           # ant -f php/php.editor test
           # ant -f php/php.latte test
-          # ant -f php/php.nette.tester test
+          ant -f php/php.nette.tester test
           # ant -f php/php.phpunit test
           # ant -f php/php.project test
           ant -f php/php.refactoring test

--- a/.travis.yml
+++ b/.travis.yml
@@ -681,7 +681,7 @@ matrix:
             - ant $OPTS -f php/php.doctrine2 test
             #- ant $OPTS -f php/php.editor test
             #- ant $OPTS -f php/php.latte test
-            #- ant $OPTS -f php/php.nette.tester test
+            - ant $OPTS -f php/php.nette.tester test
             - ant $OPTS -f php/php.phpunit test
             - ant $OPTS -f php/php.project test
             - ant $OPTS -f php/php.refactoring test

--- a/php/php.nette.tester/test/unit/data/coverage.xml
+++ b/php/php.nette.tester/test/unit/data/coverage.xml
@@ -22,23 +22,23 @@
 <coverage generated="1427797168">
   <project timestamp="1427797168">
     <metrics packages="0" files="2" loc="144" ncloc="56" classes="2" methods="10" coveredmethods="4" statements="7" coveredstatements="6" elements="17" coveredelements="10" conditionals="0" coveredconditionals="0"/>
-    <file name="%WORKDIR%/testdata/Calculator.php">
-      <metrics loc="72" ncloc="28" classes="1" methods="5" coveredmethods="4" statements="7" coveredstatements="6" elements="12" coveredelements="10" conditionals="0" coveredconditionals="0"/>
+    <file name="%WORKDIR%%SEP%testdata%SEP%Calculator.php">
+      <metrics loc="49" ncloc="28" classes="1" methods="5" coveredmethods="4" statements="7" coveredstatements="6" elements="12" coveredelements="10" conditionals="0" coveredconditionals="0"/>
       <class name="Calculator">
         <metrics methods="5" coveredmethods="4" statements="7" coveredstatements="6" conditionals="0" coveredconditionals="0" elements="12" coveredelements="10"/>
       </class>
-      <line num="47" type="stmt" count="1"/>
+      <line num="23" type="stmt" count="1"/>
+      <line num="26" type="stmt" count="1"/>
+      <line num="30" type="stmt" count="1"/>
+      <line num="34" type="stmt" count="1"/>
+      <line num="39" type="stmt" count="1"/>
+      <line num="40" type="stmt" count="1"/>
+      <line num="42" type="stmt" count="1"/>
+      <line num="46" type="stmt" count="0"/>
       <line num="50" type="stmt" count="1"/>
-      <line num="54" type="stmt" count="1"/>
-      <line num="58" type="stmt" count="1"/>
-      <line num="62" type="stmt" count="1"/>
-      <line num="63" type="stmt" count="1"/>
-      <line num="65" type="stmt" count="1"/>
-      <line num="69" type="stmt" count="0"/>
-      <line num="73" type="stmt" count="1"/>
     </file>
-    <file name="%WORKDIR%/testdata/Calculator2.php">
-      <metrics loc="72" ncloc="28" classes="1" methods="5" coveredmethods="0" statements="0" coveredstatements="0" elements="5" coveredelements="0" conditionals="0" coveredconditionals="0"/>
+    <file name="%WORKDIR%%SEP%testdata%SEP%Calculator2.php">
+      <metrics loc="49" ncloc="28" classes="1" methods="5" coveredmethods="0" statements="0" coveredstatements="0" elements="5" coveredelements="0" conditionals="0" coveredconditionals="0"/>
       <class name="Calculator2">
         <metrics methods="5" coveredmethods="0" statements="0" coveredstatements="0" conditionals="0" coveredconditionals="0" elements="5" coveredelements="0"/>
       </class>

--- a/php/php.nette.tester/test/unit/src/org/netbeans/modules/php/nette/tester/coverage/CloverLogParserTest.java
+++ b/php/php.nette.tester/test/unit/src/org/netbeans/modules/php/nette/tester/coverage/CloverLogParserTest.java
@@ -32,10 +32,6 @@ import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.php.spi.testing.coverage.Coverage;
 import org.netbeans.modules.php.spi.testing.coverage.FileMetrics;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-
 public class CloverLogParserTest extends NbTestCase {
 
     public CloverLogParserTest(String name) {
@@ -55,32 +51,32 @@ public class CloverLogParserTest extends NbTestCase {
         assertEquals(new File(getDataDir(), "testdata/Calculator.php").getAbsolutePath(), file.getPath());
         FileMetrics metrics = file.getMetrics();
         assertNotNull(metrics);
-        assertEquals(72, metrics.getLineCount());
+        assertEquals(49, metrics.getLineCount());
         assertEquals(7, metrics.getStatements());
         assertEquals(6, metrics.getCoveredStatements());
         assertNotNull(file.getLines());
         assertEquals(9, file.getLines().size());
         Coverage.Line line = file.getLines().get(0);
-        assertEquals(47, line.getNumber());
+        assertEquals(23, line.getNumber());
         assertEquals(1, line.getHitCount());
         line = file.getLines().get(1);
-        assertEquals(50, line.getNumber());
+        assertEquals(26, line.getNumber());
         assertEquals(1, line.getHitCount());
         line = file.getLines().get(2);
-        assertEquals(54, line.getNumber());
+        assertEquals(30, line.getNumber());
         assertEquals(1, line.getHitCount());
         line = file.getLines().get(7);
-        assertEquals(69, line.getNumber());
+        assertEquals(46, line.getNumber());
         assertEquals(0, line.getHitCount());
         line = file.getLines().get(8);
-        assertEquals(73, line.getNumber());
+        assertEquals(50, line.getNumber());
         assertEquals(1, line.getHitCount());
 
         file = files.get(1);
         assertEquals(new File(getDataDir(), "testdata/Calculator2.php").getAbsolutePath(), file.getPath());
         metrics = file.getMetrics();
         assertNotNull(metrics);
-        assertEquals(72, metrics.getLineCount());
+        assertEquals(49, metrics.getLineCount());
         assertEquals(0, metrics.getStatements());
         assertEquals(0, metrics.getCoveredStatements());
         assertNotNull(file.getLines());
@@ -98,7 +94,8 @@ public class CloverLogParserTest extends NbTestCase {
         Path path = file.toPath();
         Charset charset = StandardCharsets.UTF_8;
         String content = new String(Files.readAllBytes(path), charset);
-        content = content.replaceAll("%WORKDIR%", getDataDir().getAbsolutePath());
+        content = content.replace("%WORKDIR%", getDataDir().getAbsolutePath());
+        content = content.replace("%SEP%", File.separator);
         Files.write(path, content.getBytes(charset));
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4483

- Directory separators had to be replaced with system-dependent value.
- Because Windows use \ as separator, replacement text has to be quoted.
- Updated test to match line numbers after license change.
- Enabled tests in Travis and Github Actions