### PR TITLE
Ensure document state is consistent after unnamed is saved.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1014,22 +1014,19 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
             Document doc = ec.getDocument();
             // the document may be not opened yet. Clash with in-memory content can happen only if
             // the doc was opened prior to request reception.
-            if (doc != null) {
-                String text = params.getTextDocument().getText();
-                try {
-                    // could be faster with CharSequence, but requires a dependency on
-                    // org.netbeans.modules.editor.util
-                    if (!text.contentEquals(doc.getText(0, doc.getLength()))) {
-                        doc.remove(0, doc.getLength());
-                        doc.insertString(0, text, null);
-                    }
-                } catch (BadLocationException ex) {
-                    Exceptions.printStackTrace(ex);
-                    //TODO: include stack trace:
-                    client.logMessage(new MessageParams(MessageType.Error, ex.getMessage()));
+            String text = params.getTextDocument().getText();
+            try {
+                if (doc == null) {
+                    doc = ec.openDocument();
                 }
-            } else {
-                doc = ec.openDocument();
+                if (!text.contentEquals(doc.getText(0, doc.getLength()))) {
+                    doc.remove(0, doc.getLength());
+                    doc.insertString(0, text, null);
+                }
+            } catch (BadLocationException ex) {
+                Exceptions.printStackTrace(ex);
+                //TODO: include stack trace:
+                client.logMessage(new MessageParams(MessageType.Error, ex.getMessage()));
             }
             openedDocuments.put(params.getTextDocument().getUri(), doc);
             runDiagnoticTasks(params.getTextDocument().getUri());

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.swing.text.Document;
 import javax.swing.text.StyledDocument;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
@@ -277,6 +278,7 @@ public class ServerTest extends NbTestCase {
     private class OpenCloseHook {
         private Semaphore didOpenCompleted = new Semaphore(0);
         private Semaphore didCloseCompleted = new Semaphore(0);
+        private Semaphore didChangeCompleted = new Semaphore(0);
         
         public void accept(String n, Object params){
             switch (n) {
@@ -286,9 +288,23 @@ public class ServerTest extends NbTestCase {
                 case "didClose":
                     didCloseCompleted.release();
                     break;
+                case "didChange":
+                    didChangeCompleted.release();
+                    break;
             }
         }
     }
+    
+    private static final String SAMPLE_CODE = 
+                "public class Test \n"
+                + "{ \n"
+                + "  int i = \"\".hashCode();\n"
+                + "  public void run() {\n"
+                + "    this.test(); \n"
+                + "  }\n\n"
+                + "  /**Test.*/public void test() {\n"
+                + "  }\n"
+                + "}";
     
     /**
      * Checks that opening the document preserves lines. This is necessary for breakpoints
@@ -306,16 +322,7 @@ public class ServerTest extends NbTestCase {
         File src2 = new File(getWorkDir(), "Test2.java");
         File src3 = new File(getWorkDir(), "Test3.java");
         src.getParentFile().mkdirs();
-        String code = 
-                "public class Test \n"
-                + "{ \n"
-                + "  int i = \"\".hashCode();\n"
-                + "  public void run() {\n"
-                + "    this.test(); \n"
-                + "  }\n\n"
-                + "  /**Test.*/public void test() {\n"
-                + "  }\n"
-                + "}";
+        String code = SAMPLE_CODE;
         String code2 = code.replace("Test", "Test2");
         String code3 = code.replace("Test", "Test3");
         try (Writer w = new FileWriter(src)) {
@@ -408,6 +415,53 @@ public class ServerTest extends NbTestCase {
         nl3 = NbDocument.findLineNumber(d, p3.getOffset());
         assertEquals(line3, lineObject3.getLineNumber());
         assertEquals(line3, nl3);
+    }
+    
+    /**
+     * Simulates Ctrl-N ve VScode plus paste of initial content, then save. According to the
+     * report, DidOpen will come with an empty forced initial content. The DidChange comes that will
+     * inject the pasted content. 
+     * @throws Exception 
+     */
+    public void testSimulateNewUnnamedFile() throws Exception {
+        File src = new File(getWorkDir(), "Test.java");
+        
+        String code = SAMPLE_CODE;
+        // write in an initial code on the disk
+        try (Writer w = new FileWriter(src)) {
+            w.write(code);
+        }
+        
+        FileObject f1 = FileUtil.toFileObject(src);
+        OpenCloseHook hook = new OpenCloseHook();
+        TextDocumentServiceImpl.HOOK_NOTIFICATION = hook::accept;
+
+        Launcher<LanguageServer> serverLauncher = LSPLauncher.createClientLauncher(new LspClient(), client.getInputStream(), client.getOutputStream());
+        serverLauncher.startListening();
+        LanguageServer server = serverLauncher.getRemoteProxy();
+        InitializeResult result = server.initialize(new InitializeParams()).get();
+        
+        // open with empty initial content.
+        String uriString = src.toURI().toString();
+        server.getTextDocumentService().didOpen(
+                new DidOpenTextDocumentParams(new TextDocumentItem(uriString, "java", 0, ""))
+        );
+        
+        EditorCookie cake = f1.getLookup().lookup(EditorCookie.class);
+        assertTrue(hook.didOpenCompleted.tryAcquire(400, TimeUnit.MILLISECONDS));
+        
+        VersionedTextDocumentIdentifier id = new VersionedTextDocumentIdentifier(uriString, 1);
+        server.getTextDocumentService().didChange(new DidChangeTextDocumentParams(
+                id, Arrays.asList(
+                    new TextDocumentContentChangeEvent(new Range(new Position(0, 0), new Position(0, 0)), 0, code)
+                )
+        ));
+        
+        assertTrue(hook.didChangeCompleted.tryAcquire(400, TimeUnit.MILLISECONDS));
+        
+        Document doc = cake.openDocument();
+        assertEquals(code, doc.getText(0, doc.getLength()));
+        
     }
     
     public void testCodeActionWithRemoval() throws Exception {


### PR DESCRIPTION
In a scenario when the user initially presses `CTRL-N` in VS Code, then saves a file with some contents, a sequence `didOpen`, `didChange` is fired that requires the server to create an empty content file in its internal buffer although the file is already saved on the disk with non-empty content.

Fixed in `TextDocumentServiceImpl` and added a relevant testcase.
