### PR TITLE
Fix call to find jdkhome using /usr/libexec/java_home for macOS Big Sur.

### DIFF
--- a/platform/o.n.bootstrap/launcher/unix/nbexec
+++ b/platform/o.n.bootstrap/launcher/unix/nbexec
@@ -140,10 +140,13 @@ if [ -z "$jdkhome" ] ; then
         # try to find JDK
         case "`uname`" in
             Darwin*)
+            # check if JAVA_HOME is empty string since java_home will return the value of JAVA_HOME
+            if [ -z "$JAVA_HOME" ]; then
+                unset JAVA_HOME
+            fi
             # read Java Preferences
             if [ -x "/usr/libexec/java_home" ]; then
-                jdkhome=`/usr/libexec/java_home --version 1.8.0+ --failfast`
-
+                jdkhome=`/usr/libexec/java_home --version 1.8+`
             # JDK1.8 as a fallback
             elif [ -f "/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home/bin/java" ] ; then
                 jdkhome="/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home"


### PR DESCRIPTION
JDK is not found on macOS Big Sur due to changes the `/usr/libexec/java_home`

1.  It no longer works with `--failfast` and a `+` used in the `-v` argument
2. It will return whatever  is contained in the environment variable `JAVA_HOME` regardless of arguments passed in.
3. if `JAVA_HOME` is set and is empty, it will return an empty string.
4. Removing `--failfast` does not break functionality on earlier versions of macOS.

Below are tests run on clean install of macOS Big Sur running in a VM

```
 % /usr/libexec/java_home -V                                                
Matching Java Virtual Machines (3):
    15.0.1 (x86_64) "AdoptOpenJDK" - "AdoptOpenJDK 15" /Library/Java/JavaVirtualMachines/adoptopenjdk-15.jdk/Contents/Home
    11.0.9 (x86_64) "AdoptOpenJDK" - "AdoptOpenJDK 11" /Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home
    1.8.0_275 (x86_64) "AdoptOpenJDK" - "AdoptOpenJDK 8" /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
/Library/Java/JavaVirtualMachines/adoptopenjdk-15.jdk/Contents/Home
```

If you have the environment variable `JAVA_HOME` set, java_home will return the value of `JAVA_HOME` regardless of the arguments provided to `java_home`.
```
% export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home
% /usr/libexec/java_home -v 1.8+ --failfast                                           
/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home
%
```

If `JAVA_HOME` is set to an empty string then an empty string is returned from `java_home`.


```
 % export JAVA_HOME=
 % /usr/libexec/java_home -v 1.8+ --failfast
 % 
```


If JAVA_HOME is not set and you use a '+' in the '-v' and also have '--failfast' it will not find a JDK.


```
% unset JAVA_HOME
% /usr/libexec/java_home -v 1.8+ --failfast
The operation couldn’t be completed. Unable to locate a Java Runtime that supports (null).
Please visit http://www.java.com for information on installing Java.
```


The '-v' with a '+' works without '--failfast' but also returns the same as not using '-v'


```
% unset JAVA_HOME                          
% /usr/libexec/java_home -v 1.8+           
/Library/Java/JavaVirtualMachines/adoptopenjdk-15.jdk/Contents/Home
% /usr/libexec/java_home        
/Library/Java/JavaVirtualMachines/adoptopenjdk-15.jdk/Contents/Home
% 
```