### PR TITLE
DAP command 'stackTrace' throws exceptions on Windows.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
@@ -288,7 +288,7 @@ public final class NbProtocolServer implements IDebugProtocolServer {
                     URI sourceURI = frame.getSourceURI();
                     if (sourceURI != null && sourceURI.getPath() != null) {
                         Source source = new Source();
-                        source.setName(Paths.get(sourceURI.getPath()).getFileName().toString());
+                        source.setName(Paths.get(sourceURI).getFileName().toString());
                         source.setPath(sourceURI.getPath());
                         source.setSourceReference(0);
                         stackFrame.setSource(source);


### PR DESCRIPTION
Processing of the DAP command `stackTrace` throws the following exception on Windows:
java.nio.file.InvalidPathException: Illegal char <:> at index 2: /C:/Sources/micronaut-sandbox/project_212_8_gradle/demo/src/main/java/com/example/Application.java
	at sun.nio.fs.WindowsPathParser.normalize(WindowsPathParser.java:182)
	at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:153)
	at sun.nio.fs.WindowsPathParser.parse(WindowsPathParser.java:77)
	at sun.nio.fs.WindowsPath.parse(WindowsPath.java:94)
	at sun.nio.fs.WindowsFileSystem.getPath(WindowsFileSystem.java:255)
	at java.nio.file.Paths.get(Paths.java:84)
	at org.netbeans.modules.java.lsp.server.debugging.NbProtocolServer.stackTrace(NbProtocolServer.java:291)

To fix this, Paths.get(...) is called with correct argument.