### PR TITLE
[NETBEANS-4762] Fixing Lombok in Gradle Projects

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
@@ -69,8 +69,7 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
             MODULE_COMPILE_PATH,
             MODULE_CLASS_PATH,
             MODULE_EXECUTE_PATH,
-            MODULE_EXECUTE_CLASS_PATH,
-            MODULE_PROCESSOR_PATH
+            MODULE_EXECUTE_CLASS_PATH
     ));
 
 
@@ -80,29 +79,25 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
 
     public ClassPathProviderImpl(Project project) {
         this.project = project;
-        this.pcl = new PropertyChangeListener() {
+        this.pcl = (PropertyChangeEvent evt) -> {
+            if (NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())) {
+                GradleJavaProject p = GradleJavaProject.get(ClassPathProviderImpl.this.project);
+                if (p != null) {
+                    updateGroups(p.getSourceSets().keySet());
+                } else {
+                    //We are no longer a Java Project
+                    updateGroups(Collections.<String>emptySet());
 
-            @Override
-            public void propertyChange(PropertyChangeEvent evt) {
-                if (NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())) {
-                    GradleJavaProject p = GradleJavaProject.get(ClassPathProviderImpl.this.project);
-                    if (p != null) {
-                        updateGroups(p.getSourceSets().keySet());
-                    } else {
-                        //We are no longer a Java Project
-                        updateGroups(Collections.<String>emptySet());
-
-                    }
                 }
-                if (NbGradleProject.PROP_RESOURCES.endsWith(evt.getPropertyName())) {
-                    URI uri = (URI) evt.getNewValue();
-                    if ((uri != null) && (uri.getPath() != null) && uri.getPath().endsWith(MODULE_INFO_JAVA)) {
-                        GradleJavaProject gjp = GradleJavaProject.get(ClassPathProviderImpl.this.project);
-                        if (gjp != null) {
-                            GradleJavaSourceSet ss = gjp.containingSourceSet(Utilities.toFile(uri));
-                            if ((ss != null) && (groups.get(ss.getName()) != null)) {
-                                groups.get(ss.getName()).reset();
-                            }
+            }
+            if (NbGradleProject.PROP_RESOURCES.endsWith(evt.getPropertyName())) {
+                URI uri = (URI) evt.getNewValue();
+                if ((uri != null) && (uri.getPath() != null) && uri.getPath().endsWith(MODULE_INFO_JAVA)) {
+                    GradleJavaProject gjp = GradleJavaProject.get(ClassPathProviderImpl.this.project);
+                    if (gjp != null) {
+                        GradleJavaSourceSet ss = gjp.containingSourceSet(Utilities.toFile(uri));
+                        if ((ss != null) && (groups.get(ss.getName()) != null)) {
+                            groups.get(ss.getName()).reset();
                         }
                     }
                 }
@@ -199,7 +194,6 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
                 case MODULE_EXECUTE_CLASS_PATH: return getModuleLegacyRuntimeClassPath();
 
                 case PROCESSOR_PATH: return getJava8AnnotationProcessorPath();
-                case MODULE_PROCESSOR_PATH: return getModuleAnnotationProcessorPath();
 
                 default: return null;
             }
@@ -316,14 +310,6 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
                 moduleCompile = createMultiplexClassPath(getJava8CompileClassPath(), ClassPath.EMPTY);
             }
             return moduleCompile;
-        }
-
-        private synchronized ClassPath getModuleAnnotationProcessorPath() {
-            if (moduleAnnotationProcessor == null) {
-                //TODO: This one is pretty identical to the Java8 annotation processor path, maybe it should be removed?
-                moduleAnnotationProcessor = createMultiplexClassPath(getJava8AnnotationProcessorPath(), getJava8AnnotationProcessorPath());
-            }
-            return moduleAnnotationProcessor;
         }
 
         private ClassPath createMultiplexClassPath(ClassPath modulePath, ClassPath classPath) {


### PR DESCRIPTION
It seems supporting MODULE_PROCESSOR_PATH in Gradle breaks annotation processor detection.
I've checked, the Maven plugin does not support this classpath, as well as the support is new in 12.1 for Gradle

See: https://github.com/apache/netbeans/blob/a04b626ec6293b4f0e3006a726ffcc121a2af313/java/java.source.base/src/org/netbeans/modules/java/source/indexing/APTUtils.java#L392

here decided if the MODULE_PROCESSOR_PATH is provided the isModule is true and NB tries to read the information through the Module however that does not provide the Lombok service providers. It maybe a bug in our Module implementation or a bug in Lombok

This PR just simply removes the support of MODULE_PROCESSOR_PATH from the classpath implementation for Gradle.