### PR TITLE
StatusDisplayer messages remoted to LSP client.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientCapabilities.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientCapabilities.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import org.eclipse.lsp4j.InitializeParams;
+
+/**
+ * Encapsulates all nbcode-specific client capabilities. Need to be passed in
+ * an object:
+ * <code><pre>
+ * "nbcodeCapabilities" : {
+ *      "statusBarMessageSupport"? : boolean
+ *      ...
+ * }
+ * </pre></code>
+ * @author sdedic
+ */
+public final class NbCodeClientCapabilities {
+    /**
+     * Supports status bar messages:
+     * <ul>
+     * <li>window/showStatusBarMessage
+     * </ul>
+     */
+    private Boolean statusBarMessageSupport;
+
+    public Boolean getStatusBarMessageSupport() {
+        return statusBarMessageSupport;
+    }
+
+    public boolean hasStatusBarMessageSupport() {
+        return statusBarMessageSupport != null && statusBarMessageSupport.booleanValue();
+    }
+
+    public void setStatusBarMessageSupport(Boolean statusBarMessageSupport) {
+        this.statusBarMessageSupport = statusBarMessageSupport;
+    }
+    
+    public static NbCodeClientCapabilities get(InitializeParams initParams) {
+        if (initParams == null) {
+            return null;
+        }
+        Object ext = initParams.getInitializationOptions();
+        if (!(ext instanceof JsonElement)) {
+            return null;
+        }
+        InitializationExtendedCapabilities root = new GsonBuilder().
+                /*
+                    hypothetically needed for formatting options with Either type
+                registerTypeAdapterFactory(new EitherTypeAdapter.Factory()).
+                */
+                create().
+                fromJson((JsonElement)ext, InitializationExtendedCapabilities.class);
+        return root == null ? null : root.getNbcodeCapabilities();
+                
+    }
+    
+    static final class InitializationExtendedCapabilities {
+        private NbCodeClientCapabilities nbcodeCapabilities;
+
+        public NbCodeClientCapabilities getNbcodeCapabilities() {
+            return nbcodeCapabilities;
+        }
+
+        public void setNbcodeCapabilities(NbCodeClientCapabilities nbcodeCapabilities) {
+            this.nbcodeCapabilities = nbcodeCapabilities;
+        }
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientWrapper.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientWrapper.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
+import org.eclipse.lsp4j.ApplyWorkspaceEditResponse;
+import org.eclipse.lsp4j.ConfigurationParams;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.SemanticHighlightingParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.WorkspaceFolder;
+
+/**
+ * Convenience wrapper that binds language client's remote proxy together with
+ * other useful methods. Will be sent out as THE client by the server core code.
+ * 
+ * @author sdedic
+ */
+class NbCodeClientWrapper implements NbCodeLanguageClient {
+    private final NbCodeLanguageClient remote;
+    private volatile NbCodeClientCapabilities  clientCaps;
+
+    public NbCodeClientWrapper(NbCodeLanguageClient remote) {
+        this.remote = remote;
+        this.clientCaps = new NbCodeClientCapabilities();
+    }
+
+    public void setClientCaps(NbCodeClientCapabilities clientCaps) {
+        if (clientCaps != null) {
+            this.clientCaps = clientCaps;
+        }
+    }
+    
+    @Override
+    public NbCodeClientCapabilities getNbCodeCapabilities() {
+        return clientCaps;
+    }
+
+    @Override
+    public void showStatusBarMessage(ShowStatusMessageParams params) {
+        remote.showStatusBarMessage(params);
+    }
+
+    @Override
+    public CompletableFuture<ApplyWorkspaceEditResponse> applyEdit(ApplyWorkspaceEditParams params) {
+        return remote.applyEdit(params);
+    }
+
+    @Override
+    public CompletableFuture<Void> registerCapability(RegistrationParams params) {
+        return remote.registerCapability(params);
+    }
+
+    @Override
+    public CompletableFuture<Void> unregisterCapability(UnregistrationParams params) {
+        return remote.unregisterCapability(params);
+    }
+
+    @Override
+    public void telemetryEvent(Object object) {
+        remote.telemetryEvent(object);
+    }
+
+    @Override
+    public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+        remote.publishDiagnostics(diagnostics);
+    }
+
+    @Override
+    public void showMessage(MessageParams messageParams) {
+        remote.showMessage(messageParams);
+    }
+
+    @Override
+    public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+        return remote.showMessageRequest(requestParams);
+    }
+
+    @Override
+    public void logMessage(MessageParams message) {
+        remote.logMessage(message);
+    }
+
+    @Override
+    public CompletableFuture<List<WorkspaceFolder>> workspaceFolders() {
+        return remote.workspaceFolders();
+    }
+
+    @Override
+    public CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams) {
+        return remote.configuration(configurationParams);
+    }
+
+    @Override
+    public void semanticHighlighting(SemanticHighlightingParams params) {
+        remote.semanticHighlighting(params);
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeLanguageClient.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeLanguageClient.java
@@ -40,4 +40,10 @@ public interface NbCodeLanguageClient extends LanguageClient {
      */
     @JsonNotification("window/showStatusBarMessage")
     public void showStatusBarMessage(@NonNull ShowStatusMessageParams params);
+    
+    /**
+     * Returns extended code capabilities.
+     * @return code capabilities.
+     */
+    public NbCodeClientCapabilities getNbCodeCapabilities();
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeLanguageClient.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeLanguageClient.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+/**
+ * An extension to the standard LanguageClient that adds several messages missing
+ * from the official LSP protocol.s
+ * @author sdedic
+ */
+public interface NbCodeLanguageClient extends LanguageClient {
+    
+    /**
+     * Shows a message in the status bar. Log- and Info-type messages are shown "as is".
+     * The other message types can be decorated by an icon according to {@link MessageParams#getType}.
+     * The message will be hidden after specified number of milliseconds; 0 means the client
+     * controls when the message is hidden.
+     * 
+     * @param params message type and text.
+     */
+    @JsonNotification("window/showStatusBarMessage")
+    public void showStatusBarMessage(@NonNull ShowStatusMessageParams params);
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -35,12 +35,15 @@ import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
-import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.jsonrpc.JsonRpcException;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
+import org.eclipse.lsp4j.jsonrpc.MessageIssueException;
+import org.eclipse.lsp4j.jsonrpc.messages.Message;
 import org.eclipse.lsp4j.launch.LSPLauncher;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
@@ -57,6 +60,11 @@ import org.netbeans.api.project.Sources;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.AbstractLookup;
+import org.openide.util.lookup.InstanceContent;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ProxyLookup;
 
 /**
  *
@@ -68,7 +76,7 @@ public final class Server {
     
     public static void launchServer(InputStream in, OutputStream out) {
         LanguageServerImpl server = new LanguageServerImpl();
-        Launcher<LanguageClient> serverLauncher = LSPLauncher.createServerLauncher(server, in, out);
+        Launcher<NbCodeLanguageClient> serverLauncher = createLauncher(server, in, out);
         ((LanguageClientAware) server).connect(serverLauncher.getRemoteProxy());
         Future<Void> runningServer = serverLauncher.startListening();
         try {
@@ -77,14 +85,56 @@ public final class Server {
             Exceptions.printStackTrace(ex);
         }
     }
+    
+    private static Launcher<NbCodeLanguageClient> createLauncher(LanguageServerImpl server, InputStream in, OutputStream out) {
+        return new LSPLauncher.Builder<NbCodeLanguageClient>()
+            .setLocalService(server)
+            .setRemoteInterface(NbCodeLanguageClient.class)
+            .setInput(in)
+            .setOutput(out)
+            .wrapMessages(new ConsumeWithLookup(server.getSessionLookup())::attachLookup)
+            .create();
+    }
+    
+    /**
+     * Processes message while the default Lookup is set to 
+     * {@link LanguageServerImpl#getSessionLookup()}.
+     */
+    private static class ConsumeWithLookup {
+        private final Lookup sessionLookup;
 
+        public ConsumeWithLookup(Lookup sessionLookup) {
+            this.sessionLookup = sessionLookup;
+        }
+        
+        public MessageConsumer attachLookup(MessageConsumer delegate) {
+            return new MessageConsumer() {
+                @Override
+                public void consume(Message msg) throws MessageIssueException, JsonRpcException {
+                    Lookups.executeWith(sessionLookup, () -> {
+                        delegate.consume(msg);
+                    });
+                }
+            };
+        }
+    }
+    
     private static class LanguageServerImpl implements LanguageServer, LanguageClientAware {
 
         private static final Logger LOG = Logger.getLogger(LanguageServerImpl.class.getName());
         private LanguageClient client;
         private final TextDocumentService textDocumentService = new TextDocumentServiceImpl();
         private final WorkspaceService workspaceService = new WorkspaceServiceImpl();
-
+        private final InstanceContent   sessionServices = new InstanceContent();
+        private final Lookup sessionLookup = new ProxyLookup(
+                new AbstractLookup(sessionServices),
+                Lookup.getDefault()
+        );
+        
+        Lookup getSessionLookup() {
+            return sessionLookup;
+        }
+        
         @Override
         public CompletableFuture<InitializeResult> initialize(InitializeParams init) {
             List<FileObject> projectCandidates = new ArrayList<>();
@@ -142,7 +192,8 @@ public final class Server {
             try {
                 JavaSource.create(ClasspathInfo.create(ClassPath.EMPTY, ClassPath.EMPTY, ClassPath.EMPTY))
                           .runWhenScanFinished(cc -> {
-                  client.showMessage(new MessageParams(MessageType.Info, INDEXING_COMPLETED));
+                  ((NbCodeLanguageClient)client).showStatusBarMessage(
+                          new ShowStatusMessageParams(MessageType.Info, INDEXING_COMPLETED, 0));
                   //todo: refresh diagnostics all open editor?
                 }, true);
             } catch (IOException ex) {
@@ -185,6 +236,15 @@ public final class Server {
         @Override
         public void connect(LanguageClient client) {
             this.client = client;
+            
+            sessionServices.add(new WorkspaceIOContext() {
+                @Override
+                protected LanguageClient client() {
+                    return client;
+                }
+            });
+            sessionServices.add(new WorkspaceUIContext(client));
+            
             ((LanguageClientAware) getTextDocumentService()).connect(client);
             ((LanguageClientAware) getWorkspaceService()).connect(client);
         }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ShowStatusMessageParams.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ShowStatusMessageParams.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import java.util.Objects;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.xtext.xbase.lib.Pure;
+
+/**
+ *
+ * @author sdedic
+ */
+public class ShowStatusMessageParams extends MessageParams {
+    private Integer timeout;
+
+    public ShowStatusMessageParams(MessageType type, String message) {
+        super(type, message);
+    }
+
+    public ShowStatusMessageParams(MessageType type, String message, int timeout) {
+        super(type, message);
+        this.timeout = timeout;
+    }
+
+    @Pure
+    public Integer getTimeout() {
+        return timeout;
+    }
+
+    public ShowStatusMessageParams setTimeout(Integer timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
+    @Pure
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 53 * hash + (timeout == null ? 7 : this.timeout.hashCode());
+        return hash;
+    }
+
+    @Pure
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ShowStatusMessageParams other = (ShowStatusMessageParams) obj;
+        if (Objects.equals(this.timeout, other.timeout)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -172,6 +172,7 @@ import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.Fix;
 import org.netbeans.spi.editor.hints.LazyFixList;
 import org.netbeans.spi.java.hints.JavaFix;
+import org.openide.awt.StatusDisplayer;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -194,7 +195,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
 
     private final Map<String, Document> openedDocuments = new HashMap<>();
     private final Map<String, RequestProcessor.Task> diagnosticTasks = new HashMap<>();
-    private LanguageClient client;
+    private NbCodeLanguageClient client;
 
     public TextDocumentServiceImpl() {
     }
@@ -245,7 +246,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
 
     @Override
     public void connect(LanguageClient client) {
-        this.client = client;
+        this.client = (NbCodeLanguageClient)client;
     }
 
     private static class ItemFactoryImpl implements JavaCompletionTask.ItemFactory<CompletionItem> {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -23,7 +23,6 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.ExecuteCommandParams;
-import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.services.LanguageClient;
@@ -42,7 +41,7 @@ import org.openide.util.lookup.Lookups;
  */
 public final class WorkspaceServiceImpl implements WorkspaceService, LanguageClientAware {
 
-    private LanguageClient client;
+    private NbCodeLanguageClient client;
 
     public WorkspaceServiceImpl() {
     }
@@ -84,6 +83,6 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
 
     @Override
     public void connect(LanguageClient client) {
-        this.client = client;
+        this.client = (NbCodeLanguageClient)client;
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceUIContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceUIContext.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.netbeans.modules.java.lsp.server.ui.UIContext;
+import org.openide.awt.StatusDisplayer;
+
+/**
+ *
+ * @author sdedic
+ */
+class WorkspaceUIContext extends UIContext {
+    private final NbCodeLanguageClient nbClient;
+    private final LanguageClient client;
+
+    public WorkspaceUIContext(LanguageClient client) {
+        this.client = client;
+        if (client instanceof NbCodeLanguageClient) {
+            nbClient = (NbCodeLanguageClient)client;
+        } else {
+            nbClient = null;
+        }
+    }
+
+    @Override
+    protected boolean isValid() {
+        return true;
+    }
+
+    @Override
+    protected void showMessage(MessageParams msg) {
+        client.showMessage(msg);
+    }
+
+    @Override
+    protected void logMessage(MessageParams msg) {
+        client.logMessage(msg);
+    }
+
+    @Override
+    protected StatusDisplayer.Message showStatusMessage(ShowStatusMessageParams msg) {
+        if (nbClient != null) {
+            nbClient.showStatusBarMessage(msg);
+        } else {
+            client.showMessage(msg);
+        }
+        return null;
+    }
+    
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceUIContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceUIContext.java
@@ -28,16 +28,10 @@ import org.openide.awt.StatusDisplayer;
  * @author sdedic
  */
 class WorkspaceUIContext extends UIContext {
-    private final NbCodeLanguageClient nbClient;
-    private final LanguageClient client;
+    private final NbCodeLanguageClient client;
 
-    public WorkspaceUIContext(LanguageClient client) {
+    public WorkspaceUIContext(NbCodeLanguageClient client) {
         this.client = client;
-        if (client instanceof NbCodeLanguageClient) {
-            nbClient = (NbCodeLanguageClient)client;
-        } else {
-            nbClient = null;
-        }
     }
 
     @Override
@@ -57,8 +51,8 @@ class WorkspaceUIContext extends UIContext {
 
     @Override
     protected StatusDisplayer.Message showStatusMessage(ShowStatusMessageParams msg) {
-        if (nbClient != null) {
-            nbClient.showStatusBarMessage(msg);
+        if (client.getNbCodeCapabilities().hasStatusBarMessageSupport()) {
+            client.showStatusBarMessage(msg);
         } else {
             client.showMessage(msg);
         }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractLspStatusDisplayer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractLspStatusDisplayer.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.lsp.server.ui;
 import javax.swing.event.ChangeListener;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
+import org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams;
 import org.openide.awt.StatusDisplayer;
 
 public abstract class AbstractLspStatusDisplayer extends StatusDisplayer {
@@ -56,8 +57,8 @@ public abstract class AbstractLspStatusDisplayer extends StatusDisplayer {
         } else {
             type = MessageType.Info;
         }
-        ctx.showMessage(new MessageParams(type, text));
-        return (int timeInMillis) -> {
+        Message m = ctx.showStatusMessage(new ShowStatusMessageParams(type, text, 0));
+        return m != null ? m : (int timeInMillis) -> {
         };
     }
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/UIContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/UIContext.java
@@ -21,6 +21,8 @@ package org.netbeans.modules.java.lsp.server.ui;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import org.eclipse.lsp4j.MessageParams;
+import org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams;
+import org.openide.awt.StatusDisplayer.Message;
 import org.openide.util.Lookup;
 
 public abstract class UIContext {
@@ -49,6 +51,8 @@ public abstract class UIContext {
 
     protected abstract boolean isValid();
     protected abstract void showMessage(MessageParams msg);
+    protected abstract void logMessage(MessageParams msg);
+    protected abstract Message showStatusMessage(ShowStatusMessageParams msg);
 
 
     private static final class LogImpl extends UIContext {
@@ -60,6 +64,17 @@ public abstract class UIContext {
         @Override
         protected void showMessage(MessageParams msg) {
             System.err.println(msg.getType() + ": " + msg.getMessage());
+        }
+
+        @Override
+        protected void logMessage(MessageParams msg) {
+            System.err.println(msg.getType() + ": " + msg.getMessage());
+        }
+
+        @Override
+        protected Message showStatusMessage(ShowStatusMessageParams msg) {
+            System.out.println(msg.getType() + ": " + msg.getMessage());
+            return (int timeInMillis) -> {};
         }
 
         @Override

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -184,7 +184,12 @@ export function activate(context: ExtensionContext) {
                 ]
             },
             outputChannelName: 'Java',
-            revealOutputChannelOn: 4 // never
+            revealOutputChannelOn: 4,
+            initializationOptions : {
+                'nbcodeCapabilities' : {
+                    'statusBarMessageSupport' : true
+                }
+            }
         }
 
         // Create the language client and start the client.

--- a/java/java.lsp.server/vscode/src/protocol.ts
+++ b/java/java.lsp.server/vscode/src/protocol.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+'use strict';
+
+import {
+    NotificationType,
+    ShowMessageParams
+} from 'vscode-languageclient';
+
+export interface ShowStatusMessageParams extends ShowMessageParams {
+    /**
+     * The timeout
+     */
+    timeout?: number;
+}
+
+export namespace StatusMessageRequest {
+    export const type = new NotificationType<ShowStatusMessageParams, void>('window/showStatusBarMessage');
+};


### PR DESCRIPTION
StatusDisplayer messages displayed in VSCode's 'Extension Status' statusbar item - or anywhere the LSP client likes. This is different to `showMessage` defined by the LSP protocol, which typically displays alerts or notifications that require an action; status bar messaes are less obtrusive. Also different from `logMessage` that only appears in an output together with e.g. debug messages.

Relatively unrelated change: moved `Lookups.lookupWith` from the build action to an interceptor for all messages received by the LSP endpoint.