### PR TITLE
[NETBEANS-4667] Fix broken npm search

### DIFF
--- a/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/exec/NpmExecutable.java
+++ b/webcommon/javascript.nodejs/src/org/netbeans/modules/javascript/nodejs/exec/NpmExecutable.java
@@ -215,6 +215,7 @@ public class NpmExecutable {
         List<String> params = new ArrayList<>();
         params.add("search"); // NOI18N
         params.add("--long"); // NOI18N
+        params.add("--parseable"); // NOI18N
         params.add(searchTerm);
         String result = null;
         StringBuilderInputProcessorFactory factory = new StringBuilderInputProcessorFactory();


### PR DESCRIPTION
IDE npm search (Web project > properties > npm > add) is broken due to output format change in npm.
This commit uses npm --parseable flag to fix and simplify output parsing.
Tested with npm 6.14.4