### PR TITLE
[NETBEANS-4650] Fix code completion for traits of use and group use statements

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -920,6 +920,13 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
                     }
                     completionResult.add(new PHPCompletionItem.InterfaceItem(iface, request, QualifiedNameKind.FULLYQUALIFIED, false));
                 }
+                // NETBEANS-4650
+                for (TraitElement trait : request.index.getTraits(nameQuery)) {
+                    if (CancelSupport.getDefault().isCancelled()) {
+                        return;
+                    }
+                    completionResult.add(new PHPCompletionItem.TraitItem(trait, request));
+                }
                 break;
             case CONST:
                 for (ConstantElement constant : request.index.getConstants(nameQuery)) {
@@ -974,6 +981,13 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
                         return;
                     }
                     completionResult.add(new PHPCompletionItem.InterfaceItem(iface, request, kind, false));
+                }
+                // NETBEANS-4650
+                for (TraitElement trait : request.index.getTraits(nameQuery)) {
+                    if (CancelSupport.getDefault().isCancelled()) {
+                        return;
+                    }
+                    completionResult.add(new PHPCompletionItem.TraitItem(trait, request));
                 }
                 break;
             case CONST:

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4650/nb4650.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4650/nb4650.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Test;
+trait MyTrait{}
+
+namespace TestTrait;
+
+use Test\MyTrait;
+use Test\{
+    MyTrait
+};
+
+class MyClass{}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4650/nb4650.php.testNb4650_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4650/nb4650.php.testNb4650_01.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+use Test\M|yTrait;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      MyTrait                         [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb4650/nb4650.php.testNb4650_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb4650/nb4650.php.testNb4650_02.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+My|Trait
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CLASS      MyTrait                         [PUBLIC]   Test

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/tests241902/issue241902.php.testUseCase1.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/tests241902/issue241902.php.testUseCase1.completion
@@ -6,3 +6,4 @@ PACKAGE    First                           [PUBLIC]   null
 PACKAGE    Second                          [PUBLIC]   First
 CLASS      ThirdC                          [PUBLIC]   First\Second
 CLASS      ThirdI                          [PUBLIC]   First\Second
+CLASS      ThirdT                          [PUBLIC]   First\Second

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb4650Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb4650Test.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class PHPCodeCompletionNb4650Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionNb4650Test(String testName) {
+        super(testName);
+    }
+
+    public void testNb4650_01() throws Exception {
+        testNb4650("use Test\\M^yTrait;");
+    }
+
+    public void testNb4650_02() throws Exception {
+        testNb4650("    My^Trait");
+    }
+
+    private void testNb4650(String caretLine) throws Exception {
+        checkCompletion("testfiles/completion/lib/nb4650/nb4650.php", caretLine, false);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/nb4650"))
+            })
+        );
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4650

Example code:
```php

namespace Test;
trait MyTrait{}

namespace TestTrait;

use Test\MyTrait; // here
use Test\{
    MyTrait // here
};

class MyClass{}
```