### PR TITLE
[NETBEANS-4185] Support for self return type

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/impl/VariousUtils.java
@@ -225,8 +225,9 @@ public final class VariousUtils {
             QualifiedName name = QualifiedName.create(returnType);
             assert name != null : returnType;
             String typeName = name.toString();
-            if (Type.ARRAY.equals(typeName)) {
+            if (Type.ARRAY.equals(typeName) || Type.SELF.equals(typeName)) {
                 // For "array" type PHPDoc can contain more specific definition, i.e. MyClass[]
+                // For "self" type PHPDoc can contain more specific definition, i.e. static or $this
                 String typeFromPHPDoc = getReturnTypeFromPHPDoc(root, functionDeclaration);
                 if (typeFromPHPDoc != null) {
                     return typeFromPHPDoc;

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php
@@ -1,0 +1,99 @@
+<?php
+
+class A {
+
+    /**
+     * returnStatic method.
+     *
+     * @return static
+     */
+    public function returnStatic(): self {
+        return new static;
+    }
+
+    /**
+     * staticReturnStatic method.
+     *
+     * @return static
+     */
+    public static function staticReturnStatic(): self {
+        return new static;
+    }
+
+    /**
+     * returnSelf method.
+     */
+    public function returnSelf(): self {
+        return new self;
+    }
+
+    /**
+     * staticReturnSelf method.
+     */
+    public static function staticReturnSelf(): self {
+        return new self;
+    }
+
+    /**
+     * returnThis method.
+     *
+     * @return $this
+     */
+    public function returnThis(): self {
+        return $this;
+    }
+
+
+    public function testA() {
+        return "testA";
+    }
+
+    public static function staticTestA() {
+        return "staticTestA";
+    }
+
+}
+
+class B extends A {
+
+    public function testB() {
+        return "testB";
+    }
+
+    public static function staticTestB() {
+        return "staticTestB";
+    }
+
+}
+
+// return static
+echo get_class((new B)->returnStatic()) . PHP_EOL; // B
+echo get_class(B::staticReturnStatic()) . PHP_EOL; // B
+
+echo (new B)->returnStatic()->testB() . PHP_EOL; // testB
+echo B::staticReturnStatic()->staticTestB() . PHP_EOL; // staticTestB
+echo B::staticReturnStatic()::staticTestB() . PHP_EOL; // staticTestB (PHP7)
+
+$b = new B();
+echo $b::staticReturnStatic()->staticTestB() . PHP_EOL; // staticTestB
+echo $b::staticReturnStatic()::staticTestB() . PHP_EOL; // staticTestB (PHP7)
+echo $b->returnStatic()::staticTestB() . PHP_EOL; // staticTestB (PHP7)
+
+// return self
+echo get_class((new B)->returnSelf()) . PHP_EOL; // A
+echo get_class(B::staticReturnSelf()) . PHP_EOL; // A
+
+echo (new B)->returnSelf()->testA() . PHP_EOL; // testA
+echo B::staticReturnSelf()->staticTestA() . PHP_EOL; // staticTestA
+echo B::staticReturnSelf()::staticTestA() . PHP_EOL; // staticTestA (PHP7)
+
+echo $b::staticReturnSelf()->staticTestA() . PHP_EOL; // staticTestA
+echo $b::staticReturnSelf()::staticTestA() . PHP_EOL; // staticTestA (PHP7)
+echo $b->returnSelf()::staticTestA() . PHP_EOL; // staticTestA (PHP7)
+
+// return this
+echo get_class((new B)->returnThis()) . PHP_EOL; // B
+
+echo (new B)->returnThis()->testB() . PHP_EOL; // testB
+
+echo $b->returnThis()::staticTestB() . PHP_EOL; // staticTestB (PHP7)

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_01.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+echo (new B)->returnSelf()->|testA() . PHP_EOL; // testA
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [PUBLIC]   A
+METHOD     returnStatic()                  [PUBLIC]   A
+METHOD     returnThis()                    [PUBLIC]   A
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     testA()                         [PUBLIC]   A

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_02.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+echo B::staticReturnSelf()->|staticTestA() . PHP_EOL; // staticTestA
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [PUBLIC]   A
+METHOD     returnStatic()                  [PUBLIC]   A
+METHOD     returnThis()                    [PUBLIC]   A
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     testA()                         [PUBLIC]   A

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_03.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+echo B::staticReturnSelf()::|staticTestA() . PHP_EOL; // staticTestA (PHP7)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_04.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+echo $b::staticReturnSelf()->|staticTestA() . PHP_EOL; // staticTestA
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [PUBLIC]   A
+METHOD     returnStatic()                  [PUBLIC]   A
+METHOD     returnThis()                    [PUBLIC]   A
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     testA()                         [PUBLIC]   A

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_05.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+echo $b::staticReturnSelf()::|staticTestA() . PHP_EOL; // staticTestA (PHP7)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnSelf_06.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+echo $b->returnSelf()::|staticTestA() . PHP_EOL; // staticTestA (PHP7)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_01.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+echo (new B)->returnStatic()->|testB() . PHP_EOL; // testB
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [PUBLIC]   A
+METHOD     returnStatic()                  [PUBLIC]   A
+METHOD     returnThis()                    [PUBLIC]   A
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     staticTestB()                   [STATIC]   B
+METHOD     testA()                         [PUBLIC]   A
+METHOD     testB()                         [PUBLIC]   B

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_02.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+echo B::staticReturnStatic()->|staticTestB() . PHP_EOL; // staticTestB
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [PUBLIC]   A
+METHOD     returnStatic()                  [PUBLIC]   A
+METHOD     returnThis()                    [PUBLIC]   A
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     staticTestB()                   [STATIC]   B
+METHOD     testA()                         [PUBLIC]   A
+METHOD     testB()                         [PUBLIC]   B

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_03.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+echo B::staticReturnStatic()::|staticTestB() . PHP_EOL; // staticTestB (PHP7)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     staticTestB()                   [STATIC]   B

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_04.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+echo $b::staticReturnStatic()->|staticTestB() . PHP_EOL; // staticTestB
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [PUBLIC]   A
+METHOD     returnStatic()                  [PUBLIC]   A
+METHOD     returnThis()                    [PUBLIC]   A
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     staticTestB()                   [STATIC]   B
+METHOD     testA()                         [PUBLIC]   A
+METHOD     testB()                         [PUBLIC]   B

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_05.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+echo $b::staticReturnStatic()::|staticTestB() . PHP_EOL; // staticTestB (PHP7)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     staticTestB()                   [STATIC]   B

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnStatic_06.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+echo $b->returnStatic()::|staticTestB() . PHP_EOL; // staticTestB (PHP7)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     staticTestB()                   [STATIC]   B

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnThis_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnThis_01.completion
@@ -1,0 +1,12 @@
+Code completion result for source line:
+echo (new B)->returnThis()->|testB() . PHP_EOL; // testB
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [PUBLIC]   A
+METHOD     returnStatic()                  [PUBLIC]   A
+METHOD     returnThis()                    [PUBLIC]   A
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     staticTestB()                   [STATIC]   B
+METHOD     testA()                         [PUBLIC]   A
+METHOD     testB()                         [PUBLIC]   B

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnThis_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4185/nb4185.php.testReturnThis_02.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+echo $b->returnThis()::|staticTestB() . PHP_EOL; // staticTestB (PHP7)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     staticReturnSelf()              [STATIC]   A
+METHOD     staticReturnStatic()            [STATIC]   A
+METHOD     staticTestA()                   [STATIC]   A
+METHOD     staticTestB()                   [STATIC]   B

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb4185Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb4185Test.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHPCodeCompletionNb4185Test  extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionNb4185Test(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[]{
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/nb4185/"))
+            })
+        );
+    }
+
+    // static
+    public void testReturnStatic_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo (new B)->returnStatic()->^testB()", false);
+    }
+
+    public void testReturnStatic_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo B::staticReturnStatic()->^staticTestB()", false);
+    }
+
+    public void testReturnStatic_03() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo B::staticReturnStatic()::^staticTestB()", false);
+    }
+
+    public void testReturnStatic_04() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo $b::staticReturnStatic()->^staticTestB()", false);
+    }
+
+    public void testReturnStatic_05() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo $b::staticReturnStatic()::^staticTestB()", false);
+    }
+
+    public void testReturnStatic_06() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo $b->returnStatic()::^staticTestB()", false);
+    }
+
+    // self
+    public void testReturnSelf_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo (new B)->returnSelf()->^testA()", false);
+    }
+
+    public void testReturnSelf_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo B::staticReturnSelf()->^staticTestA()", false);
+    }
+
+    public void testReturnSelf_03() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo B::staticReturnSelf()::^staticTestA()", false);
+    }
+
+    public void testReturnSelf_04() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo $b::staticReturnSelf()->^staticTestA()", false);
+    }
+
+    public void testReturnSelf_05() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo $b::staticReturnSelf()::^staticTestA()", false);
+    }
+
+    public void testReturnSelf_06() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo $b->returnSelf()::^staticTestA()", false);
+    }
+
+    // this
+    public void testReturnThis_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo (new B)->returnThis()->^testB()", false);
+    }
+
+    public void testReturnThis_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4185/nb4185.php", "echo $b->returnThis()::^staticTestB()", false);
+    }
+
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4185

Added test files based on [PHPCodeCompletion269108Test](https://github.com/apache/netbeans/blob/master/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion269108Test.java) testing same feature but without return type in method.

Fixed case when native return type `self` is used in combination with PHPDoc annotations `@return static` and `@return $this.`