### PR TITLE
Do not tear down debugger UI in a headless mode.

### DIFF
--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
@@ -395,6 +395,9 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
 
     @Override
     public void engineRemoved (final DebuggerEngine engine) {
+        if (GraphicsEnvironment.isHeadless()) {
+            return ;
+        }
         DebuggerModule dm = DebuggerModule.findObject(DebuggerModule.class);
         if (dm != null && dm.isClosing()) {
             // Do not interfere with closeDebuggerUI()


### PR DESCRIPTION
This is a headless check, corresponding to the existing one in `engineAdded` method.