### PR TITLE
[NETBEANS-5007] Prevent endless restarts when changing JDKs.

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -251,7 +251,9 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
     let ideRunning = new Promise((resolve, reject) => {
         let collectedText : string | null = '';
         function logAndWaitForEnabled(text: string) {
-            activationPending = false;
+            if (p == nbProcess) {
+                activationPending = false;
+            }
             log.append(text);
             if (collectedText == null) {
                 return;
@@ -357,7 +359,9 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                 },
                 closed : function(): CloseAction {
                     log.appendLine("Connection to Apache NetBeans Language Server closed.");
-                    restartWithJDKLater(10000, false);
+                    if (!activationPending) {
+                        restartWithJDKLater(10000, false);
+                    }
                     return CloseAction.DoNotRestart;
                 }
             }


### PR DESCRIPTION
When changing JDKs using GraalVM's extension UI, the vscode kills Apache Language Server (ALS), but then the ALS extensions notices that the channel to ALS broke and restarts it again ... killing the instance. The channel closes again etc etc.

This patch should prevent restarts if the process was killed *because of* a deliberate restart.