### PR TITLE
Refresh unloadable Gradle/Maven project after successful build

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
@@ -269,7 +269,8 @@ public class ActionProviderImpl implements ActionProvider {
                     boolean canReload = project.getLookup().lookup(BeforeReloadActionHook.class).beforeReload(action, outerCtx, task.result(), out1);
                     if (needReload && canReload) {
                         String[] reloadArgs = RunUtils.evaluateActionArgs(project, mapping.getName(), mapping.getReloadArgs(), outerCtx);
-                        prj.reloadProject(true, maxQualily, reloadArgs);
+                        RequestProcessor.Task reloadTask = prj.reloadProject(true, maxQualily, reloadArgs);
+                        reloadTask.waitFinished();
                     }
                     project.getLookup().lookup(AfterBuildActionHook.class).afterAction(action, outerCtx, task.result(), out1);
                     for (AfterBuildActionHook l : context.lookupAll(AfterBuildActionHook.class)) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
@@ -76,6 +76,7 @@ import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.execute.RunConfig.ExecFlag;
+import org.netbeans.spi.project.ActionProgress;
 import org.netbeans.spi.project.support.ProjectOperations;
 import org.netbeans.spi.project.ui.support.DefaultProjectOperations;
 import org.openide.awt.ActionID;
@@ -205,7 +206,6 @@ public class ActionProviderImpl implements ActionProvider {
         if (argLine == null) {
             return;
         }
-
         final StringWriter writer = new StringWriter();
 
         PrintWriter out = new PrintWriter(writer);
@@ -258,10 +258,15 @@ public class ActionProviderImpl implements ActionProvider {
             boolean canReload = project.getLookup().lookup(BeforeReloadActionHook.class).beforeReload(action, ctx, 0, null);
             if (needReload && canReload) {
                 String[] reloadArgs = RunUtils.evaluateActionArgs(project, mapping.getName(), mapping.getReloadArgs(), ctx);
-                prj.reloadProject(true, maxQualily, reloadArgs);
+                final ActionProgress g = ActionProgress.start(context);
+                RequestProcessor.Task reloadTask = prj.reloadProject(true, maxQualily, reloadArgs);
+                reloadTask.addTaskListener((t) -> {
+                    g.finished(true);
+                });
             }
         } else {
             final ExecutorTask task = RunUtils.executeGradle(cfg, writer.toString());
+            final ActionProgress g = ActionProgress.start(context);
             final Lookup outerCtx = ctx;
             task.addTaskListener((Task t) -> {
                 try {
@@ -279,6 +284,7 @@ public class ActionProviderImpl implements ActionProvider {
                 } finally {
                     task.getInputOutput().getOut().close();
                     task.getInputOutput().getErr().close();
+                    g.finished(task.result() == 0);
                 }
             });
         }

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -255,8 +255,8 @@ public final class NbGradleProjectImpl implements Project {
         return prj;
     }
 
-    void reloadProject(final boolean ignoreCache, final Quality aim, final String... args) {
-        RELOAD_RP.post(() -> {
+    RequestProcessor.Task reloadProject(final boolean ignoreCache, final Quality aim, final String... args) {
+        return RELOAD_RP.post(() -> {
             project = loadProject(ignoreCache, aim, args);
             ACCESSOR.doFireReload(watcher);
         });

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
@@ -120,11 +120,11 @@ public final class RunUtils {
     public static ExecutorTask executeGradle(RunConfig config, String initialOutput) {
         LifecycleManager.getDefault().saveAll();
 
-        GradleExecutor exec = new GradleDaemonExecutor(config);
+        GradleDaemonExecutor exec = new GradleDaemonExecutor(config);
         ExecutorTask task = executeGradleImpl(config.getTaskDisplayName(), exec, initialOutput);
         GRADLE_TASKS.put(config, exec);
 
-        return task;
+        return exec.createTask(task);
     }
 
     /**

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
@@ -54,12 +54,15 @@ import org.netbeans.api.progress.ProgressHandle;
 import org.netbeans.api.progress.ProgressHandleFactory;
 import org.netbeans.api.project.ProjectInformation;
 import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.modules.gradle.NbGradleProjectImpl;
+import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.GradleDistributionManager.GradleDistribution;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import org.netbeans.modules.gradle.spi.execute.GradleDistributionProvider;
 import org.netbeans.modules.gradle.spi.execute.GradleJavaPlatformProvider;
 import org.netbeans.spi.project.ui.support.BuildExecutionSupport;
 import org.openide.awt.StatusDisplayer;
+import org.openide.execution.ExecutorTask;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
@@ -83,6 +86,7 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
     private OutputStream outStream;
     private OutputStream errStream;
     private boolean cancelling;
+    private GradleTask gradleTask;
 
     @SuppressWarnings("LeakingThisInConstructor")
     public GradleDaemonExecutor(RunConfig config) {
@@ -196,6 +200,7 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
             }
             buildLauncher.run();
             StatusDisplayer.getDefault().setStatusText(Bundle.BUILD_SUCCESS(getProjectName()));
+            gradleTask.finish(0);
         } catch (BuildCancelledException ex) {
             showAbort();
         } catch (UncheckedException | BuildException ex) {
@@ -330,5 +335,44 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
 
     private static String gradleExecutable() {
         return Utilities.isWindows() ? "bin\\gradle.bat" : "bin/gradle"; //NOI18N
+    }
+
+    public final ExecutorTask createTask(ExecutorTask process) {
+        assert gradleTask == null;
+        gradleTask = new GradleTask(process);
+        return gradleTask;
+    }
+
+    private static final class GradleTask extends ExecutorTask {
+        private final ExecutorTask delegate;
+        private Integer result;
+
+        GradleTask(ExecutorTask delegate) {
+            super(() -> {});
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void stop() {
+            this.delegate.stop();
+        }
+
+        @Override
+        public int result() {
+            if (result != null) {
+                return result;
+            }
+            return this.delegate.result();
+        }
+
+        @Override
+        public InputOutput getInputOutput() {
+            return this.delegate.getInputOutput();
+        }
+
+        public void finish(int result) {
+            this.result = result;
+            notifyFinished();
+        }
     }
 }

--- a/java/maven/src/org/netbeans/modules/maven/ActionProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/ActionProviderImpl.java
@@ -275,10 +275,8 @@ public class ActionProviderImpl implements ActionProvider {
             final ActionProgress listener = ActionProgress.start(lookup);
             final ExecutorTask task = RunUtils.run(rc);
             if (task != null) {
-                task.addTaskListener(new TaskListener() {
-                    @Override public void taskFinished(Task t) {
-                        listener.finished(task.result() == 0);
-                    }
+                task.addTaskListener((Task t) -> {
+                    listener.finished(task.result() == 0);
                 });
             } else {
                 listener.finished(false);

--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -467,15 +467,16 @@ public final class NbMavenProjectImpl implements Project {
 
 
 
-    public void fireProjectReload() {
+    public RequestProcessor.Task fireProjectReload() {
         //#227101 not only AWT and project read/write mutex has to be checked, there are some additional more
         //complex scenarios that can lead to deadlock. Just give up and always fire changes in separate RP.
         if (Boolean.getBoolean("test.reload.sync")) {
             reloadTask.run();
             //for tests just do sync reload, even though silly, even sillier is to attempt to sync the threads..
-            return;
+        } else {
+            reloadTask.schedule(0); //asuming here that schedule(0) will move the scheduled task in the queue if not yet executed
         }
-        reloadTask.schedule(0); //asuming here that schedule(0) will move the scheduled task in the queue if not yet executed
+        return reloadTask;
     }
 
     public static void refreshLocalRepository(NbMavenProjectImpl project) {

--- a/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
@@ -63,6 +63,7 @@ import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.RequestProcessor;
+import org.openide.util.Task;
 import org.openide.util.Utilities;
 
 /**
@@ -546,8 +547,8 @@ public final class NbMavenProject {
     /**
      * 
      */ 
-    private void fireProjectReload() {
-        project.fireProjectReload();
+    private RequestProcessor.Task fireProjectReload() {
+        return project.fireProjectReload();
     }
     
     private void doFireReload() {

--- a/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
@@ -58,6 +58,8 @@ import org.netbeans.api.extexecution.base.Processes;
 import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.api.progress.ProgressHandle;
 import org.netbeans.api.progress.ProgressHandleFactory;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.maven.NbMavenProjectImpl;
 import org.netbeans.modules.maven.api.Constants;
 import org.netbeans.modules.maven.api.FileUtilities;
 import org.netbeans.modules.maven.api.NbMavenProject;
@@ -318,18 +320,13 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
                 ioput.getErr().close();
                 actionStatesAtFinish(out.createResumeFromFinder(), out.getExecutionTree());
                 markFreeTab();
-                RP.post(new Runnable() { //#103460
-                    @Override
-                    public void run() {
-                        //TODO we eventually know the coordinates of all built projects via EventSpy.
-                        if (clonedConfig.getProject() != null) {
-                            NbMavenProject.fireMavenProjectReload(clonedConfig.getProject());
-                        }
-                    }
-                });
-                
+                final Project prj = clonedConfig.getProject();
+                NbMavenProjectImpl impl = prj.getLookup().lookup(NbMavenProjectImpl.class);
+                if (impl != null) {
+                    RequestProcessor.Task reloadTask = impl.fireProjectReload();
+                    reloadTask.waitFinished();
+                }
             }
-            
         }
     }
 


### PR DESCRIPTION
Continuation of #2464 - once a build on unloadable Gradle project successfully finishes, then let's schedule a reload to bring the module to loadable state:
* opening unloadable project shall show a fix https://user-images.githubusercontent.com/26887752/96404352-fff94100-11da-11eb-931b-d6cdcbf1ed95.png 
* after invoking it, the build is started
* when finished, the project is refreshed

Ideally the fix disappears and one can invoke "Start Debugging".