### PR TITLE
[NETBEANS-1972] Initial Groovy Support Module for Gradle

### DIFF
--- a/groovy/gradle.groovy/build.xml
+++ b/groovy/gradle.groovy/build.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project basedir="." default="build" name="groovy/gradle.groovy">
+    <description>Builds, tests, and runs the project org.netbeans.modules.gradle.groovy</description>
+    <import file="../../nbbuild/templates/projectized.xml"/>
+</project>

--- a/groovy/gradle.groovy/manifest.mf
+++ b/groovy/gradle.groovy/manifest.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+AutoUpdate-Show-In-Client: false
+OpenIDE-Module: org.netbeans.modules.gradle.groovy
+OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/groovy/Bundle.properties
+OpenIDE-Module-Specification-Version: 1.0
+

--- a/groovy/gradle.groovy/nbproject/project.properties
+++ b/groovy/gradle.groovy/nbproject/project.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+javac.source=1.8
+javac.compilerargs=-Xlint -Xlint:-serial
+is.eager=true

--- a/groovy/gradle.groovy/nbproject/project.xml
+++ b/groovy/gradle.groovy/nbproject/project.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.apisupport.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/nb-module-project/3">
+            <code-name-base>org.netbeans.modules.gradle.groovy</code-name-base>
+            <module-dependencies>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.gradle</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>2.6</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.groovy.support</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.31</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.projectapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.41</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.projectuiapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.78</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.projectuiapi.base</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.78</specification-version>
+                    </run-dependency>
+                </dependency>
+            </module-dependencies>
+            <public-packages/>
+        </data>
+    </configuration>
+</project>

--- a/groovy/gradle.groovy/src/org/netbeans/modules/gradle/groovy/Bundle.properties
+++ b/groovy/gradle.groovy/src/org/netbeans/modules/gradle/groovy/Bundle.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+OpenIDE-Module-Name=Gradle Groovy

--- a/groovy/gradle.groovy/src/org/netbeans/modules/gradle/groovy/RecommendedPrivilegedTemplatesImpl.java
+++ b/groovy/gradle.groovy/src/org/netbeans/modules/gradle/groovy/RecommendedPrivilegedTemplatesImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.groovy;
+
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.netbeans.spi.project.ui.PrivilegedTemplates;
+import org.netbeans.spi.project.ui.RecommendedTemplates;
+
+/**
+ *
+ * @author lkishalmi
+ */
+@ProjectServiceProvider(service = {RecommendedTemplates.class, PrivilegedTemplates.class}, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/groovy-base")
+public class RecommendedPrivilegedTemplatesImpl  implements RecommendedTemplates, PrivilegedTemplates {
+
+    // List of primarily supported templates categories
+    private static final String[] TYPES = new String[] {
+        "groovy"
+    };
+
+    private static final String[] TEMPLATES = new String[] {
+        "Templates/Groovy/GroovyClass.groovy",
+        "Templates/Groovy/GroovyTrait.groovy"
+    };
+
+    @Override
+    public String[] getRecommendedTypes() {
+        return TYPES;
+    }
+
+    @Override
+    public String[] getPrivilegedTemplates() {
+        return TEMPLATES;
+    }
+}

--- a/groovy/groovy.support/nbproject/project.xml
+++ b/groovy/groovy.support/nbproject/project.xml
@@ -422,6 +422,7 @@
                 </test-type>
             </test-dependencies>
             <friend-packages>
+                <friend>org.netbeans.modules.gradle.groovy</friend>
                 <friend>org.netbeans.modules.groovy.antproject</friend>
                 <friend>org.netbeans.modules.groovy.editor</friend>
                 <friend>org.netbeans.modules.groovy.grails</friend>

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -1011,6 +1011,7 @@ nb.cluster.groovy.depends=\
         nb.cluster.java,\
         nb.cluster.enterprise
 nb.cluster.groovy=\
+        gradle.groovy,\
         groovy.antproject,\
         groovy.editor,\
         groovy.gsp,\


### PR DESCRIPTION
This one is just laying some groundwork for upcoming changes.
@JaroslavTulach I marked this one as eager load and this is not a dependee of the Groovy Kit. Is that Ok? The Maven Groovy support is a regular module and Groovy Kit depends on it.
@svenreimers would it be Ok to make Groovy Support module to public, or shall we live with the friend dependencies.