### PR TITLE
[NETBEANS-4308] Deadlock in SQLEditorSupport

### DIFF
--- a/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLEditorSupport.java
+++ b/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLEditorSupport.java
@@ -481,7 +481,7 @@ public class SQLEditorSupport extends DataEditorSupport
         }
     }
     
-    private synchronized void closeLogger() {
+    private void closeLogger() {
         synchronized (loggerLock) {
             if (logger != null) {
                 logger.close();


### PR DESCRIPTION
Remove the synchronization in SQLEditorSupport#closeLogger. The critical
part (ensuring logger is not closed while it could be acquired) is
protected by the finer grained loggerLock and thus the monitor on
SQLEditorSupport is not needed.

The deadlock sequence showed:

- the EDT held the monitor of SQLEditorSupport
- a task was dispatched into a request processor
- the EDT waited for the task to finish
- the task tried to enter the monitor of SQLEditorSupport