### PR TITLE
Increase the major version for php.editor

### DIFF
--- a/php/php.dbgp/manifest.mf
+++ b/php/php.dbgp/manifest.mf
@@ -3,5 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.php.dbgp
 OpenIDE-Module-Layer: org/netbeans/modules/php/dbgp/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/dbgp/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.50
-
+OpenIDE-Module-Specification-Version: 1.51

--- a/php/php.dbgp/nbproject/project.xml
+++ b/php/php.dbgp/nbproject/project.xml
@@ -171,7 +171,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.2</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/php/php.editor/manifest.mf
+++ b/php/php.editor/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module: org.netbeans.modules.php.editor
+OpenIDE-Module: org.netbeans.modules.php.editor/2
 OpenIDE-Module-Layer: org/netbeans/modules/php/editor/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/editor/resources/Bundle.properties
 OpenIDE-Module-Implementation-Version: 2

--- a/php/php.editor/nbproject/project.properties
+++ b/php/php.editor/nbproject/project.properties
@@ -20,7 +20,7 @@ build.compiler=extJavac
 nbjavac.ignore.missing.enclosing=**/CUP$ASTPHP5Parser$actions.class
 javac.compilerargs=-J-Xmx512m
 nbm.needs.restart=true
-spec.version.base=1.89.0
+spec.version.base=2.0
 release.external/predefined_vars-1.0.zip=docs/predefined_vars.zip
 sigtest.gen.fail.on.error=false
 

--- a/php/php.editor/nbproject/project.xml
+++ b/php/php.editor/nbproject/project.xml
@@ -606,6 +606,8 @@
                 <friend>org.netbeans.modules.php.refactoring</friend>
                 <friend>org.netbeans.modules.php.smarty</friend>
                 <friend>org.netbeans.modules.php.symfony</friend>
+                <friend>org.netbeans.modules.php.zend</friend>
+                <friend>org.netbeans.modules.php.zend2</friend>
                 <friend>org.netbeans.modules.spellchecker.bindings.php</friend>
                 <package>org.netbeans.modules.php.editor.api</package>
                 <package>org.netbeans.modules.php.editor.api.elements</package>

--- a/php/php.kit/manifest.mf
+++ b/php/php.kit/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.kit
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/kit/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.72
+OpenIDE-Module-Specification-Version: 1.73
 OpenIDE-Module-Recommends: cnb.org.netbeans.modules.languages.ini, cnb.org.netbeans.modules.languages.neon, cnb.org.netbeans.modules.php.apigen, cnb.org.netbeans.modules.web.client.kit, cnb.org.netbeans.modules.websvc.saas.codegen.php, cnb.org.netbeans.modules.websvc.saas.kit, org.netbeans.modules.selenium2.php.Selenium2PhpSupportImpl

--- a/php/php.kit/nbproject/project.xml
+++ b/php/php.kit/nbproject/project.xml
@@ -52,7 +52,8 @@
                 <dependency>
                     <code-name-base>org.netbeans.modules.php.editor</code-name-base>
                     <run-dependency>
-                        <specification-version>1.28.0</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/php/php.refactoring/manifest.mf
+++ b/php/php.refactoring/manifest.mf
@@ -3,5 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.php.refactoring
 OpenIDE-Module-Layer: org/netbeans/modules/refactoring/php/resources/mf-layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/refactoring/php/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.41
+OpenIDE-Module-Specification-Version: 1.42
 

--- a/php/php.refactoring/nbproject/project.xml
+++ b/php/php.refactoring/nbproject/project.xml
@@ -135,7 +135,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.43</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/php/php.smarty/manifest.mf
+++ b/php/php.smarty/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.smarty
 OpenIDE-Module-Layer: org/netbeans/modules/php/smarty/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/smarty/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.96
+OpenIDE-Module-Specification-Version: 1.97
 

--- a/php/php.smarty/nbproject/project.xml
+++ b/php/php.smarty/nbproject/project.xml
@@ -217,7 +217,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.43</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/php/php.symfony/manifest.mf
+++ b/php/php.symfony/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.symfony
 OpenIDE-Module-Layer: org/netbeans/modules/php/symfony/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/symfony/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.54
+OpenIDE-Module-Specification-Version: 1.55
 

--- a/php/php.symfony/nbproject/project.xml
+++ b/php/php.symfony/nbproject/project.xml
@@ -146,6 +146,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
+                        <release-version>2</release-version>
                         <implementation-version/>
                     </run-dependency>
                 </dependency>

--- a/php/php.zend/manifest.mf
+++ b/php/php.zend/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.zend
 OpenIDE-Module-Layer: org/netbeans/modules/php/zend/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/zend/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.42
+OpenIDE-Module-Specification-Version: 1.43
 

--- a/php/php.zend/nbproject/project.xml
+++ b/php/php.zend/nbproject/project.xml
@@ -143,6 +143,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
+                        <release-version>2</release-version>
                         <implementation-version/>
                     </run-dependency>
                 </dependency>

--- a/php/php.zend2/manifest.mf
+++ b/php/php.zend2/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.zend2
 OpenIDE-Module-Layer: org/netbeans/modules/php/zend2/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/zend2/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 0.26
+OpenIDE-Module-Specification-Version: 0.27
 

--- a/php/php.zend2/nbproject/project.xml
+++ b/php/php.zend2/nbproject/project.xml
@@ -119,6 +119,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
+                        <release-version>2</release-version>
                         <implementation-version/>
                     </run-dependency>
                 </dependency>

--- a/php/spellchecker.bindings.php/manifest.mf
+++ b/php/spellchecker.bindings.php/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.spellchecker.bindings.php
 OpenIDE-Module-Layer: org/netbeans/modules/spellchecker/bindings/php/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/spellchecker/bindings/php/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 0.10
+OpenIDE-Module-Specification-Version: 0.11
 

--- a/php/spellchecker.bindings.php/nbproject/project.xml
+++ b/php/spellchecker.bindings.php/nbproject/project.xml
@@ -83,7 +83,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.65</specification-version>
+                        <release-version>2</release-version>
+                        <specification-version>2.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
There are incompatible API changes. e.g.
- `ASTPHP5Parser.createDispatch*`
- `ASTPHP5Symbols.T_*`

See: #2504 