### PR TITLE
[NETBEANS-4573] PHP CS Fixer doesn't work with a directory and a file

### DIFF
--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/CodingStandardsFixer.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/commands/CodingStandardsFixer.java
@@ -172,15 +172,17 @@ public final class CodingStandardsFixer {
     public List<Result> analyze(CodingStandardsFixerParams params, FileObject file) {
         assert file.isValid() : "Invalid file given: " + file;
         try {
-            
-            Integer result = getExecutable(Bundle.CodingStandardsFixer_analyze(analyzeGroupCounter++), findWorkDir(file))
+            File workDir = findWorkDir(file);
+            Integer result = getExecutable(Bundle.CodingStandardsFixer_analyze(analyzeGroupCounter++), workDir)
                     .additionalParameters(getParameters(params, file))
                     .runAndWait(getDescriptor(), "Running coding standards fixer..."); // NOI18N
             if (result == null) {
                 return null;
             }
-
-            return CodingStandardsFixerReportParser.parse(XML_LOG, file);
+            // if the project for the file is not found(i.e. if the workDir is not found),
+            // the results are not shown in the inspector window
+            FileObject root = workDir != null ? FileUtil.toFileObject(workDir) : file;
+            return CodingStandardsFixerReportParser.parse(XML_LOG, root);
         } catch (CancellationException ex) {
             // cancelled
             return Collections.emptyList();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4573

The relative paths from the working directory are used in XML log if the working directory is set. So, set it as the root directory.