### PR TITLE
[NETBEANS-4696] html parser dont wait for projects open

### DIFF
--- a/webcommon/javascript2.knockout/nbproject/project.xml
+++ b/webcommon/javascript2.knockout/nbproject/project.xml
@@ -97,15 +97,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.projectuiapi.base</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.78</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.openide.filesystems</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/webcommon/javascript2.knockout/src/org/netbeans/modules/javascript2/knockout/index/KnockoutIndex.java
+++ b/webcommon/javascript2.knockout/src/org/netbeans/modules/javascript2/knockout/index/KnockoutIndex.java
@@ -26,10 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.logging.Logger;
 import org.netbeans.api.project.Project;
-import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.modules.parsing.spi.indexing.support.IndexResult;
 import org.netbeans.modules.parsing.spi.indexing.support.QuerySupport;
 import org.openide.filesystems.FileObject;
@@ -40,12 +37,8 @@ import org.openide.util.Exceptions;
  * @author Roman Svitanic
  */
 public class KnockoutIndex {
-
-    private static final Logger LOGGER = Logger.getLogger(KnockoutIndex.class.getSimpleName());
-
     private static final Map<Project, KnockoutIndex> INDEXES = new WeakHashMap<>();
     private final QuerySupport querySupport;
-    private static boolean areProjectsOpen = false;
 
     public static KnockoutIndex get(Project project) throws IOException {
         if (project == null) {
@@ -54,16 +47,6 @@ public class KnockoutIndex {
         synchronized (INDEXES) {
             KnockoutIndex index = INDEXES.get(project);
             if (index == null) {
-                if (!areProjectsOpen) {
-                    try {
-                        // just be sure that the projects are open
-                        OpenProjects.getDefault().openProjects().get();
-                    } catch (InterruptedException | ExecutionException ex) {
-                        Exceptions.printStackTrace(ex);
-                    } finally {
-                        areProjectsOpen = true;
-                    }
-                }
                 Collection<FileObject> sourceRoots = QuerySupport.findRoots(project,
                         null /* all source roots */,
                         Collections.<String>emptyList(),


### PR DESCRIPTION
The html parser, in twisty paths, is used from many areas (for example, braceMatching). Without this change, the parser waits for project open, and this created a deadlock. (#2340 takes care of one side). However, according to analysis by @jtulach in the issue report, the html parser should not be calling into the projectui api.

This PR does not fix that, it does avoid blocking on the project ui api. A careful analysis of the html parsing code, and how it's used, should be done to see if there are any unexpected consequences of this change.

The eventual goal is to completely remove the dependency as outlined in the analysis as seen in issue [NETBEANS-4696].