### PR TITLE
Bugfixes for VSCode and Gradle

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,20 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="reusetabs">
+            <api name="general"/>
+            <summary>Default for reusing tabs</summary>
+            <version major="2" minor="5"/>
+            <date day="15" month="10" year="2020"/>
+            <author login="jtulach"/>
+            <compatibility semantic="compatible"/>
+            <description>
+                <p>
+                    Introducing <a href="@TOP@architecture-summary.html#group-branding">branding APIs</a>
+                    to configure default value for <b>reusing tabs</b> in Gradle projects.
+                </p>
+            </description>
+        </change>
         <change id="gradle-buildsrc-project">
             <api name="general"/>
             <summary>GradleFiles SPI has the methods to deal with the buildSrc project.</summary>

--- a/extide/gradle/arch.xml
+++ b/extide/gradle/arch.xml
@@ -130,6 +130,14 @@
 
 
  <answer id="exec-property">
+     <api category="devel" group="branding" name="DEFAULT_REUSE_OUTPUT" type="export">
+         Brand the <code>DEFAULT_REUSE_OUTPUT</code> key in a 
+         <code>org.netbeans.modules.gradle.spi.Bundle</code> file
+         with one of the values <code>true</code> or <code>false</code>
+         to specify the default behavior of reusing output by your application.
+         Use <code>never</code> value, if the reuse shall never be done,
+         regardless of the settings value.
+     </api> 
  </answer>
 
  <answer id="resources-file">

--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle/2
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.4
+OpenIDE-Module-Specification-Version: 2.5

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/AbstractGradleExecutor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/AbstractGradleExecutor.java
@@ -19,6 +19,8 @@
 
 package org.netbeans.modules.gradle.execute;
 
+import java.awt.EventQueue;
+import java.awt.GraphicsEnvironment;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.execute.RunConfig;
 import org.netbeans.modules.gradle.api.execute.RunUtils;
@@ -36,7 +38,6 @@ import org.openide.util.RequestProcessor;
 import static org.netbeans.modules.gradle.execute.Bundle.*;
 import java.io.File;
 import java.util.ArrayList;
-import javax.swing.SwingUtilities;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 import static org.netbeans.modules.gradle.api.execute.RunConfig.ExecFlag.REPEATABLE;
@@ -128,7 +129,7 @@ public abstract class AbstractGradleExecutor extends OutputTabMaintainer<Abstrac
     }
 
     protected final void actionStatesAtStart() {
-        SwingUtilities.invokeLater(new Runnable() {
+        invokeUILater(new Runnable() {
             @Override
             public void run() {
                 disableAction(tabContext.rerun);
@@ -139,7 +140,7 @@ public abstract class AbstractGradleExecutor extends OutputTabMaintainer<Abstrac
     }
 
     protected final void actionStatesAtFinish() {
-        SwingUtilities.invokeLater(new Runnable() {
+        invokeUILater(new Runnable() {
             @Override
             public void run() {
                 enableAction(tabContext.rerun);
@@ -297,5 +298,11 @@ public abstract class AbstractGradleExecutor extends OutputTabMaintainer<Abstrac
             AbstractGradleExecutor.this.cancel();
         }
 
+    }
+    private static void invokeUILater(Runnable runnable) {
+        if (GraphicsEnvironment.isHeadless()) {
+            return;
+        }
+        EventQueue.invokeLater(runnable);
     }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleSettings.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleSettings.java
@@ -24,6 +24,7 @@ import java.util.prefs.Preferences;
 import org.gradle.util.GradleVersion;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine.LogLevel;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine.StackTrace;
+import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.NbPreferences;
 
@@ -190,8 +191,17 @@ public final class GradleSettings {
         getPreferences().putBoolean(PROP_REUSE_OUTPUT_TABS, b);
     }
 
+    @NbBundle.Messages({
+        "#reuse output tabs: true, false, never",
+        "#NOI18N",
+        "DEFAULT_REUSE_OUTPUT=true"
+    })
     public boolean isReuseOutputTabs() {
-        return getPreferences().getBoolean(PROP_REUSE_OUTPUT_TABS, true);
+        String def = Bundle.DEFAULT_REUSE_OUTPUT();
+        if ("never".equals(def)) { // NOI18N
+            return false;
+        }
+        return getPreferences().getBoolean(PROP_REUSE_OUTPUT_TABS, "true".equals(def)); // NOI18N
     }
 
     public void setOffline(boolean b) {

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/spi/Bundle_test.properties
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/spi/Bundle_test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DEFAULT_REUSE_OUTPUT=never

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/spi/GradleSettingsTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/spi/GradleSettingsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.spi;
+
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.openide.util.NbBundle;
+import org.openide.util.NbPreferences;
+
+public class GradleSettingsTest {
+    @Before
+    public void cleanUpSettings() throws BackingStoreException {
+        Preferences p = NbPreferences.forModule(GradleSettings.class);
+        p.clear();
+    }
+    
+    @Test
+    public void testReuseOutputTabsByDefault() {
+        NbBundle.setBranding(null);
+        final GradleSettings s = GradleSettings.getDefault();
+        assertTrue("By default reuse tabs in NetBeans IDE", s.isReuseOutputTabs());
+        s.setReuseOutputTabs(false);
+        assertFalse("Now set to false", s.isReuseOutputTabs());
+        s.setReuseOutputTabs(true);
+        assertTrue("Now set to true", s.isReuseOutputTabs());
+    }
+    
+    @Test
+    public void testReuseOutputTabsWithBranding() {
+        NbBundle.setBranding("test");
+        final GradleSettings s = GradleSettings.getDefault();
+        assertFalse("Allow branding to disable reuse of tabs", s.isReuseOutputTabs());
+        s.setReuseOutputTabs(true);
+        assertFalse("Now set to true, but we branded to 'never'", s.isReuseOutputTabs());
+    }
+
+    
+}

--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-gradle.jar/org/netbeans/modules/gradle/spi/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-gradle.jar/org/netbeans/modules/gradle/spi/Bundle.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DEFAULT_REUSE_OUTPUT=never

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceIOContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceIOContext.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.netbeans.modules.java.lsp.server.ui.IOContext;
+
+abstract class WorkspaceIOContext extends IOContext {
+
+    WorkspaceIOContext() {
+    }
+
+    @Override
+    protected void stdOut(String line) {
+        if ("\n".equals(line)) {
+            return;
+        }
+        if (client() != null) {
+            client().logMessage(new MessageParams(MessageType.Info, line));
+        }
+    }
+
+    @Override
+    protected void stdErr(String line) {
+        if ("\n".equals(line)) {
+            return;
+        }
+        if (client() != null) {
+            client().logMessage(new MessageParams(MessageType.Error, line));
+        }
+    }
+
+    @Override
+    protected boolean isValid() {
+        return client() != null;
+    }
+
+    protected abstract LanguageClient client();
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -24,7 +24,6 @@ import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.MessageParams;
-import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.services.LanguageClient;
@@ -34,7 +33,6 @@ import org.netbeans.api.debugger.ActionsManager;
 import org.netbeans.api.debugger.DebuggerManager;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
-import org.netbeans.modules.java.lsp.server.ui.IOContext;
 import org.netbeans.modules.java.lsp.server.ui.UIContext;
 import org.netbeans.spi.project.ActionProvider;
 import org.openide.util.Lookup;
@@ -45,11 +43,11 @@ import org.openide.util.lookup.ProxyLookup;
  *
  * @author lahvac
  */
-public class WorkspaceServiceImpl implements WorkspaceService, LanguageClientAware {
+public final class WorkspaceServiceImpl implements WorkspaceService, LanguageClientAware {
 
     private LanguageClient client;
     private UIContext ctx;
-    private final WorkspaceContext ioContext;
+    private final WorkspaceIOContext ioContext;
 
     public WorkspaceServiceImpl() {
         this.ioContext = new WorkspaceContext();
@@ -108,24 +106,10 @@ public class WorkspaceServiceImpl implements WorkspaceService, LanguageClientAwa
         };
     }
 
-    private class WorkspaceContext extends IOContext {
+    private final class WorkspaceContext extends WorkspaceIOContext {
         @Override
-        protected void stdOut(String line) {
-            if (client != null) {
-                client.logMessage(new MessageParams(MessageType.Info, line));
-            }
-        }
-
-        @Override
-        protected void stdErr(String line) {
-            if (client != null) {
-                client.logMessage(new MessageParams(MessageType.Error, line));
-            }
-        }
-
-        @Override
-        protected boolean isValid() {
-            return client != null;
+        protected LanguageClient client() {
+            return client;
         }
     }
 }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceContextTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceContextTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.DidChangeConfigurationParams;
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class WorkspaceContextTest {
+
+    public WorkspaceContextTest() {
+    }
+
+    @Test
+    public void testPrintLinesNoNewLines() {
+        List<MessageParams> msgs = new ArrayList<>();
+        MockLanguageClient mlc = new MockLanguageClient(msgs);
+        WorkspaceIOContext wc = new WorkspaceIOContext() {
+            @Override
+            protected LanguageClient client() {
+                return mlc;
+            }
+        };
+
+        wc.stdOut("ahoj");
+        wc.stdOut("\n");
+        wc.stdErr("there!");
+        wc.stdErr("\n");
+
+        assertEquals("Two messages", 2, msgs.size());
+
+        assertEquals("ahoj", msgs.get(0).getMessage());
+        assertEquals("there!", msgs.get(1).getMessage());
+    }
+
+    private static final class MockLanguageClient implements LanguageClient {
+        private final List<MessageParams> messages;
+
+        MockLanguageClient(List<MessageParams> messages) {
+            this.messages = messages;
+        }
+
+        @Override
+        public void telemetryEvent(Object object) {
+            fail();
+        }
+
+        @Override
+        public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+            fail();
+        }
+
+        @Override
+        public void showMessage(MessageParams messageParams) {
+            fail();
+        }
+
+        @Override
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+            fail();
+            return null;
+        }
+
+        @Override
+        public void logMessage(MessageParams message) {
+            messages.add(message);
+        }
+    }
+}

--- a/java/java.lsp.server/vscode/README.md
+++ b/java/java.lsp.server/vscode/README.md
@@ -31,9 +31,10 @@ To build the VS Code extension invoke:
 ```bash
 netbeans$ ant build
 netbeans$ cd java/java.lsp.server
-java.lsp.server$ ant build-vscode-ext
+java.lsp.server$ ant build-vscode-ext -D3rdparty.modules=.*nbjavac.*
 ```
 
+The `3rdparty.modules` property doesn't have to be set at all.
 The resulting extension is then in the `build` directory, with the `.vsix` extension.
 
 ### Building for Development
@@ -42,13 +43,14 @@ If you want to develop the extension, use these steps for building instead:
 
 ```bash
 netbeans$ cd java/java.lsp.server
-java.lsp.server$ ant build-lsp-server
+java.lsp.server$ ant build-lsp-server -D3rdparty.modules=.*nbjavac.*
 java.lsp.server$ cd vscode
 vscode$ npm install
 vscode$ npm run watch
 ```
 
-This would be faster than building the `.vsix` file. Find the instructions
+The `3rdparty.modules` property doesn't have to be set at all.
+This target is faster than building the `.vsix` file. Find the instructions
 for running and debugging below.
 
 ### Cleaning

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -130,7 +130,7 @@
 		"watch": "tsc -watch -p ./",
 		"pretest": "npm run compile && npm run lint",
 		"test": "node ./out/test/runTest.js",
-		"nbcode": "./nbcode/bin/nbcode"
+		"nbcode": "node ./out/nbcode.js"
 	},
 	"devDependencies": {
 		"@types/vscode": "^1.47.0",

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -46,8 +46,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
@@ -549,8 +547,9 @@ public class JavacParser extends Parser {
             final NewComilerTask nct = (NewComilerTask)task;
             if (nct.getCompilationController() == null || nct.getTimeStamp() != parseId) {
                 try {
-                    nct.setCompilationController(
-                        JavaSourceAccessor.getINSTANCE().createCompilationController(new CompilationInfoImpl(this, file, root, null, null, cachedSnapShot, true)),
+                    CompilationInfoImpl cii = new CompilationInfoImpl(this, file, root, null, null, cachedSnapShot, true);
+                    cii.setParsedTrees(new HashMap<>());
+                    nct.setCompilationController(JavaSourceAccessor.getINSTANCE().createCompilationController(cii),
                         parseId);
                 } catch (IOException ioe) {
                     throw new ParseException ("Javac Failure", ioe);


### PR DESCRIPTION
Invoking the "Java: Compile Workspace" on a Maven project prints empty lines. Removing `"\n"` lines altogether. The EOL character is implicitly present in the previous line.

Avoiding usage of `invokeLater` when in headless mode in Gradle: edc2ff9

Branding API (like the [one in Maven](https://github.com/apache/netbeans/pull/2427)) to disable output reuse: e29dfe1