### PR TITLE
CachingArchiveProvider should return a proper Archive for jar URLs th…

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchiveProvider.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CachingArchiveProvider.java
@@ -107,7 +107,7 @@ public final class CachingArchiveProvider {
     public Archive getArchive(@NonNull final URL root, final boolean cacheFile)  {
         final URI rootURI = toURI(root);
         Archive archive;
-        
+
         synchronized (this) {
             archive = archives.get(rootURI);
         }
@@ -254,7 +254,8 @@ public final class CachingArchiveProvider {
                 return EMPTY;
             }
         }
-        if ("jar".equals(protocol)) {       //NOI18N
+        if ("jar".equals(protocol) &&      //NOI18N
+            root.first().getPath().endsWith("!/")) { //CachingArchive does not handle paths inside the archive - skip and use FileObjectArchive      //NOI18N
             URL inner = FileUtil.getArchiveFile(root.first());
             protocol = inner.getProtocol();
             if ("file".equals(protocol)) {  //NOI18N

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingArchiveProviderTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/CachingArchiveProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.source.parsing;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.stream.StreamSupport;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.netbeans.junit.NbTestCase;
+import org.openide.util.Utilities;
+
+public class CachingArchiveProviderTest extends NbTestCase {
+
+    public CachingArchiveProviderTest(String name) {
+        super(name);
+    }
+
+    //verify jar URLs with paths inside the archive work:
+    public void testZipWithPath() throws IOException {
+        clearWorkDir();
+        File wd = getWorkDir();
+        File zip = new File(wd, "test.zip");
+        try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zip))) {
+            out.putNextEntry(new ZipEntry("module/test/test.txt"));
+        }
+        Archive archive = CachingArchiveProvider.getDefault().getArchive(new URL("jar:" + Utilities.toURI(zip).toURL().toString() + "!/module"), false);
+        assertNotNull(archive.getFile("test/test.txt"));
+        assertEquals(1, StreamSupport.stream(archive.getFiles("test", null, null, null, false).spliterator(), false).count());
+    }
+
+}


### PR DESCRIPTION
…at have paths inside the archive.

CachingArchiveProvider.getArchive does not return a correct archive for URLs like "jar:file:.../src.zip!/java.base" (i.e. when there is a path after "!/").

One side-effect of the problem here is that first determination of parameter names for classes from JDK is very, very slow. The reason is:
CachingArchiveProvider.getArchive is asked to provide archive for various URLs like "jar:file:.../src.zip!/java.base", "jar:file:.../src.zip!/java.compiler", etc. Because these URLs are different, CachingArchiveProvider will create a new (fast FastJar-based) CachingArchive for each, forcing the zip parsing quite a few times, which is slow. But - the output is wrong anyway, as the resulting archives ignore the path inside the archive.

The proposal here is to avoid creating the fast CachingArchive, but simply use one based on FileObjects. While the second one may be slower, it should make a huge difference - this is likely to only happen for cases like src.zip, and we don't need to read from them much. The advantage is that we avoid the repetitive zip parsing, improving first determination of parameter names, improving "startup".
