### PR TITLE
Enable limited DialogDisplayer emulation over LSP.

### DIFF
--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspDialogDisplayer.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspDialogDisplayer.java
@@ -26,6 +26,6 @@ import org.openide.util.lookup.ServiceProvider;
  *
  * @author sdedic
  */
-//@ServiceProvider(service = DialogDisplayer.class, position = 1000)
+@ServiceProvider(service = DialogDisplayer.class, position = 1000)
 public class LspDialogDisplayer extends AbstractDialogDisplayer {
 }


### PR DESCRIPTION
The implementation has been already integrated into `origin` (and then merged into `master`), this commit just enables `DialogDisplayer` remoting implementation for the next release cycle.