### PR TITLE
[NETBEANS-3428] FlatLaf: fix selection background color in output view

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -162,6 +162,7 @@ nb.diff.sidebar.changed.color=rgb(30, 75, 112)
 # output
 nb.output.foreground=@foreground
 nb.output.backgorund=#2B2B2B
+nb.output.selectionBackground=#214283
 nb.output.err.foreground=#FF4040
 nb.output.input=#CC7832
 nb.output.link.foreground=$Component.linkColor

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
@@ -70,3 +70,6 @@ PropSheet.setForeground=@foreground
 
 # QuickSearch
 nb.quicksearch.border=1,1,1,1,@background
+
+# output
+nb.output.selectionBackground=#89BCED


### PR DESCRIPTION
Simple fix for selection background in output view, which was nearly unreadable. 
Used same selection background colors as in editor.

Before:

![image](https://user-images.githubusercontent.com/5604048/90983571-7416c000-e56f-11ea-80a2-a328d40257e5.png)

After:

![image](https://user-images.githubusercontent.com/5604048/90983576-79740a80-e56f-11ea-83fb-2f6c568aced1.png)

Before:

![image](https://user-images.githubusercontent.com/5604048/90983666-19319880-e570-11ea-8fcb-19dde96cc5bf.png)

After:

![image](https://user-images.githubusercontent.com/5604048/90983670-1f277980-e570-11ea-88c1-408c0cd82f51.png)
