### PR TITLE
Stack trace analyzer needs to understand modular stack traces.

### DIFF
--- a/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyser.java
+++ b/java/java.navigation/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyser.java
@@ -58,6 +58,7 @@ class StackLineAnalyser {
         "\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*";    // NOI18N
     private static final Pattern LINE_PATTERN = Pattern.compile(
         "at\\s" +                                       //  initial at // NOI18N
+        "("+IDENTIFIER+"(?:\\."+IDENTIFIER+")*/)?" + // optional module name // NOI18N
         "(("+IDENTIFIER+"(\\."+IDENTIFIER+")*)\\.)?("+IDENTIFIER+")" + // class name // NOI18N
         "\\.("+IDENTIFIER+"|\\<init\\>|\\<clinit\\>)\\((?:"+IDENTIFIER+"(?:\\."+IDENTIFIER+")*/)?" +IDENTIFIER+"\\.java" + // method and file name // NOI18N
         "\\:([0-9]*)\\)");                              // line number // NOI18N
@@ -72,22 +73,26 @@ class StackLineAnalyser {
         if (matcher.find()) {
             int lineNumber = -1;
             try {
-                lineNumber = Integer.parseInt(matcher.group(6));
+                lineNumber = Integer.parseInt(matcher.group(7));
             } catch (NumberFormatException nfe) {
                 return null;
             }
-            if (matcher.group(1)==null ) {
-                return new Link(matcher.group(4),
+            int moduleStart = -1;
+            if (matcher.group(1) != null) {
+                moduleStart = matcher.start(1);
+            }
+            if (matcher.group(2)==null ) {
+                return new Link(matcher.group(5),
                             lineNumber,
-                            matcher.start(4),
-                            matcher.end(6)+1
+                            moduleStart != (-1) ? moduleStart : matcher.start(5),
+                            matcher.end(7)+1
                             );
                 
             }
-            return new Link(matcher.group(1) + matcher.group(4),
+            return new Link(matcher.group(2) + matcher.group(5),
                             lineNumber,
-                            matcher.start(1),
-                            matcher.end(6)+1
+                            moduleStart != (-1) ? moduleStart : matcher.start(2),
+                            matcher.end(7)+1
                             );
         }
         return null;

--- a/java/java.navigation/test/unit/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyserTest.java
+++ b/java/java.navigation/test/unit/src/org/netbeans/modules/java/stackanalyzer/StackLineAnalyserTest.java
@@ -46,6 +46,8 @@ public class StackLineAnalyserTest extends NbTestCase {
         assertTrue(StackLineAnalyser.matches("at javaapplication8.Main$1.run(Main.java:32)"));
         assertTrue(StackLineAnalyser.matches("at javaapplication8.Main$Inner.go(Main.java:40)"));
         assertTrue(StackLineAnalyser.matches("             [exec]     at org.openide.filesystems.FileUtil.normalizeFileOnMac(FileUtil.java:1714)"));
+        assertTrue(StackLineAnalyser.matches("at java.base/java.lang.String.lastIndexOf(String.java:1627)"));
+        assertTrue(StackLineAnalyser.matches(" at java.base/java.lang.String.lastIndexOf(String.java:1627)"));
     }
 
     @Test
@@ -68,6 +70,12 @@ public class StackLineAnalyserTest extends NbTestCase {
         l = StackLineAnalyser.analyse("at java.lang.String.lastIndexOf(String.java:1627) dfasdf");
         assertEquals(3, l.getStartOffset());
         assertEquals(49, l.getEndOffset());
+        l = StackLineAnalyser.analyse("at java.base/java.lang.String.lastIndexOf(String.java:1627)");
+        assertEquals(3, l.getStartOffset());
+        assertEquals(59, l.getEndOffset());
+        l = StackLineAnalyser.analyse(" at java.base/java.lang.String.lastIndexOf(String.java:1627)");
+        assertEquals(4, l.getStartOffset());
+        assertEquals(60, l.getEndOffset());
     }
 
     @Test


### PR DESCRIPTION
Since JDK 9, stack traces may contain optional module names, like:
	at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.enter(JavacTaskImpl.java:282)

But, the stack trace analyzer in NetBeans does not understand these lines. This patch tweaks the analyzer to understand lines with modules. It does not use the module name, though - so far does not seem to be really necessary.