### PR TITLE
[NETBEANS-4665] - Upgrade Bouncy Castle from 1.68 to 1.70

### DIFF
--- a/ide/bcpg/external/bcpg-jdk15on-1.70-license.txt
+++ b/ide/bcpg/external/bcpg-jdk15on-1.70-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle Java OpenPGP/BCPG
-Version: 1.64
+Version: 1.70
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcpg/external/binaries-list
+++ b/ide/bcpg/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-56956A8C63CCADF62E7C678571CF86F30BD84441 org.bouncycastle:bcpg-jdk15on:1.64
+062F72EC06F31A6C31A3F3355FCE0384B21126D7 org.bouncycastle:bcpg-jdk15on:1.70

--- a/ide/bcpg/nbproject/project.properties
+++ b/ide/bcpg/nbproject/project.properties
@@ -14,7 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
 release.external/bcpg-jdk15on-1.70.jar=modules/bcpg.jar
 is.autoload=true

--- a/ide/bcpg/nbproject/project.xml
+++ b/ide/bcpg/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcpg.jar</runtime-relative-path>
-                <binary-origin>external/bcpg-jdk15on-1.64.jar</binary-origin>
+                <binary-origin>external/bcpg-jdk15on-1.70.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcpkix/external/bcpkix-jdk15on-1.70-license.txt
+++ b/ide/bcpkix/external/bcpkix-jdk15on-1.70-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle Java Provider
-Version: 1.68
+Version: 1.70
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcpkix/external/binaries-list
+++ b/ide/bcpkix/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-81DA950604FF0B2652348CBD2B48FDE46CED9867 org.bouncycastle:bcpkix-jdk15on:1.68
+F81E5AF49571A9D5A109A88F239A73CE87055417 org.bouncycastle:bcpkix-jdk15on:1.70

--- a/ide/bcpkix/nbproject/project.properties
+++ b/ide/bcpkix/nbproject/project.properties
@@ -14,7 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
 release.external/bcpkix-jdk15on-1.70.jar=modules/bcpkix.jar
 is.autoload=true

--- a/ide/bcpkix/nbproject/project.properties
+++ b/ide/bcpkix/nbproject/project.properties
@@ -14,5 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcpkix-jdk15on-1.68.jar=modules/bcpkix.jar
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
+release.external/bcpkix-jdk15on-1.70.jar=modules/bcpkix.jar
 is.autoload=true

--- a/ide/bcpkix/nbproject/project.xml
+++ b/ide/bcpkix/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>bcpkix.jar</runtime-relative-path>
-                <binary-origin>external/bcpkix-jdk15on-1.68.jar</binary-origin>
+                <binary-origin>external/bcpkix-jdk15on-1.70.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/bcprov/external/bcprov-jdk15on-1.70-license.txt
+++ b/ide/bcprov/external/bcprov-jdk15on-1.70-license.txt
@@ -1,5 +1,5 @@
 Name: Bouncy Castle Java Provider
-Version: 1.68
+Version: 1.70
 License: MIT-bouncycastle
 Origin: https://www.bouncycastle.org/latest_releases.html
 Description: Legion of the Bouncy Castle Java cryptography APIs

--- a/ide/bcprov/external/binaries-list
+++ b/ide/bcprov/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-46A080368D38B428D237A59458F9BC915222894D org.bouncycastle:bcprov-jdk15on:1.68
+4636A0D01F74ACAF28082FB62B317F1080118371 org.bouncycastle:bcprov-jdk15on:1.70

--- a/ide/bcprov/nbproject/project.properties
+++ b/ide/bcprov/nbproject/project.properties
@@ -14,5 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-release.external/bcprov-jdk15on-1.68.jar=modules/bcprov.jar
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
+release.external/bcprov-jdk15on-1.70.jar=modules/bcprov.jar
 is.autoload=true

--- a/ide/bcprov/nbproject/project.properties
+++ b/ide/bcprov/nbproject/project.properties
@@ -14,7 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
 release.external/bcprov-jdk15on-1.70.jar=modules/bcprov.jar
 is.autoload=true

--- a/ide/bcutil/build.xml
+++ b/ide/bcutil/build.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -8,28 +7,15 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License.  You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
-
 -->
-<project xmlns="http://www.netbeans.org/ns/project/1">
-    <type>org.netbeans.modules.apisupport.project</type>
-    <configuration>
-        <data xmlns="http://www.netbeans.org/ns/nb-module-project/2">
-            <code-name-base>bcprov</code-name-base>
-            <module-dependencies/>
-            <public-packages/>
-            <class-path-extension>
-                <runtime-relative-path>bcprov.jar</runtime-relative-path>
-                <binary-origin>external/bcprov-jdk15on-1.70.jar</binary-origin>
-            </class-path-extension>
-        </data>
-    </configuration>
+<project name="ide/bcutil" default="build" basedir=".">
+    <import file="../../nbbuild/templates/projectized.xml"/>
+    <target name="jar"/>
 </project>

--- a/ide/bcutil/external/bcutil-jdk15on-1.70-license.txt
+++ b/ide/bcutil/external/bcutil-jdk15on-1.70-license.txt
@@ -1,0 +1,24 @@
+Name: Bouncy Castle ASN.1 Extension and Utility APIs
+Version: 1.70
+License: MIT-bouncycastle
+Origin: https://www.bouncycastle.org/latest_releases.html
+Description: Legion of the Bouncy Castle Java cryptography APIs
+
+Copyright (c) 2000 - 2019 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/ide/bcutil/external/binaries-list
+++ b/ide/bcutil/external/binaries-list
@@ -14,7 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
-release.external/bcpg-jdk15on-1.70.jar=modules/bcpg.jar
-is.autoload=true
+54280E7195A7430D7911DED93FC01E07300B9526 org.bouncycastle:bcutil-jdk15on:1.70

--- a/ide/bcutil/manifest.mf
+++ b/ide/bcutil/manifest.mf
@@ -1,0 +1,1 @@
+OpenIDE-Module: bcutil

--- a/ide/bcutil/nbproject/project.properties
+++ b/ide/bcutil/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
-release.external/bcpg-jdk15on-1.70.jar=modules/bcpg.jar
+release.external/bcutil-jdk15on-1.70.jar=modules/bcutil.jar
 is.autoload=true

--- a/ide/bcutil/nbproject/project.properties
+++ b/ide/bcutil/nbproject/project.properties
@@ -14,7 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
 release.external/bcutil-jdk15on-1.70.jar=modules/bcutil.jar
 is.autoload=true

--- a/ide/bcutil/nbproject/project.xml
+++ b/ide/bcutil/nbproject/project.xml
@@ -23,12 +23,12 @@
     <type>org.netbeans.modules.apisupport.project</type>
     <configuration>
         <data xmlns="http://www.netbeans.org/ns/nb-module-project/2">
-            <code-name-base>bcprov</code-name-base>
+            <code-name-base>bcutil</code-name-base>
             <module-dependencies/>
             <public-packages/>
             <class-path-extension>
-                <runtime-relative-path>bcprov.jar</runtime-relative-path>
-                <binary-origin>external/bcprov-jdk15on-1.70.jar</binary-origin>
+                <runtime-relative-path>bcutil.jar</runtime-relative-path>
+                <binary-origin>external/bcutil-jdk15on-1.70.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -86,8 +86,6 @@ extide/gradle/external/gradle-7.4-bin.zip platform/libs.junit4/external/junit-4.
 extide/gradle/external/gradle-7.4-bin.zip platform/libs.testng/external/jcommander-1.78.jar
 extide/gradle/external/gradle-7.4-bin.zip platform/o.apache.commons.io/external/commons-io-2.6.jar
 extide/gradle/external/gradle-7.4-bin.zip enterprise/cloud.oracle/external/jsr305-3.0.2.jar
-extide/gradle/external/gradle-7.4-bin.zip ide/bcpkix/external/bcpkix-jdk15on-1.68.jar
-extide/gradle/external/gradle-7.4-bin.zip ide/bcprov/external/bcprov-jdk15on-1.68.jar
 extide/gradle/external/gradle-7.4-bin.zip platform/o.apache.commons.codec/external/commons-codec-1.15.jar
 extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-9.2.jar
 extide/gradle/external/gradle-7.4-bin.zip platform/libs.asm/external/asm-commons-9.2.jar

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -320,6 +320,7 @@ nb.cluster.ide=\
         bcpg,\
         bcpkix,\
         bcprov,\
+        bcutil,\
         bugtracking,\
         bugtracking.bridge,\
         bugtracking.commons,\


### PR DESCRIPTION
Library Notes:
- Many bug fixes and improvements

NetBeans Notes:
- Upgrade `bcprov`, `bcpg` and `bcpkix`
- Add a new module `ide/bcutil` due to a refactoring in version 1.69
- Remove entry in ignored-overlaps file

[Web Page](https://bouncycastle.org/latest_releases.html)
[Releases Notes](https://bouncycastle.org/releasenotes.html)

NetBeans Testing:

- Full build done 
- Checked the files had been downloaded and placed at `/netbeans/ide/modules/bcprov.jar`, `/netbeans/ide/modules/bcpg.jar`, `/netbeans/ide/modules/bcpkix.jar` and `/netbeans/ide/modules/bcutil.jar`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS 
- Checked that the Module-Specification-Version is increased in the starting log. `bcprov [1.70 1.70]`, `bcpg [1.68 1.70]`, `bcpkix [1.70 1.70]` and `bcutil [1.70 1.70]`
