### PR TITLE
Propagate a launch error to the client.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -18,17 +18,17 @@
  */
 package org.netbeans.modules.java.lsp.server.debugging.launch;
 
-import com.sun.jdi.VMDisconnectedException;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.debugger.DebuggerManager;
@@ -63,7 +63,9 @@ public abstract class NbLaunchDelegate {
         Pair<ActionProvider, String> providerAndCommand = findTarget(toRun, debug);
         CompletableFuture<Void> launchFuture = new CompletableFuture<>();
         if (providerAndCommand == null) {
-            launchFuture.completeExceptionally(new CancellationException("Cannot find " + (debug ? "debug" : "run") + " action!"));
+            launchFuture.completeExceptionally(new ResponseErrorException(new ResponseError(
+                    ResponseErrorCode.MethodNotFound,
+                    "Cannot find " + (debug ? "debug" : "run") + " action!", null)));
             return launchFuture;
         }
         NbProcessConsole ioContext = new NbProcessConsole(consoleMessages);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
@@ -101,6 +101,9 @@ public final class NbLaunchRequestHandler {
         activeLaunchHandler.nbLaunch(file, context, !noDebug, new OutputListener(context)).thenRun(() -> {
             activeLaunchHandler.postLaunch(launchArguments, context);
             resultFuture.complete(null);
+        }).exceptionally(e -> {
+            resultFuture.completeExceptionally(e);
+            return null;
         });
         return resultFuture;
     }


### PR DESCRIPTION
This change assures that an error during launch is propagated to the client.
The ResponseError's message is displayed in an error dialog in VSCode.