### PR TITLE
[NETBEANS-4840] - Fix NullPointerException when activating plugins

### DIFF
--- a/platform/o.n.bootstrap/src/org/netbeans/Util.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Util.java
@@ -287,11 +287,11 @@ public final class Util {
                     for (Dependency dep : f.getDependenciesArray()) {
                         if (dep.getType() == Dependency.TYPE_REQUIRES) {
                             Collection<Module> providers = providersOf.get(dep.getName());
-                            if (providers.contains(m1)) {
-                                providers = new ArrayList<>(providers);
-                                providers.remove(m1);
-                            }
                             if (providers != null) {
+                                if (providers.contains(m1)) {
+                                    providers = new ArrayList<>(providers);
+                                    providers.remove(m1);
+                                }
                                 l = fillMapSlot(m, m1);
                                 l.addAll(providers);
                             }


### PR DESCRIPTION
Fresh build of current master and then try to activate any of the java related plugins will end in a `java.lang.NullPointerException`.

Plugins that fail to activate:
- Developing NetBeans
- Groovy
- JavaFX2
- Java SE
- Java Web and EE

This was integrated by [PR-2390](https://github.com/apache/netbeans/pull/2390). 

Do not know if there is a special way of handling this operation that @sdedic would need. 