### PR TITLE
Read "exec.mainClass" property from POM file, before asking for the main class.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/runjar/RunJarPrereqChecker.java
+++ b/java/maven/src/org/netbeans/modules/maven/runjar/RunJarPrereqChecker.java
@@ -82,7 +82,7 @@ public class RunJarPrereqChecker implements PrerequisitesChecker {
         if ((ActionProvider.COMMAND_RUN.equals(actionName) ||
                 ActionProvider.COMMAND_DEBUG.equals(actionName) ||
                 ActionProvider.COMMAND_PROFILE.equals(actionName))) {
-            String mc = null;
+            String mc = config.getMavenProject().getProperties().getProperty("exec.mainClass");
             for (Map.Entry<? extends String,? extends String> entry : config.getProperties().entrySet()) {
                 if (entry.getValue().contains("${packageClassName}")) { //NOI18N
                     //show dialog to choose main class.


### PR DESCRIPTION
When the pom.xml contains the "exec.mainClass" property, use that as the main class and do not ask the user.
The "exec.mainClass" property is set in some existing pom.xml files, like Micronaut projects, for instance.