### PR TITLE
Change repo link in documentation

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/Arch-default-arch-where.xsl
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Arch-default-arch-where.xsl
@@ -27,7 +27,8 @@
     <xsl:template match="/" >
         <p>
             The sources for the module are in the
-            <a href="http://hg.netbeans.org/">NetBeans Mercurial repositories</a>.
+            <a href="https://gitbox.apache.org/repos/asf?p=netbeans.git">Apache Git repositories</a> 
+            or in the <a href="https://github.com/apache/netbeans">GitHub repositories</a>.
         </p>
     </xsl:template>    
         </xsl:stylesheet> 


### PR DESCRIPTION
Change link generated in the Javadoc from old Netbeans Mercurial repository to Apache Gt repository.