### PR TITLE
[NETBEANS-4507] Fix Composer search when package has no description

### DIFF
--- a/php/php.composer/src/org/netbeans/modules/php/composer/output/parsers/CliParser.java
+++ b/php/php.composer/src/org/netbeans/modules/php/composer/output/parsers/CliParser.java
@@ -56,7 +56,8 @@ class CliParser implements Parser {
             }
             // current
             split = line.split(" ", 2); // NOI18N
-            result.add(new SearchResult(split[0].trim(), split[1].trim()));
+            String description = split.length == 2 ? split[1].trim() : ""; // NOI18N
+            result.add(new SearchResult(split[0].trim(), description));
         }
         return result;
     }

--- a/php/php.composer/test/unit/src/org/netbeans/modules/php/composer/output/parsers/CliParserTest.java
+++ b/php/php.composer/test/unit/src/org/netbeans/modules/php/composer/output/parsers/CliParserTest.java
@@ -107,8 +107,17 @@ public class CliParserTest extends NbTestCase {
         assertEquals("Sends your logs to: files, sockets, inboxes, databases and various web services", result.getDescription());
     }
 
-    public void testParseSearchEmptyDescription() {
+    public void testParseSearchEmptyDescriptionLegacy() {
         String chunk = "monolog/monolog:";
+        List<SearchResult> results = cliParser.parseSearch(chunk);
+        assertEquals(1, results.size());
+        SearchResult result = results.get(0);
+        assertEquals("monolog/monolog", result.getName());
+        assertEquals("", result.getDescription());
+    }
+
+    public void testParseSearchEmptyDescription() {
+        String chunk = "monolog/monolog";
         List<SearchResult> results = cliParser.parseSearch(chunk);
         assertEquals(1, results.size());
         SearchResult result = results.get(0);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4507

Fixed parsing of `composer search` output when package does not have
description.

This happens when [composer-asset-plugin](https://github.com/fxpio/composer-asset-plugin) is installed. Then output contains also packages without description.