### PR TITLE
Avoid conflicts with other Java extensions

### DIFF
--- a/java/java.lsp.server/vscode/README.md
+++ b/java/java.lsp.server/vscode/README.md
@@ -104,3 +104,10 @@ following locations:
 - current system path
 
 As soon as one of the settings is changed, the NbCode Java part is restarted.
+
+## Conflicts with other Java Extensions
+
+Apache NetBeans Language Server extension isn't the only Java supporting
+extension. To avoid duplicated code completion and other misleading clashes
+the extension disables certain functionality known to cause problems. This
+behavior can be disabled by setting `netbeans.conflict.check` setting to `false`.

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -36,10 +36,20 @@
 					"default": null,
 					"description": "Specifies JDK for the Apache NetBeans Language Server"
 				},
-                                "netbeans.verbose": {
-                                        "type": "boolean",
-                                        "default": false,
-                                        "description": "Enables verbose messages from the Apache NetBeans Language Server"
+				"netbeans.verbose": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enables verbose messages from the Apache NetBeans Language Server"
+				},
+				"netbeans.conflict.check" : {
+					"type" : "boolean",
+					"default" : true,
+					"description": "Avoid conflicts with other Java extensions"
+				},
+                                "java.test.editor.enableShortcuts": {
+                                    "type": "boolean",
+                                    "default": false,
+                                    "description": "Enable Run/Debug test in editor"
                                 }
 			}
 		},


### PR DESCRIPTION
Apache NetBeans Language Server extension isn't the only Java supporting
extension. To avoid duplicated code completion and other misleading clashes
the extension disables certain functionality known to cause problems. This
behavior can be disabled by setting `netbeans.conflict.check` setting to `false`.