### PR TITLE
[NETBEANS-4509] PHP - code completion for function with return type

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
@@ -224,10 +224,18 @@ public final class VariousUtils {
         if (returnType != null) {
             QualifiedName name = QualifiedName.create(returnType);
             assert name != null : returnType;
-            if (returnType instanceof NullableType) {
-                return CodeUtils.NULLABLE_TYPE_PREFIX + name.toString();
+            String typeName = name.toString();
+            if (Type.ARRAY.equals(typeName)) {
+                // For "array" type PHPDoc can contain more specific definition, i.e. MyClass[]
+                String typeFromPHPDoc = getReturnTypeFromPHPDoc(root, functionDeclaration);
+                if (typeFromPHPDoc != null) {
+                    return typeFromPHPDoc;
+                }
             }
-            return name.toString();
+            if (returnType instanceof NullableType) {
+                return CodeUtils.NULLABLE_TYPE_PREFIX + typeName;
+            }
+            return typeName;
         }
         return getReturnTypeFromPHPDoc(root, functionDeclaration);
     }

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/arrays/arrays.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/arrays/arrays.php
@@ -20,6 +20,14 @@ function arrayFunctionName() {
     return array(new ArraysCc());
 }
 
+/**
+ *
+ * @return ArraysCc[] foo
+ */
+function arrayFunctionTyped(): array {
+    return array(new ArraysCc());
+}
+
 (new ArraysCc)->field[0]->field;
 
 $a = array(new ArraysCc());
@@ -29,5 +37,10 @@ arrayFunctionName()[0]->field;
 
 $b = arrayFunctionName();
 $b[0]->field;
+
+arrayFunctionTyped()[0]->field;
+
+$c = arrayFunctionTyped();
+$c[0]->field;
 
 ?>

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/arrays/arrays.php.testArrays_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/arrays/arrays.php.testArrays_05.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+arrayFunctionTyped()[0]->|field;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     method()                        [PUBLIC]   ArraysCc
+VARIABLE   ArraysCc[][int][string] field   [PUBLIC]   ArraysCc

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/arrays/arrays.php.testArrays_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/arrays/arrays.php.testArrays_06.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+$c[0]->|field;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     method()                        [PUBLIC]   ArraysCc
+VARIABLE   ArraysCc[][int][string] field   [PUBLIC]   ArraysCc

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPArrayCodeCompletionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPArrayCodeCompletionTest.java
@@ -53,6 +53,14 @@ public class PHPArrayCodeCompletionTest extends PHPCodeCompletionTestBase {
         checkCompletion("testfiles/completion/lib/arrays/arrays.php", "$b[0]->^field;", false);
     }
 
+    public void testArrays_05() throws Exception {
+        checkCompletion("testfiles/completion/lib/arrays/arrays.php", "arrayFunctionTyped()[0]->^field;", false);
+    }
+
+    public void testArrays_06() throws Exception {
+        checkCompletion("testfiles/completion/lib/arrays/arrays.php", "$c[0]->^field;", false);
+    }
+
     @Override
     protected Map<String, ClassPath> createClassPathsForTest() {
         return Collections.singletonMap(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4509

Fixed code completion of functions with return type "array" and specific
type in "@return" in DocBlock.

Example:
```php
/**
 * @return \SplFileInfo[]
 */
function getFiles(): array { }

foreach (getFiles() as $file) {
    $file->^ // Offers methods from \SplFileInfo
}
```
Before this fix methods from `\SplFileInfo` will not be offered.