### PR TITLE
[NETBEANS-4889] Remove extide <-> apisupport cyrcular dependency on tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ matrix:
         
         - name: Pristine platform build
           jdk: openjdk8
+          env:
+            - ANT_OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false"
           script: 
             - ant -quiet build-source-config -Dcluster.config=platform
             - mkdir tmpplatform
@@ -335,6 +337,7 @@ matrix:
             - ant $OPTS build
           script:
             - ant $OPTS -f extide/o.apache.tools.ant.module test
+            - ant $OPTS -f extide/gradle test
             
         - name: Test Java modules with nb-javac on Java 8
           jdk: openjdk8

--- a/extide/gradle/nbproject/project.xml
+++ b/extide/gradle/nbproject/project.xml
@@ -330,11 +330,6 @@
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.apisupport.project</code-name-base>
-                        <compile-dependency/>
-                        <test/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
                         <recursive/>
                         <compile-dependency/>
@@ -349,6 +344,11 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.openide.filesystems</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.openide.modules</code-name-base>
                         <compile-dependency/>
                         <test/>
                     </test-dependency>

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
@@ -67,7 +67,7 @@ public final class NbGradleProjectFactory implements ProjectFactory2 {
         }
         File suspect = FileUtil.toFile(dir);
         GradleFiles files = new GradleFiles(suspect);
-        if (files.isRootProject()) return true;
+        if (files.isRootProject() || files.isBuildSrcProject()) return true;
         
         if ((files.getSettingsScript() != null) && !files.isBuildSrcProject()) {
             SubProjectDiskCache spCache = SubProjectDiskCache.get(files.getRootDir());

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
@@ -25,18 +25,22 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.junit.NbTestCase;
-import org.netbeans.modules.apisupport.project.InstalledFileLocatorImpl;
 import org.netbeans.modules.project.uiapi.ProjectOpenedTrampoline;
 import org.netbeans.spi.project.ui.ProjectOpenedHook;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.test.TestFileUtils;
+import org.openide.modules.DummyInstalledFileLocator;
 
 /**
  *
  * @author lkishalmi
  */
 public class AbstractGradleProjectTestCase extends NbTestCase {
+
+    @org.openide.util.lookup.ServiceProvider(service=org.openide.modules.InstalledFileLocator.class)
+    public static class InstalledFileLocator extends DummyInstalledFileLocator {
+    }
 
     public AbstractGradleProjectTestCase(String name) {
         super(name);
@@ -50,7 +54,7 @@ public class AbstractGradleProjectTestCase extends NbTestCase {
         super.setUp();
         clearWorkDir();
         destDirF = getTestNBDestDir();
-        InstalledFileLocatorImpl.registerDestDir(destDirF);
+        DummyInstalledFileLocator.registerDestDir(destDirF);
     }
 
     @Override
@@ -77,7 +81,9 @@ public class AbstractGradleProjectTestCase extends NbTestCase {
                 ret = ret.getFileObject(p) != null ? ret.getFileObject(p): ret.createFolder(p);
             }
         }
-        TestFileUtils.writeFile(ret, "build.gradle", buildScript);
+        if (buildScript != null) {
+            TestFileUtils.writeFile(ret, "build.gradle", buildScript);
+        }
         if (settingsScript != null) {
             TestFileUtils.writeFile(ret, "settings.gradle", settingsScript);
         }

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectFactoryTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectFactoryTest.java
@@ -74,7 +74,7 @@ public class NbGradleProjectFactoryTest extends AbstractGradleProjectTestCase {
     public void testBuildSrcProject() throws Exception {
         int rnd = new Random().nextInt(1000000);
         FileObject a = createGradleProject("projectA-" + rnd,
-                "apply plugin: 'java'\n", null);
+                "apply plugin: 'java'\n", "");
         FileObject b = createGradleProject("projectA-" + rnd + "/buildSrc",
                 null, null);
         assertTrue(NbGradleProjectFactory.isProjectCheck(a, false));

--- a/platform/openide.modules/test/unit/src/org/openide/modules/DummyInstalledFileLocator.java
+++ b/platform/openide.modules/test/unit/src/org/openide/modules/DummyInstalledFileLocator.java
@@ -16,26 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-package org.netbeans.modules.apisupport.project;
+package org.openide.modules;
 
 import java.io.File;
-import junit.framework.TestCase;
 
 /**
  *
  * @author Jaroslav Tulach
  */
-@org.openide.util.lookup.ServiceProvider(service=org.openide.modules.InstalledFileLocator.class)
-public class InstalledFileLocatorImpl extends org.openide.modules.InstalledFileLocator {
+public class DummyInstalledFileLocator extends org.openide.modules.InstalledFileLocator {
     private static File installDir;
 
 
     /**
      * Creates a new instance of InstalledFileLocatorImpl
      */
-    public InstalledFileLocatorImpl() {
-}
+    public DummyInstalledFileLocator() {
+    }
 
 
     public File locate(String relativePath, String codeNameBase, boolean localized) {


### PR DESCRIPTION
Well this makes the Gradle tests run by Travis. I'm not sure if I'm right on the apisupport.