### PR TITLE
[NETBEANS-3600] Added Gradle wrapper distribution change detection.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
@@ -96,7 +96,7 @@ public final class GradleProjectCache {
     private static final Map<File, Set<File>> SUB_PROJECT_DIR_CACHE = new ConcurrentHashMap<>();
 
     // Increase this number if new info is gathered from the projects.
-    private static final int COMPATIBLE_CACHE_VERSION = 13;
+    private static final int COMPATIBLE_CACHE_VERSION = 14;
 
     private GradleProjectCache() {
     }
@@ -446,8 +446,9 @@ public final class GradleProjectCache {
         assert gp.getQuality().betterThan(FALLBACK) : "Never attempt to cache FALLBACK projects."; //NOi18N
         //TODO: Make it possible to handle external file set as cache.
         GradleFiles gf = new GradleFiles(gp.getBaseProject().getProjectDir(), true);
-
-        ProjectCacheEntry entry = new ProjectCacheEntry(new StoredProjectInfo(data), gp, gf.getProjectFiles());
+        Set<File> cacheInvalidators = new HashSet<>(gf.getProjectFiles());
+        if (gf.hasWrapper()) cacheInvalidators.add(gf.getWrapperProperties());
+        ProjectCacheEntry entry = new ProjectCacheEntry(new StoredProjectInfo(data), gp, cacheInvalidators);
         File cacheFile = new File(getCacheDir(gp), INFO_CACHE_FILE_NAME);
         if (!cacheFile.exists()) {
             cacheFile.getParentFile().mkdirs();


### PR DESCRIPTION
Well, this one handles local wrapper distributionUrl (used in netbeans-gradle-tooling) also adds the change detection if the wrapper distribution changes which forces reload of the project.

The ```GradleDistributionManager.getWrapperDistributionURI()``` is a new public API. I have not increased the version number as the whole ```GradleDistributionManager``` is new in the upcoming release.