### PR TITLE
Make LSP servers work even for files outside of any project

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.lsp.client;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -144,7 +145,7 @@ public class LSPBindings {
                                                    }
                                                }
                                            };
-                                           
+
                                            for (LanguageServerProvider provider : MimeLookup.getLookup(mimeType).lookupAll(LanguageServerProvider.class)) {
                                                final Lookup lkp = prj != null ? Lookups.fixed(prj, mimeTypeInfo, restarter) : Lookups.fixed(mimeTypeInfo, restarter);
                                                LanguageServerDescription desc = provider.startServer(lkp);
@@ -217,7 +218,10 @@ public class LSPBindings {
     private static InitializeResult initServer(Process p, LanguageServer server, FileObject root) throws InterruptedException, ExecutionException {
        InitializeParams initParams = new InitializeParams();
        initParams.setRootUri(Utils.toURI(root));
-       initParams.setRootPath(FileUtil.toFile(root).getAbsolutePath()); //some servers still expect root path
+       final File rootFile = FileUtil.toFile(root);
+       if (rootFile != null) {
+           initParams.setRootPath(rootFile.getAbsolutePath()); //some servers still expect root path
+       }
        initParams.setProcessId(0);
        TextDocumentClientCapabilities tdcc = new TextDocumentClientCapabilities();
        DocumentSymbolCapabilities dsc = new DocumentSymbolCapabilities();

--- a/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/LSPBindingsTest.java
+++ b/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/LSPBindingsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.lsp.client;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import static junit.framework.TestCase.assertNotNull;
+import org.eclipse.lsp4j.ServerCapabilities;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import org.junit.Test;
+import org.netbeans.api.editor.mimelookup.MimePath;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.junit.MockServices;
+import org.netbeans.modules.editor.mimelookup.MimeLookupCacheSPI;
+import org.netbeans.modules.lsp.client.spi.LanguageServerProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.MIMEResolver;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+
+public class LSPBindingsTest {
+
+    @Test
+    public void testGetBindingsOnNonProjectFolder() throws Exception {
+        MockServices.setServices(MockMimeLookupCacheSPI.class, MockMimeResolver.class);
+
+        FileObject folder = FileUtil.createMemoryFileSystem().getRoot().createFolder("myfolder");
+        FileObject file = folder.createData("data.mock-txt");
+        assertEquals("application/mock-txt", file.getMIMEType());
+        assertNull("No project owner", FileOwnerQuery.getOwner(file));
+
+        LSPBindings bindings = LSPBindings.getBindings(file);
+        assertNotNull("Bindings for the projectless file found", bindings);
+    }
+
+    public static final class MockMimeLookupCacheSPI extends MimeLookupCacheSPI {
+        @Override
+        public Lookup getLookup(MimePath mp) {
+            assertEquals("application/mock-txt", mp.getPath());
+            return Lookups.fixed(new MockLSP());
+        }
+    }
+
+    public static final class MockLSP implements LanguageServerProvider {
+        @Override
+        public LanguageServerDescription startServer(Lookup lookup) {
+            final MockProcess process = new MockProcess();
+            return LanguageServerDescription.create(process.in, process.out, process);
+        }
+    }
+
+    public final static class MockMimeResolver extends MIMEResolver {
+
+        public MockMimeResolver() {
+        }
+
+        @Override
+        public String findMIMEType(FileObject fo) {
+            return fo.hasExt("mock-txt") ? "application/mock-txt" : null;
+        }
+    }
+
+    static final class MockProcess extends Process {
+        final ByteArrayInputStream in;
+        final ByteArrayOutputStream out;
+
+        public MockProcess() {
+            this.in = new ByteArrayInputStream(new byte[0]);
+            this.out = new ByteArrayOutputStream();
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return out;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return in;
+        }
+
+        @Override
+        public InputStream getErrorStream() {
+            return in;
+        }
+
+        @Override
+        public int waitFor() throws InterruptedException {
+            throw new InterruptedException();
+        }
+
+        @Override
+        public boolean isAlive() {
+            StackTraceElement[] stack = new Exception().getStackTrace();
+            if (stack[1].getMethodName().equals("initServer")) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public int exitValue() {
+            return 0;
+        }
+
+        @Override
+        public void destroy() {
+        }
+    }
+}

--- a/webcommon/typescript.editor/src/org/netbeans/modules/typescript/editor/TypeScriptDataObjectDataObject.java
+++ b/webcommon/typescript.editor/src/org/netbeans/modules/typescript/editor/TypeScriptDataObjectDataObject.java
@@ -38,7 +38,7 @@ import org.openide.util.NbBundle.Messages;
         displayName = "#LBL_TypeScriptDataObject_LOADER",
         mimeType = "application/x-typescript",
         extension = {"ts"},
-        position = 600
+        position = 193 // lower than 218 as CND also recognizes .ts file
 )
 @DataObject.Registration(
         mimeType = "application/x-typescript",


### PR DESCRIPTION
Yesterday I tweeted about great [NetBeans support for TypeScript](https://twitter.com/JaroslavTulach/status/1295985307020484613) then I realized it only works in projects. Not for standalone files. I decided to fix it.