### PR TITLE
Spell NetBeans with capital N and capital B

### DIFF
--- a/java/java.lsp.server/nbcode/integration/nbproject/build-impl.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/build-impl.xml
@@ -34,7 +34,7 @@
     <nbmproject2:property name="harness.dir" value="nbplatform.${nbplatform.active}.harness.dir" xmlns:nbmproject2="http://www.netbeans.org/ns/nb-module-project/2"/>
     <nbmproject2:property name="nbplatform.active.dir" value="nbplatform.${nbplatform.active}.netbeans.dest.dir" xmlns:nbmproject2="http://www.netbeans.org/ns/nb-module-project/2"/>
     <nbmproject2:evalprops property="cluster.path.evaluated" value="${cluster.path}" xmlns:nbmproject2="http://www.netbeans.org/ns/nb-module-project/2"/>
-    <fail message="Path to 'platform' cluster missing in $${cluster.path} property or using corrupt Netbeans Platform (missing harness).">
+    <fail message="Path to 'platform' cluster missing in $${cluster.path} property or using corrupt NetBeans Platform (missing harness).">
         <condition>
             <not>
                 <contains string="${cluster.path.evaluated}" substring="platform"/>

--- a/java/java.lsp.server/nbcode/nbproject/build-impl.xml
+++ b/java/java.lsp.server/nbcode/nbproject/build-impl.xml
@@ -31,7 +31,7 @@
     <sproject:property name="harness.dir" value="nbplatform.${nbplatform.active}.harness.dir"/>
     <sproject:property name="nbplatform.active.dir" value="nbplatform.${nbplatform.active}.netbeans.dest.dir"/>
     <sproject:evalprops property="cluster.path.evaluated" value="${cluster.path}"/>
-    <fail message="Path to 'platform' cluster missing in $${cluster.path} property or using corrupt Netbeans Platform (missing harness).">
+    <fail message="Path to 'platform' cluster missing in $${cluster.path} property or using corrupt NetBeans Platform (missing harness).">
         <condition>
             <not>
                 <contains string="${cluster.path.evaluated}" substring="platform"/>

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "apache-netbeans-java",
-	"displayName": "Apache Netbeans Language Server",
+	"displayName": "Apache NetBeans Language Server",
 	"description": "An Apache NetBeans Language Server plugin for Visual Studio Code",
 	"author": "Apache NetBeans",
 	"license": "Apache 2.0",


### PR DESCRIPTION
@jisedlac noticed error in spelling the name of the VSCode extension.