### PR TITLE
[NETBEANS-1454] Add break-word to supported values for word-break

### DIFF
--- a/ide/css.editor/external/binaries-list
+++ b/ide/css.editor/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 901D8F815922C435D985DA3814D20E34CC7622CB css21-spec.zip
-83E794DFF9A39401AC65252C8E10157761584224 css3-spec.zip
+123E52BDC74F5DC90F99C8C2B0993D678D60AE81 css3-spec.zip

--- a/ide/css.editor/external/css3-spec-howtocreate.txt
+++ b/ide/css.editor/external/css3-spec-howtocreate.txt
@@ -1,0 +1,69 @@
+Licensed to the Apache Software Foundation (ASF) under one or more contributor
+license agreements; and to You under the Apache License, Version 2.0.
+
+--------------------------------------------------------------------------------
+How to update the css3-spec.zip?
+--------------------------------------------------------------------------------
+
+The css3-spec.zip file contains a copy/mirror of the w3c spec pages for various
+CSS3 modules. The file can be rebuild by using the wget tool to create a copy
+of the current state of the documents.
+
+1. Create an empty directory "css3-spec" and change into it:
+
+mkdir css3-spec
+cd css3-spec
+
+2. Do the mirroring:
+
+wget --adjust-extension --convert-links --page-requisites -e robots=off \
+http://www.w3.org/TR/css3-2d-transforms/ \
+http://www.w3.org/TR/css3-3d-transforms/ \
+http://www.w3.org/TR/css3-animations/ \
+http://www.w3.org/TR/css3-background/ \
+http://www.w3.org/TR/css3-box/ \
+http://www.w3.org/TR/css3-cascade/ \
+http://www.w3.org/TR/css3-color/ \
+http://www.w3.org/TR/css3-conditional/ \
+http://www.w3.org/TR/css3-content/ \
+http://www.w3.org/TR/css3-exclusions/ \
+http://www.w3.org/TR/css3-flexbox/ \
+http://www.w3.org/TR/css3-fonts/ \
+http://www.w3.org/TR/css3-gcpm/ \
+http://www.w3.org/TR/css3-grid/ \
+http://www.w3.org/TR/css3-hyperlinks/ \
+http://www.w3.org/TR/css3-images/ \
+http://www.w3.org/TR/css3-linebox/ \
+http://www.w3.org/TR/css3-lists/ \
+http://www.w3.org/TR/css3-marquee/ \
+http://www.w3.org/TR/css3-mediaqueries/ \
+http://www.w3.org/TR/css3-multicol/ \
+http://www.w3.org/TR/css3-namespace/ \
+http://www.w3.org/TR/css3-page/ \
+http://www.w3.org/TR/css3-positioning/ \
+http://www.w3.org/TR/css3-preslev/ \
+http://www.w3.org/TR/css3-regions/ \
+http://www.w3.org/TR/css3-ruby/ \
+http://www.w3.org/TR/css3-speech/ \
+http://www.w3.org/TR/css3-text/ \
+http://www.w3.org/TR/css3-transitions/ \
+http://www.w3.org/TR/css3-ui/ \
+http://www.w3.org/TR/css3-values/ \
+http://www.w3.org/TR/css3-writing-modes/
+
+3. Check that the contents still looks sane and mirroring worked
+
+4. ZIP the mirrored data
+
+rm ../css3-spec.zip
+zip -r ../css3-spec.zip .
+
+5. Cleanup
+
+cd ..
+rm -r css3-spec
+
+6. Upload the created file to the osuosl.org binary server and update
+   binaries-list
+
+For the upload see: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=115507251

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/StandardPropertiesHelpResolver.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/StandardPropertiesHelpResolver.java
@@ -167,8 +167,8 @@ public class StandardPropertiesHelpResolver extends HelpResolver {
                         Matcher findSectionEnd = sectionEndFinder.matcher(urlContent.subSequence(from, urlContent.length()));
                         if (findSectionEnd.find()) {
                             String help = urlContent.substring(sectionStart, from + findSectionEnd.start());
-                            help = help.replaceAll("[A-Za-z-]+\\.(png|jpg)\"",getSpecURL() + MODULE_ARCHIVE_PATH + moduleFolderName + "/" + "$0");
-                            return help;                      
+                            help = "<base href=\"" + propertyHelpURL.toExternalForm() +"\">" + help;
+                            return help;
                         }
                     }
 

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/properties/text.properties
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/properties/text.properties
@@ -82,7 +82,7 @@ text-transform=none | [ [ capitalize | uppercase | lowercase ] || fullwidth || f
 
 white-space=normal | pre | nowrap | pre-wrap | pre-line | inherit | initial | <var-fn>
 
-word-break=normal | keep-all | break-all | inherit | initial | <var-fn>
+word-break=normal | keep-all | break-all | break-word | inherit | initial | <var-fn>
 
 word-spacing=<spacing-limit> {1,3} | inherit | initial
 


### PR DESCRIPTION
The NetBeans CSS integration is missing the value word-break for the property break-word. The CSS3 specification was updated to include that value.

In addition to the updated grammar, the specification files bundled with netbeans were updated.