### PR TITLE
[NETBEANS-4981] Install nbjavac when needed

### DIFF
--- a/java/java.lsp.server/build.xml
+++ b/java/java.lsp.server/build.xml
@@ -30,7 +30,9 @@
     </target>
     <target name="build-lsp-server" depends="-set-use-jdk-javac,build,test-init,proxy-setup" description="Prepares NetBeans bits for vscode extensions">
         <ant dir="nbcode" target="build-zip" inheritall="false" inheritrefs="false" />
-        <unzip src="nbcode/dist/nbcode.zip" dest="${lsp.build.dir}/../" />
+        <unzip src="nbcode/dist/nbcode.zip" dest="${lsp.build.dir}/../">
+            <globmapper from="nbcode/nb/*" to="nbcode/nbcode/*"/>
+        </unzip>
         <mkdir dir="${lsp.build.dir}/bin" />
         <copy todir="${lsp.build.dir}/bin" file="script/bin/nbcode" overwrite="true" />
         <mkdir dir="${lsp.build.dir}/etc" />

--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -20,6 +20,7 @@ cluster.path=\
     ${nbplatform.active.dir}/extide:\
     ${nbplatform.active.dir}/ide:\
     ${nbplatform.active.dir}/java:\
+    ${nbplatform.active.dir}/nb:\
     ${nbplatform.active.dir}/platform:\
     ${nbplatform.active.dir}/webcommon
 disabled.modules=\
@@ -94,11 +95,13 @@ disabled.modules=\
     org.netbeans.modules.ant.hints,\
     org.netbeans.modules.ant.kit,\
     org.netbeans.modules.applemenu,\
+    org.netbeans.modules.autoupdate.pluginimporter,\
     org.netbeans.modules.beans,\
     org.netbeans.modules.bugtracking,\
     org.netbeans.modules.bugtracking.bridge,\
     org.netbeans.modules.bugtracking.commons,\
     org.netbeans.modules.bugzilla,\
+    org.netbeans.modules.bugzilla.exceptionreporter,\
     org.netbeans.modules.cordova,\
     org.netbeans.modules.cordova.platforms,\
     org.netbeans.modules.cordova.platforms.android,\
@@ -118,6 +121,7 @@ disabled.modules=\
     org.netbeans.modules.db.sql.visualeditor,\
     org.netbeans.modules.dbapi,\
     org.netbeans.modules.dbschema,\
+    org.netbeans.modules.deadlock.detector,\
     org.netbeans.modules.debugger.jpda.ant,\
     org.netbeans.modules.debugger.jpda.js,\
     org.netbeans.modules.debugger.jpda.jsui,\
@@ -174,6 +178,8 @@ disabled.modules=\
     org.netbeans.modules.hudson.ui,\
     org.netbeans.modules.i18n,\
     org.netbeans.modules.i18n.form,\
+    org.netbeans.modules.ide.branding,\
+    org.netbeans.modules.ide.branding.kit,\
     org.netbeans.modules.ide.kit,\
     org.netbeans.modules.image,\
     org.netbeans.modules.j2ee.core.utilities,\
@@ -307,6 +313,7 @@ disabled.modules=\
     org.netbeans.modules.testng.ui,\
     org.netbeans.modules.textmate.lexer,\
     org.netbeans.modules.typescript.editor,\
+    org.netbeans.modules.uihandler.exceptionreporter,\
     org.netbeans.modules.usersguide,\
     org.netbeans.modules.utilities,\
     org.netbeans.modules.utilities.project,\
@@ -326,6 +333,7 @@ disabled.modules=\
     org.netbeans.modules.websvc.jaxws21,\
     org.netbeans.modules.websvc.jaxws21api,\
     org.netbeans.modules.websvc.saas.codegen.java,\
+    org.netbeans.modules.welcome,\
     org.netbeans.modules.xml,\
     org.netbeans.modules.xml.axi,\
     org.netbeans.modules.xml.catalog.ui,\
@@ -344,6 +352,7 @@ disabled.modules=\
     org.netbeans.modules.xsl,\
     org.netbeans.spi.editor.hints.projects,\
     org.netbeans.swing.dirchooser,\
+    org.netbeans.upgrader,\
     org.openide.compat,\
     org.openide.execution.compat8,\
     org.openide.options,\

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -172,7 +172,6 @@ import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.Fix;
 import org.netbeans.spi.editor.hints.LazyFixList;
 import org.netbeans.spi.java.hints.JavaFix;
-import org.openide.awt.StatusDisplayer;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -250,6 +250,7 @@ function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext,
                         srv.disconnect();
                         return;
                     }
+                    debugPort = -1;
                     srv.stdout.on("data", (chunk) => {
                         if (debugPort < 0) {
                             const info = chunk.toString().match(/Debug Server Adapter listening at port (\d*)/);

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -23,7 +23,10 @@ import { commands, window, workspace, ExtensionContext, ProgressLocation } from 
 import {
     LanguageClient,
     LanguageClientOptions,
+    CloseAction,
+    ErrorAction,
     StreamInfo,
+    Message,
     MessageType,
 } from 'vscode-languageclient';
 
@@ -121,8 +124,8 @@ export function activate(context: ExtensionContext) {
 
     // find acceptable JDK and launch the Java part
     findJDK((specifiedJDK) => {
-        activateWithJDK(specifiedJDK, context, log);
-    })
+        activateWithJDK(specifiedJDK, context, log, true);
+    });
 
     //register debugger:
     let configProvider = new NetBeansConfigurationProvider();
@@ -138,7 +141,9 @@ export function activate(context: ExtensionContext) {
                 const commands = await vscode.commands.getCommands();
                 if (commands.includes('java.build.workspace')) {
                     p.report({ message: 'Compiling workspace...' });
-                    client.outputChannel.show(true);
+                    if (client != null) {
+                        client.outputChannel.show(true);
+                    }
                     const start = new Date().getTime();
                     const res = await vscode.commands.executeCommand('java.build.workspace');
                     const elapsed = new Date().getTime() - start;
@@ -158,9 +163,11 @@ export function activate(context: ExtensionContext) {
     }));
 }
 
-function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext, log : vscode.OutputChannel): void {
+function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext, log : vscode.OutputChannel, notifyKill: boolean): void {
     if (nbProcess) {
-        vscode.window.setStatusBarMessage("Restarting Apache NetBeans Language Server.", 2000);
+        if (notifyKill) {
+            vscode.window.setStatusBarMessage("Restarting Apache NetBeans Language Server.", 2000);
+        }
         nbProcess.kill();
     }
 
@@ -274,25 +281,32 @@ function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext,
                 'nbcodeCapabilities' : {
                     'statusBarMessageSupport' : true
                 }
+            },
+            errorHandler: {
+                error : function(_error: Error, _message: Message, count: number): ErrorAction {
+                    return ErrorAction.Continue;
+                },
+                closed : function(): CloseAction {
+                    activateWithJDK(specifiedJDK, context, log, false);
+                    return CloseAction.DoNotRestart;
+                }
             }
         }
 
-        if (!client) {
-            // Create the language client and start the client.
-            client = new LanguageClient(
-                    'java',
-                    'NetBeans Java',
-                    connection,
-                    clientOptions
-            );
-
-            // Start the client. This will also launch the server
-            client.start();
-            client.onReady().then(() => {
-                commands.executeCommand('setContext', 'nbJavaLSReady', true);
-                client.onNotification(StatusMessageRequest.type, showStatusBarMessage);
-            });
+        if (client) {
+            client.stop();
         }
+        client = new LanguageClient(
+                'java',
+                'NetBeans Java',
+                connection,
+                clientOptions
+        );
+        client.start();
+        client.onReady().then(() => {
+            commands.executeCommand('setContext', 'nbJavaLSReady', true);
+            client.onNotification(StatusMessageRequest.type, showStatusBarMessage);
+        });
     }).catch((reason) => {
         log.append(reason);
         window.showErrorMessage('Error initializing ' + reason);
@@ -339,9 +353,6 @@ function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext,
                     installProcess.stderr.on('data', logData);
                     installProcess.on('close', function(code: number) {
                         log.append("Additional Java Support installed with exit code " + code);
-                        if (nbProcess) {
-                            nbProcess.kill();
-                        }
                     });
                 }
             });

--- a/java/java.source.base/src/org/netbeans/api/java/source/JavaSource.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/JavaSource.java
@@ -174,7 +174,7 @@ public final class JavaSource {
      * and classpath represented by given {@link ClasspathInfo}.
      * @param cpInfo the classpaths to be used.
      * @param files for which the {@link JavaSource} should be created
-     * @return a new {@link JavaSource}
+     * @return a new {@link JavaSource} or {@code null} if the essential infrastructure is missing
      * @throws IllegalArgumentException if fileObject or cpInfo is null
      */
     public static @NullUnknown JavaSource create(final @NonNull ClasspathInfo cpInfo, final @NonNull Collection<? extends FileObject> files) throws IllegalArgumentException {

--- a/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/ModuleOptions.java
+++ b/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/ModuleOptions.java
@@ -482,14 +482,22 @@ public class ModuleOptions extends OptionProcessor {
         public CLIProgressUIWorker(Env env) {
             this.env = env;
         }
+
         @Override
         public void processProgressEvent(ProgressEvent event) {
-            env.getOutputStream().println(event.getMessage());
+            printEvent(event);
         }
+
         @Override
         public void processSelectedProgressEvent(ProgressEvent event) {
-            env.getOutputStream().println(event.getMessage());
+            printEvent(event);
+        }
+
+        private void printEvent(ProgressEvent event) {
+            final String msg = event.getMessage();
+            if (msg != null && msg.length() > 0) {
+                env.getOutputStream().println(msg);
+            }
         }
     }
-    
 }


### PR DESCRIPTION
The best way to solve [NETBEANS-4981](https://issues.apache.org/jira/browse/NETBEANS-4981) and bring the Apache NetBeans Language Server VSCode experience to users of JDK8 is to mimic the same functionality the NetBeans IDE provides on JDK8 - e.g. to ask the user to download `nbjavac`.

This PR is my attempt to do so.