### PR TITLE
[NETBEANS-4848] Use compile classpath as annotation path before Gradle 5.0

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/groovy/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.groovy
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/groovy/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.groovy
@@ -252,6 +252,11 @@ class NbProjectInfoBuilder {
                         }
                         model.info["sourceset_${sourceSet.name}_configuration_annotation"] = sourceSet.annotationProcessorConfigurationName;
                     }
+                    beforeGradle('5.0') {
+                        if (model.info["sourceset_${sourceSet.name}_classpath_annotation"] == null || model.info["sourceset_${sourceSet.name}_classpath_annotation"].isEmpty()) {
+                            model.info["sourceset_${sourceSet.name}_classpath_annotation"] = storeSet(sourceSet.compileClasspath.files)
+                        }
+                    }
                     model.info["sourceset_${sourceSet.name}_configuration_compile"] = sourceSet.compileConfigurationName;
                     model.info["sourceset_${sourceSet.name}_configuration_runtime"] = sourceSet.runtimeConfigurationName;
                 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
@@ -96,7 +96,7 @@ public final class GradleProjectCache {
     private static final Map<File, Set<File>> SUB_PROJECT_DIR_CACHE = new ConcurrentHashMap<>();
 
     // Increase this number if new info is gathered from the projects.
-    private static final int COMPATIBLE_CACHE_VERSION = 14;
+    private static final int COMPATIBLE_CACHE_VERSION = 15;
 
     private GradleProjectCache() {
     }


### PR DESCRIPTION
The annotationProcessorPath has been introduced in Gradle 4.6 as a replacement of compileClasspath for annotation processors. The usage of the compile classpath quickly become deprecated in Gradle 4.7. Gradle 5.0 and above does not accept annotation processors on compile classpath. 
NetBeans 12.0 supports the annotationProcessorPath, though it breaks the compatibility with pre-Gradle 5.0 projects. This PR adds that compatibility back.