### PR TITLE
[NETBEANS-4503] Code completion does not work in functions declared inside methods

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// https://issues.apache.org/jira/browse/NETBEANS-4503
+class NETBEANS4503Test
+{
+
+    public function testMethod() {
+        $test = "test";
+        function testNestedFunction() {
+            echo "testNestedFunction()" . PHP_EOL;
+            $e = new Example();
+            $e->test(); // test1
+
+            function testNestedFunction2() {
+                echo "testNestedFunction2()" . PHP_EOL;
+                $ex = new Example();
+                $ex->test(); // test2
+            }
+            testNestedFunction2(); // test3
+        }
+        testNestedFunction(); // test4
+        testNestedFunction2();
+    }
+
+    public function testMethod2() {
+        testNestedFunction2();
+    }
+
+}
+
+class Example
+{
+    public function test() {
+    }
+}
+
+function testGlobalFunction() {
+    echo "testGlobalFunction()" . PHP_EOL;
+
+    function testNestedGlobalFunction() {
+        echo "testNestedGlobalFunction()" . PHP_EOL;
+        $example = new Example();
+        $example->test(); // test5
+    }
+    testNestedGlobalFunction();
+
+}
+
+$test = new NETBEANS4503Test();
+$test->testMethod();
+$test->testMethod2();
+testNestedFunction2(); // test6
+//testNestedFunction(); error becuase the testNestedFunction is redeclare
+testGlobalFunction();
+testNestedGlobalFunction();
+
+// Output
+//
+//testNestedFunction()
+//testNestedFunction2()
+//testNestedFunction2()
+//testNestedFunction2()
+//testNestedFunction2()
+//testGlobalFunction()
+//testNestedGlobalFunction()
+//testNestedGlobalFunction()

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_01.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+$e->|test(); // test1
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     test()                          [PUBLIC]   Example

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_02.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+$ex->|test(); // test2
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     test()                          [PUBLIC]   Example

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_03.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+testNes|tedFunction2(); // test3
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     testNestedFunction()            [PUBLIC]   nb4503.php
+METHOD     testNestedFunction2()           [PUBLIC]   nb4503.php
+METHOD     testNestedGlobalFunction()      [PUBLIC]   nb4503.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_04.completion
@@ -1,0 +1,9 @@
+Code completion result for source line:
+test|NestedFunction(); // test4
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     testGlobalFunction()            [PUBLIC]   nb4503.php
+METHOD     testMethod()                    [PUBLIC]   NETBEANS4503Test
+METHOD     testMethod2()                   [PUBLIC]   NETBEANS4503Test
+METHOD     testNestedFunction()            [PUBLIC]   nb4503.php
+METHOD     testNestedFunction2()           [PUBLIC]   nb4503.php
+METHOD     testNestedGlobalFunction()      [PUBLIC]   nb4503.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_05.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+$example->|test(); // test5
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     test()                          [PUBLIC]   Example

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4503/nb4503.php.testNb4503_06.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+te|stNestedFunction2(); // test6
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     testGlobalFunction()            [PUBLIC]   nb4503.php
+METHOD     testNestedFunction()            [PUBLIC]   nb4503.php
+METHOD     testNestedFunction2()           [PUBLIC]   nb4503.php
+METHOD     testNestedGlobalFunction()      [PUBLIC]   nb4503.php

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb4503Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb4503Test.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHPCodeCompletionNb4503Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionNb4503Test(String testName) {
+        super(testName);
+    }
+
+    public void testNb4503_01() throws Exception {
+        testNb4503("            $e->^test(); // test1");
+    }
+
+    public void testNb4503_02() throws Exception {
+        testNb4503("                $ex->^test(); // test2");
+    }
+
+    public void testNb4503_03() throws Exception {
+        testNb4503("            testNes^tedFunction2(); // test3");
+    }
+
+    public void testNb4503_04() throws Exception {
+        testNb4503("        test^NestedFunction(); // test4");
+    }
+
+    public void testNb4503_05() throws Exception {
+        testNb4503("        $example->^test(); // test5");
+    }
+
+    public void testNb4503_06() throws Exception {
+        testNb4503("te^stNestedFunction2(); // test6");
+    }
+
+    private void testNb4503(String caretLine) throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4503/nb4503.php", caretLine, false);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/nb4503"))
+            })
+        );
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4503

#### 1st commit

Nested functions are in a Method/FunctionScope.
However, they are added as elements of a NamespaceScope.
i.e. Method/FunctionScope doesn't have nested FunctionScopes. NamespaceScope has them.
So, (not return the child result simply,) check whether the child result contains the parent result in the `VariableScopeFinder.findWrapper()`.

#### 2nd commit

Unit test(testNb4503_01()) failed on GitHub Actions after I pushed the first commit.
However, It passed on my local pc.

After I've tried some things, I've somehow reproduced it.
```java
    public void testNb4503_01() throws Exception {
        Thread.sleep(1000); // added this, then reproduced
        testNb4503("            $e->^test(); // test1");
    }
```
Unfortunately, if I set a breakpoint, I couldn't reproduce it. Just used `println()` to investigate the cause. 

The cause:
A cached `Source` instance may be removed after elements are indexed.
So, the test file is scanned again when the test is run. If there are elements for LazyBuild, we may not be able to get the correct result.
To avoiding that, after elements are scanned lazily, find the scope again.