### PR TITLE
[NETBEANS-4908] Enable run/debug single when the suitable task is provided by the Gradle project.

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,21 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="expose-project-action-mapping-provider">
+            <api name="general"/>
+            <summary>Make ProjectActionMappingProvider available for other modules.</summary>
+            <version major="2" minor="6"/>
+            <date day="15" month="10" year="2020"/>
+            <author login="lkishalmi"/>
+            <compatibility semantic="compatible"/>
+            <description>
+                <p>
+                    Made  <a href="@TOP@/org/netbeans/modules/gradle/spi/actions/ProjectActionMappingProvider.html">ProjectActionMappingProvider</a> available
+                    for other modules, so they either can provide an alternative implementation or most probably able to take a sneak peek on
+                    the current action configuration.
+                </p>
+            </description>
+        </change>
         <change id="reusetabs">
             <api name="general"/>
             <summary>Default for reusing tabs</summary>

--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -96,6 +96,14 @@ is the proper place.
                     for other modules, so they either can provide an alternative implementation or most probably able to take a sneak peek on
                     the current action configuration.
                 </p>
+                <p>
+                    In order to make other modules interpret the action mapping in context <a href="@TOP@/org/netbeans/modules/gradle/api/execute/RunUtils.html">RunUtils</a> got a new evaluateActionArgs
+                    utility method which can replace tokens provided in ActionMapping arguments.
+                </p>
+                <p>
+                    Finally to support this token replacement, <a href="@TOP@/org/netbeans/modules/gradle/spi/actions/ReplacementTokenProvider.html">ReplacementTokenProvider</a>
+                    got a new static method <code>replaceTokens</code>.
+                </p>
             </description>
         </change>
         <change id="reusetabs">

--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle/2
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.5
+OpenIDE-Module-Specification-Version: 2.6

--- a/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
@@ -47,7 +47,7 @@ import static org.netbeans.modules.gradle.Bundle.*;
 import org.netbeans.modules.gradle.actions.KeyValueTableModel;
 import org.netbeans.modules.gradle.api.execute.ActionMapping;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
-import org.netbeans.modules.gradle.actions.ProjectActionMappingProvider;
+import org.netbeans.modules.gradle.spi.actions.ProjectActionMappingProvider;
 import org.netbeans.modules.gradle.customizer.CustomActionMapping;
 import org.netbeans.modules.gradle.spi.actions.AfterBuildActionHook;
 import org.netbeans.modules.gradle.spi.actions.BeforeBuildActionHook;

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -432,10 +432,12 @@ public final class NbGradleProjectImpl implements Project {
             filesToWatch = fileProvider.getFiles();
             if (filesToWatch != null) {
                 for (File f : filesToWatch) {
-                    try {
-                        FileUtil.addFileChangeListener(this, f);
-                    } catch (IllegalArgumentException ex) {
-                        assert false : "Project opened twice in a row";
+                    if (f != null) {
+                        try {
+                            FileUtil.addFileChangeListener(this, f);
+                        } catch (IllegalArgumentException ex) {
+                            assert false : "Project opened twice in a row";
+                        }
                     }
                 }
             }
@@ -444,10 +446,12 @@ public final class NbGradleProjectImpl implements Project {
         synchronized void detachAll() {
             if (filesToWatch != null) {
                 for (File f : filesToWatch) {
-                    try {
-                        FileUtil.removeFileChangeListener(this, f);
-                    } catch (IllegalArgumentException ex) {
-                        assert false : "Project closed twice in a row";
+                    if (f != null) {
+                        try {
+                            FileUtil.removeFileChangeListener(this, f);
+                        } catch (IllegalArgumentException ex) {
+                            assert false : "Project closed twice in a row";
+                        }
                     }
                 }
             }

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/ActionToTaskUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/ActionToTaskUtils.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.gradle.actions;
 
+import org.netbeans.modules.gradle.spi.actions.ProjectActionMappingProvider;
 import org.netbeans.modules.gradle.api.execute.ActionMapping;
 import org.netbeans.modules.gradle.spi.actions.GradleActionsProvider;
 import java.util.ArrayList;

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/CustomActionRegistrationSupport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/CustomActionRegistrationSupport.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.gradle.actions;
 
+import org.netbeans.modules.gradle.spi.actions.ProjectActionMappingProvider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/GradleBaseTokenProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/GradleBaseTokenProvider.java
@@ -47,6 +47,7 @@ public class GradleBaseTokenProvider implements ReplaceTokenProvider {
             "rootDir",
             "buildDir",
             "projectName",
+            "projectPath",
             "group",
             "version",
             "status",
@@ -74,6 +75,7 @@ public class GradleBaseTokenProvider implements ReplaceTokenProvider {
         ret.put("rootDir", gbp.getRootDir().getAbsolutePath()); //NOI18N
         ret.put("buildDir", gbp.getBuildDir().getAbsolutePath()); //NOI18N
         ret.put("projectName", gbp.getName()); //NOI18N
+        ret.put("projectPath", gbp.getPath()); //NOI18N
         ret.put("group", gbp.getGroup()); //NOI18N
         ret.put("version", gbp.getVersion()); //NOI18N
         ret.put("status", gbp.getStatus());  //NOI18N

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/ProjectActionMappingProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/ProjectActionMappingProviderImpl.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.gradle.actions;
 
+import org.netbeans.modules.gradle.spi.actions.ProjectActionMappingProvider;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.ActionMapping;

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
@@ -62,6 +62,7 @@ import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
+import org.openide.util.BaseUtilities;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.Pair;
 
@@ -303,6 +304,24 @@ public final class RunUtils {
             }
         }
         return false;
+    }
+
+    /**
+     * Replace the tokens in <code>argLine</code> provided by the <code>project</code> for
+     * the action using the given context;
+     * 
+     * @param project the that holds the {@link ReplaceTokenProvider}-s.
+     * @param argLine a string which might hold tokens to be replaced.
+     * @param action  the action name to do the replacement for. It can be <code>null</code>
+     * @param context the context of the action.
+     *
+     * @return the <code>argLine</code> where the tokens are replaced.
+     * @since 2.6
+     */
+    public static String[] evaluateActionArgs(Project project, String action, String argLine, Lookup context) {
+        ReplaceTokenProvider tokenProvider = project.getLookup().lookup(ReplaceTokenProvider.class);
+        String repLine = ReplaceTokenProvider.replaceTokens(argLine, tokenProvider.createReplacements(action, context));
+        return BaseUtilities.parseParameters(repLine);
     }
 
     /**

--- a/extide/gradle/src/org/netbeans/modules/gradle/customizer/BuildActionsCustomizer.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/customizer/BuildActionsCustomizer.java
@@ -20,7 +20,7 @@
 package org.netbeans.modules.gradle.customizer;
 
 import org.netbeans.modules.gradle.api.execute.ActionMapping;
-import org.netbeans.modules.gradle.actions.ProjectActionMappingProvider;
+import org.netbeans.modules.gradle.spi.actions.ProjectActionMappingProvider;
 import org.netbeans.modules.gradle.execute.GradleCliEditorKit;
 import java.awt.CardLayout;
 import java.awt.Component;

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/actions/ProjectActionMappingProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/actions/ProjectActionMappingProvider.java
@@ -23,6 +23,20 @@ import java.util.Set;
 import org.netbeans.modules.gradle.api.execute.ActionMapping;
 
 /**
+ * An implementation of this interface can be registered in the Gradle project
+ * lookup. Gradle support already has an implementation using {@link GradleActionsProvider}-s.
+ * <p>
+ * This interface also can be used to query the Gradle command line arguments used
+ * for a specific action. Like:
+ * <pre>
+ *     Project project = some Gradle project
+ *     String action = some IDE action
+ *     Lookup context = Lookups.singleton(project); // The context of the action, it is advised to have the project in the context.
+ *     ProjectActionMappingProvider pamp = project.getLookup().lookup(ProjectActionMappingProvider.class);
+ *     ActionMapping actionMapping = pamp.findMapping(action);
+ *     GradleCommandLine cli = new GradleCommandLine(
+ *             RunUtils.evaluateAcrionArgs(project, actionMapping.getArgs(), action, context));
+ * </pre>
  * @author Laszlo Kishalmi
  * @since 2.6
  */

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/actions/ProjectActionMappingProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/actions/ProjectActionMappingProvider.java
@@ -17,13 +17,14 @@
  * under the License.
  */
 
-package org.netbeans.modules.gradle.actions;
+package org.netbeans.modules.gradle.spi.actions;
 
 import java.util.Set;
 import org.netbeans.modules.gradle.api.execute.ActionMapping;
 
 /**
  * @author Laszlo Kishalmi
+ * @since 2.6
  */
 public interface ProjectActionMappingProvider {
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/actions/ReplaceTokenProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/actions/ReplaceTokenProvider.java
@@ -49,4 +49,38 @@ public interface ReplaceTokenProvider {
      */
     Map<String, String> createReplacements(String action, Lookup context);
 
+    /**
+     * Replaces tokens in the given String. The format of the token marker is
+     * the following: {@code ${<token_key>[,<default value>]}}
+     * <p>
+     * If there would be no value or default value provided the token marker
+     * will be left untouched.
+     *
+     * @param line the input line with token markers
+     * @param replaceMap key-value map for the replacement
+     *
+     * @return the line with replaced tokens
+     *
+     * @since 2.6
+     */
+    public static String replaceTokens(String line, Map<String, String> replaceMap) {
+        StringBuilder sb = new StringBuilder(line);
+        int start = sb.indexOf("${");
+        while (start >= 0) {
+            int end = sb.indexOf("}", start);
+            int comma = sb.indexOf(",", start);
+            int keyEnd = comma > start && comma < end ? comma : end;
+            String key = sb.substring(start + 2, keyEnd);
+            String defaultValue = comma > start && comma < end ? sb.substring(comma + 1, end) : null;
+            String value = replaceMap.get(key);
+            value = value != null ? value : defaultValue;
+            if (value != null) {
+                sb.replace(start, end + 1, value);
+                start = sb.indexOf("${");
+            } else {
+                start = sb.indexOf("${", end);
+            }
+        }
+        return sb.toString();
+    }
 }

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/execute/RunUtilsTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/execute/RunUtilsTest.java
@@ -27,6 +27,8 @@ import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.modules.gradle.AbstractGradleProjectTestCase;
 import org.netbeans.modules.gradle.ProjectTrust;
 import org.openide.filesystems.FileObject;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
 
 /**
  *
@@ -70,4 +72,15 @@ public class RunUtilsTest extends AbstractGradleProjectTestCase {
         assertEquals(0, params.size());
     }
 
+    public void testEvaluateArgs1() throws Exception {
+        FileObject a = createGradleProject("projectA",
+                "apply plugin: 'java'\n", "");
+        Project prjA = ProjectManager.getDefault().findProject(a);
+        ProjectTrust.getDefault().trustProject(prjA);
+        openProject(a);
+        String[] args = RunUtils.evaluateActionArgs(prjA, null, "Project: ${projectPath}${projectName}", Lookups.singleton(prjA));
+        assertEquals(2, args.length);
+        assertEquals("Project:", args[0]);
+        assertEquals(":projectA", args[1]);
+    }
 }

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/spi/actions/ReplaceTokenProviderTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/spi/actions/ReplaceTokenProviderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.spi.actions;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.openide.util.Lookup;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class ReplaceTokenProviderTest {
+
+    public ReplaceTokenProviderTest() {
+    }
+
+    @Test
+    public void testNoReplaceTokens() {
+        String line = "This ${token} is not replaced";
+        String result = ReplaceTokenProvider.replaceTokens(line, Collections.emptyMap());
+        assertEquals(line, result);
+    }
+
+    @Test
+    public void testReplaceTokenDefaults1() {
+        String line = "This ${token,key} is replaced";
+        String result = ReplaceTokenProvider.replaceTokens(line, Collections.emptyMap());
+        assertEquals("This key is replaced", result);
+    }
+
+    @Test
+    public void testReplaceTokenDefaults2() {
+        String line = "This ${token,} is replaced";
+        String result = ReplaceTokenProvider.replaceTokens(line, Collections.emptyMap());
+        assertEquals("This  is replaced", result);
+    }
+
+    @Test
+    public void testReplaceTokens1() {
+        String line = "This ${token,key} is replaced as ${value,default}";
+        String result = ReplaceTokenProvider.replaceTokens(line, Collections.singletonMap("token", "value"));
+        assertEquals("This value is replaced as default", result);
+    }
+
+    @Test
+    public void testReplaceTokens2() {
+        String line = "Hello ${greet}!";
+        String result = ReplaceTokenProvider.replaceTokens(line, Collections.singletonMap("greet", "World"));
+        assertEquals("Hello World!", result);
+    }
+}

--- a/java/gradle.java/nbproject/project.xml
+++ b/java/gradle.java/nbproject/project.xml
@@ -31,7 +31,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.3</specification-version>
+                        <specification-version>2.6</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
@@ -45,10 +45,18 @@ import org.openide.util.Lookup;
 @ProjectServiceProvider(service = ReplaceTokenProvider.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GradleJavaTokenProvider implements ReplaceTokenProvider {
 
+    private static final String SELECTED_CLASS      = "selectedClass";     //NOI18N
+    private static final String SELECTED_CLASS_NAME = "selectedClassName"; //NOI18N
+    private static final String SELECTED_PACKAGE    = "selectedPackage";   //NOI18N
+    private static final String SELECTED_METHOD     = "selectedMethod";    //NOI18N
+    private static final String AFFECTED_BUILD_TASK = "affectedBuildTasks";//NOI18N
+
     private static final Set<String> SUPPORTED = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
-            "selectedClass",       //NOI18N
-            "selectedMethod",      //NOI18N
-            "affectedBuildTasks"   //NOI18N
+            SELECTED_CLASS,
+            SELECTED_CLASS_NAME,
+            SELECTED_METHOD,
+            SELECTED_PACKAGE,
+            AFFECTED_BUILD_TASK
     )));
 
     final Project project;
@@ -76,7 +84,15 @@ public class GradleJavaTokenProvider implements ReplaceTokenProvider {
         GradleJavaProject gjp = GradleJavaProject.get(project);
         String className = evaluateClassName(gjp, fo);
         if (className != null) {
-            map.put("selectedClass", className);
+            map.put(SELECTED_CLASS, className);
+            int dot = className.lastIndexOf('.');
+            if (dot != -1) {
+                map.put(SELECTED_CLASS_NAME, className.substring(dot + 1));
+                map.put(SELECTED_PACKAGE, className.substring(0, dot));
+            } else {
+                map.put(SELECTED_CLASS_NAME, className);
+                map.put(SELECTED_PACKAGE, "");
+            }
         }
     }
 
@@ -87,7 +103,7 @@ public class GradleJavaTokenProvider implements ReplaceTokenProvider {
             GradleJavaProject gjp = GradleJavaProject.get(project);
             String className = evaluateClassName(gjp, fo);
             String selectedMethod = method != null ? className + '.' + method.getMethodName() : className;
-            map.put("selectedMethod", selectedMethod);
+            map.put(SELECTED_METHOD, selectedMethod);
         }
     }
 
@@ -110,7 +126,7 @@ public class GradleJavaTokenProvider implements ReplaceTokenProvider {
             for (String task : buildTasks) {
                 tasks.append(task).append(' ');
             }
-            map.put("affectedBuildTasks", tasks.toString()); //NOI18N
+            map.put(AFFECTED_BUILD_TASK, tasks.toString()); //NOI18N
         }
     }
 

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/JavaActionProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/JavaActionProvider.java
@@ -99,7 +99,8 @@ public class JavaActionProvider extends DefaultGradleActionsProvider {
                             case COMMAND_RUN_SINGLE:
                                 ProjectActionMappingProvider pamp = project.getLookup().lookup(ProjectActionMappingProvider.class);
                                 ActionMapping runSingleMapping = pamp.findMapping(COMMAND_RUN_SINGLE);
-                                Set<String> runSingleTasks = new GradleCommandLine(runSingleMapping.getArgs()).getTasks();
+                                GradleCommandLine cli = new GradleCommandLine(RunUtils.evaluateActionArgs(project, action, runSingleMapping.getArgs(), context));
+                                Set<String> runSingleTasks = cli.getTasks();
                                 if (gbp.getTaskNames().containsAll(runSingleTasks) || RunUtils.isAugmentedBuildEnabled(project)) {
                                     File f = FileUtil.toFile(fo);
                                     GradleJavaSourceSet sourceSet = gjp.containingSourceSet(f);
@@ -112,6 +113,7 @@ public class JavaActionProvider extends DefaultGradleActionsProvider {
                                     }
                                 }
                                 break;
+
                             case COMMAND_TEST_SINGLE:
                             case COMMAND_DEBUG_TEST_SINGLE:
                             case COMMAND_RUN_SINGLE_METHOD:

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/JavaActionProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/JavaActionProvider.java
@@ -27,12 +27,16 @@ import org.netbeans.modules.gradle.spi.actions.DefaultGradleActionsProvider;
 import org.netbeans.modules.gradle.spi.actions.GradleActionsProvider;
 import static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet.SourceType.*;
 import java.io.File;
+import java.util.Set;
 import static org.netbeans.spi.project.ActionProvider.*;
 import static org.netbeans.api.java.project.JavaProjectConstants.*;
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.SourceUtils;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.queries.FileBuiltQuery;
+import org.netbeans.modules.gradle.api.execute.ActionMapping;
+import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
+import org.netbeans.modules.gradle.spi.actions.ProjectActionMappingProvider;
 import static org.netbeans.spi.project.SingleMethod.COMMAND_DEBUG_SINGLE_METHOD;
 import static org.netbeans.spi.project.SingleMethod.COMMAND_RUN_SINGLE_METHOD;
 import org.openide.filesystems.FileObject;
@@ -93,7 +97,10 @@ public class JavaActionProvider extends DefaultGradleActionsProvider {
                                 break;
                             case COMMAND_DEBUG_SINGLE:
                             case COMMAND_RUN_SINGLE:
-                                if (RunUtils.isAugmentedBuildEnabled(project)) {
+                                ProjectActionMappingProvider pamp = project.getLookup().lookup(ProjectActionMappingProvider.class);
+                                ActionMapping runSingleMapping = pamp.findMapping(COMMAND_RUN_SINGLE);
+                                Set<String> runSingleTasks = new GradleCommandLine(runSingleMapping.getArgs()).getTasks();
+                                if (gbp.getTaskNames().containsAll(runSingleTasks) || RunUtils.isAugmentedBuildEnabled(project)) {
                                     File f = FileUtil.toFile(fo);
                                     GradleJavaSourceSet sourceSet = gjp.containingSourceSet(f);
                                     if ((sourceSet != null) && fo.isData()) {
@@ -129,7 +136,5 @@ public class JavaActionProvider extends DefaultGradleActionsProvider {
         }
         return ret;
     }
-
-
 
 }


### PR DESCRIPTION
Well it is a bit more than I thought at first. At the start I would have checked only the existence of runSingle task, though if I remember someone would have liked run task defined for certain executable class in his project. With this pr run.single action can be redefined to use a ```run${selectedClassName}``` task.