### PR TITLE
[NETBEANS-4745] Include immutable objects for fxml editor identification

### DIFF
--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxDefinitionKind.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/completion/beans/FxDefinitionKind.java
@@ -48,6 +48,11 @@ public enum FxDefinitionKind {
     LIST,
 
     /**
+     * Readonly/immutable object, type is getter return type.
+     */
+    GETTER,
+
+    /**
      * Attached property
      */
     ATTACHED;


### PR DESCRIPTION
Using NamedArg annotation on constructors parameters, find immutable objects that are OK in fxml editor.

@sdedic  could you take a look (you wrote the original code). I'm not that familiar with Mirror stuff or with fxml...