### PR TITLE
Add asf.yaml file to ease configuration

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+github:
+  description: "Apache NetBeans"
+  homepage: https://netbeans.apache.org/
+  labels:
+    - netbeans
+  features:
+    wiki: false
+    issues: false
+    projects: false
+  enabled_merge_buttons:
+    squash:  true
+    merge:   true
+    rebase:  true
+notifications:
+    commits:      commits@netbeans.apache.org
+    issues:       notifications@netbeans.apache.org
+    pullrequests: notifications@netbeans.apache.org
+    jira_options: link label worklog


### PR DESCRIPTION
According to current configuraiotn https://gitbox.apache.org/schemes.cgi?netbeans we only put PR in the worklog.

I guess that previously we had a label showing pr available. So using asf.yaml file from infra to get it again + configuration

label: Add a 'pull-request-available' label to referenced tickets.
link: Add a link to the GitHub PR/issue when it's opened to the referenced Jira ticket.
