### PR TITLE
[NETBEANS-4901] Remove the `--progressbar` option

### DIFF
--- a/php/php.phpdoc/src/org/netbeans/modules/php/phpdoc/PhpDocScript.java
+++ b/php/php.phpdoc/src/org/netbeans/modules/php/phpdoc/PhpDocScript.java
@@ -151,7 +151,7 @@ public final class PhpDocScript {
                 "run", // NOI18N
                 // params
                 "--ansi", // NOI18N
-                "--progressbar", // NOI18N
+                // "--progressbar" doesn't exist since PHPDocumentor 3
                 // from
                 "--directory", // NOI18N
                 sanitizePath(FileUtil.toFile(phpModule.getSourceDirectory()).getAbsolutePath()),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4901

- PHPDocumentor 3 doesn't have this option

```
Options:
  -t, --target[=TARGET]                          Path where to store the generated output
      --cache-folder[=CACHE-FOLDER]              Path where to store the cache files
  -f, --filename[=FILENAME]                      File to parse, glob patterns are supported. Provide multiple options of this type to add
                                                 multiple files. (multiple values allowed)
  -d, --directory[=DIRECTORY]                    directory to parse, glob patterns are supported. Provide multiple options of this type to add
                                                 multiple directories. (multiple values allowed)
      --encoding[=ENCODING]                      encoding to be used to interpret source files with
      --extensions[=EXTENSIONS]                  Provide multiple options of this type to add multiple extensions. default is php (multiple values allowed)
  -i, --ignore[=IGNORE]                          File(s) and directories (relative to the source-code directory) that will be ignored. Glob patterns are supported. Add multiple options of this type of add more ignore patterns (multiple values allowed)
      --ignore-tags[=IGNORE-TAGS]                Tag that will be ignored, defaults to none. package, subpackage and ignore may not be ignored. Add multiple options of this type to ignore multiple tags. (multiple values allowed)
      --hidden                                   Use this option to tell phpDocumentor to parse files and directories that begin with a period (.), by default these are ignored
      --ignore-symlinks                          Ignore symlinks to other files or directories, default is on
  -m, --markers[=MARKERS]                        Comma-separated list of markers/tags to filter (multiple values allowed)
      --title[=TITLE]                            Sets the title for this project; default is the phpDocumentor logo
      --force                                    Forces a full build of the documentation, does not increment existing documentation
      --validate                                 Validates every processed file using PHP Lint, costs a lot of performance
      --visibility[=VISIBILITY]                  Specifies the parse visibility that should be displayed in the documentation. Add multiple options of
                                                 this type to specify multiple levels.("public,protected") (multiple values allowed)
      --defaultpackagename[=DEFAULTPACKAGENAME]  Name to use for the default package. [default: "Default"]
      --sourcecode                               Whether to include syntax highlighted source code
      --template[=TEMPLATE]                      Name of the template to use (optional) (multiple values allowed)
      --examples-dir[=EXAMPLES-DIR]              Directory to seacher for example files referenced by @example tags
  -s, --setting[=SETTING]                        Provide custom setting(s) as "key=value", run again with --list-settings for a list (multiple values allowed)
      --list-settings                            Returns a list of available settings
      --parseprivate                             Whether to parse DocBlocks marked with @internal tag
  -h, --help                                     Display this help message
  -q, --quiet                                    Do not output any message
  -V, --version                                  Display this application version
      --ansi                                     Force ANSI output
      --no-ansi                                  Disable ANSI output
  -n, --no-interaction                           Do not ask any interactive question
  -c, --config[=CONFIG]                          Location of a custom configuration file
      --log[=LOG]                                Log file to write to
  -e, --env=ENV                                  The Environment name. [default: "prod"]
      --no-debug                                 Switches off debug mode.
  -v|vv|vvv, --verbose                           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

```

## version 2.9.1
with `--progresbar`
```
"/usr/bin/php" "/home/junichi11/phars/phpDocumentor-2.9.1.phar" "run" "--ansi" "--progressbar" "--directory" "/home/junichi11/NetBeansProjects/01_PHP/PHPDocumentor" "--target" "/home/junichi11/NetBeansProjects/01_PHP/PHPDocumentor/test" "--title" "PHPDocumentor"
Collecting files .. OK
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967

 1/2 [==============>-------------]  50%
 2/2 [============================] 100%

  1/17 [=>--------------------------]   5%
  2/17 [===>------------------------]  11%
  3/17 [====>-----------------------]  17%
  4/17 [======>---------------------]  23%
  5/17 [========>-------------------]  29%Initializing parser .. OK
Parsing files
Storing cache in "/home/junichi11/NetBeansProjects/01_PHP/PHPDocumentor/test" .. OK
Load cache                                                         ..    0.000s
Preparing template "clean"                                         ..    0.002s
Preparing 17 transformations                                       ..    0.000s
Build "elements" index                                             ..    0.000s
Replace textual FQCNs with object aliases                          ..    0.000s
Resolve @link and @see tags in descriptions                        ..    0.000s
Enriches inline example tags with their sources                    ..    0.000s
Build "packages" index                                             ..    0.000s
Build "namespaces" index and add namespaces to "elements"          ..    0.000s
Collect all markers embedded in tags                               ..    0.000s
Transform analyzed project into artifacts                          .. 
  6/17 [=========>------------------]  35%
  7/17 [===========>----------------]  41%PHP Warning:  count(): Parameter must be an array or an object that implements Countable in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/twig/twig/lib/Twig/Extension/Core.php on line 1275
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/twig/twig/lib/Twig/Extension/Core.php on line 1275
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/twig/twig/lib/Twig/Extension/Core.php on line 1275
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/twig/twig/lib/Twig/Extension/Core.php on line 1275

  8/17 [=============>--------------]  47%
  9/17 [==============>-------------]  52%
 10/17 [================>-----------]  58%
 11/17 [==================>---------]  64%
 12/17 [===================>--------]  70%
 13/17 [=====================>------]  76%
 14/17 [=======================>----]  82%
 15/17 [========================>---]  88%
 16/17 [==========================>-]  94%
 17/17 [============================] 100%
Unable to find the `dot` command of the GraphViz package. Is GraphViz correctly installed and present in your path?   0.026s
Analyze results and write report to log                            ..    0.000s
Done.
```

without `--progressbar`
```
"/usr/bin/php" "/home/junichi11/phars/phpDocumentor-2.9.1.phar" "run" "--ansi" "--directory" "/home/junichi11/NetBeansProjects/01_PHP/PHPDocumentor" "--target" "/home/junichi11/NetBeansProjects/01_PHP/PHPDocumentor/test" "--title" "PHPDocumentor"
Collecting files .. OK
Initializing parser .. OK
Parsing files
Parsing /home/junichi11/NetBeansProjects/01_PHP/PHPDocumentor/index.php
Parsing /home/junichi11/NetBeansProjects/01_PHP/PHPDocumentor/src/test.php
Storing cache in "/home/junichi11/NetBeansProjects/01_PHP/PHPDocumentor/test" .. OK
Load cache                                                         ..    0.000s
Preparing template "clean"                                         ..    0.002s
Preparing 17 transformations                                       ..    0.000s
Build "elements" index                                             ..    0.000s
Replace textual FQCNs with object aliases                          ..    0.000s
Resolve @link and @see tags in descriptions                        ..    0.000s
Enriches inline example tags with their sources                    ..    0.000s
Build "packages" index                                             ..    0.000s
Build "namespaces" index and add namespaces to "elements"          ..    0.000s
Collect all markers embedded in tags                               ..    0.000s
Transform analyzed project into artifacts                          .. 
Applying 17 transformations
  Initialize writer "phpDocumentor\Plugin\Core\Transformer\Writer\FileIo"
  Initialize writer "phpDocumentor\Plugin\Twig\Writer\Twig"
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
PHP Notice:  Trying to access array offset on value of type null in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php on line 967
  Initialize writer "phpDocumentor\Plugin\Graphs\Writer\Graph"
  Execute transformation using writer "FileIo"
  Execute transformation using writer "FileIo"
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/twig/twig/lib/Twig/Extension/Core.php on line 1275
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/twig/twig/lib/Twig/Extension/Core.php on line 1275
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/twig/twig/lib/Twig/Extension/Core.php on line 1275
PHP Warning:  count(): Parameter must be an array or an object that implements Countable in phar:///home/junichi11/phars/phpDocumentor-2.9.1.phar/vendor/twig/twig/lib/Twig/Extension/Core.php on line 1275
  Execute transformation using writer "FileIo"
  Execute transformation using writer "FileIo"
  Execute transformation using writer "FileIo"
  Execute transformation using writer "twig"
  Execute transformation using writer "twig"
  Execute transformation using writer "twig"
  Execute transformation using writer "twig"
  Execute transformation using writer "twig"
  Execute transformation using writer "twig"
  Execute transformation using writer "twig"
  Execute transformation using writer "twig"
  Execute transformation using writer "twig"
  Execute transformation using writer "twig"
  Execute transformation using writer "twig"
  Execute transformation using writer "Graph"
Unable to find the `dot` command of the GraphViz package. Is GraphViz correctly installed and present in your path?   0.033s
Analyze results and write report to log                            ..    0.000s
Done.

```

## version 3.0.0

```
version 3.0.0
"/usr/bin/php" "/home/junichi11/phars/phpDocumentor.phar" "run" "--ansi" "--directory" "/home/junichi11/NetBeansProjects/01_PHP/PHPDocumentor" "--target" "/home/junichi11/NetBeansProjects/01_PHP/PHPDocumentor/test" "--title" "PHPDocumentor"
phpDocumentor v3.0.0
 2/2 [============================] 100%  1/19 [=>--------------------------]   5%
Parsing files

Applying transformations (can take a while)
 19/19 [============================] 100%
All done in 0 seconds!
Done.
```