### PR TITLE
Grammatically incorrect constants in ExceptionBreakpoint deprecated and replaced with grammatically correct names.

### DIFF
--- a/java/api.debugger.jpda/apichanges.xml
+++ b/java/api.debugger.jpda/apichanges.xml
@@ -945,6 +945,20 @@ These are mainly class and thread filters and hit counts.
         <class package="org.netbeans.api.debugger.jpda" name="InvalidExpressionException" />
         <issue number="268011"/>
     </change>
+
+    <change>
+        <api name="JPDADebuggerAPI"/>
+        <summary>Grammatically incorrect constants deprecated.</summary>
+        <version major="3" minor="18"/>
+        <date day="9" month="10" year="2020"/>
+        <author login="mentlicher"/>
+        <compatibility addition="yes" source="compatible" binary="compatible"/>
+        <description>
+            The grammatically incorrect constants in <code>ExceptionBreakpoint</code>
+            class are deprecated and replaced with grammatically correct names.
+        </description>
+        <class package="org.netbeans.api.debugger.jpda" name="ExceptionBreakpoint" />
+    </change>
 </changes>
 
   <!-- Now the surrounding HTML text and document structure: -->

--- a/java/api.debugger.jpda/manifest.mf
+++ b/java/api.debugger.jpda/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.debugger.jpda/2
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/debugger/jpda/Bundle.properties
-OpenIDE-Module-Specification-Version: 3.17
+OpenIDE-Module-Specification-Version: 3.18
 OpenIDE-Module-Package-Dependencies: com.sun.jdi[VirtualMachineManager]
 

--- a/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ExceptionBreakpoint.java
+++ b/java/api.debugger.jpda/src/org/netbeans/api/debugger/jpda/ExceptionBreakpoint.java
@@ -32,14 +32,14 @@ import org.openide.util.NbBundle;
 
 
 /**
- * Notifies about exceptions throw in debugged JVM.
+ * Notifies about exceptions thrown in debugged JVM.
  *
  * <br><br>
  * <b>How to use it:</b>
  * <pre style="background-color: rgb(255, 255, 153);">
  *    DebuggerManager.addBreakpoint (ExceptionBreakpoint.create (
  *        "java.lang.NullPointerException",
- *        ExceptionBreakpoint.TYPE_EXCEPTION_UNCATCHED
+ *        ExceptionBreakpoint.TYPE_EXCEPTION_UNCAUGHT
  *    ));</pre>
  * This breakpoint stops when NullPointerException is throw and uncatched.
  *
@@ -58,17 +58,39 @@ public class ExceptionBreakpoint extends JPDABreakpoint {
     /** Property name constant. */
     public static final String          PROP_CONDITION = "condition"; // NOI18N
 
-    /** Catch type constant. <i>[sic]</i> "caught" */
+    /** Catch type constant. <i>[sic]</i> "caught"
+     * @deprecated Use {@link #TYPE_EXCEPTION_CAUGHT} */
+    @Deprecated
     public static final int             TYPE_EXCEPTION_CATCHED = 1;
-    /** Catch type constant. <i>[sic]</i> "uncaught" */
+    /** Catch type constant. <i>[sic]</i> "uncaught"
+     * @deprecated Use {@link #TYPE_EXCEPTION_UNCAUGHT} */
+    @Deprecated
     public static final int             TYPE_EXCEPTION_UNCATCHED = 2;
-    /** Catch type constant. <i>[sic]</i> "caught/uncaught" */
+    /** Catch type constant. <i>[sic]</i> "caught/uncaught"
+     * @deprecated Use {@link #TYPE_EXCEPTION_CAUGHT_UNCAUGHT} */
+    @Deprecated
     public static final int             TYPE_EXCEPTION_CATCHED_UNCATCHED = 3;
+
+    /**
+     * Catch type constant that matches those exceptions that are caught by the user code.
+     * @since 3.18
+     */
+    public static final int             TYPE_EXCEPTION_CAUGHT = 1;
+    /**
+     * Catch type constant that matches those exceptions that are not caught by the user code and run through.
+     * @since 3.18
+     */
+    public static final int             TYPE_EXCEPTION_UNCAUGHT = 2;
+    /**
+     * Catch type constant that matches all exceptions regardless of where and if they are caught.
+     * @since 3.18
+     */
+    public static final int             TYPE_EXCEPTION_CAUGHT_UNCAUGHT = 3;
 
     private String                      exceptionClassName = "";
     private String[]                    classFilters = new String [0];
     private String[]                    classExclusionFilters = new String [0];
-    private int                         catchType = TYPE_EXCEPTION_UNCATCHED;
+    private int                         catchType = TYPE_EXCEPTION_UNCAUGHT;
     private String                      condition = ""; // NOI18N
 
     
@@ -79,8 +101,8 @@ public class ExceptionBreakpoint extends JPDABreakpoint {
      * Creates a new breakpoint for given parameters.
      *
      * @param exceptionClassName class name filter
-     * @param catchType one of constants: TYPE_EXCEPTION_CATCHED, 
-     *   TYPE_EXCEPTION_UNCATCHED, TYPE_EXCEPTION_CATCHED_UNCATCHED
+     * @param catchType one of constants: {@link #TYPE_EXCEPTION_CAUGHT},
+     *   {@link #TYPE_EXCEPTION_UNCAUGHT, {@link #TYPE_EXCEPTION_CAUGHT_UNCAUGHT}.
      * @return a new breakpoint for given parameters
      */
     public static ExceptionBreakpoint create (
@@ -200,7 +222,7 @@ public class ExceptionBreakpoint extends JPDABreakpoint {
      */
     public void setCatchType (int catchType) {
         if (catchType == this.catchType) return;
-        if ( (catchType & (TYPE_EXCEPTION_CATCHED | TYPE_EXCEPTION_UNCATCHED)) == 0
+        if ( (catchType & (TYPE_EXCEPTION_CAUGHT | TYPE_EXCEPTION_UNCAUGHT)) == 0
            ) throw new IllegalArgumentException  ();
         int old = this.catchType;
         this.catchType = catchType;

--- a/java/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAStart.java
+++ b/java/debugger.jpda.ant/antsrc/org/netbeans/modules/debugger/jpda/ant/JPDAStart.java
@@ -627,7 +627,7 @@ public class JPDAStart extends Task implements Runnable {
     }
 
     private ExceptionBreakpoint createCompilationErrorBreakpoint() {
-        ExceptionBreakpoint b = ExceptionBreakpoint.create("java.lang.RuntimeException", ExceptionBreakpoint.TYPE_EXCEPTION_UNCATCHED);
+        ExceptionBreakpoint b = ExceptionBreakpoint.create("java.lang.RuntimeException", ExceptionBreakpoint.TYPE_EXCEPTION_UNCAUGHT);
         b.setHidden (true);
         b.addJPDABreakpointListener(new JPDABreakpointListener() {
             @Override

--- a/java/debugger.jpda.ui/nbproject/project.xml
+++ b/java/debugger.jpda.ui/nbproject/project.xml
@@ -40,7 +40,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>3.7</specification-version>
+                        <specification-version>3.18</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ExceptionBreakpointPanel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/breakpoints/ExceptionBreakpointPanel.java
@@ -64,7 +64,7 @@ public class ExceptionBreakpointPanel extends JPanel implements Controller, org.
         }
         ExceptionBreakpoint mb = ExceptionBreakpoint.create (
             className,
-            ExceptionBreakpoint.TYPE_EXCEPTION_CATCHED_UNCATCHED
+            ExceptionBreakpoint.TYPE_EXCEPTION_CAUGHT_UNCAUGHT
         );
         mb.setPrintText (
             NbBundle.getBundle (ExceptionBreakpointPanel.class).getString 
@@ -101,13 +101,13 @@ public class ExceptionBreakpointPanel extends JPanel implements Controller, org.
         cbBreakpointType.addItem (bundle.getString("LBL_Exception_Breakpoint_Type_Uncatched"));
         cbBreakpointType.addItem (bundle.getString("LBL_Exception_Breakpoint_Type_Catched_or_Uncatched"));
         switch (b.getCatchType ()) {
-            case ExceptionBreakpoint.TYPE_EXCEPTION_CATCHED:
+            case ExceptionBreakpoint.TYPE_EXCEPTION_CAUGHT:
                 cbBreakpointType.setSelectedIndex (0);
                 break;
-            case ExceptionBreakpoint.TYPE_EXCEPTION_UNCATCHED:
+            case ExceptionBreakpoint.TYPE_EXCEPTION_UNCAUGHT:
                 cbBreakpointType.setSelectedIndex (1);
                 break;
-            case ExceptionBreakpoint.TYPE_EXCEPTION_CATCHED_UNCATCHED:
+            case ExceptionBreakpoint.TYPE_EXCEPTION_CAUGHT_UNCAUGHT:
                 cbBreakpointType.setSelectedIndex (2);
                 break;
         }
@@ -247,13 +247,13 @@ public class ExceptionBreakpointPanel extends JPanel implements Controller, org.
         
         switch (cbBreakpointType.getSelectedIndex ()) {
             case 0:
-                breakpoint.setCatchType (ExceptionBreakpoint.TYPE_EXCEPTION_CATCHED);
+                breakpoint.setCatchType (ExceptionBreakpoint.TYPE_EXCEPTION_CAUGHT);
                 break;
             case 1:
-                breakpoint.setCatchType (ExceptionBreakpoint.TYPE_EXCEPTION_UNCATCHED);
+                breakpoint.setCatchType (ExceptionBreakpoint.TYPE_EXCEPTION_UNCAUGHT);
                 break;
             case 2:
-                breakpoint.setCatchType (ExceptionBreakpoint.TYPE_EXCEPTION_CATCHED_UNCATCHED);
+                breakpoint.setCatchType (ExceptionBreakpoint.TYPE_EXCEPTION_CAUGHT_UNCAUGHT);
                 break;
         }
         breakpoint.setClassFilters(conditionsPanel.getClassMatchFilter());

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsNodeModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/BreakpointsNodeModel.java
@@ -225,7 +225,7 @@ public class BreakpointsNodeModel implements NodeModel {
         } else
         if (o instanceof ExceptionBreakpoint) {
             ExceptionBreakpoint b = (ExceptionBreakpoint) o;
-            if (b.getCatchType () == b.TYPE_EXCEPTION_CATCHED)
+            if (b.getCatchType () == b.TYPE_EXCEPTION_CAUGHT)
                 return bold (b,
                     NbBundle.getMessage (
                         BreakpointsNodeModel.class,
@@ -234,7 +234,7 @@ public class BreakpointsNodeModel implements NodeModel {
                     )
                 );
             else
-            if (b.getCatchType () == b.TYPE_EXCEPTION_UNCATCHED)
+            if (b.getCatchType () == b.TYPE_EXCEPTION_UNCAUGHT)
                 return bold (b,
                     NbBundle.getMessage (
                         BreakpointsNodeModel.class,
@@ -391,7 +391,7 @@ public class BreakpointsNodeModel implements NodeModel {
         } else
         if (o instanceof ExceptionBreakpoint) {
             ExceptionBreakpoint b = (ExceptionBreakpoint) o;
-            if (b.getCatchType () == b.TYPE_EXCEPTION_CATCHED)
+            if (b.getCatchType () == b.TYPE_EXCEPTION_CAUGHT)
                 description = 
                     NbBundle.getMessage (
                         BreakpointsNodeModel.class,
@@ -399,7 +399,7 @@ public class BreakpointsNodeModel implements NodeModel {
                         b.getExceptionClassName ()
                     );
             else
-            if (b.getCatchType () == b.TYPE_EXCEPTION_UNCATCHED)
+            if (b.getCatchType () == b.TYPE_EXCEPTION_UNCAUGHT)
                 description = 
                     NbBundle.getMessage (
                         BreakpointsNodeModel.class,

--- a/java/debugger.jpda/nbproject/project.xml
+++ b/java/debugger.jpda/nbproject/project.xml
@@ -49,7 +49,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>3.7</specification-version>
+                        <specification-version>3.18</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsEngineListener.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsEngineListener.java
@@ -263,7 +263,7 @@ implements PropertyChangeListener, DebuggerManagerListener {
         Properties p = Properties.getDefault().getProperties("debugger.options.JPDA");
         boolean doCatchExceptions = p.getBoolean("CatchExceptions", false);
         if (doCatchExceptions) {
-            ExceptionBreakpoint eb = ExceptionBreakpoint.create(java.lang.Throwable.class.getName(), ExceptionBreakpoint.TYPE_EXCEPTION_UNCATCHED);
+            ExceptionBreakpoint eb = ExceptionBreakpoint.create(java.lang.Throwable.class.getName(), ExceptionBreakpoint.TYPE_EXCEPTION_UNCAUGHT);
             createBreakpointImpl(eb);
         }
     }

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsReader.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/BreakpointsReader.java
@@ -192,7 +192,7 @@ public class BreakpointsReader implements Properties.Reader, PropertyChangeListe
                 ),
                 properties.getInt (
                     ExceptionBreakpoint.PROP_CATCH_TYPE, 
-                    ExceptionBreakpoint.TYPE_EXCEPTION_CATCHED_UNCATCHED
+                    ExceptionBreakpoint.TYPE_EXCEPTION_CAUGHT_UNCAUGHT
                 )
             );
             eb.setCondition (

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/ExceptionBreakpointImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/ExceptionBreakpointImpl.java
@@ -96,9 +96,9 @@ public class ExceptionBreakpointImpl extends ClassBasedBreakpoint {
                     getEventRequestManager(),
                     referenceType,
                     (breakpoint.getCatchType () &
-                        ExceptionBreakpoint.TYPE_EXCEPTION_CATCHED) != 0,
+                        ExceptionBreakpoint.TYPE_EXCEPTION_CAUGHT) != 0,
                     (breakpoint.getCatchType () &
-                        ExceptionBreakpoint.TYPE_EXCEPTION_UNCATCHED) != 0
+                        ExceptionBreakpoint.TYPE_EXCEPTION_UNCAUGHT) != 0
                 );
                 addFilters(er, breakpoint.getClassFilters(), breakpoint.getClassExclusionFilters());
                 addEventRequest (er);

--- a/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/BreakpointsClassFilterTest.java
+++ b/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/BreakpointsClassFilterTest.java
@@ -79,8 +79,8 @@ public class BreakpointsClassFilterTest extends NbTestCase {
         FieldBreakpoint fb2 = FieldBreakpoint.create(APP_CLASS_NAME, "field2", FieldBreakpoint.TYPE_ACCESS);
         fb2.setGroupName(FILTER_GROUP_NAME);
         
-        ExceptionBreakpoint eb1 = ExceptionBreakpoint.create(NegativeArraySizeException.class.getName(), ExceptionBreakpoint.TYPE_EXCEPTION_CATCHED_UNCATCHED);
-        ExceptionBreakpoint eb2 = ExceptionBreakpoint.create(ArithmeticException.class.getName(), ExceptionBreakpoint.TYPE_EXCEPTION_CATCHED_UNCATCHED);
+        ExceptionBreakpoint eb1 = ExceptionBreakpoint.create(NegativeArraySizeException.class.getName(), ExceptionBreakpoint.TYPE_EXCEPTION_CAUGHT_UNCAUGHT);
+        ExceptionBreakpoint eb2 = ExceptionBreakpoint.create(ArithmeticException.class.getName(), ExceptionBreakpoint.TYPE_EXCEPTION_CAUGHT_UNCAUGHT);
         eb2.setGroupName(FILTER_GROUP_NAME);
         
         MethodBreakpoint mb2 = MethodBreakpoint.create(APP_CLASS_NAME, "test");

--- a/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ExceptionBreakpointTest.java
+++ b/java/debugger.jpda/test/unit/src/org/netbeans/api/debugger/jpda/ExceptionBreakpointTest.java
@@ -51,7 +51,7 @@ public class ExceptionBreakpointTest extends NbTestCase {
         try {
             ExceptionBreakpoint eb1 = ExceptionBreakpoint.create (
                 "org.netbeans.api.debugger.jpda.testapps.ExceptionTestException", 
-                ExceptionBreakpoint.TYPE_EXCEPTION_CATCHED
+                ExceptionBreakpoint.TYPE_EXCEPTION_CAUGHT
             );
             TestBreakpointListener tbl = new TestBreakpointListener (
                 "org.netbeans.api.debugger.jpda.testapps.ExceptionTestException", 


### PR DESCRIPTION
As I need to use these constants in some follow-up changes, I decided to create grammatically correct names so that the wrong ones do not spread more. The deprecated ones will stay there for compatibility reasons.