### PR TITLE
[NETBEANS-4844] Non-empy modulebootpath shall be provided for non-modular code as well.

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
@@ -299,8 +299,7 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
 
         private synchronized ClassPath getModuleBoothPath() {
             if (moduleBoot == null) {
-                //TODO: Is this Ok? Made after the Maven's ClassPathProviderImpl.getModuleBootPath
-                moduleBoot = createMultiplexClassPath(getPlatformModulesPath(), getPlatformModulesPath());
+                moduleBoot = createMultiplexClassPath(getPlatformModulesPath(), getBootClassPath());
             }
             return moduleBoot;
         }


### PR DESCRIPTION
Well it seems even a non modular project is required to fill out the moduleBoot as
https://github.com/apache/netbeans/blob/5743f22f60aac775a0a2ebb3c8a8f6d6be39ac45/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java#L1134
checks that for detecting Java 9 and up