### PR TITLE
[NETBEANS-4666] - Upgrade exec-maven-plugin from 1.5.0 to 3.0.0

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/defaultActionMappings.xml
+++ b/java/maven/src/org/netbeans/modules/maven/execute/defaultActionMappings.xml
@@ -114,7 +114,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:1.5.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
         </goals>
         <properties>
             <exec.args>-classpath %classpath ${packageClassName}</exec.args>
@@ -128,7 +128,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:1.5.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
         </goals>
         <properties>
             <exec.args>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>
@@ -143,7 +143,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:1.5.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
         </goals>
         <properties>
             <exec.args>-classpath %classpath ${packageClassName}</exec.args>
@@ -159,7 +159,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:1.5.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
         </goals>
         <properties>
             <exec.args>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>
@@ -224,7 +224,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:1.5.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
         </goals>
         <properties>
             <exec.args>-classpath %classpath ${packageClassName}</exec.args>
@@ -239,7 +239,7 @@
         </packagings>
         <goals>
             <goal>process-classes</goal>
-            <goal>org.codehaus.mojo:exec-maven-plugin:1.5.0:exec</goal>
+            <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
         </goals>
         <properties>
             <exec.args>-classpath %classpath ${packageClassName}</exec.args>

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/api/customizer/ModelHandle2Test.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/api/customizer/ModelHandle2Test.java
@@ -162,7 +162,7 @@ public class ModelHandle2Test extends NbTestCase {
 "            </packagings>\n" +
 "            <goals>\n" +
 "                <goal>process-classes</goal>\n" +
-"                <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>\n" +
+"                <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>\n" +
 "            </goals>\n" +
 "            <properties>\n" +
 "                <exec.args>-XX:MaxPermSize=512m -classpath %classpath ${packageClassName}</exec.args>\n" +
@@ -177,7 +177,7 @@ public class ModelHandle2Test extends NbTestCase {
 "            </packagings>\n" +
 "            <goals>\n" +
 "                <goal>process-classes</goal>\n" +
-"                <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>\n" +
+"                <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>\n" +
 "            </goals>\n" +
 "            <properties>\n" +
 "                <exec.args>-XX:MaxPermSize=512m -agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>\n" +
@@ -199,7 +199,7 @@ public class ModelHandle2Test extends NbTestCase {
 "            </packagings>\n" +
 "            <goals>\n" +
 "                <goal>process-classes</goal>\n" +
-"                <goal>org.codehaus.mojo:exec-maven-plugin:1.2.1:exec</goal>\n" +
+"                <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>\n" +
 "            </goals>\n" +
 "            <properties>\n" +
 "                <exec.args>-XX:MaxPermSize=512m -agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>\n" +
@@ -223,7 +223,7 @@ public class ModelHandle2Test extends NbTestCase {
             RunConfig run = ActionToGoalUtils.createRunConfig("debug.single.main", (NbMavenProjectImpl) project, project.getLookup());
             assertEquals("Two goals: " + run.getGoals(), 2, run.getGoals().size());
             assertEquals("process-classes", run.getGoals().get(0));
-            assertEquals("org.codehaus.mojo:exec-maven-plugin:1.2.1:exec", run.getGoals().get(1));
+            assertEquals("org.codehaus.mojo:exec-maven-plugin:3.0.0:exec", run.getGoals().get(1));
             assertEquals("One profile activated in action: " + run.getActivatedProfiles(), 1, run.getActivatedProfiles().size());
             assertEquals("jetty", run.getActivatedProfiles().get(0));
         }

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/execute/ModelRunConfigTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/execute/ModelRunConfigTest.java
@@ -260,7 +260,7 @@ public class ModelRunConfigTest extends NbTestCase {
                 + "            <plugin>\n"
                 + "                <groupId>org.codehaus.mojo</groupId>\n"
                 + "                <artifactId>exec-maven-plugin</artifactId>\n"
-                + "                <version>1.4.0</version>\n"
+                + "                <version>3.0.0</version>\n"
                 + "                <configuration>\n"
                 + "                    <executable>${java.home}/bin/java</executable>\n"
                 +                      argsString 


### PR DESCRIPTION
Notes:
- Support for JPMS module path for exec:java
- 4 Bug fixes
- 10 Enhancements

[Web Page](http://www.mojohaus.org/exec-maven-plugin/)
[Releases Notes](https://github.com/mojohaus/exec-maven-plugin/releases)

NetBeans Testing:
- Full build done
- Started NetBeans and ensure the log didn't have any errors or new warnings
- Checked that the maven actions had the new version inside a maven project:
  Project Properties > Actions > `Run Project`, `Run file via main()`, `Debug project`, `Debug file via main()`, `Debug file via main()` and  `Profile file via main()`
- Run File and ensure new plugin version is used in the Output
![Screenshot from 2020-08-02 16-33-03](https://user-images.githubusercontent.com/9832133/89133094-b9028600-d4de-11ea-8651-bb5e09b4d141.png)
