### PR TITLE
Fix javadoc generation

### DIFF
--- a/platform/openide.filesystems.nb/arch.xml
+++ b/platform/openide.filesystems.nb/arch.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
Fix javadoc generation error: `[arch] file:/home/runner/work/netbeans/netbeans/platform/openide.filesystems.nb/arch.xml:2: The processing instruction target matching "[xX][mM][lL]" is not allowed.` derived from https://github.com/apache/netbeans/pull/2402