### PR TITLE
[NETBEANS-5028] PHP - improved display of constant in code completion

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02.completion
@@ -11,14 +11,14 @@ VARIABLE   array $array1                   [PUBLIC]   spreadOperatorInArrayExpre
 VARIABLE   array $array2                   [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array2_a                 [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array3                   [PUBLIC]   spreadOperatorInArrayExpression.php
-CONSTANT   BAR_CONSTANT ?                  [PUBLIC]   Bar
-CONSTANT   CONSTANT ?                      [PUBLIC]   Foo
-CONSTANT   CONSTANT1 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT1a ?                    [PUBLIC]   Foo
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   Foo
+CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
+CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform
 VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02a.completion
@@ -12,14 +12,14 @@ VARIABLE   array $array2                   [PUBLIC]   spreadOperatorInArrayExpre
 VARIABLE   array $array2_a                 [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array3                   [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array3_a                 [PUBLIC]   spreadOperatorInArrayExpression.php
-CONSTANT   BAR_CONSTANT ?                  [PUBLIC]   Bar
-CONSTANT   CONSTANT ?                      [PUBLIC]   Foo
-CONSTANT   CONSTANT1 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT1a ?                    [PUBLIC]   Foo
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   Foo
+CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
+CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform
 VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_03.completion
@@ -13,14 +13,14 @@ VARIABLE   array $array2_a                 [PUBLIC]   spreadOperatorInArrayExpre
 VARIABLE   array $array3                   [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array3_a                 [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array4                   [PUBLIC]   spreadOperatorInArrayExpression.php
-CONSTANT   BAR_CONSTANT ?                  [PUBLIC]   Bar
-CONSTANT   CONSTANT ?                      [PUBLIC]   Foo
-CONSTANT   CONSTANT1 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT1a ?                    [PUBLIC]   Foo
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   Foo
+CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
+CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform
 VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_04.completion
@@ -13,14 +13,14 @@ VARIABLE   array $array2_a                 [PUBLIC]   spreadOperatorInArrayExpre
 VARIABLE   array $array3                   [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array3_a                 [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array4                   [PUBLIC]   spreadOperatorInArrayExpression.php
-CONSTANT   BAR_CONSTANT ?                  [PUBLIC]   Bar
-CONSTANT   CONSTANT ?                      [PUBLIC]   Foo
-CONSTANT   CONSTANT1 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT1a ?                    [PUBLIC]   Foo
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   Foo
+CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
+CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform
 VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_01.completion
@@ -4,13 +4,13 @@ const CONSTANT1 = [...|CONSTANT];
 PACKAGE    Bar                             [PUBLIC]   null
 PACKAGE    Foo                             [PUBLIC]   null
 CLASS      Qux                             [PUBLIC]   Bar
-CONSTANT   BAR_CONSTANT ?                  [PUBLIC]   Bar
-CONSTANT   CONSTANT ?                      [PUBLIC]   Foo
-CONSTANT   CONSTANT1 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT1a ?                    [PUBLIC]   Foo
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   Foo
+CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
+CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
 ------------------------------------
 KEYWORD    array                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_02.completion
@@ -4,13 +4,13 @@ const CONSTANT2 = [100, ...CONSTANT, ...|CONSTANT1,];
 PACKAGE    Bar                             [PUBLIC]   null
 PACKAGE    Foo                             [PUBLIC]   null
 CLASS      Qux                             [PUBLIC]   Bar
-CONSTANT   BAR_CONSTANT ?                  [PUBLIC]   Bar
-CONSTANT   CONSTANT ?                      [PUBLIC]   Foo
-CONSTANT   CONSTANT1 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT1a ?                    [PUBLIC]   Foo
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   Foo
+CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
+CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
 ------------------------------------
 KEYWORD    array                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_03.completion
@@ -1,10 +1,10 @@
 Code completion result for source line:
 const CONSTANT3 = [...CONSTANT2, 100 => 0, ...CONSTANT|];
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-CONSTANT   CONSTANT ?                      [PUBLIC]   Foo
-CONSTANT   CONSTANT1 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT1a ?                    [PUBLIC]   Foo
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   Foo
+CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_05.completion
@@ -2,4 +2,4 @@ Code completion result for source line:
 const CONSTANT4 = [...CONSTANT2, 100 => 0, ...\Bar\|BAR_CONSTANT];
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 CLASS      Qux                             [PUBLIC]   Bar
-CONSTANT   BAR_CONSTANT ?                  [PUBLIC]   Bar
+CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_09.completion
@@ -4,13 +4,13 @@ const BAR_CONSTANT = |[];
 PACKAGE    Bar                             [PUBLIC]   null
 PACKAGE    Foo                             [PUBLIC]   null
 CLASS      Qux                             [PUBLIC]   Bar
-CONSTANT   BAR_CONSTANT ?                  [PUBLIC]   Bar
-CONSTANT   CONSTANT ?                      [PUBLIC]   Foo
-CONSTANT   CONSTANT1 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT1a ?                    [PUBLIC]   Foo
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   Foo
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   Foo
+CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
+CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
 ------------------------------------
 KEYWORD    array                                      null


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5028

Improves display of array constant in code completion.
Uses short array format, displays first item in array, indicates more elements in array.

Before:
![netbeans5028-before](https://user-images.githubusercontent.com/4249184/99157641-0e982280-26cb-11eb-8b9a-d9e04eff2b91.png)

After:
![netbeans5028-after](https://user-images.githubusercontent.com/4249184/99157643-122ba980-26cb-11eb-983c-a9c3ed52af24.png)
