### PR TITLE
[NETBEANS-4925] - cleanup Map raw type warnings..

### DIFF
--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/BreakpointAnnotationListener.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/BreakpointAnnotationListener.java
@@ -40,9 +40,8 @@ import org.netbeans.modules.cpplite.debugger.DebuggerBreakpointAnnotation;
 public class BreakpointAnnotationListener extends DebuggerManagerAdapter 
 implements PropertyChangeListener {
     
-    private Map breakpointToAnnotation = new HashMap ();
-    
- 
+    private Map<CPPLiteBreakpoint, DebuggerBreakpointAnnotation> breakpointToAnnotation = new HashMap<>();
+   
     @Override
     public String[] getProperties () {
         return new String[] {DebuggerManager.PROP_BREAKPOINTS};

--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/DomainEditor.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/DomainEditor.java
@@ -466,10 +466,10 @@ public class DomainEditor {
     
 
     public HashMap<String,Map> getSunDatasourcesFromXml(){
-        HashMap<String,Map> dSources = new HashMap<String,Map>();
+        HashMap<String, Map> dSources = new HashMap<>();
         Document domainDoc = getDomainDocument();
         if (domainDoc != null) {
-            HashMap<String,NamedNodeMap> dsMap = getDataSourcesAttrMap(domainDoc);
+            Map<String,NamedNodeMap> dsMap = getDataSourcesAttrMap(domainDoc);
             HashMap<String,Node> cpMap = getConnPoolsNodeMap(domainDoc);
             dsMap.keySet().removeAll(Arrays.asList(sysDatasources));
             String[] ds = dsMap.keySet().toArray(new String[dsMap.size()]);
@@ -497,7 +497,7 @@ public class DomainEditor {
         NodeList propsNodeList = cpElement.getElementsByTagName(CONST_PROP);
 
         //Cycle through each property element
-        HashMap<String, String> map = new HashMap<>();
+        Map<String, String> map = new HashMap<>();
         for (int j = 0; j < propsNodeList.getLength(); j++) {
             Node propNode = propsNodeList.item(j);
             NamedNodeMap propsMap = propNode.getAttributes();
@@ -533,7 +533,7 @@ public class DomainEditor {
     }
 
     public HashMap<String,Map> getConnPoolsFromXml(){
-        HashMap<String,Map> pools = new HashMap<String,Map>();
+        HashMap<String, Map> pools = new HashMap<>();
         Document domainDoc = getDomainDocument();
         if (domainDoc != null) {
             HashMap<String,Node> cpMap = getConnPoolsNodeMap(domainDoc);

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/application/DDProvider.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/application/DDProvider.java
@@ -56,7 +56,7 @@ public final class DDProvider {
     private static final String APP_13_DOCTYPE = "-//Sun Microsystems, Inc.//DTD J2EE Application 1.3//EN"; //NOI18N
     private static final DDProvider ddProvider = new DDProvider();
     
-    private final Map ddMap;
+    private final Map<FileObject, ApplicationProxy> ddMap;
 
     private static final Logger LOGGER = Logger.getLogger(DDProvider.class.getName());
 
@@ -64,7 +64,7 @@ public final class DDProvider {
     
     private DDProvider() {
         //ddMap=new java.util.WeakHashMap(5);
-        ddMap = new HashMap(5);
+        ddMap = new HashMap<>(5);
     }
     
     /**

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/ejb/DDProvider.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/ejb/DDProvider.java
@@ -58,13 +58,13 @@ import org.openide.util.Exceptions;
 public final class DDProvider {
     private static final String EJB_21_DOCTYPE = "http://java.sun.com/xml/ns/j2ee/ejb-jar_2_1.xsd"; //NOI18N
     private static final DDProvider ddProvider = new DDProvider();
-    private final Map ddMap;
+    private final Map<Object, EjbJarProxy> ddMap;
 
     /** 
      * Creates a new instance of DDProvider.
      */
     private DDProvider() {
-        ddMap = new HashMap(5);
+        ddMap = new HashMap<>(5);
     }
 
     /**
@@ -142,16 +142,7 @@ public final class DDProvider {
     }
 
     private EjbJarProxy getFromCache (Object o) {
-        /*       WeakReference wr = (WeakReference) ddMap.get(o);
-       if (wr == null) {
-           return null;
-       }
-       EjbJarProxy ejbJarProxy = (EjbJarProxy) wr.get ();
-       if (ejbJarProxy == null) {
-           ddMap.remove (o);
-       }
-       return ejbJarProxy;*/
-        return (EjbJarProxy) ddMap.get(o);
+        return ddMap.get(o);
     }
 
     private void putToCache(Object o, EjbJarProxy ejbJarProxy) {

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/ComponentBeanMultiple.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/ComponentBeanMultiple.java
@@ -25,6 +25,8 @@
 package org.netbeans.modules.j2ee.dd.impl.common;
 
 import java.util.logging.Level;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.logging.Logger;
 import org.netbeans.modules.schema2beans.Version;
 import org.netbeans.modules.j2ee.dd.api.common.IconInterface;
@@ -85,13 +87,13 @@ public abstract class ComponentBeanMultiple extends DescriptionBeanMultiple impl
         }
     }
     
-    public void setAllDisplayNames(java.util.Map displayNames) throws VersionNotSupportedException {
+    public void setAllDisplayNames(Map displayNames) throws VersionNotSupportedException {
         removeAllDisplayNames();
         if (displayNames!=null) {
             java.util.Iterator entries = displayNames.entrySet().iterator();
             int i=0;
             while (entries.hasNext()) {
-                java.util.Map.Entry entry = (java.util.Map.Entry) entries.next();
+                Map.Entry entry = (Map.Entry) entries.next();
                 String key = (String) entry.getKey();
                 addDisplayName((String) entry.getValue());
                 setDisplayNameXmlLang(i++, key);
@@ -113,8 +115,8 @@ public abstract class ComponentBeanMultiple extends DescriptionBeanMultiple impl
             return getDisplayName(null);
         } catch (VersionNotSupportedException ex){return null;}
     }
-    public java.util.Map getAllDisplayNames() {
-        java.util.Map map =new java.util.HashMap();
+    public Map getAllDisplayNames() {
+        Map<String, String> map =new HashMap<>();
         for (int i=0;i<sizeDisplayName();i++) {
             String desc=getDisplayName(i);
             String loc=getDisplayNameXmlLang(i);
@@ -124,7 +126,7 @@ public abstract class ComponentBeanMultiple extends DescriptionBeanMultiple impl
     }
     
     public void removeDisplayNameForLocale(String locale) throws VersionNotSupportedException {
-        java.util.Map map = new java.util.HashMap();
+        Map map = new java.util.HashMap();
         for (int i=0;i<sizeDisplayName();i++) {
             String desc=getDisplayName(i);
             String loc=getDisplayNameXmlLang(i);
@@ -236,8 +238,8 @@ public abstract class ComponentBeanMultiple extends DescriptionBeanMultiple impl
         }
         return null;
     }
-    public java.util.Map getAllIcons() {
-        java.util.Map map =new java.util.HashMap();
+    public Map getAllIcons() {
+        Map map =new java.util.HashMap();
         org.netbeans.modules.j2ee.dd.api.common.Icon[] icons = getIcon();
         for (int i=0;i<icons.length;i++) {
             String[] iconPair = new String[] {icons[i].getSmallIcon(),icons[i].getLargeIcon()};

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/DescriptionBeanMultiple.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/DescriptionBeanMultiple.java
@@ -25,6 +25,9 @@
 
 package org.netbeans.modules.j2ee.dd.impl.common;
 
+import java.util.Map;
+import java.util.HashMap;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.modules.schema2beans.Version;
@@ -77,7 +80,7 @@ public abstract class DescriptionBeanMultiple extends EnclosingBean implements D
         }
     }
     
-    public void setAllDescriptions(java.util.Map descriptions) throws VersionNotSupportedException {
+    public void setAllDescriptions(Map descriptions) throws VersionNotSupportedException {
         removeAllDescriptions();
         if (descriptions!=null) {
             java.util.Iterator keys = descriptions.keySet().iterator();
@@ -106,8 +109,8 @@ public abstract class DescriptionBeanMultiple extends EnclosingBean implements D
             return null;
         }
     }
-    public java.util.Map getAllDescriptions() {
-        java.util.Map map =new java.util.HashMap();
+    public Map getAllDescriptions() {
+        Map<String, String> map =new HashMap<>();
         for (int i=0;i<sizeDescription();i++) {
             String desc=getDescription(i);
             String loc=getDescriptionXmlLang(i);
@@ -117,7 +120,7 @@ public abstract class DescriptionBeanMultiple extends EnclosingBean implements D
     }
     
     public void removeDescriptionForLocale(String locale) throws VersionNotSupportedException {
-        java.util.Map map = new java.util.HashMap();
+        Map<String, String> map = new HashMap<>();
         for (int i=0;i<sizeDescription();i++) {
             String desc=getDescription(i);
             String loc=getDescriptionXmlLang(i);

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/DomainEditor.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/DomainEditor.java
@@ -460,7 +460,7 @@ public class DomainEditor {
     
 
     public HashMap<String,Map> getSunDatasourcesFromXml(){
-        HashMap<String,Map> dSources = new HashMap<String,Map>();
+        HashMap<String,Map> dSources = new HashMap<>();
         Document domainDoc = getDomainDocument();
         if (domainDoc != null) {
             HashMap<String,NamedNodeMap> dsMap = getDataSourcesAttrMap(domainDoc);
@@ -526,7 +526,7 @@ public class DomainEditor {
     }
 
     public HashMap<String,Map> getConnPoolsFromXml(){
-        HashMap<String,Map> pools = new HashMap<String,Map>();
+        HashMap<String,Map> pools = new HashMap<>();
         Document domainDoc = getDomainDocument();
         if (domainDoc != null) {
             HashMap<String,Node> cpMap = getConnPoolsNodeMap(domainDoc);

--- a/enterprise/weblogic.common/src/org/netbeans/modules/weblogic/common/RemoteLogInputReader.java
+++ b/enterprise/weblogic.common/src/org/netbeans/modules/weblogic/common/RemoteLogInputReader.java
@@ -278,13 +278,13 @@ public class RemoteLogInputReader implements InputReader {
                 return;
             }
 
-            Map columnIndexMap = (Map) connection.getAttribute(wldf, "ColumnIndexMap"); // NOI18N
-            recordIdIndex = ((Integer) columnIndexMap.get("RECORDID")); // NOI18N
-            timestampIndex = ((Integer) columnIndexMap.get("DATE")); // NOI18N
-            severityIndex = ((Integer) columnIndexMap.get("SEVERITY")); // NOI18N
-            subsystemIndex = ((Integer) columnIndexMap.get("SUBSYSTEM")); // NOI18N
-            messageIdIndex = ((Integer) columnIndexMap.get("MSGID")); // NOI18N
-            messageIndex = ((Integer) columnIndexMap.get("MESSAGE")); // NOI18N
+            Map<String, Integer> columnIndexMap = (Map<String, Integer>)connection.getAttribute(wldf, "ColumnIndexMap"); // NOI18N
+            recordIdIndex  = columnIndexMap.get("RECORDID"); // NOI18N
+            timestampIndex = columnIndexMap.get("DATE"); // NOI18N
+            severityIndex  = columnIndexMap.get("SEVERITY"); // NOI18N
+            subsystemIndex = columnIndexMap.get("SUBSYSTEM"); // NOI18N
+            messageIdIndex = columnIndexMap.get("MSGID"); // NOI18N
+            messageIndex   = columnIndexMap.get("MESSAGE"); // NOI18N
             configured = true;
         }
 

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java
@@ -167,11 +167,11 @@ public class SourceGroupSupport {
     }
 
     private static Map createFoldersToSourceGroupsMap(final SourceGroup[] sourceGroups) {
-        Map result;
+        Map<FileObject, SourceGroup> result;
         if (sourceGroups.length == 0) {
             result = Collections.EMPTY_MAP;
         } else {
-            result = new HashMap(2 * sourceGroups.length, .5f);
+            result = new HashMap<>(2 * sourceGroups.length, .5f);
             for (int i = 0; i < sourceGroups.length; i++) {
                 SourceGroup sourceGroup = sourceGroups[i];
                 result.put(sourceGroup.getRootFolder(), sourceGroup);

--- a/ide/db/src/org/netbeans/modules/db/explorer/action/GrabTableHelper.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/action/GrabTableHelper.java
@@ -131,10 +131,10 @@ public class GrabTableHelper {
      */
     private static void setColumnFormatToStandard(DatabaseConnector connector,
             AbstractTableColumn column) {
-        Map props = connector.getDatabaseSpecification().getProperties();
+        Map<String, Map> props = connector.getDatabaseSpecification().getProperties();
         Map cprops = connector.getDatabaseSpecification().getCommandProperties(
                 Specification.CREATE_TABLE);
-        Map bindmap = (Map) cprops.get("Binding");                     // NOI18N
+        Map<String, String> bindmap = (Map) cprops.get("Binding");                     // NOI18N
         String tname = (String) bindmap.get(TableColumn.COLUMN);
         column.setFormat((String) ((Map) props.get(tname)).get(
                 "Format"));                                             //NOI18N

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/DefaultPathRecognizer.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/DefaultPathRecognizer.java
@@ -114,8 +114,8 @@ public final class DefaultPathRecognizer extends PathRecognizer {
         this.mimeTypes = mimeTypes;
     }
 
-    private static Set<String> readIdsAttribute(Map fileAttributes, String attributeName) {
-        Set<String> ids = new HashSet<String>();
+    private static Set<String> readIdsAttribute(Map<String, ?> fileAttributes, String attributeName) {
+        Set<String> ids = new HashSet<>();
         
         Object attributeValue = fileAttributes.get(attributeName); //NOI18N
         if (attributeValue instanceof String) {

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebugTreeView.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/debugging/DebugTreeView.java
@@ -165,7 +165,7 @@ public class DebugTreeView extends BeanTreeView {
             try {
                 Field drawingCacheField = BasicTreeUI.class.getDeclaredField("drawingCache");
                 drawingCacheField.setAccessible(true);
-                Map table = (Map) drawingCacheField.get(tui);
+                Map<BasicTreeUI, Map> table = (Map) drawingCacheField.get(tui);
                 table.clear();
             } catch (Exception ex) {}
         }

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
@@ -39,17 +39,17 @@ import org.netbeans.modules.xml.spi.dom.*;
 class DTDGrammar implements ExtendedGrammarQuery {
     
     // element name keyed
-    private Map elementDecls, attrDecls;
+    private Map<String, Set>  elementDecls, attrDecls;
     
     // Map<elementName:String, model:String || model:ContentModel || null>
     // this map is filled asynchronously as it takes some time
     private Map contentModels;
     
     // Map<elementname + " " + attributename, List<String>>
-    private Map attrEnumerations;
+    private Map<String, List> attrEnumerations;
     
     // Map<elementname + " " + attributename, String>
-    private Map defaultAttributeValues;
+    private Map<String, String> defaultAttributeValues;
     
     private Set<String> entities, notations;
 

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
@@ -593,7 +593,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
      */
     private static class Item {
         /** */
-        private static Map itemMap;
+        private static Map<Class, Item> itemMap;
 
         /** */
         private final NamedClass clazz;
@@ -651,12 +651,12 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
          */
         private static Item getItem (Class clazz) {
             if ( itemMap == null ) {
-                itemMap = new HashMap();
+                itemMap = new HashMap<>();
             }
             
-            Item item = (Item) itemMap.get (clazz);
+            Item item = itemMap.get(clazz);
             if ( item == null ) {
-                itemMap.put (clazz, item = new Item (new NamedClass (clazz)));
+                itemMap.put(clazz, item = new Item (new NamedClass (clazz)));
             }
             return item;
         }

--- a/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
@@ -76,7 +76,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
      * should contain XPath expression.  The element name keys should
      * not contain the namespace prefix.
      */
-    private static Map exprAttributes;
+    private static Map<String, String> exprAttributes;
 
     /** A set containing all functions allowed in XSLT */
     private static Set xslFunctions;
@@ -388,7 +388,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
     private static Map getExprAttributes() {
         if (exprAttributes == null) {
-            exprAttributes = new HashMap();
+            exprAttributes = new HashMap<>();
             exprAttributes.put("key", "use"); // NOI18N
             exprAttributes.put("value-of", "select"); // NOI18N
             exprAttributes.put("copy-of", "select"); // NOI18N

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/DebuggerAntLogger.java
@@ -284,7 +284,7 @@ public class DebuggerAntLogger extends AntLogger {
     private Map<AntDebugger, AntSession> runningDebuggers2 = new HashMap<>();
     private Set<File> filesToDebug = new HashSet<>();
     /** File => WeakReference -> ExecutorTask */
-    private Map fileExecutors = new HashMap();
+    private Map<File, WeakReference> fileExecutors = new HashMap<>();
     
     void debugFile (File f) {
         filesToDebug.add (f);

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointAnnotationListener.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/breakpoints/BreakpointAnnotationListener.java
@@ -40,9 +40,8 @@ import org.netbeans.modules.ant.debugger.DebuggerBreakpointAnnotation;
 public class BreakpointAnnotationListener extends DebuggerManagerAdapter 
 implements PropertyChangeListener {
     
-    private Map breakpointToAnnotation = new HashMap ();
-    
- 
+    private Map<AntBreakpoint, DebuggerBreakpointAnnotation> breakpointToAnnotation = new HashMap<>();
+  
     @Override
     public String[] getProperties () {
         return new String[] {DebuggerManager.PROP_BREAKPOINTS};

--- a/java/dbschema/src/org/netbeans/modules/dbschema/SchemaElement.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/SchemaElement.java
@@ -89,7 +89,7 @@ public class SchemaElement extends DBElement implements Node.Cookie {
     }
 
     /** Cache for read schemas. */
-    protected static Map schemaCache = new HashMap();
+    protected static Map<String, SchemaElement> schemaCache = new HashMap<>();
     
     /** Last used schema. */
     private static SchemaElement lastSchema;

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/SchemaElementImpl.java
@@ -343,17 +343,17 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                 rs = dmd.getImportedKeys(catalog, schema, tables.get(i).toString());
 
             if (rs != null) {
-                Map rset = new HashMap();
+                Map<Integer, String> rset = new HashMap();
                 String c1, c2, s1, s2;
                 while (rs.next()) {
                     if (bridge != null) {
                         rset = bridge.getDriverSpecification().getRow();
                         
                         //test references between two schemas
-                        c1 = (String) rset.get(new Integer(1));
-                        s1 = (String) rset.get(new Integer(2));
-                        c2 = (String) rset.get(new Integer(5));
-                        s2 = (String) rset.get(new Integer(6));
+                        c1 = rset.get(new Integer(1));
+                        s1 = rset.get(new Integer(2));
+                        c2 = rset.get(new Integer(5));
+                        s2 = rset.get(new Integer(6));
                         
                         if (comp(c1, c2)) {
                             if (! comp(s1, s2))
@@ -361,10 +361,10 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                         } else
                             continue;                            
                         
-                        pkSchema = (String) rset.get(new Integer(2));
-                        fkSchema = (String) rset.get(new Integer(6));
+                        pkSchema = rset.get(new Integer(2));
+                        fkSchema = rset.get(new Integer(6));
                         if ((pkSchema == fkSchema) || (pkSchema.equals(fkSchema))) {
-                            refTable = (String) rset.get(new Integer(3));
+                            refTable = rset.get(new Integer(3));
                             if (! tables.contains(refTable))
                                 tables.add(refTable);
                         }
@@ -503,11 +503,11 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                         if (rs != null) {
                             if (! all) {
                                 String colName;
-                                Map rset = new HashMap();
+                                Map<Integer, String> rset = new HashMap<>();
                                 while (rs.next()) {
                                     if (bridge != null) {
                                         rset = bridge.getDriverSpecification().getRow();
-                                        colName = (String) rset.get(new Integer(4));
+                                        colName = rset.get(new Integer(4));
                                         rset.clear();
                                     } else
                                         colName = rs.getString("COLUMN_NAME").trim(); //NOI18N                                    
@@ -582,7 +582,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                             rs = cp.getDatabaseMetaData().getImportedKeys(cp.getConnection().getCatalog(), cp.getSchema(), tables.get(j).toString());
                         
                         if (rs != null) {
-                            Map rset = new HashMap();
+                            Map<Integer, String> rset = new HashMap();
                             LinkedList local = new LinkedList();
                             LinkedList ref = new LinkedList();
                             LinkedList fk = new LinkedList();
@@ -592,10 +592,10 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                                     rset = bridge.getDriverSpecification().getRow();
                                     
                                     //test references between two schemas
-                                    c1 = (String) rset.get(new Integer(1));
-                                    s1 = (String) rset.get(new Integer(2));
-                                    c2 = (String) rset.get(new Integer(5));
-                                    s2 = (String) rset.get(new Integer(6));
+                                    c1 = rset.get(new Integer(1));
+                                    s1 = rset.get(new Integer(2));
+                                    c2 = rset.get(new Integer(5));
+                                    s2 = rset.get(new Integer(6));
 
                                     if (comp(c1, c2)) {
                                         if (! comp(s1, s2))
@@ -603,7 +603,7 @@ public class SchemaElementImpl extends DBElementImpl implements SchemaElement.Im
                                     } else
                                         continue;                            
                                     
-                                    fkName = (String) rset.get(new Integer(12));
+                                    fkName = rset.get(new Integer(12));
                                     if (fkName == null)
                                         continue;
                                     else

--- a/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/jdbcimpl/TableElementImpl.java
@@ -170,7 +170,7 @@ public class TableElementImpl extends DBElementImpl implements TableElement.Impl
                 String colName, colNull, colSize, colDec;
                 String strAutoIncrement = null;
                 if (rs != null) {
-                    Map rset = new HashMap();
+                    Map<Integer, String> rset = new HashMap<>();
                     while (rs.next()) {
                         if (bridge != null) {
                             rset = bridge.getDriverSpecification().getRow();

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/JPDAStart.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/jtreg/JPDAStart.java
@@ -121,7 +121,7 @@ public class JPDAStart implements Runnable {
                 // TODO: revisit later when http://developer.java.sun.com/developer/bugParade/bugs/4932074.html gets integrated into JDK
                 // This code parses the address string "HOST:PORT" to extract PORT and then point debugee to localhost:PORT
                 // This is NOT a clean solution to the problem but it SHOULD work in 99% cases
-                final Map args = lc.defaultArguments();
+                final Map<String, Connector.Argument> args = lc.defaultArguments();
                 String address = lc.startListening(args);
 //                try {
                     int colon = address.indexOf(':');

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
@@ -158,7 +158,7 @@ public class SourceGroupSupport {
         return null;
     }
 
-    private static Map createFoldersToSourceGroupsMap(final SourceGroup[] sourceGroups) {
+    private static Map<FileObject, SourceGroup> createFoldersToSourceGroupsMap(final SourceGroup[] sourceGroups) {
         Map<FileObject, SourceGroup> result;
         if (sourceGroups.length == 0) {
             result = Collections.emptyMap();
@@ -173,7 +173,7 @@ public class SourceGroupSupport {
     }
 
     private static Set<SourceGroup> getTestSourceGroups(SourceGroup[] sourceGroups) {
-        Map foldersToSourceGroupsMap = createFoldersToSourceGroupsMap(sourceGroups);
+        Map<FileObject, SourceGroup> foldersToSourceGroupsMap = createFoldersToSourceGroupsMap(sourceGroups);
         Set<SourceGroup> testGroups = new HashSet<>();
         for (int i = 0; i < sourceGroups.length; i++) {
             testGroups.addAll(getTestTargets(sourceGroups[i], foldersToSourceGroupsMap));

--- a/platform/api.templates/src/org/netbeans/api/templates/CreateFromTemplateImpl.java
+++ b/platform/api.templates/src/org/netbeans/api/templates/CreateFromTemplateImpl.java
@@ -236,7 +236,7 @@ final class CreateFromTemplateImpl {
         
         if (defaultMode != FileBuilder.Mode.COPY && frm instanceof MapFormat) {
             MapFormat mf = (MapFormat)frm;
-            Map m = mf.getMap();
+            Map<String, Object> m = mf.getMap();
             Map x = null;
             for (String s: params.keySet()) {
                 if (m.containsKey(s)) {

--- a/platform/core.netigso/nbproject/project.properties
+++ b/platform/core.netigso/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -109,11 +109,11 @@ import org.openide.util.io.NbObjectInputStream;
  */
 @SuppressWarnings("unchecked")
 final class XMLMapAttr implements Map {
-    Map/*<String,Attr>*/ map;
+    Map<String, Attr> map;
 
     /** Creates new XMLMapAttr and delegetaor is instanced */
     public XMLMapAttr() {
-        this.map = new HashMap(5);
+        this.map = new HashMap<>(5);
     }
 
     static Attr createAttributeAndDecode(String key, String value) {
@@ -262,11 +262,11 @@ final class XMLMapAttr implements Map {
         Object[] keyValuePair = ModifiedAttribute.translateInto((String) p1, p2);
         String key = (String) keyValuePair[0];
         Object value = keyValuePair[1];
-        Object toStore;
+        Attr toStore;
         if (value == null) {
             toStore = null;
         } else if (value instanceof Attr) {
-            toStore = value;
+            toStore = (Attr)value;
         } else if (value instanceof Method && key.startsWith("methodvalue:")) { // NOI18N
             Method m = (Method)value;
             key = key.substring("methodvalue:".length()); // NOI18N


### PR DESCRIPTION
Hey, it's me again.. The Netbeans Rust Remover..

There are a bunch of warnings related to raw type usage of the Map interface..

   [repeat] /home/bwalker/src/netbeans/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java:170: warning: [rawtypes] found raw type: Map
   [repeat]         Map result;
   [repeat]         ^
   [repeat]   missing type arguments for generic class Map<K,V>
   [repeat]   where K,V are type-variables:
   [repeat]     K extends Object declared in interface Map
   [repeat]     V extends Object declared in interface Map

This change cleans some of this up..