### PR TITLE
Using Incomplete classpath to indicate unloadable Gradle project

### DIFF
--- a/java/java.hints/nbproject/project.properties
+++ b/java/java.hints/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-spec.version.base=1.93.0
+spec.version.base=1.94.0
 
 javac.source=1.8
 

--- a/java/java.hints/src/org/netbeans/modules/java/hints/project/IncompleteClassPath.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/project/IncompleteClassPath.java
@@ -78,8 +78,7 @@ public class IncompleteClassPath implements ErrorRule<Void> {
     public void cancel() {
     }
 
-    private static final class ResolveFix implements Fix {
-
+    public static final class ResolveFix implements Fix {
         private final Project prj;
 
         ResolveFix(@NonNull final Project prj) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -150,6 +150,7 @@ import org.netbeans.modules.java.editor.options.MarkOccurencesSettings;
 import org.netbeans.modules.java.hints.errors.ImportClass;
 import org.netbeans.modules.java.hints.infrastructure.CreatorBasedLazyFixList;
 import org.netbeans.modules.java.hints.infrastructure.ErrorHintsProvider;
+import org.netbeans.modules.java.hints.project.IncompleteClassPath;
 import org.netbeans.modules.java.hints.spiimpl.JavaFixImpl;
 import org.netbeans.modules.java.hints.spiimpl.hints.HintsInvoker;
 import org.netbeans.modules.java.hints.spiimpl.options.HintsSettings;
@@ -877,6 +878,13 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
             //TODO: ordering
 
             for (Fix f : fixes) {
+                if (f instanceof IncompleteClassPath.ResolveFix) {
+                    CodeAction action = new CodeAction(f.getText());
+                    action.setDiagnostics(Collections.singletonList(diag));
+                    action.setKind(CodeActionKind.QuickFix);
+                    action.setCommand(new Command(f.getText(), Server.JAVA_BUILD_WORKSPACE));
+                    result.add(Either.forRight(action));
+                }
                 if (f instanceof ImportClass.FixImport) {
                     //TODO: FixImport is not a JavaFix, create one. Is there a better solution?
                     String text = f.getText();

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CompilationInfoImpl.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/CompilationInfoImpl.java
@@ -556,13 +556,13 @@ public final class CompilationInfoImpl {
                     if (errors == null) {
                         source2Errors.put(file, errors = new Diagnostics());
                         if (this.jfo != null && this.jfo == file) {
-                            errors.add(-1, new IncompleteClassPath(this.jfo));
+                            errors.add(0, new IncompleteClassPath(this.jfo));
                         }
                     }
                 } else {
                     errors = new Diagnostics();
                     if (this.jfo != null && this.jfo == file) {
-                        errors.add(-1, new IncompleteClassPath(this.jfo));
+                        errors.add(0, new IncompleteClassPath(this.jfo));
                     }
                 }
             } else {
@@ -702,7 +702,7 @@ public final class CompilationInfoImpl {
 
             IncompleteClassPath(final JavaFileObject file) {
                 this.file = file;
-    }
+            }
 
             @Override
             public Kind getKind() {
@@ -716,7 +716,7 @@ public final class CompilationInfoImpl {
 
             @Override
             public long getPosition() {
-                return -1;
+                return 0;
             }
 
             @Override


### PR DESCRIPTION
When a Gradle project is initially created/opened, it usually misses its JAR libraries. It makes little sense to parse its sources. For that one can use `getFlags() => Flag.INCOMPLETE` to prevent the Java parsing infrastructure from attempting to parse the source.

Moreover the infrastructure adds a hint to the first line of the source file to show `ProjectProblems` dialog or, in case of VSCode, to build the workspace.

After the (priming) build, the project state should be re-checked and the classpath should remove its `INCOMPLETE` flag.