### PR TITLE
[NETBEANS-4535] Better way to detect sources and javadocs in Gradle Projects

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
@@ -156,11 +156,19 @@ class GradleBaseProjectBuilder implements ProjectInfoExtractor.Result {
         unresolvedProblems = unresolvedProblems != null ? unresolvedProblems : Collections.<String, String>emptyMap();
         Map<String, ModuleDependency> components = new HashMap<>();
         for (Map.Entry<String, Set<File>> entry : arts.entrySet()) {
-            ModuleDependency dep = new ModuleDependency(entry.getKey(), entry.getValue());
-
-            components.put(entry.getKey(), dep);
-            dep.sources = sources.get(entry.getKey());
-            dep.javadoc = javadocs.get(entry.getKey());
+            String componentId = entry.getKey();
+            // Looking at cache first as we might have the chance to find Sources and Javadocs
+            ModuleDependency dep = resolveModuleDependency(gradleUserHome, componentId);
+            if (!dep.getArtifacts().equals(entry.getValue())) {
+                dep = new ModuleDependency(componentId, entry.getValue());
+            }
+            components.put(componentId, dep);
+            if (sources.containsKey(componentId)) {
+                dep.sources = sources.get(entry.getKey());
+            }
+            if (javadocs.containsKey(componentId)) {
+                dep.javadoc = javadocs.get(entry.getKey());
+            }
         }
         Map<String, ProjectDependency> projects = new HashMap<>();
         for (Map.Entry<String, File> entry : prjs.entrySet()) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleProjects.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleProjects.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.modules.gradle.GradleModuleFileCache21;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 
 /**
@@ -45,7 +46,10 @@ public final class GradleProjects {
      * not available.
      */
     public static File getSources(File binary) {
-        return GradleArtifactStore.getDefault().getSources(binary);
+        GradleModuleFileCache21 cache = GradleModuleFileCache21.getGradleFileCache();
+        GradleModuleFileCache21.CachedArtifactVersion av = cache.resolveCachedArtifactVersion(binary.toPath());
+        GradleModuleFileCache21.CachedArtifactVersion.Entry sources = av != null ? av.getSources() : null;
+        return sources != null ? sources.getPath().toFile() : GradleArtifactStore.getDefault().getSources(binary);
     }
 
     /**
@@ -55,7 +59,10 @@ public final class GradleProjects {
      * not available.
      */
     public static File getJavadoc(File binary) {
-        return GradleArtifactStore.getDefault().getJavadoc(binary);
+        GradleModuleFileCache21 cache = GradleModuleFileCache21.getGradleFileCache();
+        GradleModuleFileCache21.CachedArtifactVersion av = cache.resolveCachedArtifactVersion(binary.toPath());
+        GradleModuleFileCache21.CachedArtifactVersion.Entry javadoc = av != null ? av.getJavaDoc() : null;
+        return javadoc != null ? javadoc.getPath().toFile() : GradleArtifactStore.getDefault().getJavadoc(binary);
     }
 
     /**
@@ -146,4 +153,5 @@ public final class GradleProjects {
             }
         }
     }
+
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/nodes/ConfigurationsNode.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/nodes/ConfigurationsNode.java
@@ -223,7 +223,6 @@ public class ConfigurationsNode extends AbstractNode {
         })
         @Override
         protected Node[] createNodesForKey(GradleDependency key) {
-            GradleProject gp = project.getGradleProject();
             ArrayList<Node> ret = new ArrayList<>(1);
             switch (key.getType()) {
                 case MODULE: {
@@ -234,7 +233,7 @@ public class ConfigurationsNode extends AbstractNode {
                         if (fo != null) {
                             try {
                                 DataObject dataObject = DataObject.find(fo);
-                                ret.add(new ModuleFilterNode(project, dep, artifact, dataObject.getNodeDelegate().cloneNode()));
+                                ret.add(new ModuleFilterNode(project, dep, dataObject));
                             } catch (DataObjectNotFoundException ex) {
                                 // Should not happen here
                             }
@@ -328,10 +327,10 @@ public class ConfigurationsNode extends AbstractNode {
 
         private final NbGradleProjectImpl project;
         private final GradleDependency.ModuleDependency module;
-        private final File mainJar;
+        private final DataObject mainJar;
 
-        public ModuleFilterNode(NbGradleProjectImpl project, GradleDependency.ModuleDependency module, File mainJar, Node original) {
-            super(original);
+        public ModuleFilterNode(NbGradleProjectImpl project, GradleDependency.ModuleDependency module, DataObject mainJar) {
+            super(mainJar.getNodeDelegate().cloneNode());
             this.project = project;
             this.module = module;
             this.mainJar = mainJar;
@@ -340,15 +339,14 @@ public class ConfigurationsNode extends AbstractNode {
 
         @Override
         public Action[] getActions(boolean context) {
-            GradleArtifactStore store = GradleArtifactStore.getDefault();
             List<Action> actions = new ArrayList<>(3);
-            actions.add(new OpenJavadocAction(FileUtil.toFileObject(mainJar)));
-            if (store.getSources(mainJar) == null) {
+            actions.add(new OpenJavadocAction(mainJar.getPrimaryFile()));
+            if (module.getSources().isEmpty()) {
                 Action download = ActionProviderImpl.createCustomGradleAction(project, "Download Sources",
                         ActionProviderImpl.COMMAND_DL_SOURCES, Lookups.singleton(RunUtils.simpleReplaceTokenProvider(REQUESTED_COMPONENT, module.getId())));
                 actions.add(download);
             }
-            if (store.getJavadoc(mainJar) == null) {
+            if (module.getJavadoc().isEmpty()) {
                 Action download = ActionProviderImpl.createCustomGradleAction(project, "Download Javadoc",
                         ActionProviderImpl.COMMAND_DL_JAVADOC, Lookups.singleton(RunUtils.simpleReplaceTokenProvider(REQUESTED_COMPONENT, module.getId())));
                 actions.add(download);
@@ -365,24 +363,27 @@ public class ConfigurationsNode extends AbstractNode {
         public String getShortDescription() {
             StringBuilder sb = new StringBuilder("<html>");
             sb.append("Artifact Id: <b>").append(module.getId()).append("</b><br/>");
-            sb.append("File: ").append(mainJar.getAbsolutePath());
+            sb.append("File: ").append(mainJar.getPrimaryFile().getPath());
             return sb.toString();
         }
 
         @Override
         public String getDisplayName() {
-            return module.getVersion().isEmpty() ? module.getName() : module.getName() + ":" + module.getVersion();
+            String prefix = module.getName() + "-" + module.getVersion() + "-"; //NOI18N
+            String mainJarName = mainJar.getPrimaryFile().getName();
+            String postfix = mainJarName.startsWith(prefix) ? mainJarName.substring(prefix.length()) : null;
+            String moduleName = module.getVersion().isEmpty() ? module.getName() : module.getName() + ":" + module.getVersion(); //NOI18N
+            return postfix != null ? moduleName + " [" + postfix + "]" : moduleName; //NOI18N
         }
 
         @Override
         public Image getIcon(int type) {
-            GradleArtifactStore store = GradleArtifactStore.getDefault();
             Image ret = ImageUtilities.loadImage(ARTIFACT_ICON);
-            if (store.getJavadoc(mainJar) != null) {
+            if (!module.getSources().isEmpty()) {
                 Image javadoc = ImageUtilities.loadImage(JAVADOC_BADGE);
                 ret = ImageUtilities.mergeImages(ret, javadoc, 0, 8);
             }
-            if (store.getSources(mainJar) != null) {
+            if (!module.getJavadoc().isEmpty()) {
                 Image sources = ImageUtilities.loadImage(SOURCES_BADGE);
                 ret = ImageUtilities.mergeImages(ret, sources, 8, 8);
             }


### PR DESCRIPTION
Just to utilize the GradleModuleFileCache21 a bit more, added some code which help find the sources and javadocs more reliably.
This fixes the issue with not finding those artifacts on JavaFx projects.