### PR TITLE
Avoid registering the LSP client's hyperlink provider unless the given file is handled by the LSP client.

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/HyperlinkProviderImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/HyperlinkProviderImpl.java
@@ -77,7 +77,7 @@ public class HyperlinkProviderImpl implements HyperlinkProviderExt {
             }
             TokenSequence<?> ts = TokenHierarchy.get(doc).tokenSequence();
             if (ts == null) {
-                return null;
+                return ident;
             }
             ts.move(offset);
             if (ts.moveNext() && ts.token().id() == TextmateTokenId.TEXTMATE) {

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/TextDocumentSyncServerCapabilityHandler.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/TextDocumentSyncServerCapabilityHandler.java
@@ -131,7 +131,6 @@ public class TextDocumentSyncServerCapabilityHandler {
             return; //ignore
 
         openDocument2PanesCount.computeIfAbsent(doc, d -> {
-            doc.putProperty(HyperlinkProviderImpl.class, true);
             doc.putProperty(TextDocumentSyncServerCapabilityHandler.class, true);
             ensureDidOpenSent(doc);
             doc.addDocumentListener(new DocumentListener() { //XXX: listener
@@ -288,6 +287,8 @@ public class TextDocumentSyncServerCapabilityHandler {
                 //already opened:
                 return ;
             }
+
+            doc.putProperty(HyperlinkProviderImpl.class, true);
 
             String uri = Utils.toURI(file);
             String[] text = new String[1];


### PR DESCRIPTION
This is a tweak to:
https://github.com/apache/netbeans/pull/2483

The LSP client's hyperlink provider should ignore files that are not handled by the LSP client (for performance reasons, at least), this patch moves the flag at a more correct place. Sorry I didn't have time to look at 2483, and for trouble with this bug.