### PR TITLE
Update GitHub action dependency to fix error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,7 @@ jobs:
           restore-keys: ${{ runner.os }}-
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.3.1
+        uses: shivammathur/setup-php@2.8.0
         with:
           php-version: '7.4'
           tools: pecl


### PR DESCRIPTION
Update `shivammathur/setup-php` GitHub action dependency to fix GitHub action deprecation error.

```
 Error: Unable to process command '::add-path::/home/runner/.composer/vendor/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```