### PR TITLE
Fix: Multiple CustomIndexer with same Mime-Type use the priority of the IndexerFactory + Tooltip of columns in result-table

### DIFF
--- a/ide/db.dataview/src/org/netbeans/modules/db/dataview/util/DataViewUtils.java
+++ b/ide/db.dataview/src/org/netbeans/modules/db/dataview/util/DataViewUtils.java
@@ -190,10 +190,11 @@ public class DataViewUtils {
 
         if (isString(column.getJdbcType())) {
             strBuf.append("<tr> <td>&nbsp;").append(NbBundle.getMessage(DataViewUtils.class, "TOOLTIP_column_length")).append("</td> <td> &nbsp; : &nbsp; <b>");
+            strBuf.append(column.getDisplaySize()).append("</b> </td> </tr>");
         } else {
             strBuf.append("<tr> <td>&nbsp;").append(NbBundle.getMessage(DataViewUtils.class, "TOOLTIP_column_precision")).append("</td> <td> &nbsp; : &nbsp; <b>");
+            strBuf.append(column.getPrecision()).append("</b> </td> </tr>");
         }
-        strBuf.append(column.getPrecision()).append("</b> </td> </tr>");
 
         if (isScaleRequired(column.getJdbcType())) {
             strBuf.append("<tr> <td>&nbsp;").append(NbBundle.getMessage(DataViewUtils.class, "TOOLTIP_column_scale")).append("</td> <td> &nbsp; : &nbsp; <b>");

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerCache.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerCache.java
@@ -464,7 +464,7 @@ public abstract class IndexerCache <T extends SourceIndexerFactory> {
 
                 // the comparator instance must not be cached, because it uses data
                 // from the default lookup
-                Collections.sort(_orderedInfos, new C());
+                Collections.sort(_orderedInfos, new C().thenComparing(IIC));
                 sortInfosByMimeType(_infosByMimeType);
                 if (transientUpdate) {
                     return new Object [] {


### PR DESCRIPTION
If you have multiple CustomIndexer with the same Mime-Type and you override the method "getPriority" in the corresponding IndexerFactory, this priority is ignored/never used.
So there is the bug, that sometimes it can be that this CustomIndexers are executed in the wrong order.

If you execute a query on the db, a result-table appears. There you can hover about the column-name und you can see some additional information about the structure of the column. If the column is of the type string, it also shows the attribute "length" with the precision of the column. This doesn't make sense, because by string there is no precision.
It occured with MariaDB and with a column of the type char(36).