### PR TITLE
Ant task to display generated Javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ $ ant -Ddo.build.windows.launchers=true
 sudo apt install make mingw-w64
 ```
 
+#### Generating Javadoc 
+
+Build javadoc:
+```
+$ ant build javadoc
+```
+
+**Note** Run `javadoc-nb` task in Netbeans to run the javadoc build and display it in a web browser.
+
 ### Running NetBeans
 
 Run the build:

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -394,6 +394,10 @@ metabuild.hash=${metabuild.hash}</echo>
   <target name="javadoc" depends="bootstrap" description="Builds Javadoc for all NetBeans modules with some APIs">
       <ant dir="javadoctools" target="build-javadoc"/>
   </target>
+  
+  <target name="javadoc-nb" depends="javadoc" description="Builds Javadoc and opens it in a web browser">
+      <nbbrowse file="${netbeans.javadoc.dir}/index.html"/>
+  </target>
 
   <!-- build source zips for selected modules - useful for populating maven repository only-->
   <target name="build-source-zips" depends="init" description="Builds source zips for maven repository inclusion.">


### PR DESCRIPTION
Add `javadoc-nb` ant task at root project level like the `javadoc-nb` ant task available at module level to display the generated javadoc.