### PR TITLE
Check Javadoc build using GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,34 @@ jobs:
 
       - name: Test Netbeans Build System
         run: ant -Dcluster.config=basic localtest
+        
+  linux-javadoc:
+    name: Check Javadoc build
+    runs-on: ubuntu-18.04
+    env:
+      ANT_OPTS: -Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Caching dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.hgexternalcache
+          key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
+          restore-keys: ${{ runner.os }}-
+
+      - name: Get maven coordinates
+        run: ant getallmavencoordinates
+
+      - name: Build nbms
+        run: ant build-nbms
+
+      - name: Build source zips
+        run: ant build-source-zips
+        
+      - name: Build javadoc
+        run: ant build-javadoc
 
   linux-php:
     name: Linux build of PHP cluster


### PR DESCRIPTION
Add GitHub action job to check errors on Javadoc generation.