### PR TITLE
Quicksearch API allows to check for cancel.

### DIFF
--- a/platform/spi.quicksearch/apichanges.xml
+++ b/platform/spi.quicksearch/apichanges.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<?xml-stylesheet type="text/xml" href="CHANGEME/nbbuild/javadoctools/apichanges.xsl"?>
+<!DOCTYPE apichanges PUBLIC "-//NetBeans//DTD API changes list 1.0//EN" "../../nbbuild/javadoctools/apichanges.dtd">
+
+
+<apichanges>
+    <apidefs>
+        <apidef name="quicksearch_spi">Quicksearch SPI</apidef>
+    </apidefs>
+
+  <changes>
+      <change id="isObsolete">
+          <api name="quicksearch_spi"/>
+          <summary>
+              Allows to check for obsoleted resultset.
+          </summary>
+          <version major="1" minor="37"/>
+          <date day="7" month="8" year="2020"/>
+          <author login="sdedic"/>
+          <compatibility binary="compatible" source="compatible" addition="yes"/>
+          <description>
+              A <a href="@TOP@/org/netbeans/spi/quicksearch/SearchProvider.html">SearchProvider</a> that 
+              is searching and cannot find a result can check whether the result is still valid, using
+              <a href="@TOP@/org/netbeans/spi/quicksearch/SearchResponse.html#isObsolete--"><code>SearchResponse.isObsolete()</code></a>.
+              It was only possible to check for terminated search when a new item was added.
+          </description>
+          <class package="org.netbeans.spi.quicksearch" name="SearchResponse"/>
+      </change>
+      
+  </changes>
+
+    <!-- Now the surrounding HTML text and document structure: -->
+
+    <htmlcontents>
+<!--
+
+                            NO NO NO NO NO!
+
+         ==============>    DO NOT EDIT ME!  <==============
+
+          AUTOMATICALLY GENERATED FROM APICHANGES.XML, DO NOT EDIT
+
+                SEE CHANGEME/apichanges.xml
+
+-->
+    <head>
+      <title>Change History for the Progress API</title>
+      <link rel="stylesheet" href="prose.css" type="text/css"/>
+    </head>
+    <body>
+
+<p class="overviewlink"><a href="overview-summary.html">Overview</a></p>
+
+<h1>Introduction</h1>
+
+<p>This document lists changes made to the Progress API/SPI.</p>
+
+<!-- The actual lists of changes, as summaries and details: -->
+
+      <hr/><standard-changelists module-code-name="org.netbeans.spi.quicksearch"/>
+
+      <hr/><p>@FOOTER@</p>
+
+    </body>
+  </htmlcontents>
+
+</apichanges>

--- a/platform/spi.quicksearch/manifest.mf
+++ b/platform/spi.quicksearch/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.spi.quicksearch
 OpenIDE-Module-Layer: org/netbeans/modules/quicksearch/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/spi/quicksearch/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.36
+OpenIDE-Module-Specification-Version: 1.37
 

--- a/platform/spi.quicksearch/nbproject/project.properties
+++ b/platform/spi.quicksearch/nbproject/project.properties
@@ -18,5 +18,6 @@ is.autoload=true
 javac.source=1.6
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
+javadoc.apichanges=${basedir}/apichanges.xml
 
 test.config.stableBTD.includes=**/*Test.class

--- a/platform/spi.quicksearch/nbproject/project.xml
+++ b/platform/spi.quicksearch/nbproject/project.xml
@@ -117,6 +117,7 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.core.startup</code-name-base>
+                        <recursive/>
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.libs.junit4</code-name-base>

--- a/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/CategoryResult.java
+++ b/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/CategoryResult.java
@@ -121,7 +121,9 @@ public final class CategoryResult implements Runnable {
     }
 
     public boolean isObsolete() {
-        return obsolete;
+        synchronized (LOCK) {
+            return obsolete;
+        }
     }
 
     /** Sends notification about category change, always runs in EQ thread */

--- a/platform/spi.quicksearch/src/org/netbeans/spi/quicksearch/SearchProvider.java
+++ b/platform/spi.quicksearch/src/org/netbeans/spi/quicksearch/SearchProvider.java
@@ -65,6 +65,11 @@ public interface SearchProvider {
      *  }
      * </pre>
      * 
+     * It may happen that the Provider searches for some considerable time, or searches
+     * a considerable number of items without any results. It may check use 
+     * {@link SearchResponse#isObsolete()} to determine if the search was cancelled 
+     * or obsoleted without adding any items.
+     * <p>
      * Threading: This method can be called outside EQ thread by infrastructure.
      * 
      * @param request Search request object that contains information what to

--- a/platform/spi.quicksearch/src/org/netbeans/spi/quicksearch/SearchResponse.java
+++ b/platform/spi.quicksearch/src/org/netbeans/spi/quicksearch/SearchResponse.java
@@ -99,5 +99,19 @@ public final class SearchResponse {
                 new ResultsModel.ItemResult(catResult, sRequest, action,
                 htmlDisplayName, shortcut, displayHint));
     }
+    
+    /**
+     * Determines if the response is already obsolete. The result is the same as the 
+     * return value from {@link #addResult(java.lang.Runnable, java.lang.String)}: if
+     * false, the Provider should terminate the search immediately. Provider can query
+     * this status in case it does not find any results so it does not waste time
+     * searching further. 
+     * 
+     * @return true, if the result is obsolete.
+     * @since 12.2
+     */
+    public boolean isObsolete() {
+        return catResult.isObsolete();
+    }
 
 }

--- a/platform/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/ObsoleteSupportTest.java
+++ b/platform/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/ObsoleteSupportTest.java
@@ -35,7 +35,7 @@ public class ObsoleteSupportTest extends NbTestCase {
     public void testObsoleteSupport () throws Exception {
         System.out.println("Testing obsolete support...");
 
-        UnitTestUtils.prepareTest(new String [] { "/org/netbeans/modules/quicksearch/resources/testGetProviders.xml" });
+        UnitTestUtils.prepareTest(new String [] { "org/netbeans/modules/quicksearch/resources/testGetProviders.xml" });
         ResultsModel rm = ResultsModel.getInstance();
 
         CommandEvaluator.evaluate("test obsolete 1", rm);

--- a/platform/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/ProviderModelTest.java
+++ b/platform/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/ProviderModelTest.java
@@ -41,7 +41,7 @@ public class ProviderModelTest extends NbTestCase {
     
     /** Tests ProviderModel functionality */
     public void testGetProviders () throws Exception {
-        UnitTestUtils.prepareTest(new String [] { "/org/netbeans/modules/quicksearch/resources/testGetProviders.xml" });
+        UnitTestUtils.prepareTest(new String [] { "org/netbeans/modules/quicksearch/resources/testGetProviders.xml" });
         
         ProviderModel model = ProviderModel.getInstance();
         

--- a/platform/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/UnitTestUtils.java
+++ b/platform/spi.quicksearch/test/unit/src/org/netbeans/modules/quicksearch/UnitTestUtils.java
@@ -22,9 +22,7 @@ package org.netbeans.modules.quicksearch;
 import java.beans.PropertyVetoException;
 import java.io.IOException;
 import java.net.URL;
-import javax.swing.text.Utilities;
 import junit.framework.Assert;
-import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.Repository;
 import org.openide.filesystems.XMLFileSystem;
 import org.openide.util.Lookup;
@@ -59,7 +57,7 @@ public class UnitTestUtils extends ProxyLookup {
         URL[] layers = new URL[stringLayers.length];
         
         for (int cntr = 0; cntr < layers.length; cntr++) {
-            layers[cntr] = Utilities.class.getResource(stringLayers[cntr]);
+            layers[cntr] = UnitTestUtils.class.getClassLoader().getResource(stringLayers[cntr]);
         }
         
         XMLFileSystem system = new XMLFileSystem();


### PR DESCRIPTION
I've been working with a Quicksearch provider and I noticed that while the Provider can check whether the search query was cancelled when calling `addResult` to the response, there's no way to check if the search was cancelled if the Provider is unable to find any item. In my case, the SearcProvider continues to search even if a new query has been created (provided the Provider still did not found anything).

This simple addition would allow to cancel even such empty-result searches.