### PR TITLE
[NETBEANS-4832] Avoid assertion & NPE in fxml code completion

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/ElementUtils.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/ElementUtils.java
@@ -60,6 +60,11 @@ public class ElementUtils {
         for (ModuleElement me : allModules) {
             TypeElement found = getTypeElementByBinaryName(task, me, name);
 
+            if (result == found) {
+                // avoid returning null, partial fix for [NETBEANS-4832]
+                continue;
+            }
+
             if (found != null) {
                 if ((ModuleSymbol) me == syms.unnamedModule) {
                     foundInUnamedModule = true;

--- a/java/java.source.base/src/org/netbeans/modules/java/source/ElementUtils.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/ElementUtils.java
@@ -72,7 +72,7 @@ public class ElementUtils {
                 if (result != null) {
                     if (foundInUnamedModule == true) {
                         for (TypeElement elem : new TypeElement[]{result, found}) {
-                            if ((elem.getKind() == ElementKind.CLASS || elem.getKind() == ElementKind.INTERFACE)
+                            if ((elem.getKind().isClass() || elem.getKind().isInterface())
                                     && (((ClassSymbol) elem).packge().modle != syms.unnamedModule)) {
                                 return elem;
                             }

--- a/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/FXMLCompletion2.java
+++ b/javafx/javafx2.editor/src/org/netbeans/modules/javafx2/editor/FXMLCompletion2.java
@@ -30,7 +30,8 @@ import javax.xml.parsers.SAXParserFactory;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.api.java.source.ClasspathInfo;
-import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.CompilationController;
+import org.netbeans.api.java.source.JavaSource.Phase;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.java.source.parsing.ClasspathInfoProvider;
@@ -131,7 +132,7 @@ public class FXMLCompletion2 implements CompletionProvider {
             private int queryType;
             private boolean fxmlParsing = true;
             private CompletionContext ctx;
-            private CompilationInfo ci;
+            private CompilationController cc;
             private FxmlParserResult fxmlResult;
 
             public Task(ClasspathInfo cpInfo, JTextComponent component, CompletionResultSet resultSet, Document doc, int caretOffset, int queryType) {
@@ -160,7 +161,9 @@ public class FXMLCompletion2 implements CompletionProvider {
                     return;
                 }
                 Parser.Result result = resultIterator.getParserResult();
-                ci = CompilationInfo.get(result);
+                // [NETBEANS-4832] CompController (not CompInfo) for module info (partial fix)
+                cc = CompilationController.get(result);
+                cc.toPhase(Phase.ELEMENTS_RESOLVED);
 
                 ctx = new CompletionContext(doc, caretOffset, queryType);
 
@@ -171,7 +174,7 @@ public class FXMLCompletion2 implements CompletionProvider {
                 // bug in parsing API: snapshot source not modified just after modification to the source file
                 try {
                     TokenHierarchy<?> th = TokenHierarchy.get(doc);
-                    ctx.init(th, ci, fxmlResult); 
+                    ctx.init(th, cc, fxmlResult); 
                 } finally {
                     if (doc instanceof AbstractDocument) {
                         ((AbstractDocument)doc).readUnlock();


### PR DESCRIPTION
@sdedic could you take a look at this fix.

The assertion was due to CompilerInfo not having a list of modules. Fixed in `FXMLCompletion2.Q.Taks.run` with the getPackageElement:
```
    ci = CompilationInfo.get(result);
    // following populates module info, partial fix for [NETBEANS-4832]
    ci.getElements().getPackageElement("java.lang");
```

This fixed code completion inside an UI element, for example<Label.../>"

However there was an NPE inside a list, for example in`<children>...</children>`. This was fixed by what looks like a bug/oversight in `ElementUtils.getTypeElementByBinaryName`.

In FxIncludeCompleter.createCompleter
```
    TypeMirror tm = prop.getType().resolve(ctx.getCompilationInfo());
```
returned null which causes NPE in jdk.  fixed by the identity check in
```
    ElementUtils.getTypeElementByBinaryName
```
