### PR TITLE
Improving the behavior of cpplite project - building should have prop…

### DIFF
--- a/cpplite/cpplite.project/nbproject/project.xml
+++ b/cpplite/cpplite.project/nbproject/project.xml
@@ -59,6 +59,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.extexecution.base</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>1.14</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.projectapi</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -110,6 +119,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.openide.io</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.59</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.loaders</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -131,6 +148,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>7.52</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.text</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>6.77</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/ActionProviderImpl.java
+++ b/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/ActionProviderImpl.java
@@ -19,17 +19,28 @@
 package org.netbeans.modules.cpplite.project;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.netbeans.api.extexecution.ExecutionDescriptor;
 import org.netbeans.api.extexecution.ExecutionService;
+import org.netbeans.api.extexecution.print.ConvertedLine;
+import org.netbeans.api.extexecution.print.LineConvertor;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.cpplite.debugger.api.Debugger;
 import org.netbeans.modules.cpplite.project.runner.Runner;
 import org.netbeans.spi.project.ActionProvider;
+import org.openide.LifecycleManager;
+import org.openide.cookies.LineCookie;
+import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.modules.InstalledFileLocator;
+import org.openide.text.Line;
 import org.openide.util.Lookup;
+import org.openide.windows.OutputEvent;
+import org.openide.windows.OutputListener;
 
 /**
  *
@@ -54,11 +65,21 @@ public class ActionProviderImpl implements ActionProvider {
         return SUPPORTED_ACTIONS;
     }
 
+    private static final Pattern ERROR_LINE = Pattern.compile("(.*):(\\d+):(\\d+):.*");
+
     @Override
     public void invokeAction(String command, Lookup context) throws IllegalArgumentException {
         BuildConfiguration config = prj.getActiveBuildConfiguration();
         File module = InstalledFileLocator.getDefault().locate("modules/org-netbeans-modules-cpplite-project.jar", "org.netbeans.modules.cpplite.project", false);
+        ExecutionDescriptor executionDescriptor = new ExecutionDescriptor()
+                .showProgress(true)
+                .showSuspended(true)
+                .frontWindowOnError(true)
+                .controllable(true)
+                .errConvertorFactory(() -> new ErrorLineConvertor())
+                .outConvertorFactory(() -> new ErrorLineConvertor());
         ExecutionService.newService(() -> {
+            LifecycleManager.getDefault().saveAll();
             if (COMMAND_DEBUG.equals(command)) {
                 List<List<String>> executablesFor = config.executablesFor(COMMAND_RUN);
                 return Debugger.startInDebugger(executablesFor.get(0));
@@ -66,7 +87,7 @@ public class ActionProviderImpl implements ActionProvider {
             List<List<String>> executablesFor = config.executablesFor(command);
             String arg = executablesFor.stream().map(c -> quote(c.stream().map(p -> quote(p)).collect(Collectors.joining(" ")))).collect(Collectors.joining(" "));
             return new ProcessBuilder("java", "-classpath", module.getAbsolutePath(), Runner.class.getName(), arg).directory(FileUtil.toFile(prj.getProjectDirectory())).start();
-        }, new ExecutionDescriptor(), ProjectUtils.getInformation(prj).getDisplayName() + " - " + command).run();
+        }, executionDescriptor, ProjectUtils.getInformation(prj).getDisplayName() + " - " + command).run();
     }
 
     private String quote(String s) {
@@ -81,4 +102,34 @@ public class ActionProviderImpl implements ActionProvider {
         return prj.getActiveBuildConfiguration().executablesFor(command) != null;
     }
     
+    private static class ErrorLineConvertor implements LineConvertor {
+
+        @Override
+        public List<ConvertedLine> convert(String line) {
+            Matcher matcher = ERROR_LINE.matcher(line);
+            if (matcher.matches()) {
+                String fileName = matcher.group(1);
+                int lineNum = Integer.parseInt(matcher.group(2)) - 1;
+                int columnNum = Integer.parseInt(matcher.group(3)) - 1;
+                return Collections.singletonList(ConvertedLine.forText(line, new OutputListener() {
+                    @Override
+                    public void outputLineSelected(OutputEvent ev) {}
+                    @Override
+                    public void outputLineAction(OutputEvent ev) {
+                        FileObject file = FileUtil.toFileObject(new File(fileName));
+                        if (file == null) {
+                            //TODO
+                            return;
+                        }
+                        LineCookie lc = file.getLookup().lookup(LineCookie.class);
+                        lc.getLineSet().getCurrent(lineNum).show(Line.ShowOpenType.OPEN, Line.ShowVisibilityType.FOCUS, columnNum);
+                    }
+                    @Override
+                    public void outputLineCleared(OutputEvent ev) {}
+                }));
+            }
+            return Collections.singletonList(ConvertedLine.forText(line, null));
+        }
+    }
+
 }

--- a/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/CPPLiteProject.java
+++ b/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/CPPLiteProject.java
@@ -20,6 +20,8 @@ package org.netbeans.modules.cpplite.project;
 
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import org.netbeans.api.project.Project;
@@ -29,11 +31,14 @@ import org.netbeans.spi.project.ProjectFactory;
 import org.netbeans.spi.project.ProjectFactory2;
 import org.netbeans.spi.project.ProjectState;
 import org.netbeans.spi.project.ui.PrivilegedTemplates;
+import org.netbeans.spi.project.ui.ProjectOpenedHook;
 import org.netbeans.spi.project.ui.RecommendedTemplates;
 import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.NbPreferences;
+import org.openide.util.RequestProcessor;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -43,6 +48,9 @@ import org.openide.util.lookup.ServiceProvider;
  */
 public class CPPLiteProject implements Project {
     
+    private static final Logger LOG = Logger.getLogger(ProjectOpenedHookImpl.class.getName());
+    private static final RequestProcessor WORKER = new RequestProcessor(CPPLiteProject.class.getName(), 1, false, false);
+
     public static final String PROJECT_KEY = "org-netbeans-modules-cpplite-project-CPPLiteProject";
     public static final String KEY_COMPILE_COMMANDS = "compile-commands";
     public static final String KEY_COMPILE_COMMANDS_EXECUTABLE = "compile-commands-executable";
@@ -92,6 +100,7 @@ public class CPPLiteProject implements Project {
                                     new CPPLiteCProjectConfigurationProvider(getRootPreferences(projectDirectory)),
                                     new RecommendedTemplatesImpl(),
                                     new PrivilegedTemplatesImpl(),
+                                    new ProjectOpenedHookImpl(),
                                     this);
         buildConfigurations.set(BuildConfiguration.read(getBuildPreferences(projectDirectory)));
     }
@@ -187,4 +196,34 @@ public class CPPLiteProject implements Project {
             return TEMPLATES;
         }
     }
+    private static class ProjectOpenedHookImpl extends ProjectOpenedHook {
+
+        @Override
+        protected void projectOpened() {
+            WORKER.post(() -> {
+                //ensure cpplite is not disabled:
+                FileObject modules = FileUtil.getConfigFile("Modules"); // NOI18N
+                if (modules == null) {
+                    return;
+                }
+                for (FileObject cpplite : modules.getChildren()) {
+                    if (!cpplite.getNameExt().contains("cpplite")) {
+                        continue;
+                    }
+                    try {
+                        if (cpplite.getAttribute("ergonomicsUnused") != null) {
+                            cpplite.setAttribute("ergonomicsUnused", 0); // NOI18N
+                        }
+                    } catch (IOException ex) {
+                        LOG.log(Level.INFO, null, ex);
+                    }
+                }
+            });
+        }
+
+        @Override
+        protected void projectClosed() {}
+
+    }
+
 }

--- a/ergonomics/ide.ergonomics/cpplite.properties
+++ b/ergonomics/ide.ergonomics/cpplite.properties
@@ -16,3 +16,4 @@
 # under the License.
 
 mainModule=org.netbeans.modules.cpplite.kit
+extra.project.marker.class=org.netbeans.modules.cpplite.project.CPPLiteProject

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureInfo.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureInfo.java
@@ -231,6 +231,10 @@ public final class FeatureInfo {
         return s;
     }
 
+    public final String getExtraProjectMarkerClass() {
+        return properties.getProperty("extra.project.marker.class");
+    }
+
     static final class ExtraModuleInfo {
         private final Pattern cnb;
         private final SpecificationVersion recMinJDK;

--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureManager.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureManager.java
@@ -382,7 +382,17 @@ implements PropertyChangeListener, LookupListener {
                     continue;
                 }
                 if (fi.isProject(d) == 0) {
-                    continue;
+                    boolean markedProject = false;
+                    try {
+                        String markerClass = fi.getExtraProjectMarkerClass();
+                        if (markerClass != null) {
+                            Class testClass = projects[i].getClass().getClassLoader().loadClass(markerClass);
+                            markedProject |= projects[i].getLookup().lookup(testClass) != null;
+                        }
+                    } catch (ClassNotFoundException ex) {}
+                    if (!markedProject) {
+                        continue;
+                    }
                 }
                 markUsed(unused, fi, cnb2Date, date2Files);
             }


### PR DESCRIPTION
…er output; ergonomics should not disable the modules while the project is being used.

The output improvements are probably not controversial, but the ergonomics tweak probably is.

The issue is that feature-off-demand will disable "unused" features after 5 sessions. But, it detects used projects based on a file pattern inside the project. For the cpplite project, we have no specific file pattern inside the project, which is fine per Projects API. Please note the cpplite project does not even require "Makefile" or anything like that to work.

So, the workaround used here is that the cpplite project marks itself as "used" on the filesystem.