### PR TITLE
Fix unittest for webcommon caused by download failures from cdnjs

### DIFF
--- a/webcommon/javascript2.extjs/test/unit/src/org/netbeans/modules/javascript2/extjs/model/ExtModelTest.java
+++ b/webcommon/javascript2.extjs/test/unit/src/org/netbeans/modules/javascript2/extjs/model/ExtModelTest.java
@@ -23,6 +23,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import org.netbeans.modules.javascript2.model.ModelTestBase;
 
 /**
@@ -36,12 +37,15 @@ public class ExtModelTest extends ModelTestBase {
     }
 
     @Override
+    @SuppressWarnings("NestedAssignment")
     protected void setUp() throws Exception {
         super.setUp();
         File classManagerJs = new File(getDataDir(), "testfiles/completion/applyMethod/ClassManager.js");
         if(! classManagerJs.exists()) {
             URL source = new URL("https://cdnjs.cloudflare.com/ajax/libs/extjs/4.2.1/src/class/ClassManager.js");
-            try(InputStream is = source.openStream();
+            URLConnection connection = source.openConnection();
+            connection.addRequestProperty("User-Agent", "NetBeans Unittesting");
+            try(InputStream is = connection.getInputStream();
                 OutputStream os = new FileOutputStream(classManagerJs)) {
                 byte[] buffer = new byte[1024 * 10];
                 int read;

--- a/webcommon/javascript2.extjs/test/unit/src/org/netbeans/modules/javascript2/extjs/model/JsStructureTest.java
+++ b/webcommon/javascript2.extjs/test/unit/src/org/netbeans/modules/javascript2/extjs/model/JsStructureTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import org.netbeans.modules.javascript2.editor.JsTestBase;
 import org.openide.filesystems.FileObject;
 
@@ -38,12 +39,15 @@ public class JsStructureTest extends JsTestBase {
     }
 
     @Override
+    @SuppressWarnings("NestedAssignment")
     protected void setUp() throws Exception {
         super.setUp();
         File classManagerJs = new File(getDataDir(), "testfiles/completion/applyMethod/ClassManager.js");
         if(! classManagerJs.exists()) {
             URL source = new URL("https://cdnjs.cloudflare.com/ajax/libs/extjs/4.2.1/src/class/ClassManager.js");
-            try(InputStream is = source.openStream();
+            URLConnection connection = source.openConnection();
+            connection.addRequestProperty("User-Agent", "NetBeans Unittesting");
+            try(InputStream is = connection.getInputStream();
                 OutputStream os = new FileOutputStream(classManagerJs)) {
                 byte[] buffer = new byte[1024 * 10];
                 int read;


### PR DESCRIPTION
It seems that for some networks CDNJS requires sending a User-Agent
header. This changeset adds it to the requests.