### PR TITLE
[NETBEANS-4755] - remove use of deprecated API - getURL()

### DIFF
--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/AppClientProject.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/AppClientProject.java
@@ -442,7 +442,7 @@ public final class AppClientProject implements Project, FileChangeListener {
         
         if (fo.getParent ().equals (libFolder)) {
             try {
-                cpMod.getClassPathModifier().addRoots(new URL[] {FileUtil.getArchiveRoot(fo.getURL())}, ProjectProperties.JAVAC_CLASSPATH);
+                cpMod.getClassPathModifier().addRoots(new URL[] {FileUtil.getArchiveRoot(fo.toURL())}, ProjectProperties.JAVAC_CLASSPATH);
             } catch (IOException e) {
                 Exceptions.printStackTrace(e);
             }
@@ -572,7 +572,7 @@ public final class AppClientProject implements Project, FileChangeListener {
                         List<URL> libs = new LinkedList<URL>();
                         for (int i = 0; i < children.length; i++) {
                             if (FileUtil.isArchiveFile(children[i])) {
-                                libs.add(FileUtil.getArchiveRoot(children[i].getURL()));
+                                libs.add(FileUtil.getArchiveRoot(children[i].toURL()));
                             }
                         }
                         cpMod.getClassPathModifier().addRoots(libs.toArray(new URL[libs.size()]), ProjectProperties.JAVAC_CLASSPATH);

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EjbJarMultiViewDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/multiview/EjbJarMultiViewDataObject.java
@@ -618,10 +618,7 @@ public class EjbJarMultiViewDataObject extends DDMultiViewDataObject
         }
         
         public void view() {
-            try {
-                HtmlBrowser.URLDisplayer.getDefault().showURL(primary.getFile().getURL());
-            } catch (FileStateInvalidException e) {
-            }
+            HtmlBrowser.URLDisplayer.getDefault().showURL(primary.getFile().toURL());
         }
     }
     

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/web/DDDataNode.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/web/DDDataNode.java
@@ -72,12 +72,7 @@ public class DDDataNode extends DataNode {
         org.xml.sax.SAXException saxError = dataObject.getSaxError();
         if (saxError == null) {
             if (dataObject instanceof DDFragmentDataObject) {
-                URL url = null;
-                try {
-                    url = dataObject.getPrimaryFile().getURL();
-                } catch (FileStateInvalidException ex) {
-                    // ignore
-                }
+                URL url = dataObject.getPrimaryFile().toURL();
                 return NbBundle.getBundle(DDDataNode.class).getString("HINT_web_fragment_dd") + (url != null ? " ["+url+"]" : "");
             }
             else

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarProject.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarProject.java
@@ -698,7 +698,7 @@ public class EjbJarProject implements Project, FileChangeListener {
         
         if (fo.getParent ().equals (libFolder)) {
             try {
-                classPathModifier.addRoots(new URL[] {FileUtil.getArchiveRoot(fo.getURL())}, ProjectProperties.JAVAC_CLASSPATH);
+                classPathModifier.addRoots(new URL[] {FileUtil.getArchiveRoot(fo.toURL())}, ProjectProperties.JAVAC_CLASSPATH);
             }
             catch (IOException e) {
                 Exceptions.printStackTrace(e);

--- a/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/query/J2eePlatformSourceForBinaryQuery.java
+++ b/enterprise/j2eeserver/src/org/netbeans/modules/j2ee/deployment/impl/query/J2eePlatformSourceForBinaryQuery.java
@@ -120,12 +120,8 @@ public class J2eePlatformSourceForBinaryQuery implements SourceForBinaryQueryImp
         if (normalizedURL == null) {
             FileObject fo = URLMapper.findFileObject(url);
             if (fo != null) {
-                try {
-                    normalizedURL = fo.getURL();
-                    this.normalizedURLCache.put (url, normalizedURL);
-                } catch (FileStateInvalidException e) {
-                    Exceptions.printStackTrace(e);
-                }
+                normalizedURL = fo.toURL();
+                this.normalizedURLCache.put (url, normalizedURL);
             }
         }
         return normalizedURL;

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/ClientHandlerButtonListener.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/ClientHandlerButtonListener.java
@@ -196,7 +196,7 @@ public class ClientHandlerButtonListener implements ActionListener {
                 FileObject localWsdlFile =
                         support.getWsdlFolder(false).getFileObject(client.getLocalWsdl());
                 File f = FileUtil.toFile(bindingHandlerFO);
-                String relativePath = Utilities.relativize(f.toURI(), new URI(localWsdlFile.getURL().toExternalForm()));
+                String relativePath = Utilities.relativize(f.toURI(), new URI(localWsdlFile.toURL().toExternalForm()));
                 GlobalBindings gb = bindingsModel.getGlobalBindings();
                 try {
                     bindingsModel.startTransaction();

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/JaxWsClientNode.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/nodes/JaxWsClientNode.java
@@ -394,22 +394,18 @@ public class JaxWsClientNode extends AbstractNode implements OpenCookie, Refresh
     
     WsdlModeler getWsdlModeler() {
         if (getLocalWsdl()!=null) {
-            try {
-                WsdlModeler modeler = WsdlModelerFactory.getDefault().getWsdlModeler(wsdlFileObject.getURL());
-                if (modeler!=null) {
-//                    String packageName = client.getPackageName();
-//                    if (packageName!=null && client.isPackageNameForceReplace()) {
-//                        // set the package name for the modeler
-//                        modeler.setPackageName(packageName);
-//                    } else {
-//                        modeler.setPackageName(null);
-//                    }
-                    modeler.setCatalog(jaxWsSupport.getCatalog());
-//                    setBindings(modeler);
-                    return modeler;
-                }
-            } catch (FileStateInvalidException ex) {
-                ErrorManager.getDefault().log(ex.getLocalizedMessage());
+            WsdlModeler modeler = WsdlModelerFactory.getDefault().getWsdlModeler(wsdlFileObject.toURL());
+            if (modeler!=null) {
+//              String packageName = client.getPackageName();
+//              if (packageName!=null && client.isPackageNameForceReplace()) {
+//                  // set the package name for the modeler
+//                  modeler.setPackageName(packageName);
+//              } else {
+//                  modeler.setPackageName(null);
+//              }
+                modeler.setCatalog(jaxWsSupport.getCatalog());
+//              setBindings(modeler);
+                return modeler;
             }
         } else {
             ErrorManager.getDefault().log(ErrorManager.ERROR, NbBundle.getMessage(JaxWsNode.class,"ERR_missingLocalWsdl"));

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/wizards/JaxWsClientCreator.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/wizards/JaxWsClientCreator.java
@@ -76,7 +76,7 @@ public class JaxWsClientCreator implements ClientCreator {
         //Boolean useDispatch = (Boolean) wiz.getProperty(ClientWizardProperties.USEDISPATCH);
         //if (wsdlUrl==null) wsdlUrl = "file:"+(filePath.startsWith("/")?filePath:"/"+filePath); //NOI18N
         if(wsdlUrl == null) {
-            wsdlUrl = FileUtil.toFileObject(FileUtil.normalizeFile(new File(filePath))).getURL().toExternalForm();
+            wsdlUrl = FileUtil.toFileObject(FileUtil.normalizeFile(new File(filePath))).toURL().toExternalForm();
         }
         FileObject localWsdlFolder = jaxWsSupport.getWsdlFolder(true);
         

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/wizards/JaxWsServiceCreator.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/wizards/JaxWsServiceCreator.java
@@ -227,7 +227,7 @@ public class JaxWsServiceCreator implements ServiceCreator {
         //if (wsdlUrl==null) wsdlUrl = "file:"+(filePath.startsWith("/")?filePath:"/"+filePath); //NOI18N
 
         if(wsdlUrl == null) {
-            wsdlUrl = FileUtil.toFileObject(FileUtil.normalizeFile(new File(filePath))).getURL().toExternalForm();
+            wsdlUrl = FileUtil.toFileObject(FileUtil.normalizeFile(new File(filePath))).toURL().toExternalForm();
         }
         FileObject localWsdlFolder = jaxWsSupport.getWsdlFolder(true);
 

--- a/enterprise/web.core/src/org/netbeans/modules/web/jspcompiler/JspAntLogger.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/jspcompiler/JspAntLogger.java
@@ -143,11 +143,7 @@ public final class JspAntLogger extends AntLogger {
                     // and create the hyperlink if needed
                     if (jspSource != null) {
                         if (messageLevel <= sessionLevel && !event.isConsumed()) {
-                            try {
-                                session.println(file, true, session.createStandardHyperlink(jspSource.getURL(), jspErrorText, lineNumber, columnNumber, -1, -1));
-                            } catch (FileStateInvalidException e) {
-                                assert false : e;
-                            }
+                            session.println(file, true, session.createStandardHyperlink(jspSource.toURL(), jspErrorText, lineNumber, columnNumber, -1, -1));
                         }
                     }
                 }

--- a/enterprise/web.core/src/org/netbeans/modules/web/jspcompiler/TldAntLogger.java
+++ b/enterprise/web.core/src/org/netbeans/modules/web/jspcompiler/TldAntLogger.java
@@ -145,11 +145,7 @@ public final class TldAntLogger extends AntLogger {
                 }
                 
                 if (messageLevel <= sessionLevel && !event.isConsumed()) {
-                    try {
-                        session.println(tldFile, true, session.createStandardHyperlink(tldSource.getURL(), errorText + tldFile, lineNumber, columnNumber, -1, -1));
-                    } catch (FileStateInvalidException e) {
-                        assert false : e;
-                    }
+                    session.println(tldFile, true, session.createStandardHyperlink(tldSource.toURL(), errorText + tldFile, lineNumber, columnNumber, -1, -1));
                 }
             }
             event.consume();

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebFreeFormActionProvider.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebFreeFormActionProvider.java
@@ -637,7 +637,7 @@ public class WebFreeFormActionProvider implements ActionProvider {
      * @return the line number (0-based), or -1 if not found
      */
     static final int findLine(FileObject file, final String match, final String elementLocalName, final String elementAttributeName) throws IOException, SAXException, ParserConfigurationException {
-        InputSource in = new InputSource(file.getURL().toString());
+        InputSource in = new InputSource(file.toURL().toString());
         SAXParserFactory factory = SAXParserFactory.newInstance();
         factory.setNamespaceAware(true);
         SAXParser parser = factory.newSAXParser();

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebModules.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebModules.java
@@ -192,12 +192,7 @@ public class WebModules implements WebModuleProvider, AntProjectListener, ClassP
         SourceGroup sg [] = ProjectUtils.getSources (project).getSourceGroups (JavaProjectConstants.SOURCES_TYPE_JAVA);
         Set<FileObject> srcRootSet = new HashSet<FileObject>();
         for (int i = 0; i < sg.length; i++) {
-            URL entry; 
-            try {
-                entry = sg[i].getRootFolder().getURL();
-            } catch (FileStateInvalidException x) {
-                throw new AssertionError(x);
-            }
+            URL entry = sg[i].getRootFolder().toURL();
             // There is important calling this. Withouth calling this, will not work java cc in Jsp editor correctly.
             SourceForBinaryQuery.Result res = SourceForBinaryQuery.findSourceRoots (entry);
             FileObject srcForBin [] = res.getRoots ();

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/classpath/JspSourcePathImplementation.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/classpath/JspSourcePathImplementation.java
@@ -77,11 +77,7 @@ final class JspSourcePathImplementation implements ClassPathImplementation, Prop
         if (webDocbaseDir != null) {
             FileObject webDocbaseDirFO = helper.resolveFileObject(webDocbaseDir);
             if (webDocbaseDirFO != null) {
-                try {
-                    webDocbaseDirRes = ClassPathSupport.createResource(webDocbaseDirFO.getURL());
-                } catch (FileStateInvalidException e) {
-                    Exceptions.printStackTrace(e);
-                }
+                webDocbaseDirRes = ClassPathSupport.createResource(webDocbaseDirFO.toURL());
             }
         }
         synchronized (this) {

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/client/wizard/JaxWsClientCreator.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/client/wizard/JaxWsClientCreator.java
@@ -125,7 +125,7 @@ public class JaxWsClientCreator implements ClientCreator {
         Boolean useDispatch = (Boolean) wiz.getProperty(ClientWizardProperties.USEDISPATCH);
         //if (wsdlUrl==null) wsdlUrl = "file:"+(filePath.startsWith("/")?filePath:"/"+filePath); //NOI18N
         if(wsdlUrl == null){
-            wsdlUrl = FileUtil.toFileObject(FileUtil.normalizeFile(new File(filePath))).getURL().toExternalForm();
+            wsdlUrl = FileUtil.toFileObject(FileUtil.normalizeFile(new File(filePath))).toURL().toExternalForm();
         }
         String packageName = (String)wiz.getProperty(ClientWizardProperties.WSDL_PACKAGE_NAME);
         if (packageName!=null && packageName.length()==0) packageName=null;

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/ClientHandlerButtonListener.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/ClientHandlerButtonListener.java
@@ -200,7 +200,7 @@ public class ClientHandlerButtonListener implements ActionListener {
                 FileObject localWsdlFile =
                         support.getLocalWsdlFolderForClient(client.getName(), false).getFileObject(client.getLocalWsdlFile());
                 File f = FileUtil.toFile(bindingHandlerFO);
-                String relativePath = Utilities.relativize(f.toURI(), new URI(localWsdlFile.getURL().toExternalForm()));
+                String relativePath = Utilities.relativize(f.toURI(), new URI(localWsdlFile.toURL().toExternalForm()));
                 GlobalBindings gb = bindingsModel.getGlobalBindings();
                 try {
                     bindingsModel.startTransaction();

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/JaxWsChildren.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/nodes/JaxWsChildren.java
@@ -144,7 +144,6 @@ public class JaxWsChildren extends Children.Keys<Object>/* implements MDRChangeL
     @Override
     protected void addNotify() {
         if (isFromWsdl()) {
-            try {
                 FileObject localWsdlFolder = getJAXWSSupport().getLocalWsdlFolderForService(service.getName(),false);
                 if (localWsdlFolder == null) {
                     Logger.getLogger(this.getClass().getName()).log(Level.INFO,"missing folder for wsdl file"); // NOI18
@@ -155,7 +154,7 @@ public class JaxWsChildren extends Children.Keys<Object>/* implements MDRChangeL
                     localWsdlFolder.getFileObject(service.getLocalWsdlFile());
                 if (wsdlFo==null) return;
                 if (wsdlModeler==null) { 
-                    wsdlModeler = WsdlModelerFactory.getDefault().getWsdlModeler(wsdlFo.getURL());
+                    wsdlModeler = WsdlModelerFactory.getDefault().getWsdlModeler(wsdlFo.toURL());
                 }
                 if (wsdlModeler==null) {
                     return;
@@ -192,10 +191,6 @@ public class JaxWsChildren extends Children.Keys<Object>/* implements MDRChangeL
                         }
                     }
                 });
-            } catch (FileStateInvalidException ex) {
-                ErrorManager.getDefault().log(ex.getLocalizedMessage());
-                updateKeys();
-            }
         } else {
             assert(implClass != null);
             if (fcl == null) {
@@ -497,11 +492,10 @@ public class JaxWsChildren extends Children.Keys<Object>/* implements MDRChangeL
     void refreshKeys(boolean downloadWsdl, final boolean refreshImplClass, String newWsdlUrl) {
         if (!isFromWsdl()) return;
         super.addNotify();
-        try {
-            // copy to local wsdl first
-            JAXWSSupport support = getJAXWSSupport();
+        // copy to local wsdl first
+        JAXWSSupport support = getJAXWSSupport();
             
-            if (downloadWsdl) {
+        if (downloadWsdl) {
                 String serviceName = getNode().getName();
                 FileObject xmlResorcesFo = support.getLocalWsdlFolderForService(serviceName,true);
                 FileObject localWsdl = null;
@@ -586,7 +580,7 @@ public class JaxWsChildren extends Children.Keys<Object>/* implements MDRChangeL
             }
             FileObject wsdlFo = 
                 localWsdlFolder.getFileObject(service.getLocalWsdlFile());
-            wsdlModeler = WsdlModelerFactory.getDefault().getWsdlModeler(wsdlFo.getURL());
+            wsdlModeler = WsdlModelerFactory.getDefault().getWsdlModeler(wsdlFo.toURL());
             String packageName = service.getPackageName();
             if (packageName!=null && service.isPackageNameForceReplace()) {
                 // set the package name for the modeler
@@ -693,10 +687,7 @@ public class JaxWsChildren extends Children.Keys<Object>/* implements MDRChangeL
                         }
                     }
                 }
-            });
-        } catch (FileStateInvalidException ex) {
-            ErrorManager.getDefault().log(ex.getLocalizedMessage());
-        }
+        });
     }
     
     private void regenerateJavaArtifacts() {

--- a/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/saas/RestResourceGenerator.java
+++ b/enterprise/websvc.core/src/org/netbeans/modules/websvc/core/jaxws/saas/RestResourceGenerator.java
@@ -127,7 +127,7 @@ public class RestResourceGenerator {
                     FileObject localWsdlFolder = clientSupport.getLocalWsdlFolderForClient(clientName, false);
 
                     FileObject localWsdl = localWsdlFolder.getFileObject(client.getLocalWsdlFile());
-                    WsdlModeler wsdlModeler = WsdlModelerFactory.getDefault().getWsdlModeler(localWsdl.getURL());
+                    WsdlModeler wsdlModeler = WsdlModelerFactory.getDefault().getWsdlModeler(localWsdl.toURL());
                     wsdlModeler.setPackageName(clientPackageName);
                     wsdlModeler.setCatalog(clientSupport.getCatalog());
                     WsdlModel model = wsdlModeler.getAndWaitForWsdlModel();

--- a/enterprise/websvc.customization/src/org/netbeans/modules/websvc/customization/multiview/ExternalBindingTablePanel.java
+++ b/enterprise/websvc.customization/src/org/netbeans/modules/websvc/customization/multiview/ExternalBindingTablePanel.java
@@ -117,7 +117,7 @@ public class ExternalBindingTablePanel extends DefaultTablePanel{
         }
         try{
             relativePath = Utilities.relativize(FileUtil.toFile(wsdlFolder).toURI(),
-                    new URI(localWsdlFile.getURL().toExternalForm()));
+                    new URI(localWsdlFile.toURL().toExternalForm()));
         }catch(Exception e){
             return "Unable to obtain relative path";
         }

--- a/enterprise/websvc.jaxwsapi/src/org/netbeans/modules/websvc/jaxws/spi/ProjectJAXWSSupport.java
+++ b/enterprise/websvc.jaxwsapi/src/org/netbeans/modules/websvc/jaxws/spi/ProjectJAXWSSupport.java
@@ -404,13 +404,8 @@ public abstract class ProjectJAXWSSupport implements JAXWSSupportImpl {
     }
 
     public URL getCatalog() {
-        try {
-            FileObject catalog = getCatalogFileObject();
-            return catalog==null?null:catalog.getURL();
-        } catch (FileStateInvalidException ex) {
-            return null;
-        }
-
+        FileObject catalog = getCatalogFileObject();
+        return catalog == null ? null : catalog.toURL();
     }
 
     private FileObject getWsdlFolderForService(String name) throws IOException {

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutWizard.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/ShortcutWizard.java
@@ -84,7 +84,7 @@ public final class ShortcutWizard extends WizardDescriptor {
                 for (FileObject kid : build.getChildren()) {
                     if (isAntScript(kid)) {
                         try {
-                            Document doc = XMLUtil.parse(new InputSource(kid.getURL().toString()), false, false, /*XXX*/ null, null);
+                            Document doc = XMLUtil.parse(new InputSource(kid.toURL().toString()), false, false, /*XXX*/ null, null);
                             NodeList nl = doc.getElementsByTagName("ant"); // NOI18N
                             if (nl.getLength() == 1) {
                                 Element ael = (Element) nl.item(0);

--- a/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLDataObject.java
+++ b/ide/db.core/src/org/netbeans/modules/db/sql/loader/SQLDataObject.java
@@ -61,12 +61,8 @@ public class SQLDataObject extends MultiDataObject {
     }
 
     public boolean isConsole() {
-        try {
-            // the "console" files are stored in the SFS
-            return "nbfs".equals(getPrimaryFile().getURL().getProtocol()) && !isTemplate(); // NOI18N
-        } catch (FileStateInvalidException e) {
-            return false;
-        }
+        // the "console" files are stored in the SFS
+        return "nbfs".equals(getPrimaryFile().toURL().getProtocol()) && !isTemplate(); // NOI18N
     }
 
     void addCookie(Node.Cookie cookie) {

--- a/ide/diff/src/org/netbeans/modules/diff/PatchAction.java
+++ b/ide/diff/src/org/netbeans/modules/diff/PatchAction.java
@@ -73,12 +73,8 @@ public class PatchAction extends NodeAction {
         if (nodes.length == 1) {
             FileObject fo = DiffAction.getFileFromNode(nodes[0]);
             if (fo != null) {
-                try {
-                    // #63460
-                    return fo.getURL().getProtocol().equals("file");  // NOI18N
-                } catch (FileStateInvalidException fsiex) {
-                    return false;
-                }
+                // #63460
+                return fo.toURL().getProtocol().equals("file");  // NOI18N
             }
         }
         return false;

--- a/ide/editor/src/org/netbeans/modules/editor/impl/NbURLMapper.java
+++ b/ide/editor/src/org/netbeans/modules/editor/impl/NbURLMapper.java
@@ -93,11 +93,7 @@ public final class NbURLMapper extends URLMapper {
         }
         
         if (f != null) {
-            try {
-                return f.getURL();
-            } catch (FileStateInvalidException e) {
-                LOG.log(Level.WARNING, "Can't get URL for " + f, e); //NOI18N
-            }
+            return f.toURL();
         }
         
         return null;

--- a/ide/image/src/org/netbeans/modules/image/ImageDataObject.java
+++ b/ide/image/src/org/netbeans/modules/image/ImageDataObject.java
@@ -151,11 +151,7 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
      * @return the image url
      */
     URL getImageURL() {
-        try {
-            return getPrimaryFile().getURL();
-        } catch (FileStateInvalidException ex) {
-            return null;
-        }
+        return getPrimaryFile().toURL();
     }
 
     /** Gets image data for the image object.
@@ -239,12 +235,8 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
             }
             
             /** Gets value of property. Overrides superclass method. */
-            public Icon getValue() throws InvocationTargetException {
-                try {
-                    return new ImageIcon(obj.getPrimaryFile().getURL());
-                } catch (FileStateInvalidException fsie) {
-                    throw new InvocationTargetException(fsie);
-                }
+            public Icon getValue() {
+                return new ImageIcon(obj.getPrimaryFile().toURL());
             }
             
             /** Gets property editor. */
@@ -265,15 +257,8 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
                 public void paintValue(Graphics g, Rectangle r) {
                     ImageIcon icon = null;
                     
-                    try {
-                        icon = (ImageIcon)ThumbnailProperty.this.getValue();
-                    } catch(InvocationTargetException ioe) {
-                        if(Boolean.getBoolean("netbeans.debug.exceptions")) { // NOI18N
-                            ErrorManager.getDefault().notify(ioe);
-                        }
-                    }
-                    
-                    if(icon != null) {
+                    icon = (ImageIcon)ThumbnailProperty.this.getValue();
+                    if (icon != null) {
                         int iconWidth = icon.getIconWidth();
                         int iconHeight = icon.getIconHeight();
                         
@@ -330,13 +315,8 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
 
           /** Gets value of property. Overrides superclass method. */
           public Integer getValue() throws InvocationTargetException {
-             try {
-                final Icon icon = new ImageIcon(getDataObject().getPrimaryFile().
-                      getURL());
-                return Integer.valueOf(icon.getIconWidth());
-             } catch (FileStateInvalidException fsie) {
-                throw new InvocationTargetException(fsie);
-             }
+              final Icon icon = new ImageIcon(getDataObject().getPrimaryFile().toURL());
+              return Integer.valueOf(icon.getIconWidth());
           }
        } // End of class ImageWidthProperty.
 
@@ -353,13 +333,8 @@ public class ImageDataObject extends MultiDataObject implements CookieSet.Factor
 
           /** Gets value of property. Overrides superclass method. */
           public Integer getValue() throws InvocationTargetException {
-             try {
-                final Icon icon = new ImageIcon(getDataObject().getPrimaryFile().
-                      getURL());
-                return Integer.valueOf(icon.getIconHeight());
-             } catch (FileStateInvalidException fsie) {
-                throw new InvocationTargetException(fsie);
-             }
+              final Icon icon = new ImageIcon(getDataObject().getPrimaryFile().toURL());
+              return Integer.valueOf(icon.getIconHeight());
           }
        } // End of class ImageHeightProperty.
     } // End of class ImageNode.

--- a/ide/properties/src/org/netbeans/modules/properties/PropertiesEncoding.java
+++ b/ide/properties/src/org/netbeans/modules/properties/PropertiesEncoding.java
@@ -139,11 +139,7 @@ public final class PropertiesEncoding extends FileEncodingQueryImplementation {
         }
 
         private synchronized void updateURL(FileObject file) {
-            try {
-                fileURL = file.getURL();
-            } catch (FileStateInvalidException ex) {
-                fileURL = null;
-            }
+            fileURL = file.toURL();
         }
 
         public void fileDeleted(FileEvent fe) { }

--- a/ide/spi.palette/src/org/netbeans/modules/palette/PaletteEnvironmentProvider.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/PaletteEnvironmentProvider.java
@@ -144,7 +144,7 @@ public class PaletteEnvironmentProvider implements Environment.Provider {
             try {
                 XMLReader reader = getXMLReader();
                 FileObject fo = xmlDataObject.getPrimaryFile();
-                String urlString = fo.getURL().toExternalForm();
+                String urlString = fo.toURL().toExternalForm();
                 InputSource is = new InputSource(fo.getInputStream());
                 is.setSystemId(urlString);
                 reader.setContentHandler(handler);

--- a/ide/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/RetrieverImpl.java
+++ b/ide/xml.retriever/src/org/netbeans/modules/xml/retriever/impl/RetrieverImpl.java
@@ -105,7 +105,7 @@ public class RetrieverImpl extends Retriever {
             } else {
                 // For Maven based projects the project directory doesn't contain cached catalogs. 
                 //  In these cases should be used catalog.xml within destination directory.
-                cfuri = destinationDir.getParent().getURL().toURI().resolve(Utilities.PRIVATE_CATALOG_URI_STR);
+                cfuri = destinationDir.getParent().toURL().toURI().resolve(Utilities.PRIVATE_CATALOG_URI_STR);
             }
         }else{
             cfuri = relativePathToCatalogFile;

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/parser/ParsingSupport.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/parser/ParsingSupport.java
@@ -97,7 +97,7 @@ public abstract class ParsingSupport {
     protected TreeDocumentRoot parse(FileObject fo) throws IOException, TreeException{
         
         try {
-            URL url = fo.getURL();
+            URL url = fo.toURL();
             InputSource in = new InputSource(url.toExternalForm());  //!!! we could try ti get encoding from MIME content type
             in.setByteStream(fo.getInputStream());
             return parse(in);

--- a/ide/xml.tools/src/org/netbeans/modules/xml/tools/generator/GenerateDTDSupport.java
+++ b/ide/xml.tools/src/org/netbeans/modules/xml/tools/generator/GenerateDTDSupport.java
@@ -249,12 +249,7 @@ public final class GenerateDTDSupport implements XMLGenerateCookie  {
     private boolean scanTemplate() {
         URL url = null;
         XMLReader parser = null;
-        try {
-            url = template.getPrimaryFile().getURL();
-        } catch (FileStateInvalidException e) {
-            warning = e.getLocalizedMessage();
-            return false;
-        }
+        url = template.getPrimaryFile().toURL();
 
         String system = url.toExternalForm();
         try {

--- a/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Convertors.java
+++ b/ide/xml.xdm/src/org/netbeans/modules/xml/xdm/nodes/Convertors.java
@@ -92,15 +92,10 @@ public final class Convertors {
         if (system == null) {
             Object obj = doc.getProperty(Document.StreamDescriptionProperty);        
             if (obj instanceof DataObject) {
-                try { 
-                        DataObject dobj = (DataObject) obj;
-                        FileObject fo = dobj.getPrimaryFile();
-                        URL url = fo.getURL();
-                        system = url.toExternalForm();
-                } catch (IOException io) {
-                    ErrorManager emgr = (ErrorManager) Lookup.getDefault().lookup(ErrorManager.class);
-                    emgr.notify(io);
-                }
+                DataObject dobj = (DataObject) obj;
+                FileObject fo = dobj.getPrimaryFile();
+                URL url = fo.toURL();
+                system = url.toExternalForm();
             } else {
                 ErrorManager emgr = (ErrorManager) Lookup.getDefault().lookup(ErrorManager.class);
                 emgr.log("XML:Convertors:Unknown stream description:" + obj);

--- a/ide/xml/src/org/netbeans/modules/xml/XMLDataObject.java
+++ b/ide/xml/src/org/netbeans/modules/xml/XMLDataObject.java
@@ -357,10 +357,7 @@ public final class XMLDataObject extends org.openide.loaders.XMLDataObject
         /**
          */
         public void view () {
-            try {
-                HtmlBrowser.URLDisplayer.getDefault().showURL(primary.getFile().getURL());
-            } catch (FileStateInvalidException e) {
-            }
+            HtmlBrowser.URLDisplayer.getDefault().showURL(primary.getFile().toURL());
         }
 
     } // end of class ViewSupport

--- a/ide/xsl/src/org/netbeans/modules/xsl/transform/TransformPerformer.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/transform/TransformPerformer.java
@@ -429,7 +429,7 @@ public class TransformPerformer {
             if ( data.getProcessOutput() == TransformHistory.APPLY_DEFAULT_ACTION ) {
                 GuiUtil.performDefaultAction(resultFO);
             } else if ( data.getProcessOutput() == TransformHistory.OPEN_IN_BROWSER ) {
-                showURL(resultFO.getURL());
+                showURL(resultFO.toURL());
             }
         }
         
@@ -537,7 +537,7 @@ public class TransformPerformer {
             if ( file != null ) {
                 fileURL = file.toURI().toURL();
             } else {
-                fileURL = fileObject.getURL();
+                fileURL = fileObject.toURL();
             }
             return fileURL;
         }

--- a/ide/xsl/src/org/netbeans/modules/xsl/ui/TransformPanel.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/ui/TransformPanel.java
@@ -114,11 +114,7 @@ public final class TransformPanel extends javax.swing.JPanel {
             ( xml_stylesheet != null ) ) {
                 setXSL(xml_stylesheet);
             }
-            try {
-                baseURL = xmlFileObject.getParent().getURL();
-            } catch (FileStateInvalidException exc) {
-                // ignore it
-            }
+            baseURL = xmlFileObject.getParent().toURL();
         }
         if ( xslDataObject != null ) {
             setXSL(TransformUtil.getURLName(xslDataObject.getPrimaryFile()));
@@ -128,11 +124,7 @@ public final class TransformPanel extends javax.swing.JPanel {
                 setInput(xslHistory.getLastXML());
             }
             if ( baseURL == null ) {
-                try {
-                    baseURL = xslFileObject.getParent().getURL();
-                } catch (FileStateInvalidException exc) {
-                    // ignore it
-                }
+                baseURL = xslFileObject.getParent().toURL();
             }
         }
         

--- a/ide/xsl/src/org/netbeans/modules/xsl/utils/TransformUtil.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/utils/TransformUtil.java
@@ -83,7 +83,7 @@ public class TransformUtil {
 
             fileURL = file.toURL();
         } else {
-            fileURL = fileObject.getURL();
+            fileURL = fileObject.toURL();
         }
 
         return fileURL.toExternalForm();

--- a/java/beans/src/org/netbeans/modules/beans/beaninfo/BiIconEditor.java
+++ b/java/beans/src/org/netbeans/modules/beans/beaninfo/BiIconEditor.java
@@ -219,7 +219,7 @@ final class BiIconEditor extends PropertyEditorSupport implements ExPropertyEdit
                 : resourcePath;
         FileObject res = cp.findResource(path);
         if (res != null && res.canRead() && res.isData()) {
-            return res.getURL();
+            return res.toURL();
         } else {
             throw new FileNotFoundException(path);
         }

--- a/java/dbschema/src/org/netbeans/modules/dbschema/SchemaElementUtil.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/SchemaElementUtil.java
@@ -58,11 +58,7 @@ public class SchemaElementUtil {
             synchronized (SchemaElement.schemaCache) {
                 String tempURL = ""; //NOI18N
                 if (schemaFO != null)
-                    try {
-                        tempURL = schemaFO.getURL().toString();
-                    } catch (Exception exc) {
-                        Logger.getLogger("global").log(Level.INFO, null, exc);
-                    }
+                    tempURL = schemaFO.toURL().toString();
                 
                 if (schemaFO == null)
                     se = (SchemaElement) SchemaElement.schemaCache.get(name);

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/RecaptureSchema.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/wizard/RecaptureSchema.java
@@ -70,11 +70,7 @@ public class RecaptureSchema {
             System.out.println("[dbschema] url='" + elem.getUrl() + "'");
         }
         final FileObject fo1 = dobj.getPrimaryFile();
-        try {
-            SchemaElement.removeFromCache(elem.getName().getFullName() + "#" + fo1.getURL().toString()); //NOI18N
-        } catch (FileStateInvalidException ex) {
-            Logger.getLogger("global").log(Level.INFO, null, ex);
-        } 
+        SchemaElement.removeFromCache(elem.getName().getFullName() + "#" + fo1.toURL().toString()); //NOI18N
         
         TableElement tableAndViewElements[] = elem.getTables();
         // now break down to tables and views

--- a/java/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAReload.java
+++ b/java/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAReload.java
@@ -171,26 +171,20 @@ public class JPDAReload extends Task {
     }
     
     private String classToSourceURL (FileObject fo) {
-        try {
-            ClassPath cp = ClassPath.getClassPath (fo, ClassPath.EXECUTE);
-            FileObject root = cp.findOwnerRoot (fo);
-            String resourceName = cp.getResourceName (fo, '/', false);
-            if (resourceName == null) {
-                getProject().log("Can not find classpath resource for "+fo+", skipping...", Project.MSG_ERR);
-                return null;
-            }
-            int i = resourceName.indexOf ('$');
-            if (i > 0)
-                resourceName = resourceName.substring (0, i);
-            FileObject[] sRoots = SourceForBinaryQuery.findSourceRoots 
-                (root.getURL ()).getRoots ();
-            ClassPath sourcePath = ClassPathSupport.createClassPath (sRoots);
-            FileObject rfo = sourcePath.findResource (resourceName + ".java");
-            if (rfo == null) return null;
-            return rfo.getURL ().toExternalForm ();
-        } catch (FileStateInvalidException ex) {
-            ex.printStackTrace ();
+        ClassPath cp = ClassPath.getClassPath (fo, ClassPath.EXECUTE);
+        FileObject root = cp.findOwnerRoot (fo);
+        String resourceName = cp.getResourceName (fo, '/', false);
+        if (resourceName == null) {
+            getProject().log("Can not find classpath resource for "+fo+", skipping...", Project.MSG_ERR);
             return null;
         }
+        int i = resourceName.indexOf ('$');
+        if (i > 0)
+            resourceName = resourceName.substring (0, i);
+        FileObject[] sRoots = SourceForBinaryQuery.findSourceRoots(root.toURL()).getRoots ();
+        ClassPath sourcePath = ClassPathSupport.createClassPath (sRoots);
+        FileObject rfo = sourcePath.findResource (resourceName + ".java");
+        if (rfo == null) return null;
+        return rfo.toURL().toExternalForm();
     }
 }

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/BreakpointsExpandableGroup.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/BreakpointsExpandableGroup.java
@@ -174,11 +174,7 @@ abstract class BreakpointsExpandableGroup<T> implements OutlineComboBox.Expandab
         
         @Override
         public String toString() {
-            try {
-                return fo.getURL().toExternalForm();
-            } catch (FileStateInvalidException ex) {
-                return "file://"+fo.getPath();
-            }
+            return fo.toURL().toExternalForm();
         }
 
         @Override

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsReader.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsReader.java
@@ -325,20 +325,14 @@ public class BreakpointsReader implements Properties.Reader, PropertyChangeListe
             if (tgp != null) {
                 FileObject fo = tgp.getFileObject();
                 if (fo != null) {
-                    try {
-                        URL url = fo.getURL();
-                        fileURL = url.toExternalForm();
-                    } catch (FileStateInvalidException ex) {
-                    }
+                    URL url = fo.toURL();
+                    fileURL = url.toExternalForm();
                 }
                 Project project = tgp.getProject();
                 if (project != null) {
                     fo = project.getProjectDirectory();
-                    try {
-                        URL url = fo.getURL();
+                        URL url = fo.toURL();
                         projectURL = url.toExternalForm();
-                    } catch (FileStateInvalidException ex) {
-                    }
                 }
                 type = tgp.getType();
             }

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/TreeEvaluator.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/TreeEvaluator.java
@@ -157,11 +157,8 @@ public class TreeEvaluator {
                 // Try to define some context that should work...
                 FileObject systemFO = org.netbeans.api.java.classpath.GlobalPathRegistry.getDefault().findResource("java/lang/System.java");    // NOI18N
                 if (systemFO != null) {
-                    try {
-                        url = systemFO.getURL().toString();
-                        line = 100;
-                    } catch (FileStateInvalidException ex) {
-                    }
+                    url = systemFO.toURL().toString();
+                    line = 100;
                 }
             }
         }

--- a/java/form.nb/src/org/netbeans/modules/nbform/project/ClassSourceResolver.java
+++ b/java/form.nb/src/org/netbeans/modules/nbform/project/ClassSourceResolver.java
@@ -242,19 +242,15 @@ public class ClassSourceResolver implements ClassSource.Resolver {
             SourceGroup[] sgs = sources.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA);
             List<URL> list = new ArrayList<URL>();
             for (SourceGroup sg : sgs) {
-                try {
-                    ClassPath cp = ClassPath.getClassPath(sg.getRootFolder(), ClassPath.SOURCE);
-                    if (cp != null) {
-                        for (FileObject fob : cp.getRoots()) {
-                            URL[] urls = UnitTestForSourceQuery.findSources(fob);
-                            if (urls.length == 0) {
-                                BinaryForSourceQuery.Result result = BinaryForSourceQuery.findBinaryRoots(fob.getURL());
-                                list.addAll(Arrays.asList(result.getRoots()));
-                            }
+                ClassPath cp = ClassPath.getClassPath(sg.getRootFolder(), ClassPath.SOURCE);
+                if (cp != null) {
+                    for (FileObject fob : cp.getRoots()) {
+                        URL[] urls = UnitTestForSourceQuery.findSources(fob);
+                        if (urls.length == 0) {
+                            BinaryForSourceQuery.Result result = BinaryForSourceQuery.findBinaryRoots(fob.toURL());
+                            list.addAll(Arrays.asList(result.getRoots()));
                         }
                     }
-                } catch (FileStateInvalidException fsiex) {
-                    FormUtils.LOGGER.log(Level.INFO, fsiex.getMessage(), fsiex);
                 }
             }
             return list;

--- a/java/form/src/org/netbeans/modules/form/editors/CustomIconEditor.java
+++ b/java/form/src/org/netbeans/modules/form/editors/CustomIconEditor.java
@@ -247,13 +247,8 @@ public class CustomIconEditor extends javax.swing.JPanel {
     }
 
     private FileObject[] findSourceRoots(FileObject fo) {
-        try {
-            ClassPath cp = ClassPath.getClassPath(propertyEditor.getSourceFile(), ClassPath.EXECUTE);
-            return SourceForBinaryQuery.findSourceRoots(cp.findOwnerRoot(fo).getURL()).getRoots();
-        } catch (FileStateInvalidException fsiex) {
-            Logger.getLogger(CustomIconEditor.class.getName()).log(Level.INFO, null, fsiex);
-        }
-        return null;
+        ClassPath cp = ClassPath.getClassPath(propertyEditor.getSourceFile(), ClassPath.EXECUTE);
+        return SourceForBinaryQuery.findSourceRoots(cp.findOwnerRoot(fo).toURL()).getRoots();
     }
 
     private FileObject findSourceRootOf(FileObject[] roots, String resName) {

--- a/java/form/src/org/netbeans/modules/form/editors/IconEditor.java
+++ b/java/form/src/org/netbeans/modules/form/editors/IconEditor.java
@@ -434,13 +434,13 @@ public class IconEditor extends PropertyEditorSupport
         if (fo != null) {
             try {
                 try {
-                    Image image = ImageIO.read(fo.getURL());
+                    Image image = ImageIO.read(fo.toURL());
                     if (image != null) { // issue 157546
                         return new NbImageIcon(TYPE_CLASSPATH, resName, new ImageIcon(image));
                     }
                 } catch (IllegalArgumentException iaex) { // Issue 178906
                     Logger.getLogger(IconEditor.class.getName()).log(Level.INFO, null, iaex);
-                    return new NbImageIcon(TYPE_CLASSPATH, resName, new ImageIcon(fo.getURL()));
+                    return new NbImageIcon(TYPE_CLASSPATH, resName, new ImageIcon(fo.toURL()));
                 }
             } catch (IOException ex) { // should not happen
                 Logger.getLogger(IconEditor.class.getName()).log(Level.WARNING, null, ex);

--- a/java/form/src/org/netbeans/modules/form/palette/PaletteItemDataObject.java
+++ b/java/form/src/org/netbeans/modules/form/palette/PaletteItemDataObject.java
@@ -168,7 +168,7 @@ public class PaletteItemDataObject extends MultiDataObject implements CookieSet.
             XMLReader reader = XMLUtil.createXMLReader();
             PaletteItemHandler handler = new PaletteItemHandler();
             reader.setContentHandler(handler);
-            InputSource input = new InputSource(getPrimaryFile().getURL().toExternalForm());
+            InputSource input = new InputSource(getPrimaryFile().toURL().toExternalForm());
             reader.parse(input);
             // TODO report errors, validate using DTD?
             

--- a/java/form/src/org/netbeans/modules/form/project/ProjectClassLoader.java
+++ b/java/form/src/org/netbeans/modules/form/project/ProjectClassLoader.java
@@ -187,11 +187,7 @@ class ProjectClassLoader extends ClassLoader {
         Set<URL> urls = new HashSet<URL>();
         List<FileObject> fos = sources.findAllResources(name);
         for (FileObject fo : fos) {
-            try {
-                urls.add(fo.getURL());
-            } catch (FileStateInvalidException ex) {
-                ErrorManager.getDefault().notify(ErrorManager.INFORMATIONAL, ex);
-            }
+            urls.add(fo.toURL());
         }
         Enumeration<URL> e = projectClassLoaderDelegate.getResources(name);
         while (e.hasMoreElements()) {

--- a/java/hudson.ant/src/org/netbeans/modules/hudson/ant/JobCreator.java
+++ b/java/hudson.ant/src/org/netbeans/modules/hudson/ant/JobCreator.java
@@ -68,7 +68,7 @@ public class JobCreator extends JPanel implements ProjectHudsonJobCreator {
             FileObject projectXml = project.getProjectDirectory().getFileObject("nbproject/project.xml"); // NOI18N
             if (projectXml != null && projectXml.isData()) {
                 try {
-                    Document doc = XMLUtil.parse(new InputSource(projectXml.getURL().toString()), false, true, null, null);
+                    Document doc = XMLUtil.parse(new InputSource(projectXml.toURL().toString()), false, true, null, null);
                     String type = XPathFactory.newInstance().newXPath().evaluate(
                             "/*/*[local-name(.)='type']", doc.getDocumentElement()); // NOI18N
                     for (AntBasedJobCreator handler : Lookup.getDefault().lookupAll(AntBasedJobCreator.class)) {

--- a/java/i18n/src/org/netbeans/modules/i18n/wizard/Util.java
+++ b/java/i18n/src/org/netbeans/modules/i18n/wizard/Util.java
@@ -179,15 +179,9 @@ final class Util extends org.netbeans.modules.i18n.Util {
                 FileObject primaryFile = dobj.getPrimaryFile();
                 
                 boolean isLocal;
-                try {
-                    isLocal = !primaryFile.isVirtual()
+                isLocal = !primaryFile.isVirtual()
                               && primaryFile.isValid()
-                              && primaryFile.getURL().getProtocol()
-                                      .equals("file");                  //NOI18N
-                } catch (FileStateInvalidException ex) {
-                    isLocal = false;
-                }
-                
+                              && primaryFile.toURL().getProtocol().equals("file");  //NOI18N
                 if (isLocal == false) {
                     return false;
                 }

--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintRegistry.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintRegistry.java
@@ -244,14 +244,12 @@ public class DeclarativeHintRegistry implements HintProvider, ClassPathBasedHint
 
         try {
             if (file != null) {
-                ClassLoader l = new URLClassLoader(new URL[] {file.getParent().getURL()});
+                ClassLoader l = new URLClassLoader(new URL[] {file.getParent().toURL()});
 
                 bundle = NbBundle.getBundle("Bundle", Locale.getDefault(), l);
             } else {
                 bundle = null;
             }
-        } catch (FileStateInvalidException ex) {
-            bundle = null;
         } catch (MissingResourceException ex) {
             //TODO: log?
             bundle = null;

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
@@ -589,14 +589,10 @@ public class InspectAndRefactorPanel extends javax.swing.JPanel implements Popup
         pref.clear();
         int count = 0;
         for (Object next : files) {
-            try {
-                if (next instanceof FileObject) {
-                    pref.put(basekey + count++, ((FileObject) next).getURL().toExternalForm());
-                } else {
-                    pref.put(basekey + count++, ((NonRecursiveFolder) next).getFolder().getURL().toExternalForm());
-                }
-            } catch (FileStateInvalidException ex) {
-                Exceptions.printStackTrace(ex);
+            if (next instanceof FileObject) {
+                pref.put(basekey + count++, ((FileObject)next).toURL().toExternalForm());
+            } else {
+                pref.put(basekey + count++, ((NonRecursiveFolder)next).getFolder().toURL().toExternalForm());
             }
         }
         pref.flush();

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceForBinaryQuery.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceForBinaryQuery.java
@@ -140,12 +140,8 @@ public class J2SELibrarySourceForBinaryQuery implements SourceForBinaryQueryImpl
         if (normalizedURL == null) {
             FileObject fo = URLMapper.findFileObject(url);
             if (fo != null) {
-                try {
-                    normalizedURL = fo.getURL();
-                    this.normalizedURLCache.put (url, normalizedURL);
-                } catch (FileStateInvalidException e) {
-                    Exceptions.printStackTrace(e);
-                }
+                normalizedURL = fo.toURL();
+                this.normalizedURLCache.put (url, normalizedURL);
             }
         }
         return normalizedURL;

--- a/java/java.source.ant/src/org/netbeans/modules/java/source/ant/ProjectRunnerImpl.java
+++ b/java/java.source.ant/src/org/netbeans/modules/java/source/ant/ProjectRunnerImpl.java
@@ -716,7 +716,7 @@ public class ProjectRunnerImpl implements JavaRunnerImplementation {
                     File sourceFile = FileUtil.toFile(source);
 
                     if (sourceFile == null) {
-                        LOG.log(Level.WARNING, "Source URL: {0} cannot be translated to file, skipped", source.getURL().toExternalForm());
+                        LOG.log(Level.WARNING, "Source URL: {0} cannot be translated to file, skipped", source.toURL().toExternalForm());
                         continue;
                     }
 

--- a/java/java.source.base/src/org/netbeans/modules/java/source/classpath/CacheSourceForBinaryQueryImpl.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/classpath/CacheSourceForBinaryQueryImpl.java
@@ -131,7 +131,7 @@ public class CacheSourceForBinaryQueryImpl implements SourceForBinaryQueryImplem
                 final AnnotationProcessingQuery.Result result = AnnotationProcessingQuery.getAnnotationProcessingOptions(sourceRoot);
                 final URL annotationOutputURL = result.sourceOutputDirectory();
                 final FileObject userAnnotationOutput = annotationOutputURL == null ? null : URLMapper.findFileObject(annotationOutputURL);
-                final FileObject cacheAnnoationOutput = FileUtil.toFileObject(JavaIndex.getAptFolder(sourceRoot.getURL(), false));
+                final FileObject cacheAnnoationOutput = FileUtil.toFileObject(JavaIndex.getAptFolder(sourceRoot.toURL(), false));
                 return userAnnotationOutput == null ?
                     cacheAnnoationOutput == null ?
                         new FileObject[0] :

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaFileFilterListener.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaFileFilterListener.java
@@ -56,7 +56,7 @@ final class JavaFileFilterListener implements ChangeListener {
         assert root != null;
         boolean result = true;
         try {
-            final URL rootURL = root.getURL();
+            final URL rootURL = root.toURL();
             synchronized (listensOn) {
                 JavaFileFilterImplementation filter = listensOn.get(rootURL);
                 if (filter == null) {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacFlowListener.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacFlowListener.java
@@ -64,7 +64,7 @@ public class JavacFlowListener {
         }
         else {
             try {
-                return this.flowCompleted.contains(fo.getURL().toURI());
+                return this.flowCompleted.contains(fo.toURL().toURI());
             } catch (Exception e) {
                 return false;
             }

--- a/java/java.source/src/org/netbeans/modules/java/JavaNode.java
+++ b/java/java.source/src/org/netbeans/modules/java/JavaNode.java
@@ -679,11 +679,7 @@ public final class JavaNode extends DataNode implements ChangeListener {
                     }
                 };
                 
-                try {
-                    ExecutableFilesIndex.DEFAULT.addChangeListener(file.getURL(), _executableListener);
-                } catch (FileStateInvalidException ex) {
-                    Exceptions.printStackTrace(ex);
-                }
+                ExecutableFilesIndex.DEFAULT.addChangeListener(file.toURL(), _executableListener);
                 
                 synchronized (node) {
                     if (node.executableListener == null) {

--- a/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
+++ b/java/java.sourceui/src/org/netbeans/api/java/source/ui/ElementJavadoc.java
@@ -1169,21 +1169,17 @@ public class ElementJavadoc {
             final FileObject resource = cp.findResource(toSearch);
             if (resource != null) {
                 final FileObject root = cp.findOwnerRoot(resource);
-                try {
-                    final URL rootURL = root.getURL();
-                    if (JavadocForBinaryQuery.findJavadoc(rootURL).getRoots().length == 0) {
-                        FileObject userRoot = FileUtil.getArchiveFile(root);
-                        if (userRoot == null) {
-                            userRoot = root;
-                        }
-                        return NbBundle.getMessage(
+                final URL rootURL = root.toURL();
+                if (JavadocForBinaryQuery.findJavadoc(rootURL).getRoots().length == 0) {
+                    FileObject userRoot = FileUtil.getArchiveFile(root);
+                    if (userRoot == null) {
+                        userRoot = root;
+                    }
+                    return NbBundle.getMessage(
                                 ElementJavadoc.class,
                                 "javadoc_content_not_found_attach",
                                 rootURL.toExternalForm(),
                                 FileUtil.getFileDisplayName(userRoot));
-                    }
-                } catch (FileStateInvalidException ex) {
-                    Exceptions.printStackTrace(ex);
                 }
             }
         }

--- a/java/javawebstart/src/org/netbeans/modules/javawebstart/RunJavaws.java
+++ b/java/javawebstart/src/org/netbeans/modules/javawebstart/RunJavaws.java
@@ -54,7 +54,7 @@ public class RunJavaws implements ActionProvider {
         try {
             final Process p =
             new ProcessBuilder(FileUtil.toFile(JavaPlatform.getDefault().findTool("javaws")).getAbsolutePath(),
-                    context.lookup(DataObject.class).getPrimaryFile().getURL().toString()).start();
+                    context.lookup(DataObject.class).getPrimaryFile().toURL().toString()).start();
             RP.post(new Runnable() {
                 @Override public void run() {
                     try {

--- a/java/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSProjectPropertiesUtils.java
+++ b/java/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSProjectPropertiesUtils.java
@@ -369,7 +369,7 @@ public final class JWSProjectPropertiesUtils {
         }
         Document xmlDoc = null;
         try {
-            xmlDoc = XMLUtil.parse(new InputSource(buildXmlFO.getURL().toExternalForm()), false, true, null, null);
+            xmlDoc = XMLUtil.parse(new InputSource(buildXmlFO.toURL().toExternalForm()), false, true, null, null);
         } catch (SAXException ex) {
             Exceptions.printStackTrace(ex);
         }

--- a/java/junit.ant/src/org/netbeans/modules/junit/ant/JUnitTestSession.java
+++ b/java/junit.ant/src/org/netbeans/modules/junit/ant/JUnitTestSession.java
@@ -97,7 +97,7 @@ public class JUnitTestSession extends TestSession{
                 FileObject[] rootsCP = cp.getRoots();
                 for(FileObject fo: rootsCP){
                     try{
-                        FileObject[] aaa = SourceForBinaryQuery.findSourceRoots(fo.getURL()).getRoots();
+                        FileObject[] aaa = SourceForBinaryQuery.findSourceRoots(fo.toURL()).getRoots();
                         roots.addAll(Arrays.asList(aaa));
                     }catch(Exception e){}
                 }

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/SourceUtilsEx.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/SourceUtilsEx.java
@@ -201,7 +201,7 @@ public final class SourceUtilsEx {
         for (FileObject fo : fos) {
             FileObject root = cp.findOwnerRoot(fo);
             assert root != null;
-            FileObject[] sourceRoots = SourceForBinaryQuery.findSourceRoots(root.getURL()).getRoots();
+            FileObject[] sourceRoots = SourceForBinaryQuery.findSourceRoots(root.toURL()).getRoots();
             ClassPath sourcePath = ClassPathSupport.createClassPath(sourceRoots);
             LinkedList<FileObject> folders = new LinkedList<FileObject>(sourcePath.findAllResources(pkgName));
 

--- a/java/testng.ant/src/org/netbeans/modules/testng/ant/TestNGTestSession.java
+++ b/java/testng.ant/src/org/netbeans/modules/testng/ant/TestNGTestSession.java
@@ -141,7 +141,7 @@ public class TestNGTestSession extends TestSession {
                 FileObject[] rootsCP = cp.getRoots();
                 for (FileObject fo : rootsCP) {
                     try {
-                        FileObject[] aaa = SourceForBinaryQuery.findSourceRoots(fo.getURL()).getRoots();
+                        FileObject[] aaa = SourceForBinaryQuery.findSourceRoots(fo.toURL()).getRoots();
                         roots.addAll(Arrays.asList(aaa));
                     } catch (Exception e) {
                     }

--- a/java/whitelist/src/org/netbeans/modules/whitelist/index/WhiteListIndexerPlugin.java
+++ b/java/whitelist/src/org/netbeans/modules/whitelist/index/WhiteListIndexerPlugin.java
@@ -142,7 +142,7 @@ public class WhiteListIndexerPlugin implements JavaIndexerPlugin {
     @CheckForNull
     private static DocumentIndex getIndex(@NonNull final FileObject root) {
         try {
-            final File whiteListFolder = roots2whiteListDirs.get(root.getURL());
+            final File whiteListFolder = roots2whiteListDirs.get(root.toURL());
             if (whiteListFolder != null) {
                 final DocumentIndex index = IndexManager.createDocumentIndex(whiteListFolder);
                 return index.getStatus() == Index.Status.VALID ? index : null;

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorSupport.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/SAXGeneratorSupport.java
@@ -363,7 +363,7 @@ public final class SAXGeneratorSupport implements XMLGenerateCookie {
             }
 
             in = previous.getInputStream();
-            InputSource input = new InputSource(previous.getURL().toExternalForm());
+            InputSource input = new InputSource(previous.toURL().toExternalForm());
             input.setByteStream(in);
 
             SAXBindingsHandlerImpl handler = new SAXBindingsHandlerImpl();

--- a/platform/javahelp/src/org/netbeans/modules/javahelp/HelpCtxProcessor.java
+++ b/platform/javahelp/src/org/netbeans/modules/javahelp/HelpCtxProcessor.java
@@ -84,7 +84,7 @@ public final class HelpCtxProcessor implements Environment.Provider {
                     return instance;
                 }
                 try {
-                    Document doc = XMLUtil.parse(new InputSource(obj.getPrimaryFile().getURL().toString()), true, false, XMLUtil.defaultErrorHandler(), EntityCatalog.getDefault());
+                    Document doc = XMLUtil.parse(new InputSource(obj.getPrimaryFile().toURL().toString()), true, false, XMLUtil.defaultErrorHandler(), EntityCatalog.getDefault());
                     Element el = doc.getDocumentElement();
                     if (!el.getNodeName().equals("helpctx")) { // NOI18N
                         throw new IOException();

--- a/platform/javahelp/src/org/netbeans/modules/javahelp/HelpSetProcessor.java
+++ b/platform/javahelp/src/org/netbeans/modules/javahelp/HelpSetProcessor.java
@@ -70,7 +70,7 @@ public final class HelpSetProcessor implements Environment.Provider {
             }
             public @Override Object instanceCreate() throws IOException, ClassNotFoundException {
                 try {
-                    Document doc = XMLUtil.parse(new InputSource(obj.getPrimaryFile().getURL().toString()), true, false, XMLUtil.defaultErrorHandler(), EntityCatalog.getDefault());
+                    Document doc = XMLUtil.parse(new InputSource(obj.getPrimaryFile().toURL().toString()), true, false, XMLUtil.defaultErrorHandler(), EntityCatalog.getDefault());
                     Element el = doc.getDocumentElement();
                     if (!el.getNodeName().equals("helpsetref")) { // NOI18N
                         throw new IOException();

--- a/platform/openide.loaders/src/org/openide/loaders/XMLDataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/XMLDataObject.java
@@ -525,7 +525,7 @@ public class XMLDataObject extends MultiDataObject {
     */
     final Document parsePrimaryFile () throws IOException, SAXException {
         if (ERR.isLoggable(Level.FINE)) ERR.fine("parsePrimaryFile" + " for " + this);
-        String loc = getPrimaryFile().getURL().toExternalForm();
+        String loc = getPrimaryFile().toURL().toExternalForm();
         try {
             return XMLUtil.parse(new InputSource(loc), false, /* #36295 */true, errorHandler, getSystemResolver());
         } catch (IOException e) {


### PR DESCRIPTION
Remove the use of a deprecated API, getURL()..

   [repeat] /home/bwalker/src/netbeans/platform/openide.loaders/src/org/openide/loaders/XMLDataObject.java:528: warning: [deprecation] getURL() in FileObject has been deprecated
   [repeat]         String loc = getPrimaryFile().getURL().toExternalForm();
   [repeat]                                      ^

In addition, this deprecated API never throws an exception. So once the change was made, also
had to removed references to the unused exception.