### PR TITLE
Wait for DAP server init before run/debug.

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -374,7 +374,21 @@ export function deactivate(): Thenable<void> {
 class NetBeansDebugAdapterDescriptionFactory implements vscode.DebugAdapterDescriptorFactory {
 
     createDebugAdapterDescriptor(_session: vscode.DebugSession, _executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-        return new vscode.DebugAdapterServer(debugPort);
+        return new Promise<vscode.DebugAdapterDescriptor>((resolve, reject) => {
+            let cnt = 10;
+            const fnc = () => {
+                if (debugPort < 0) {
+                    if (cnt-- > 0) {
+                        setTimeout(fnc, 1000);
+                    } else {
+                        reject(new Error('Apache NetBeans Debug Server Adapter not yet initialized. Please wait for a while and try again.'));
+                    }
+                } else {
+                    resolve(new vscode.DebugAdapterServer(debugPort));
+                }
+            }
+            fnc();
+        });
     }
 }
 


### PR DESCRIPTION
When trying to run/debug a Java program before the Apache NetBeans DAP Server finishes its initialization a cryptic error message is shown in VSCode UI. Run/debug actions should wait for DAP server init.