### PR TITLE
[NETBEANS-4520] Enable File Chooser in non-project New File Wizard

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/SimpleTargetChooserPanelGUI.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/SimpleTargetChooserPanelGUI.java
@@ -493,10 +493,10 @@ public class SimpleTargetChooserPanelGUI extends javax.swing.JPanel implements A
                 //non project space
                 String previousTargetFolder = getTargetFolder(); //can be relative or absolute..
                 SourceGroup group = (SourceGroup)locationComboBox.getSelectedItem();
-                if (group == null) { // #161478
-                    return;
+                FileObject oldFo = null;
+                if (group != null) {
+                    oldFo = previousTargetFolder != null ? group.getRootFolder().getFileObject(previousTargetFolder) : group.getRootFolder();
                 }
-                FileObject oldFo = previousTargetFolder != null ? group.getRootFolder().getFileObject(previousTargetFolder) : group.getRootFolder();
                 if (oldFo == null && previousTargetFolder != null) {
                     oldFo = FileUtil.toFileObject(FileUtil.normalizeFile(new File(previousTargetFolder)));
                 }
@@ -506,13 +506,13 @@ public class SimpleTargetChooserPanelGUI extends javax.swing.JPanel implements A
                     new FileChooserBuilder(SimpleTargetChooserPanel.class)
                         .setDirectoriesOnly(true)
                         .setDefaultWorkingDirectory(currFile)
-                        .forceUseOfDefaultWorkingDirectory(true)
+                        .forceUseOfDefaultWorkingDirectory(group != null) //if no source group, allow other directories
                         .showSaveDialog();
 
                 FileObject fo = targetFolder != null ? FileUtil.toFileObject(FileUtil.normalizeFile(targetFolder)) : null;
 
                 if ( fo != null && fo.isFolder() ) {
-                    String path =  FileUtil.getRelativePath(group.getRootFolder(), fo);
+                    String path =  group == null ? null : FileUtil.getRelativePath(group.getRootFolder(), fo);
                     if (path == null) {
                          path = fo.getPath();
                     }


### PR DESCRIPTION
If there is no active project, then the New File Wizard does not allow to open the file chooser for selecting the folder. This patch fixes that without affecting unintended side effects. This is more of feature enhancement.

**Before**
![before](https://user-images.githubusercontent.com/12849684/85972831-0307c180-b99f-11ea-85cf-569a69c0d15f.gif)

**After**
![after](https://user-images.githubusercontent.com/12849684/85972838-07cc7580-b99f-11ea-8f07-1dd1141acacc.gif)

**Expected funtionality unaffected**
![no-sideeffects](https://user-images.githubusercontent.com/12849684/85972942-482bf380-b99f-11ea-878b-c3cf1e139e85.gif)

