### PR TITLE
Replace Oracle license with ALv2 license header in Bundle.properties …

### DIFF
--- a/cnd/cnd.api.model/src/org/netbeans/modules/cnd/api/model/resources/Bundle.properties
+++ b/cnd/cnd.api.model/src/org/netbeans/modules/cnd/api/model/resources/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.apt/src/org/netbeans/modules/cnd/apt/Bundle.properties
+++ b/cnd/cnd.apt/src/org/netbeans/modules/cnd/apt/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.classview/src/org/netbeans/modules/cnd/classview/actions/Bundle.properties
+++ b/cnd/cnd.classview/src/org/netbeans/modules/cnd/classview/actions/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 CTL_SelectInClasses=Classes
 CTL_NavigateSelectInClasses=Select in &Classes

--- a/cnd/cnd.classview/src/org/netbeans/modules/cnd/classview/resources/Bundle.properties
+++ b/cnd/cnd.classview/src/org/netbeans/modules/cnd/classview/resources/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Name=C/C++ Class View

--- a/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/Bundle.properties
+++ b/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/projectimport/Bundle.properties
+++ b/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/projectimport/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 ConfigureActionName=Configure
 

--- a/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/wizard/Bundle.properties
+++ b/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/wizard/Bundle.properties
@@ -1,38 +1,3 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
-#
-# You may use the binary however you like. The source file license is:
-#
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
 
 WIZARD_TITLE_TXT=Configure Code Assistance Wizard
 ACTION_TITLE_TXT=Configure Code Assistance...

--- a/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/wizard/api/support/Bundle.properties
+++ b/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/wizard/api/support/Bundle.properties
@@ -1,37 +1,18 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 FixInclude.Progress.AnalyzeRoot=Check Included Files...

--- a/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/wizard/support/impl/Bundle.properties
+++ b/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/wizard/support/impl/Bundle.properties
@@ -1,37 +1,18 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 UpdateCodeAssistance=Update Code Assistance

--- a/cnd/cnd.dwarfdiscovery/src/org/netbeans/modules/cnd/dwarfdiscovery/Bundle.properties
+++ b/cnd/cnd.dwarfdiscovery/src/org/netbeans/modules/cnd/dwarfdiscovery/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.dwarfdiscovery/src/org/netbeans/modules/cnd/dwarfdiscovery/provider/Bundle.properties
+++ b/cnd/cnd.dwarfdiscovery/src/org/netbeans/modules/cnd/dwarfdiscovery/provider/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 # Sample ResourceBundle properties file
 Binaries_Provider_Name=Analyze Object and Executable Files

--- a/cnd/cnd.dwarfdump/src/org/netbeans/modules/cnd/dwarfdump/resources/Bundle.properties
+++ b/cnd/cnd.dwarfdump/src/org/netbeans/modules/cnd/dwarfdump/resources/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.highlight/src/org/netbeans/modules/cnd/highlight/error/Bundle.properties
+++ b/cnd/cnd.highlight/src/org/netbeans/modules/cnd/highlight/error/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 LABL_CppParserAnnotationError=C/C++ parser errors
 HighlightProvider_HyperlinkActionsHints={0}\nFor extra info hold {1} and move mouse over include directive

--- a/cnd/cnd.highlight/src/org/netbeans/modules/cnd/highlight/error/includes/Bundle.properties
+++ b/cnd/cnd.highlight/src/org/netbeans/modules/cnd/highlight/error/includes/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 ErrorIncludeDialog_Title=Failed #include/#error Directives
 ErrorIncludeDialog_AccessibleName=View failed preprocessor directives

--- a/cnd/cnd.highlight/src/org/netbeans/modules/cnd/highlight/resources/Bundle.properties
+++ b/cnd/cnd.highlight/src/org/netbeans/modules/cnd/highlight/resources/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.highlight/src/org/netbeans/modules/cnd/highlight/semantic/Bundle.properties
+++ b/cnd/cnd.highlight/src/org/netbeans/modules/cnd/highlight/semantic/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 CppParserMarkOccurrencesAnnotation=Mark Occurrences
 LABL_CppMarkOccurrencesAnnotation=Mark Occurrences for C/C++ editor

--- a/cnd/cnd.makeproject.ui/src/org/netbeans/modules/cnd/makeproject/ui/configurations/Bundle.properties
+++ b/cnd/cnd.makeproject.ui/src/org/netbeans/modules/cnd/makeproject/ui/configurations/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 # Sample ResourceBundle properties file
 

--- a/cnd/cnd.modeldiscovery/src/org/netbeans/modules/cnd/modeldiscovery/Bundle.properties
+++ b/cnd/cnd.modeldiscovery/src/org/netbeans/modules/cnd/modeldiscovery/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.modeldiscovery/src/org/netbeans/modules/cnd/modeldiscovery/provider/Bundle.properties
+++ b/cnd/cnd.modeldiscovery/src/org/netbeans/modules/cnd/modeldiscovery/provider/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 # analyze object files in folder
 Model_Provider_Name=Search file system for C/C++ header files

--- a/cnd/cnd.modelimpl/src/org/netbeans/modules/cnd/modelimpl/platform/Bundle.properties
+++ b/cnd/cnd.modelimpl/src/org/netbeans/modules/cnd/modelimpl/platform/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 MSG_ParsingProgress=Parsing {0} ...
 MSG_CodeAssistanceInitializationTask=Initializing Code Assistance for {0}.

--- a/cnd/cnd.modelimpl/src/org/netbeans/modules/cnd/modelimpl/resources/Bundle.properties
+++ b/cnd/cnd.modelimpl/src/org/netbeans/modules/cnd/modelimpl/resources/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.modelui/src/org/netbeans/modules/cnd/modelui/Bundle.properties
+++ b/cnd/cnd.modelui/src/org/netbeans/modules/cnd/modelui/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.modelui/src/org/netbeans/modules/cnd/modelui/actions/Bundle.properties
+++ b/cnd/cnd.modelui/src/org/netbeans/modules/cnd/modelui/actions/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 CTL_ReparseProject=Reparse Project
 CTL_ReparseProjects=Reparse {0} Projects

--- a/cnd/cnd.modelui/src/org/netbeans/modules/cnd/modelui/parsing/Bundle.properties
+++ b/cnd/cnd.modelui/src/org/netbeans/modules/cnd/modelui/parsing/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 MSG_LowMemory=Lack of memory
 

--- a/cnd/cnd.modelui/src/org/netbeans/modules/cnd/modelui/switcher/Bundle.properties
+++ b/cnd/cnd.modelui/src/org/netbeans/modules/cnd/modelui/switcher/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 CTL_SwitcherDialogAction=C/C++ Code Assistance
 CTL_SwitchProjectAction=C/C++ Code Assistance

--- a/cnd/cnd.modelui/src/org/netbeans/modules/cnd/modelui/trace/Bundle.properties
+++ b/cnd/cnd.modelui/src/org/netbeans/modules/cnd/modelui/trace/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 CTL_TestProjectReferencesAction=Resolving: Test All References
 CTL_TestProjectReferencesPerformanceAction=Performance: Test All References...

--- a/cnd/cnd.modelutil/src/org/netbeans/modules/cnd/modelutil/resources/Bundle.properties
+++ b/cnd/cnd.modelutil/src/org/netbeans/modules/cnd/modelutil/resources/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.remote.ui/src/org/netbeans/modules/cnd/remote/ui/Bundle.properties
+++ b/cnd/cnd.remote.ui/src/org/netbeans/modules/cnd/remote/ui/Bundle.properties
@@ -1,43 +1,19 @@
-
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-
-# Copyright 2010 Oracle and/or its affiliates. All rights reserved.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
- 
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
- 
-# Contributor(s):
- 
-# Portions Copyrighted 2008 Sun Microsystems, Inc.
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 # AddServerDialog
 LBL_ServerTF=&Development Server:

--- a/cnd/cnd.repository/src/org/netbeans/modules/cnd/repository/resources/Bundle.properties
+++ b/cnd/cnd.repository/src/org/netbeans/modules/cnd/repository/resources/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 OpenIDE-Module-Display-Category=C/C++
 OpenIDE-Module-Long-Description=\

--- a/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/compilerset/Bundle.properties
+++ b/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/compilerset/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 NO_COMPILERS_FOUND_MSG=\
 No suitable compilers were found on your system. The IDE needs a suitable set of compilers and other build tools in order to work correctly.\n\n\

--- a/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/options/Bundle.properties
+++ b/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/options/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 CndOptions_Title=C/C++ Settings
 CndOptionsCategory_Name=&C/C++

--- a/cnd/cnd.toolchain/src/org/netbeans/modules/cnd/api/toolchain/Bundle.properties
+++ b/cnd/cnd.toolchain/src/org/netbeans/modules/cnd/api/toolchain/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 CCompiler=C Compiler
 CCCompiler=C++ Compiler

--- a/cnd/cnd.toolchain/src/org/netbeans/modules/cnd/spi/toolchain/Bundle.properties
+++ b/cnd/cnd.toolchain/src/org/netbeans/modules/cnd/spi/toolchain/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 DetectHostInfo=\
 findInPath() {\n\

--- a/cnd/cnd.toolchain/src/org/netbeans/modules/cnd/toolchain/compilerset/Bundle.properties
+++ b/cnd/cnd.toolchain/src/org/netbeans/modules/cnd/toolchain/compilerset/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 LBL_EmptyCompilerSetName=None
 LBL_EmptyCompilerSetDisplayName=No Compilers Found

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/ui/options/Bundle.properties
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/ui/options/Bundle.properties
@@ -1,38 +1,19 @@
-# This module is part of NetBeans and is open-source.
-# You can see http://www.netbeans.org/about/legal/index.html for details.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# You may use the binary however you like. The source file license is:
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-#
-# Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-#
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# Contributor(s):
-#
-# The Original Software is NetBeans. The Initial Developer of the Original
-# Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-# Microsystems, Inc. All Rights Reserved.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 # OtherOptionsPanel
 TAB_CndOtherOptionsTab=Other

--- a/contrib/cnd.diagnostics.clank/src/org/netbeans/modules/cnd/diagnostics/clank/resources/Bundle.properties
+++ b/contrib/cnd.diagnostics.clank/src/org/netbeans/modules/cnd/diagnostics/clank/resources/Bundle.properties
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 OpenIDE-Module-Name=C/C++ JClank Diagnostics
 HINT_DIAGNOSTIC_PIN=Clank Diagnostic Error Path Details
 LAB_diagnostics-error=Clank Diagnostics Error

--- a/contrib/odcs.cnd/src/org/netbeans/modules/odcs/cnd/ui/Bundle.properties
+++ b/contrib/odcs.cnd/src/org/netbeans/modules/odcs/cnd/ui/Bundle.properties
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 DevelopVMConnectionPanel.userLabel.text=User:
 DevelopVMConnectionPanel.hostLabel.text=Host:
 DevelopVMConnectionPanel.userField.text=


### PR DESCRIPTION
Replace Oracle license with ALv2 license header in Bundle.properties files.
    
These files were part of the Oracle Netbeans donation #4 & #5.
