### PR TITLE
Modularizing Javascript/HTML

### DIFF
--- a/enterprise/j2ee.common/nbproject/project.xml
+++ b/enterprise/j2ee.common/nbproject/project.xml
@@ -192,15 +192,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.9</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.java.platform</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/enterprise/j2ee.ejbcore/nbproject/project.xml
+++ b/enterprise/j2ee.ejbcore/nbproject/project.xml
@@ -256,15 +256,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.9</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.java.platform</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/enterprise/j2ee.ejbjarproject/nbproject/project.xml
+++ b/enterprise/j2ee.ejbjarproject/nbproject/project.xml
@@ -226,15 +226,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.9</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.java.platform</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/enterprise/web.core.syntax/nbproject/project.xml
+++ b/enterprise/web.core.syntax/nbproject/project.xml
@@ -240,7 +240,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.0</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/web.el/nbproject/project.xml
+++ b/enterprise/web.el/nbproject/project.xml
@@ -165,15 +165,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.html.editor</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>2</release-version>
-                        <specification-version>2.0</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.j2ee.metadata</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/enterprise/web.jsf.editor/nbproject/project.xml
+++ b/enterprise/web.jsf.editor/nbproject/project.xml
@@ -571,6 +571,7 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.javascript2.editor</code-name-base>
+                        <recursive/>
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.lexer</code-name-base>

--- a/enterprise/web.jsf.editor/nbproject/project.xml
+++ b/enterprise/web.jsf.editor/nbproject/project.xml
@@ -196,7 +196,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.31</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/InjectCompositeComponent.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/InjectCompositeComponent.java
@@ -23,7 +23,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
@@ -37,6 +36,7 @@ import org.netbeans.modules.editor.NbEditorUtilities;
 import org.netbeans.modules.editor.indent.api.Indent;
 import org.netbeans.modules.html.editor.api.HtmlKit;
 import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
+import org.netbeans.modules.html.editor.lib.api.HtmlParsingResult;
 import org.netbeans.modules.html.editor.lib.api.elements.CloseTag;
 import org.netbeans.modules.html.editor.lib.api.elements.Element;
 import org.netbeans.modules.html.editor.lib.api.elements.ElementType;
@@ -152,7 +152,7 @@ public class InjectCompositeComponent {
             public void run(ResultIterator resultIterator) throws Exception {
                 ResultIterator ri = WebUtils.getResultIterator(resultIterator, HtmlKit.HTML_MIME_TYPE);
                 if (ri != null) {
-                    HtmlParserResult result = (HtmlParserResult) ri.getParserResult();
+                    HtmlParsingResult result = (HtmlParsingResult) ri.getParserResult();
                     if (result != null) {
                         declaredPrefixes.set(result.getNamespaces());
                     }

--- a/enterprise/web.jsf/nbproject/project.xml
+++ b/enterprise/web.jsf/nbproject/project.xml
@@ -179,7 +179,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.0</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/web.struts/nbproject/project.xml
+++ b/enterprise/web.struts/nbproject/project.xml
@@ -163,15 +163,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.9</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.java.project</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/enterprise/websvc.core/nbproject/project.xml
+++ b/enterprise/websvc.core/nbproject/project.xml
@@ -226,15 +226,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.9</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.java.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/groovy/groovy.gsp/nbproject/project.xml
+++ b/groovy/groovy.gsp/nbproject/project.xml
@@ -164,7 +164,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.39</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/csl.api/apichanges.xml
+++ b/ide/csl.api/apichanges.xml
@@ -25,6 +25,31 @@
 <apidef name="csl.api">Common Scripting Language API</apidef>
 </apidefs>
 <changes>
+    <change id="ExtraMockServices">
+        <summary>Allow subclasses to inject instances to MockLookup</summary>
+        <version major="2" minor="65"/>
+        <date day="30" month="9" year="2020"/>
+        <author login="sdedic"/>
+        <compatibility addition="yes"/>
+        <description>
+            Subclasses of <code>o.n.m.csl.api.test.TestBase</code> may subclass <code>createExtraMockLookupContent</code> to
+            add extra services into the <code>MockLookup</code> during test setup.
+        </description>
+        <class package="org.netbeans.modules.csl.api.test" name="TestBase" link="no"/>
+    </change>
+    <change id="Remove-BaseDocument">
+        <summary>BaseDocument references reduced</summary>
+        <version major="2" minor="65"/>
+        <date day="30" month="9" year="2020"/>
+        <author login="sdedic"/>
+        <compatibility addition="yes" deprecation="yes"/>
+        <description>
+            Decprecated API dependency on BaseDocument that introduces (unnecessary) dependency on <code>editor.lib</code> module
+            in clients.
+        </description>
+        <class package="org.netbeans.modules.csl.api" name="EditList"/>
+        <class package="org.netbeans.modules.csl.spi" name="GsfUtilities"/>
+    </change>
     <change id="TypesSplit">
         <summary>Separate common non UI classes</summary>
         <version major="2" minor="54"/>

--- a/ide/csl.api/nbproject/project.properties
+++ b/ide/csl.api/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-spec.version.base=2.64.0
+spec.version.base=2.65.0
 is.autoload=true
 javac.source=1.8
 

--- a/ide/csl.api/src/org/netbeans/modules/csl/api/AbstractCamelCasePosition.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/api/AbstractCamelCasePosition.java
@@ -24,8 +24,9 @@ import java.util.prefs.Preferences;
 import javax.swing.Action;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
+import org.netbeans.api.editor.document.AtomicLockDocument;
+import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.editor.BaseAction;
-import org.netbeans.editor.BaseDocument;
 import org.netbeans.lib.editor.util.swing.DocumentUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
@@ -65,11 +66,11 @@ public abstract class AbstractCamelCasePosition extends BaseAction {
                     originalAction.actionPerformed(evt);
                 }
             } else {
-                final BaseDocument bdoc = org.netbeans.editor.Utilities.getDocument(target);
+                AtomicLockDocument bdoc = LineDocumentUtils.as(target.getDocument(), AtomicLockDocument.class);
                 if (bdoc != null) {
                     bdoc.runAtomic(new Runnable() {
                         public void run() {
-                            DocumentUtilities.setTypingModification(bdoc, true);
+                            DocumentUtilities.setTypingModification(target.getDocument(), true);
                             try {
                                 int offset = newOffset(target);
                                 if (offset != -1) {
@@ -78,7 +79,7 @@ public abstract class AbstractCamelCasePosition extends BaseAction {
                             } catch (BadLocationException ble) {
                                 target.getToolkit().beep();
                             } finally {
-                                DocumentUtilities.setTypingModification(bdoc, false);
+                                DocumentUtilities.setTypingModification(target.getDocument(), false);
                             }
                         }
                     });

--- a/ide/csl.api/src/org/netbeans/modules/csl/api/CamelCaseOperations.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/api/CamelCaseOperations.java
@@ -22,7 +22,8 @@ package org.netbeans.modules.csl.api;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
-import org.netbeans.editor.BaseDocument;
+import org.netbeans.api.editor.document.AtomicLockDocument;
+import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.editor.Utilities;
 import org.openide.ErrorManager;
 
@@ -100,22 +101,17 @@ import org.openide.ErrorManager;
             return;
         }
         final Document document = textComponent.getDocument();
-        Runnable r = new Runnable() {
-            public @Override void run() {
-                try {
-                    if (length > 0) {
-                        document.remove(offset, length);
-                    }
-                    document.insertString(offset, text, null);
-                } catch (BadLocationException ble) {
-                    ErrorManager.getDefault().notify(ble);
+        AtomicLockDocument ld = LineDocumentUtils.asRequired(document, AtomicLockDocument.class);
+        // rely on editor utilities API to provide a stub, one is defined for the base Document class.
+        ld.runAtomic(() -> {
+            try {
+                if (length > 0) {
+                    document.remove(offset, length);
                 }
+                document.insertString(offset, text, null);
+            } catch (BadLocationException ble) {
+                ErrorManager.getDefault().notify(ble);
             }
-        };
-        if (document instanceof BaseDocument) {
-            ((BaseDocument)document).runAtomic(r);
-        } else {
-            r.run();
-        }
+        });
     }
 }

--- a/ide/csl.api/src/org/netbeans/modules/csl/api/GoToDeclarationAction.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/api/GoToDeclarationAction.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.csl.api;
 
 import javax.swing.text.JTextComponent;
-import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.csl.editor.hyperlink.GoToSupport;
 
 /**
@@ -30,7 +29,7 @@ public final class GoToDeclarationAction extends org.netbeans.editor.ext.ExtKit.
  
     @Override
     public boolean gotoDeclaration(JTextComponent target) {
-        GoToSupport.performGoTo((BaseDocument) target.getDocument(),
+        GoToSupport.performGoTo(target.getDocument(),
                 target.getCaretPosition());
 
         return true;

--- a/ide/csl.api/src/org/netbeans/modules/csl/api/InstantRenameAction.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/api/InstantRenameAction.java
@@ -25,13 +25,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.swing.Action;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
 import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import org.netbeans.modules.parsing.api.Embedding;
 
@@ -39,7 +39,6 @@ import org.netbeans.modules.parsing.api.Source;
 import org.netbeans.modules.parsing.api.UserTask;
 import org.netbeans.modules.parsing.spi.ParseException;
 import org.netbeans.editor.BaseAction;
-import org.netbeans.editor.BaseDocument;
 import org.netbeans.editor.Utilities;
 import org.netbeans.modules.csl.core.Language;
 import org.netbeans.modules.csl.core.LanguageRegistry;
@@ -149,8 +148,7 @@ public class InstantRenameAction extends BaseAction {
                                     break;
                                 }
 
-                                BaseDocument baseDoc = (BaseDocument)target.getDocument();
-                                List<Language> list = LanguageRegistry.getInstance().getEmbeddedLanguages(baseDoc, caret);
+                                List<Language> list = LanguageRegistry.getInstance().getEmbeddedLanguages(target.getDocument(), caret);
                                 for (Language language : list) {
                                     if (language.getInstantRenamer() != null) {
                                         //the parser result matching with the language is just
@@ -186,7 +184,7 @@ public class InstantRenameAction extends BaseAction {
 
                     if (changePoints[0] != null) {
                         final BadLocationException[] exc = new BadLocationException[1];
-                        final BaseDocument baseDoc = (BaseDocument)target.getDocument();
+                        final Document baseDoc = target.getDocument();
                         baseDoc.render(new Runnable() {
                             public void run() {
                                 try {

--- a/ide/csl.api/src/org/netbeans/modules/csl/api/SelectCodeElementAction.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/api/SelectCodeElementAction.java
@@ -31,7 +31,6 @@ import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 
 import org.netbeans.editor.BaseAction;
-import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.csl.core.Language;
 import org.netbeans.modules.csl.core.LanguageRegistry;
 import org.netbeans.modules.csl.spi.ParserResult;
@@ -184,8 +183,7 @@ public final class SelectCodeElementAction extends BaseAction {
         }
         
         private KeystrokeHandler getBracketCompletion(Document doc, int offset) {
-            BaseDocument baseDoc = (BaseDocument)doc;
-            List<Language> list = LanguageRegistry.getInstance().getEmbeddedLanguages(baseDoc, offset);
+            List<Language> list = LanguageRegistry.getInstance().getEmbeddedLanguages(doc, offset);
             for (Language l : list) {
                 if (l.getBracketCompletion() != null) {
                     return l.getBracketCompletion();

--- a/ide/csl.api/src/org/netbeans/modules/csl/core/GsfIndentTask.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/core/GsfIndentTask.java
@@ -20,9 +20,9 @@ package org.netbeans.modules.csl.core;
 
 import java.util.List;
 import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.modules.csl.api.Formatter;
-import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.editor.indent.spi.Context;
 import org.netbeans.modules.editor.indent.spi.ExtraLock;
 import org.netbeans.modules.editor.indent.spi.IndentTask;
@@ -40,7 +40,7 @@ public class GsfIndentTask implements IndentTask {
         //Formatter f = getFormatter();
 
         Formatter f = null;
-        BaseDocument baseDoc = (BaseDocument)context.document();
+        Document baseDoc = context.document();
         List<Language> list = LanguageRegistry.getInstance().getEmbeddedLanguages(baseDoc, context.startOffset());
         if (context.endOffset()-context.startOffset() < 4) { // for line reindents etc.
             for (Language l : list) {

--- a/ide/csl.api/src/org/netbeans/modules/csl/core/LanguageRegistry.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/core/LanguageRegistry.java
@@ -28,11 +28,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.text.Document;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenSequence;
-import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.csl.editor.codetemplates.CslCorePackageAccessor;
 import org.openide.filesystems.FileAttributeEvent;
 import org.openide.filesystems.FileChangeListener;
@@ -146,32 +146,31 @@ public final class LanguageRegistry implements Iterable<Language> {
         return result;
     }
 
-    public List<Language> getEmbeddedLanguages(BaseDocument doc, int offset) {
+    public List<Language> getEmbeddedLanguages(Document doc, int offset) {
         List<Language> result = new ArrayList<Language>();
 
-        doc.readLock(); // Read-lock due to Token hierarchy use
-        try {
-            // TODO - I should only do this for languages which CAN have it
-            /*
-     at org.netbeans.lib.lexer.inc.IncTokenList.reinit(IncTokenList.java:113)
-        at org.netbeans.lib.lexer.TokenHierarchyOperation.setActiveImpl(TokenHierarchyOperation.java:257)
-        at org.netbeans.lib.lexer.TokenHierarchyOperation.isActiveImpl(TokenHierarchyOperation.java:308)
-        at org.netbeans.lib.lexer.TokenHierarchyOperation.tokenSequence(TokenHierarchyOperation.java:344)
-        at org.netbeans.lib.lexer.TokenHierarchyOperation.tokenSequence(TokenHierarchyOperation.java:338)
-        at org.netbeans.api.lexer.TokenHierarchy.tokenSequence(TokenHierarchy.java:183)
-        at org.netbeans.modules.csl.LanguageRegistry.getEmbeddedLanguages(LanguageRegistry.java:336)
-        at org.netbeans.modules.gsfret.hints.infrastructure.SuggestionsTask.getHintsProviderLanguage(SuggestionsTask.java:70)
-        at org.netbeans.modules.gsfret.hints.infrastructure.SuggestionsTask.run(SuggestionsTask.java:94)
-        at org.netbeans.modules.gsfret.hints.infrastructure.SuggestionsTask.run(SuggestionsTask.java:63)
-[catch] at org.netbeans.napi.gsfret.source.Source$CompilationJob.run(Source.java:1272)             * 
-             */
-            TokenSequence ts = TokenHierarchy.get(doc).tokenSequence();
-            if (ts != null) {
-                addLanguages(result, ts, offset);
+        doc.render(
+            () -> {
+                // Read-lock due to Token hierarchy use
+                /*
+         at org.netbeans.lib.lexer.inc.IncTokenList.reinit(IncTokenList.java:113)
+            at org.netbeans.lib.lexer.TokenHierarchyOperation.setActiveImpl(TokenHierarchyOperation.java:257)
+            at org.netbeans.lib.lexer.TokenHierarchyOperation.isActiveImpl(TokenHierarchyOperation.java:308)
+            at org.netbeans.lib.lexer.TokenHierarchyOperation.tokenSequence(TokenHierarchyOperation.java:344)
+            at org.netbeans.lib.lexer.TokenHierarchyOperation.tokenSequence(TokenHierarchyOperation.java:338)
+            at org.netbeans.api.lexer.TokenHierarchy.tokenSequence(TokenHierarchy.java:183)
+            at org.netbeans.modules.csl.LanguageRegistry.getEmbeddedLanguages(LanguageRegistry.java:336)
+            at org.netbeans.modules.gsfret.hints.infrastructure.SuggestionsTask.getHintsProviderLanguage(SuggestionsTask.java:70)
+            at org.netbeans.modules.gsfret.hints.infrastructure.SuggestionsTask.run(SuggestionsTask.java:94)
+            at org.netbeans.modules.gsfret.hints.infrastructure.SuggestionsTask.run(SuggestionsTask.java:63)
+    [catch] at org.netbeans.napi.gsfret.source.Source$CompilationJob.run(Source.java:1272)             * 
+                 */
+                TokenSequence ts = TokenHierarchy.get(doc).tokenSequence();
+                if (ts != null) {
+                    addLanguages(result, ts, offset);
+                }
             }
-        } finally {
-            doc.readUnlock();
-        }
+        );
 
         String mimeType = (String) doc.getProperty("mimeType"); // NOI18N
         if (mimeType != null) {

--- a/ide/csl.api/src/org/netbeans/modules/csl/spi/CommentHandler.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/spi/CommentHandler.java
@@ -21,7 +21,8 @@ package org.netbeans.modules.csl.spi;
 import java.util.ArrayList;
 import javax.swing.text.Document;
 import org.netbeans.api.annotations.common.NonNull;
-import org.netbeans.editor.BaseDocument;
+import org.netbeans.api.editor.document.AtomicLockDocument;
+import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.lib.editor.util.CharSequenceUtilities;
 import org.netbeans.lib.editor.util.swing.DocumentUtilities;
 
@@ -113,9 +114,9 @@ public interface CommentHandler {
 
                 }
             };
-
-            if(doc instanceof BaseDocument) {
-                ((BaseDocument)doc).runAtomic(task);
+            AtomicLockDocument ald = LineDocumentUtils.as(doc, AtomicLockDocument.class);
+            if(ald != null) {
+                ald.runAtomic(task);
             } else {
                 task.run();
             }

--- a/ide/css.editor/nbproject/project.xml
+++ b/ide/css.editor/nbproject/project.xml
@@ -448,6 +448,7 @@
                 <friend>org.netbeans.modules.html.editor</friend>
                 <friend>org.netbeans.modules.javafx2.editor</friend>
                 <friend>org.netbeans.modules.javascript2.editor</friend>
+                <friend>org.netbeans.modules.javascript2.html</friend>
                 <friend>org.netbeans.modules.javascript2.jade</friend>
                 <friend>org.netbeans.modules.javascript2.jquery</friend>
                 <friend>org.netbeans.modules.web.inspect</friend>

--- a/ide/css.lib/nbproject/project.xml
+++ b/ide/css.lib/nbproject/project.xml
@@ -185,6 +185,7 @@
                 <friend>org.netbeans.modules.html.editor</friend>
                 <friend>org.netbeans.modules.javafx2.editor</friend>
                 <friend>org.netbeans.modules.javascript2.editor</friend>
+                <friend>org.netbeans.modules.javascript2.html</friend>
                 <friend>org.netbeans.modules.javascript2.jade</friend>
                 <friend>org.netbeans.modules.web.inspect</friend>
                 <package>org.netbeans.modules.css.lib.api</package>

--- a/ide/css.visual/nbproject/project.xml
+++ b/ide/css.visual/nbproject/project.xml
@@ -119,7 +119,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.12</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/actions/EditCSSRulesNodeAction.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/actions/EditCSSRulesNodeAction.java
@@ -22,6 +22,7 @@ import org.netbeans.modules.css.visual.api.EditCSSRulesAction;
 import java.util.Collections;
 import org.netbeans.modules.css.visual.HtmlSourceElementHandle;
 import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
+import org.netbeans.modules.html.editor.lib.api.HtmlParsingResult;
 import org.netbeans.modules.html.editor.lib.api.SourceElementHandle;
 import org.netbeans.modules.html.editor.lib.api.elements.OpenTag;
 import org.netbeans.modules.parsing.api.ParserManager;
@@ -29,6 +30,7 @@ import org.netbeans.modules.parsing.api.ResultIterator;
 import org.netbeans.modules.parsing.api.Source;
 import org.netbeans.modules.parsing.api.UserTask;
 import org.netbeans.modules.parsing.spi.ParseException;
+import org.netbeans.modules.parsing.spi.Parser;
 import org.netbeans.modules.web.common.api.WebUtils;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
@@ -71,14 +73,15 @@ public class EditCSSRulesNodeAction extends NodeAction {
                     public void run(ResultIterator resultIterator) throws Exception {
                         ResultIterator ri = WebUtils.getResultIterator(resultIterator, "text/html");
                         if (ri != null) {
-                            HtmlParserResult result = (HtmlParserResult)ri.getParserResult();
+                            Parser.Result parserResult = ri.getParserResult();
+                            HtmlParsingResult result = (HtmlParsingResult)parserResult;
                             
                             final EditCSSRulesAction action = new EditCSSRulesAction();
                             action.setContext(file);
                             
-                            org.netbeans.modules.html.editor.lib.api.elements.Node resolved = sourceElementHandle.resolve(result);
+                            org.netbeans.modules.html.editor.lib.api.elements.Node resolved = sourceElementHandle.resolve(parserResult);
                             if(resolved != null) {
-                                action.setHtmlSourceElementHandle((OpenTag)resolved, result.getSnapshot(), file);
+                                action.setHtmlSourceElementHandle((OpenTag)resolved, ri.getParserResult().getSnapshot(), file);
 
                                 RequestProcessor.getDefault().post(new Runnable() {
                                     @Override

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorPreferencesKeys.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/EditorPreferencesKeys.java
@@ -429,12 +429,6 @@ public final class EditorPreferencesKeys {
      */
     public static final String COLORING_NAME_LIST = "coloring-name-list"; // NOI18N
 
-    /** The list of the token contexts that the kit can use.
-    * The editor-ui uses this setting to determine all the token-ids
-    * and token-categories for the colorings.
-    */
-    public static final String TOKEN_CONTEXT_LIST = "token-context-list"; // NOI18N
-
     /** Suffix added to the coloring settings. The resulting name is used
      * as the name of the setting.
      * @deprecated Use Editor Settings and Editor Settings Storage APIs instead.

--- a/ide/html.custom/nbproject/project.xml
+++ b/ide/html.custom/nbproject/project.xml
@@ -111,7 +111,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.46</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/html.editor.lib/nbproject/project.xml
+++ b/ide/html.editor.lib/nbproject/project.xml
@@ -270,6 +270,7 @@
                 <friend>org.netbeans.modules.html.parser</friend>
                 <friend>org.netbeans.modules.html.validation</friend>
                 <friend>org.netbeans.modules.javascript2.editor</friend>
+                <friend>org.netbeans.modules.javascript2.html</friend>
                 <friend>org.netbeans.modules.javascript2.jade</friend>
                 <friend>org.netbeans.modules.javascript2.jquery</friend>
                 <friend>org.netbeans.modules.javascript2.react</friend>

--- a/ide/html.editor.lib/src/org/netbeans/modules/html/editor/lib/XmlSTElements.java
+++ b/ide/html.editor.lib/src/org/netbeans/modules/html/editor/lib/XmlSTElements.java
@@ -21,10 +21,8 @@ package org.netbeans.modules.html.editor.lib;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import org.netbeans.editor.BaseElement;
 import org.netbeans.modules.html.editor.lib.api.ProblemDescription;
 import org.netbeans.modules.html.editor.lib.api.elements.*;
-import org.netbeans.modules.html.editor.lib.plain.TextElement;
 import org.netbeans.modules.web.common.api.LexerUtils;
 import org.openide.util.CharSequences;
 

--- a/ide/html.editor/manifest.mf
+++ b/ide/html.editor/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.html.editor/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/html/editor/resources/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/html/editor/resources/layer.xml
-OpenIDE-Module-Specification-Version: 2.65
+OpenIDE-Module-Specification-Version: 2.66
 AutoUpdate-Show-In-Client: false

--- a/ide/html.editor/module-auto-deps.xml
+++ b/ide/html.editor/module-auto-deps.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!DOCTYPE transformations PUBLIC "-//NetBeans//DTD Module Automatic Dependencies 1.0//EN" "http://www.netbeans.org/dtds/module-auto-deps-1_0.dtd">
+
+<transformations version="1.0">
+    <transformationgroup>
+        <description>HtmlIndex API separated</description>
+        <transformation>
+            <trigger-dependency type="older">
+                <module-dependency codenamebase="org.netbeans.modules.html.editor" spec="2.66"/>
+            </trigger-dependency>
+            <implies>
+                <result>
+                    <module-dependency codenamebase="org.netbeans.modules.html.indexing"/>
+                </result>
+            </implies>
+        </transformation>
+    </transformationgroup>
+</transformations>

--- a/ide/html.editor/nbproject/project.xml
+++ b/ide/html.editor/nbproject/project.xml
@@ -277,7 +277,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.58</specification-version>
+                        <specification-version>1.109</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/html.editor/nbproject/project.xml
+++ b/ide/html.editor/nbproject/project.xml
@@ -203,6 +203,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.html.indexing</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.0</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.html.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -459,10 +467,6 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.html</code-name-base>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.html.editor</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/HtmlErrorFilter.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/HtmlErrorFilter.java
@@ -24,7 +24,6 @@ import java.util.List;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.csl.api.HintSeverity;
 import org.netbeans.modules.csl.api.Rule;
-import org.netbeans.modules.html.editor.lib.api.SyntaxAnalyzerResult;
 import org.netbeans.modules.csl.api.Error;
 import org.netbeans.modules.csl.api.Hint;
 import org.netbeans.modules.csl.api.HintsProvider;
@@ -38,6 +37,8 @@ import org.netbeans.modules.html.editor.api.gsf.ErrorBadgingRule;
 import org.netbeans.modules.html.editor.api.gsf.HtmlErrorFilterContext;
 import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
 import org.netbeans.modules.html.editor.hints.HtmlHintsProvider;
+import org.netbeans.modules.parsing.spi.Parser;
+import org.netbeans.modules.web.common.api.WebPageMetadata;
 import org.openide.filesystems.FileObject;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -133,17 +134,17 @@ public class HtmlErrorFilter implements ErrorFilter {
         return filtered;
     }
     
-    public static boolean isErrorCheckingEnabled(SyntaxAnalyzerResult result) {
+    public static boolean isErrorCheckingEnabled(Parser.Result result) {
         return !isErrorCheckingDisabledForFile(result) && isErrorCheckingEnabledForMimetype(result);
     }
 
-    public static boolean isErrorCheckingDisabledForFile(SyntaxAnalyzerResult result) {
-        FileObject fo = result.getSource().getSourceFileObject();
+    public static boolean isErrorCheckingDisabledForFile(Parser.Result result) {
+        FileObject fo = result.getSnapshot().getSource().getFileObject();
         return fo != null && fo.getAttribute(DISABLE_ERROR_CHECKS_KEY) != null;
     }
 
-    public static boolean isErrorCheckingEnabledForMimetype(SyntaxAnalyzerResult result) {
-        return HtmlPreferences.isHtmlErrorCheckingEnabledForMimetype(org.netbeans.modules.html.editor.api.Utils.getWebPageMimeType(result));
+    public static boolean isErrorCheckingEnabledForMimetype(Parser.Result result) {
+        return HtmlPreferences.isHtmlErrorCheckingEnabledForMimetype(WebPageMetadata.getContentMimeType(result, true));
     }
     
     @ServiceProvider(service=ErrorFilter.Factory.class)

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/HtmlExtensions.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/HtmlExtensions.java
@@ -21,9 +21,9 @@ package org.netbeans.modules.html.editor;
 import java.util.Collection;
 import java.util.Collections;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
-import org.netbeans.modules.html.editor.api.Utils;
 import org.netbeans.modules.html.editor.api.gsf.HtmlExtension;
 import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
+import org.netbeans.modules.web.common.api.WebPageMetadata;
 import org.openide.util.Lookup;
 
 /**
@@ -50,7 +50,7 @@ public class HtmlExtensions {
      * @return 
      */
     public static boolean isApplicationPiece(HtmlParserResult result) {
-        String mimeType = Utils.getWebPageMimeType(result.getSyntaxAnalyzerResult());
+        String mimeType = WebPageMetadata.getContentMimeType(result, true);
         for(HtmlExtension ex : getRegisteredExtensions(mimeType)) {
             if(ex.isApplicationPiece(result)) {
                 return true;

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/HtmlSourceUtils.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/HtmlSourceUtils.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.html.editor;
 
-import java.net.URL;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -34,15 +33,14 @@ import org.netbeans.modules.csl.spi.support.ModificationResult;
 import org.netbeans.modules.csl.spi.support.ModificationResult.Difference;
 import org.netbeans.modules.editor.NbEditorDocument;
 import org.netbeans.modules.editor.indent.api.IndentUtils;
-import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
+import org.netbeans.modules.html.editor.lib.api.HtmlParsingResult;
 import org.netbeans.modules.html.editor.lib.api.elements.*;
 import org.netbeans.modules.html.editor.refactoring.ExtractInlinedStyleRefactoringPlugin;
-import org.netbeans.modules.parsing.api.indexing.IndexingManager;
+import org.netbeans.modules.parsing.api.Snapshot;
 import org.netbeans.modules.web.common.api.LexerUtils;
 import org.netbeans.modules.web.common.api.WebUtils;
 import org.netbeans.spi.lexer.MutableTextInput;
 import org.openide.filesystems.FileObject;
-import org.openide.filesystems.URLMapper;
 import org.openide.text.CloneableEditorSupport;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
@@ -107,7 +105,8 @@ public class HtmlSourceUtils {
      * @return true if the import was successful
      */
     public static boolean importStyleSheet(ModificationResult modificationResult, 
-            HtmlParserResult result, 
+            HtmlParsingResult result,
+            Snapshot snapshot, 
             FileObject targetFile) {
         
         try {
@@ -171,24 +170,24 @@ public class HtmlSourceUtils {
                 //TODO probably missing head tag? - generate? html tag may be missing as well
                 return false;
             }
-            int insertOffset = result.getSnapshot().getOriginalOffset(embeddedInsertOffset);
+            int insertOffset = snapshot.getOriginalOffset(embeddedInsertOffset);
             if (insertOffset == -1) {
                 return false; //cannot properly map back
             }
-            int baseIndent = Utilities.getRowIndent((BaseDocument) result.getSnapshot().getSource().getDocument(true), insertOffset);
+            int baseIndent = Utilities.getRowIndent((BaseDocument) snapshot.getSource().getDocument(true), insertOffset);
             if (baseIndent == -1) {
                 //in case of empty line
                 baseIndent = 0;
             }
             
-            Document document = result.getSnapshot().getSource().getDocument(true);
+            Document document = snapshot.getSource().getDocument(true);
             if (increaseIndent.get()) {
                 //add one indent level (after HEAD open tag)
                 baseIndent += IndentUtils.indentLevelSize(document);
             }
 
             //generate the embedded id selector section
-            FileObject file = result.getSnapshot().getSource().getFileObject();
+            FileObject file = snapshot.getSource().getFileObject();
             String baseIndentString = IndentUtils.createIndentString(document, baseIndent);
             String linkRelativePath = WebUtils.getRelativePath(file, targetFile);
             String linkText = new StringBuilder().append('\n').

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/api/Utils.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/api/Utils.java
@@ -106,7 +106,7 @@ public class Utils {
 
         return null;
     }
-
+    
     //and now the magic...
     //the method returns an artificial mimetype so the user can enable/disable the error checks
     //for particular content. For example the text/facelets+xhtml mimetype is returned for
@@ -114,6 +114,14 @@ public class Utils {
     //even if their mimetype is text/html
     //sure the correct solution would be to let the mimeresolver to create different mimetype,
     //but since the resolution can be pretty complex it is not done this way
+    /**
+     * Computes MIME type based on the content.
+     * @param result
+     * @return
+     * @deprecated for most usages, it should
+     * be possible to use {@link WebPageMetadata#getContentMimeType}.
+     */
+    @Deprecated
     public static String getWebPageMimeType(SyntaxAnalyzerResult result) {
         InstanceContent ic = new InstanceContent();
         ic.add(result);

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/api/completion/HtmlCompletionItem.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/api/completion/HtmlCompletionItem.java
@@ -34,7 +34,6 @@ import org.netbeans.modules.editor.indent.api.Indent;
 import org.netbeans.spi.editor.completion.*;
 import java.awt.Color;
 import java.awt.EventQueue;
-import java.awt.Image;
 import java.awt.event.KeyEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -400,6 +399,13 @@ public class HtmlCompletionItem implements CompletionItem {
         hash = 97 * hash + (this.helpId != null ? this.helpId.hashCode() : 0);
         return hash;
     }
+
+    @Override
+    public String toString() {
+        return getItemText();
+    }
+    
+    
 
     //------------------------------------------------------------------------------
     /**

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlCompletionQuery.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/completion/HtmlCompletionQuery.java
@@ -51,6 +51,7 @@ import org.netbeans.modules.parsing.spi.ParseException;
 import org.netbeans.modules.parsing.spi.Parser;
 import org.netbeans.modules.web.common.api.LexerUtils;
 import org.netbeans.modules.web.common.api.ValueCompletion;
+import org.netbeans.modules.web.common.api.WebPageMetadata;
 import org.netbeans.spi.editor.completion.CompletionItem;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
@@ -194,7 +195,7 @@ public class HtmlCompletionQuery extends UserTask {
         HtmlModel model = htmlResult.model();
 
         Snapshot snapshot = parserResult.getSnapshot();
-        String sourceMimetype = Utils.getWebPageMimeType(syntaxResult);
+        String sourceMimetype = WebPageMetadata.getContentMimeType(parserResult, true);
         int astOffset = snapshot.getEmbeddedOffset(offset);
 
         //in some cases the embedded offset cannot be mapped, then we can do very less

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlDeclarationFinder.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlDeclarationFinder.java
@@ -105,7 +105,7 @@ public class HtmlDeclarationFinder implements DeclarationFinder {
                         if (htmlRi != null) {
                             HtmlParserResult result = (HtmlParserResult) htmlRi.getParserResult();
                             if(result != null) {
-                                String sourceMimetype = Utils.getWebPageMimeType(result.getSyntaxAnalyzerResult());
+                                String sourceMimetype = WebPageMetadata.getContentMimeType(result, true);
                                 DOC_TO_WEB_MIMETYPE_CACHE.put(document, sourceMimetype);
                             }
                         }
@@ -125,7 +125,7 @@ public class HtmlDeclarationFinder implements DeclarationFinder {
         if (loc != null) {
             return loc;
         }
-        String sourceMimetype = Utils.getWebPageMimeType(result.getSyntaxAnalyzerResult());
+        String sourceMimetype = WebPageMetadata.getContentMimeType(result, true);
         for (HtmlExtension ext : HtmlExtensions.getRegisteredExtensions(sourceMimetype)) {
             loc = ext.findDeclaration(info, caretOffset);
             if (loc != null) {

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlSemanticAnalyzer.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/gsf/HtmlSemanticAnalyzer.java
@@ -25,12 +25,12 @@ import org.netbeans.modules.csl.api.ColoringAttributes;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.csl.api.SemanticAnalyzer;
 import org.netbeans.modules.html.editor.HtmlExtensions;
-import org.netbeans.modules.html.editor.api.Utils;
 import org.netbeans.modules.html.editor.api.gsf.HtmlExtension;
 import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
 import org.netbeans.modules.parsing.spi.Parser.Result;
 import org.netbeans.modules.parsing.spi.Scheduler;
 import org.netbeans.modules.parsing.spi.SchedulerEvent;
+import org.netbeans.modules.web.common.api.WebPageMetadata;
 
 /**
  *
@@ -57,7 +57,7 @@ public class HtmlSemanticAnalyzer extends SemanticAnalyzer {
         final Map<OffsetRange, Set<ColoringAttributes>> highlights = new HashMap<>();
         HtmlParserResult htmlResult = (HtmlParserResult) result;
 
-        String sourceMimetype = Utils.getWebPageMimeType(htmlResult.getSyntaxAnalyzerResult());
+        String sourceMimetype = WebPageMetadata.getContentMimeType(result, true);
         //process extensions
         for (HtmlExtension ext : HtmlExtensions.getRegisteredExtensions(sourceMimetype)) {
             if (cancelled) {

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/hints/css/AddStylesheetLinkHintFix.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/hints/css/AddStylesheetLinkHintFix.java
@@ -21,10 +21,9 @@ package org.netbeans.modules.html.editor.hints.css;
 import java.util.Collections;
 import javax.swing.text.Document;
 import org.netbeans.modules.csl.api.HintFix;
-import org.netbeans.modules.csl.api.RuleContext;
 import org.netbeans.modules.csl.spi.support.ModificationResult;
 import org.netbeans.modules.html.editor.HtmlSourceUtils;
-import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
+import org.netbeans.modules.html.editor.lib.api.HtmlParsingResult;
 import org.netbeans.modules.parsing.api.ParserManager;
 import org.netbeans.modules.parsing.api.ResultIterator;
 import org.netbeans.modules.parsing.api.Source;
@@ -68,11 +67,11 @@ public class AddStylesheetLinkHintFix implements HintFix {
             public void run(ResultIterator resultIterator) throws Exception {
                 //html must be top level
                 Result result = resultIterator.getParserResult();
-                if(!(result instanceof HtmlParserResult)) {
+                if(!(result instanceof HtmlParsingResult)) {
                     return ;
                 }
                 ModificationResult modification = new ModificationResult();
-                if(HtmlSourceUtils.importStyleSheet(modification, (HtmlParserResult)result, externalStylesheet)) {
+                if(HtmlSourceUtils.importStyleSheet(modification, (HtmlParsingResult)result, result.getSnapshot(), externalStylesheet)) {
                     modification.commit();
 //                    if(doc != null) {
 //                        //refresh the index for the modified file

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/hints/css/CreateRuleInStylesheet.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/hints/css/CreateRuleInStylesheet.java
@@ -33,7 +33,7 @@ import org.netbeans.modules.css.model.api.Rule;
 import org.netbeans.modules.css.model.api.StyleSheet;
 import org.netbeans.modules.html.editor.HtmlSourceUtils;
 import org.netbeans.modules.html.editor.Utils;
-import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
+import org.netbeans.modules.html.editor.lib.api.HtmlParsingResult;
 import org.netbeans.modules.parsing.api.ParserManager;
 import org.netbeans.modules.parsing.api.ResultIterator;
 import org.netbeans.modules.parsing.api.Source;
@@ -110,11 +110,11 @@ public class CreateRuleInStylesheet implements HintFix {
                 public void run(ResultIterator resultIterator) throws Exception {
                     //html must be top level
                     Result result = resultIterator.getParserResult();
-                    if (!(result instanceof HtmlParserResult)) {
+                    if (!(result instanceof HtmlParsingResult)) {
                         return;
                     }
                     ModificationResult modification = new ModificationResult();
-                    if (HtmlSourceUtils.importStyleSheet(modification, (HtmlParserResult) result, externalStylesheet)) {
+                    if (HtmlSourceUtils.importStyleSheet(modification, (HtmlParsingResult)result, result.getSnapshot(), externalStylesheet)) {
                         modification.commit();
 //                        if (doc != null) {
 //                            HtmlSourceUtils.forceReindex(sourceFile);

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/indexing/Entry.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/indexing/Entry.java
@@ -22,9 +22,9 @@ import org.netbeans.modules.csl.api.OffsetRange;
 
 public class Entry {
 
-    private String name;
-    private OffsetRange astRange;
-    private OffsetRange documentRange;
+    private final String name;
+    private final OffsetRange astRange;
+    private final OffsetRange documentRange;
 
     protected Entry(String name, OffsetRange astRange, OffsetRange documentRange) {
         this.name = name;

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlFileModel.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlFileModel.java
@@ -28,11 +28,12 @@ import java.util.logging.Logger;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.html.editor.api.HtmlKit;
 import org.netbeans.modules.html.editor.api.completion.HtmlCompletionItem;
-import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
 import org.netbeans.modules.html.editor.completion.AttrValuesCompletion;
+import org.netbeans.modules.html.editor.lib.api.HtmlParsingResult;
 import org.netbeans.modules.html.editor.lib.api.elements.*;
 import org.netbeans.modules.parsing.api.*;
 import org.netbeans.modules.parsing.spi.ParseException;
+import org.netbeans.modules.parsing.spi.Parser;
 import org.netbeans.modules.web.common.api.LexerUtils;
 import org.netbeans.modules.web.common.api.ValueCompletion;
 import org.netbeans.modules.web.common.api.WebUtils;
@@ -49,7 +50,8 @@ public class HtmlFileModel {
     private static final boolean LOG = LOGGER.isLoggable(Level.FINE);
     private List<HtmlLinkEntry> references;
     private List<OffsetRange> embeddedCssSections;
-    private HtmlParserResult parserResult;
+    private HtmlParsingResult htmlResult;
+    private Parser.Result parserResult;
 
     public HtmlFileModel(Source source) throws ParseException {
         ParserManager.parse(Collections.singletonList(source), new UserTask() {
@@ -57,20 +59,22 @@ public class HtmlFileModel {
             public void run(ResultIterator resultIterator) throws Exception {
                 ResultIterator ri = WebUtils.getResultIterator(resultIterator, HtmlKit.HTML_MIME_TYPE);
                 if (ri != null) {
-                    parserResult = (HtmlParserResult) ri.getParserResult();
+                    parserResult = ri.getParserResult();
+                    htmlResult = (HtmlParsingResult) ri.getParserResult();
                     init();
                 }
             }
         });
     }
 
-    public HtmlFileModel(HtmlParserResult parserResult) {
+    public HtmlFileModel(Parser.Result parserResult, HtmlParsingResult htmlResult) {
         this.parserResult = parserResult;
+        this.htmlResult = htmlResult;
         init();
     }
 
-    public HtmlParserResult getParserResult() {
-        return parserResult;
+    public HtmlParsingResult getParserResult() {
+        return htmlResult;
     }
 
     public Snapshot getSnapshot() {
@@ -113,7 +117,7 @@ public class HtmlFileModel {
     }
 
     private void init() {
-        Iterator<Element> elements = parserResult.getSyntaxAnalyzerResult().getElementsIterator();
+        Iterator<Element> elements = htmlResult.getSyntaxAnalyzerResult().getElementsIterator();
         while (elements.hasNext()) {
             Element element = elements.next();
             switch (element.type()) {

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlIndexer.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlIndexer.java
@@ -28,6 +28,7 @@ import org.netbeans.api.project.Project;
 import org.netbeans.modules.html.editor.api.HtmlKit;
 import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
 import org.netbeans.modules.html.editor.api.index.HtmlIndex;
+import org.netbeans.modules.html.editor.lib.api.HtmlParsingResult;
 import org.netbeans.modules.parsing.api.Snapshot;
 import org.netbeans.modules.parsing.spi.Parser.Result;
 import org.netbeans.modules.parsing.spi.indexing.Context;
@@ -52,8 +53,6 @@ public class HtmlIndexer extends EmbeddingIndexer {
     private static final Logger LOGGER = Logger.getLogger(HtmlIndexer.class.getSimpleName());
     private static final boolean LOG = LOGGER.isLoggable(Level.FINE);
 
-    public static final String REFERS_KEY = "imports"; //NOI18N
-    
     private static RequestProcessor RP = new RequestProcessor();
 
     @Override
@@ -64,12 +63,12 @@ public class HtmlIndexer extends EmbeddingIndexer {
                 LOGGER.log(Level.FINE, "indexing {0}", fo.getPath()); //NOI18N
             }
 
-            HtmlFileModel model = new HtmlFileModel(parserResult, (HtmlParserResult)parserResult);
+            HtmlFileModel model = new HtmlFileModel(parserResult, (HtmlParsingResult)parserResult);
 
             IndexingSupport support = IndexingSupport.getInstance(context);
             IndexDocument document = support.createDocument(indexable);
 
-            storeEntries(model.getReferences(), document, REFERS_KEY);
+            storeEntries(model.getReferences(), document, HtmlIndex.REFERS_KEY);
 
             support.addDocument(document);
 

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlIndexer.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlIndexer.java
@@ -29,7 +29,6 @@ import org.netbeans.modules.html.editor.api.HtmlKit;
 import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
 import org.netbeans.modules.html.editor.api.index.HtmlIndex;
 import org.netbeans.modules.parsing.api.Snapshot;
-import org.netbeans.modules.parsing.api.indexing.IndexingManager;
 import org.netbeans.modules.parsing.spi.Parser.Result;
 import org.netbeans.modules.parsing.spi.indexing.Context;
 import org.netbeans.modules.parsing.spi.indexing.EmbeddingIndexer;
@@ -65,7 +64,7 @@ public class HtmlIndexer extends EmbeddingIndexer {
                 LOGGER.log(Level.FINE, "indexing {0}", fo.getPath()); //NOI18N
             }
 
-            HtmlFileModel model = new HtmlFileModel((HtmlParserResult)parserResult);
+            HtmlFileModel model = new HtmlFileModel(parserResult, (HtmlParserResult)parserResult);
 
             IndexingSupport support = IndexingSupport.getInstance(context);
             IndexDocument document = support.createDocument(indexable);

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlLinkEntry.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/indexing/HtmlLinkEntry.java
@@ -23,11 +23,15 @@ import org.netbeans.modules.web.common.api.FileReference;
 import org.netbeans.modules.web.common.api.WebUtils;
 import org.openide.filesystems.FileObject;
 
-public class HtmlLinkEntry extends Entry {
+/**
+ * Describes an external content referenced from HTML document. 
+ * @author sdedic
+ */
+public final class HtmlLinkEntry extends Entry {
 
-    private String tagName;
-    private String attributeName;
-    private FileReference ref;
+    private final String tagName;
+    private final String attributeName;
+    private final FileReference ref;
 
     public HtmlLinkEntry(FileObject baseFile, String link, OffsetRange astRange, OffsetRange documentRange, String tagName, String attributeName) {
         super(link, astRange, documentRange);

--- a/ide/html.editor/src/org/netbeans/modules/html/editor/refactoring/ExtractInlinedStyleRefactoringPlugin.java
+++ b/ide/html.editor/src/org/netbeans/modules/html/editor/refactoring/ExtractInlinedStyleRefactoringPlugin.java
@@ -42,7 +42,7 @@ import org.netbeans.modules.css.refactoring.api.Entry;
 import org.netbeans.modules.css.refactoring.api.RefactoringElementType;
 import org.netbeans.modules.editor.indent.api.IndentUtils;
 import org.netbeans.modules.html.editor.HtmlSourceUtils;
-import org.netbeans.modules.html.editor.api.gsf.HtmlParserResult;
+import org.netbeans.modules.html.editor.lib.api.HtmlParsingResult;
 import org.netbeans.modules.html.editor.lib.api.elements.*;
 import org.netbeans.modules.html.editor.refactoring.api.ExtractInlinedStyleRefactoring;
 import org.netbeans.modules.html.editor.refactoring.api.SelectorType;
@@ -138,7 +138,9 @@ public class ExtractInlinedStyleRefactoringPlugin implements RefactoringPlugin {
 
     private boolean importStyleSheet(ModificationResult modificationResult, RefactoringContext context) {
         FileObject target = refactoring.getExternalSheet();
-        return HtmlSourceUtils.importStyleSheet(modificationResult, context.getModel().getParserResult(), target);
+        return HtmlSourceUtils.importStyleSheet(modificationResult, 
+                context.getModel().getParserResult(), 
+                context.getModel().getSnapshot(), target);
     }
 
     private boolean refactorToStyleSheet(ModificationResult modificationResult, RefactoringContext context) {
@@ -154,7 +156,7 @@ public class ExtractInlinedStyleRefactoringPlugin implements RefactoringPlugin {
     private boolean refactorToNewEmbeddedSection(ModificationResult modifications, RefactoringContext context) {
         try {
             //create a new embedded css section
-            HtmlParserResult result = context.getModel().getParserResult();
+            HtmlParsingResult result = context.getModel().getParserResult();
 
             final AtomicInteger insertPositionRef = new AtomicInteger(-1);
             final AtomicBoolean increaseIndent = new AtomicBoolean();

--- a/ide/html.indexing/build.xml
+++ b/ide/html.indexing/build.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project basedir="." default="build" name="ide/html.indexing">
+    <description>Builds, tests, and runs the project org.netbeans.modules.html.indexing</description>
+    <import file="../../nbbuild/templates/projectized.xml"/>
+</project>

--- a/ide/html.indexing/manifest.mf
+++ b/ide/html.indexing/manifest.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+AutoUpdate-Show-In-Client: false
+OpenIDE-Module: org.netbeans.modules.html.indexing
+OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/html/indexing/Bundle.properties
+OpenIDE-Module-Specification-Version: 1.0
+

--- a/ide/html.indexing/nbproject/project.properties
+++ b/ide/html.indexing/nbproject/project.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+javac.source=1.7
+javac.compilerargs=-Xlint -Xlint:-serial
+is.autoload=true

--- a/ide/html.indexing/nbproject/project.xml
+++ b/ide/html.indexing/nbproject/project.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.apisupport.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/nb-module-project/3">
+            <code-name-base>org.netbeans.modules.html.indexing</code-name-base>
+            <module-dependencies>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.parsing.indexing</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.19</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.projectapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.78</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.web.common</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.58</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.filesystems</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.20</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.17</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.lookup</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>8.44</specification-version>
+                    </run-dependency>
+                </dependency>
+            </module-dependencies>
+            <public-packages>
+                <package>org.netbeans.modules.html.editor.api.index</package>
+            </public-packages>
+        </data>
+    </configuration>
+</project>

--- a/ide/html.indexing/src/org/netbeans/modules/html/editor/api/index/HtmlIndex.java
+++ b/ide/html.indexing/src/org/netbeans/modules/html/editor/api/index/HtmlIndex.java
@@ -36,7 +36,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.html.editor.indexing.HtmlIndexer;
 import org.netbeans.modules.parsing.spi.indexing.support.IndexResult;
 import org.netbeans.modules.parsing.spi.indexing.support.QuerySupport;
 import org.netbeans.modules.web.common.api.DependenciesGraph;
@@ -57,8 +56,21 @@ import org.openide.util.Exceptions;
  */
 public class HtmlIndex {
 
-    private static final Logger LOGGER = Logger.getLogger(HtmlIndex.class.getSimpleName());
-    private static final boolean LOG = LOGGER.isLoggable(Level.FINE);
+    /**
+     * Name of the index file.
+     */
+    public static final String NAME = "html"; //NOI18N
+    
+    /**
+     * Index version.
+     */
+    public static final int VERSION = 2;
+
+    /**
+     * Name of the field with references.
+     */
+    public static final String REFERS_KEY = "imports"; //NOI18N
+
     private static final Map<Project, HtmlIndex> INDEXES = new WeakHashMap<>();
 
     /**
@@ -93,7 +105,7 @@ public class HtmlIndex {
                 null /* all source roots */,
                 Collections.<String>emptyList(),
                 Collections.<String>emptyList());
-        this.querySupport = QuerySupport.forRoots(HtmlIndexer.Factory.NAME, HtmlIndexer.Factory.VERSION, sourceRoots.toArray(new FileObject[]{}));
+        this.querySupport = QuerySupport.forRoots(NAME, VERSION, sourceRoots.toArray(new FileObject[]{}));
         this.changeSupport = new ChangeSupport(this);
     }
 
@@ -145,11 +157,12 @@ public class HtmlIndex {
      * @throws IOException
      */
     public AllDependenciesMaps getAllDependencies() throws IOException {
-        Collection<? extends IndexResult> results = filterDeletedFiles(querySupport.query(HtmlIndexer.REFERS_KEY, "", QuerySupport.Kind.PREFIX, HtmlIndexer.REFERS_KEY));
+        Collection<? extends IndexResult> results = filterDeletedFiles(querySupport.query(
+                REFERS_KEY, "", QuerySupport.Kind.PREFIX, REFERS_KEY));
         Map<FileObject, Collection<FileReference>> source2dests = new HashMap<>();
         Map<FileObject, Collection<FileReference>> dest2sources = new HashMap<>();
         for (IndexResult result : results) {
-            String importsValue = result.getValue(HtmlIndexer.REFERS_KEY);
+            String importsValue = result.getValue(REFERS_KEY);
             if (importsValue != null) {
                 FileObject file = result.getFile();
                 Collection<String> imports = decodeListValue(importsValue);
@@ -181,10 +194,10 @@ public class HtmlIndex {
      * Returns list of all remote URLs
      */
     public List<URL> getAllRemoteDependencies() throws IOException {
-        Collection<? extends IndexResult> results = filterDeletedFiles(querySupport.query(HtmlIndexer.REFERS_KEY, "", QuerySupport.Kind.PREFIX, HtmlIndexer.REFERS_KEY));
+        Collection<? extends IndexResult> results = filterDeletedFiles(querySupport.query(REFERS_KEY, "", QuerySupport.Kind.PREFIX, REFERS_KEY));
         Set<String> paths = new HashSet<>();
         for (IndexResult result : results) {
-            String importsValue = result.getValue(HtmlIndexer.REFERS_KEY);
+            String importsValue = result.getValue(REFERS_KEY);
             if(importsValue != null) {
                 paths.addAll(decodeListValue(importsValue));
             }

--- a/ide/html.indexing/src/org/netbeans/modules/html/indexing/Bundle.properties
+++ b/ide/html.indexing/src/org/netbeans/modules/html/indexing/Bundle.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+OpenIDE-Module-Name=HTML Indexing Support
+OpenIDE-Module-Display-Category=Editing

--- a/ide/html.indexing/src/org/netbeans/modules/html/indexing/DependentFileQueryImpl.java
+++ b/ide/html.indexing/src/org/netbeans/modules/html/indexing/DependentFileQueryImpl.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.netbeans.modules.web.clientproject;
+package org.netbeans.modules.html.indexing;
 
 import java.io.IOException;
 import java.util.Collection;

--- a/ide/web.common/apichanges.xml
+++ b/ide/web.common/apichanges.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<?xml-stylesheet type="text/xml" href="../../nbbuild/javadoctools/apichanges.xsl"?>
+<!DOCTYPE apichanges PUBLIC "-//NetBeans//DTD API changes list 1.0//EN" "../../nbbuild/javadoctools/apichanges.dtd">
+
+<apichanges>
+
+  <apidefs>
+    <apidef name="webcommon">Webpage Common APIs</apidef>
+  </apidefs>
+
+<!-- ACTUAL CHANGES BEGIN HERE: -->
+
+  <changes>
+      <change id="webpage.content.mime">
+          <summary>
+              Detection of content MIME type
+          </summary>
+          <version major="1" minor="109"/>
+          <date day="7" month="10" year="2020"/>
+          <author login="sdedic"/>
+          <compatibility addition="yes" binary="compatible" source="compatible"/>
+          <description>
+              <p>
+                  Exported query for long-existed <a href="@TOP@/org/netbeans/modules/web/common/api/WebPageMetadata.html#MIMETYPE">
+                  WebPageMetadata.html.MIMETYPE</a>.
+              </p>
+          </description>
+          <class package="org.netbeans.modules.web.common.api" name="WebPageMetadata"/>
+      </change>
+  </changes>
+
+  <!-- Now the surrounding HTML text and document structure: -->
+
+  <htmlcontents>
+    <head>
+      <title>Change History for the Friend Core APIs</title>
+      <link rel="stylesheet" href="prose.css" type="text/css"/>
+    </head>
+    <body>
+
+<p class="overviewlink"><a href="overview-summary.html">Overview</a></p>
+
+<h1>Introduction</h1>
+
+<p>
+This document lists changes made to the API between core/startup and core
+modules. It is a friend API so it does not need to be developed compatibly,
+and indeed it is not. 
+</p>
+
+<!-- The actual lists of changes, as summaries and details: -->
+
+      <hr/><standard-changelists module-code-name="org.netbeans.core.startup"/>
+
+      <hr/><p>@FOOTER@</p>
+
+    </body>
+  </htmlcontents>
+
+</apichanges>

--- a/ide/web.common/manifest.mf
+++ b/ide/web.common/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.web.common
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/web/common/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.108
+OpenIDE-Module-Specification-Version: 1.109
 

--- a/ide/web.common/nbproject/project.properties
+++ b/ide/web.common/nbproject/project.properties
@@ -19,6 +19,7 @@
 is.autoload=true
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
+javadoc.apichanges=${basedir}/apichanges.xml
 
 test.config.stableBTD.includes=**/*Test.class
 test.config.stableBTD.excludes=\

--- a/ide/web.common/nbproject/project.xml
+++ b/ide/web.common/nbproject/project.xml
@@ -211,6 +211,7 @@
                 <friend>org.netbeans.modules.html.custom</friend>
                 <friend>org.netbeans.modules.html.editor</friend>
                 <friend>org.netbeans.modules.html.editor.lib</friend>
+                <friend>org.netbeans.modules.html.indexing</friend>
                 <friend>org.netbeans.modules.html.knockout</friend>
                 <friend>org.netbeans.modules.html.ojet</friend>
                 <friend>org.netbeans.modules.html.parser</friend>

--- a/java/j2ee.persistence/nbproject/project.xml
+++ b/java/j2ee.persistence/nbproject/project.xml
@@ -247,16 +247,7 @@
                     <code-name-base>org.netbeans.modules.java.editor</code-name-base>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>2.35</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.21</specification-version>
+                        <specification-version>2.78</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.editor.lib/apichanges.xml
+++ b/java/java.editor.lib/apichanges.xml
@@ -83,6 +83,19 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="JavaFoldManager.deprecated">
+            <summary>JavaFoldManager class deprecated</summary>
+            <version major="1" minor="1.49"/>
+            <date day="7" month="10" year="2020"/>
+            <author login="sdedic"/>
+            <compatibility binary="compatible" source="compatible" semantic="incompatible" deprecation="yes"/>
+            <description>
+                Java Editor dependencies on ext.* editor interfaces have been cut off, its Folding implementation does not derive
+                from the <a href="@TOP@/org/netbeans/editor/ext/java/JavaFoldManager.html">org.netbeans.editor.ext.java.JavaFoldManager</a> class. The <code>*_FOLD_TYPE</code> definitions
+                are still valid, although deprecated. Generic <a href="@org-netbeans-modules-editor-fold@/org/netbeans/api/editor/fold/FoldType.html">FoldType.*</a>
+                values should be used whenever possible.
+            </description>
+        </change>
         <change id="old-editor-settings-deprecation">
             <summary>Removing old settings classes</summary>
             <version major="1" minor="9"/>

--- a/java/java.editor.lib/manifest.mf
+++ b/java/java.editor.lib/manifest.mf
@@ -1,6 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.java.editor.lib/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/lib/java/editor/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.49
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module-Layer: org/netbeans/lib/java/editor/layer.xml

--- a/java/java.editor.lib/manifest.mf
+++ b/java/java.editor.lib/manifest.mf
@@ -1,5 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.java.editor.lib/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/lib/java/editor/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.48
+OpenIDE-Module-Specification-Version: 1.49
 AutoUpdate-Show-In-Client: false
+OpenIDE-Module-Layer: org/netbeans/lib/java/editor/layer.xml

--- a/java/java.editor.lib/nbproject/project.properties
+++ b/java/java.editor.lib/nbproject/project.properties
@@ -21,3 +21,6 @@ javadoc.apichanges=${basedir}/apichanges.xml
 
 javac.source=1.7
 
+spec.version.base: 1.49.0
+is.autoload=true
+

--- a/java/java.editor.lib/nbproject/project.xml
+++ b/java/java.editor.lib/nbproject/project.xml
@@ -26,6 +26,15 @@
             <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
             <module-dependencies>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.java.editor</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <implementation-version/>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.editor.document</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.editor.lib/src/org/netbeans/editor/ext/java/JavaFoldManager.java
+++ b/java/java.editor.lib/src/org/netbeans/editor/ext/java/JavaFoldManager.java
@@ -22,35 +22,29 @@ package org.netbeans.editor.ext.java;
 import org.netbeans.api.editor.fold.FoldType;
 import org.netbeans.spi.editor.fold.FoldManager;
 
-import static org.netbeans.editor.ext.java.Bundle.*;
-import org.openide.util.NbBundle;
+import org.netbeans.modules.java.editor.fold.JavaElementFoldManager;
 
 /**
  * Java fold maintainer creates and updates folds for java sources.
  *
  * @author Miloslav Metelka
  * @version 1.00
+ * @deprecated This package introduces a dependency on an obsoleted pre-NetBeans 6.5 features.
+ * It is possible to use generic {@link FoldType} categories and use {@link FoldType#isKindOf(org.netbeans.api.editor.fold.FoldType)}.
  */
 
+@Deprecated
 public abstract class JavaFoldManager implements FoldManager {
 
     public static final FoldType INITIAL_COMMENT_FOLD_TYPE = FoldType.INITIAL_COMMENT; // NOI18N
 
-    @NbBundle.Messages("FoldType_Imports=Imports")
-    public static final FoldType IMPORTS_FOLD_TYPE = FoldType.create("import", FoldType_Imports(), 
-	     new org.netbeans.api.editor.fold.FoldTemplate(0, 0, "...")); // NOI18N
+    public static final FoldType IMPORTS_FOLD_TYPE = JavaElementFoldManager.IMPORTS_FOLD_TYPE;
     
-    @NbBundle.Messages("FoldType_Javadoc=Javadoc Comments")
-    public static final FoldType JAVADOC_FOLD_TYPE = FoldType.DOCUMENTATION.derive("javadoc", FoldType_Javadoc(), 
-	     new org.netbeans.api.editor.fold.FoldTemplate(3, 2, "/**...*/")); // NOI18N
+    public static final FoldType JAVADOC_FOLD_TYPE = JavaElementFoldManager.JAVADOC_FOLD_TYPE;
 
-    @NbBundle.Messages("FoldType_Methods=Methods")
-    public static final FoldType CODE_BLOCK_FOLD_TYPE = FoldType.MEMBER.derive("method", FoldType_Methods(), 
-	     new org.netbeans.api.editor.fold.FoldTemplate(1, 1, "{...}")); // NOI18N
+    public static final FoldType CODE_BLOCK_FOLD_TYPE = JavaElementFoldManager.CODE_BLOCK_FOLD_TYPE;
     
-    @NbBundle.Messages("FoldType_InnerClasses=Inner Classes")
-    public static final FoldType INNERCLASS_TYPE = FoldType.NESTED.derive("innerclass", "Inner Classes", 
-	     new org.netbeans.api.editor.fold.FoldTemplate(1, 1, "{...}")); // NOI18N
+    public static final FoldType INNERCLASS_TYPE = JavaElementFoldManager.INNERCLASS_TYPE;
     
     private static final String IMPORTS_FOLD_DESCRIPTION = "..."; // NOI18N
 

--- a/java/java.editor.lib/src/org/netbeans/lib/java/editor/Bundle.properties
+++ b/java/java.editor.lib/src/org/netbeans/lib/java/editor/Bundle.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-OpenIDE-Module-Name=Java Editor Library
+OpenIDE-Module-Name=Java Editor Library (deprecated)
 OpenIDE-Module-Display-Category=Java
-OpenIDE-Module-Short-Description=Contains java editor library implementation
+OpenIDE-Module-Short-Description=Contains java editor library implementation (deprecated)
 OpenIDE-Module-Long-Description=Java Editor Library contains editing support for java files that can be used in standalone editor
 

--- a/java/java.editor.lib/src/org/netbeans/lib/java/editor/LegacyJavasettingsInitializer.java
+++ b/java/java.editor.lib/src/org/netbeans/lib/java/editor/LegacyJavasettingsInitializer.java
@@ -17,10 +17,13 @@
  * under the License.
  */
 
-package org.netbeans.modules.editor.java;
+package org.netbeans.lib.java.editor;
 
-import org.netbeans.editor.Acceptor;
-import org.netbeans.editor.AcceptorFactory;
+import java.util.Arrays;
+import java.util.List;
+import org.netbeans.editor.TokenContext;
+import org.netbeans.editor.ext.java.JavaLayerTokenContext;
+import org.netbeans.editor.ext.java.JavaTokenContext;
 
 /**
 * Nb settings for Java.
@@ -29,29 +32,14 @@ import org.netbeans.editor.AcceptorFactory;
 * @version 1.00
 */
 
-public final class NbJavaSettingsInitializer {
-
-    public static Acceptor getAbbrevResetAcceptor() {
-        return AcceptorFactory.NON_JAVA_IDENTIFIER;
-    }
-    public static Acceptor getIdentifierAcceptor() {
-        return AcceptorFactory.JAVA_IDENTIFIER;
-    }
-    public static Acceptor getIndentHotCharsAcceptor() {
-        return indentHotCharsAcceptor;
-    }
-    private NbJavaSettingsInitializer() {
+public final class LegacyJavasettingsInitializer {
+    private LegacyJavasettingsInitializer() {
     }
 
-    private static final Acceptor indentHotCharsAcceptor = new Acceptor() {
-        public boolean accept(char ch) {
-            switch (ch) {
-                case '{': //NOI18N
-                case '}': //NOI18N
-                    return true;
-            }
-            return false;
-        }
-    };
-    
+    public static List getTokenContextList() {
+        return Arrays.asList(new TokenContext[] {
+            JavaTokenContext.context,
+            JavaLayerTokenContext.context
+        });
+    }
 }

--- a/java/java.editor.lib/src/org/netbeans/lib/java/editor/LegacyPreferences.xml
+++ b/java/java.editor.lib/src/org/netbeans/lib/java/editor/LegacyPreferences.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE editor-preferences PUBLIC "-//NetBeans//DTD Editor Preferences 1.0//EN" "http://www.netbeans.org/dtds/EditorPreferences-1_0.dtd">
+
+<editor-preferences>
+    <entry javaType="methodvalue" name="token-context-list">
+        <value><![CDATA[org.netbeans.lib.java.editor.LegacyJavasettingsInitializer.getTokenContextList]]></value>
+    </entry>
+</editor-preferences>

--- a/java/java.editor.lib/src/org/netbeans/lib/java/editor/layer.xml
+++ b/java/java.editor.lib/src/org/netbeans/lib/java/editor/layer.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd" [
+    <!ENTITY eclipse-global-keymap SYSTEM "eclipse-global-keymap.xml">
+]>
+<filesystem>
+    <folder name="Editors">
+        <folder name="text">
+            <folder name="x-java">
+                <folder name="Preferences">
+                    <folder name="Defaults">
+                        <file name="org-netbeans-modules-editor-java-preferences-legacy.xml" url="LegacyPreferences.xml" />
+                    </folder>
+                </folder>
+            </folder>
+        </folder>
+    </folder>
+</filesystem>

--- a/java/java.editor/module-auto-deps.xml
+++ b/java/java.editor/module-auto-deps.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<!DOCTYPE transformations PUBLIC "-//NetBeans//DTD Module Automatic Dependencies 1.0//EN" "http://www.netbeans.org/dtds/module-auto-deps-1_0.dtd">
+
+<transformations version="1.0">
+    <transformationgroup>
+        <description>Removed dependencies on pre-6.5 formatting</description>
+        <transformation>
+            <trigger-dependency type="older">
+                <module-dependency codenamebase="org.netbeans.modules.java.editor" major="1" spec="2.78.0"/>
+            </trigger-dependency>
+            <implies>
+                <result>
+                    <module-dependency codenamebase="org.netbeans.modules.java.editor.lib" major="1" spec="1.49"/>
+                </result>
+            </implies>
+        </transformation>
+    </transformationgroup>
+</transformations>

--- a/java/java.editor/module-auto-deps.xml
+++ b/java/java.editor/module-auto-deps.xml
@@ -31,7 +31,7 @@
             </trigger-dependency>
             <implies>
                 <result>
-                    <module-dependency codenamebase="org.netbeans.modules.java.editor.lib" major="1" spec="1.49"/>
+                    <module-dependency codenamebase="org.netbeans.modules.java.editor.lib" major="1" spec="1.49.0"/>
                 </result>
             </implies>
         </transformation>

--- a/java/java.editor/nbproject/project.properties
+++ b/java/java.editor/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 javadoc.title=Java Editor
 
-spec.version.base=2.77.0
+spec.version.base=2.78.0
 test.qa-functional.cp.extra=${editor.dir}/modules/org-netbeans-modules-editor-fold.jar
 javac.source=1.8
 #test.unit.cp.extra=

--- a/java/java.editor/nbproject/project.xml
+++ b/java/java.editor/nbproject/project.xml
@@ -210,15 +210,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.29</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.java.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.editor/nbproject/project.xml
+++ b/java/java.editor/nbproject/project.xml
@@ -521,11 +521,6 @@
                         <test/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.java.editor</code-name-base>
-                        <recursive/>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.java.editor.base</code-name-base>
                         <compile-dependency/>
                         <test/>
@@ -603,7 +598,7 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.java.editor</code-name-base>
+                        <code-name-base>org.netbeans.modules.java.editor.base</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaKit.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaKit.java
@@ -44,15 +44,14 @@ import org.netbeans.api.java.source.CodeStyle;
 import org.netbeans.api.lexer.InputAttributes;
 import org.netbeans.editor.*;
 import org.netbeans.editor.Utilities;
-import org.netbeans.editor.ext.java.*;
 import org.netbeans.api.java.queries.SourceLevelQuery;
 import org.netbeans.editor.ext.ExtKit;
-import org.netbeans.lib.editor.codetemplates.api.CodeTemplateManager;
 import org.netbeans.modules.editor.MainMenuAction;
 import org.netbeans.modules.editor.NbEditorKit;
 import org.netbeans.modules.editor.NbEditorUtilities;
 import org.netbeans.modules.editor.indent.api.Indent;
 import org.netbeans.modules.java.editor.codegen.InsertSemicolonAction;
+import org.netbeans.modules.java.editor.fold.JavaElementFoldManager;
 import org.netbeans.modules.java.editor.imports.ClipboardHandler;
 import org.netbeans.modules.java.editor.imports.FastImportAction;
 import org.netbeans.modules.java.editor.imports.JavaFixAllImports;
@@ -67,7 +66,6 @@ import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
-import org.openide.util.NbPreferences;
 
 /**
 * Java editor kit with appropriate document
@@ -118,6 +116,10 @@ public class JavaKit extends NbEditorKit {
 //        return new JavaFormatter(this.getClass());
 //    }
 
+    /** Comment with the '//' prefix */
+    public static final BaseTokenID LINE_COMMENT
+        = new BaseTokenID("line-comment", 7 /* magic constant from java.editor.lib */); // NOI18N
+
     protected void initDocument(BaseDocument doc) {
 //        doc.addLayer(new JavaDrawLayerFactory.JavaLayer(),
 //                JavaDrawLayerFactory.JAVA_LAYER_VISIBILITY);
@@ -135,7 +137,8 @@ public class JavaKit extends NbEditorKit {
                   }
       
                   public void syntaxUpdateToken(TokenID id, TokenContextPath contextPath, int offset, int length) {
-                      if (JavaTokenContext.LINE_COMMENT == id) {
+                      // PENDING: this whole init code ought to be factored out to java.editor.lib probably.
+                      if (id != null && id.getNumericID() == LINE_COMMENT.getNumericID()) {
                           tokenList.add(new TokenInfo(id, contextPath, offset, length));
                       }
                   }
@@ -618,7 +621,7 @@ public class JavaKit extends NbEditorKit {
         public void actionPerformed(ActionEvent evt, JTextComponent target) {
             FoldHierarchy hierarchy = FoldHierarchy.get(target);
             // Hierarchy locking done in the utility method
-            FoldUtilities.expand(hierarchy, JavaFoldManager.JAVADOC_FOLD_TYPE);
+            FoldUtilities.expand(hierarchy, JavaElementFoldManager.JAVADOC_FOLD_TYPE);
         }
     }
 
@@ -635,7 +638,7 @@ public class JavaKit extends NbEditorKit {
         public void actionPerformed(ActionEvent evt, JTextComponent target) {
             FoldHierarchy hierarchy = FoldHierarchy.get(target);
             // Hierarchy locking done in the utility method
-            FoldUtilities.collapse(hierarchy, JavaFoldManager.JAVADOC_FOLD_TYPE);
+            FoldUtilities.collapse(hierarchy, JavaElementFoldManager.JAVADOC_FOLD_TYPE);
         }
     }
 
@@ -654,8 +657,8 @@ public class JavaKit extends NbEditorKit {
             FoldHierarchy hierarchy = FoldHierarchy.get(target);
             // Hierarchy locking done in the utility method
             List types = new ArrayList();
-            types.add(JavaFoldManager.CODE_BLOCK_FOLD_TYPE);
-            types.add(JavaFoldManager.IMPORTS_FOLD_TYPE);
+            types.add(JavaElementFoldManager.CODE_BLOCK_FOLD_TYPE);
+            types.add(JavaElementFoldManager.IMPORTS_FOLD_TYPE);
             FoldUtilities.expand(hierarchy, types);
         }
     }
@@ -674,8 +677,8 @@ public class JavaKit extends NbEditorKit {
             FoldHierarchy hierarchy = FoldHierarchy.get(target);
             // Hierarchy locking done in the utility method
             List types = new ArrayList();
-            types.add(JavaFoldManager.CODE_BLOCK_FOLD_TYPE);
-            types.add(JavaFoldManager.IMPORTS_FOLD_TYPE);
+            types.add(JavaElementFoldManager.CODE_BLOCK_FOLD_TYPE);
+            types.add(JavaElementFoldManager.IMPORTS_FOLD_TYPE);
             FoldUtilities.collapse(hierarchy, types);
         }
     }

--- a/java/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManager.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManager.java
@@ -40,29 +40,114 @@ import javax.swing.text.JTextComponent;
 import org.netbeans.api.editor.fold.Fold;
 import org.netbeans.api.editor.fold.FoldType;
 import org.netbeans.api.java.source.CompilationInfo;
-import org.netbeans.editor.ext.java.JavaFoldManager;
 import org.netbeans.modules.java.editor.base.fold.JavaElementFoldVisitor;
 import org.netbeans.modules.java.editor.semantic.ScanningCancellableTask;
 import org.netbeans.spi.editor.fold.FoldHierarchyTransaction;
 import org.netbeans.spi.editor.fold.FoldInfo;
+import org.netbeans.spi.editor.fold.FoldManager;
 import org.netbeans.spi.editor.fold.FoldOperation;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.loaders.DataObjectNotFoundException;
 import org.openide.util.Exceptions;
+import org.openide.util.NbBundle;
 
 /**
  *
  * @author Jan Lahoda
  */
-public class JavaElementFoldManager extends JavaFoldManager {
+public class JavaElementFoldManager implements FoldManager {
     
     private FoldOperation operation;
     private FileObject    file;
     private JavaElementFoldTask task;
     private boolean first = true;
     
+
+    public static final FoldType INITIAL_COMMENT_FOLD_TYPE = FoldType.INITIAL_COMMENT; // NOI18N
+
+    @NbBundle.Messages("FoldType_Imports=Imports")
+    public static final FoldType IMPORTS_FOLD_TYPE = FoldType.create("import", Bundle.FoldType_Imports(), 
+	     new org.netbeans.api.editor.fold.FoldTemplate(0, 0, "...")); // NOI18N
+    
+    @NbBundle.Messages("FoldType_Javadoc=Javadoc Comments")
+    public static final FoldType JAVADOC_FOLD_TYPE = FoldType.DOCUMENTATION.derive("javadoc", Bundle.FoldType_Javadoc(), 
+	     new org.netbeans.api.editor.fold.FoldTemplate(3, 2, "/**...*/")); // NOI18N
+
+    @NbBundle.Messages("FoldType_Methods=Methods")
+    public static final FoldType CODE_BLOCK_FOLD_TYPE = FoldType.MEMBER.derive("method", Bundle.FoldType_Methods(), 
+	     new org.netbeans.api.editor.fold.FoldTemplate(1, 1, "{...}")); // NOI18N
+    
+    @NbBundle.Messages("FoldType_InnerClasses=Inner Classes")
+    public static final FoldType INNERCLASS_TYPE = FoldType.NESTED.derive("innerclass", "Inner Classes", 
+	     new org.netbeans.api.editor.fold.FoldTemplate(1, 1, "{...}")); // NOI18N
+    
+    private static final String IMPORTS_FOLD_DESCRIPTION = "..."; // NOI18N
+
+    private static final String COMMENT_FOLD_DESCRIPTION = "/*...*/"; // NOI18N
+
+    private static final String JAVADOC_FOLD_DESCRIPTION = "/**...*/"; // NOI18N
+    
+    private static final String CODE_BLOCK_FOLD_DESCRIPTION = "{...}"; // NOI18N
+
+    @Deprecated
+    public static final FoldTemplate INITIAL_COMMENT_FOLD_TEMPLATE
+        = new FoldTemplate(INITIAL_COMMENT_FOLD_TYPE, COMMENT_FOLD_DESCRIPTION, 2, 2);
+
+    @Deprecated
+    public static final FoldTemplate IMPORTS_FOLD_TEMPLATE
+        = new FoldTemplate(IMPORTS_FOLD_TYPE, IMPORTS_FOLD_DESCRIPTION, 0, 0);
+
+    @Deprecated
+    public static final FoldTemplate JAVADOC_FOLD_TEMPLATE
+        = new FoldTemplate(JAVADOC_FOLD_TYPE, JAVADOC_FOLD_DESCRIPTION, 3, 2);
+
+    @Deprecated
+    public static final FoldTemplate CODE_BLOCK_FOLD_TEMPLATE
+        = new FoldTemplate(CODE_BLOCK_FOLD_TYPE, CODE_BLOCK_FOLD_DESCRIPTION, 1, 1);
+
+    @Deprecated
+    public static final FoldTemplate INNER_CLASS_FOLD_TEMPLATE
+        = new FoldTemplate(INNERCLASS_TYPE, CODE_BLOCK_FOLD_DESCRIPTION, 1, 1);
+
+    
+    protected static final class FoldTemplate {
+        
+        private FoldType type;
+        
+        private String description;
+        
+        private int startGuardedLength;
+        
+        private int endGuardedLength;
+        
+        protected FoldTemplate(FoldType type, String description,
+        int startGuardedLength, int endGuardedLength) {
+            this.type = type;
+            this.description = description;
+            this.startGuardedLength = startGuardedLength;
+            this.endGuardedLength = endGuardedLength;
+        }
+        
+        public FoldType getType() {
+            return type;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+        
+        public int getStartGuardedLength() {
+            return startGuardedLength;
+        }
+        
+        public int getEndGuardedLength() {
+            return endGuardedLength;
+        }
+
+    }
+
     public void init(FoldOperation operation) {
         this.operation = operation;
     }

--- a/java/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManager.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/fold/JavaElementFoldManager.java
@@ -83,35 +83,6 @@ public class JavaElementFoldManager implements FoldManager {
     public static final FoldType INNERCLASS_TYPE = FoldType.NESTED.derive("innerclass", "Inner Classes", 
 	     new org.netbeans.api.editor.fold.FoldTemplate(1, 1, "{...}")); // NOI18N
     
-    private static final String IMPORTS_FOLD_DESCRIPTION = "..."; // NOI18N
-
-    private static final String COMMENT_FOLD_DESCRIPTION = "/*...*/"; // NOI18N
-
-    private static final String JAVADOC_FOLD_DESCRIPTION = "/**...*/"; // NOI18N
-    
-    private static final String CODE_BLOCK_FOLD_DESCRIPTION = "{...}"; // NOI18N
-
-    @Deprecated
-    public static final FoldTemplate INITIAL_COMMENT_FOLD_TEMPLATE
-        = new FoldTemplate(INITIAL_COMMENT_FOLD_TYPE, COMMENT_FOLD_DESCRIPTION, 2, 2);
-
-    @Deprecated
-    public static final FoldTemplate IMPORTS_FOLD_TEMPLATE
-        = new FoldTemplate(IMPORTS_FOLD_TYPE, IMPORTS_FOLD_DESCRIPTION, 0, 0);
-
-    @Deprecated
-    public static final FoldTemplate JAVADOC_FOLD_TEMPLATE
-        = new FoldTemplate(JAVADOC_FOLD_TYPE, JAVADOC_FOLD_DESCRIPTION, 3, 2);
-
-    @Deprecated
-    public static final FoldTemplate CODE_BLOCK_FOLD_TEMPLATE
-        = new FoldTemplate(CODE_BLOCK_FOLD_TYPE, CODE_BLOCK_FOLD_DESCRIPTION, 1, 1);
-
-    @Deprecated
-    public static final FoldTemplate INNER_CLASS_FOLD_TEMPLATE
-        = new FoldTemplate(INNERCLASS_TYPE, CODE_BLOCK_FOLD_DESCRIPTION, 1, 1);
-
-    
     protected static final class FoldTemplate {
         
         private FoldType type;

--- a/java/java.editor/src/org/netbeans/modules/java/editor/fold/JavaFoldTypeProvider.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/fold/JavaFoldTypeProvider.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import org.netbeans.api.editor.fold.FoldTemplate;
 import org.netbeans.api.editor.fold.FoldType;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
-import org.netbeans.editor.ext.java.JavaFoldManager;
 import org.netbeans.spi.editor.fold.FoldTypeProvider;
 import org.openide.util.NbBundle;
 
@@ -36,11 +35,11 @@ public class JavaFoldTypeProvider implements FoldTypeProvider {
     private Collection<FoldType>   types = new ArrayList<FoldType>(5);
 
     public JavaFoldTypeProvider() {
-        types.add(JavaFoldManager.CODE_BLOCK_FOLD_TYPE);
-        types.add(JavaFoldManager.INNERCLASS_TYPE);
-        types.add(JavaFoldManager.IMPORTS_FOLD_TYPE);
-        types.add(JavaFoldManager.JAVADOC_FOLD_TYPE);
-        types.add(JavaFoldManager.INITIAL_COMMENT_FOLD_TYPE);
+        types.add(JavaElementFoldManager.CODE_BLOCK_FOLD_TYPE);
+        types.add(JavaElementFoldManager.INNERCLASS_TYPE);
+        types.add(JavaElementFoldManager.IMPORTS_FOLD_TYPE);
+        types.add(JavaElementFoldManager.JAVADOC_FOLD_TYPE);
+        types.add(JavaElementFoldManager.INITIAL_COMMENT_FOLD_TYPE);
         types.add(JavaFoldTypeProvider.BUNDLE_STRING);
     }
     

--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultPreferences.xml
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultPreferences.xml
@@ -71,9 +71,6 @@
     <entry javaType="java.lang.Boolean" name="show-deprecated-members">
         <value><![CDATA[true]]></value>
     </entry>
-    <entry javaType="methodvalue" name="token-context-list">
-        <value><![CDATA[org.netbeans.modules.editor.java.NbJavaSettingsInitializer.getTokenContextList]]></value>
-    </entry>
     <entry javaType="java.lang.Boolean" name="word-match-match-case">
         <value><![CDATA[true]]></value>
     </entry>

--- a/java/java.kit/nbproject/project.xml
+++ b/java/java.kit/nbproject/project.xml
@@ -91,14 +91,7 @@
                     <code-name-base>org.netbeans.modules.java.editor</code-name-base>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>2.8</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.9</specification-version>
+                        <specification-version>2.78</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/javadoc/nbproject/project.xml
+++ b/java/javadoc/nbproject/project.xml
@@ -118,7 +118,7 @@
                     <code-name-base>org.netbeans.modules.java.editor</code-name-base>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>2.66</specification-version>
+                        <specification-version>2.78</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -309,11 +309,6 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.java.editor</code-name-base>
-                        <recursive/>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
                         <recursive/>
                         <compile-dependency/>
                     </test-dependency>

--- a/java/refactoring.java/nbproject/project.xml
+++ b/java/refactoring.java/nbproject/project.xml
@@ -495,10 +495,6 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.java.hints</code-name-base>
                     </test-dependency>
                     <test-dependency>

--- a/java/spellchecker.bindings.java/nbproject/project.xml
+++ b/java/spellchecker.bindings.java/nbproject/project.xml
@@ -52,15 +52,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.java.editor.lib</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.4.1</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.java.lexer</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -1512,6 +1512,7 @@ nb.cluster.webcommon=\
         javascript2.editor,\
         javascript2.extdoc,\
         javascript2.extjs,\
+        javascript2.html,\
 	javascript2.jade,\
         javascript2.jquery,\
         javascript2.jsdoc,\

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -402,6 +402,7 @@ nb.cluster.ide=\
         html.custom,\
         html.editor,\
         html.editor.lib,\
+        html.indexing,\
         html.lexer,\
         html.parser,\
         html.validation,\

--- a/nbbuild/javadoctools/links.xml
+++ b/nbbuild/javadoctools/links.xml
@@ -238,3 +238,4 @@
 <link href="https://www.graalvm.org/truffle/javadoc/" offline="true" packagelistloc="./truffle"/>
 <link href="${javadoc.docs.org-netbeans-modules-jumpto}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-jumpto"/>
 <link href="${javadoc.docs.org-netbeans-modules-java-editor-lib}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-java-editor-lib"/>
+<link href="${javadoc.docs.org-netbeans-modules-web-common}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-web-common"/>

--- a/nbbuild/javadoctools/links.xml
+++ b/nbbuild/javadoctools/links.xml
@@ -237,3 +237,4 @@
 <link href="${javadoc.docs.org-netbeans-modules-textmate-lexer}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-textmate-lexer"/>
 <link href="https://www.graalvm.org/truffle/javadoc/" offline="true" packagelistloc="./truffle"/>
 <link href="${javadoc.docs.org-netbeans-modules-jumpto}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-jumpto"/>
+<link href="${javadoc.docs.org-netbeans-modules-java-editor-lib}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-java-editor-lib"/>

--- a/nbbuild/javadoctools/properties.xml
+++ b/nbbuild/javadoctools/properties.xml
@@ -234,3 +234,4 @@
 <property name="javadoc.docs.org-netbeans-modules-gradle-java" value="${javadoc.web.root}/org-netbeans-modules-gradle-java"/>
 <property name="javadoc.docs.org-netbeans-modules-textmate-lexer" value="${javadoc.web.root}/org-netbeans-modules-textmate-lexer"/>
 <property name="javadoc.docs.org-netbeans-modules-jumpto" value="${javadoc.web.root}/org-netbeans-modules-jumpto"/>
+<property name="javadoc.docs.org-netbeans-modules-java-editor-lib" value="${javadoc.web.root}/org-netbeans-modules-java-editor-lib"/>

--- a/nbbuild/javadoctools/properties.xml
+++ b/nbbuild/javadoctools/properties.xml
@@ -235,3 +235,4 @@
 <property name="javadoc.docs.org-netbeans-modules-textmate-lexer" value="${javadoc.web.root}/org-netbeans-modules-textmate-lexer"/>
 <property name="javadoc.docs.org-netbeans-modules-jumpto" value="${javadoc.web.root}/org-netbeans-modules-jumpto"/>
 <property name="javadoc.docs.org-netbeans-modules-java-editor-lib" value="${javadoc.web.root}/org-netbeans-modules-java-editor-lib"/>
+<property name="javadoc.docs.org-netbeans-modules-web-common" value="${javadoc.web.root}/org-netbeans-modules-web-common"/>

--- a/nbbuild/javadoctools/replaces.xml
+++ b/nbbuild/javadoctools/replaces.xml
@@ -235,3 +235,4 @@
 <replacefilter token="@org-netbeans-modules-textmate-lexer@" value="${javadoc.docs.org-netbeans-modules-textmate-lexer}"/>
 <replacefilter token="@org-netbeans-modules-jumpto@" value="${javadoc.docs.org-netbeans-modules-jumpto}"/>
 <replacefilter token="@org-netbeans-modules-java-editor-lib@" value="${javadoc.docs.org-netbeans-modules-java-editor-lib}"/>
+<replacefilter token="@org-netbeans-modules-web-common@" value="${javadoc.docs.org-netbeans-modules-web-common}"/>

--- a/nbbuild/javadoctools/replaces.xml
+++ b/nbbuild/javadoctools/replaces.xml
@@ -234,3 +234,4 @@
 <replacefilter token="@org-netbeans-modules-gradle-java@" value="${javadoc.docs.org-netbeans-modules-gradle-java}"/>
 <replacefilter token="@org-netbeans-modules-textmate-lexer@" value="${javadoc.docs.org-netbeans-modules-textmate-lexer}"/>
 <replacefilter token="@org-netbeans-modules-jumpto@" value="${javadoc.docs.org-netbeans-modules-jumpto}"/>
+<replacefilter token="@org-netbeans-modules-java-editor-lib@" value="${javadoc.docs.org-netbeans-modules-java-editor-lib}"/>

--- a/php/php.latte/nbproject/project.xml
+++ b/php/php.latte/nbproject/project.xml
@@ -147,7 +147,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.19</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/core.execution/src/org/netbeans/core/execution/RunClassThread.java
+++ b/platform/core.execution/src/org/netbeans/core/execution/RunClassThread.java
@@ -19,11 +19,6 @@
 
 package org.netbeans.core.execution;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Set;
 import org.openide.util.NbBundle;
 import org.openide.windows.InputOutput;
 

--- a/platform/o.n.core/src/org/netbeans/core/NbLifeExit.java
+++ b/platform/o.n.core/src/org/netbeans/core/NbLifeExit.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.core;
 
+import java.awt.GraphicsEnvironment;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -110,7 +111,9 @@ final class NbLifeExit implements Runnable {
     private void doExit(int status) {
         // save all open files
         Future<Boolean> res;
-        if (System.getProperty("netbeans.close") != null || ExitDialog.showDialog()) { // NOI18N
+        boolean noDialog = GraphicsEnvironment.isHeadless() 
+            || System.getProperty("netbeans.close") != null; // NOI18N
+        if (noDialog || ExitDialog.showDialog()) {
             res = Main.getModuleSystem().shutDownAsync(new NbLifeExit(1, status, null, onExit));
         } else {
             res = null;

--- a/platform/openide.dialogs/src/org/openide/DialogDisplayer.java
+++ b/platform/openide.dialogs/src/org/openide/DialogDisplayer.java
@@ -133,13 +133,19 @@ public abstract class DialogDisplayer {
      * @see "#30031"
      */
     private static final class Trivial extends DialogDisplayer {
+        @Override
         public Object notify(NotifyDescriptor nd) {
+            if (GraphicsEnvironment.isHeadless()) {
+                return NotifyDescriptor.CLOSED_OPTION;
+            }
+
             JDialog dialog = new StandardDialog(nd.getTitle(), true, nd, null, null);
             dialog.setVisible(true);
 
             return (nd.getValue() != null) ? nd.getValue() : NotifyDescriptor.CLOSED_OPTION;
         }
 
+        @Override
         public Dialog createDialog(final DialogDescriptor dd) {
             final StandardDialog dialog = new StandardDialog(
                     dd.getTitle(), dd.isModal(), dd, dd.getClosingOptions(), dd.getButtonListener()

--- a/platform/sendopts/src/org/netbeans/modules/sendopts/DefaultProcessor.java
+++ b/platform/sendopts/src/org/netbeans/modules/sendopts/DefaultProcessor.java
@@ -191,6 +191,8 @@ public final class DefaultProcessor extends OptionProcessor {
             if (inst instanceof ArgsProcessor) {
                 ((ArgsProcessor)inst).process(env);
             }
+        } catch (CommandException exception) {
+            throw exception;
         } catch (Exception exception) {
             throw (CommandException)new CommandException(10, exception.getLocalizedMessage()).initCause(exception);
         }

--- a/webcommon/html.angular/nbproject/project.xml
+++ b/webcommon/html.angular/nbproject/project.xml
@@ -110,7 +110,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.33</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/html.angular/nbproject/project.xml
+++ b/webcommon/html.angular/nbproject/project.xml
@@ -137,7 +137,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>0.63</specification-version>
+                        <specification-version>0.84</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/html.knockout/nbproject/project.xml
+++ b/webcommon/html.knockout/nbproject/project.xml
@@ -128,7 +128,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>0.63</specification-version>
+                        <specification-version>0.84</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/html.knockout/nbproject/project.xml
+++ b/webcommon/html.knockout/nbproject/project.xml
@@ -101,7 +101,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.34</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.editor/manifest.mf
+++ b/webcommon/javascript2.editor/manifest.mf
@@ -3,6 +3,5 @@ OpenIDE-Module: org.netbeans.modules.javascript2.editor/1
 OpenIDE-Module-Install: org/netbeans/modules/javascript2/editor/ModuleInstaller.class
 OpenIDE-Module-Layer: org/netbeans/modules/javascript2/editor/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/javascript2/editor/Bundle.properties
-OpenIDE-Module-Specification-Version: 0.83
-AutoUpdate-Show-In-Client: false
-
+OpenIDE-Module-Specification-Version: 0.84
+OpenIDE-Module-Recommends: cnb.org.netbeans.modules.html.editor

--- a/webcommon/javascript2.editor/nbproject/project.xml
+++ b/webcommon/javascript2.editor/nbproject/project.xml
@@ -75,7 +75,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.50</specification-version>
+                        <specification-version>2.65</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -85,15 +85,6 @@
                     <run-dependency>
                         <release-version>1</release-version>
                         <specification-version>1.0</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.css.editor</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>1</release-version>
-                        <specification-version>1.26</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -207,24 +198,6 @@
                     <run-dependency>
                         <release-version>1</release-version>
                         <specification-version>1.46</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.html.editor</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>2</release-version>
-                        <specification-version>2.66</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.html.editor.lib</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>3</release-version>
-                        <specification-version>3.2</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -365,7 +338,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.49</specification-version>
+                        <specification-version>1.109</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -560,6 +533,9 @@
                         <code-name-base>org.netbeans.modules.parsing.api</code-name-base>
                         <test/>
                     </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.javascript2.html</code-name-base>
+                    </test-dependency>
                 </test-type>
                 <test-type>
                     <name>qa-functional</name>
@@ -587,6 +563,9 @@
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
                     </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.javascript2.html</code-name-base>
+                    </test-dependency>
                 </test-type>
             </test-dependencies>
             <friend-packages>
@@ -597,6 +576,7 @@
                 <friend>org.netbeans.modules.javascript2.gj.bootstrap</friend>
                 <friend>org.netbeans.modules.javascript2.gj.react</friend>
                 <friend>org.netbeans.modules.javascript2.gj.typescript</friend>
+                <friend>org.netbeans.modules.javascript2.html</friend>
                 <friend>org.netbeans.modules.javascript2.react</friend>
                 <friend>org.netbeans.modules.javascript2.jquery</friend>
                 <friend>org.netbeans.modules.javascript2.kendo</friend>

--- a/webcommon/javascript2.editor/nbproject/project.xml
+++ b/webcommon/javascript2.editor/nbproject/project.xml
@@ -215,7 +215,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.37</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsDeletedTextInterceptor.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsDeletedTextInterceptor.java
@@ -19,12 +19,13 @@
 package org.netbeans.modules.javascript2.editor;
 
 import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.api.lexer.Language;
 import org.netbeans.api.lexer.TokenSequence;
-import org.netbeans.editor.BaseDocument;
+import org.netbeans.lib.editor.util.swing.DocumentUtilities;
 import org.netbeans.modules.csl.api.EditorOptions;
 import org.netbeans.modules.javascript2.lexer.api.JsTokenId;
 import org.netbeans.modules.javascript2.lexer.api.LexUtilities;
@@ -77,7 +78,8 @@ public class JsDeletedTextInterceptor implements DeletedTextInterceptor {
 
     @Override
     public void remove(Context context) throws BadLocationException {
-        BaseDocument doc = (BaseDocument) context.getDocument();
+        // Can be replaced by LineDocument, except perhaps the getChars(), which is optimized.
+        Document doc = context.getDocument();
 
         int dotPos = context.getOffset() - 1;
         // FIXME
@@ -148,9 +150,9 @@ public class JsDeletedTextInterceptor implements DeletedTextInterceptor {
             }
         case '\"': {
             if (isSmartQuotingEnabled()) {
-                char[] match = doc.getChars(dotPos, 1);
+                CharSequence match = DocumentUtilities.getText(doc, dotPos, 1);
 
-                if ((match != null) && (match[0] == ch)) {
+                if ((match != null) && (match.length() > 0) && (match.charAt(0) == ch)) {
                     doc.remove(dotPos, 1);
                 }
             }

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsTypedTextInterceptor.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsTypedTextInterceptor.java
@@ -21,6 +21,10 @@ package org.netbeans.modules.javascript2.editor;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Caret;
+import javax.swing.text.Document;
+import org.netbeans.api.editor.document.AtomicLockDocument;
+import org.netbeans.api.editor.document.LineDocument;
+import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.api.editor.mimelookup.MimeRegistration;
 import org.netbeans.api.lexer.Language;
 import org.netbeans.api.lexer.Token;
@@ -28,7 +32,7 @@ import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenId;
 import org.netbeans.api.lexer.TokenSequence;
 import org.netbeans.editor.BaseDocument;
-import org.netbeans.editor.Utilities;
+import org.netbeans.lib.editor.util.swing.DocumentUtilities;
 import org.netbeans.modules.csl.api.EditorOptions;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.csl.spi.GsfUtilities;
@@ -89,9 +93,14 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
 
     @Override
     public void afterInsert(final Context context) throws BadLocationException {
-        final BaseDocument doc = (BaseDocument) context.getDocument();
+        final Document doc = context.getDocument();
+        final LineDocument ld = LineDocumentUtils.as(doc, LineDocument.class);
+        if (ld == null) {
+            return;
+        }
+        final AtomicLockDocument ald = LineDocumentUtils.asRequired(doc, AtomicLockDocument.class);
         final AtomicReference<BadLocationException> ex = new AtomicReference<BadLocationException>();
-        doc.runAtomicAsUser(new Runnable() {
+        ald.runAtomicAsUser(new Runnable() {
 
             @Override
             public void run() {
@@ -158,9 +167,9 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
 
                             // Reindent blocks (won't do anything if } is not at the beginning of a line
                             if (ch == '}') {
-                                reindent(doc, dotPos, JsTokenId.BRACKET_RIGHT_CURLY, caret);
+                                reindent(ld, dotPos, JsTokenId.BRACKET_RIGHT_CURLY, caret);
                             } else if (ch == ']') {
-                                reindent(doc, dotPos, JsTokenId.BRACKET_RIGHT_BRACKET, caret);
+                                reindent(ld, dotPos, JsTokenId.BRACKET_RIGHT_BRACKET, caret);
                             }
                             break;
                         default:
@@ -299,7 +308,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
     public void cancelled(Context context) {
     }
 
-    private void reindent(BaseDocument doc, int offset, TokenId id, Caret caret)
+    private void reindent(LineDocument doc, int offset, TokenId id, Caret caret)
         throws BadLocationException {
         TokenSequence<? extends JsTokenId> ts = LexUtilities.getTokenSequence(
                 doc, offset, language);
@@ -314,7 +323,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
             Token<? extends JsTokenId> token = ts.token();
 
             if ((token.id() == id)) {
-                final int rowFirstNonWhite = Utilities.getRowFirstNonWhite(doc, offset);
+                final int rowFirstNonWhite = LineDocumentUtils.getLineFirstNonWhitespace(doc, offset);
                 // Ensure that this token is at the beginning of the line
                 if (ts.offset() > rowFirstNonWhite) {
 //                    if (RubyUtils.isRhtmlDocument(doc)) {
@@ -355,7 +364,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
      * @param caret caret
      * @param bracket the bracket that was inserted
      */
-    private void completeOpeningBracket(BaseDocument doc, int dotPos, Caret caret, char bracket)
+    private void completeOpeningBracket(Document doc, int dotPos, Caret caret, char bracket)
         throws BadLocationException {
         if (isCompletablePosition(doc, dotPos + 1)) {
             String matchingBracket = "" + matching(bracket);
@@ -382,7 +391,8 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
             return;
         }
         int dotPos = context.getOffset();
-        BaseDocument doc = (BaseDocument) context.getDocument();
+        Document doc = context.getDocument();
+        LineDocument ld = LineDocumentUtils.as(doc, LineDocument.class);
         if (isEscapeSequence(doc, dotPos)) { // \" or \' typed
             return;
         }
@@ -395,7 +405,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
         TokenSequence<? extends JsTokenId> ts = LexUtilities.getTokenSequence(
                 doc, dotPos, language);
 
-        if (ts == null) {
+        if (ts == null || ld == null) {
             return;
         }
 
@@ -412,7 +422,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
             previousToken = ts.token();
         }
 
-        int lastNonWhite = Utilities.getRowLastNonWhite(doc, dotPos);
+        int lastNonWhite = LineDocumentUtils.getLineLastNonWhitespace(ld, dotPos);
 
         // eol - true if the caret is at the end of line (ignoring whitespaces)
         boolean eol = lastNonWhite < dotPos;
@@ -431,7 +441,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
             }
         }
 
-        boolean completablePosition = isQuoteCompletablePosition(doc, dotPos);
+        boolean completablePosition = isQuoteCompletablePosition(ld, dotPos);
 
         boolean insideString = false;
         JsTokenId id = token.id();
@@ -477,7 +487,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
                 return; // do not complete
             } else {
                 //#69524
-                char chr = doc.getChars(dotPos, 1)[0];
+                char chr = DocumentUtilities.getText(doc, dotPos, 1).charAt(0);
 
                 if (chr == bracket) {
                     context.setText(Character.toString(bracket), 1);
@@ -501,40 +511,39 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
      * @param doc the document
      * @param dotPos position to be tested
      */
-    private boolean isCompletablePosition(BaseDocument doc, int dotPos)
+    private boolean isCompletablePosition(Document doc, int dotPos)
         throws BadLocationException {
         if (dotPos == doc.getLength()) { // there's no other character to test
 
             return true;
         } else {
             // test that we are in front of ) , " or '
-            char chr = doc.getChars(dotPos, 1)[0];
-
+            char chr = DocumentUtilities.getText(doc, dotPos, 1).charAt(0);
             return ((chr == ')') || (chr == ',') || (chr == '\"') || (chr == '\'') || (chr == '`') || (chr == ' ') ||
             (chr == ']') || (chr == '}') || (chr == '\n') || (chr == '\t') || (chr == ';'));
         }
     }
 
-    private boolean isQuoteCompletablePosition(BaseDocument doc, int dotPos)
+    private boolean isQuoteCompletablePosition(LineDocument doc, int dotPos)
         throws BadLocationException {
         if (dotPos == doc.getLength()) { // there's no other character to test
 
             return true;
         } else {
             // test that we are in front of ) , " or ' ... etc.
-            int eol = Utilities.getRowEnd(doc, dotPos);
+            int eol = LineDocumentUtils.getLineEnd(doc, dotPos);
 
             if ((dotPos == eol) || (eol == -1)) {
                 return false;
             }
 
-            int firstNonWhiteFwd = Utilities.getFirstNonWhiteFwd(doc, dotPos, eol);
+            int firstNonWhiteFwd = LineDocumentUtils.getNextNonWhitespace(doc, dotPos, eol);
 
             if (firstNonWhiteFwd == -1) {
                 return false;
             }
 
-            char chr = doc.getChars(firstNonWhiteFwd, 1)[0];
+            char chr = DocumentUtilities.getText(doc, firstNonWhiteFwd, 1).charAt(0);
 
             return ((chr == ')') || (chr == ',') || (chr == '+') || (chr == '}') || (chr == ';') ||
                (chr == ']'));
@@ -551,7 +560,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
      * @param caret caret
      * @param bracket the bracket character ']' or ')'
      */
-    private void skipClosingBracket(BaseDocument doc, Caret caret, char bracket, TokenId bracketId)
+    private void skipClosingBracket(Document doc, Caret caret, char bracket, TokenId bracketId)
         throws BadLocationException {
         int caretOffset = caret.getDot();
 
@@ -570,7 +579,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
      * @param doc document into which typing was done.
      * @param caretOffset
      */
-    private boolean isSkipClosingBracket(BaseDocument doc, int caretOffset, TokenId bracketId)
+    private boolean isSkipClosingBracket(Document doc, int caretOffset, TokenId bracketId)
         throws BadLocationException {
         // First check whether the caret is not after the last char in the document
         // because no bracket would follow then so it could not be skipped.
@@ -693,7 +702,7 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
                 bracketBalance = 0;
 
                 //token = lastRBracket.getNext();
-                TokenHierarchy<BaseDocument> th = TokenHierarchy.get(doc);
+                TokenHierarchy<Document> th = TokenHierarchy.get(doc);
 
                 int ofs = lastRBracket.offset(th);
 
@@ -751,13 +760,13 @@ public class JsTypedTextInterceptor implements TypedTextInterceptor {
     // XXX TODO Use embedded string sequence here and see if it
     // really is escaped. I know where those are!
     // TODO Adjust for JavaScript
-    private static boolean isEscapeSequence(BaseDocument doc, int dotPos)
+    private static boolean isEscapeSequence(Document doc, int dotPos)
         throws BadLocationException {
         if (dotPos <= 0) {
             return false;
         }
 
-        char previousChar = doc.getChars(dotPos - 1, 1)[0];
+        char previousChar = DocumentUtilities.getText(doc, dotPos - 1, 1).charAt(0);
 
         return previousChar == '\\';
     }

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsonCodeCompletion.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsonCodeCompletion.java
@@ -32,7 +32,6 @@ import javax.swing.text.JTextComponent;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenSequence;
-import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.csl.api.CodeCompletionContext;
 import org.netbeans.modules.csl.api.CodeCompletionHandler;
 import org.netbeans.modules.csl.api.CodeCompletionResult;
@@ -68,7 +67,7 @@ public class JsonCodeCompletion implements CodeCompletionHandler {
 
         long start = System.currentTimeMillis();
 
-        BaseDocument doc = (BaseDocument) context.getParserResult().getSnapshot().getSource().getDocument(false);
+        Document doc = (Document) context.getParserResult().getSnapshot().getSource().getDocument(false);
         if (doc == null) {
             return CodeCompletionResult.NONE;
         }
@@ -213,7 +212,7 @@ public class JsonCodeCompletion implements CodeCompletionHandler {
             int caretOffset,
             boolean upToOffset) {
         String prefix = "";
-        BaseDocument doc = (BaseDocument) info.getSnapshot().getSource().getDocument(false);
+        Document doc = (Document) info.getSnapshot().getSource().getDocument(false);
         if (doc == null) {
             return null;
         }

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/doc/JsDocumentationCompleter.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/doc/JsDocumentationCompleter.java
@@ -30,13 +30,12 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenSequence;
-import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.csl.spi.ParserResult;
 import org.netbeans.modules.editor.indent.api.IndentUtils;
-import org.netbeans.modules.javascript2.editor.Utils;
 import org.netbeans.modules.javascript2.doc.api.JsDocumentationSupport;
 import org.netbeans.modules.javascript2.doc.spi.SyntaxProvider;
 import org.netbeans.modules.javascript2.lexer.api.JsTokenId;
@@ -69,18 +68,18 @@ public class JsDocumentationCompleter {
 
     public static final RequestProcessor RP = new RequestProcessor("JavaScript Documentation Completer", 1); //NOI18N
 
-    public static void generateCompleteComment(BaseDocument doc, int caretOffset, int indent) {
+    public static void generateCompleteComment(Document doc, int caretOffset, int indent) {
         Runnable documentationGenerator = new DocumentationGenerator(doc, caretOffset, indent);
         RP.post(documentationGenerator);
     }
 
     private static class DocumentationGenerator implements Runnable {
 
-        private final BaseDocument doc;
+        private final Document doc;
         private final int offset;
         private final int indent;
 
-        public DocumentationGenerator(BaseDocument doc, int offset, int indent) {
+        public DocumentationGenerator(Document doc, int offset, int indent) {
             this.doc = doc;
             this.offset = offset;
             this.indent = indent;
@@ -206,7 +205,7 @@ public class JsDocumentationCompleter {
         }
     }
 
-    private static void generateFieldComment(BaseDocument doc, int offset, int indent, JsParserResult jsParserResult, JsObject jsObject) throws BadLocationException {
+    private static void generateFieldComment(Document doc, int offset, int indent, JsParserResult jsParserResult, JsObject jsObject) throws BadLocationException {
         StringBuilder toAdd = new StringBuilder();
         SyntaxProvider syntaxProvider = JsDocumentationSupport.getSyntaxProvider(jsParserResult);
 
@@ -226,7 +225,7 @@ public class JsDocumentationCompleter {
         doc.insertString(offset, toAdd.toString(), null);
     }
 
-    private static void generateFunctionComment(BaseDocument doc, int offset, int indent, JsParserResult jsParserResult, JsObject jsObject) throws BadLocationException {
+    private static void generateFunctionComment(Document doc, int offset, int indent, JsParserResult jsParserResult, JsObject jsObject) throws BadLocationException {
         StringBuilder toAdd = new StringBuilder();
         SyntaxProvider syntaxProvider = JsDocumentationSupport.getSyntaxProvider(jsParserResult);
         // TODO - could know constructors
@@ -266,13 +265,13 @@ public class JsDocumentationCompleter {
         return false;
     }
 
-    private static void addParameters(BaseDocument doc, StringBuilder toAdd, SyntaxProvider syntaxProvider, int indent, Collection<? extends JsObject> params) {
+    private static void addParameters(Document doc, StringBuilder toAdd, SyntaxProvider syntaxProvider, int indent, Collection<? extends JsObject> params) {
         for (JsObject jsObject : params) {
             generateDocEntry(doc, toAdd, syntaxProvider.paramTagTemplate(), indent, jsObject.getName(), null);
         }
     }
 
-    private static void addReturns(BaseDocument doc, StringBuilder toAdd, SyntaxProvider syntaxProvider, int indent, Collection<? extends TypeUsage> returns) {
+    private static void addReturns(Document doc, StringBuilder toAdd, SyntaxProvider syntaxProvider, int indent, Collection<? extends TypeUsage> returns) {
         StringBuilder sb = new StringBuilder();
 
         for (TypeUsage typeUsage : returns) {
@@ -290,7 +289,7 @@ public class JsDocumentationCompleter {
         generateDocEntry(doc, toAdd, syntaxProvider.returnTagTemplate(), indent, null, returnString);
     }
 
-    private static void generateDocEntry(BaseDocument doc, StringBuilder toAdd, String template, int indent, String name, String type) {
+    private static void generateDocEntry(Document doc, StringBuilder toAdd, String template, int indent, String name, String type) {
         toAdd.append("\n"); //NOI18N
         toAdd.append(IndentUtils.createIndentString(doc, indent));
 

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/formatter/FmtOptions.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/formatter/FmtOptions.java
@@ -47,8 +47,9 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
+import org.netbeans.api.editor.document.AtomicLockDocument;
+import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.api.editor.settings.SimpleValueNames;
-import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.editor.indent.api.Reformat;
 import org.netbeans.modules.options.editor.spi.PreferencesCustomizer;
 import org.netbeans.modules.options.editor.spi.PreviewProvider;
@@ -563,11 +564,12 @@ public class FmtOptions {
             pane.setIgnoreRepaint(true);
 
             final Document doc = pane.getDocument();
-            if (doc instanceof BaseDocument) {
+            final AtomicLockDocument ald = LineDocumentUtils.as(doc, AtomicLockDocument.class);
+            if (ald != null) {
                 final Reformat reformat = Reformat.get(doc);
                 reformat.lock();
                 try {
-                    ((BaseDocument) doc).runAtomic(new Runnable() {
+                    ald.runAtomic(new Runnable() {
                         @Override
                         public void run() {
 

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/formatter/IndentContext.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/formatter/IndentContext.java
@@ -23,8 +23,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Stack;
 import javax.swing.text.BadLocationException;
+import org.netbeans.api.editor.document.LineDocument;
+import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.editor.BaseDocument;
-import org.netbeans.editor.Utilities;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.editor.indent.spi.Context;
 import org.netbeans.modules.javascript2.lexer.api.JsTokenId;
@@ -73,22 +74,31 @@ public final class IndentContext {
 
         this.embedded = !JsTokenId.JAVASCRIPT_MIME_TYPE.equals(context.mimePath())
                 && !JsTokenId.JSON_MIME_TYPE.equals(context.mimePath());
-
-        int lineStart;
-        try {
-            lineStart = Utilities.getRowStart((BaseDocument) context.document(),
-                    context.caretOffset());
-        } catch (BadLocationException ex) {
+        LineDocument doc = LineDocumentUtils.as(context.document(), LineDocument.class);
+        
+        int lineStart = -1;
+        if (doc != null) {
+            try {
+                lineStart = LineDocumentUtils.getLineStart(doc,
+                        context.caretOffset());
+            } catch (IndexOutOfBoundsException ex) {
+            }
+        }
+        if (lineStart == -1) {
             lineStart = context.caretOffset();
         }
         this.caretLineStart = lineStart;
 
-        int lineEnd;
-        try {
-            lineEnd = Utilities.getRowEnd((BaseDocument) context.document(),
-                    context.caretOffset());
-        } catch (BadLocationException ex) {
-            lineEnd = context.caretOffset();
+        int lineEnd = -1;
+        if (doc != null) {
+            try {
+                lineEnd = LineDocumentUtils.getLineEnd(doc,
+                        context.caretOffset());
+            } catch (BadLocationException | IndexOutOfBoundsException ex) {
+            }
+        }        
+        if (lineEnd == -1) {
+             lineEnd = context.caretOffset();
         }
         this.caretLineEnd = lineEnd;
     }

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/hints/GlobalIsNotDefined.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/hints/GlobalIsNotDefined.java
@@ -28,9 +28,9 @@ import java.util.Set;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
+import org.netbeans.api.editor.document.LineDocument;
+import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.api.lexer.TokenSequence;
-import org.netbeans.editor.BaseDocument;
-import org.netbeans.editor.Utilities;
 import org.netbeans.modules.csl.api.Hint;
 import org.netbeans.modules.csl.api.HintFix;
 import org.netbeans.modules.csl.api.HintSeverity;
@@ -115,10 +115,10 @@ public class GlobalIsNotDefined extends JsAstRule {
         boolean add = false;
         Document document = context.getJsParserResult().getSnapshot().getSource().getDocument(false);
         if (offset > -1) {
-            if (document != null && document instanceof BaseDocument) {
-                BaseDocument baseDocument = (BaseDocument)document;
-                int lineOffset = Utilities.getLineOffset(baseDocument, offset);
-                int lineOffsetRange = Utilities.getLineOffset(baseDocument, range.getStart());
+            LineDocument ld = LineDocumentUtils.as(document, LineDocument.class);
+            if (ld != null) {
+                int lineOffset = LineDocumentUtils.getLineIndex(ld, offset);
+                int lineOffsetRange = LineDocumentUtils.getLineIndex(ld, range.getStart());
                 add = lineOffset == lineOffsetRange;
             }
         } else {

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/resources/layer.xml
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/resources/layer.xml
@@ -574,6 +574,8 @@
         </folder>
        </folder>
        <folder name="JavaScript">
+           <folder name="Editor">
+           </folder>
            <folder name="Model">
                <folder name="MethodCallProcessors">
                    <file name="org-netbeans-modules-javascript2-editor-extjs-ExtModelExtender$ExtDefineMethodProcessor.instance">

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/spi/CompletionContext.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/spi/CompletionContext.java
@@ -19,7 +19,7 @@
 package org.netbeans.modules.javascript2.editor.spi;
 
 /**
- *
+ * Type of completion for {@link CompletionProviderEx}.
  * @author Petr Hejl
  */
 public enum CompletionContext {

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/spi/CompletionProviderEx.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/spi/CompletionProviderEx.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.editor.spi;
+
+import java.util.List;
+import org.netbeans.modules.csl.api.CodeCompletionContext;
+import org.netbeans.modules.csl.api.CompletionProposal;
+import org.netbeans.modules.javascript2.editor.JsCompletionItem;
+
+/**
+ * Contributes {@CompletionProposal}s into javascript completion. Supersedes {@link CompletionProvider},
+ * allows to pass more context in the {!link ProposalRequest} parameter object.
+ * 
+ * @author sdedic
+ * @since 0.84
+ */
+public interface CompletionProviderEx extends CompletionProvider {
+    /**
+     * Returns completion proposals relevant for the request.
+     * @param request the completion request
+     * @return list of proposals, potentially {@code null}.
+     */
+    List<CompletionProposal> complete(ProposalRequest request);
+    
+    /**
+     * Convenience bridge for older API callers. Invokes {@link #complete(org.netbeans.modules.javascript2.editor.spi.ProposalRequest)}.
+     * Do not override unless for very specific needs.
+     * 
+     * @param ccContext parsing context
+     * @param jsCompletionContext
+     * @param prefix
+     * @return 
+     */
+    @Override
+    default List<CompletionProposal> complete(CodeCompletionContext ccContext, CompletionContext jsCompletionContext, String prefix) {
+        return complete(JsCompletionItem.createRequest(ccContext, jsCompletionContext, prefix));
+    }
+}

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/spi/ElementDocumentation.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/spi/ElementDocumentation.java
@@ -18,30 +18,19 @@
  */
 package org.netbeans.modules.javascript2.editor.spi;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import java.util.List;
-import org.netbeans.modules.csl.api.CodeCompletionContext;
-import org.netbeans.modules.csl.api.CompletionProposal;
-import org.netbeans.modules.csl.api.ElementHandle;
-import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.modules.csl.api.Documentation;
 
 /**
- *
- * @author Petr Hejl
+ * Mixin interface for ElementHandles to provide a documentation.
+ * 
+ * @author sdedic
+ * @since 0.84
  */
-public interface CompletionProvider {
-
-    List<CompletionProposal> complete(CodeCompletionContext ccContext, CompletionContext jsCompletionContext, String prefix);
-
-    String getHelpDocumentation(ParserResult info, ElementHandle element);
-    
-    @Retention(RetentionPolicy.SOURCE)
-    @Target(ElementType.TYPE)
-    public @interface Registration {
-
-        int priority() default 100;
-    }
+public interface ElementDocumentation {
+    /**
+     * Returns Documentation for the element, either URL or content.
+     * @return documentation object, or {@code null} for none.
+     */
+    @CheckForNull Documentation getDocumentation();
 }

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/spi/ProposalRequest.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/spi/ProposalRequest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.editor.spi;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.netbeans.modules.csl.api.CodeCompletionContext;
+import org.netbeans.modules.csl.spi.ParserResult;
+
+/**
+ * Context information to provide code completion proposals.
+ * 
+ * @author sdedic
+ * @since 0.84
+ */
+public final class ProposalRequest {
+    private final CodeCompletionContext context;
+    private final CompletionContext type;
+    private final Collection<String> selectors;
+    private final int offset;
+    
+    public ProposalRequest(CodeCompletionContext context, CompletionContext type, Collection<String> selectors, int anchor) {
+        this.context = context;
+        this.type = type;
+        this.selectors = selectors;
+        this.offset = anchor;
+    }
+
+    /**
+     * @return offset of the supposed symbol start in the AST.
+     */
+    public int getAnchor() {
+        return offset;
+    }
+
+    /**
+     * Provides code completion context from the parser.
+     * @return 
+     */
+    public CodeCompletionContext getContext() {
+        return context;
+    }
+
+    /**
+     * Determines the requested completion type.
+     * @return 
+     */
+    public CompletionContext getType() {
+        return type;
+    }
+
+    /**
+     * Convenience method to get the parser result.
+     * @return 
+     */
+    public ParserResult getInfo() {
+        return context.getParserResult();
+    }
+
+    /**
+     * Object or variable selectors determined from the prefix and parsed information.
+     * @return selectors.
+     */
+    public Collection<String> getSelectors() {
+        return selectors == null ? Collections.emptyList() : selectors;
+    }
+
+    /**
+     * Convenience method that returns symbol prefix.
+     * @return symbol prefix.
+     */
+    public String getPrefix() {
+        return context.getPrefix();
+    }
+}

--- a/webcommon/javascript2.editor/test/qa-functional/src/org/netbeans/modules/javascript2/editor/qaf/GeneralJavaScript.java
+++ b/webcommon/javascript2.editor/test/qa-functional/src/org/netbeans/modules/javascript2/editor/qaf/GeneralJavaScript.java
@@ -28,8 +28,6 @@ import java.util.logging.Logger;
 import javax.swing.JEditorPane;
 import javax.swing.KeyStroke;
 import javax.swing.text.BadLocationException;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
 import org.netbeans.jellytools.*;
 import org.netbeans.jellytools.modules.editor.CompletionJListOperator;
 import org.netbeans.jellytools.nodes.Node;
@@ -39,7 +37,6 @@ import org.netbeans.jemmy.JemmyProperties;
 import org.netbeans.jemmy.Waitable;
 import org.netbeans.jemmy.Waiter;
 import org.netbeans.jemmy.operators.*;
-import org.netbeans.modules.html.editor.api.completion.HtmlCompletionItem;
 import org.openide.util.Exceptions;
 
 /**
@@ -316,11 +313,7 @@ public class GeneralJavaScript extends JellyTestCase {
             int matches = 0;
             for (int i = 0; i < items.size(); i++) {
                 item = items.get(i);
-                if (item instanceof HtmlCompletionItem) {
-                    if (((HtmlCompletionItem) item).getItemText().toLowerCase().startsWith(pattern)) {
-                        matches++;
-                    }
-                } else if (item.toString().toLowerCase().startsWith(pattern)) {
+                if (item.toString().toLowerCase().startsWith(pattern)) {
                     matches++;
                 }
             }

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsSemanticAnalyzerTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsSemanticAnalyzerTest.java
@@ -18,6 +18,10 @@
  */
 package org.netbeans.modules.javascript2.editor;
 
+import java.nio.charset.Charset;
+import org.netbeans.spi.queries.FileEncodingQueryImplementation;
+import org.openide.filesystems.FileObject;
+
 /**
  *
  * @author Petr Pisl
@@ -26,6 +30,18 @@ public class JsSemanticAnalyzerTest extends JsTestBase {
 
     public JsSemanticAnalyzerTest(String testName) {
         super(testName);
+    }
+
+    @Override
+    protected Object[] createExtraMockLookupContent() {
+        return new Object[]{
+            new FileEncodingQueryImplementation() {
+                @Override
+                public Charset getEncoding(FileObject file) {
+                    return Charset.forName("UTF-8");
+                }
+            }
+        };
     }
     
     public void testAsyncFunction01() throws Exception {

--- a/webcommon/javascript2.extjs/nbproject/project.xml
+++ b/webcommon/javascript2.extjs/nbproject/project.xml
@@ -49,7 +49,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>0.63</specification-version>
+                        <specification-version>0.84</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.html/build.xml
+++ b/webcommon/javascript2.html/build.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project basedir="." default="build" name="webcommon/javascript2.html">
+    <description>Builds, tests, and runs the project org.netbeans.modules.javascript2.html</description>
+    <import file="../../nbbuild/templates/projectized.xml"/>
+</project>

--- a/webcommon/javascript2.html/manifest.mf
+++ b/webcommon/javascript2.html/manifest.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+AutoUpdate-Show-In-Client: false
+OpenIDE-Module: org.netbeans.modules.javascript2.html
+OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/javascript2/html/Bundle.properties
+OpenIDE-Module-Specification-Version: 1.0
+

--- a/webcommon/javascript2.html/nbproject/project.properties
+++ b/webcommon/javascript2.html/nbproject/project.properties
@@ -17,14 +17,4 @@
 
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-build.compiler=extJavac
-javac.compilerargs=-J-Xmx512m
-javadoc.arch=${basedir}/arch.xml
-nbm.needs.restart=true
-
-extra.module.files=\
-    jsstubs/corestubs.zip,\
-    jsstubs/domstubs.zip,\
-    jsstubs/reststubs.zip
-jnlp.indirect.jars=jsstubs/*.zip
-
+is.eager=true

--- a/webcommon/javascript2.html/nbproject/project.xml
+++ b/webcommon/javascript2.html/nbproject/project.xml
@@ -23,7 +23,7 @@
     <type>org.netbeans.modules.apisupport.project</type>
     <configuration>
         <data xmlns="http://www.netbeans.org/ns/nb-module-project/3">
-            <code-name-base>org.netbeans.modules.javascript2.kit</code-name-base>
+            <code-name-base>org.netbeans.modules.javascript2.html</code-name-base>
             <module-dependencies>
                 <dependency>
                     <code-name-base>org.netbeans.modules.csl.api</code-name-base>
@@ -31,7 +31,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.1</specification-version>
+                        <specification-version>2.65</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -40,76 +40,93 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.0</specification-version>
+                        <specification-version>1.10</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.css.editor</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.26</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.css.lib</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.78</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.html.editor.lib</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>3</release-version>
+                        <specification-version>3.2</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
                     <code-name-base>org.netbeans.modules.javascript2.editor</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
                         <specification-version>0.84</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.javascript2.extdoc</code-name-base>
-                    <run-dependency>
-                        <specification-version>1.0</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.javascript2.extjs</code-name-base>
-                    <run-dependency>
-                        <specification-version>1.0</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.javascript2.jade</code-name-base>
+                    <code-name-base>org.netbeans.modules.parsing.api</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>0.1</specification-version>
+                        <specification-version>9.17</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.javascript2.jquery</code-name-base>
+                    <code-name-base>org.netbeans.modules.projectapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.0</specification-version>
+                        <release-version>1</release-version>
+                        <specification-version>1.78</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.javascript2.jsdoc</code-name-base>
+                    <code-name-base>org.openide.filesystems</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.0</specification-version>
+                        <specification-version>9.20</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.javascript2.knockout</code-name-base>
+                    <code-name-base>org.openide.util</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.0</specification-version>
+                        <specification-version>9.17</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.javascript2.nodejs</code-name-base>
+                    <code-name-base>org.openide.util.lookup</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
                     <run-dependency>
-                        <release-version>0</release-version>
-                        <specification-version>0.4</specification-version>
+                        <specification-version>8.44</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.javascript2.prototypejs</code-name-base>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
                     <run-dependency>
-                        <specification-version>0.2</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.javascript2.requirejs</code-name-base>
-                    <run-dependency>
-                        <specification-version>0.2</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.javascript2.sdoc</code-name-base>
-                    <run-dependency>
-                        <specification-version>1.0</specification-version>
+                        <specification-version>9.18</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/Bundle.properties
+++ b/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/Bundle.properties
@@ -15,16 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.8
-javac.compilerargs=-Xlint -Xlint:-serial
-build.compiler=extJavac
-javac.compilerargs=-J-Xmx512m
-javadoc.arch=${basedir}/arch.xml
-nbm.needs.restart=true
-
-extra.module.files=\
-    jsstubs/corestubs.zip,\
-    jsstubs/domstubs.zip,\
-    jsstubs/reststubs.zip
-jnlp.indirect.jars=jsstubs/*.zip
-
+OpenIDE-Module-Name=JavaScript2 HTML/CSS support
+OpenIDE-Module-Display-Category=JavaScript

--- a/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/CssCompletionProvider.java
+++ b/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/CssCompletionProvider.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.html;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.csl.api.*;
+import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.modules.css.indexing.api.CssIndex;
+import org.netbeans.modules.javascript2.editor.spi.CompletionContext;
+import org.netbeans.modules.javascript2.editor.spi.CompletionProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.util.*;
+/**
+ *
+ * @author sdedic
+ */
+@CompletionProvider.Registration(priority = -100)
+public class CssCompletionProvider implements CompletionProvider {
+
+    @Override
+    public List<CompletionProposal> complete(CodeCompletionContext ccContext, CompletionContext jsCompletionContext, String prefix) {
+        List<CompletionProposal> resultList = new ArrayList<>();
+        
+        int caretOffset = ccContext.getParserResult().getSnapshot().getEmbeddedOffset(ccContext.getCaretOffset());
+        String pref = ccContext.getPrefix();
+        int offset = pref == null ? caretOffset : caretOffset
+                    // can't just use 'prefix.getLength()' here cos it might have been calculated with
+                    // the 'upToOffset' flag set to false
+                    - pref.length();
+        switch (jsCompletionContext) {
+            case STRING_ELEMENTS_BY_ID:
+                completeTagIds(
+                    ccContext.getParserResult(),
+                    pref,
+                    offset, 
+                    resultList);
+                break;
+            case STRING_ELEMENTS_BY_CLASS_NAME:
+                completeCSSClassNames(
+                    ccContext.getParserResult(),
+                    pref,
+                    offset, resultList);
+                break;
+        }
+        return resultList;
+    }
+
+    @Override
+    public String getHelpDocumentation(ParserResult info, ElementHandle element) {
+        return null;
+    }
+    
+    private void completeTagIds(ParserResult parserInfo, 
+            String prefix,
+            int astOffset,
+            List<CompletionProposal> resultList) {
+        FileObject fo = parserInfo.getSnapshot().getSource().getFileObject();
+        if (fo == null) {
+            return;
+        }
+        Project project = FileOwnerQuery.getOwner(fo);
+        HashSet<String> unique = new HashSet<String>();
+        try {
+            CssIndex cssIndex = CssIndex.create(project);
+            Map<FileObject, Collection<String>> findIdsByPrefix = cssIndex.findIdsByPrefix(prefix);
+
+            for (Collection<String> ids : findIdsByPrefix.values()) {
+                for (String id : ids) {
+                    if (!id.isEmpty()) {
+                        unique.add(id);
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        if (!unique.isEmpty()) {
+            for (Iterator<String> iterator = unique.iterator(); iterator.hasNext();) {
+                resultList.add(new CssIdCompletionItem(iterator.next(), parserInfo, astOffset));
+            }
+        }
+    }
+
+    private void completeCSSClassNames(ParserResult result, String prefix, int astOffset, List<CompletionProposal> resultList) {
+        FileObject fo = result.getSnapshot().getSource().getFileObject();
+        if(fo == null) {
+            return;
+        }
+        Project project = FileOwnerQuery.getOwner(fo);
+        HashSet<String> unique = new HashSet<String>();
+        try {
+            CssIndex cssIndex = CssIndex.create(project);
+            Map<FileObject, Collection<String>> findIdsByPrefix = cssIndex.findClassesByPrefix(prefix);
+
+            for (Collection<String> ids : findIdsByPrefix.values()) {
+                for (String id : ids) {
+                    if (!id.isEmpty()) {
+                        unique.add(id);
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        if (!unique.isEmpty()) {
+            for (Iterator<String> iterator = unique.iterator(); iterator.hasNext();) {
+                resultList.add(new CssIdCompletionItem(iterator.next(), 
+                        result, astOffset));
+            }
+        }
+    }
+    
+}

--- a/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/CssIdCompletionItem.java
+++ b/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/CssIdCompletionItem.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.html;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import javax.swing.ImageIcon;
+import org.netbeans.modules.csl.api.CompletionProposal;
+import org.netbeans.modules.csl.api.ElementHandle;
+import org.netbeans.modules.csl.api.ElementKind;
+import org.netbeans.modules.csl.api.HtmlFormatter;
+import org.netbeans.modules.csl.api.Modifier;
+import org.netbeans.modules.csl.api.OffsetRange;
+import org.netbeans.modules.csl.spi.ParserResult;
+import org.openide.filesystems.FileObject;
+import org.openide.util.ImageUtilities;
+
+/**
+ *
+ * @author sdedic
+ */
+class CssIdCompletionItem implements CompletionProposal {
+    private final ElementHandle element;
+    private final ParserResult parserInfo;
+    private final int astOffset;
+    private final String name;
+
+    private static ImageIcon cssIcon = null;
+
+    public CssIdCompletionItem(String name, ParserResult info, int astOffset) {
+        this.parserInfo = info;
+        this.name = name;
+        this.astOffset = astOffset;
+        this.element = null;
+    }
+
+    @Override
+    public ElementHandle getElement() {
+        return element;
+    }
+
+    @Override
+    public Set<Modifier> getModifiers() {
+        Set<Modifier> modifiers = (getElement() == null || getElement().getModifiers().isEmpty() ? Collections.EMPTY_SET : EnumSet.copyOf(getElement().getModifiers()));
+        if (modifiers.contains(Modifier.PRIVATE) && (modifiers.contains(Modifier.PUBLIC) || modifiers.contains(Modifier.PROTECTED))) {
+            modifiers.remove(Modifier.PUBLIC);
+            modifiers.remove(Modifier.PROTECTED);
+        }
+        return modifiers;
+    }
+
+    @Override
+    public int getAnchorOffset() {
+        return parserInfo.getSnapshot().getOriginalOffset(astOffset);
+    }
+
+    @Override
+    public ImageIcon getIcon() {
+        if (cssIcon == null) {
+            cssIcon = new ImageIcon(ImageUtilities.loadImage("org/netbeans/modules/javascript2/jquery/resources/style_sheet_16.png")); //NOI18N
+        }
+        return cssIcon;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getInsertPrefix() {
+        return getName();
+    }
+
+    @Override
+    public String getLhsHtml(HtmlFormatter formatter) {
+        formatter.reset();
+        formatter.appendText(getName());
+        return formatter.getText();
+    }
+
+    @Override
+    public ElementKind getKind() {
+        return ElementKind.RULE;
+    }
+
+    @Override
+    public String getRhsHtml(HtmlFormatter formatter) {
+        return null;
+    }
+    
+    @Override
+    public String getSortText() {
+        StringBuilder sb = new StringBuilder();
+        if (element != null) {
+            FileObject sourceFo = parserInfo.getSnapshot().getSource().getFileObject();
+            FileObject elementFo = element.getFileObject();
+            if (elementFo != null && sourceFo != null && sourceFo.equals(elementFo)) {
+                sb.append("1");     //NOI18N
+            } else {
+                if (OffsetRange.NONE.equals(element.getOffsetRange(parserInfo))) {
+                    sb.append("8");
+                } else {
+                    sb.append("9");     //NOI18N
+                }
+            }
+        }
+        sb.append(getName());    
+        return sb.toString();
+    }
+    
+    protected boolean isDeprecated() {
+        return element.getModifiers().contains(Modifier.DEPRECATED);
+    }
+    
+    protected void formatName(HtmlFormatter formatter) {
+        if (isDeprecated()) {
+            formatter.deprecated(true);
+            formatter.appendText(getName());
+            formatter.deprecated(false);
+        } else {
+            formatter.appendText(getName());
+        }
+    }
+    
+    @Override
+    public boolean isSmart() {
+        // TODO implemented properly
+        return false;
+    }
+
+    @Override
+    public int getSortPrioOverride() {
+        int order = 100;
+        return order;
+    }
+
+    public String getCustomInsertTemplate() {
+        return null;
+    }
+
+    public final String getFileNameURL() {
+        ElementHandle elem = getElement();
+        if (elem == null) {
+            return null;
+        }
+        FileObject fo = elem.getFileObject();
+        if (fo != null) {
+            return fo.getNameExt();
+        }
+        return getName();
+     }
+    
+}

--- a/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/HtmlAttrElement.java
+++ b/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/HtmlAttrElement.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.javascript2.editor.doc;
+package org.netbeans.modules.javascript2.html;
 
 import java.util.Collections;
 import java.util.Set;
@@ -26,21 +26,21 @@ import org.netbeans.modules.csl.api.ElementKind;
 import org.netbeans.modules.csl.api.Modifier;
 import org.netbeans.modules.csl.api.OffsetRange;
 import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.modules.html.editor.lib.api.HelpItem;
+import org.netbeans.modules.html.editor.lib.api.model.HtmlTagAttribute;
 import org.netbeans.modules.javascript2.editor.spi.ElementDocumentation;
 import org.openide.filesystems.FileObject;
 
 /**
  *
- * @author Martin Fousek <marfous@netbeans.org>
+ * @author sdedic
  */
-public class JsDocumentationElement implements ElementHandle, ElementDocumentation {
+class HtmlAttrElement implements ElementHandle, ElementDocumentation {
+    
+    private final HtmlTagAttribute attribute;
 
-    private final String name;
-    private final String documentation;
-
-    JsDocumentationElement(String name, String documentation) {
-        this.name = name;
-        this.documentation = documentation;
+    public HtmlAttrElement(HtmlTagAttribute attribute) {
+        this.attribute = attribute;
     }
 
     @Override
@@ -55,7 +55,7 @@ public class JsDocumentationElement implements ElementHandle, ElementDocumentati
 
     @Override
     public String getName() {
-        return name;
+        return attribute.getName();
     }
 
     @Override
@@ -65,7 +65,7 @@ public class JsDocumentationElement implements ElementHandle, ElementDocumentati
 
     @Override
     public ElementKind getKind() {
-        return ElementKind.OTHER;
+        return ElementKind.ATTRIBUTE;
     }
 
     @Override
@@ -85,7 +85,18 @@ public class JsDocumentationElement implements ElementHandle, ElementDocumentati
 
     @Override
     public Documentation getDocumentation() {
-        return Documentation.create(documentation);
+        HelpItem hi = attribute.getHelp();
+        if (hi == null) {
+            return null;
+        }
+        String content = attribute.getHelp().getHelpContent();
+        if (content == null) {
+            if (attribute.getHelp().getHelpResolver() != null && attribute.getHelp().getHelpURL() != null) {
+                content = attribute.getHelp().getHelpResolver().getHelpContent(attribute.getHelp().getHelpURL());
+            }
+        }
+        // PENDING: it's now possible to return URL, that will be loaded by editor infrastructure.
+        return Documentation.create(content);
     }
-
+    
 }

--- a/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/HtmlCompletionItem.java
+++ b/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/HtmlCompletionItem.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.html;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+import javax.swing.ImageIcon;
+import org.netbeans.modules.csl.api.CompletionProposal;
+import org.netbeans.modules.csl.api.ElementHandle;
+import org.netbeans.modules.csl.api.ElementKind;
+import org.netbeans.modules.csl.api.HtmlFormatter;
+import org.netbeans.modules.csl.api.Modifier;
+import org.netbeans.modules.csl.api.OffsetRange;
+import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.modules.html.editor.lib.api.model.HtmlTagAttribute;
+import org.openide.util.NbBundle;
+
+/**
+ *
+ * @author sdedic
+ */
+public class HtmlCompletionItem implements CompletionProposal {
+    private final ParserResult parserInfo;
+    private final int astOffset;
+    private final ElementHandle element;
+    private final HtmlTagAttribute attr;
+
+    public HtmlCompletionItem(ParserResult parserInfo, HtmlTagAttribute attr, int astOffset) {
+        this.parserInfo = parserInfo;
+        this.attr = attr;
+        this.astOffset = astOffset;
+        this.element = new HtmlAttrElement(attr);
+    }
+
+    @Override
+    public String getName() {
+        return attr.getName();
+    }
+
+    @Override
+    public String getInsertPrefix() {
+        return getName();
+    }
+
+    @Override
+    public String getLhsHtml(HtmlFormatter formatter) {
+        formatter.reset();
+        formatter.appendText(getName());
+        return formatter.getText();
+    }
+
+    @Override
+    public ElementKind getKind() {
+        return ElementKind.ATTRIBUTE;
+    }
+
+    @NbBundle.Messages("JsCompletionItem.lbl.html.attribute=HTML Attribute")
+    @Override
+    public String getRhsHtml(HtmlFormatter formatter) {
+        formatter.reset();
+        formatter.appendHtml("<font color=#999999>");
+        formatter.appendText(Bundle.JsCompletionItem_lbl_html_attribute());
+        formatter.appendHtml("</font>");
+        return formatter.getText();
+    }
+
+    @Override
+    public int getAnchorOffset() {
+        return parserInfo.getSnapshot().getOriginalOffset(astOffset);
+    }
+
+    @Override
+    public ElementHandle getElement() {
+        return element;
+    }
+
+    @Override
+    public String getSortText() {
+        StringBuilder sb = new StringBuilder();
+        if (OffsetRange.NONE.equals(element.getOffsetRange(parserInfo))) {
+            sb.append("8");
+        } else {
+            sb.append("9");     //NOI18N
+        }
+        sb.append(getName());    
+        return sb.toString();
+    }
+    
+    protected boolean isDeprecated() {
+        return false;
+    }
+    
+    @Override
+    public ImageIcon getIcon() {
+        return null;
+    }
+
+    @Override
+    public Set<Modifier> getModifiers() {
+        return Collections.EMPTY_SET;
+    }
+
+    @Override
+    public boolean isSmart() {
+        // TODO implemented properly
+        return false;
+    }
+
+    @Override
+    public int getSortPrioOverride() {
+        int order = 100;
+        return order;
+    }
+
+    @Override
+    public String getCustomInsertTemplate() {
+        return null;
+    }
+}

--- a/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/HtmlTagCompletionProvider.java
+++ b/webcommon/javascript2.html/src/org/netbeans/modules/javascript2/html/HtmlTagCompletionProvider.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.javascript2.html;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.netbeans.modules.csl.api.CompletionProposal;
+import org.netbeans.modules.csl.api.ElementHandle;
+import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.modules.html.editor.lib.api.HtmlVersion;
+import org.netbeans.modules.html.editor.lib.api.model.HtmlModel;
+import org.netbeans.modules.html.editor.lib.api.model.HtmlModelFactory;
+import org.netbeans.modules.html.editor.lib.api.model.HtmlTag;
+import org.netbeans.modules.html.editor.lib.api.model.HtmlTagAttribute;
+import org.netbeans.modules.javascript2.editor.spi.CompletionProvider;
+import org.netbeans.modules.javascript2.editor.spi.CompletionProviderEx;
+import org.netbeans.modules.javascript2.editor.spi.ProposalRequest;
+
+/**
+ *
+ * @author sdedic
+ */
+@CompletionProvider.Registration(priority = 0)
+public class HtmlTagCompletionProvider implements CompletionProviderEx {
+
+    @Override
+    public List<CompletionProposal> complete(ProposalRequest request) {
+        if (!request.getSelectors().contains("Element")) { // NOI18N
+            return Collections.emptyList();
+        }
+        List<CompletionProposal> resultList = new ArrayList<>();
+        for(HtmlTagAttribute attribute: getAllAttributes())  {
+            if (attribute.getName().startsWith(request.getPrefix())) {
+                resultList.add(new HtmlCompletionItem(request.getInfo(), attribute, request.getAnchor()));
+            }
+        }
+        return resultList;
+    }
+
+    @Override
+    public String getHelpDocumentation(ParserResult info, ElementHandle element) {
+        if (!(element instanceof HtmlAttrElement)) {
+            return null;
+        }
+        return ((HtmlAttrElement)element).getDocumentation().toString();
+    }
+    
+    private Collection<HtmlTagAttribute> getAllAttributes() {
+        HtmlModel htmlModel = HtmlModelFactory.getModel(HtmlVersion.HTML5);
+        Map<String, HtmlTagAttribute> result = new HashMap<String, HtmlTagAttribute>();
+        for (HtmlTag htmlTag : htmlModel.getAllTags()) {
+            for (HtmlTagAttribute htmlTagAttribute : htmlTag.getAttributes()) {
+                // attributes can probably differ per tag so we can just offer some of them,
+                // at least for the CC purposes it should be complete list of attributes for unknown tag
+                if (!result.containsKey(htmlTagAttribute.getName())) {
+                    result.put(htmlTagAttribute.getName(), htmlTagAttribute);
+                }
+            }
+        }
+        return result.values();
+    }
+
+}

--- a/webcommon/javascript2.jquery/nbproject/project.xml
+++ b/webcommon/javascript2.jquery/nbproject/project.xml
@@ -85,7 +85,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>0.63</specification-version>
+                        <specification-version>0.84</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.nodejs/nbproject/project.xml
+++ b/webcommon/javascript2.nodejs/nbproject/project.xml
@@ -79,15 +79,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.html.editor</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>2</release-version>
-                        <specification-version>2.50</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.javascript2.editor</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/webcommon/javascript2.nodejs/nbproject/project.xml
+++ b/webcommon/javascript2.nodejs/nbproject/project.xml
@@ -84,7 +84,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>0.63</specification-version>
+                        <specification-version>0.84</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -317,6 +317,10 @@
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
                         <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.html.editor</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
                 </test-type>

--- a/webcommon/javascript2.react/nbproject/project.xml
+++ b/webcommon/javascript2.react/nbproject/project.xml
@@ -58,7 +58,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.33</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.requirejs/nbproject/project.xml
+++ b/webcommon/javascript2.requirejs/nbproject/project.xml
@@ -138,7 +138,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>0.63</specification-version>
+                        <specification-version>0.84</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/javascript2.requirejs/nbproject/project.xml
+++ b/webcommon/javascript2.requirejs/nbproject/project.xml
@@ -111,7 +111,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.49</specification-version>
+                        <specification-version>2.66</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/web.client.kit/nbproject/project.xml
+++ b/webcommon/web.client.kit/nbproject/project.xml
@@ -94,7 +94,7 @@
                 <dependency>
                     <code-name-base>org.netbeans.modules.web.clientproject</code-name-base>
                     <run-dependency>
-                        <specification-version>1.8</specification-version>
+                        <specification-version>1.97</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/web.clientproject.api/manifest.mf
+++ b/webcommon/web.clientproject.api/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.web.clientproject.api
 OpenIDE-Module-Layer: org/netbeans/modules/web/clientproject/api/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/web/clientproject/api/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.113
+OpenIDE-Module-Specification-Version: 1.114
 

--- a/webcommon/web.clientproject.api/nbproject/project.xml
+++ b/webcommon/web.clientproject.api/nbproject/project.xml
@@ -96,12 +96,11 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.html.editor</code-name-base>
+                    <code-name-base>org.netbeans.modules.html.indexing</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>2</release-version>
-                        <specification-version>2.38</specification-version>
+                        <specification-version>1.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/webcommon/web.clientproject/manifest.mf
+++ b/webcommon/web.clientproject/manifest.mf
@@ -3,5 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.web.clientproject
 OpenIDE-Module-Layer: org/netbeans/modules/web/clientproject/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/web/clientproject/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.96
+OpenIDE-Module-Specification-Version: 1.97
 OpenIDE-Module-Provides: org.netbeans.modules.web.clientproject

--- a/webcommon/web.clientproject/nbproject/project.xml
+++ b/webcommon/web.clientproject/nbproject/project.xml
@@ -112,15 +112,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.html.editor</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>2</release-version>
-                        <specification-version>2.5</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.parsing.api</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/webcommon/web.clientproject/nbproject/project.xml
+++ b/webcommon/web.clientproject/nbproject/project.xml
@@ -212,7 +212,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.101</specification-version>
+                        <specification-version>1.114</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
Adjustments that lead to better reuse of javascript / HTML support. Javascript modules are quite tangled with HTML (and vice versa) since they have been always developed in parallel. With `nodejs` and similar technologies, javascript can be used independently without embedding into HTML (PHP) web pages. This PR partially loosens the dependencies, but many of them still remain. Some minor issues / warnings were fixed during the course.

Outline of main changes:
- `HtmlIndex` API separated from the HTML Editor module. Many modules have dependencies on the Index, querying files, but not necessarily on HTML editing features. Becomes more important in headless modes.
- JavaScript HTML support separated from basic Javascript editing (just completion at the moment). This is a beginning of the effort that could de-entagle JS/HTML supports

These changes allowed to reduce module dependencies, especially non-visual modules to *.editor modules (which are more or less UI-oriented). IMHO it's good to separate infrastructure/evaluators from presentation layer - if not for better architecture, then for better testing.

I've tried to consolidate the work into several topic-oriented commits for easier review.