### PR TITLE
[INFRA-21017] Apache marketplace publisher is asf.

### DIFF
--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -9,7 +9,7 @@
 		"type": "git",
 		"url": "https://github.com/apache/netbeans"
 	},
-	"publisher": "jlahoda",
+	"publisher": "asf",
 	"categories": [],
 	"keywords": [
 		"multi-root ready"


### PR DESCRIPTION
@gmcdonald wrote in [INFRA-21017](https://issues.apache.org/jira/browse/INFRA-21017) that the Apache Software Foundation is going to own [Marketplace](https://marketplace.visualstudio.com) publisher named `asf`. Updating the record in `package.json`.