### PR TITLE
[NETBEANS-4699] Make it easy to create dynamically updated ProxyLookup instances without subclassing

### DIFF
--- a/platform/openide.util.lookup/apichanges.xml
+++ b/platform/openide.util.lookup/apichanges.xml
@@ -25,6 +25,33 @@
     <apidef name="lookup">Lookup API</apidef>
 </apidefs>
 <changes>
+    <change id="ProxyLookupController">
+        <api name="lookup"/>
+        <summary>Add ProxyLookup.Controller to set lookups dynamically without 
+            subclassing</summary>
+        <version major="8" minor="43"/>
+        <date year="2020" month="7" day="4"/>
+        <author login="tboudreau"/>
+        <compatibility addition="yes" source="compatible" semantic="compatible" binary="compatible"/>
+        <description>
+            <p>
+                One of the most common usages of  <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html">ProxyLookup</a>
+                is to dynamically change the set of lookups being delegated to. However the 
+                <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html#setLookups-org.openide.util.Lookup...-">setLookups(...)</a>
+                method is <code>protected</code>. To avoid the need to subclass 
+                <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html">ProxyLookup</a>
+                this change introduces
+                <a href="@TOP@/org/openide/util/lookup/ProxyLookup.Controller.html">ProxyLookup.Controller</a>
+                that gives the creator of <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html">ProxyLookup</a>
+                a way to call 
+                <a href="@TOP@/org/openide/util/lookup/ProxyLookup.Controller.html#setLookups-org.openide.util.Lookup...-">setLookups(...)</a>
+                without exposing the method to others having just a reference to 
+                the <a href="@TOP@/org/openide/util/lookup/ProxyLookup.html">ProxyLookup</a>.
+            </p>
+        </description>
+        <class name="ProxyLookup" package="org.openide.util.lookup"/>
+        <issue number="NETBEANS-4699"/>
+    </change>    
     <change id="AbstractProcessorSupportedSource">
         <api name="lookup"/>
         <summary>Declare support for all source levels.</summary>

--- a/platform/openide.util.lookup/manifest.mf
+++ b/platform/openide.util.lookup/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.util.lookup
 OpenIDE-Module-Localizing-Bundle: org/openide/util/lookup/Bundle.properties
-OpenIDE-Module-Specification-Version: 8.42
+OpenIDE-Module-Specification-Version: 8.43
 

--- a/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookupFactoryMethodsTest.java
+++ b/platform/openide.util.lookup/test/unit/src/org/openide/util/lookup/ProxyLookupFactoryMethodsTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.util.lookup;
+
+import java.util.Arrays;
+import static java.util.Arrays.asList;
+import java.util.HashSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.openide.util.Lookup;
+import org.openide.util.LookupEvent;
+import org.openide.util.LookupListener;
+import org.openide.util.lookup.ProxyLookupFactoryMethodsTest.TThreadFactory.TThread;
+
+/**
+ *
+ * @author Tim Boudreau
+ */
+public class ProxyLookupFactoryMethodsTest {
+
+    private ProxyLookup.Controller controller1;
+    private ProxyLookup.Controller controller2;
+
+    private Lookup createWithSingleConsumer(Lookup... lookups) {
+        ProxyLookup.Controller controller = new ProxyLookup.Controller();
+        controller1 = controller;
+        ProxyLookup result = new ProxyLookup(controller);
+        result.setLookups(lookups);
+        return result;
+    }
+
+    private Lookup createWithBiConsumer(Lookup... lookups) {
+        ProxyLookup.Controller controller = new ProxyLookup.Controller();
+        controller2 = controller;
+        ProxyLookup result = new ProxyLookup(controller);
+        result.setLookups(lookups);
+        return result;
+    }
+
+    @Test
+    public void testCannotUseControllerOnMultipleLookups() {
+        ProxyLookup.Controller ctrllr = new ProxyLookup.Controller();
+        ProxyLookup first = new ProxyLookup(ctrllr);
+        assertTrue(first.lookupAll(String.class).isEmpty());
+        try {
+            ProxyLookup second = new ProxyLookup(ctrllr);
+            fail("Exception should have been thrown using controller more than "
+                    + "once but was able to create " + second);
+        } catch (IllegalStateException ex) {
+            // ok
+        }
+    }
+
+    @Test
+    public void testStartWithEmptyController() {
+        ProxyLookup.Controller ctrllr = new ProxyLookup.Controller();
+        ProxyLookup lkp = new ProxyLookup(ctrllr);
+        assertTrue(lkp.lookupAll(String.class).isEmpty());
+        ctrllr.setLookups(Lookups.fixed("a"), Lookups.fixed("b"));
+        assertEquals(new HashSet<>(Arrays.asList("a", "b")),
+                new HashSet<>(lkp.lookupAll(String.class)));
+    }
+
+    @Test
+    public void testSimpleFactory() {
+        Lookup a = Lookups.fixed("a");
+        Lookup b = Lookups.fixed("b");
+        Lookup c = Lookups.fixed("c");
+
+        Lookup target = createWithSingleConsumer(a, b);
+        assertNotNull(controller1);
+        assertTrue(target.lookupAll(String.class).containsAll(asList("a", "b")));
+        assertFalse(target.lookupAll(String.class).contains("c"));
+
+        controller1.setLookups(new Lookup[]{a, b, c});
+        assertTrue(target.lookupAll(String.class).containsAll(asList("a", "b", "c")));
+
+        controller1.setLookups(new Lookup[0]);
+        assertTrue(target.lookupAll(String.class).isEmpty());
+    }
+
+    @Test
+    public void testThreadedFactory() throws Throwable {
+        ExecutorService svc = Executors.newSingleThreadExecutor(new TThreadFactory());
+        Lookup a = Lookups.fixed("a");
+        Lookup b = Lookups.fixed("b");
+        Lookup c = Lookups.fixed("c");
+
+        Lookup target = createWithBiConsumer(a, b);
+        Lookup.Result<String> result = target.lookupResult(String.class);
+
+        LL lis = new LL();
+        result.addLookupListener(lis);
+        // Ugh, ProxyLookup.LazyList does not implement the contract
+        // of Collection.equals().
+        assertEquals(new HashSet<>(result.allInstances()), new HashSet<>(Arrays.asList("a", "b")));
+
+        assertNotNull(controller2);
+        assertTrue(target.lookupAll(String.class).containsAll(asList("a", "b")));
+        assertFalse(target.lookupAll(String.class).contains("c"));
+
+        controller2.setLookups(svc, new Lookup[]{a, b, c});
+
+        lis.assertNotifiedInExecutor();
+
+        assertTrue(target.lookupAll(String.class).containsAll(asList("a", "b", "c")));
+        assertEquals(new HashSet<>(result.allInstances()), new HashSet<>(Arrays.asList("a", "b", "c")));
+
+        controller2.setLookups(svc, new Lookup[0]);
+        lis.assertNotifiedInExecutor();
+        assertTrue(target.lookupAll(String.class).isEmpty());
+        assertTrue(result.allInstances().isEmpty());
+
+        controller2.setLookups(null, new Lookup[]{b, c});
+        assertTrue(target.lookupAll(String.class).containsAll(asList("b", "c")));
+        assertEquals(new HashSet<>(result.allInstances()), new HashSet<>(Arrays.asList("b", "c")));
+        lis.assertNotifiedSynchronously();
+    }
+
+    static final class TThreadFactory implements ThreadFactory {
+
+        @Override
+        public Thread newThread(Runnable r) {
+            return new TThread(r);
+        }
+
+        static class TThread extends Thread {
+
+            TThread(Runnable r) {
+                super(r);
+                setName("test-thread");
+                setDaemon(true);
+            }
+        }
+    }
+
+    static class LL implements LookupListener {
+
+        private Thread notifyThread;
+        private CountDownLatch latch = new CountDownLatch(1);
+
+        void assertNotifiedInExecutor() throws InterruptedException {
+            CountDownLatch l;
+            synchronized (this) {
+                l = latch;
+            }
+            latch.await(10, TimeUnit.SECONDS);
+            Thread t;
+            synchronized (this) {
+                t = notifyThread;
+                notifyThread = null;
+            }
+            assertNotNull(t);
+            assertTrue(t instanceof TThread);
+        }
+
+        void assertNotifiedSynchronously() throws InterruptedException {
+            assertSame(Thread.currentThread(), notifyThread);
+        }
+
+        @Override
+        public void resultChanged(LookupEvent ev) {
+            CountDownLatch l;
+            synchronized (this) {
+                notifyThread = Thread.currentThread();
+                l = latch;
+                latch = new CountDownLatch(1);
+                assert l != null;
+            }
+            l.countDown();
+        }
+
+    }
+
+}


### PR DESCRIPTION
One of the most common uses of `ProxyLookup` is to dynamically change the set of `Lookup`s being proxied (a quick grep finds 53 such cases in the NetBeans source base, and I can think of > 10 I have written in external modules).  For each consumer of the API that needs to do this, it is necessary to write identical subclasses with a public or package visibility method that exposes one of `ProxyLookup`'s `setLookups()` methods.

This patch adds `ProxyLookup.create(Consumer<Consumer<Lookup[]>>)` and `ProxyLookup.createThreaded(Consumer<BiConsumer<Executor, Lookup[]>>) `to satisfy the non-threaded and threaded-event-delivery variants supported as protected methods on ProxyLookup.  These allow a mechanism for updating the set of proxied lookups to be passed to the caller without exposing that machanism to consumers of the returned Lookup or any code other that which immediately instantiates it, which was the objection @jtulach had many years ago to exposing it as public.