### PR TITLE
Minor improvements for php.api.phpmodule

### DIFF
--- a/php/php.api.phpmodule/manifest.mf
+++ b/php/php.api.phpmodule/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.api.phpmodule
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/api/phpmodule/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.71
+OpenIDE-Module-Specification-Version: 2.72

--- a/php/php.api.phpmodule/src/org/netbeans/modules/php/api/PhpVersion.java
+++ b/php/php.api.phpmodule/src/org/netbeans/modules/php/api/PhpVersion.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.php.api;
 
+import java.time.LocalDate;
 import org.openide.util.NbBundle;
 
 /**
@@ -117,6 +118,11 @@ public enum PhpVersion {
      */
     public static PhpVersion getLegacy() {
         PhpVersion[] phpVersions = PhpVersion.values();
+        for (PhpVersion phpVersion : phpVersions) {
+            if (phpVersion.isSupportedVersion()) {
+                return phpVersion;
+            }
+        }
         return phpVersions[phpVersions.length - 2];
     }
 
@@ -180,9 +186,66 @@ public enum PhpVersion {
         return this.compareTo(PhpVersion.PHP_74) >= 0;
     }
 
+    /**
+     * Check whether this is supported version yet by PHP official.
+     *
+     * @return {@code true} if this is supported version, {@code false}
+     * otherwise
+     * @since 2.72
+     */
+    public boolean isSupportedVersion() {
+        return Period.valueOf(name()).isSupportedVersion();
+    }
+
     @Override
     public String toString() {
         return getDisplayName();
+    }
+
+    /**
+     * Valid period for each php version.
+     * https://www.php.net/supported-versions.php
+     */
+    private enum Period {
+        // Use the same name as PhpVersion
+        PHP_5(LocalDate.of(2005, 11, 24), LocalDate.of(2011, 1, 6), LocalDate.of(2011, 1, 6)),
+        PHP_53(LocalDate.of(2009, 6, 30), LocalDate.of(2014, 8, 14), LocalDate.of(2014, 8, 14)),
+        PHP_54(LocalDate.of(2012, 3, 1), LocalDate.of(2014, 9, 14), LocalDate.of(2014, 9, 14)),
+        PHP_55(LocalDate.of(2013, 6, 20), LocalDate.of(2015, 7, 10), LocalDate.of(2015, 7, 10)),
+        PHP_56(LocalDate.of(2014, 8, 28), LocalDate.of(2017, 1, 19), LocalDate.of(2018, 12, 31)),
+        PHP_70(LocalDate.of(2015, 12, 3), LocalDate.of(2017, 12, 3), LocalDate.of(2018, 12, 3)),
+        PHP_71(LocalDate.of(2016, 12, 1), LocalDate.of(2018, 12, 1), LocalDate.of(2019, 12, 1)),
+        PHP_72(LocalDate.of(2017, 11, 30), LocalDate.of(2019, 11, 30), LocalDate.of(2020, 11, 30)),
+        PHP_73(LocalDate.of(2018, 12, 6), LocalDate.of(2020, 12, 6), LocalDate.of(2021, 12, 6)),
+        PHP_74(LocalDate.of(2019, 11, 28), LocalDate.of(2021, 11, 28), LocalDate.of(2022, 11, 28)),
+        ;
+
+        private final LocalDate initialRelease;
+        private final LocalDate activeSupport;
+        private final LocalDate securitySupport;
+
+        private Period(LocalDate initialRelease, LocalDate activeSupport, LocalDate securitySupport) {
+            this.initialRelease = initialRelease;
+            this.activeSupport = activeSupport;
+            this.securitySupport = securitySupport;
+        }
+
+        public LocalDate getInitialRelease() {
+            return initialRelease;
+        }
+
+        public LocalDate getActiveSupport() {
+            return activeSupport;
+        }
+
+        public LocalDate getSecuritySupport() {
+            return securitySupport;
+        }
+
+        public boolean isSupportedVersion() {
+            return LocalDate.now().isBefore(securitySupport);
+        }
+
     }
 
 };

--- a/php/php.api.phpmodule/src/org/netbeans/modules/php/api/validation/ValidationResult.java
+++ b/php/php.api.phpmodule/src/org/netbeans/modules/php/api/validation/ValidationResult.java
@@ -46,6 +46,7 @@ public final class ValidationResult {
 
     /**
      * Copy constructor.
+     * @param anotherResult another validation result
      */
     public ValidationResult(ValidationResult anotherResult) {
         merge(anotherResult);
@@ -81,6 +82,20 @@ public final class ValidationResult {
     }
 
     /**
+     * Get the first error.
+     *
+     * @return the first error or {@code null} if there are no errors
+     * @since 2.72
+     */
+    @CheckForNull
+    public Message getFirstError() {
+        if (hasErrors()) {
+            return errors.get(0);
+        }
+        return null;
+    }
+
+    /**
      * Check whether there are some warnings present.
      * @return {@code true} if the validation result contains any warning
      * @see #isFaultless()
@@ -96,6 +111,20 @@ public final class ValidationResult {
     public List<Message> getWarnings() {
         return new ArrayList<>(warnings);
 
+    }
+
+    /**
+     * Get the first warning.
+     *
+     * @return the first warning or {@code null} if there are no warnings
+     * @since 2.72
+     */
+    @CheckForNull
+    public Message getFirstWarning() {
+        if (hasWarnings()) {
+            return warnings.get(0);
+        }
+        return null;
     }
 
     /**

--- a/php/php.api.phpmodule/test/unit/src/org/netbeans/modules/php/api/PhpVersionTest.java
+++ b/php/php.api.phpmodule/test/unit/src/org/netbeans/modules/php/api/PhpVersionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.api;
+
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+public class PhpVersionTest {
+
+    public PhpVersionTest() {
+    }
+
+    @Test
+    public void testIsSupportedVersion() {
+        try {
+            for (PhpVersion phpVersion : PhpVersion.values()) {
+                phpVersion.isSupportedVersion();
+            }
+        } catch (IllegalArgumentException e) {
+            fail(e.getMessage() + " (Check whether new version is added to PhpVersion.Period)");
+        }
+    }
+
+}


### PR DESCRIPTION
- Add the `isSupportedVersion()` method to the PhpVersion

    - Check whether the version is supported yet by PHP official
    - Improve the `getLegacy()` method

- Add the `getFirstError()` and the `getFirstWarning()` methods to the `ValidationResult` class