### PR TITLE
Search for JDK in typical location

### DIFF
--- a/java/java.lsp.server/vscode/README.md
+++ b/java/java.lsp.server/vscode/README.md
@@ -91,3 +91,16 @@ and connect from the VSCode extension:
 ```bash
 vscode$ code --extensionDevelopmentPath=`pwd` path_to_the_maven_project
 ```
+
+## Selecting the JDK
+
+The NbCode Java part needs to run on a JDK. The JDK is being searched in
+following locations:
+
+- `netbeans.jdkhome` setting (workspace then user settings)
+- `java.home` setting (workspace then user settings)
+- `JDK_HOME` environment variable
+- `JAVA_HOME` environment variable
+- current system path
+
+As soon as one of the settings is changed, the NbCode Java part is restarted.

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "apache-netbeans-java",
-	"displayName": "Apache Netbeans Java for VSCode",
-	"description": "An Apache NetBeans Java plugin for Visual Studio Code",
+	"displayName": "Apache Netbeans Language Server",
+	"description": "An Apache NetBeans Language Server plugin for Visual Studio Code",
 	"author": "Apache NetBeans",
 	"license": "Apache 2.0",
 	"version": "0.1.0",
@@ -34,12 +34,12 @@
 						"null"
 					],
 					"default": null,
-					"description": "Specifies the JDK on which the Java language server should be run"
+					"description": "Specifies JDK for the Apache NetBeans Language Server"
 				},
                                 "netbeans.verbose": {
                                         "type": "boolean",
                                         "default": false,
-                                        "description": "Enables verbose messages from the Java Language Server"
+                                        "description": "Enables verbose messages from the Apache NetBeans Language Server"
                                 }
 			}
 		},

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -272,20 +272,22 @@ function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext,
             }
         }
 
-        // Create the language client and start the client.
-        client = new LanguageClient(
-                'java',
-                'NetBeans Java',
-                connection,
-                clientOptions
-        );
+        if (!client) {
+            // Create the language client and start the client.
+            client = new LanguageClient(
+                    'java',
+                    'NetBeans Java',
+                    connection,
+                    clientOptions
+            );
 
-        // Start the client. This will also launch the server
-        client.start();
-        client.onReady().then(() => {
-            commands.executeCommand('setContext', 'nbJavaLSReady', true);
-            client.onNotification(StatusMessageRequest.type, showStatusBarMessage);
-        });
+            // Start the client. This will also launch the server
+            client.start();
+            client.onReady().then(() => {
+                commands.executeCommand('setContext', 'nbJavaLSReady', true);
+                client.onNotification(StatusMessageRequest.type, showStatusBarMessage);
+            });
+        }
     }).catch((reason) => {
         log.append(reason);
         window.showErrorMessage('Error initializing ' + reason);

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -103,16 +103,16 @@ function findJDK(onChange: (path : string | null) => void): void {
 export function activate(context: ExtensionContext) {
     vscode.extensions.all.forEach((e) => {
         if (e.extensionPath.indexOf("redhat.java") >= 0) {
-            vscode.window.showInformationMessage(`redhat.java found at ${e.extensionPath} - supressing`);
+            vscode.window.showInformationMessage(`redhat.java found at ${e.extensionPath} - Suppressing some services to not clash with Apache NetBeans Language Server.`);
             workspace.getConfiguration().update('java.completion.enabled', false, false).then(() => {
-                vscode.window.showInformationMessage('Disabling redhat.java code completion');
+                vscode.window.showInformationMessage('Disabling redhat.java code completion. Usage of only one Java extension is recommended.');
             }, (reason) => {
                 vscode.window.showInformationMessage('Disabling redhat.java code completion failed ' + reason);
             });
         }
     });
 
-    let log = vscode.window.createOutputChannel("Java Language Server");
+    let log = vscode.window.createOutputChannel("Apache NetBeans Language Server");
 
     // find acceptable JDK and launch the Java part
     findJDK((specifiedJDK) => {
@@ -155,7 +155,7 @@ export function activate(context: ExtensionContext) {
 
 function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext, log : vscode.OutputChannel): void {
     if (nbProcess) {
-        vscode.window.showInformationMessage("Restarting Java Language Server.");
+        vscode.window.setStatusBarMessage("Restarting Apache NetBeans Language Server.", 2000);
         nbProcess.kill();
     }
 
@@ -168,7 +168,7 @@ function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext,
         verbose: beVerbose
     };
 
-    let launchMsg = `Launching Java Language Server with ${specifiedJDK ? specifiedJDK : 'default system JDK'}`;
+    let launchMsg = `Launching Apache NetBeans Language Server with ${specifiedJDK ? specifiedJDK : 'default system JDK'}`;
     log.appendLine(launchMsg);
     vscode.window.setStatusBarMessage(launchMsg, 2000);
 
@@ -195,7 +195,7 @@ function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext,
         nbProcess = p;
         nbProcess.on('close', function(code: number) {
             if (p == nbProcess && code != 0) {
-                vscode.window.showWarningMessage("Java Language Server exited with " + code);
+                vscode.window.showWarningMessage("Apache NetBeans Language Server exited with " + code);
             }
             if (collectedText != null) {
                 let match = collectedText.match(/org.netbeans.modules.java.lsp.server[^\n]*/)
@@ -205,7 +205,7 @@ function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext,
                     log.appendLine("Cannot find org.netbeans.modules.java.lsp.server in the log!");
                 }
                 log.show(false);
-                reject("Java Language Server not enabled!");
+                reject("Apache NetBeans Language Server not enabled!");
             } else {
                 log.appendLine("Exit code " + code);
             }

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -24,13 +24,13 @@ import {
     LanguageClient,
     LanguageClientOptions,
     StreamInfo,
-    ShowMessageParams, MessageType,
+    MessageType,
 } from 'vscode-languageclient';
 
 import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
-import { spawn, ChildProcess, SpawnOptions } from 'child_process';
+import { ChildProcess } from 'child_process';
 import * as vscode from 'vscode';
 import * as launcher from './nbcode';
 import { StatusMessageRequest, ShowStatusMessageParams  } from './protocol';
@@ -79,10 +79,10 @@ export function activate(context: ExtensionContext) {
     
     let log = vscode.window.createOutputChannel("Java Language Server");
 
-    vscode.extensions.all.forEach((e, index) => {
+    vscode.extensions.all.forEach((e) => {
         if (e.extensionPath.indexOf("redhat.java") >= 0) {
             vscode.window.showInformationMessage(`redhat.java found at ${e.extensionPath} - supressing`);
-            workspace.getConfiguration().update('java.completion.enabled', false, false).then((ok) => {
+            workspace.getConfiguration().update('java.completion.enabled', false, false).then(() => {
                 vscode.window.showInformationMessage('Disabling redhat.java code completion');
             }, (reason) => {
                 vscode.window.showInformationMessage('Disabling redhat.java code completion failed ' + reason);
@@ -134,7 +134,7 @@ export function activate(context: ExtensionContext) {
         });
     });
 
-    ideRunning.then((value) => {
+    ideRunning.then(() => {
         const connection = () => new Promise<StreamInfo>((resolve, reject) => {
             const server = net.createServer(socket => {
                 server.close();
@@ -204,7 +204,7 @@ export function activate(context: ExtensionContext) {
 
         // Start the client. This will also launch the server
         client.start();
-        client.onReady().then((value) => {
+        client.onReady().then(() => {
             commands.executeCommand('setContext', 'nbJavaLSReady', true);
             client.onNotification(StatusMessageRequest.type, showStatusBarMessage);
         });
@@ -287,7 +287,7 @@ export function deactivate(): Thenable<void> {
 
 class NetBeansDebugAdapterDescriptionFactory implements vscode.DebugAdapterDescriptorFactory {
 
-    createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    createDebugAdapterDescriptor(_session: vscode.DebugSession, _executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
         return new vscode.DebugAdapterServer(debugPort);
     }
 }
@@ -295,7 +295,7 @@ class NetBeansDebugAdapterDescriptionFactory implements vscode.DebugAdapterDescr
 
 class NetBeansConfigurationProvider implements vscode.DebugConfigurationProvider {
 
-    resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
+    resolveDebugConfiguration(_folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, _token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
         if (!config.type) {
             config.type = 'java-polyglot';
         }

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -101,18 +101,18 @@ function findJDK(onChange: (path : string | null) => void): void {
 }
 
 export function activate(context: ExtensionContext) {
-    vscode.extensions.all.forEach((e) => {
-        if (e.extensionPath.indexOf("redhat.java") >= 0) {
-            vscode.window.showInformationMessage(`redhat.java found at ${e.extensionPath} - Suppressing some services to not clash with Apache NetBeans Language Server.`);
-            workspace.getConfiguration().update('java.completion.enabled', false, false).then(() => {
-                vscode.window.showInformationMessage('Disabling redhat.java code completion. Usage of only one Java extension is recommended.');
-            }, (reason) => {
-                vscode.window.showInformationMessage('Disabling redhat.java code completion failed ' + reason);
-            });
-        }
-    });
-
     let log = vscode.window.createOutputChannel("Apache NetBeans Language Server");
+
+    let e = vscode.extensions.getExtension('redhat.java');
+    log.appendLine(`workspace ${workspace.name}`);
+    if (e && workspace.name) {
+        vscode.window.showInformationMessage(`redhat.java found at ${e.extensionPath} - Suppressing some services to not clash with Apache NetBeans Language Server.`);
+        workspace.getConfiguration().update('java.completion.enabled', false, false).then(() => {
+            vscode.window.showInformationMessage('Disabling redhat.java code completion. Usage of only one Java extension is recommended.');
+        }, (reason) => {
+            vscode.window.showInformationMessage('Disabling redhat.java code completion failed ' + reason);
+        });
+    }
 
     // find acceptable JDK and launch the Java part
     findJDK((specifiedJDK) => {


### PR DESCRIPTION
It all started with a bug report: Java Language Server ignores `JAVA_HOME` environment variable. Then it continued with a discussion and the conclusion was made to mimic behavior of the existing VSCode Java extension. E.g. to search locations:

- `netbeans.jdkhome` setting (workspace then user settings)
- `java.home` setting (workspace then user settings)
- `JDK_HOME` environment variable
- `JAVA_HOME` environment variable
- current system path

`netbeans.jdkhome` is checked to give the user chance to exactly specify JDK just for NbCode. Other locations are checked for compatibility reasons.

As soon as `netbeans.jdkhome` or  `java.home` settings are set the NbCode Java part is restarted.