### PR TITLE
[NETBEANS-4777] - Fix wrong binary-origin path for slf4j-api

### DIFF
--- a/ide/slf4j.api/nbproject/project.properties
+++ b/ide/slf4j.api/nbproject/project.properties
@@ -14,5 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
 release.external/slf4j-api-1.7.28.jar=modules/slf4j-api.jar
 is.autoload=true

--- a/ide/slf4j.api/nbproject/project.xml
+++ b/ide/slf4j.api/nbproject/project.xml
@@ -28,7 +28,7 @@
             <public-packages/>
             <class-path-extension>
                 <runtime-relative-path>slf4j-api.jar</runtime-relative-path>
-                <binary-origin>external/org.slf4j.api-1.7.28.jar</binary-origin>
+                <binary-origin>external/slf4j-api-1.7.28.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Currently is:
external/org.slf4j.api-1.7.28.jar

Should be:
external/slf4j-api-1.7.28.jar

NetBeans Testing:

- Full build done
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS