### PR TITLE
[NETBEANS-4541] Set working directory when running PHP CS Fixer

### DIFF
--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/CodingStandardsFixer.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/CodingStandardsFixer.java
@@ -29,7 +29,10 @@ import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.extexecution.ExecutionDescriptor;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
 import org.netbeans.modules.php.analysis.CodingStandardsFixerParams;
 import org.netbeans.modules.php.analysis.options.AnalysisOptions;
 import org.netbeans.modules.php.analysis.parsers.CodingStandardsFixerReportParser;
@@ -169,7 +172,8 @@ public final class CodingStandardsFixer {
     public List<Result> analyze(CodingStandardsFixerParams params, FileObject file) {
         assert file.isValid() : "Invalid file given: " + file;
         try {
-            Integer result = getExecutable(Bundle.CodingStandardsFixer_analyze(analyzeGroupCounter++))
+            
+            Integer result = getExecutable(Bundle.CodingStandardsFixer_analyze(analyzeGroupCounter++), findWorkDir(file))
                     .additionalParameters(getParameters(params, file))
                     .runAndWait(getDescriptor(), "Running coding standards fixer..."); // NOI18N
             if (result == null) {
@@ -187,18 +191,48 @@ public final class CodingStandardsFixer {
         return null;
     }
 
+    /**
+     * Finds project directory for the given file since it can contain
+     * {@code .php_cs}, {@code .php_cs.dist}.
+     *
+     * @param file file to find project directory for
+     * @return project directory or {@code null}
+     */
+    @CheckForNull
+    private File findWorkDir(FileObject file) {
+        assert file != null;
+        Project project = FileOwnerQuery.getOwner(file);
+        File workDir = null;
+        if (project != null) {
+            workDir = FileUtil.toFile(project.getProjectDirectory());
+            if (LOGGER.isLoggable(Level.FINE)) {
+                if (workDir != null) {
+                    LOGGER.log(Level.FINE, "Project directory for {0} is found in {1}", new Object[]{FileUtil.toFile(file), workDir}); // NOI18N
+                } else {
+                    // the file/directory may not be in a PHP project
+                    LOGGER.log(Level.FINE, "Project directory for {0} is not found", FileUtil.toFile(file)); // NOI18N
+                }
+            }
+        }
+        return workDir;
+    }
+
     private PhpExecutable getExecutable(PhpModule phpModule, String title) {
         return new PhpExecutable(codingStandardsFixerPath)
                 .optionsSubcategory(AnalysisOptionsPanelController.OPTIONS_SUB_PATH)
                 .displayName(title);
     }
 
-    private PhpExecutable getExecutable(String title) {
-        return new PhpExecutable(codingStandardsFixerPath)
+    private PhpExecutable getExecutable(String title, @NullAllowed File workDir) {
+        PhpExecutable executable = new PhpExecutable(codingStandardsFixerPath)
                 .optionsSubcategory(AnalysisOptionsPanelController.OPTIONS_SUB_PATH)
                 .fileOutput(XML_LOG, "UTF-8", false) // NOI18N
                 .redirectErrorStream(false)
                 .displayName(title);
+        if (workDir != null) {
+            executable.workDir(workDir);
+        }
+        return executable;
     }
 
     private ExecutionDescriptor getDescriptor(PhpModule phpModule) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4541

Set working directory when PHP CS Fixer is run.
Project configuration file is now found.

Output before: `Loaded config default.`
Output after: `Loaded config default from "C:\Devel\PhpProject\.php_cs.dist".`