### PR TITLE
[NETBEANS-4940] Workaround for caret-on-TAB drawing issue

### DIFF
--- a/ide/editor.lib/apichanges.xml
+++ b/ide/editor.lib/apichanges.xml
@@ -83,6 +83,21 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="caret-min-width">
+            <summary>Allow to specify minimum caret width</summary>
+            <version major="4" minor="17"/>
+            <date day="3" month="11" year="2020"/>
+            <author login="errael"/>
+            <compatibility binary="compatible" semantic="compatible" source="compatible" addition="yes" deprecation="no" deletion="no"/>
+            <description>
+                <p>
+                    If present, JTextComponent property "CARET_MIN_WIDTH" with a value
+                    of type IntUnaryOpertor is used by BaseCaret to override constant 2.
+                </p>
+            </description>
+            <class name="BaseCaret" package="org.netbeans.editor"/>
+            <issue number="NETBEANS-4940"/>
+        </change>
         <change id="editor-document-split">
             <summary>Document handling split</summary>
             <version major="4" minor="0"/>

--- a/ide/editor.lib/arch.xml
+++ b/ide/editor.lib/arch.xml
@@ -19,8 +19,8 @@
     under the License.
 
 -->
-<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
-  <!ENTITY api-questions SYSTEM "../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
+<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
+  <!ENTITY api-questions SYSTEM "../../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
 ]>
 
 <api-answers
@@ -467,6 +467,12 @@ Description of public packages:
     <api type="export" name="line-limit" category="private" group="property">
         Document property that determines the number of characters in the longest line
         determined during the document loading from a reader by the editor kit. 
+    </api>
+    <br/>
+    <api type="export" name="CARET_MIN_WIDTH" category="devel" group="property">
+        Component client property that provides an <code>IntUnaryOperator</code>
+        which is invoked with a document offset and returns a minimum caret width.
+        This overrides a constant 2 minimum caret width.
     </api>
 </answer>
 

--- a/ide/editor.lib/src/org/netbeans/editor/BaseCaret.java
+++ b/ide/editor.lib/src/org/netbeans/editor/BaseCaret.java
@@ -54,11 +54,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.function.IntUnaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
+
 import javax.swing.Action;
 import javax.swing.JComponent;
 import javax.swing.JScrollBar;
@@ -80,6 +82,7 @@ import javax.swing.event.EventListenerList;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.Position;
 import javax.swing.text.StyleConstants;
+
 import org.netbeans.api.editor.fold.FoldHierarchyEvent;
 import org.netbeans.api.editor.fold.FoldHierarchyListener;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
@@ -401,9 +404,14 @@ AtomicLockListener, FoldHierarchyListener {
                                 c, offset, Position.Bias.Forward);
                         // [TODO] Temporary fix - impl should remember real bounds computed by paintCustomCaret()
                         if (newCaretBounds != null) {
-                            newCaretBounds.width = Math.max(newCaretBounds.width, 2);
+                            int minwidth = 2;
+                            // [NETBEANS-4940] Caret drawing problems over a TAB
+                            Object o = component.getClientProperty("CARET_MIN_WIDTH");
+                            if(o instanceof IntUnaryOperator) {
+                                minwidth = ((IntUnaryOperator)o).applyAsInt(offset);
+                            }
+                            newCaretBounds.width = Math.max(newCaretBounds.width, minwidth);
                         }
-
                     } catch (BadLocationException e) {
                         newCaretBounds = null;
                         Utilities.annotateLoggable(e);


### PR DESCRIPTION
In ide/editor/lib/BaseCaret there's
```
newCaretBounds = c.getUI().modelToView(
        c, offset, Position.Bias.Forward);
// [TODO] Temporary fix - impl should remember real bounds computed by paintCustomCaret()
if (newCaretBounds != null) {
    newCaretBounds.width = Math.max(newCaretBounds.width, 2);
}
```
When offset is sitting on a TAB character,
editor.lib2's TabView's `modelToViewChecked(int offset, Shape alloc,...` does
```
        mutableBounds.width = 1;
        return mutableBounds;
```
So the min of 2 applies and the caret drawing code gets a graphics context with clip width of 2.

This causes a drawing problem for the caret which can be ovserved in NetBeans. The problem may be exacerbated for plugins that provide their own caret. This fix provides a workaround that can be used by plugins until (if) the problem is addressed.

