### PR TITLE
Upgrade payara-micro-maven-plugin to v1.3.0

### DIFF
--- a/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/plugin/resources/pom.xml.ftl
+++ b/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/plugin/resources/pom.xml.ftl
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>fish.payara.maven.plugins</groupId>
                 <artifactId>payara-micro-maven-plugin</artifactId>
-                <version>1.0.6</version>
+                <version>1.3.0</version>
                 <configuration>
                     <payaraVersion>${r"${version.payara}"}</payaraVersion>
                     <deployWar>false</deployWar>


### PR DESCRIPTION
https://mvnrepository.com/artifact/fish.payara.maven.plugins/payara-micro-maven-plugin is used by pom.xml's freemarker template in Payara Micro modules which is generated during conversion of simple maven web application to Payara Micro maven application. The version upgrade is in the template file.