### PR TITLE
[NETBEANS-4896] Classpath Fixes for Gradle Java projects

### DIFF
--- a/java/gradle.java/nbproject/project.xml
+++ b/java/gradle.java/nbproject/project.xml
@@ -340,9 +340,10 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.openide.modules</code-name-base>
-                        <run-dependency/>
+                        <compile-dependency/>
                         <test/>
-                    </test-dependency>                    <test-dependency>
+                    </test-dependency>
+                    <test-dependency>
                         <code-name-base>org.openide.util.ui</code-name-base>
                         <compile-dependency/>
                         <test/>

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
@@ -306,7 +306,7 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
 
         private synchronized ClassPath getModuleCompilePath() {
             if (moduleCompile == null) {
-                moduleCompile = createMultiplexClassPath(getJava8CompileClassPath(), ClassPath.EMPTY);
+                moduleCompile = createMultiplexClassPath(getJava8CompileClassPath(), getJava8CompileClassPath());
             }
             return moduleCompile;
         }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/CompileClassPathImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/CompileClassPathImpl.java
@@ -41,6 +41,7 @@ public final class CompileClassPathImpl extends AbstractSourceSetClassPathImpl {
         GradleJavaSourceSet ss = getSourceSet();
         if (ss != null)  {
             addAllFile(ret, ss.getCompileClassPath());
+            addAllFile(ret, ss.getOutputClassDirs());
         }
         return ret;
     }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
@@ -155,11 +155,13 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
         SourceType stype = soureType2SourceType(type);
         if (stype != null) {
             ArrayList<SourceGroup> ret = new ArrayList<>();
+            Set<File> processed = new HashSet();
             for (String group : gradleSources.keySet()) {
                 Set<File> dirs = gradleSources.get(group).getSourceDirs(stype);
                 boolean unique = dirs.size() == 1;
                 for (File dir : dirs) {
-                    if (dir.isDirectory()) {
+                    if (!processed.contains(dir) && dir.isDirectory()) {
+                        processed.add(dir);
                         ret.add(createSourceGroup(unique, group, dir, stype));
                     }
                 }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/SourceClassPathImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/SourceClassPathImpl.java
@@ -40,11 +40,7 @@ public final class SourceClassPathImpl extends AbstractSourceSetClassPathImpl {
         List<URL> ret = new ArrayList<>();
         GradleJavaSourceSet ss = getSourceSet();
         if (ss != null) {
-
             addAllFile(ret, ss.getAllDirs());
-            for (GradleJavaSourceSet sourceDependency : ss.getSourceDependencies()) {
-                addAllFile(ret, sourceDependency.getAllDirs());
-            }
         }
         return ret;
     }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceForBinary.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceForBinary.java
@@ -78,13 +78,11 @@ public class GradleSourceForBinary implements SourceForBinaryQueryImplementation
                             for (GradleJavaSourceSet ss : prj.getSourceSets().values()) {
                                 File outputDir = ss.getCompilerArgs(JAVA).contains("--module-source-path") ? //NOI18N
                                         root.getParentFile() : root;
-                                for (File dir : ss.getOutputClassDirs()) {
-                                    if (outputDir.equals(dir)) {
-                                        ret = new Res(project, ss.getName(), EnumSet.of(JAVA, GROOVY, SCALA, GENERATED));
-                                        break;
-                                    }
+                                if (ss.getOutputClassDirs().contains(outputDir)) {
+                                    ret = new Res(project, ss.getName(), EnumSet.of(JAVA, GROOVY, SCALA, GENERATED));
+                                    break;
                                 }
-                                if (root.equals(ss.getOutputResources())) {
+                                if ((ret == null) && root.equals(ss.getOutputResources())) {
                                     ret = new Res(project, ss.getName(), EnumSet.of(RESOURCES));
                                 }
                                 if (ret != null) {


### PR DESCRIPTION
This one shall fix: 
https://github.com/lkishalmi/gradle-modular-calculator tests.
Also along with #2439 this can make javafx.base module load without any warnings. Other javafx modules are not necessary configured well in Gradle, they might live on the custom --module-source-path defined for the JavaC.