### PR TITLE
[NETBEANS-591] Cannot debug failed test method from Test results window

### DIFF
--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/resources/build-impl.xsl
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/resources/build-impl.xsl
@@ -2429,6 +2429,7 @@ exists or setup the property manually. For example like this:
             <target name="debug-test-method">
                 <xsl:attribute name="depends">init,compile-test-single,-debug-start-debugger-test,-debug-start-debuggee-test-method</xsl:attribute>
             </target>
+            <target name="debug-single-method" depends="debug-test-method" />
             
             <target name="-do-debug-fix-test">
                 <xsl:attribute name="if">netbeans.home</xsl:attribute>

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/resources/build-impl.xsl
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/resources/build-impl.xsl
@@ -2406,6 +2406,7 @@ exists or setup the property manually. For example like this:
             <target name="debug-test-method">
                 <xsl:attribute name="depends">init,compile-test-single,-debug-start-debugger-test,-debug-start-debuggee-test-method</xsl:attribute>
             </target>
+            <target name="debug-single-method" depends="debug-test-method" />
             
             <target name="-do-debug-fix-test">
                 <xsl:attribute name="if">netbeans.home</xsl:attribute>

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/resources/build-impl.xsl
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/resources/build-impl.xsl
@@ -2727,6 +2727,7 @@ exists or setup the property manually. For example like this:
             <target name="debug-test-method">
                 <xsl:attribute name="depends">init,compile-test-single,-debug-start-debugger-test,-debug-start-debuggee-test-method</xsl:attribute>
             </target>
+            <target name="debug-single-method" depends="debug-test-method" />
 
             <target name="-do-debug-fix-test">
                 <xsl:attribute name="if">netbeans.home</xsl:attribute>

--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/resources/build-impl.xsl
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/resources/build-impl.xsl
@@ -2576,6 +2576,7 @@ is divided into following sections:
             <target name="debug-test-method">
                 <xsl:attribute name="depends">init,compile-test-single,-init-test-run-module-properties,-debug-start-debugger-test,-debug-start-debuggee-test-method</xsl:attribute>
             </target>
+            <target name="debug-single-method" depends="debug-test-method" />
             
             <target name="-do-debug-fix-test">
                 <xsl:attribute name="if">netbeans.home</xsl:attribute>

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/resources/build-impl.xsl
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/resources/build-impl.xsl
@@ -3021,6 +3021,7 @@ is divided into following sections:
             <target name="debug-test-method">
                 <xsl:attribute name="depends">init,compile-test-single,-init-test-run-module-properties,-debug-start-debugger-test,-debug-start-debuggee-test-method</xsl:attribute>
             </target>
+            <target name="debug-single-method" depends="debug-test-method" />
             
             <target name="-do-debug-fix-test">
                 <xsl:attribute name="if">netbeans.home</xsl:attribute>


### PR DESCRIPTION
This commit adds the missing `debug-single-method` ant target which is
attached to "Debug Focused Test Method" menu item in Test files.

    ant -f "/home/siddhesh/Masters/CS5010 PDP/lab3-starter-dungeon" -Dnb.internal.action.name=debug.single.method - 
    Djavac.includes=dungeon/MedievalLevelBuilderTest.java -Dtest.method=testAddGoblins - 
    Dtest.class=dungeon.MedievalLevelBuilderTest debug-single-method
    Target "debug-single-method" does not exist in the project "Lab_3". 
    BUILD FAILED (total time: 0 seconds)

I tested by modifying my build-impl.xml file locally.

 The `debug-single-method` target is only found in 5 java files and no ant xml files. Ant files have `debug-test-method` target but it appears in only one java file. I am not sure which is the correct one so I kept both in the build-impl.xml.

![debug-single-test](https://user-images.githubusercontent.com/12849684/94513175-02740680-01ec-11eb-83f6-9860a1edca3d.png)
![debug-test-method](https://user-images.githubusercontent.com/12849684/94513178-04d66080-01ec-11eb-9e0e-6b0704b0b457.png)
