### PR TITLE
[NETBEANS-4620] NullPointerException - finding occurrences

### DIFF
--- a/ide/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
+++ b/ide/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
@@ -127,17 +127,16 @@ public class SearchComboBoxEditor implements ComboBoxEditor {
                 // selection is not removed when text is input via IME
                 // so, just remove it when the caret is changed
                 if ("caret".equals(evt.getPropertyName())) { // NOI18N
-                    if (evt.getOldValue() instanceof Caret) {
+                    if (evt.getOldValue() instanceof Caret
+                            && evt.getNewValue() instanceof Caret) { // NETBEANS-4620 check new value is not null but Caret
                         Caret oldCaret = (Caret) evt.getOldValue();
-                        if (oldCaret != null) {
-                            int dotPosition = oldCaret.getDot();
-                            int markPosition = oldCaret.getMark();
-                            if (dotPosition != markPosition) {
-                                try {
-                                    editorPane.getDocument().remove(Math.min(markPosition, dotPosition), Math.abs(markPosition - dotPosition));
-                                } catch (BadLocationException ex) {
-                                    LOG.log(Level.WARNING, "Invalid removal offset: {0}", ex.offsetRequested()); // NOI18N
-                                }
+                        int dotPosition = oldCaret.getDot();
+                        int markPosition = oldCaret.getMark();
+                        if (dotPosition != markPosition) {
+                            try {
+                                editorPane.getDocument().remove(Math.min(markPosition, dotPosition), Math.abs(markPosition - dotPosition));
+                            } catch (BadLocationException ex) {
+                                LOG.log(Level.WARNING, "Invalid removal offset: {0}", ex.offsetRequested()); // NOI18N
                             }
                         }
                     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4620
Probably https://issues.apache.org/jira/browse/NETBEANS-4623, too

To avoid NPE, check new value is not `null` but `Caret`. If it's `null`, `BasicTextUI.editor` field may be `null`.

```
java.lang.NullPointerException
	at java.desktop/javax.swing.plaf.basic.BasicTextUI.modelToView(BasicTextUI.java:1104)
	at java.desktop/javax.swing.plaf.basic.BasicTextUI.modelToView(BasicTextUI.java:1089)
	at java.desktop/javax.swing.plaf.basic.BasicTextUI.modelToView(BasicTextUI.java:1065)
	at org.netbeans.modules.editor.search.SearchComboBoxEditor$ManageViewPositionListener.changed(SearchComboBoxEditor.java:290)
	at org.netbeans.modules.editor.search.SearchComboBoxEditor$ManageViewPositionListener.removeUpdate(SearchComboBoxEditor.java:277)
	at org.netbeans.lib.editor.util.swing.PriorityDocumentListenerList.removeUpdate(PriorityDocumentListenerList.java:91)
	at java.desktop/javax.swing.text.AbstractDocument.fireRemoveUpdate(AbstractDocument.java:261)
	at org.netbeans.editor.BaseDocument.fireRemoveUpdate(BaseDocument.java:1650)
	at org.netbeans.editor.BaseDocument.handleRemove(BaseDocument.java:1022)
	at org.netbeans.editor.BaseDocument$FilterBypassImpl.remove(BaseDocument.java:2639)
	at java.desktop/javax.swing.text.DocumentFilter.remove(DocumentFilter.java:79)
	at org.netbeans.editor.BaseDocument.remove(BaseDocument.java:935)
	at org.netbeans.modules.editor.search.SearchComboBoxEditor$3.propertyChange(SearchComboBoxEditor.java:137)
```

The other NPE:

```
java.lang.NullPointerException at java.desktop/javax.swing.text.JTextComponent.write(JTextComponent.java:1655) at
java.desktop/javax.swing.JEditorPane.getText(JEditorPane.java:1451) at
org.netbeans.modules.editor.search.SearchBar.showNumberOfMatches(SearchBar.java:1039) at
org.netbeans.modules.editor.search.SearchBar$13.caretUpdate(SearchBar.java:502) at 
```
JTextComponent.write is the following:

```java
    public void write(Writer out) throws IOException {
        Document doc = getDocument();
        try {
            getUI().getEditorKit(this).write(out, doc, 0, doc.getLength());
        } catch (BadLocationException e) {
            throw new IOException(e.getMessage());
        }
    }
```
I've confirmed that `editorPane.getUI().getEditorKit(editorPane)` is `null`, when the new value is `null`. So we should be able to avoid NPE.

#### Steps to reproduce the problem in beta version

- Select longer text than "Find" text field length
- Run Find([Ctrl] + [F])
- Click any place in editor (clear selection)
- Run Find([Ctrl] + [F])
- NPE occurs

CC: @DevCharly 