### PR TITLE
[NETBEANS-4500] Fixed tests for PHP Editor on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           ant -f php/php.composer test
           ant -f php/php.dbgp test
           ant -f php/php.doctrine2 test
-          # ant -f php/php.editor test
+          ant -f php/php.editor test
           ant -f php/php.latte test
           ant -f php/php.nette.tester test
           ant -f php/php.phpunit test

--- a/.travis.yml
+++ b/.travis.yml
@@ -679,6 +679,7 @@ matrix:
             - ant $OPTS -f php/php.composer test
             #- ant $OPTS -f php/php.dbgp test
             - ant $OPTS -f php/php.doctrine2 test
+            # PHP Editor tests can't be run on Travis because they run 90 minutes.
             #- ant $OPTS -f php/php.editor test
             - ant $OPTS -f php/php.latte test
             - ant $OPTS -f php/php.nette.tester test

--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -423,7 +423,7 @@ public abstract class CslTestBase extends NbTestCase {
                     }
 
                     InputStream is = fo.getInputStream();
-                    BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 
                     while (true) {
                         String line = reader.readLine();

--- a/php/php.editor/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/verification/IntroduceSuggestion.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.php.editor.verification;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -465,11 +466,11 @@ public class IntroduceSuggestion extends SuggestionRule {
             int length = fileName.length();
             if (length > 30) {
                 fileName = fileName.substring(length - 30);
-                final int indexOf = fileName.indexOf("/");
+                final int indexOf = fileName.indexOf(File.separator);
                 if (indexOf != -1) { //NOI18N
                     fileName = fileName.substring(indexOf);
                 }
-                fileName = String.format("...%s/%s.php", fileName, className); //NOI18N
+                fileName = String.format("...%s%s%s.php", fileName, File.separator, className); //NOI18N
             }
             return Bundle.IntroduceHintClassDesc(classNameWithNsPart, fileName);
         }

--- a/php/php.editor/test/unit/data/testfiles/verification/testIntroduceSuggestion.php.testIntroduceSuggestion_01.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/testIntroduceSuggestion.php.testIntroduceSuggestion_01.hints
@@ -1,4 +1,4 @@
 new MyClass();^
 -------------
 HINT:Introduce Hint
-FIX:Create Class "MyClass" in .../data/testfiles/verification/MyClass.php
+FIX:Create Class "MyClass" in ...%SEP%data%SEP%testfiles%SEP%verification%SEP%MyClass.php

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/js/JsFormatterEmbeddedTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/js/JsFormatterEmbeddedTest.java
@@ -19,6 +19,8 @@
 
 package org.netbeans.modules.php.editor.js;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import junit.framework.Test;
 import org.netbeans.api.html.lexer.HTMLTokenId;
 import org.netbeans.junit.NbModuleSuite;
@@ -27,6 +29,9 @@ import org.netbeans.modules.html.editor.lib.api.HtmlVersion;
 import org.netbeans.modules.javascript2.lexer.api.JsTokenId;
 import org.netbeans.modules.php.editor.PHPTestBase;
 import org.netbeans.modules.php.editor.lexer.PHPTokenId;
+import org.netbeans.spi.queries.FileEncodingQueryImplementation;
+import org.openide.filesystems.FileObject;
+import org.openide.util.test.MockLookup;
 
 public class JsFormatterEmbeddedTest extends PHPTestBase {
 
@@ -58,6 +63,13 @@ public class JsFormatterEmbeddedTest extends PHPTestBase {
         } catch (IllegalStateException ise) {
             // Ignore -- we've already registered this either via layers or other means
         }
+
+        MockLookup.setInstances(new FileEncodingQueryImplementation() {
+            @Override
+            public Charset getEncoding(FileObject file) {
+                return StandardCharsets.UTF_8;
+            }
+        });
     }
 
     public void testEmbeddedSimple1() throws Exception {

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/PhpParserErrorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/parser/PhpParserErrorTest.java
@@ -18,7 +18,12 @@
  */
 package org.netbeans.modules.php.editor.parser;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.netbeans.modules.php.editor.PHPTestBase;
+import org.netbeans.spi.queries.FileEncodingQueryImplementation;
+import org.openide.filesystems.FileObject;
+import org.openide.util.test.MockLookup;
 
 /**
  *
@@ -33,6 +38,13 @@ public class PhpParserErrorTest extends PHPTestBase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+
+        MockLookup.setInstances(new FileEncodingQueryImplementation() {
+            @Override
+            public Charset getEncoding(FileObject file) {
+                return StandardCharsets.UTF_8;
+            }
+        });
     }
 
     @Override

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/HintsTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/HintsTest.java
@@ -18,6 +18,11 @@
  */
 package org.netbeans.modules.php.editor.verification;
 
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.netbeans.modules.php.api.PhpVersion;
 import org.openide.filesystems.FileObject;
 
@@ -29,6 +34,13 @@ public class HintsTest extends PHPHintsTestBase {
 
     public HintsTest(String testName) {
         super(testName);
+    }
+
+    @Override
+    protected File getDataFile(String relFilePath) {
+        // Overriden because CslTestBase loads file from different location.
+        File inputFile = new File(getDataDir(), relFilePath);
+        return inputFile;
     }
 
     public void testModifiersCheckHint() throws Exception {
@@ -149,6 +161,8 @@ public class HintsTest extends PHPHintsTestBase {
     }
 
     public void testIntroduceSuggestion_01() throws Exception {
+        // Needs to replace directory separators in expected result.
+        fixContent(new File(getDataDir(), getTestDirectory() + "testIntroduceSuggestion.php.testIntroduceSuggestion_01.hints"));
         checkHints(new IntroduceSuggestion(), "testIntroduceSuggestion.php", "new MyClass();^");
     }
 
@@ -728,6 +742,14 @@ public class HintsTest extends PHPHintsTestBase {
     public void testFieldRedeclarationTypedProperties20Hint_02() throws Exception {
         // PHP 7.4
         checkHints(new FieldRedeclarationHintError(), "testFieldRedeclarationTypedProperties20Hint_02.php");
+    }
+
+    private void fixContent(File file) throws Exception {
+        Path path = file.toPath();
+        Charset charset = StandardCharsets.UTF_8;
+        String content = new String(Files.readAllBytes(path), charset);
+        content = content.replace("%SEP%", File.separator);
+        Files.write(path, content.getBytes(charset));
     }
 
     //~ Inner classes


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4500

- Use UTF-8 when opening files.
- Use system-specific directory separators.
- Enabled tests in Github Actions.