### PR TITLE
[NETBEANS-5042] Fix call to find jdkhome using /usr/libexec/java_home for macOS Big Sur.

### DIFF
--- a/platform/o.n.bootstrap/launcher/unix/nbexec
+++ b/platform/o.n.bootstrap/launcher/unix/nbexec
@@ -140,10 +140,13 @@ if [ -z "$jdkhome" ] ; then
         # try to find JDK
         case "`uname`" in
             Darwin*)
+            # check if JAVA_HOME is empty string since java_home will return the value of JAVA_HOME
+            if [ -z "$JAVA_HOME" ]; then
+                unset JAVA_HOME
+            fi
             # read Java Preferences
             if [ -x "/usr/libexec/java_home" ]; then
-                jdkhome=`/usr/libexec/java_home --version 1.8.0+ --failfast`
-
+                jdkhome=`/usr/libexec/java_home --version 1.8+`
             # JDK1.8 as a fallback
             elif [ -f "/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home/bin/java" ] ; then
                 jdkhome="/Library/Java/JavaVirtualMachines/jdk1.8.0.jdk/Contents/Home"


### PR DESCRIPTION
This is a cherry-pick of #2545 to the delivery branch which would go into release122 for rc3