### PR TITLE
[NETBEANS-4696] maven project open use no-lock getModuleName

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/queries/UnitTestsCompilerOptionsQueryImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/UnitTestsCompilerOptionsQueryImpl.java
@@ -18,13 +18,9 @@
  */
 package org.netbeans.modules.maven.queries;
 
-import com.sun.source.tree.CompilationUnitTree;
-import com.sun.source.tree.ModuleTree;
-import com.sun.source.tree.Tree;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,15 +29,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.java.queries.SourceLevelQuery;
-import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.SourceUtils;
 import org.netbeans.modules.maven.NbMavenProjectImpl;
 import org.netbeans.modules.maven.api.NbMavenProject;
 import static org.netbeans.modules.maven.classpath.ClassPathProviderImpl.MODULE_INFO_JAVA;
@@ -64,7 +58,6 @@ import org.openide.util.WeakListeners;
  * @see org.netbeans.modules.java.api.common.queries.UnitTestsCompilerOptionsQueryImpl
  */
 public final class UnitTestsCompilerOptionsQueryImpl implements CompilerOptionsQueryImplementation {
-    private static final Logger LOG = Logger.getLogger(UnitTestsCompilerOptionsQueryImpl.class.getName());
     private static final SpecificationVersion JDK9 = new SpecificationVersion("9"); //NOI18N
 
     private final AtomicReference<ResultImpl> result;
@@ -282,32 +275,7 @@ public final class UnitTestsCompilerOptionsQueryImpl implements CompilerOptionsQ
         
         @CheckForNull
         private static String getModuleName(@NonNull final FileObject moduleInfo) {
-            try {
-                final String[] res = new String[1];
-                final JavaSource src = JavaSource.forFileObject(moduleInfo);
-                if (src != null) {
-                    src.runUserActionTask((cc) -> {
-                        cc.toPhase(JavaSource.Phase.PARSED);
-                        final CompilationUnitTree cu = cc.getCompilationUnit();
-                        for (Tree decl : cu.getTypeDecls()) {
-                            if (decl.getKind().name().equals("MODULE")) {
-                                res[0] = ((ModuleTree)decl).getName().toString();
-                                break;
-                            }
-                        }
-                    }, true);
-                }
-                return res[0];
-            } catch (IOException ioe) {
-                LOG.log(
-                        Level.WARNING,
-                        "Cannot read module declaration in: {0} due to: {1}",   //NOI18N
-                        new Object[]{
-                            FileUtil.getFileDisplayName(moduleInfo),
-                            ioe.getMessage()
-                        });
-                return null;
-            }
+            return SourceUtils.parseModuleName(moduleInfo);
         }
     
         private static enum TestMode {


### PR DESCRIPTION
This change avoids the deadlock by having maven projects open use the non-locking `SourceUtils.parseModuleName(moduleInfo)` instead of invoking the parser.

It should be a safe change. Another change, for the other bad actor in the deadlock, is forthcoming

@tzezula Will you review?