### PR TITLE
[NETBEANS-3342] Fix Netbeans Installer on macOS to work with Java 8 and Java 11+

### DIFF
--- a/nbbuild/binaries-default-properties.xml
+++ b/nbbuild/binaries-default-properties.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project name="binaries-default-properties" default="netbeans" basedir=".">
+  <property name="binaries.cache" location="${user.home}/.hgexternalcache"/>
+  <property name="binaries.server" value="https://netbeans.osuosl.org/binaries/"/>
+</project>

--- a/nbbuild/default-properties.xml
+++ b/nbbuild/default-properties.xml
@@ -66,8 +66,7 @@
 
   <property name="test.dist.dir" location="${nb.build.dir}/testdist"/>
   
-  <property name="binaries.cache" location="${user.home}/.hgexternalcache"/>
-  <property name="binaries.server" value="https://netbeans.osuosl.org/binaries/"/>
+  <import file="binaries-default-properties.xml"/>
 
   <target name="-load-build-properties">
     <property file="${nb_all}/nbbuild/build.properties"/>

--- a/nbbuild/installer/infra/build/build.sh
+++ b/nbbuild/installer/infra/build/build.sh
@@ -124,6 +124,8 @@ if [ -z "$ANT_OPTS" ] ; then
     ANT_OPTS="-Xmx768m"
 fi
 
+ANT_OPTS="$ANT_OPTS -DIS_NB_INSTALLER=true"
+
 java8output=`"$JAVA_HOME/bin/java" -version 2>&1 | grep 1.8.0`
 
 if [ -n "$java7output" ] ; then

--- a/nbi/engine/build.xml
+++ b/nbi/engine/build.xml
@@ -24,6 +24,16 @@
     <property file="build.properties"/>
     <property file="${native.dirname}/build.properties"/>
 
+    <!-- prepend bootclasspath for JDK 9+ JEP 272: Platform-Specific Desktop Features stubs -->
+    <condition property="desktop-classes-classes.dir" value="build/desktop-classes-classes" else="${build.dir}/desktop-classes-classes">
+      <isset property="IS_NB_INSTALLER"/>
+    </condition>
+    <condition property="endorsed.classpath" value="${desktop-classes-classes.dir}" else="" >
+      <not>
+        <isset property="permit.jdk9.builds"/>
+      </not>
+    </condition>
+
     <import file="nbproject/build-impl.xml"/>
     <import file="${native.dirname}/build.xml"/>
     
@@ -32,7 +42,44 @@
     ======================================================================== -->
     <target name="-post-clean" depends="native-clean"/>
     <target name="-post-compile" depends="native-build,copy-native,create-jar-contents-list,probe"/>
+
+    <!-- =======================================================================
+        Support JDK 9+ JEP 272: Platform-Specific Desktop Features.
+    ======================================================================== -->
+
+    <condition property="relative.nbbuild.dir" value="../../../../../../.." else="../..">
+      <isset property="IS_NB_INSTALLER"/>
+    </condition>
     
+    <!-- NetBeans Installer makes a copy then compiles again so check if directory exists -->
+    <condition property="nbbuild.dir" value="${relative.nbbuild.dir}/nbbuild" else="../../../../../../../../../../../../nbbuild">
+      <available file="${relative.nbbuild.dir}/nbbuild"/>
+    </condition>    
+    
+    <target name="-define-downloadbinaries-task" unless="have-downloadbinaries-task">
+      <taskdef name="downloadbinaries" classname="org.netbeans.nbbuild.extlibs.DownloadBinaries" classpath="${nbbuild.dir}/build/antclasses"/>
+      <property name="have-downloadbinaries-task" value="true" />
+    </target>
+
+    <import file="${nbbuild.dir}/binaries-default-properties.xml"/>
+
+    <target name="-download.release.files" depends="-define-downloadbinaries-task">
+        <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
+            <manifest dir=".">
+                <include name="external/binaries-list"/>
+            </manifest>
+        </downloadbinaries>
+    </target>
+
+    <available property="desktop.classes.available" classname="java.awt.desktop.AppEvent"/>
+
+    <target name="-compile-depend" depends="-download.release.files" unless="desktop.classes.available">
+          <mkdir dir="${build.dir}/desktop-classes-src" />
+          <unzip src="external/applemenu-external-desktop-classes-8.2.zip" dest="${build.dir}/desktop-classes-src"/>
+          <mkdir dir="${build.dir}/desktop-classes-classes" />
+          <javac srcdir="${build.dir}/desktop-classes-src" destdir="${build.dir}/desktop-classes-classes"/>
+    </target>
+
     <!-- =======================================================================
         NetBeans Installer engine specific targets
     ======================================================================== -->
@@ -145,8 +192,8 @@
         <available property="probe.javac.target" value="1.6" classname="java.lang.Module"/>
         <available property="probe.javac.source" value="1.6" file="${nbjdk.home}/bin/jmod"/>
         <available property="probe.javac.target" value="1.6" file="${nbjdk.home}/bin/jmod"/>
-        <property name="probe.javac.source" value="1.3"/>
-        <property name="probe.javac.target" value="1.1"/>
+        <property name="probe.javac.source" value="1.4"/>
+        <property name="probe.javac.target" value="1.4"/>
         <mkdir dir="${build.classes.dir}/org/netbeans/installer/utils/applications/"/>
         <javac srcdir="probesrc" destdir="${build.classes.dir}/org/netbeans/installer/utils/applications/" source="${probe.javac.source}" debug="true" deprecation="true" target="${probe.javac.target}"/>
     </target>

--- a/nbi/engine/external/applemenu-external-desktop-classes-8.2-license.txt
+++ b/nbi/engine/external/applemenu-external-desktop-classes-8.2-license.txt
@@ -1,0 +1,389 @@
+Name: External Desktop Classes
+Description: Provides java.awt.desktop classes to support compilation on JDK 8.
+Version: 8.2
+License: CDDL-1.0
+Source: file://applemenu-external-desktop-classes-8.2.zip
+Origin: NetBeans
+Type: compile-time
+Comment: Allows to build code leveraging JDK 9's java.awt.desktop classes on JDK 8.
+
+COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0
+
+1. Definitions.
+
+1.1. "Contributor" means each individual or entity that
+creates or contributes to the creation of Modifications.
+
+1.2. "Contributor Version" means the combination of the
+Original Software, prior Modifications used by a
+Contributor (if any), and the Modifications made by that
+particular Contributor.
+
+1.3. "Covered Software" means (a) the Original Software, or
+(b) Modifications, or (c) the combination of files
+containing Original Software with files containing
+Modifications, in each case including portions thereof.
+
+1.4. "Executable" means the Covered Software in any form
+other than Source Code.
+
+1.5. "Initial Developer" means the individual or entity
+that first makes Original Software available under this
+License.
+
+1.6. "Larger Work" means a work which combines Covered
+Software or portions thereof with code not governed by the
+terms of this License.
+
+1.7. "License" means this document.
+
+1.8. "Licensable" means having the right to grant, to the
+maximum extent possible, whether at the time of the initial
+grant or subsequently acquired, any and all of the rights
+conveyed herein.
+
+1.9. "Modifications" means the Source Code and Executable
+form of any of the following:
+
+A. Any file that results from an addition to,
+deletion from or modification of the contents of a
+file containing Original Software or previous
+Modifications;
+
+B. Any new file that contains any part of the
+Original Software or previous Modification; or
+
+C. Any new file that is contributed or otherwise made
+available under the terms of this License.
+
+1.10. "Original Software" means the Source Code and
+Executable form of computer software code that is
+originally released under this License.
+
+1.11. "Patent Claims" means any patent claim(s), now owned
+or hereafter acquired, including without limitation,
+method, process, and apparatus claims, in any patent
+Licensable by grantor.
+
+1.12. "Source Code" means (a) the common form of computer
+software code in which modifications are made and (b)
+associated documentation included in or with such code.
+
+1.13. "You" (or "Your") means an individual or a legal
+entity exercising rights under, and complying with all of
+the terms of, this License. For legal entities, "You"
+includes any entity which controls, is controlled by, or is
+under common control with You. For purposes of this
+definition, "control" means (a) the power, direct or
+indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (b) ownership
+of more than fifty percent (50%) of the outstanding shares
+or beneficial ownership of such entity.
+
+2. License Grants.
+
+2.1. The Initial Developer Grant.
+
+Conditioned upon Your compliance with Section 3.1 below and
+subject to third party intellectual property claims, the
+Initial Developer hereby grants You a world-wide,
+royalty-free, non-exclusive license:
+
+(a) under intellectual property rights (other than
+patent or trademark) Licensable by Initial Developer,
+to use, reproduce, modify, display, perform,
+sublicense and distribute the Original Software (or
+portions thereof), with or without Modifications,
+and/or as part of a Larger Work; and
+
+(b) under Patent Claims infringed by the making,
+using or selling of Original Software, to make, have
+made, use, practice, sell, and offer for sale, and/or
+otherwise dispose of the Original Software (or
+portions thereof).
+
+(c) The licenses granted in Sections 2.1(a) and (b)
+are effective on the date Initial Developer first
+distributes or otherwise makes the Original Software
+available to a third party under the terms of this
+License.
+
+(d) Notwithstanding Section 2.1(b) above, no patent
+license is granted: (1) for code that You delete from
+the Original Software, or (2) for infringements
+caused by: (i) the modification of the Original
+Software, or (ii) the combination of the Original
+Software with other software or devices.
+
+2.2. Contributor Grant.
+
+Conditioned upon Your compliance with Section 3.1 below and
+subject to third party intellectual property claims, each
+Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than
+patent or trademark) Licensable by Contributor to
+use, reproduce, modify, display, perform, sublicense
+and distribute the Modifications created by such
+Contributor (or portions thereof), either on an
+unmodified basis, with other Modifications, as
+Covered Software and/or as part of a Larger Work; and
+
+(b) under Patent Claims infringed by the making,
+using, or selling of Modifications made by that
+Contributor either alone and/or in combination with
+its Contributor Version (or portions of such
+combination), to make, use, sell, offer for sale,
+have made, and/or otherwise dispose of: (1)
+Modifications made by that Contributor (or portions
+thereof); and (2) the combination of Modifications
+made by that Contributor with its Contributor Version
+(or portions of such combination).
+
+(c) The licenses granted in Sections 2.2(a) and
+2.2(b) are effective on the date Contributor first
+distributes or otherwise makes the Modifications
+available to a third party.
+
+(d) Notwithstanding Section 2.2(b) above, no patent
+license is granted: (1) for any code that Contributor
+has deleted from the Contributor Version; (2) for
+infringements caused by: (i) third party
+modifications of Contributor Version, or (ii) the
+combination of Modifications made by that Contributor
+with other software (except as part of the
+Contributor Version) or other devices; or (3) under
+Patent Claims infringed by Covered Software in the
+absence of Modifications made by that Contributor.
+
+3. Distribution Obligations.
+
+3.1. Availability of Source Code.
+
+Any Covered Software that You distribute or otherwise make
+available in Executable form must also be made available in
+Source Code form and that Source Code form must be
+distributed only under the terms of this License. You must
+include a copy of this License with every copy of the
+Source Code form of the Covered Software You distribute or
+otherwise make available. You must inform recipients of any
+such Covered Software in Executable form as to how they can
+obtain such Covered Software in Source Code form in a
+reasonable manner on or through a medium customarily used
+for software exchange.
+
+3.2. Modifications.
+
+The Modifications that You create or to which You
+contribute are governed by the terms of this License. You
+represent that You believe Your Modifications are Your
+original creation(s) and/or You have sufficient rights to
+grant the rights conveyed by this License.
+
+3.3. Required Notices.
+
+You must include a notice in each of Your Modifications
+that identifies You as the Contributor of the Modification.
+You may not remove or alter any copyright, patent or
+trademark notices contained within the Covered Software, or
+any notices of licensing or any descriptive text giving
+attribution to any Contributor or the Initial Developer.
+
+3.4. Application of Additional Terms.
+
+You may not offer or impose any terms on any Covered
+Software in Source Code form that alters or restricts the
+applicable version of this License or the recipients'
+rights hereunder. You may choose to offer, and to charge a
+fee for, warranty, support, indemnity or liability
+obligations to one or more recipients of Covered Software.
+However, you may do so only on Your own behalf, and not on
+behalf of the Initial Developer or any Contributor. You
+must make it absolutely clear that any such warranty,
+support, indemnity or liability obligation is offered by
+You alone, and You hereby agree to indemnify the Initial
+Developer and every Contributor for any liability incurred
+by the Initial Developer or such Contributor as a result of
+warranty, support, indemnity or liability terms You offer.
+
+3.5. Distribution of Executable Versions.
+
+You may distribute the Executable form of the Covered
+Software under the terms of this License or under the terms
+of a license of Your choice, which may contain terms
+different from this License, provided that You are in
+compliance with the terms of this License and that the
+license for the Executable form does not attempt to limit
+or alter the recipient's rights in the Source Code form
+from the rights set forth in this License. If You
+distribute the Covered Software in Executable form under a
+different license, You must make it absolutely clear that
+any terms which differ from this License are offered by You
+alone, not by the Initial Developer or Contributor. You
+hereby agree to indemnify the Initial Developer and every
+Contributor for any liability incurred by the Initial
+Developer or such Contributor as a result of any such terms
+You offer.
+
+3.6. Larger Works.
+
+You may create a Larger Work by combining Covered Software
+with other code not governed by the terms of this License
+and distribute the Larger Work as a single product. In such
+a case, You must make sure the requirements of this License
+are fulfilled for the Covered Software.
+
+4. Versions of the License.
+
+4.1. New Versions.
+
+Sun Microsystems, Inc. is the initial license steward and
+may publish revised and/or new versions of this License
+from time to time. Each version will be given a
+distinguishing version number. Except as provided in
+Section 4.3, no one other than the license steward has the
+right to modify this License.
+
+4.2. Effect of New Versions.
+
+You may always continue to use, distribute or otherwise
+make the Covered Software available under the terms of the
+version of the License under which You originally received
+the Covered Software. If the Initial Developer includes a
+notice in the Original Software prohibiting it from being
+distributed or otherwise made available under any
+subsequent version of the License, You must distribute and
+make the Covered Software available under the terms of the
+version of the License under which You originally received
+the Covered Software. Otherwise, You may also choose to
+use, distribute or otherwise make the Covered Software
+available under the terms of any subsequent version of the
+License published by the license steward.
+
+4.3. Modified Versions.
+
+When You are an Initial Developer and You want to create a
+new license for Your Original Software, You may create and
+use a modified version of this License if You: (a) rename
+the license and remove any references to the name of the
+license steward (except to note that the license differs
+from this License); and (b) otherwise make it clear that
+the license contains terms which differ from this License.
+
+5. DISCLAIMER OF WARRANTY.
+
+COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON AN "AS IS"
+BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED
+SOFTWARE IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR
+PURPOSE OR NON-INFRINGING. THE ENTIRE RISK AS TO THE QUALITY AND
+PERFORMANCE OF THE COVERED SOFTWARE IS WITH YOU. SHOULD ANY
+COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE
+INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF
+ANY NECESSARY SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF
+WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO USE OF
+ANY COVERED SOFTWARE IS AUTHORIZED HEREUNDER EXCEPT UNDER THIS
+DISCLAIMER.
+
+6. TERMINATION.
+
+6.1. This License and the rights granted hereunder will
+terminate automatically if You fail to comply with terms
+herein and fail to cure such breach within 30 days of
+becoming aware of the breach. Provisions which, by their
+nature, must remain in effect beyond the termination of
+this License shall survive.
+
+6.2. If You assert a patent infringement claim (excluding
+declaratory judgment actions) against Initial Developer or
+a Contributor (the Initial Developer or Contributor against
+whom You assert such claim is referred to as "Participant")
+alleging that the Participant Software (meaning the
+Contributor Version where the Participant is a Contributor
+or the Original Software where the Participant is the
+Initial Developer) directly or indirectly infringes any
+patent, then any and all rights granted directly or
+indirectly to You by such Participant, the Initial
+Developer (if the Initial Developer is not the Participant)
+and all Contributors under Sections 2.1 and/or 2.2 of this
+License shall, upon 60 days notice from Participant
+terminate prospectively and automatically at the expiration
+of such 60 day notice period, unless if within such 60 day
+period You withdraw Your claim with respect to the
+Participant Software against such Participant either
+unilaterally or pursuant to a written agreement with
+Participant.
+
+6.3. In the event of termination under Sections 6.1 or 6.2
+above, all end user licenses that have been validly granted
+by You or any distributor hereunder prior to termination
+(excluding licenses granted to You by any distributor)
+shall survive termination.
+
+7. LIMITATION OF LIABILITY.
+
+UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT
+(INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE
+INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF
+COVERED SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE
+LIABLE TO ANY PERSON FOR ANY INDIRECT, SPECIAL, INCIDENTAL, OR
+CONSEQUENTIAL DAMAGES OF ANY CHARACTER INCLUDING, WITHOUT
+LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK
+STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER
+COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN
+INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF
+LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL
+INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT
+APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO
+NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR
+CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT
+APPLY TO YOU.
+
+8. U.S. GOVERNMENT END USERS.
+
+The Covered Software is a "commercial item," as that term is
+defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of "commercial
+computer software" (as that term is defined at 48 C.F.R.
+252.227-7014(a)(1)) and "commercial computer software
+documentation" as such terms are used in 48 C.F.R. 12.212 (Sept.
+1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R. 227.7202-1
+through 227.7202-4 (June 1995), all U.S. Government End Users
+acquire Covered Software with only those rights set forth herein.
+This U.S. Government Rights clause is in lieu of, and supersedes,
+any other FAR, DFAR, or other clause or provision that addresses
+Government rights in computer software under this License.
+
+9. MISCELLANEOUS.
+
+This License represents the complete agreement concerning subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the
+extent necessary to make it enforceable. This License shall be
+governed by the law of the jurisdiction specified in a notice
+contained within the Original Software (except to the extent
+applicable law, if any, provides otherwise), excluding such
+jurisdiction's conflict-of-law provisions. Any litigation
+relating to this License shall be subject to the jurisdiction of
+the courts located in the jurisdiction and venue specified in a
+notice contained within the Original Software, with the losing
+party responsible for costs, including, without limitation, court
+costs and reasonable attorneys' fees and expenses. The
+application of the United Nations Convention on Contracts for the
+International Sale of Goods is expressly excluded. Any law or
+regulation which provides that the language of a contract shall
+be construed against the drafter shall not apply to this License.
+You agree that You alone are responsible for compliance with the
+United States export administration regulations (and the export
+control laws and regulation of any other countries) when You use,
+distribute or otherwise make available any Covered Software.
+
+10. RESPONSIBILITY FOR CLAIMS.
+
+As between Initial Developer and the Contributors, each party is
+responsible for claims and damages arising, directly or
+indirectly, out of its utilization of rights under this License
+and You agree to work with Initial Developer and Contributors to
+distribute such responsibility on an equitable basis. Nothing
+herein is intended or shall be deemed to constitute any admission
+of liability.

--- a/nbi/engine/external/binaries-list
+++ b/nbi/engine/external/binaries-list
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+1D14F4B56AD34841339698565B17BBAE755B0E61 applemenu-external-desktop-classes-8.2.zip

--- a/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/CommonLauncher.java
+++ b/nbi/engine/src/org/netbeans/installer/utils/system/launchers/impl/CommonLauncher.java
@@ -294,6 +294,13 @@ public abstract class CommonLauncher extends Launcher {
                 case 49: return 5;
                 case 50: return 6;
                 case 51: return 7;
+                case 52: return 8;
+                case 53: return 9;
+                case 54: return 10;
+                case 55: return 11;
+                case 56: return 12;
+                case 57: return 13;
+                case 58: return 14;
                 default : return -1;
             }
         } else {            

--- a/nbi/engine/src/org/netbeans/installer/wizard/containers/InitializeMacJDK8.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/containers/InitializeMacJDK8.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.installer.wizard.containers;
+
+import com.apple.eawt.Application;
+import com.apple.eawt.ApplicationAdapter;
+import com.apple.eawt.ApplicationEvent;
+
+/**
+ *
+ * @author christian.oyarzun
+ */
+public class InitializeMacJDK8 {
+    public static void initialize(SwingFrameContainer frameContainer)
+    {
+        final Application application = Application.getApplication();
+        if(application == null) {
+            // e.g. running OpenJDK port via X11 on Mac OS X
+            return;
+        }
+        application.removeAboutMenuItem();
+        application.removePreferencesMenuItem();
+        application.addApplicationListener(new ApplicationAdapter() {
+
+            @Override
+            public void handleQuit(ApplicationEvent event) {
+                frameContainer.cancelContainer();
+            }
+        });
+
+    }
+}

--- a/nbi/engine/src/org/netbeans/installer/wizard/containers/InitializeMacJDK9.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/containers/InitializeMacJDK9.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.installer.wizard.containers;
+
+import java.awt.Desktop;
+import java.awt.desktop.QuitEvent;
+import java.awt.desktop.QuitHandler;
+import java.awt.desktop.QuitResponse;
+
+/**
+ *
+ * @author christian.oyarzun
+ */
+public class InitializeMacJDK9 {
+public static void initialize(SwingFrameContainer frameContainer)
+    {
+        Desktop desktop = Desktop.getDesktop();
+        if (desktop != null)
+        {
+            desktop.setQuitHandler((QuitEvent e, QuitResponse response) -> frameContainer.cancelContainer());
+        }
+    }
+}

--- a/nbi/engine/src/org/netbeans/installer/wizard/containers/SwingFrameContainer.java
+++ b/nbi/engine/src/org/netbeans/installer/wizard/containers/SwingFrameContainer.java
@@ -35,6 +35,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import javax.swing.AbstractAction;
 import javax.swing.ImageIcon;
@@ -415,26 +416,31 @@ public class SwingFrameContainer extends NbiFrame implements SwingContainer {
             }
         });
     }
-    
+
     private void initializeMacOS() {
         if (SystemUtils.isMacOS()) {
-            final Application application = Application.getApplication();
-            if(application == null) {
-                // e.g. running OpenJDK port via X11 on Mac OS X
-                return;
+            if (!initializeMacJDK("org.netbeans.installer.wizard.containers.initializeMacJDK8")) { // NOI18N
+               // JDK 8 failed, try JDK 9
+               initializeMacJDK("org.netbeans.installer.wizard.containers.initializeMacJDK9");
             }
-            application.removeAboutMenuItem();
-            application.removePreferencesMenuItem();
-            application.addApplicationListener(new ApplicationAdapter() {
-
-                @Override
-                public void handleQuit(ApplicationEvent event) {
-                    cancelContainer();
-                }
-            });
         }
     }
-    private void cancelContainer() {
+
+    private boolean initializeMacJDK(String className) {
+        try {
+            Class initializer = Class.forName(className);
+            @SuppressWarnings("unchecked")
+            Method m = initializer.getDeclaredMethod("initialize", new Class[0] ); // NOI18N
+            m.invoke(initializer, this);
+            return true;
+        }catch (NoClassDefFoundError e) {
+        }catch (ClassNotFoundException e) {
+        }catch (Exception e) {
+        }
+        return false;
+    }
+
+    void cancelContainer() {
         if (currentUi != null) {
             if (contentPane.getCancelButton().isEnabled()) {
                 currentUi.evaluateCancelButtonClick();


### PR DESCRIPTION
This pull request fixes the NetBean RCP installer on macOS with Java 11+ since `com.apple.eawt` classes were removed with JEP 272

Supersedes the following PRs and addresses their comments: 

-  Closes #1929
-  Closes #2015

@mcdonnell-john and/or @arusinha can you please review this PR.

Note: once this PR is merged and we have a new release, we will need to update https://github.com/apache/netbeans-mavenutils-nbm-maven-harness to use the latest nbi-engine nbm as it is currently using RELEASE112. 