### PR TITLE
Hacktoberfest opt-in

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,6 +19,7 @@ github:
   homepage: https://netbeans.apache.org/
   labels:
     - netbeans
+    - hacktoberfest # Hacktoberfest topic
   features:
     wiki: false
     issues: false


### PR DESCRIPTION
The rules for participating in the [Hacktoberfest](https://hacktoberfest.digitalocean.com/) have changed this year: https://hacktoberfest.digitalocean.com/hacktoberfest-update

> We’re making Hacktoberfest opt-in only for projects – which maintainers can do simply by adding the ‘hacktoberfest’ topic to a repository.

This PR adds the hacktoberfest topic to allow this project to be included in the participating projects.