### PR TITLE
Add support for static imports in code templates

### DIFF
--- a/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaCodeTemplateProcessorTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/editor/java/JavaCodeTemplateProcessorTest.java
@@ -18,11 +18,13 @@
  */
 package org.netbeans.modules.editor.java;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.Arrays;
 import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
 import javax.swing.text.Document;
 import javax.swing.text.EditorKit;
 import org.junit.Test;
@@ -38,6 +40,8 @@ import org.openide.filesystems.FileUtil;
 
 public class JavaCodeTemplateProcessorTest extends NbTestCase {
 
+    private FileObject testFile;
+    
     public JavaCodeTemplateProcessorTest(String name) {
         super(name);
     }
@@ -63,10 +67,12 @@ public class JavaCodeTemplateProcessorTest extends NbTestCase {
 
     private void doTestTemplateInsert(String template, String code, String expected) throws Exception {
         clearWorkDir();
-        FileObject testFile = FileUtil.toFileObject(getWorkDir()).createData("Test.java");
+        testFile = FileUtil.toFileObject(getWorkDir()).createData("Test.java");
         EditorKit kit = new JavaKit();
         JEditorPane pane = new JEditorPane();
-        pane.setEditorKit(kit);
+        SwingUtilities.invokeAndWait(() -> {
+            pane.setEditorKit(kit);
+        });
         Document doc = pane.getDocument();
         doc.putProperty(Document.StreamDescriptionProperty, testFile);
         doc.putProperty(Language.class, JavaTokenId.language());
@@ -90,10 +96,71 @@ public class JavaCodeTemplateProcessorTest extends NbTestCase {
         assertEquals(expectedText, doc.getText(0, doc.getLength()));
         assertEquals(resultCaretOffset, pane.getCaretPosition());
     }
-
-    @Override
-    protected boolean runInEQ() {
-        return true;
+    
+    @Test
+    public void testShouldAddStaticImportForTemplateParameterWithStaticImportHint() throws Exception {
+        doTestTemplateInsert("int max = ${param staticImport=\"java.lang.Math.max\" editable=false}(0, 1);",
+                             "public class Test {\n" +
+                             "    private void t(String... args) {\n" +
+                             "        |\n" +
+                             "    }\n" +
+                             "}",
+                             "public class Test {\n" +
+                             "    private void t(String... args) {\n" +
+                             "        int max = max(0, 1);|\n" +
+                             "    }\n" +
+                             "}");
+        assertFileObjectTextMatchesRegex("(?s)\\s*?import static java\\.lang\\.Math\\.max;\\s*?public class Test.*?");
+    }
+    
+    @Test
+    public void testShouldNotAddDuplicatesOfStaticImportForTemplateParameterWithStaticImportHint() throws Exception {
+        doTestTemplateInsert("int max = ${param staticImport=\"java.lang.Math.max\" editable=false}(0, 1);",
+                             "public class Test {\n" +
+                             "    private void t(String... args) {\n" +
+                             "        |\n" +
+                             "    }\n" +
+                             "}",
+                             "public class Test {\n" +
+                             "    private void t(String... args) {\n" +
+                             "        int max = max(0, 1);|\n" +
+                             "    }\n" +
+                             "}");
+        doTestTemplateInsert("int max = ${param staticImport=\"java.lang.Math.max\" editable=false}(0, 1);",
+                             "public class Test {\n" +
+                             "    private void t(String... args) {\n" +
+                             "        int max = max(0, 1);\n" +
+                             "        |\n"+
+                             "    }\n" +
+                             "}",
+                             "public class Test {\n" +
+                             "    private void t(String... args) {\n" +
+                             "        int max = max(0, 1);\n" +
+                             "        int max = max(0, 1);|\n" +
+                             "    }\n" +
+                             "}");
+        assertFileObjectTextMatchesRegex("(?s)\\s*?import static java\\.lang\\.Math\\.max;\\s*?public class Test.*?");
+    }
+    
+    @Test
+    public void testWhenOnlyIdentifierWithoutTypeIsSpecifiedThenDoNotAddStaticImport() throws Exception {
+        doTestTemplateInsert("int max = ${param staticImport=\"max\" editable=false}(0, 1);",
+                             "public class Test {\n" +
+                             "    private void t(String... args) {\n" +
+                             "        |\n" +
+                             "    }\n" +
+                             "}",
+                             "public class Test {\n" +
+                             "    private void t(String... args) {\n" +
+                             "        int max = max(0, 1);|\n" +
+                             "    }\n" +
+                             "}");
+        assertFileObjectTextMatchesRegex("(?s)\\s*?public class Test.*?");
+    }
+    
+    private void assertFileObjectTextMatchesRegex(String regex) throws IOException {
+        String text = testFile.asText();
+        assertTrue("The file text must match the regular expression", text.matches(regex));
     }
 
 }


### PR DESCRIPTION
This PR is my attempt to add support for static imports in code templates. I've added an additional hint `staticImport` for the Java Code Template Processor. When processed by the processor, a static import declaration and static member identifier will be added to the source code. From the user's perspective, this will work something like this:

![static-import-in-code-template](https://user-images.githubusercontent.com/64587659/95567039-d5b9bd80-0a3b-11eb-89af-2f13120218a2.gif)
