### PR TITLE
[NETBEANS-4718] Disallow FXML controller in default package when modu…

### DIFF
--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectUtils.java
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/JFXProjectUtils.java
@@ -31,6 +31,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.CRC32;
 import java.util.zip.Checksum;
+
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.xml.parsers.DocumentBuilder;
@@ -41,6 +42,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
+
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -61,6 +63,8 @@ import org.netbeans.modules.java.j2seproject.api.J2SEPropertyEvaluator;
 import org.netbeans.modules.javafx2.platform.api.JavaFXPlatformUtils;
 import org.netbeans.modules.javafx2.platform.api.JavaFxRuntimeInclusion;
 import org.netbeans.modules.javafx2.project.JavaFXProjectWizardIterator.WizardType;
+import org.netbeans.modules.javafx2.project.fxml.SourceGroupSupport;
+import org.netbeans.modules.javafx2.project.fxml.SourceGroupSupport.SourceGroupProxy;
 import org.netbeans.modules.javafx2.project.ui.JSEApplicationClassChooser;
 import org.netbeans.spi.project.ProjectIconAnnotator;
 import org.netbeans.spi.project.support.ant.AntProjectHelper;
@@ -1775,6 +1779,18 @@ public final class JFXProjectUtils {
                 throw (IOException) mux.getException();
             }
         }
+    }
+
+    private static final String MODULE_INFO = "module-info.java"; // NOI18N
+
+    // as in org.netbeans.modules.maven.api.ModuleInfoUtils.hasModuleInfoInSource;
+    public static boolean hasModuleInfo(SourceGroupSupport support) {
+        for (SourceGroupProxy sourceGroup : support.getSourceGroups()) {
+            if(sourceGroup.getRootFolder().getFileObject(MODULE_INFO) != null) {
+                return true;
+            }
+        }
+        return false;
     }
     
 }

--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/Bundle.properties
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/Bundle.properties
@@ -91,6 +91,7 @@ WARN_ConfigureFXMLPanel_Provide_Java_Name=Provide valid Java Controller File nam
 WARN_ConfigureFXMLPanel_Provide_CSS_Name=Provide valid CSS File name
 WARN_ConfigureFXMLPanel_Provide_Package_Name=Provide valid Package name
 WARN_ConfigureFXMLPanel_Package_Invalid=The Package is not a folder
+WARN_ConfigureFXMLPanel_Default_Package_Invalid=Default Package not allowed
 
 #MSG_FXMLTemplateWizardIterator_Folder_Exists=Directory already exists: {0}
 MSG_fs_or_folder_does_not_exist=The target folder does not exist.

--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/ConfigureFXMLControllerPanelVisual.java
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/fxml/ConfigureFXMLControllerPanelVisual.java
@@ -22,6 +22,7 @@ import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
+
 import javax.swing.ComboBoxModel;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.JFileChooser;
@@ -31,6 +32,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+
+import org.netbeans.modules.javafx2.project.JFXProjectUtils;
 import org.netbeans.spi.java.project.support.ui.PackageView;
 import org.netbeans.spi.project.ui.templates.support.Templates;
 import org.openide.WizardDescriptor;
@@ -672,6 +675,11 @@ public class ConfigureFXMLControllerPanelVisual extends JPanel implements Action
             if (component.isControllerEnabled()) {
                 if (!FXMLTemplateWizardIterator.isValidPackageName(component.getPackageName())) {
                     FXMLTemplateWizardIterator.setErrorMessage("WARN_ConfigureFXMLPanel_Provide_Package_Name", settings); // NOI18N
+                    return false;
+                }
+
+                if (JFXProjectUtils.hasModuleInfo(support) && component.getPackageName().isEmpty()) {
+                    FXMLTemplateWizardIterator.setErrorMessage("WARN_ConfigureFXMLPanel_Default_Package_Invalid", settings); // NOI18N
                     return false;
                 }
 


### PR DESCRIPTION
…lar java

I encouraged someone to file this bug, then they went and assigned it to me, sigh. Anyway, I suspect there are widespread problems with the `JavaFX 2 support` netbeans module related to modular java, but this is a fix for the reported problem (and I'll be filing some other bugs). In the wizard, a validation message is shown, next is disabled when there's module-info and the default package is selected for the controller.

I couldn't find any general module-info handling libraries. It looks like separate projects do their own thing.