### PR TITLE
[NETBEANS-5029] PHP - generated methods are public by default

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSGenerator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSGenerator.java
@@ -425,7 +425,7 @@ public final class CGSGenerator implements CodeGenerator {
                 cgsInfo.setHowToGenerate(GenWay.AS_JAVA);
             }
             cgsInfo.setFluentSetter(preferences.getBoolean(FLUENT_SETTER_PROJECT_PROPERTY, false));
-            cgsInfo.setPublicModifier(preferences.getBoolean(PUBLIC_MODIFIER_PROJECT_PROPERTY, false));
+            cgsInfo.setPublicModifier(preferences.getBoolean(PUBLIC_MODIFIER_PROJECT_PROPERTY, true));
         }
         DialogDescriptor desc = new DialogDescriptor(genType.createPanel(cgsInfo), genType.getDialogTitle());
         Dialog dialog = DialogDisplayer.getDefault().createDialog(desc);

--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSInfo.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSInfo.java
@@ -116,7 +116,7 @@ public final class CGSInfo {
         hasConstructor = false;
         this.generateDoc = true;
         fluentSetter = false;
-        isPublicModifier = false;
+        isPublicModifier = true;
         this.howToGenerate = CGSGenerator.GenWay.AS_JAVA;
         this.phpVersion = phpVersion != null ? phpVersion : PhpVersion.getDefault();
     }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
@@ -212,24 +212,28 @@ public class SelectedPropertyMethodsCreatorTest extends PHPTestBase {
 
     public void testGetterWithType_01() throws Exception {
         CGSInfo cgsInfo = getCgsInfo("class Foo {^", PhpVersion.PHP_70);
+        cgsInfo.setPublicModifier(false);
         checkResult(new SelectedPropertyMethodsCreator().create(
                 selectAllProperties(cgsInfo.getPossibleGetters()), new SinglePropertyMethodCreator.SingleGetterCreator(cgsInfo)));
     }
 
     public void testGetterWithType_02() throws Exception {
         CGSInfo cgsInfo = getCgsInfo("class Foo {^", PhpVersion.PHP_55);
+        cgsInfo.setPublicModifier(false);
         checkResult(new SelectedPropertyMethodsCreator().create(
                 selectAllProperties(cgsInfo.getPossibleGetters()), new SinglePropertyMethodCreator.SingleGetterCreator(cgsInfo)));
     }
 
     public void testGetterWithMoreTypes_01() throws Exception {
         CGSInfo cgsInfo = getCgsInfo("class Foo {^", PhpVersion.PHP_70);
+        cgsInfo.setPublicModifier(false);
         checkResult(new SelectedPropertyMethodsCreator().create(
                 selectAllProperties(cgsInfo.getPossibleGetters()), new SinglePropertyMethodCreator.SingleGetterCreator(cgsInfo)));
     }
 
     public void testGetterWithMoreTypes_02() throws Exception {
         CGSInfo cgsInfo = getCgsInfo("class Foo {^", PhpVersion.PHP_56);
+        cgsInfo.setPublicModifier(false);
         checkResult(new SelectedPropertyMethodsCreator().create(
                 selectAllProperties(cgsInfo.getPossibleGetters()), new SinglePropertyMethodCreator.SingleGetterCreator(cgsInfo)));
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5029

Changes default value for generating public modifier of constructor/getters/setters to enabled.

![constructor-generator](https://user-images.githubusercontent.com/4249184/99178040-9d2e9300-270f-11eb-83b4-55a5428fd39c.png)