### PR TITLE
[NETBEANS-4717] Upgrade Gradle Tooling API to 6.6

### DIFF
--- a/extide/libs.gradle/external/binaries-list
+++ b/extide/libs.gradle/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-BC6C7B5786F53AD8CCC6B8E4AE57AF601269E947 gradle-tooling-api-6.3.jar
+74D642F331F4893E34F5063EE9A152D8C29D8323 gradle-tooling-api-6.6.jar

--- a/extide/libs.gradle/external/gradle-tooling-api-6.6-license.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-6.6-license.txt
@@ -1,7 +1,7 @@
 Name: Gradle Wrapper
 Description: Gradle Tooling API
-Version: 6.3
-Files: gradle-tooling-api-6.3.jar
+Version: 6.6
+Files: gradle-tooling-api-6.6.jar
 License: Apache-2.0
 Origin: Gradle Inc.
 URL: https://gradle.org/

--- a/extide/libs.gradle/external/gradle-tooling-api-6.6-notice.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-6.6-notice.txt
@@ -1,8 +1,8 @@
 Gradle Inc.'s Gradle Tooling API
-Copyright 2007-2019 Gradle Inc.
+Copyright 2007-2020 Gradle Inc.
 
 This product includes software developed at
 Gradle Inc. (https://gradle.org/).
 
 This product includes/uses SLF4J (https://www.slf4j.org/)
-developed by QOS.ch, 2004-2019
+developed by QOS.ch, 2004-2020

--- a/extide/libs.gradle/manifest.mf
+++ b/extide/libs.gradle/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.libs.gradle/6
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/libs/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 6.5
+OpenIDE-Module-Specification-Version: 6.6
 

--- a/extide/libs.gradle/nbproject/project.properties
+++ b/extide/libs.gradle/nbproject/project.properties
@@ -22,4 +22,4 @@ javac.compilerargs=-Xlint -Xlint:-serial
 # For more information, please see http://wiki.netbeans.org/SignatureTest
 sigtest.gen.fail.on.error=false
 
-release.external/gradle-tooling-api-6.3.jar=modules/gradle/gradle-tooling-api.jar
+release.external/gradle-tooling-api-6.6.jar=modules/gradle/gradle-tooling-api.jar

--- a/extide/libs.gradle/nbproject/project.xml
+++ b/extide/libs.gradle/nbproject/project.xml
@@ -39,7 +39,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>gradle/gradle-tooling-api.jar</runtime-relative-path>
-                <binary-origin>external/gradle-tooling-api-6.3.jar</binary-origin>
+                <binary-origin>external/gradle-tooling-api-6.6.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Regular Gradle Tooling API upgrade.