### PR TITLE
[NETBEANS-4469] Fix NoSuchFieldError from refactorings on JCInstanceOf.clazz which was renamed

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
@@ -5895,7 +5895,7 @@ public class CasualDiff {
     }
 
     private boolean matchTypeTest(JCInstanceOf t1, JCInstanceOf t2) {
-        return treesMatch(t1.clazz, t2.clazz) && treesMatch(t1.expr, t2.expr);
+        return treesMatch(getPattern(t1), getPattern(t2)) && treesMatch(t1.expr, t2.expr);
     }
 
     private boolean matchIndexed(JCArrayAccess t1, JCArrayAccess t2) {


### PR DESCRIPTION
The field name of `JCInstanceOf.clazz` was changed to `JCInstanceOf.pattern` in late 2019 in the JDK sources of javac.

CasualDiff.java  already contains a method to look up the correct field via reflection, but
one case of directly referencing the original field was not changed, and causes a
NoSuchFieldError in the move inner to outer level refactoring (and likely elsewhere).