### PR TITLE
Maven branding configuration API and robustness improvement

### DIFF
--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -83,6 +83,21 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="reusetabs-cos">
+           <api name="general"/>
+           <summary>Default for reusing tabs and compile on save</summary>
+           <version major="2" minor="141"/>
+           <date day="12" month="10" year="2020"/>
+           <author login="jtulach"/>
+           <compatibility semantic="compatible"/>
+           <description>
+               <p>
+                   Introducing <a href="@TOP@architecture-summary.html#group-branding">branding APIs</a>
+                   to configure default value for <b>reusing tabs</b> and also for
+                   <b>compile on save behavior</b> in Maven projects.
+               </p>
+           </description>
+        </change>
         <change id="jpda-attach-trigger">
            <api name="general"/>
            <summary>Attach to Debugger on triggers</summary>

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -169,6 +169,25 @@
           in case reparsing starts too soon (wasting CPU) or too late (impeding editing).
       </api>
   </p>
+  
+  <p>
+      <api category="devel" group="branding" name="DEFAULT_REUSE_OUTPUT" type="export">
+          Brand the <code>DEFAULT_REUSE_OUTPUT</code> key in a 
+          <code>org.netbeans.modules.maven.options.Bundle</code> file
+          with one of the values <code>true</code> or <code>false</code>
+          to specify the default behavior of reusing output by your application.
+          Use <code>never</code> value, if the reuse shall never be done,
+          regardless of the settings value.
+      </api> 
+      <api category="devel" group="branding" name="DEFAULT_COMPILE_ON_SAVE" type="export">
+          Brand the <code>DEFAULT_COMPILE_ON_SAVE</code> key in a 
+          <code>org.netbeans.modules.maven.api.execute.Bundle</code> file
+          with one of the values <code>all</code> or <code>node</code>
+          to specify the default behavior of compile on save in Maven 
+          projects.
+      </api> 
+  </p>
+  
  </answer>
  
  <answer id="resources-file">

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -182,7 +182,7 @@
       <api category="devel" group="branding" name="DEFAULT_COMPILE_ON_SAVE" type="export">
           Brand the <code>DEFAULT_COMPILE_ON_SAVE</code> key in a 
           <code>org.netbeans.modules.maven.api.execute.Bundle</code> file
-          with one of the values <code>all</code> or <code>node</code>
+          with one of the values <code>all</code> or <code>none</code>
           to specify the default behavior of compile on save in Maven 
           projects.
       </api> 

--- a/java/maven/manifest.mf
+++ b/java/maven/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven/2
-OpenIDE-Module-Specification-Version: 2.140
+OpenIDE-Module-Specification-Version: 2.141
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/maven/layer.xml
 AutoUpdate-Show-In-Client: false

--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -74,6 +74,7 @@ import org.netbeans.modules.maven.configurations.M2ConfigProvider;
 import org.netbeans.modules.maven.configurations.M2Configuration;
 import org.netbeans.modules.maven.configurations.ProjectProfileHandlerImpl;
 import org.netbeans.modules.maven.cos.CopyResourcesOnSave;
+import org.netbeans.modules.maven.debug.MavenJPDAStart;
 import org.netbeans.modules.maven.embedder.EmbedderFactory;
 import org.netbeans.modules.maven.embedder.MavenEmbedder;
 import org.netbeans.modules.maven.modelcache.MavenProjectCache;
@@ -881,7 +882,8 @@ public final class NbMavenProjectImpl implements Project {
                     LookupMergerSupport.createClassPathModifierMerger(),
                     new UnitTestsCompilerOptionsQueryImpl(this),
                     new PomCompilerOptionsQueryImpl(this),
-                    LookupMergerSupport.createCompilerOptionsQueryMerger()
+                    LookupMergerSupport.createCompilerOptionsQueryMerger(),
+                    MavenJPDAStart.create(this)
         );
     }
 

--- a/java/maven/src/org/netbeans/modules/maven/api/execute/RunUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/execute/RunUtils.java
@@ -33,6 +33,7 @@ import org.netbeans.modules.maven.execute.BeanRunConfig;
 import org.netbeans.modules.maven.execute.MavenCommandLineExecutor;
 import org.netbeans.spi.project.AuxiliaryProperties;
 import org.openide.execution.ExecutorTask;
+import org.openide.util.NbBundle;
 import org.openide.windows.WindowManager;
 
 /**
@@ -119,7 +120,11 @@ public final class RunUtils {
         return new BeanRunConfig(original);
     }
 
-    
+    @NbBundle.Messages({
+        "#compile on save: all, none",
+        "#NOI18N",
+        "DEFAULT_COMPILE_ON_SAVE=all"
+    })
     public static boolean isCompileOnSaveEnabled(Project prj) {
         AuxiliaryProperties auxprops = prj.getLookup().lookup(AuxiliaryProperties.class);
         if (auxprops == null) {
@@ -128,9 +133,9 @@ public final class RunUtils {
         }
         String cos = auxprops.get(Constants.HINT_COMPILE_ON_SAVE, true);
         if (cos == null) {
-            cos = "all";
+            cos = Bundle.DEFAULT_COMPILE_ON_SAVE();
         }
-        return !"none".equalsIgnoreCase(cos) && BuildArtifactMapper.isCompileOnSaveSupported();
+        return !"none".equalsIgnoreCase(cos) && BuildArtifactMapper.isCompileOnSaveSupported(); // NOI18N
     }
     
     public static boolean isCompileOnSaveEnabled(RunConfig config) {

--- a/java/maven/src/org/netbeans/modules/maven/debug/DebuggerChecker.java
+++ b/java/maven/src/org/netbeans/modules/maven/debug/DebuggerChecker.java
@@ -229,8 +229,9 @@ public class DebuggerChecker implements LateBoundPrerequisitesChecker, Execution
                 config.setProperty(key, orig != null ? orig + ' ' + vmargs : vmargs);
             }
             try {
-                JPDAStart start = new JPDAStart(context.getInputOutput(), config.getActionName());
-                NbMavenProject prj = config.getProject().getLookup().lookup(NbMavenProject.class);
+                final Project p = config.getProject();
+                NbMavenProject prj = p.getLookup().lookup(NbMavenProject.class);
+                MavenJPDAStart start = p.getLookup().lookup(MavenJPDAStart.class);
                 start.setName(prj.getMavenProject().getArtifactId());
                 String stopClass = config.getProperties().get("jpda.stopclass");
                 if (stopClass == null) {
@@ -245,7 +246,7 @@ public class DebuggerChecker implements LateBoundPrerequisitesChecker, Execution
                 if (addCP != null) {
                     start.setAdditionalSourcePath(addCP);
                 }
-                String val = start.execute(config.getProject());
+                String val = start.execute(context.getInputOutput());
                 for (Map.Entry<String,String> entry : NbCollections.checkedMapByFilter(config.getProperties(), String.class, String.class, true).entrySet()) {
                     StringBuilder buf = new StringBuilder(entry.getValue());
                     String replaceItem = "${jpda.address}"; //NOI18N

--- a/java/maven/src/org/netbeans/modules/maven/debug/MavenJPDAStart.java
+++ b/java/maven/src/org/netbeans/modules/maven/debug/MavenJPDAStart.java
@@ -73,7 +73,7 @@ public final class MavenJPDAStart {
     
     
     private final Project project;
-    private Future<?> lastFuture;
+    private volatile Future<?> lastFuture;
 
     private MavenJPDAStart(Project p) {
         this.project = p;

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -38,11 +38,11 @@ import java.util.prefs.Preferences;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.netbeans.api.annotations.common.CheckForNull;
-import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.modules.maven.embedder.EmbedderFactory;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
+import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
 import org.openide.util.WeakSet;
 
@@ -284,9 +284,18 @@ public final class MavenSettings  {
     public void setShowLoggingLevel(boolean show) {
         getPreferences().putBoolean(PROP_SHOW_LOGGING_LEVEL, show);
     }
-    
+
+    @NbBundle.Messages({
+        "#reuse output: true, false, never",
+        "#NOI18N",
+        "DEFAULT_REUSE_OUTPUT=true"
+    })
     public boolean isReuseOutputTabs() {
-        return getPreferences().getBoolean(PROP_REUSE_OUTPUT, true);
+        String def = Bundle.DEFAULT_REUSE_OUTPUT();
+        if ("never".equals(def)) { // NOI18N
+            return false;
+        }
+        return getPreferences().getBoolean(PROP_REUSE_OUTPUT, "true".equals(def)); // NOI18N
     }
 
     public void setReuseOutputTabs(boolean reuse) {

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectImplTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectImplTest.java
@@ -33,6 +33,7 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.junit.RandomlyFails;
+import org.netbeans.modules.maven.debug.MavenJPDAStart;
 import org.netbeans.modules.projectapi.nb.TimedWeakReference;
 import org.netbeans.spi.project.LookupMerger;
 import org.netbeans.spi.project.ProjectServiceProvider;
@@ -63,7 +64,18 @@ public class NbMavenProjectImplTest extends NbTestCase {
     protected @Override String logRoot() {
         return "org.netbeans.modules.maven";
     }
-
+    
+    public void testMavenJPDAStartInLookup() throws Exception {
+        assertLookupObject("[base, jar]", "jar");
+        assertLookupObject("[base, war]", "war");
+        assertLookupObject("[base]", "ear");
+        // Now test dynamic changes to packaging:
+        FileObject pd = wd.getFileObject("prj-war");
+        Project prj = ProjectManager.getDefault().findProject(pd);
+        MavenJPDAStart jpda = prj.getLookup().lookup(MavenJPDAStart.class);
+        assertNotNull("Single MavenJPDAStart instance per project", jpda);
+    }
+    
     public void testPackagingTypeSpecificLookup() throws Exception {
         assertLookupObject("[base, jar]", "jar");
         assertLookupObject("[base, war]", "war");
@@ -77,6 +89,7 @@ public class NbMavenProjectImplTest extends NbTestCase {
                 + "<packaging>jar</packaging><version>1.0</version></project>");
         assertEquals("[base, jar]", prj.getLookup().lookup(I.class).m());
     }
+    
     private void assertLookupObject(String result, String packaging) throws Exception {
         FileObject pd = wd.createFolder("prj-" + packaging);
         TestFileUtils.writeFile(pd, "pom.xml", "<project><modelVersion>4.0.0</modelVersion>"

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/api/execute/Bundle_test.properties
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/api/execute/Bundle_test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DEFAULT_COMPILE_ON_SAVE=none

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/api/execute/RunUtilsTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/api/execute/RunUtilsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.api.execute;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.netbeans.api.project.Project;
+import org.netbeans.spi.project.AuxiliaryProperties;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle;
+import org.openide.util.lookup.Lookups;
+
+public class RunUtilsTest {
+    
+    public RunUtilsTest() {
+    }
+    
+    @Test
+    public void testIsCompileOnSaveEnabledByDefault() {
+        NbBundle.setBranding(null);
+        boolean result = RunUtils.isCompileOnSaveEnabled(new MockPrj());
+        assertTrue("By default use CoS in NetBeans IDE", result);
+    }
+    
+    @Test
+    public void testIsCompileOnSaveEnabledWithBranding() {
+        NbBundle.setBranding("test");
+        boolean result = RunUtils.isCompileOnSaveEnabled(new MockPrj());
+        assertFalse("Allow branding to disable CoS", result);
+    }
+
+    private static class MockPrj implements Project {
+        public MockPrj() {
+        }
+
+        @Override
+        public FileObject getProjectDirectory() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Lookup getLookup() {
+            return Lookups.fixed(new EmptyAuxProps());
+        }
+
+        private static class EmptyAuxProps implements AuxiliaryProperties {
+            public EmptyAuxProps() {
+            }
+
+            @Override
+            public String get(String key, boolean shared) {
+                return null;
+            }
+
+            @Override
+            public void put(String key, String value, boolean shared) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Iterable<String> listKeys(boolean shared) {
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+    
+}

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/options/Bundle_test.properties
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/options/Bundle_test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DEFAULT_REUSE_OUTPUT=never

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/options/MavenSettingsTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/options/MavenSettingsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.options;
+
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.openide.util.NbBundle;
+import org.openide.util.NbPreferences;
+
+public class MavenSettingsTest {
+    @Before
+    public void cleanUpSettings() throws BackingStoreException {
+        Preferences p = NbPreferences.forModule(MavenSettings.class);
+        p.clear();
+    }
+    
+    @Test
+    public void testReuseOutputTabsByDefault() {
+        NbBundle.setBranding(null);
+        final MavenSettings s = MavenSettings.getDefault();
+        assertTrue("By default reuse tabs in NetBeans IDE", s.isReuseOutputTabs());
+        s.setReuseOutputTabs(false);
+        assertFalse("Now set to false", s.isReuseOutputTabs());
+        s.setReuseOutputTabs(true);
+        assertTrue("Now set to true", s.isReuseOutputTabs());
+    }
+    
+    @Test
+    public void testReuseOutputTabsWithBranding() {
+        NbBundle.setBranding("test");
+        final MavenSettings s = MavenSettings.getDefault();
+        assertFalse("Allow branding to disable reuse of tabs", s.isReuseOutputTabs());
+        s.setReuseOutputTabs(true);
+        assertFalse("Now set to true, but we branded to 'never'", s.isReuseOutputTabs());
+    }
+
+    
+}


### PR DESCRIPTION
I am helping to build an [application on top of the NetBeans](https://github.com/JaroslavTulach/netbeans/tree/java-lsp-server-debugging-attempt2/java/java.lsp.server/nbcode) Platform and Java support (both Maven and Gradle) which has a completely different UI.

The default behavior of "reusing output tabs" in Maven doesn't suite my use-case. I'd prefer each Maven execution to request new tab. Also the "compile on save" behavior is problematic - my application doesn't have the project configuration options to turn it on/off (yet), so it is safer to just disable it altogether: this is made possible (via branding) in bac26b5

The other problem is related to debugging (and I have witnessed it in NetBeans from time to time): When you launch a debugging, but the Maven script execution fails, the system continues to listen for the debuggee to attach. If you just fix the problem and try to debug again, it doesn't work - the previous "listening" has to be stopped by the "Finish Debugging" action. Quite annoying even in NetBeans. Moreover, my application doesn't have the "Finish Debugging" action at all. I want to solve it by 68d7ceb - if the above situation is detected, the previous "listening" on the same Maven project is cancelled and new one started automatically.