### PR TITLE
[NETBEANS-4854] - Fix wrong classpaths

### DIFF
--- a/enterprise/web.freeform/nbproject/project.properties
+++ b/enterprise/web.freeform/nbproject/project.properties
@@ -15,13 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.6
-javac.compilerargs=-Xlint:unchecked
+javac.source=1.8
+javac.compilerargs=-Xlint -Xlint:-serial
 
 javadoc.arch=${basedir}/arch.xml
 
-test-unit-sys-prop.xtest.data=${nb_all}/ant.freeform/test/unit/data
-test.unit.data.dir=${nb_all}/ant.freeform/test/unit/data
+test-unit-sys-prop.xtest.data=${nb_all}/java/ant.freeform/test/unit/data
+test.unit.data.dir=${nb_all}/java/ant.freeform/test/unit/data
 test-unit-sys-prop.test.ant.home=${o.apache.tools.ant.module.dir}/ant
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/db/nbproject/project.properties
+++ b/ide/db/nbproject/project.properties
@@ -38,7 +38,7 @@ lib.cp=\
 
 
 test.unit.cp.extra=\
-    ${nb_all}/db/external/derby-10.14.2.0.jar
+    ${nb_all}/ide/db/external/derby-10.14.2.0.jar
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/java/java.project.ui/nbproject/project.properties
+++ b/java/java.project.ui/nbproject/project.properties
@@ -29,7 +29,7 @@ test.unit.run.cp.extra=${tools.jar}
 test-unit-sys-prop.test.bridge.jar=${o.apache.tools.ant.module.dir}/ant/nblib/bridge.jar
 # May be overridden to e.g. test against a different version of Ant:
 test-unit-sys-prop.test.ant.home=${o.apache.tools.ant.module.dir}/ant
-test-unit-sys-prop.test.junit.jar=${nb_all}/libs.junit4/external/junit-4.12.jar
+test-unit-sys-prop.test.junit.jar=${nb_all}/platform/libs.junit4/external/junit-4.12.jar
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/java/java.project.ui/test/qa-functional/src/projects/LibrariesTest.java
+++ b/java/java.project.ui/test/qa-functional/src/projects/LibrariesTest.java
@@ -182,9 +182,8 @@ public class LibrariesTest extends JellyTestCase {
         set.add("jar:nbinst://org.netbeans.modules.web.struts/modules/ext/struts/struts.jar!/");
         librariesUrls.put("struts", set);
         set = new TreeSet<String>();
-        set.add("jar:nbinst://org.netbeans.modules.junit/docs/junit-3.8.2-api.zip!/");
-        set.add("jar:nbinst://org.netbeans.modules.junit/modules/ext/junit-3.8.2.jar!/");
-        set.add("jar:nbinst://org.netbeans.modules.junit/modules/ext/junit-4.1.jar!/");
+        set.add("jar:nbinst://org.netbeans.modules.junit/docs/junit-4.12-javadoc.jar!/");
+        set.add("jar:nbinst://org.netbeans.modules.junit/modules/ext/junit-4.12.jar!/");
         librariesUrls.put("junit", set);
         set = new TreeSet<String>();
         set.add("jar:nbinst://org.netbeans.modules.java.j2seproject/ant/extra/org-netbeans-modules-java-j2seproject-copylibstask.jar!/");

--- a/java/java.project/nbproject/project.properties
+++ b/java/java.project/nbproject/project.properties
@@ -28,7 +28,7 @@ test.unit.run.cp.extra=${tools.jar}
 test-unit-sys-prop.test.bridge.jar=${o.apache.tools.ant.module.dir}/ant/nblib/bridge.jar
 # May be overridden to e.g. test against a different version of Ant:
 test-unit-sys-prop.test.ant.home=${o.apache.tools.ant.module.dir}/ant
-test-unit-sys-prop.test.junit.jar=${nb_all}/libs.junit4/external/junit-4.12.jar
+test-unit-sys-prop.test.junit.jar=${nb_all}/platform/libs.junit4/external/junit-4.12.jar
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -409,7 +409,7 @@ metabuild.hash=${metabuild.hash}</echo>
       <taskdef name="checkhelpsetsbin" classname="org.netbeans.nbbuild.CheckHelpSetsBin">
         <classpath>
           <pathelement location="${nbantext.jar}"/>
-            <fileset dir="${nb_all}/javahelp/external">
+            <fileset dir="${nb_all}/platform/javahelp/external">
               <include name="jh*.jar"/>
             </fileset>
         </classpath>
@@ -1275,9 +1275,9 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
   <target name="hg-l10n-kit">
     <property name="l10n.kit" location="${nb.build.dir}/l10n.zip"/>
     <zip destfile="${l10n.kit}">
-        <fileset dir="${nb_all}" includesfile="${nb_all}/installer/l10n.list"/>
+        <fileset dir="${nb_all}" includesfile="${nb_all}/nbbuild/installer/l10n.list"/>
         <fileset dir="${nb_all}" includesfile="${nb_all}/nbi/l10n.list"/>
-        <fileset dir="${nb_all}" includesfile="${nb_all}/ide.branding/l10n.list"/>
+        <fileset dir="${nb_all}" includesfile="${nb_all}/nb/ide.branding/l10n.list"/>
     </zip>
   </target>
 

--- a/nbbuild/installer/jnlp/build.xml
+++ b/nbbuild/installer/jnlp/build.xml
@@ -77,7 +77,7 @@
                 <selector refid="no-extensions" />
             </fileset>
         </path>
-        <property location="${nb_all}/installer/jnlp/release/" name="dirname"/>
+        <property location="${nb_all}/nbbuild/installer/jnlp/release/" name="dirname"/>
         <!-- save directory name for replacing back -->
         <replace file="release/nb-launch.jnlp" token="${dirname}" value="D#I#R#_#N#A#M#E"/>
         <pathconvert dirsep="${file.separator}" pathsep="" property="jar-files-list" refid="jarfiles"/>

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -575,7 +575,7 @@ If you are sure you want to build with JDK 9+ anyway, use: -Dpermit.jdk9.builds=
         <taskdef name="checkhelpsets" classname="org.netbeans.nbbuild.CheckHelpSets">
             <classpath>
                 <pathelement location="${nbantext.jar}"/>
-                <fileset dir="${nb_all}/javahelp/external">
+                <fileset dir="${nb_all}/platform/javahelp/external">
                     <include name="jh*.jar"/>
                 </fileset>
             </classpath>

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/FixTestDependencies.properties
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/FixTestDependencies.properties
@@ -44,5 +44,5 @@ test.unit.run.cp.extra=\
     ${core/progress.dir}/modules/org-netbeans-api-progress.jar
 test-unit-sys-prop.test.bridge.jar=${cluster}/ant/nblib/bridge.jar
 test-unit-sys-prop.test.ant.home=${cluster}/ant
-test-unit-sys-prop.test.junit.jar=${junit.dir}/modules/ext/junit-3.8.2.jar
+test-unit-sys-prop.test.junit.jar=${junit.dir}/modules/ext/junit-4.12.jar
 extra.module.files=ant/extra/org-netbeans-modules-java-j2seproject-copylibstask.jar

--- a/nbbuild/test/unit/src/org/netbeans/nbbuild/FixTestDependenciesPass.properties
+++ b/nbbuild/test/unit/src/org/netbeans/nbbuild/FixTestDependenciesPass.properties
@@ -23,5 +23,5 @@ javadoc.arch=${basedir}/arch.xml
 test.unit.run.cp.extra=${tools.jar}
 test-unit-sys-prop.test.bridge.jar=${cluster}/ant/nblib/bridge.jar
 test-unit-sys-prop.test.ant.home=${cluster}/ant
-test-unit-sys-prop.test.junit.jar=${junit.dir}/modules/ext/junit-3.8.2.jar
+test-unit-sys-prop.test.junit.jar=${junit.dir}/modules/ext/junit-4.12.jar
 extra.module.files=ant/extra/org-netbeans-modules-java-j2seproject-copylibstask.jar

--- a/platform/core.osgi/nbproject/project.properties
+++ b/platform/core.osgi/nbproject/project.properties
@@ -23,7 +23,7 @@ cp.extra=\
 test.unit.cp.extra=\
     ${ant.core.lib}:\
     ${nbantext.jar}:\
-    ${nb_all}/javahelp/external/jhall-2.0_05.jar
+    ${nb_all}/platform/javahelp/external/jhall-2.0_05.jar
 test-unit-sys-prop.java.awt.headless=true
 test-unit-sys-prop.platform.dir=${cluster}
 #test.filter.trace=false

--- a/websvccommon/websvc.saas.codegen/nbproject/project.properties
+++ b/websvccommon/websvc.saas.codegen/nbproject/project.properties
@@ -22,4 +22,4 @@ test.unit.run.cp.extra=${tools.jar}
 test-unit-sys-prop.test.bridge.jar=${o.apache.tools.ant.module.dir}/ant/nblib/bridge.jar
 # May be overridden to e.g. test against a different version of Ant:
 test-unit-sys-prop.test.ant.home=${o.apache.tools.ant.module.dir}/ant
-test-unit-sys-prop.test.junit.jar=${nb_all}/libs.junit4/external/junit-4.12.jar
+test-unit-sys-prop.test.junit.jar=${nb_all}/platform/libs.junit4/external/junit-4.12.jar


### PR DESCRIPTION
[NETBEANS-4854](https://issues.apache.org/jira/browse/NETBEANS-4854)

NetBeans Testing:

- Full build done
- Started NetBeans and ensure the log didn't have any errors or new warnings
- Activate all plugins
- Test a maven and ant projects
- Checked every path changed in this PR was correct
