### PR TITLE
Fixing removal of a double-quote inside a text block.

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/TypingCompletion.java
@@ -76,7 +76,7 @@ class TypingCompletion {
         int caretOffset = context.isBackwardDelete() ? context.getOffset() - 1 : context.getOffset();
         if (removedChar == '\"') {
             if ((ts.token().id() == JavaTokenId.STRING_LITERAL && ts.offset() == caretOffset) ||
-                (ts.token().id() == JavaTokenId.MULTILINE_STRING_LITERAL && ts.offset() <= caretOffset - 2)) {
+                (ts.token().id() == JavaTokenId.MULTILINE_STRING_LITERAL && ts.offset() == caretOffset - 2)) {
                 context.getDocument().remove(caretOffset, 1);
             }
         } else if (removedChar == '\'') {

--- a/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/TypingCompletionUnitTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/TypingCompletionUnitTest.java
@@ -1375,6 +1375,18 @@ public void testPositionInTextBlock() throws Exception {
         ctx.assertDocumentTextEquals("t(\"\"\"\n  |\"\"\")");
     } 
     
+    public void testTextBlock6() throws Exception {
+        try {
+            SourceVersion.valueOf("RELEASE_13");
+        } catch (IllegalArgumentException ex) {
+            //OK, skip test:
+            return ;
+        }
+        Context ctx = new Context(new JavaKit(), "t(\"\"\"\n|\"\n\"\"\")");
+        ctx.typeChar('\f');
+        ctx.assertDocumentTextEquals("t(\"\"\"\n\n\"\"\")");
+    } 
+    
     public void testCorrectHandlingOfStringEscapes184059() throws Exception {
         assertTrue(isInsideString("foo\n\"bar|\""));
         assertTrue(isInsideString("foo\n\"bar\\\"|\""));


### PR DESCRIPTION
Consider code like:
"""
"|
"""

Where '|' is the caret position. Now press backspace. This will delete the ", but also the next character (newline in this case). This makes editing inside the text block quite annoying.

Not sure if this breaks some other text block editing scenario - tests are passing, but may be cases not covered by tests.
