### PR TITLE
[NETBEANS-4646] Fix completionInvoke hint in code templates

### DIFF
--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateParameterImpl.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateParameterImpl.java
@@ -78,6 +78,7 @@ public final class CodeTemplateParameterImpl {
     
     private boolean userModified;
 
+    private boolean completionInvoke;
 
     CodeTemplateParameterImpl(CodeTemplateInsertHandler handler,
     String parametrizedText, int parametrizedTextOffset) {
@@ -143,6 +144,10 @@ public final class CodeTemplateParameterImpl {
     
     public boolean isUserModified() {
         return userModified;
+    }
+    
+    boolean isCompletionInvoke() {
+        return completionInvoke;
     }
     
     void markUserModified() {
@@ -344,6 +349,9 @@ public final class CodeTemplateParameterImpl {
             defaultValue = name;
         }
         value = defaultValue;
+        
+        String completionInvokeHint = getHints().get(CodeTemplateParameter.COMPLETION_INVOKE_HINT_NAME);
+        completionInvoke = Boolean.parseBoolean(completionInvokeHint);
         
         if (name.equals(CodeTemplateParameter.CURSOR_PARAMETER_NAME)
                 || name.equals(CodeTemplateParameter.NO_FORMAT_PARAMETER_NAME)

--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegionManagerEvent.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextRegionManagerEvent.java
@@ -63,4 +63,15 @@ public final class TextRegionManagerEvent extends EventObject {
         return previousTextSync;
     }
 
+    /**
+     * Returns text sync for which the document modifications are being replicated across the respective regions.
+     * 
+     * @return active text sync, can be {@code null}.
+     * 
+     * @since 1.53
+     */
+    public TextSync activeTextSync() {
+        return textRegionManager().activeTextSync();
+    }
+
 }

--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextSync.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/textsync/TextSync.java
@@ -35,6 +35,7 @@ public final class TextSync {
     
     private static int EDITABLE_FLAG = 1;
     private static int CARET_MARKER_FLAG = 2;
+    private static int COMPLETION_INVOKE_FLAG = 4;
 
     private TextSyncGroup<?> textSyncGroup;
     
@@ -138,6 +139,32 @@ public final class TextSync {
             flags |= CARET_MARKER_FLAG;
         else
             flags &= ~CARET_MARKER_FLAG;
+    }
+
+    /**
+     * Returns whether the code completion should be invoked when this text sync becomes active.
+     * 
+     * @return  {@code true} if the code completion should be invoked, {@code false} otherwise.
+     * 
+     * @since 1.53
+     */
+    public boolean isCompletionInvoke() {
+        return (flags & COMPLETION_INVOKE_FLAG) != 0;
+    }
+
+    /**
+     * Sets whether the code completion should be invoked when this text sync becomes active.
+     * 
+     * @param completionInvoke determines whether the code completion should be invoked.
+     * 
+     * @since 1.53
+     */
+    public void setCompletionInvoke(boolean completionInvoke) {
+        if (completionInvoke) {
+            flags |= COMPLETION_INVOKE_FLAG;
+        } else {
+            flags &= ~COMPLETION_INVOKE_FLAG;
+        }
     }
 
     public void addRegion(TextRegion<?> region) {

--- a/ide/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CodeTemplateInsertHandlerTest.java
+++ b/ide/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CodeTemplateInsertHandlerTest.java
@@ -19,17 +19,42 @@
 package org.netbeans.lib.editor.codetemplates;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.Document;
 import org.junit.Test;
-import static org.junit.Assert.*;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.lib.editor.codetemplates.api.CodeTemplate;
+import org.netbeans.lib.editor.codetemplates.api.CodeTemplateManager;
 import org.netbeans.lib.editor.codetemplates.spi.CodeTemplateParameter;
+import org.netbeans.lib.editor.codetemplates.storage.CodeTemplateSettingsImpl;
+import org.netbeans.modules.editor.NbEditorKit;
 
 /**
  *
  * @author markiewb
  */
-public class CodeTemplateInsertHandlerTest {
+public class CodeTemplateInsertHandlerTest  extends NbTestCase {
+    
+    private CodeTemplateInsertHandler handler;
+    private CodeTemplateManager manager;
+    private JEditorPane editor;
 
+    public CodeTemplateInsertHandlerTest(String testName) {
+        super(testName);
+    }
+    
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        editor = new JEditorPane();
+        SwingUtilities.invokeAndWait(() -> editor.setEditorKit(new NbEditorKit()));
+        Document document = editor.getDocument();
+        manager = CodeTemplateManager.get(document);
+    }
+    
     @Test
     public void testPrioritizeParameters() {
         CodeTemplateSpiPackageAccessor get = CodeTemplateSpiPackageAccessor.get();
@@ -41,4 +66,24 @@ public class CodeTemplateInsertHandlerTest {
         assertEquals(Arrays.asList(paramC, paramB, paramA), prioritizeParameters);
     }
 
+    @Test
+    public void test_WhenActiveTextRegionHasCompletionInvokeHint_ThenInvokeCodeCompletion() {
+        CodeTemplate codeTemplate = manager.createTemporary("${param completionInvoke}");
+        handler = new CodeTemplateInsertHandler(
+                codeTemplate, editor, Collections.emptyList(), CodeTemplateSettingsImpl.OnExpandAction.FORMAT);
+        assertFalse(handler.isCompletionInvoked());
+        handler.insertTemplate();
+        assertTrue(handler.isCompletionInvoked());
+    }
+    
+    @Test
+    public void test_WhenActiveTextRegionHasNoCompletionInvokeHint_ThenDoNotInvokeCodeCompletion() {
+        CodeTemplate codeTemplate = manager.createTemporary("${param default=\"\"}");
+        handler = new CodeTemplateInsertHandler(
+                codeTemplate, editor, Collections.emptyList(), CodeTemplateSettingsImpl.OnExpandAction.FORMAT);
+        assertFalse(handler.isCompletionInvoked());
+        handler.insertTemplate();
+        assertFalse(handler.isCompletionInvoked());
+    }
+    
 }

--- a/ide/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CodeTemplateParameterImplTest.java
+++ b/ide/editor.codetemplates/test/unit/src/org/netbeans/lib/editor/codetemplates/CodeTemplateParameterImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.lib.editor.codetemplates;
+
+import java.util.Collections;
+import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.Document;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.lib.editor.codetemplates.api.CodeTemplate;
+import org.netbeans.lib.editor.codetemplates.api.CodeTemplateManager;
+import org.netbeans.lib.editor.codetemplates.storage.CodeTemplateSettingsImpl;
+import org.netbeans.modules.editor.NbEditorKit;
+
+/**
+ *
+ * @author: Arthur Sadykov
+ */
+public class CodeTemplateParameterImplTest extends NbTestCase {
+
+    private CodeTemplateInsertHandler handler;
+
+    public CodeTemplateParameterImplTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    public void setUp() throws Exception  {
+        JEditorPane editor = new JEditorPane();
+        SwingUtilities.invokeAndWait(() -> editor.setEditorKit(new NbEditorKit()));
+        Document document = editor.getDocument();
+        CodeTemplateManager manager = CodeTemplateManager.get(document);
+        CodeTemplate codeTemplate = manager.createTemporary("${param}");
+        handler = new CodeTemplateInsertHandler(
+                codeTemplate, editor, Collections.emptyList(), CodeTemplateSettingsImpl.OnExpandAction.FORMAT);
+    }
+
+    public void test_WhenParameterNotContainsCompletionInvokeHint_ThenCompletionInvokeFieldMustBeSetToFalse() {
+        assertCompletionInvokeFieldIsSetToFalse("${param editable=true default=\"name\"}");
+    }
+
+    public void test_WhenParameterContainsCompletionInvokeHintSetToTrue_ThenCompletionInvokeFieldMustBeSetToTrue() {
+        assertCompletionInvokeFieldIsSetToTrue("${param editable=true completionInvoke}");
+        assertCompletionInvokeFieldIsSetToTrue("${param editable=true completionInvoke=true default=\"name\"}");
+    }
+
+    public void test_WhenParameterContainsCompletionInvokeHintSetToFalse_ThenCompletionInvokeFieldMustBeSetToFalse() {
+        assertCompletionInvokeFieldIsSetToFalse("${param editable=false completionInvoke=false}");
+        assertCompletionInvokeFieldIsSetToFalse("${param editable=true completionInvoke=\"maybe\" default=\"name\"}");
+    }
+
+    private void assertCompletionInvokeFieldIsSetToTrue(String parametrizedText) {
+        CodeTemplateParameterImpl parameterImpl = new CodeTemplateParameterImpl(handler, parametrizedText, 0);
+        assertTrue("Parameter must have completionInvoke hint set to true", parameterImpl.isCompletionInvoke());
+    }
+
+    private void assertCompletionInvokeFieldIsSetToFalse(String parametrizedText) {
+        CodeTemplateParameterImpl parameterImpl = new CodeTemplateParameterImpl(handler, parametrizedText, 0);
+        assertFalse("Parameter must have completionInvoke hint set to false", parameterImpl.isCompletionInvoke());
+    }
+}

--- a/php/php.phpdoc/src/org/netbeans/modules/php/phpdoc/PhpDocScript.java
+++ b/php/php.phpdoc/src/org/netbeans/modules/php/phpdoc/PhpDocScript.java
@@ -151,7 +151,7 @@ public final class PhpDocScript {
                 "run", // NOI18N
                 // params
                 "--ansi", // NOI18N
-                "--progressbar", // NOI18N
+                // "--progressbar" doesn't exist since PHPDocumentor 3
                 // from
                 "--directory", // NOI18N
                 sanitizePath(FileUtil.toFile(phpModule.getSourceDirectory()).getAbsolutePath()),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4646

Before:

![completion-invoke-hint-before](https://user-images.githubusercontent.com/64587659/97749375-c5fc3900-1b10-11eb-9294-fe9b304299a1.gif)

After:

![completion-invoke-hint-after](https://user-images.githubusercontent.com/64587659/97749450-e9bf7f00-1b10-11eb-88bc-635de8ffb796.gif)
