### PR TITLE
[NETBEANS-4627] FlatLaf: fix wrong background color of search result table in Find Tasks Editor

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -122,7 +122,6 @@ nb.bugtracking.comment.background=#f00
 nb.bugtracking.comment.foreground=@foreground
 nb.bugtracking.label.highlight=rgb(205, 205, 0)
 nb.bugtracking.table.background=$Table.background
-nb.bugtracking.table.background=#0f0
 nb.bugtracking.table.background.alternate=darken($Table.background,5%)
 nb.bugtracking.new.color=rgb(73, 210, 73)
 nb.bugtracking.modified.color=rgb(26, 184, 255)


### PR DESCRIPTION
Simple fix for https://issues.apache.org/jira/browse/NETBEANS-4627

Before:

![image](https://user-images.githubusercontent.com/5604048/90982735-6827ff80-e569-11ea-86a0-cf8996823205.png)

After:

![image](https://user-images.githubusercontent.com/5604048/90982821-2ba8d380-e56a-11ea-800e-6c53a84e9c1b.png)
