### PR TITLE
Avoid NPE in BridgingIOProvider when using null color

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
@@ -199,7 +199,7 @@ public final class RunUtils {
                 new ProxyNonSelectableInputOutput(io));
         if (initialOutput != null) {
             try {
-                if (IOColorPrint.isSupported(io)) {
+                if (IOColorPrint.isSupported(io) && IOColors.isSupported(io)) {
                     IOColorPrint.print(io, initialOutput, IOColors.getColor(io, IOColors.OutputType.LOG_DEBUG));
                 } else {
                     io.getOut().println(initialOutput);

--- a/platform/openide.io/src/org/openide/io/BridgingIOProvider.java
+++ b/platform/openide.io/src/org/openide/io/BridgingIOProvider.java
@@ -22,7 +22,6 @@ import java.awt.Color;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Reader;
-import java.io.StringWriter;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.logging.Level;
@@ -236,7 +235,7 @@ public class BridgingIOProvider<IO, S extends PrintWriter, P, F>
         private final IO ioDelegate;
 
         public BridgingOutputWriter(IO ioDelegate, S delegate) {
-            super(new StringWriter());
+            super(delegate);
             this.writerDelegate = delegate;
             this.ioDelegate = ioDelegate;
         }
@@ -294,9 +293,10 @@ public class BridgingIOProvider<IO, S extends PrintWriter, P, F>
                 boolean important, Color color) throws IOException {
 
             Hyperlink h = listenerToHyperlink(listener, important);
+            final OutputColor outColor = color == null ? null : OutputColor.rgb(color.getRGB());
             providerDelegate.print(ioDelegate,
                     providerDelegate.getOut(ioDelegate), text.toString(),
-                    h, OutputColor.rgb(color.getRGB()), false);
+                    h, outColor, false);
         }
     }
 

--- a/platform/openide.io/test/unit/src/org/openide/io/BridgingIOProviderTest.java
+++ b/platform/openide.io/test/unit/src/org/openide/io/BridgingIOProviderTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.io;
+
+import java.awt.Color;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.Writer;
+import java.util.Set;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.netbeans.api.io.Hyperlink;
+import org.netbeans.api.io.OutputColor;
+import org.netbeans.api.io.ShowOperation;
+import org.netbeans.spi.io.InputOutputProvider;
+import org.openide.util.Lookup;
+import org.openide.windows.IOColorPrint;
+import org.openide.windows.IOColors;
+import org.openide.windows.IOProvider;
+import org.openide.windows.InputOutput;
+import org.openide.windows.OutputWriter;
+
+public class BridgingIOProviderTest {
+
+    public BridgingIOProviderTest() {
+    }
+
+    @Test
+    public void bridgeToPrint() {
+        MockIOP mock = new MockIOP();
+        IOProvider provider = BridgingIOProvider.create(mock);
+        InputOutput io = provider.getIO("test", true);
+        StringBuilder sb = mock.assertBuilder();
+        final OutputWriter stdOut = io.getOut();
+        stdOut.println("Hello there!");
+        assertEquals("Hello there!\n", sb.toString());
+    }
+
+    @Test
+    public void bridgeToColorLessProvider() throws IOException {
+        MockIOP mock = new MockIOP();
+        IOProvider provider = BridgingIOProvider.create(mock);
+        InputOutput io = provider.getIO("test", true);
+        assertFalse("No colors", IOColors.isSupported(io));
+        assertTrue("Color print supported!?", IOColorPrint.isSupported(io));
+        IOColorPrint.print(io, "Red!", Color.RED);
+        StringBuilder sb = mock.assertBuilder();
+        assertEquals("Red!", sb.toString());
+    }
+
+    @Test
+    public void bridgeToNullColor() throws IOException {
+        MockIOP mock = new MockIOP();
+        IOProvider provider = BridgingIOProvider.create(mock);
+        InputOutput io = provider.getIO("test", true);
+        assertFalse("No colors", IOColors.isSupported(io));
+        assertTrue("Color print supported!?", IOColorPrint.isSupported(io));
+        IOColorPrint.print(io, "Null!", null);
+        StringBuilder sb = mock.assertBuilder();
+        assertEquals("Null!", sb.toString());
+    }
+
+    private static class MockBuilder {
+        final StringBuilder io = new StringBuilder();
+        final PrintWriter out = new PrintWriter(new AppendWriter(io));
+    }
+
+    private static final class MockIOP implements InputOutputProvider<MockBuilder, PrintWriter, Void, Void> {
+        private MockBuilder last;
+
+        public StringBuilder assertBuilder() {
+            try {
+                assertNotNull(last);
+                return last.io;
+            } finally {
+                last = null;
+            }
+        }
+
+        @Override
+        public String getId() {
+            return "mock";
+        }
+
+        @Override
+        public MockBuilder getIO(String name, boolean newIO, Lookup lookup) {
+            assertNull(last);
+            last = new MockBuilder();
+            return last;
+        }
+
+        @Override
+        public Reader getIn(MockBuilder io) {
+            return new StringReader(io.toString());
+        }
+
+        @Override
+        public PrintWriter getOut(MockBuilder io) {
+            return io.out;
+        }
+
+        @Override
+        public PrintWriter getErr(MockBuilder io) {
+            return io.out;
+        }
+
+        @Override
+        public void print(MockBuilder io, PrintWriter writer, String text, Hyperlink link, OutputColor color, boolean printLineEnd) {
+            if (printLineEnd) {
+                writer.println(text);
+            } else {
+                writer.print(text);
+            }
+        }
+
+        @Override
+        public Lookup getIOLookup(MockBuilder io) {
+            return Lookup.EMPTY;
+        }
+
+        @Override
+        public void resetIO(MockBuilder io) {
+        }
+
+        @Override
+        public void showIO(MockBuilder io, Set<ShowOperation> operations) {
+        }
+
+        @Override
+        public void closeIO(MockBuilder io) {
+        }
+
+        @Override
+        public boolean isIOClosed(MockBuilder io) {
+            return false;
+        }
+
+        @Override
+        public Void getCurrentPosition(MockBuilder io, PrintWriter writer) {
+            return null;
+        }
+
+        @Override
+        public void scrollTo(MockBuilder io, PrintWriter writer, Void position) {
+        }
+
+        @Override
+        public Void startFold(MockBuilder io, PrintWriter writer, boolean expanded) {
+            return null;
+        }
+
+        @Override
+        public void endFold(MockBuilder io, PrintWriter writer, Void fold) {
+        }
+
+        @Override
+        public void setFoldExpanded(MockBuilder io, PrintWriter writer, Void fold, boolean expanded) {
+        }
+
+        @Override
+        public String getIODescription(MockBuilder io) {
+            return "mock";
+        }
+
+        @Override
+        public void setIODescription(MockBuilder io, String description) {
+        }
+    }
+
+    private static final class AppendWriter extends Writer {
+        private final StringBuilder io;
+
+        private AppendWriter(StringBuilder io) {
+            this.io = io;
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            io.append(cbuf, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+
+    }
+}


### PR DESCRIPTION
I've got a `NullPointerException` while working on [java.lsp.server debugging](https://github.com/JaroslavTulach/netbeans/tree/java-lsp-server-debugging-attempt2):
```
java.lang.NullPointerException
        at org.openide.io.BridgingIOProvider$BridgingIOColorPrint.print(BridgingIOProvider.java:299)
        at org.openide.windows.IOColorPrint.print(IOColorPrint.java:68)
        at org.netbeans.modules.gradle.api.execute.RunUtils.executeGradleImpl(RunUtils.java:206)
        at org.netbeans.modules.gradle.api.execute.RunUtils.executeGradle(RunUtils.java:123)
        at org.netbeans.modules.gradle.ActionProviderImpl.invokeProjectAction(ActionProviderImpl.java:266)
        at org.netbeans.modules.gradle.ActionProviderImpl.invokeAction(ActionProviderImpl.java:137)
        at org.netbeans.modules.java.lsp.server.debugging.launch.NbLaunchDelegate.lambda$nbLaunch$0(NbLaunchDelegate.java:115)
```
The problem is that `BridgingIOProvider` isn't ready for `null` color. This PR fixes it and adds some unit tests that, for example discover unexpected usage of `new StringWriter()` in bridging `OutputWriter` constructor!?

In addition to that I've added a check into Gradle code to verify that both `IOColorPrint` and `IOColors` are supported.