### PR TITLE
NETBEANS-4989 modifying default branch name to main

### DIFF
--- a/ide/git/src/org/netbeans/modules/git/utils/GitUtils.java
+++ b/ide/git/src/org/netbeans/modules/git/utils/GitUtils.java
@@ -114,7 +114,7 @@ public final class GitUtils {
     public static final String PREFIX_R_TAGS = "refs/tags/"; //NOI18N
     public static final String PREFIX_R_REMOTES = "refs/remotes/"; //NOI18N
     public static final ProgressMonitor NULL_PROGRESS_MONITOR = new NullProgressMonitor();
-    public static final String MASTER = "master"; //NOI18N
+    public static final String MASTER = "main"; //NOI18N
     private static final Set<File> loggedRepositories = new HashSet<File>();
     public static final String REMOTE_ORIGIN = "origin"; //NOI18N
     public static final String ORIGIN = "origin"; //NOI18N


### PR DESCRIPTION
[NETBEANS-4989](1)

Creating a new repository in Github now includes the default branch name 'main' over 'master'. Updating NetBeans to initialise  a new repository with the default branch name main.

<img width="1217" alt="main" src="https://user-images.githubusercontent.com/20171342/98093490-ec5b0500-1e7f-11eb-9729-4f762708d0db.png">

[1]:https://issues.apache.org/jira/browse/NETBEANS-4989