### PR TITLE
Prevent NullPointerException from LSP HyperlinkProvider

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/HyperlinkProviderImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/HyperlinkProviderImpl.java
@@ -72,14 +72,16 @@ public class HyperlinkProviderImpl implements HyperlinkProviderExt {
         try {
             //XXX: not really using the server, are we?
             int[] ident = Utilities.getIdentifierBlock((BaseDocument) doc, offset);
+            if (ident == null) {
+                return null;
+            }
             TokenSequence<?> ts = TokenHierarchy.get(doc).tokenSequence();
+            if (ts == null) {
+                return null;
+            }
             ts.move(offset);
             if (ts.moveNext() && ts.token().id() == TextmateTokenId.TEXTMATE) {
-                if (ident != null) {
-                    return new int[] {ts.offset(), ts.offset() + ts.token().length()};
-                } else {
-                    return null;
-                }
+                return new int[]{ts.offset(), ts.offset() + ts.token().length()};
             }
             return ident;
         } catch (BadLocationException ex) {


### PR DESCRIPTION
The LSP HyperlinkProvider is registered for every document. It expects,
that documents always provide token sequences. This assumption is
invalid and the calls need to be guarded agains null token sequences.

Observed backtrace:

```
SEVERE [global]
java.lang.NullPointerException
	at org.netbeans.modules.lsp.client.bindings.HyperlinkProviderImpl.getHyperlinkSpan(HyperlinkProviderImpl.java:76)
	at org.netbeans.modules.lsp.client.bindings.HyperlinkProviderImpl.isHyperlinkPoint(HyperlinkProviderImpl.java:62)
	at org.netbeans.lib.editor.hyperlink.HyperlinkOperation.findProvider(HyperlinkOperation.java:266)
	at org.netbeans.lib.editor.hyperlink.HyperlinkOperation.performHyperlinking(HyperlinkOperation.java:224)
	at org.netbeans.lib.editor.hyperlink.HyperlinkOperation.keyPressed(HyperlinkOperation.java:382)
	at java.desktop/java.awt.AWTEventMulticaster.keyPressed(AWTEventMulticaster.java:258)
	at java.desktop/java.awt.AWTEventMulticaster.keyPressed(AWTEventMulticaster.java:257)
```