### PR TITLE
Improve GraalVM script engines interoperability.

### DIFF
--- a/harness/nbjunit/apichanges.xml
+++ b/harness/nbjunit/apichanges.xml
@@ -34,6 +34,21 @@
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="hamcrest">
+        <api name="nbjunit"/>
+        <summary>Support for Hamcrest library</summary>
+        <version major="1" minor="99"/>
+        <date day="15" month="7" year="2020"/>
+        <author login="sdedic"/>
+        <compatibility addition="yes"/>
+        <description>
+            <p>
+                NbModuleSuite loads <code>org.hamcrest</code> from the same
+                classloader as <code>org.junit</code> classes to prevent LinkageErrors.
+            </p>
+        </description>
+        <class package="org.netbeans.junit" name="NbModuleSuite"/>
+    </change>
     <change id="ignore.support">
         <api name="nbjunit"/>
         <summary>JUnit ignore annotation</summary>

--- a/harness/nbjunit/manifest.mf
+++ b/harness/nbjunit/manifest.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.nbjunit/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/junit/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.98
+OpenIDE-Module-Specification-Version: 1.99

--- a/harness/nbjunit/src/org/netbeans/junit/NbModuleSuite.java
+++ b/harness/nbjunit/src/org/netbeans/junit/NbModuleSuite.java
@@ -1431,6 +1431,9 @@ public class NbModuleSuite {
                 if (res.startsWith("org.junit") || res.startsWith("org/junit")) {
                     return true;
                 }
+                if (res.startsWith("org.hamcrest") || res.startsWith("org/hamcrest")) {
+                    return true;
+                }
                 if (res.startsWith("org.netbeans.junit") || res.startsWith("org/netbeans/junit")) {
                     if (res.startsWith("org.netbeans.junit.ide") || res.startsWith("org/netbeans/junit/ide")) {
                         return false;

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEngine.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEngine.java
@@ -31,9 +31,11 @@ import org.graalvm.polyglot.Value;
 final class GraalEngine implements ScriptEngine, Invocable {
 
     private final GraalEngineFactory factory;
+    private final ScriptContext langContext;
 
     GraalEngine(GraalEngineFactory f) {
         this.factory = f;
+        this.langContext = new LangContext(factory.id, f.ctx);
     }
 
     private String id() {
@@ -41,8 +43,8 @@ final class GraalEngine implements ScriptEngine, Invocable {
     }
 
     @Override
-    public GraalContext getContext() {
-        return factory.ctx;
+    public ScriptContext getContext() {
+        return langContext;
     }
 
     @Override
@@ -55,20 +57,38 @@ final class GraalEngine implements ScriptEngine, Invocable {
         Value result = evalImpl(arg1, src);
         return unbox(result);
     }
-
-    private Value evalImpl(ScriptContext arg1, String src) throws ScriptException {
-
+    
+    private static interface ScriptAction {
+        public Value run();
+    }
+    
+    private Value handleException(ScriptAction r) throws ScriptException {
         try {
-            return ((GraalContext) arg1).ctx().eval(id(), src);
+            return r.run();
         } catch (PolyglotException e) {
+            if (e.isHostException()) {
+                try {
+                    throw e.asHostException();
+                } catch (RuntimeException | Error err) {
+                    throw err;
+                } catch (Throwable hostEx) {
+                    e.initCause(hostEx);
+                    throw e;
+                }
+            }
+            // avoid exposing polyglot stack frames - might be confusing.
             throw new ScriptException(e);
         }
     }
 
+    private Value evalImpl(ScriptContext arg1, String src) throws ScriptException {
+        return handleException(() -> ((GraalContext) arg1).ctx().eval(id(), src));
+    }
+    
     @Override
     public Object eval(Reader arg0, ScriptContext arg1) throws ScriptException {
         Source src = Source.newBuilder(id(), arg0, null).buildLiteral();
-        Value result = ((GraalContext)arg1).ctx().eval(src);
+        Value result = handleException(() -> ((GraalContext)arg1).ctx().eval(src));
         return unbox(result);
     }
 
@@ -94,11 +114,12 @@ final class GraalEngine implements ScriptEngine, Invocable {
 
     @Override
     public void put(String arg0, Object arg1) {
+        getBindings(ScriptContext.ENGINE_SCOPE).put(arg0, arg1);
     }
 
     @Override
     public Object get(String arg0) {
-        return null;
+        return getBindings(ScriptContext.ENGINE_SCOPE).get(arg0);
     }
 
     @Override
@@ -108,6 +129,14 @@ final class GraalEngine implements ScriptEngine, Invocable {
 
     @Override
     public void setBindings(Bindings arg0, int arg1) {
+        // allow setting the same bindins as already active in the factory;
+        // this is done by ScriptEngineManager before it returns the engine.
+        if (arg1 == ScriptContext.GLOBAL_SCOPE) {
+            if (factory.ctx.getGlobals() == arg0) {
+                return;
+            }
+        }
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -122,34 +151,41 @@ final class GraalEngine implements ScriptEngine, Invocable {
 
     @Override
     public Object invokeMethod(Object thiz, String name, Object... args) throws ScriptException, NoSuchMethodException {
-        if (!(thiz instanceof Value)) {
-            throw new IllegalArgumentException();
+        final Value thisValue = factory.ctx.ctx().asValue(thiz);
+        if (!thisValue.canInvokeMember(name)) {
+            if (!thisValue.hasMember(name)) {
+                throw new NoSuchMethodException(name);
+            } else {
+                throw new NoSuchMethodException(name + " is not a function");
+            }
         }
-        final Value thisValue = (Value) thiz;
-        Value fn = thisValue.getMember(name);
-        if (!fn.canExecute()) {
-            throw new NoSuchMethodException(name);
-        }
-        Value result = fn.execute(args);
-        return unbox(result);
+        return unbox(handleException(() -> thisValue.invokeMember(name, args)));
+    }
+    
+    private GraalContext graalContext() {
+        return factory.ctx;
     }
 
     @Override
     public Object invokeFunction(String name, Object... args) throws ScriptException, NoSuchMethodException {
-        final Value fn = evalImpl(getContext(), name);
-        final Value result = fn.execute(args);
-        return unbox(result);
+        final Value fn = evalImpl(graalContext(), name);
+        return unbox(handleException(() -> fn.execute(args)));
     }
 
     @Override
     public <T> T getInterface(Class<T> clasz) {
-        return getInterface(getContext().ctx().getPolyglotBindings(), clasz);
+        return getInterface(graalContext().ctx().getPolyglotBindings(), clasz);
     }
 
     @Override
     public <T> T getInterface(Object thiz, Class<T> clasz) {
         if (thiz instanceof Value) {
             return ((Value) thiz).as(clasz);
+        }
+        Value v = factory.ctx.ctx().asValue(thiz);
+        T ret = v.as(clasz);
+        if (ret != null) {
+            return ret;
         }
         if (clasz.isInstance(thiz)) {
             return clasz.cast(thiz);
@@ -161,12 +197,6 @@ final class GraalEngine implements ScriptEngine, Invocable {
         if (result.isNull()) {
             return null;
         }
-        if (result.isNumber()) {
-            return result.as(Number.class);
-        }
-        if (result.isString()) {
-            return result.as(String.class);
-        }
-        return result;
+        return result.as(Object.class);
     }
 }

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEngine.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEngine.java
@@ -67,14 +67,8 @@ final class GraalEngine implements ScriptEngine, Invocable {
             return r.run();
         } catch (PolyglotException e) {
             if (e.isHostException()) {
-                try {
-                    throw e.asHostException();
-                } catch (RuntimeException | Error err) {
-                    throw err;
-                } catch (Throwable hostEx) {
-                    e.initCause(hostEx);
-                    throw e;
-                }
+                e.initCause(e.asHostException());
+                throw e;
             }
             // avoid exposing polyglot stack frames - might be confusing.
             throw new ScriptException(e);

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEngineFactory.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEngineFactory.java
@@ -31,6 +31,7 @@ final class GraalEngineFactory implements ScriptEngineFactory {
     final String id;
     final Language language;
     final GraalContext ctx;
+    private GraalEngine eng;
 
     GraalEngineFactory(GraalContext ctx, String id, Language language) {
         this.id = id;
@@ -95,7 +96,14 @@ final class GraalEngineFactory implements ScriptEngineFactory {
 
     @Override
     public ScriptEngine getScriptEngine() {
-        return new GraalEngine(this);
+        // return the same instance to indicate the engines actually
+        // retain all the context through Polyglot Context object.
+        synchronized (this) {
+            if (eng == null) {
+                eng = new GraalEngine(this);
+            }
+            return eng;
+        }
     }
 
     @Override

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/LangContext.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/LangContext.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.libs.graalsdk.impl;
+
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.SimpleBindings;
+import org.graalvm.polyglot.Context;
+
+/**
+ *
+ * @author sdedic
+ */
+final class LangContext implements ScriptContext {
+    final String   langId;
+    final GraalContext  global;
+    Bindings langBindings;
+
+    public LangContext(String langId, GraalContext global) {
+        this.langId = langId;
+        this.global = global;
+    }
+
+    @Override
+    public void setBindings(Bindings arg0, int arg1) {
+        throw new UnsupportedOperationException("Not supported."); 
+    }
+
+    @Override
+    public Bindings getBindings(int scope) {
+        if (scope == ENGINE_SCOPE) {
+            synchronized (this) {
+                if (langBindings != null) {
+                    return langBindings;
+                }
+            }
+            if (langBindings == null) {
+                Context c = global.ctx();
+                synchronized (this) {
+                    if (langBindings == null) {
+                        langBindings = new SimpleBindings(c.getBindings(langId).as(Map.class));
+                    }
+                }
+            }
+            return langBindings;
+        }
+        return global.getBindings(scope);
+    }
+
+    @Override
+    public void setAttribute(String key, Object value, int scope) {
+        if (scope == GLOBAL_SCOPE) {
+            global.setAttribute(key, value, scope);
+            return;
+        }
+        getBindings(scope).put(key, value);
+    }
+
+    @Override
+    public Object getAttribute(String key, int scope) {
+        if (scope == GLOBAL_SCOPE) {
+            return global.getAttribute(key, scope);
+        }
+        return getBindings(scope).get(key);
+    }
+
+    @Override
+    public Object removeAttribute(String key, int scope) {
+        if (scope == GLOBAL_SCOPE) {
+            return global.removeAttribute(key, scope);
+        }
+        return getBindings(scope).remove(key);
+    }
+
+    @Override
+    public Object getAttribute(String key) {
+        Bindings eb = getBindings(ENGINE_SCOPE);
+        if (eb.containsKey(key)) {
+            return eb.get(key);
+        } else {
+            return global.getAttribute(key);
+        }
+    }
+
+    @Override
+    public int getAttributesScope(String key) {
+        Bindings eb = getBindings(ENGINE_SCOPE);
+        if (eb.containsKey(key)) {
+            return GLOBAL_SCOPE;
+        } else {
+            return global.getAttributesScope(key);
+        }
+    }
+
+    @Override
+    public Writer getWriter() {
+        return global.getWriter();
+    }
+
+    @Override
+    public Writer getErrorWriter() {
+        return global.getErrorWriter();
+    }
+
+    @Override
+    public void setWriter(Writer writer) {
+        global.setWriter(writer);
+    }
+
+    @Override
+    public void setErrorWriter(Writer writer) {
+        global.setErrorWriter(writer);
+    }
+
+    @Override
+    public Reader getReader() {
+        return global.getReader();
+    }
+
+    @Override
+    public void setReader(Reader reader) {
+        global.setReader(reader);
+    }
+
+    @Override
+    public List<Integer> getScopes() {
+        return Arrays.asList(ENGINE_SCOPE, GLOBAL_SCOPE);
+    }
+}

--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/package-info.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/package-info.java
@@ -385,6 +385,20 @@ Found GraalVM:python
  * global scope, so the Java object holds the only reference to it.</li>
  * </ul>
  *
+ * <h2>Exception handling</h2>
+ * Exceptions are thrown in different way, depending on whether <b>the script</b>
+ * (guest language) raised the error, or the error came from the host language, e.g.
+ * a java object called from the script. 
+ * <ul>
+ * <li>Exceptions from the script code are always
+ * reported as {@link ScriptException} that provides the appropriate details.
+ * <li>Checked exceptions from host (java) code, unhandled by the script are raised as
+ * some {@link RuntimeException} subclasses; the {@link Throwable#getCause} then indicates
+ * the original cause for the exception.
+ * <li>Unchecked exceptions are directly propagated.
+ * {@codesnippet org.netbeans.libs.graalsdk.ScriptingTutorial#handleScriptExceptions}
+ * </ul>
+ * 
  * </div>
  * <script src="doc-files/tutorial.js"></script>
  */

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/JavaScriptEnginesTest.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/JavaScriptEnginesTest.java
@@ -179,6 +179,7 @@ public class JavaScriptEnginesTest {
         Point point = inv().getInterface(rawPoint, Point.class);
         if (point == null) {
             assumeNotNashorn();
+            assumeNotGraalJsFromJDK();
         }
         assertNotNull("Converted to typed interface", point);
 
@@ -287,10 +288,11 @@ public class JavaScriptEnginesTest {
 
         Sum sum = new Sum();
         Object raw = ((Invocable) engine).invokeMethod(fn, "call", null, sum);
-
+        
         ArrayLike res = ((Invocable) engine).getInterface(raw, ArrayLike.class);
         if (res == null) {
             assumeNotNashorn();
+            assumeNotGraalJsFromJDK();
         }
         assertNotNull("Result looks like array", res);
 
@@ -305,6 +307,10 @@ public class JavaScriptEnginesTest {
 
     private void assumeNotNashorn() {
         Assume.assumeFalse(engine.getFactory().getNames().contains("Nashorn"));
+    }
+
+    private void assumeNotGraalJsFromJDK() {
+        Assume.assumeFalse(engine.getFactory().getNames().contains("Graal.js"));
     }
 
     @Test
@@ -410,7 +416,7 @@ public class JavaScriptEnginesTest {
      * @throws Exception 
      */
     @Test
-    public void hostExceptionReportedAsRuntime() throws Exception {
+    public void hostRuntimeExceptionsAccessible() throws Exception {
         // Note: this seems to be broken on GraalVM's JDK js - runtime exceptions are wrapped into
         // polyglot wrapper and cannot be determined through the chain of getCauses().
         assumeFalse(engine.getFactory().getEngineName().toLowerCase().contains("graal.js"));

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/JavaScriptEnginesTest.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/JavaScriptEnginesTest.java
@@ -18,21 +18,27 @@
  */
 package org.netbeans.libs.graalsdk;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.NoSuchElementException;
+import javax.script.Bindings;
 import javax.script.Invocable;
+import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Assume;
+import static org.junit.Assume.assumeFalse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -348,5 +354,100 @@ public class JavaScriptEnginesTest {
     @Test(expected = ScriptException.class)
     public void error() throws Exception {
         engine.eval("throw 'Hi'");
+    }
+
+    /**
+     * Checks that exception originating in the script/lang code will be reported
+     * as ScriptException.
+     * @throws Exception 
+     */
+    @Test
+    public void guestExceptionReportedAsRuntime() throws Exception {
+        try {
+            engine.eval("var a = null; a.fn();");
+            fail("Exception expected");
+        } catch (ScriptException ex) {
+            Throwable c = ex.getCause();
+            Assert.assertThat(c, CoreMatchers.is(CoreMatchers.instanceOf(RuntimeException.class)));
+        }
+    }
+
+    public class Callback {
+        public void fn() throws Exception {
+            throw new NoSuchElementException();
+        }
+        
+        public void fn2() throws IOException {
+            throw new IOException();
+        }
+    }
+    
+    /**
+     * Checks that exception thrown in the callback Java code is reported 'as is'.
+     * @throws Exception 
+     */
+    @Test
+    public void hostCheckedExceptionAccessible() throws Exception {
+        // Note: this seems to be broken on GraalVM's JDK js - runtime exceptions are wrapped into
+        // polyglot wrapper and cannot be determined through the chain of getCauses().
+        assumeFalse(engine.getFactory().getEngineName().toLowerCase().contains("graal.js"));
+        
+        try {
+            engine.eval("var x; function setGlobalX(p) { x = p }");
+            ((Invocable)engine).invokeFunction("setGlobalX", new Callback());
+            engine.eval("x.fn2();");
+            fail("Exception expected");
+        } catch (RuntimeException ex) {
+            Throwable c = ex.getCause();
+            Assert.assertThat(c, CoreMatchers.is(CoreMatchers.instanceOf(IOException.class)));
+        } catch (Exception ex) {
+            fail("Runtime subclass is expected");
+        }
+    }
+
+    /**
+     * Checks that exception thrown in the callback Java code is reported 'as is'.
+     * @throws Exception 
+     */
+    @Test
+    public void hostExceptionReportedAsRuntime() throws Exception {
+        // Note: this seems to be broken on GraalVM's JDK js - runtime exceptions are wrapped into
+        // polyglot wrapper and cannot be determined through the chain of getCauses().
+        assumeFalse(engine.getFactory().getEngineName().toLowerCase().contains("graal.js"));
+        
+        try {
+            engine.eval("var x; function setGlobalX(p) { x = p }");
+            ((Invocable)engine).invokeFunction("setGlobalX", new Callback());
+            engine.eval("x.fn();");
+            fail("Exception expected");
+        } catch (ScriptException ex) {
+            Throwable c = ex.getCause();
+            Assert.assertThat(c, CoreMatchers.is(CoreMatchers.instanceOf(NoSuchElementException.class)));
+        } catch (NoSuchElementException ex) {
+            // this is OK
+        } catch (Exception ex) {
+            
+        }
+    }
+    
+    /** 
+     * Checks that values assigned by various mehtods are visible:
+     * @throws Exception 
+     */
+    @Test
+    public void testEngineGlobalVariablesVisible() throws Exception {
+        Bindings b = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        b.put("a", 1111);
+        Object o = engine.eval("var b = 3333; a");
+        assertEquals(1111, o);
+        assertEquals(3333, b.get("b"));
+        
+        engine.getContext().setAttribute("a", 2222, ScriptContext.ENGINE_SCOPE);
+        o = engine.eval("var b = 4444; a");
+        assertEquals(2222, o);
+        assertEquals(4444, engine.getContext().getAttribute("b"));
+        assertEquals(4444, engine.getContext().getAttribute("b", ScriptContext.ENGINE_SCOPE));
+        assertNull(engine.getContext().getAttribute("b", ScriptContext.GLOBAL_SCOPE));
+        
     }
 }

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/ScriptingTutorial.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/ScriptingTutorial.java
@@ -628,7 +628,7 @@ public class ScriptingTutorial extends NbTestCase {
         }
         
         // the last exception is a runtime exception originating from java.
-        // it will be reported 'as is'
+        // it will be reported 'as is' or wrapped, depending on the engine
         try {
             Object jsFunction = engine.eval(
                   "(function(cb, l) {"
@@ -638,6 +638,9 @@ public class ScriptingTutorial extends NbTestCase {
             ((Invocable) engine).invokeMethod(jsFunction, "call", null, cb, new LinkedList());
         } catch (NoSuchElementException ex) {
             // this is a checked java exception; it's thrown unchanged.
+        } catch (RuntimeException ex) {
+            // ... or wrapped in a Runtime:
+            assertTrue(ex.getCause() instanceof NoSuchElementException);
         } catch (Exception ex) {
             fail("NoSuchElement expected");
         }

--- a/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/ScriptingTutorial.java
+++ b/ide/libs.graalsdk/test/unit/src/org/netbeans/libs/graalsdk/ScriptingTutorial.java
@@ -18,14 +18,18 @@
  */
 package org.netbeans.libs.graalsdk;
 
+import java.io.IOException;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.function.Function;
 import javax.script.Invocable;
 import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
 import org.netbeans.api.scripting.Scripting;
 
 
@@ -578,4 +582,65 @@ public class ScriptingTutorial extends NbTestCase {
 
     // END: org.netbeans.libs.graalsdk.ScriptingTutorial#accessJavaScriptJSONObjectFromJava
 
+    public void testHandleScriptException() throws Exception {
+        handleScriptExceptions();
+    }
+    
+    public static class Callback {
+        public String next(List<String> l) {
+            return l.iterator().next();
+        }
+        
+        public void io() throws IOException {
+            throw new IOException("");
+        }
+    }
+    
+    // Checkstyle: stop
+    public void handleScriptExceptions() throws Exception {
+        // BEGIN: org.netbeans.libs.graalsdk.ScriptingTutorial#handleScriptExceptions
+        // this is error in Javascript (null dereference), so ScriptException will be thrown,
+        // with scripting engine's implementation exception inside.
+        try {
+            engine.eval(
+                 "var a = null;\n"
+                + "a.call(null)");
+        } catch (ScriptException ex) {
+        }
+        
+        // The callback will throw a checked exception - something that happens
+        // "outside" the script in the runtime: will throw RuntimeException subclass
+        // with the real exception set as cause.
+        Callback cb = new Callback();
+        try {
+            Object jsFunction = engine.eval(
+                  "(function(cb) {"
+                + " cb.io();"
+                + "})"
+            );
+            ((Invocable) engine).invokeMethod(jsFunction, "call", null, cb);
+        } catch (RuntimeException ex) {
+            // this is a checked java exception; it's just wrapped into a
+            // RuntimeException:
+            assertTrue(ex.getCause() instanceof IOException);
+        } catch (Exception ex) {
+            fail("Runtime expected");
+        }
+        
+        // the last exception is a runtime exception originating from java.
+        // it will be reported 'as is'
+        try {
+            Object jsFunction = engine.eval(
+                  "(function(cb, l) {"
+                + " cb.next(l);"
+                + "})"
+            );
+            ((Invocable) engine).invokeMethod(jsFunction, "call", null, cb, new LinkedList());
+        } catch (NoSuchElementException ex) {
+            // this is a checked java exception; it's thrown unchanged.
+        } catch (Exception ex) {
+            fail("NoSuchElement expected");
+        }
+        // END: org.netbeans.libs.graalsdk.ScriptingTutorial#handleScriptExceptions
+    }
 }

--- a/platform/api.scripting/test/unit/src/org/netbeans/api/scripting/JavaScriptEnginesTest.java
+++ b/platform/api.scripting/test/unit/src/org/netbeans/api/scripting/JavaScriptEnginesTest.java
@@ -125,7 +125,7 @@ public class JavaScriptEnginesTest {
         try {
             assertEquals("seventy seven", 77, global.mul(11, 7));
         } catch (Exception ex) {
-            assertTrue("GraalVM:js exposes only exported symbols", engineName.equals("GraalVM:js"));
+            assertTrue("GraalVM:js exposes only exported symbols: " + engine.getFactory().getNames(), engine.getFactory().getNames().contains("GraalVM:js"));
         }
         assertEquals("mulExported is accessible in all engines", 77, global.mulExported(11, 7));
     }
@@ -149,7 +149,8 @@ public class JavaScriptEnginesTest {
 
         Point point = inv().getInterface(rawPoint, Point.class);
         if (point == null) {
-            Assume.assumeFalse(engineName.contains("Nashorn"));
+            assumeNotNashorn();
+            assumeNotGraalJsFromJDK();
         }
         assertNotNull("Converted to typed interface", point);
 
@@ -227,7 +228,8 @@ public class JavaScriptEnginesTest {
 
         ArrayLike res = ((Invocable) engine).getInterface(raw, ArrayLike.class);
         if (res == null) {
-            Assume.assumeFalse(engineName.contains("Nashorn"));
+            assumeNotNashorn();
+            assumeNotGraalJsFromJDK();
         }
         assertNotNull("Result looks like array", res);
 
@@ -238,6 +240,14 @@ public class JavaScriptEnginesTest {
         assertEquals("a", list.get(2));
         assertEquals(Math.PI, list.get(3));
         assertEquals(sum, list.get(4));
+    }
+
+    private void assumeNotNashorn() {
+        Assume.assumeFalse(engine.getFactory().getNames().contains("Nashorn"));
+    }
+
+    private void assumeNotGraalJsFromJDK() {
+        Assume.assumeFalse(engine.getFactory().getNames().contains("Graal.js"));
     }
 
     @Test

--- a/platform/libs.junit4/manifest.mf
+++ b/platform/libs.junit4/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.libs.junit4
-OpenIDE-Module-Specification-Version: 1.26
+OpenIDE-Module-Specification-Version: 1.27
 OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/junit4/Bundle.properties
 

--- a/platform/libs.junit4/nbproject/project.xml
+++ b/platform/libs.junit4/nbproject/project.xml
@@ -30,6 +30,8 @@
                 <package>junit.framework</package>
                 <package>junit.runner</package>
                 <package>junit.textui</package>
+                <package>org.hamcrest</package>
+                <package>org.hamcrest.core</package>
                 <package>org.junit</package>
                 <package>org.junit.matchers</package>
                 <package>org.junit.rules</package>


### PR DESCRIPTION
There are a few types of changes:
- the exceptions thrown are better reported: the original exception is attached as the `cause` of the `RuntimeException` (actually `PolyglotException`) thrown from eval/invoke methods.
- better (un)wrapping of `org.graalvm.polyglot.Value` from/to POJOs
- the `ScriptEngine` returned by `Scripting.createManager()` will support `ScriptContext.ENGINE` scope as the top-level language scope.
- global attributes are now supported, even before the first `eval` or other `Context`-creating method on the Engine is called.

I also somewhat checked the testu results agains GraalVM 20.1 (now travis runs 19.3.1)