### PR TITLE
[NETBEANS-4824] - General Availability for javadoc 15

### DIFF
--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
@@ -63,7 +63,7 @@ public final class J2SEPlatformDefaultJavadocImpl implements J2SEPlatformDefault
         OFFICIAL_JAVADOC.put("12", "https://docs.oracle.com/en/java/javase/12/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("13", "https://docs.oracle.com/en/java/javase/13/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("14", "https://docs.oracle.com/en/java/javase/14/docs/api/"); // NOI18N
-        OFFICIAL_JAVADOC.put("15", "https://download.java.net/java/early_access/jdk15/docs/api/"); // NOI18N Early access
+        OFFICIAL_JAVADOC.put("15", "https://docs.oracle.com/en/java/javase/15/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("16", "https://download.java.net/java/early_access/jdk16/docs/api/"); // NOI18N Early access
     }
 


### PR DESCRIPTION
Update link to javadoc 15 now that is in general availability

Before:
https://download.java.net/java/early_access/jdk15/docs/api/

After:
https://docs.oracle.com/en/java/javase/15/docs/api/