### PR TITLE
[NETBEANS-4664] - Upgrade JDBC PostgreSQL from 42.2.10 to 42.2.16

### DIFF
--- a/ide/db.drivers/external/binaries-list
+++ b/ide/db.drivers/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-338AF492789FD198DBD52735A22B1946030ECC96 org.postgresql:postgresql:42.2.10
+A9EE12F737BD5DC7D046E4C065E391D38D6A3CFC org.postgresql:postgresql:42.2.16

--- a/ide/db.drivers/external/postgresql-42.2.16-license.txt
+++ b/ide/db.drivers/external/postgresql-42.2.16-license.txt
@@ -1,9 +1,9 @@
 Name: PostgreSQL JDBC Driver
-Version: 42.2.10
+Version: 42.2.16
 Description: Allows Java programs to interact with a PostgreSQL database
 License: BSD-postgresql
 Origin: https://jdbc.postgresql.org/about/license.html
-Files: postgresql-42.2.10.jar
+Files: postgresql-42.2.16.jar
 Comment: Out-of-the-box support for Postgres Java database applications
 
 Copyright (c) 1997, PostgreSQL Global Development Group

--- a/ide/db.drivers/nbproject/project.properties
+++ b/ide/db.drivers/nbproject/project.properties
@@ -17,6 +17,6 @@
 
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
-release.external/postgresql-42.2.10.jar=modules/ext/postgresql-42.2.10.jar
+release.external/postgresql-42.2.16.jar=modules/ext/postgresql-42.2.16.jar
 jnlp.indirect.jars=\
-    modules/ext/postgresql-42.2.10.jar
+    modules/ext/postgresql-42.2.16.jar

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/Bundle.properties
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/Bundle.properties
@@ -20,6 +20,6 @@ OpenIDE-Module-Display-Category=Database
 OpenIDE-Module-Short-Description=JDBC database drivers
 OpenIDE-Module-Long-Description=\
     <html>This plugin provides JDBC database drivers for an improved out-of-the-box experience when developing database applications. \
-    <p>The following driver is included in this plugin: <ul> <li>PostgreSQL JDBC 4.2 Driver Version: 42.2.10</li> </ul> </p></html>
+    <p>The following driver is included in this plugin: <ul> <li>PostgreSQL JDBC 4.2 Driver Version: 42.2.16</li> </ul> </p></html>
 PostgreSQLDriver=PostgreSQL JDBC Driver
 MySQLDriver=MySQL JDBC Driver

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/PostgreSQLDriver.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/PostgreSQLDriver.xml
@@ -25,7 +25,7 @@
     <localizing-bundle>org.netbeans.modules.db.drivers.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.modules.db.drivers/modules/ext/postgresql-42.2.10.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.db.drivers/modules/ext/postgresql-42.2.16.jar!/</resource>
     </volume>
     <volume>
         <type>src</type>
@@ -38,7 +38,7 @@
     <properties>
         <property>
             <name>maven-dependencies</name>
-            <value>org.postgresql:postgresql:42.2.10:jar</value>
+            <value>org.postgresql:postgresql:42.2.16:jar</value>
         </property>
     </properties>
 </library>

--- a/ide/db.drivers/src/org/netbeans/modules/db/drivers/postgresql.xml
+++ b/ide/db.drivers/src/org/netbeans/modules/db/drivers/postgresql.xml
@@ -25,6 +25,6 @@
   <display-name value='PostgreSQL'/>
   <class value='org.postgresql.Driver'/>
   <urls>
-  	<url value="nbinst://org.netbeans.modules.db.drivers/modules/ext/postgresql-42.2.10.jar"/>
+  	<url value="nbinst://org.netbeans.modules.db.drivers/modules/ext/postgresql-42.2.16.jar"/>
   </urls>
 </driver>


### PR DESCRIPTION
Notes:
- Fix security vulnerability CVE-2020-13692 
- Minor bug fixes

[Releases Notes](https://jdbc.postgresql.org/documentation/changelog.html)

NetBeans Testing:

- Full build done
- Started NetBeans and ensure the log didn't have any errors or new warnings
- Checked that the file had been downloaded and referenced inside the Ant Library Manager
`jar:nbinst://org.netbeans.modules.db.drivers/modules/ext/postgresql-42.2.16.jar!/`