### PR TITLE
Backport of OQL finalizables fix

### DIFF
--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
@@ -275,21 +275,20 @@ public class Snapshot {
 
     public Iterator getFinalizerObjects() {
         JavaClass clazz = findClass("java.lang.ref.Finalizer"); // NOI18N
-        Instance queue = ((ObjectFieldValue) clazz.getValueOfStaticField("queue")).getInstance(); // NOI18N
-        ObjectFieldValue headFld = (ObjectFieldValue) queue.getValueOfField("head"); // NOI18N
+        Instance queue = (Instance) clazz.getValueOfStaticField("queue"); // NOI18N
+        Instance head = (Instance) queue.getValueOfField("head"); // NOI18N
 
-        List<Instance> finalizables = new ArrayList<>();
-        if (headFld != null) {
-            Instance head = headFld.getInstance();
+        List finalizables = new ArrayList();
+        if (head != null) {
             while (true) {
-                ObjectFieldValue referentFld = (ObjectFieldValue) head.getValueOfField("referent"); // NOI18N
-                ObjectFieldValue nextFld = (ObjectFieldValue) head.getValueOfField("next"); // NOI18N
+                Instance referent = (Instance) head.getValueOfField("referent"); // NOI18N
+                Instance next = (Instance) head.getValueOfField("next"); // NOI18N
 
-                if (nextFld == null || nextFld.getInstance().equals(head)) {
+                finalizables.add(referent);
+                if (next == null || next.equals(head)) {
                     break;
                 }
-                head = nextFld.getInstance();
-                finalizables.add(referentFld.getInstance());
+                head = next;
             }
         }
         return finalizables.iterator();

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/hat.js
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/hat.js
@@ -761,7 +761,7 @@ function wrapHeapSnapshot(heap) {
          */
         finalizables: function() {
             var tmp = this.snapshot.getFinalizerObjects();
-            return wrapperIterator(tmp);
+            return wrapIterator(tmp);
         },
  
         /**

--- a/profiler/profiler.oql/test/unit/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLEngineTest.java
+++ b/profiler/profiler.oql/test/unit/src/org/netbeans/modules/profiler/oql/engine/api/impl/OQLEngineTest.java
@@ -167,16 +167,16 @@ public class OQLEngineTest {
         System.out.println("heap.roots");
         final int[] counter = new int[1];
 
-        String query = "select heap.roots";
+        String query = "select heap.roots()";
 
         instance.executeQuery(query, new ObjectVisitor() {
 
             public boolean visit(Object o) {
                 counter[0]++;
-                return true;
+                return false;
             }
         });
-        assertTrue(counter[0] > 0);
+        assertTrue(counter[0] == 404);
     }
 
     @Test
@@ -184,16 +184,16 @@ public class OQLEngineTest {
         System.out.println("heap.classes");
         final int[] counter = new int[1];
 
-        String query = "select heap.classes";
+        String query = "select heap.classes()";
 
         instance.executeQuery(query, new ObjectVisitor() {
 
             public boolean visit(Object o) {
                 counter[0]++;
-                return true;
+                return false;
             }
         });
-        assertTrue(counter[0] > 0);
+        assertTrue(counter[0] == 443);
     }
 
     @Test
@@ -201,16 +201,16 @@ public class OQLEngineTest {
         System.out.println("heap.finalizables");
         final int[] counter = new int[1];
 
-        String query = "select heap.finalizables";
+        String query = "select heap.finalizables()";
 
         instance.executeQuery(query, new ObjectVisitor() {
 
             public boolean visit(Object o) {
                 counter[0]++;
-                return true;
+                return false;
             }
         });
-        assertTrue(counter[0] > 0);
+        assertTrue(counter[0] == 0);
     }
 
     @Test


### PR DESCRIPTION
Backport of OQL finalizables bugfix from VisualVM (see [d936905](https://github.com/oracle/visualvm/commit/d9369059b5017c868e831bd1317381718fbe55c1) and [bd9bf46](https://github.com/oracle/visualvm/commit/bd9bf46131fd9e6c1d25ec475775aefbc6540021)).

The PR corrects previous implementation of `heap.finalizables()` in OQL engine which used to fail with a `ClassCastException` for any heap file. Additionally, it also includes a small fix for JavaScript test cases which called several OQL functions incorrectly (reason why the failing behaviour of `finalizables` was not discovered before).

(cc: @JaroslavTulach)