### PR TITLE
[NETBEANS-4970] Incorrect formatting for lambda functions

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -1575,6 +1575,7 @@ public class FormatVisitor extends DefaultVisitor {
 
         boolean addIndent = !isAnonymousClass(node.getExpression())
                 && !(path.size() > 2 && path.get(2) instanceof LambdaFunctionDeclaration) // #259111
+                && !(node.getExpression() instanceof LambdaFunctionDeclaration) // NETBEANS-4970
                 && !(node.getExpression() instanceof MatchExpression);
 
         if (ts.token().id() == PHPTokenId.PHP_RETURN) {

--- a/php/php.editor/test/unit/data/testfiles/formatting/netbeans4970.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/netbeans4970.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+function test(): callable {
+    return function ($test): void {
+        echo "test";
+    };
+}
+
+function test2(): callable {
+return function ($test): void {
+echo "test";
+};
+}

--- a/php/php.editor/test/unit/data/testfiles/formatting/netbeans4970.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/netbeans4970.php.formatted
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+function test(): callable {
+    return function ($test): void {
+        echo "test";
+    };
+}
+
+function test2(): callable {
+    return function ($test): void {
+        echo "test";
+    };
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterTest.java
@@ -883,4 +883,9 @@ public class PHPFormatterTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/php80/matchExpression_SameLine_02.php", options);
     }
 
+    public void testNetBeans4970() throws Exception {
+        HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
+        reformatFileContents("testfiles/formatting/netbeans4970.php", options);
+    }
+
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4970

Before:
```php
<?php

function test(): callable {
    return function ($test): void {
                echo "test";
            };
}
```

After
```php
<?php

function test(): callable {
    return function ($test): void {
        echo "test";
    };
}
```