### PR TITLE
Do not report unsatisfied autoload fragments triggered by host module.

### DIFF
--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -1279,7 +1279,11 @@ public final class ModuleManager extends Modules {
             }
             for (Module m : testing) {
                 if (!modules.contains(m) && !m.isAutoload() && !m.isEager()) {
-                    throw new IllegalModuleException(IllegalModuleException.Reason.ENABLE_TESTING, m);
+                    // it is acceptable if the module is a non-autoload host fragment, and its host enabled (thus enabled the fragment):
+                    Module maybeHost =  attachModuleFragment(m);
+                    if (maybeHost == null && !testing.contains(maybeHost)) {
+                        throw new IllegalModuleException(IllegalModuleException.Reason.ENABLE_TESTING, m);
+                    }
                 }
             }
         }
@@ -1761,7 +1765,7 @@ public final class ModuleManager extends Modules {
         Collection<Module> frags = getAttachedFragments(m);
         for (Module fragMod : frags) {
             if (! fragMod.isEnabled()) {
-                maybeAddToEnableList(willEnable, mightEnable, fragMod, fragMod.isEager());
+                maybeAddToEnableList(willEnable, mightEnable, fragMod, fragMod.isAutoload() || fragMod.isEager());
             }
         }
     }

--- a/platform/o.n.bootstrap/src/org/netbeans/Util.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Util.java
@@ -286,8 +286,11 @@ public final class Util {
                     fragmentDep.add(m1);
                     for (Dependency dep : f.getDependenciesArray()) {
                         if (dep.getType() == Dependency.TYPE_REQUIRES) {
-                            List<Module> providers = providersOf.get(dep.getName());
-
+                            Collection<Module> providers = providersOf.get(dep.getName());
+                            if (providers.contains(m1)) {
+                                providers = new ArrayList<>(providers);
+                                providers.remove(m1);
+                            }
                             if (providers != null) {
                                 l = fillMapSlot(m, m1);
                                 l.addAll(providers);
@@ -297,7 +300,7 @@ public final class Util {
                             String cnb = (String) parseCodeName(dep.getName())[0];
                             Module m2 = modulesByName.get(cnb);
 
-                            if (m2 != null && modulesSet.contains(m2)) {
+                            if (m2 != null && m2 != m1 && modulesSet.contains(m2)) {
                                 l = fillMapSlot(m, m1);
                                 l.add(m2);
                             }
@@ -312,6 +315,7 @@ public final class Util {
                 m.put(m1, l);
             }
         }
+
         return m;
     }
 

--- a/platform/o.n.bootstrap/test/unit/data/jars/client-module-depend-broken.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/client-module-depend-broken.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.client
+OpenIDE-Module-Name: Client that needs broken fragment
+OpenIDE-Module-Module-Dependencies: org.foo.fragment.missing.token
+OpenIDE-Module-Public-Packages: -
+

--- a/platform/o.n.bootstrap/test/unit/data/jars/client-module-depend-frag.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/client-module-depend-frag.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.client
+OpenIDE-Module-Name: Client that Needs an autoload fragment
+OpenIDE-Module-Module-Dependencies: org.foo.fragment.auto
+OpenIDE-Module-Public-Packages: -
+

--- a/platform/o.n.bootstrap/test/unit/data/jars/client-module-depend-host.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/client-module-depend-host.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.client
+OpenIDE-Module-Name: Client that Needs a service
+OpenIDE-Module-Module-Dependencies: org.foo.host
+OpenIDE-Module-Public-Packages: -
+

--- a/platform/o.n.bootstrap/test/unit/data/jars/client-module-needs-broken.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/client-module-needs-broken.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.client
+OpenIDE-Module-Name: Client that needs broken fragment
+OpenIDE-Module-Needs: org.foo.fragment.missing.token
+OpenIDE-Module-Public-Packages: -
+

--- a/platform/o.n.bootstrap/test/unit/data/jars/client-module.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/client-module.mf
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.client
+OpenIDE-Module-Name: Client that does not need anything
+OpenIDE-Module-Public-Packages: -
+

--- a/platform/o.n.bootstrap/test/unit/data/jars/client-module/org/foo/Something.java
+++ b/platform/o.n.bootstrap/test/unit/data/jars/client-module/org/foo/Something.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.foo;
+// Does not do anything, just needs to be here & loadable.
+public class Something {
+    protected String something() {
+        return "I am a fragment host module";
+    }
+}

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-auto.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-auto.mf
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.fragment.auto
+OpenIDE-Module-Fragment-Host: org.foo.host
+OpenIDE-Module-Name: Fragment Content Autoload
+OpenIDE-Module-Public-Packages: -

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-missing-token.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-missing-token.mf
@@ -3,3 +3,6 @@ OpenIDE-Module: org.foo.fragment.missing.token
 OpenIDE-Module-Fragment-Host: org.foo.host
 OpenIDE-Module-Name: Fragment Content Module with missing token
 OpenIDE-Module-Requires: missing.token
+OpenIDE-Module-Provides: org.openide.modules.fragservice2
+OpenIDE-Module-Public-Packages: -
+

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-reg.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module-reg.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+OpenIDE-Module: org.foo.fragment.reg
+OpenIDE-Module-Fragment-Host: org.foo.host
+OpenIDE-Module-Name: Fragment Content - regular
+OpenIDE-Module-Public-Packages: -
+

--- a/platform/o.n.bootstrap/test/unit/data/jars/fragment-module.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/fragment-module.mf
@@ -2,4 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.foo.fragment
 OpenIDE-Module-Fragment-Host: org.foo.host
 OpenIDE-Module-Name: Fragment Content Module
+OpenIDE-Module-Provides: org.openide.modules.fragservice
+OpenIDE-Module-Public-Packages: -
 

--- a/platform/o.n.bootstrap/test/unit/data/jars/host-module.mf
+++ b/platform/o.n.bootstrap/test/unit/data/jars/host-module.mf
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.foo.host
 OpenIDE-Module-Name: Fragment Host module
-
+OpenIDE-Module-Public-Packages: -

--- a/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerTest.java
+++ b/platform/o.n.bootstrap/test/unit/src/org/netbeans/ModuleManagerTest.java
@@ -48,8 +48,12 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
+import java.util.logging.Handler;
 import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertNotEquals;
+import static org.netbeans.SetupHid.createTestJAR;
 import org.netbeans.junit.RandomlyFails;
 import org.openide.modules.Dependency;
 import org.openide.modules.ModuleInfo;
@@ -89,11 +93,27 @@ public class ModuleManagerTest extends SetupHid {
     public ModuleManagerTest(String name) {
         super(name);
     }
+    
+    private LogHandler logHandler = new LogHandler();
 
     @Override
     protected Level logLevel() {
         return Level.FINE;
     }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp(); 
+        Util.err.addHandler(logHandler);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        Util.err.removeHandler(logHandler);
+        super.tearDown();
+    }
+    
+    
     
     /** Load simple-module and depends-on-simple-module.
      * Make sure they can be installed and in a sane order.
@@ -2805,6 +2825,8 @@ public class ModuleManagerTest extends SetupHid {
 
         assertTrue("Host must be enabled", mgr.getEnabledModules().contains(host));
         assertTrue("Fragment must not be enabled", !mgr.getEnabledModules().contains(fragment));
+        
+        assertTrue(logHandler.warnings.isEmpty());
     }
     
     public void testEnableFragmentBeforeItsHost() throws Exception {
@@ -2858,6 +2880,170 @@ public class ModuleManagerTest extends SetupHid {
         }
     }
 
+    public void testAutoloadHostWithFragmentsDoesNotRun() throws Exception {
+        MockModuleInstaller installer = new MockModuleInstaller();
+        MockEvents ev = new MockEvents();
+        ModuleManager mgr = new ModuleManager(installer, ev);
+        mgr.mutexPrivileged().enterWriteAccess();
+
+        createTestJAR(data, jars, "client-module", null);
+
+        Module host = mgr.create(new File(jars, "host-module.jar"), null, false, true, false);
+        Module fragment = mgr.create(new File(jars, "fragment-module.jar"), null, false, true, false);
+        
+        Module client = mgr.create(new File(jars, "client-module.jar"), null, false, false, false);
+        
+        mgr.enable(client);
+
+        assertFalse("Host can't enable always", mgr.getEnabledModules().contains(host));
+        assertFalse("Fragment must not be enabled", mgr.getEnabledModules().contains(fragment));
+    }
+    
+    
+    public void testAutoloadFragmentEnablesHostAndPeers() throws Exception {
+        ModsCreator c = new ModsCreator();
+        createTestJAR(data, jars, "client-module-depend-frag", "client-module");
+        c.loadModules();
+        
+        Module client = c.mgr.create(new File(jars, "client-module-depend-frag.jar"), null, false, false, false);
+        c.mgr.enable(client);
+
+        c.checkHostAndOtherFragmentsLoaded(c.fragmentAutoload);
+    }
+    
+    public void testAutoloadHostEnablesAllFragments() throws Exception {
+        ModsCreator c = new ModsCreator();
+        createTestJAR(data, jars, "client-module-depend-host", "client-module");
+        c.loadModules();
+        
+        Module client = c.mgr.create(new File(jars, "client-module-depend-host.jar"), null, false, false, false);
+        c.mgr.enable(client);
+
+        c.checkHostAndOtherFragmentsLoaded(c.host);
+    }
+    
+    public void testBrokenAutoloadFragmentDepend() throws Exception {
+        MockModuleInstaller installer = new MockModuleInstaller();
+        MockEvents ev = new MockEvents();
+        ModuleManager mgr = new ModuleManager(installer, ev);
+        mgr.mutexPrivileged().enterWriteAccess();
+
+        createTestJAR(data, jars, "client-module-depend-broken", "client-module");
+        createTestJAR(data, jars, "fragment-module-missing-token", null);
+
+        Module host = mgr.create(new File(jars, "host-module.jar"), null, false, false, false);
+        Module fragment = mgr.create(new File(jars, "fragment-module-missing-token.jar"), null, false, false, true);
+        Module client = mgr.create(new File(jars, "client-module-depend-broken.jar"), null, false, false, false);
+        
+        try {
+            mgr.enable(client);
+        } catch (IllegalModuleException ex) {
+            assertTrue(ex.getMessage().contains("org.foo.client"));
+        }
+        
+        assertFalse(mgr.getEnabledModules().contains(host));
+        assertFalse(mgr.getEnabledModules().contains(fragment));
+        assertFalse(mgr.getEnabledModules().contains(client));
+    }
+
+    public void testBrokenAutoloadFragmentNeeds() throws Exception {
+        MockModuleInstaller installer = new MockModuleInstaller();
+        MockEvents ev = new MockEvents();
+        ModuleManager mgr = new ModuleManager(installer, ev);
+        mgr.mutexPrivileged().enterWriteAccess();
+
+        createTestJAR(data, jars, "client-module-needs-broken", "client-module");
+        createTestJAR(data, jars, "fragment-module-missing-token", null);
+
+        Module host = mgr.create(new File(jars, "host-module.jar"), null, false, false, false);
+        Module fragment = mgr.create(new File(jars, "fragment-module-missing-token.jar"), null, false, false, true);
+        Module client = mgr.create(new File(jars, "client-module-needs-broken.jar"), null, false, false, false);
+        
+        try {
+            mgr.enable(client);
+        } catch (IllegalModuleException ex) {
+            assertTrue(ex.getMessage().contains("org.foo.client"));
+        }
+        
+        assertFalse(mgr.getEnabledModules().contains(host));
+        assertFalse(mgr.getEnabledModules().contains(fragment));
+        assertFalse(mgr.getEnabledModules().contains(client));
+    }
+
+    private class LogHandler extends Handler {
+        private List<LogRecord> warnings = new ArrayList<>();
+        @Override
+        public void publish(LogRecord record) {
+            if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+                warnings.add(record);
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+        }
+    }
+    
+    private class ModsCreator {
+        private final ModuleManager mgr;
+        
+        private Module host;
+        private Module fragmentService;
+        private Module fragmentBroken;
+        private Module fragmentAutoload;
+        private Module fragmentRegular;
+        
+        private List<Module> liveFragments = new ArrayList<>();
+
+        public ModsCreator() {
+            MockModuleInstaller installer = new MockModuleInstaller();
+            MockEvents ev = new MockEvents();
+            mgr = new ModuleManager(installer, ev);
+            mgr.mutexPrivileged().enterWriteAccess();
+        }
+        
+        void loadModules() throws Exception {
+            
+            createTestJAR(data, jars, "fragment-module-reg", "fragment-module");
+            createTestJAR(data, jars, "fragment-module-auto", "fragment-module");
+            createTestJAR(data, jars, "fragment-module-missing-token", "fragment-module");
+
+            if (host == null) {
+                host = mgr.create(new File(jars, "host-module.jar"), null, false, true, false);
+            }
+            if (fragmentService == null) {
+                fragmentService = mgr.create(new File(jars, "fragment-module.jar"), null, false, true, false);
+            }
+            if (fragmentRegular == null) {
+                fragmentRegular = mgr.create(new File(jars, "fragment-module-reg.jar"), null, false, false, false);
+            }
+            if (fragmentAutoload == null) {
+                fragmentAutoload = mgr.create(new File(jars, "fragment-module-auto.jar"), null, false, true, false);
+            }
+            if (fragmentBroken == null) {
+                fragmentBroken = mgr.create(new File(jars, "fragment-module-missing-token.jar"), null, false, true, false);
+            }
+            liveFragments.add(fragmentService);
+            liveFragments.add(fragmentRegular);
+            liveFragments.add(fragmentAutoload);
+        }
+        
+        void checkHostAndOtherFragmentsLoaded(Module pickedDep) {
+            assertTrue("Fragment host must enable", mgr.getEnabledModules().contains(host));
+            for (Module m : liveFragments) {
+                if (m != pickedDep) {
+                    assertTrue("Peer fragment must be autoloaded", mgr.getEnabledModules().contains(m));
+                }
+            }
+            // the fragment with unsatisfied "needs" is not reported, as it is autoload being triggered by host module.
+            assertTrue(logHandler.warnings.isEmpty());
+        }
+    }
+    
     private File copyJar(File file, String manifest) throws IOException {
         File ret = File.createTempFile(file.getName(), "2ndcopy", file.getParentFile());
         JarFile jar = new JarFile(file);
@@ -2897,4 +3083,4 @@ public class ModuleManagerTest extends SetupHid {
         assertTrue(token + " is not among the list of provides of module " + m + " which is " + arr, ok);
         return arr;
     }
-}
+    }

--- a/platform/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateModulesTest.java
+++ b/platform/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateModulesTest.java
@@ -32,12 +32,17 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.SimpleFormatter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.netbeans.Module;
 import org.netbeans.ModuleManager;
+import org.netbeans.Util;
 import org.netbeans.core.startup.AutomaticDependencies;
 import org.netbeans.core.startup.ConsistencyVerifier;
 import org.netbeans.core.startup.Main;
@@ -53,7 +58,7 @@ public class ValidateModulesTest extends NbTestCase {
     static {
         System.setProperty("java.awt.headless", "true");
     }
-
+    
     public ValidateModulesTest(String n) {
         super(n);
     }
@@ -77,7 +82,7 @@ public class ValidateModulesTest extends NbTestCase {
                 clusters("platform|harness|ide|extide").enableModules(".*").honorAutoloadEager(true).gui(false).enableClasspathModules(false).suite());
         return suite;
     }
-
+    
     public void testInvisibleModules() throws Exception {
         Set<Manifest> manifests = loadManifests();
         Set<String> requiredBySomeone = new HashSet<String>();
@@ -143,6 +148,9 @@ public class ValidateModulesTest extends NbTestCase {
     }
 
     public void testConsistency() throws Exception {
+        LogHandler h = new LogHandler();
+        Util.err.addHandler(h);
+        
         Set<Manifest> manifests = loadManifests();
         SortedMap<String,SortedSet<String>> problems = ConsistencyVerifier.findInconsistencies(manifests, null);
         if (!problems.isEmpty()) {
@@ -197,6 +205,12 @@ public class ValidateModulesTest extends NbTestCase {
                     }
                 }
                 message.append("\nProblems found for module ").append(entry.getKey()).append(": ").append(entry.getValue());
+            }
+            if (!h.warnings.isEmpty()) {
+                message.append("\nWarnings were logged: ");
+                for (LogRecord lr : h.warnings) {
+                    message.append("\n").append(new SimpleFormatter().format(lr));
+                }
             }
             if (message.length() == 0) {
                 return;
@@ -303,4 +317,23 @@ public class ValidateModulesTest extends NbTestCase {
         }
     }
 
+    class LogHandler extends Handler {
+        List<LogRecord> warnings = new ArrayList<>();
+        
+        @Override
+        public void publish(LogRecord record) {
+            if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+                warnings.add(record);
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+        }
+        
+    }
 }


### PR DESCRIPTION
The `netbeans.libs.javafx.*` library family print warnings on startup. There are several such libraries, each providing `org.openide.modules.jre.JavaFX`, but with `OpenIDE-Module-Needs: ` that demands a specific OS. Since they are `autoload`, they do not activate on their own on startup (c.f. eager and regular modules), but only when demanded.

Some other module depends on the provided token, enabling the (autoload) fragment. The fragment enables its host (also autoload), and the host attempts to load all the remaining fragments. Since the other autoloads have unsatisfied dependencies, a warning is printed to the log - quite bloated:

```
WARNING [org.netbeans.core.modules]: Module StandardModule:org.netbeans.libs.javafx.macosx jarFile: /space/src/nb/apache/github/incubator-netbeans/nbbuild/netbeans/extra/modules/org-netbeans-libs-javafx-macosx.jar had unexpected problems: [Java > 11, needs org.openide.modules.os.MacOSX] (willEnable: [Netigso: /space/src/nb/apache/github/incubator-netbeans/nbbuild/netbeans/ide/modules/com-google-gson.jar, Netigso: /space/src/nb/apache/github/incubator-netbeans/nbbuild/netbeans/platform/modules/org-apache-commons-codec.jar, Netigso: /space/src/nb/apache/github/incubator-netbeans/nbbuild/netbeans/platform/modules/org-apache-commons-logging.jar, StandardModule:org.apache.tools.ant.module jarFile: /space/src/nb/apache/github/incubator-netbeans/nbbuild/netbeans/extide/modules/org-apache-tools-ant-module.jar, StandardModule:org.apache.xml.resolver jarFile: /space/src/nb/apache/github/incubator-netbeans/nbbuild/netbeans/ide/modules/org-
....
```
plus complete module configuration.

This warning was originally an assert, up to [NETBEANS-1481](https://issues.apache.org/jira/browse/NETBEANS-1481), but still is rather a diagnostic warning that we should avoid: the scenario used by `javafx` implementation is IMHO +- valid.

This PR disables the warning in the case the autoload fragment is enabled **by its host module**. The warning (or other messages) will be still printed if the module enables from different source, i.e. the only provider for a token, or a direct dependency.

The bad thing is that we **do not have** a mechanism that would only enable a fragment if someone needs it (true autoload); the current autoload fragments are "somewhat eager" because they all attempt to load whenever their host is loaded. I tried to find a way how to enable the "true" autoload behaviour, but it could probably break the existing code -- the runtime behaviour in 11 and 12 was  (attempt) to load all fragments.

I have added some tests to fix the current de-facto behaviour and check the logs that no warning is printed.