### PR TITLE
Fixing nbjdk.home behavior broken by #2337 

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
@@ -89,6 +89,14 @@ public class CustomJavac extends Javac {
     }
 
     @Override
+    public Path getBootclasspath() {
+        if (intVersion(getTarget()) >= 9) {
+            return null;
+        }
+        return super.getBootclasspath();
+    }
+
+    @Override
     protected void compile() {
         if (processorPath != null && processorPath.size() > 0) {
             createCompilerArg().setValue("-processorpath");


### PR DESCRIPTION
>  matthiasblaesing commented 6 hours ago in #2369:
>  @mcdonnell-john I was able to reproduce your problem. It happens if the build JDK and the target JDK are not the same. I had this in my ".nbbuild.properties":
```
#permit.jdk9.builds=true
nbjdk.home=/home/matthias/bin/jdk-8
```
> This will lead to ant finding the desktop classes, while in the compile run they are not present. 

Please accept apology for not spotting this problem sooner. This is an additional fix for #2337 to make it work `nbjdk.home=` set.

Up to @lkishalmi to decide whether to merge this, merge #2369 or merge both. 