### PR TITLE
[NETBEANS-3789] Fix missing artitact nodes in Gradle Project Configurations.

### DIFF
--- a/extide/gradle/arch.xml
+++ b/extide/gradle/arch.xml
@@ -137,7 +137,14 @@
          to specify the default behavior of reusing output by your application.
          Use <code>never</code> value, if the reuse shall never be done,
          regardless of the settings value.
-     </api> 
+     </api>
+     <api category="devel" group="systemproperty" name="netbeans.debug.gradle.info.action" type="export" >
+         Starting NetBeans with <code>netbeans.debug.gradle.info.action=true</code>
+         would make the Gradle project information loading into a debugabble JVM
+         where the debugging port is <code>5006</code>. A new debugger session
+         can be attached to that port, make the <code>netbeans-gradle-tooling</code>
+         project debuggable in action.
+     </api>
  </answer>
 
  <answer id="resources-file">

--- a/extide/gradle/netbeans-gradle-tooling/src/main/groovy/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.groovy
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/groovy/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.groovy
@@ -99,6 +99,7 @@ class NbProjectInfoBuilder {
         model.info.project_buildDir = project.buildDir;
         model.info.project_projectDir = project.projectDir;
         model.info.project_rootDir = project.rootDir;
+        model.info.gradle_user_home = project.gradle.gradleUserHomeDir;
 
         def visibleConfigurations = configurationsToSave()
         model.info.configurations = storeSet(visibleConfigurations.collect() {conf -> conf.name})

--- a/extide/gradle/netbeans-gradle-tooling/src/test/data/simple-with-tests/build.gradle
+++ b/extide/gradle/netbeans-gradle-tooling/src/test/data/simple-with-tests/build.gradle
@@ -35,27 +35,29 @@ dependencies {
     testCompile 'junit:junit:4.10'
 }
 
-task downloadDependencies << {
-     Set ids = new HashSet();
-     project.configurations.testCompile.incoming.resolutionResult.allDependencies.each() {
-        if (it instanceof ResolvedDependencyResult) {
-            if (it.requested instanceof ModuleComponentSelector) {
-                ids.add(it.selected.id)
-            }
-        }         
-     }
-     org.gradle.api.internal.artifacts.result.DefaultArtifactResolutionResult result = project.dependencies.createArtifactResolutionQuery()
-    .forComponents(ids)
-    .withArtifacts(JvmLibrary, SourcesArtifact, JavadocArtifact)
-    .execute()
-    Collection coll = result.resolvedComponents
-    for(def o: coll) {
-        def sources = o.getArtifacts(SourcesArtifact)
-        sources.each() {
-            if (it instanceof ResolvedArtifactResult) {
-                println it.file
+task('downloadDependencies') {
+    doLast {
+        Set ids = new HashSet();
+        project.configurations.testCompile.incoming.resolutionResult.allDependencies.each() {
+            if (it instanceof ResolvedDependencyResult) {
+                if (it.requested instanceof ModuleComponentSelector) {
+                    ids.add(it.selected.id)
+                }
             }
         }
+        org.gradle.api.internal.artifacts.result.DefaultArtifactResolutionResult result = project.dependencies.createArtifactResolutionQuery()
+        .forComponents(ids)
+        .withArtifacts(JvmLibrary, SourcesArtifact, JavadocArtifact)
+        .execute()
+        Collection coll = result.resolvedComponents
+        for(def o: coll) {
+            def sources = o.getArtifacts(SourcesArtifact)
+            sources.each() {
+                if (it instanceof ResolvedArtifactResult) {
+                    println it.file
+                }
+            }
 
+        }
     }
 }

--- a/extide/gradle/netbeans-gradle-tooling/src/test/data/simple-with-tests/settings.gradle
+++ b/extide/gradle/netbeans-gradle-tooling/src/test/data/simple-with-tests/settings.gradle
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+

--- a/extide/gradle/netbeans-gradle-tooling/src/test/data/simple/settings.gradle
+++ b/extide/gradle/netbeans-gradle-tooling/src/test/data/simple/settings.gradle
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+

--- a/extide/gradle/netbeans-gradle-tooling/src/test/data/unresolvable/settings.gradle
+++ b/extide/gradle/netbeans-gradle-tooling/src/test/data/unresolvable/settings.gradle
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleModuleFileCache21.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleModuleFileCache21.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.netbeans.modules.gradle.spi.GradleSettings;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public final class GradleModuleFileCache21 {
+    private static final String CLASSIFIER_SOURCES = "sources"; //NOI18N
+    private static final String CLASSIFIER_JAVADOC = "javadoc"; //NOI18N
+
+    private static final String EXT_JAR = "jar"; //NOI18N
+    private static final String EXT_POM = "pom"; //NOI18N
+
+    private static final Path FILE_CACHE_BASE = Paths.get("caches", "modules-2", "files-2.1"); //NOI18N
+    final Path cacheBaseDir;
+
+
+    public final class CachedArtifactVersion {
+        final Path path;
+        final Map<String, Entry> entries = new HashMap<>();
+
+        public final class Entry {
+            final Path path;
+
+            public Entry(String name, String hash) {
+                this.path = CachedArtifactVersion.this.getPath().resolve(Paths.get(hash, name));
+            }
+
+            public Entry(Path path) throws IllegalArgumentException {
+                if (!(path.startsWith(CachedArtifactVersion.this.path) && (path.getNameCount() - 2 == CachedArtifactVersion.this.path.getNameCount()))) {
+                    throw new IllegalArgumentException("Not a Cached Gradle Atrifact: " + path.toString());
+                }
+                this.path = path;
+            }
+
+            public Path getPath() {
+                return path;
+            }
+
+            public String getName() {
+                return path.getFileName().toString();
+            }
+
+            public String getHash() {
+                return path.getParent().toString();
+            }
+
+            public String getVersion() {
+                return CachedArtifactVersion.this.getVersion();
+            }
+            
+            public String getModule() {
+                return CachedArtifactVersion.this.getModule();
+            }
+
+            public String getOrganization() {
+                return CachedArtifactVersion.this.getOrganization();
+            }
+
+            public String getClassifier() {
+                String ret = null;
+                String prefix = getModule() + "-" + getVersion() + "-";
+                String name = getName();
+                if (name.startsWith(prefix)) {
+                    int extDot = name.lastIndexOf('.');
+                    if (extDot > prefix.length()) {
+                        ret = name.substring(prefix.length(), extDot);
+                    }
+                }
+                return ret;
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hashCode(this.getHash());
+            }
+
+            public CachedArtifactVersion getCachedArtifats() {
+                return CachedArtifactVersion.this;
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                if (this == obj) {
+                    return true;
+                }
+                if (obj == null) {
+                    return false;
+                }
+                if (getClass() != obj.getClass()) {
+                    return false;
+                }
+                final Entry other = (Entry) obj;
+                if (!Objects.equals(this.getHash(), other.getHash())) {
+                    return false;
+                }
+                return Objects.equals(getPath(), other.getPath());
+            }
+        }
+
+        public CachedArtifactVersion(String organization, String module, String version) {
+            path = cacheBaseDir.resolve(Paths.get(organization, module, version));
+            try {
+                readEntries();
+            } catch (IOException ex) {
+                //TODO: What
+            }
+        }
+
+        public CachedArtifactVersion(Path path) throws IllegalArgumentException {
+            if (!(path.startsWith(cacheBaseDir) && (path.getNameCount() - 3 == cacheBaseDir.getNameCount()))) {
+                throw new IllegalArgumentException("Not a Cached Gradle Atrifact Version dir: " + path.toString());
+            }
+            this.path = path;
+        }
+
+        public Path getPath() {
+            return path;
+        }
+
+        public String getVersion() {
+            return path.getFileName().toString();
+        }
+
+        public String getModule() {
+            return path.getParent().getFileName().toString();
+        }
+
+        public String getOrganization() {
+            return path.getParent().getParent().getFileName().toString();
+        }
+
+        public Map<String, Entry> getEntries() {
+            return Collections.unmodifiableMap(entries);
+        }
+
+        public Entry getSources() {
+            return getClassifiedEntry(CLASSIFIER_SOURCES, EXT_JAR);
+        }
+
+        public Entry getJavaDoc() {
+            return getClassifiedEntry(CLASSIFIER_JAVADOC, EXT_JAR);
+        }
+
+        public Entry getBinary() {
+            return getClassifiedEntry(null, EXT_JAR);
+        }
+
+        public Entry getPom() {
+            return getClassifiedEntry(null, EXT_POM);
+        }
+
+        public Entry getClassifiedEntry(String classifier, String extension) {
+            String name = getModule() + "-" + getVersion() + (classifier != null ? "-" + classifier : "") + "." + extension;
+            if(entries.isEmpty() && Files.exists(path)) {
+                try {
+                    readEntries();
+                } catch (IOException ex) {}
+            }
+            return entries.get(name);
+        }
+
+        private void readEntries() throws IOException {
+            if (entries.size() != Files.list(getPath()).count()) {
+                entries.clear();
+                Files.walkFileTree(getPath(), new SimpleFileVisitor<Path>() {
+                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                        try {
+                            Entry entry = new Entry(file);
+                            entries.put(entry.getName(), entry);
+                        } catch(IllegalArgumentException ex) {
+                            // Ignore non-artifact files, highly unlikely to happen
+                        }
+                        return FileVisitResult.CONTINUE;
+                    }
+                });
+            }
+        }
+    }
+
+    GradleModuleFileCache21(Path gradleHome) {
+        this.cacheBaseDir = gradleHome.resolve(FILE_CACHE_BASE);
+    }
+
+    public boolean contains(Path path) {
+        return path.startsWith(cacheBaseDir);
+    }
+
+    public CachedArtifactVersion resolveCachedArtifactVersion(Path artifact) throws IllegalArgumentException {
+        return new CachedArtifactVersion(artifact.getParent().getParent());
+    }
+
+    public CachedArtifactVersion.Entry resolveEntry(Path artifact) throws IllegalArgumentException {
+        CachedArtifactVersion av = resolveCachedArtifactVersion(artifact);
+        return av.entries.get(artifact.getFileName().toString());
+    }
+
+    public CachedArtifactVersion resolveModule(String moduleId) throws IllegalArgumentException {
+        String[] gav = gavSplit(moduleId);
+        return  new CachedArtifactVersion(gav[0], gav[1], gav[2]);
+    }
+
+    public static GradleModuleFileCache21 getGradleFileCache(Path gradleHome) {
+        return new GradleModuleFileCache21(gradleHome);
+    }
+
+    public static GradleModuleFileCache21 getGradleFileCache() {
+        return getGradleFileCache(GradleSettings.getDefault().getGradleUserHome().toPath());
+    }
+
+    public static String[] gavSplit(String gav) {
+        int firstColon = gav.indexOf(':');
+        int lastColon = gav.lastIndexOf(':');
+        if (firstColon == -1 || firstColon == lastColon) {
+            throw new IllegalArgumentException("Invalig GAV format: " + gav);
+        }
+        return new String[] {
+            gav.substring(0, firstColon),
+            gav.substring(firstColon + 1, lastColon),
+            gav.substring(lastColon + 1)
+        };
+    }
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
@@ -88,6 +88,8 @@ public final class GradleProjectCache {
     private static AtomicLong timeInLoad = new AtomicLong();
     private static AtomicInteger loadedProjects = new AtomicInteger();
 
+    private static final boolean DEBUG_GRADLE_INFO_ACTION = Boolean.getBoolean("netbeans.debug.gradle.info.action"); //NOI18N
+
     private GradleProjectCache() {
     }
 
@@ -245,7 +247,10 @@ public final class GradleProjectCache {
     private static BuildActionExecuter<NbProjectInfo> createInfoAction(ProjectConnection pconn, GradleCommandLine cmd, CancellationToken token, ProgressListener pl) {
         BuildActionExecuter<NbProjectInfo> ret = pconn.action(new NbProjectInfoAction());
         cmd.configure(ret);
-
+        if (DEBUG_GRADLE_INFO_ACTION) {
+            // This would start the Gradle Daemon in Debug Mode, so the Tooling API can be debugged as well
+            ret.addJvmArguments("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006");
+        }
         if (token != null) {
             ret.withCancellationToken(token);
         }

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import org.netbeans.modules.gradle.GradleProjectCache;
 import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache.QualifiedProjectInfo;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
@@ -38,7 +39,7 @@ import org.netbeans.modules.gradle.spi.GradleFiles;
 public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, QualifiedProjectInfo> {
 
     // Increase this number if new info is gathered from the projects.
-    private static final int COMPATIBLE_CACHE_VERSION = 16;
+    private static final int COMPATIBLE_CACHE_VERSION = 17;
     private static final String INFO_CACHE_FILE_NAME = "project-info.ser"; //NOI18N
 
     public ProjectInfoDiskCache(GradleFiles gf) {
@@ -66,12 +67,14 @@ public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, Q
 
         private final Quality quality;
         private final Map<String, Object> info;
+        private transient final Map<String, Object> ext;
         private final Set<String> problems;
         private final String gradleException;
 
         public QualifiedProjectInfo(Quality quality, NbProjectInfo pinfo) {
             this.quality = quality;
-            info = new LinkedHashMap<>(pinfo.getInfo());
+            info = new TreeMap<>(pinfo.getInfo());
+            ext = new TreeMap<>(pinfo.getExt());
             problems = new LinkedHashSet<>(pinfo.getProblems());
             gradleException = pinfo.getGradleException();
         }
@@ -83,7 +86,7 @@ public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, Q
 
         @Override
         public Map<String, Object> getExt() {
-            return Collections.emptyMap();
+            return ext != null ? ext : Collections.emptyMap();
         }
 
         @Override

--- a/extide/gradle/src/org/netbeans/modules/gradle/nodes/ConfigurationsNode.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/nodes/ConfigurationsNode.java
@@ -148,7 +148,8 @@ public class ConfigurationsNode extends AbstractNode {
 
         @Override
         protected Node createNodeForKey(GradleConfiguration conf) {
-            AbstractNode ret = new AbstractNode(Children.create(new ConfigurationChildren(project, conf.getName()), true));
+            Children ch = conf.isEmpty() ? Children.LEAF : Children.create(new ConfigurationChildren(project, conf.getName()), true);
+            AbstractNode ret = new AbstractNode(ch);
             ret.setName(conf.getName());
             ret.setShortDescription(conf.getDescription());
             StringBuilder displayName = new StringBuilder(conf.getName());


### PR DESCRIPTION
Well, this one brings back the module dependencies under the configuration node in Gradle Projects.
Half of this PR allows the Gradle side of the tooling library debugged.
The GradleModuleFileCache21 is a bit odd ball here using NIO Path instead of File or File Objects, that might be reworked later, I just had it on hand from another project of mine.
Probably this PR finishes my Gradle work for 12.2.