### PR TITLE
Provide shorter evaluation error, without the unneccessary prefix.

### DIFF
--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleEval.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleEval.java
@@ -26,6 +26,7 @@ import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.debugger.jpda.JPDAThread;
 import org.netbeans.api.debugger.jpda.ObjectVariable;
 import org.netbeans.api.debugger.jpda.Variable;
+import org.netbeans.modules.debugger.jpda.expr.InvocationExceptionTranslated;
 import org.netbeans.modules.debugger.jpda.truffle.TruffleDebugManager;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
@@ -58,6 +59,13 @@ public class TruffleEval {
                     new Variable[] { stackFrameInstance,
                                      mirrorExpression });
             return valueVar;
+        } catch (InvalidExpressionException ex) {
+            Throwable targetException = ex.getTargetException();
+            if (targetException instanceof InvocationExceptionTranslated) {
+                // We do not want to prepend Java exception message:
+                ((InvocationExceptionTranslated) targetException).resetInvocationMessage();
+            }
+            throw ex;
         } catch (InvalidObjectException | NoSuchMethodException ex) {
             try {
                 return debugger.createMirrorVar(ex.getLocalizedMessage());

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/InvocationExceptionTranslated.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/expr/InvocationExceptionTranslated.java
@@ -95,6 +95,10 @@ public class InvocationExceptionTranslated extends Exception {
         this.createdAt = new Throwable().fillInStackTrace();
     }
     
+    public void resetInvocationMessage() {
+        this.invocationMessage = null;
+    }
+
     public void setPreferredThread(JPDAThreadImpl preferredThread) {
         this.preferredThread = preferredThread;
     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
@@ -379,13 +379,13 @@ public final class NbProtocolServer implements IDebugProtocolServer {
             String expression = args.getExpression();
             if (StringUtils.isBlank(expression)) {
                 throw ErrorUtilities.createResponseErrorException(
-                    "Failed to evaluate. Reason: Empty expression cannot be evaluated.",
+                    "Empty expression cannot be evaluated.",
                     ResponseErrorCode.InvalidParams);
             }
             NbFrame stackFrame = (NbFrame) context.getThreadsProvider().getThreadObjects().getObject(args.getFrameId());
             if (stackFrame == null) {
                 throw ErrorUtilities.createResponseErrorException(
-                    "Failed to evaluate. Reason: Unknown frame " + args.getFrameId(),
+                    "Unknown frame " + args.getFrameId(),
                     ResponseErrorCode.InvalidParams);
             }
             stackFrame.getDVFrame().makeCurrent(); // The evaluation is always performed with respect to the current frame
@@ -397,7 +397,7 @@ public final class NbProtocolServer implements IDebugProtocolServer {
                 variable = debugger.evaluate(expression);
             } catch (InvalidExpressionException ex) {
                 throw ErrorUtilities.createResponseErrorException(
-                    "Failed to evaluate. Reason: " + ex.getLocalizedMessage(),
+                    ex.getLocalizedMessage(),
                     ResponseErrorCode.ParseError);
             }
             EvaluateResponse response = new EvaluateResponse();


### PR DESCRIPTION
Mainly in watches, where space is limited, it's hard to see the real evaluation error due to a long prefix text.
In case of Truffle languages if there is a `n` variables in watches, which is not present in the current scope, the used gets following error message:
`Failed to evaluate. Reason: Exception occurred in target VM: ReferenceError: n is not defined`
That's simply too long.
This change limits that to the most important part:
`ReferenceError: n is not defined`
