### PR TITLE
[NETBEANS-4123] PAC evaluator scripts runs just one at a time.

### DIFF
--- a/platform/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluator.java
+++ b/platform/core.network/src/org/netbeans/core/network/proxy/pac/impl/NbPacScriptEvaluator.java
@@ -204,7 +204,7 @@ public class NbPacScriptEvaluator implements PacScriptEvaluator {
             resultCache = null;
         }
     }
-
+    
     @Override
     public List<Proxy> findProxyForURL(URI uri) throws PacValidationException {
 
@@ -218,7 +218,10 @@ public class NbPacScriptEvaluator implements PacScriptEvaluator {
             }
         }
         try {
-            Object jsResult = scriptEngine.findProxyForURL(PacUtils.toStrippedURLStr(uri), uri.getHost());
+            Object jsResult;
+            synchronized (scriptEngine) {
+                jsResult = scriptEngine.findProxyForURL(PacUtils.toStrippedURLStr(uri), uri.getHost());
+            }
             jsResultAnalyzed = analyzeResult(uri, jsResult);
             if (canUseURLCaching && (resultCache != null)) {
                 resultCache.put(uri, jsResultAnalyzed);   // save the result in the cache


### PR DESCRIPTION
NetBeans prefer the bundled-in `GraalVM:js` javascript engine for security reasons, but that engine cannot be used by multiple threads simultaneously. In fact, no javascript `ScriptEngine` probably can, since the shared toplevel scope is not likely to be thread-safe in a single-thread language.

The patch will simply prevent two threads from simultaneous execution in the same JS context; should not deadlock as the PAC evaluation cannot reach out to java classes.
