### PR TITLE
Cleanup of not just dependencies

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
@@ -100,6 +100,9 @@ public final class RunUtils {
             SingleMethod method = methods.iterator().next();
             files.add(method.getFile());
         }
+        if (files.isEmpty()) {
+            files.addAll(lookup.lookupAll(FileObject.class));
+        }
         return files.toArray(new FileObject[files.size()]);
     }
 

--- a/ide/code.analysis/manifest.mf
+++ b/ide/code.analysis/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.code.analysis/0
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/analysis/Bundle.properties
-OpenIDE-Module-Requires: org.openide.windows.WindowManager
+OpenIDE-Module-Recommends: org.openide.windows.WindowManager
 OpenIDE-Module-Specification-Version: 1.36
 

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/api/CodeAnalysis.java
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/api/CodeAnalysis.java
@@ -24,7 +24,6 @@ import org.netbeans.modules.analysis.spi.Analyzer.WarningDescription;
 import org.openide.nodes.Node;
 import org.openide.util.Lookup;
 import org.openide.util.Utilities;
-import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ProxyLookup;
 import org.openide.windows.TopComponent;
 

--- a/ide/javascript2.debug/nbproject/project.xml
+++ b/ide/javascript2.debug/nbproject/project.xml
@@ -114,6 +114,7 @@
             <friend-packages>
                 <friend>org.netbeans.modules.debugger.jpda.js</friend>
                 <friend>org.netbeans.modules.debugger.jpda.truffle</friend>
+                <friend>org.netbeans.modules.java.lsp.server</friend>
                 <friend>org.netbeans.modules.javascript.v8debug</friend>
                 <friend>org.netbeans.modules.javascript.v8debug.ui</friend>
                 <friend>org.netbeans.modules.javascript2.debug.ui</friend>

--- a/ide/javascript2.debug/nbproject/project.xml
+++ b/ide/javascript2.debug/nbproject/project.xml
@@ -114,7 +114,6 @@
             <friend-packages>
                 <friend>org.netbeans.modules.debugger.jpda.js</friend>
                 <friend>org.netbeans.modules.debugger.jpda.truffle</friend>
-                <friend>org.netbeans.modules.java.lsp.server</friend>
                 <friend>org.netbeans.modules.javascript.v8debug</friend>
                 <friend>org.netbeans.modules.javascript.v8debug.ui</friend>
                 <friend>org.netbeans.modules.javascript2.debug.ui</friend>

--- a/ide/parsing.indexing/manifest.mf
+++ b/ide/parsing.indexing/manifest.mf
@@ -4,4 +4,5 @@ OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/parsing/indexing/Bundle.p
 OpenIDE-Module-Layer: org/netbeans/modules/parsing/impl/indexing/layer.xml
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module-Implementation-Version: 1
+OpenIDE-Module-Needs: org.netbeans.modules.parsing.impl.indexing.implspi.ActiveDocumentProvider
 

--- a/ide/parsing.indexing/nbproject/project.properties
+++ b/ide/parsing.indexing/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=9.18.0
+spec.version.base=9.19.0
 is.autoload=true
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml

--- a/ide/parsing.nb/manifest.mf
+++ b/ide/parsing.nb/manifest.mf
@@ -2,4 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.parsing.nb
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/parsing/nb/Bundle.properties
 OpenIDE-Module-Install: org/netbeans/modules/parsing/nb/Installer.class
+OpenIDE-Module-Provides: org.netbeans.modules.parsing.impl.indexing.implspi.ActiveDocumentProvider
 AutoUpdate-Show-In-Client: false

--- a/ide/parsing.nb/nbproject/project.properties
+++ b/ide/parsing.nb/nbproject/project.properties
@@ -17,6 +17,6 @@
 is.eager=true
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=1.13.0
+spec.version.base=1.14.0
 #javadoc.apichanges=${basedir}/apichanges.xml
 #javadoc.files=

--- a/ide/projectapi.nb/manifest.mf
+++ b/ide/projectapi.nb/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.projectapi.nb
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/projectapi/nb/Bundle.properties
-OpenIDE-Module-Provides: cnb.org.netbeans.modules.projectapi.nb
-OpenIDE-Module-Specification-Version: 1.13
+OpenIDE-Module-Provides: org.netbeans.spi.project.ProjectManagerImplementation
+OpenIDE-Module-Specification-Version: 1.14
 AutoUpdate-Show-In-Client: false

--- a/ide/projectapi.nb/nbproject/project.xml
+++ b/ide/projectapi.nb/nbproject/project.xml
@@ -40,7 +40,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.59</specification-version>
+                        <specification-version>1.78</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/projectapi/manifest.mf
+++ b/ide/projectapi/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.projectapi/1
-OpenIDE-Module-Specification-Version: 1.77
+OpenIDE-Module-Specification-Version: 1.78
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/projectapi/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/projectapi/layer.xml
-OpenIDE-Module-Recommends: cnb.org.netbeans.modules.projectapi.nb
+OpenIDE-Module-Needs: org.netbeans.spi.project.ProjectManagerImplementation

--- a/ide/projectui/apichanges.xml
+++ b/ide/projectui/apichanges.xml
@@ -30,6 +30,20 @@
     </apidefs>
 
     <changes>
+        <change id="LOAD_PROJECTS_ON_START">
+            <api name="recent"/>
+            <summary>Disable loading of projects on startup</summary>
+            <version major="1" minor="69"/>
+            <date year="2020" month="9" day="30"/>
+            <author login="jtulach"/>
+            <compatibility addition="yes"/>
+            <description>
+                <p>
+                    A branding API to disable loading of previously opened
+                    projects - <a href="architecture-summary.html#group-branding">LOAD_PROJECTS_ON_START</a>.
+                </p>
+            </description>
+        </change>
         <change id="SelectAndExpandProjectAPI">
             <api name="recent"/>
             <summary>Added <code>ProjectActionUtils</code></summary>

--- a/ide/projectui/arch.xml
+++ b/ide/projectui/arch.xml
@@ -19,8 +19,8 @@
     under the License.
 
 -->
-<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
-  <!ENTITY api-questions SYSTEM "../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
+<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
+  <!ENTITY api-questions SYSTEM "../../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
 ]>
 
 <api-answers
@@ -482,6 +482,16 @@
     These properties affect which category and project are preselected in 1st panel
     of <code>NewProjectWizard</code>. If properties are empty (as default) then 
     category/project are selected by UI spec.
+  </p>
+  <p>
+      By default this module also opens all projects that were opened before
+      shutting down. This behavior can however be disabled in application using
+      this module: <api name="LOAD_PROJECTS_ON_START" group="branding" type="export" category="stable">
+        To disable loading of previously opened projects on startup
+          set <code>LOAD_PROJECTS_ON_START=false</code> in
+          <code>org/netbeans/modules/project/ui/Bundle.properties</code>
+          branding file in your application.
+      </api>
   </p>
  </answer>
 

--- a/ide/projectui/nbproject/project.properties
+++ b/ide/projectui/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
-spec.version.base=1.68.0
+spec.version.base=1.69.0
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
@@ -441,12 +441,18 @@ public final class OpenProjectList {
                 }
             });
         }
-            
+
+        @NbBundle.Messages({
+            "LOAD_PROJECTS_ON_START=true"
+        })
         private void loadOnBackground() {
-            lazilyOpenedProjects = new ArrayList<Project>();
-            List<URL> URLs = OpenProjectListSettings.getInstance().getOpenProjectsURLs();
-            final List<Project> initial = new ArrayList<Project>();
-            final LinkedList<Project> projects = URLs2Projects(URLs);
+            lazilyOpenedProjects = new ArrayList<>();
+            final boolean loadProjectsOnStart = "true".equals(Bundle.LOAD_PROJECTS_ON_START());
+            List<URL> urls = loadProjectsOnStart ?
+                    OpenProjectListSettings.getInstance().getOpenProjectsURLs() :
+                    Collections.emptyList();
+            final List<Project> initial = new ArrayList<>();
+            final LinkedList<Project> projects = URLs2Projects(urls);
             OpenProjectList.MUTEX.writeAccess(new Mutex.Action<Void>() {
                 public @Override Void run() {
                     toOpenProjects.addAll(projects);

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
@@ -88,8 +88,10 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
 
     @Override
     public void engineAdded (DebuggerEngine engine) {
-        openEngineComponents(engine);
-        setupToolbar(engine);
+        if (!GraphicsEnvironment.isHeadless()) {
+            openEngineComponents(engine);
+            setupToolbar(engine);
+        }
     }
 
     private void openEngineComponents (final DebuggerEngine engine) {
@@ -315,9 +317,6 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
     }
 
     private void setupToolbar(final DebuggerEngine engine) {
-        if (GraphicsEnvironment.isHeadless()) {
-            return;
-        }
         final List<Component> buttonsToClose = new ArrayList<Component>();
         buttonsToClose.add(new java.awt.Label("EMPTY"));
         final boolean isFirst;

--- a/ide/web.browser.api/manifest.mf
+++ b/ide/web.browser.api/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.web.browser.api
 OpenIDE-Module-Layer: org/netbeans/modules/web/browser/ui/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/web/browser/api/Bundle.properties
-OpenIDE-Module-Requires: org.openide.windows.WindowManager
+OpenIDE-Module-Recommends: org.openide.windows.WindowManager
 OpenIDE-Module-Specification-Version: 1.55

--- a/java/maven/src/org/netbeans/modules/maven/spi/actions/AbstractMavenActionsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/spi/actions/AbstractMavenActionsProvider.java
@@ -88,6 +88,10 @@ public abstract class AbstractMavenActionsProvider implements MavenActionsProvid
             files.add(method.getFile());
         }
 
+        if (files.isEmpty()) {
+            files.addAll(lookup.lookupAll(FileObject.class));
+        }
+        
         return files.toArray(new FileObject[files.size()]);
     }
 

--- a/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdateCatalogParser.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdateCatalogParser.java
@@ -81,7 +81,8 @@ class AutoUpdateCatalogParser extends DefaultHandler {
     
     private static enum ELEMENTS {
         module_updates, module_group, notification, module, description,
-        module_notification, external_package, manifest, l10n, license, UNKNOWN;
+        module_notification, external_package, manifest, l10n, license,
+        message_digest, UNKNOWN;
 
         private static ELEMENTS valueOfOrUnknown(String qName) {
             try {
@@ -240,6 +241,8 @@ class AutoUpdateCatalogParser extends DefaultHandler {
                 break;
             case manifest :
                 break;
+            case message_digest:
+                break;
             case description :
                 ERR.info ("Not supported yet.");
                 break;
@@ -347,6 +350,8 @@ class AutoUpdateCatalogParser extends DefaultHandler {
                 // put module into UpdateItems
                 items.put (desc.getId (), m);
                 
+                break;
+            case message_digest:
                 break;
             case description :
                 ERR.info ("Not supported yet.");

--- a/platform/o.n.bootstrap/src/org/netbeans/CLIHandler.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/CLIHandler.java
@@ -1293,6 +1293,9 @@ public abstract class CLIHandler extends Object {
             if (ex.getMessage().equals("Broken pipe")) { // NOI18N
                 return true;
             }
+            if (ex.getMessage().contains("SIGPIPE")) { // NOI18N
+                return true;
+            }
             if (ex.getMessage().startsWith("Connection reset by peer")) { // NOI18N
                 return true;
             }
@@ -1345,7 +1348,8 @@ public abstract class CLIHandler extends Object {
                     // read provided data
                     int really = requestedVersion >= 1 ? is.readInt() : is.read ();
                     if (really > 0) {
-                        return is.read(b, off, really);
+                        is.readFully(b, off, really);
+                        return really;
                     } else {
                         if (really < 0) {
                             return really;

--- a/platform/openide.windows/src/org/openide/windows/DummyWindowManager.java
+++ b/platform/openide.windows/src/org/openide/windows/DummyWindowManager.java
@@ -20,6 +20,7 @@
 package org.openide.windows;
 
 import java.awt.Frame;
+import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.awt.Rectangle;
 import java.awt.event.WindowAdapter;
@@ -301,6 +302,10 @@ final class DummyWindowManager extends WindowManager {
     }
 
     protected void topComponentOpen(TopComponent tc) {
+        if (GraphicsEnvironment.isHeadless()) {
+            return;
+        }
+
         JFrame f = (JFrame) SwingUtilities.getAncestorOfClass(JFrame.class, tc);
 
         if (f == null) {

--- a/platform/settings/nbproject/project.properties
+++ b/platform/settings/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.apichanges=${basedir}/apichanges.xml
 javadoc.arch=${basedir}/arch.xml
 


### PR DESCRIPTION
While working on [java.lsp.server debugging](https://github.com/JaroslavTulach/netbeans/tree/java-lsp-server-debugging-attempt2) various issues with module dependencies, their ability to run in headless mode, to run without `core.windows` module, etc. have been identified. This PR is my attempt to bring them into NetBeans master branch.

The most important (from my architect perspective) is the new "branding API" to prevent open projects to be reopened on the application start. With the `LOAD_PROJECTS_ON_START=false` the system always starts with no projects opened.
