### PR TITLE
[NETBEANS-4515] - remove use of proprietary API - ARRAYLENGTH

### DIFF
--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SeparatorTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SeparatorTest.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.api.java.source.gen;
 
-import com.sun.org.apache.bcel.internal.generic.ARRAYLENGTH;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
The code has a test case that uses a proprietary API field - ARRAYLENGTH..

...
 [nb-javac] /home/travis/build/apache/netbeans/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SeparatorTest.java:21: warning: ARRAYLENGTH is internal proprietary API and may be removed in a future release

 [nb-javac] import com.sun.org.apache.bcel.internal.generic.ARRAYLENGTH;

 [nb-javac]                                                ^

 [nb-javac] /home/travis/build/apache/netbeans/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SeparatorTest.java:21: warning: ARRAYLENGTH is internal proprietary API and may be removed in a future release

 [nb-javac] import com.sun.org.apache.bcel.internal.generic.ARRAYLENGTH;

 [nb-javac]                                                ^

 [nb-javac] /home/travis/build/apache/netbeans/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/SeparatorTest.java:21: warning: ARRAYLENGTH is internal proprietary API and may be removed in a future release

 [nb-javac] import com.sun.org.apache.bcel.internal.generic.ARRAYLENGTH;

 [nb-javac]                                                ^
...

Remove the import of this class as it's not used and causes spurious warnings..