### PR TITLE
[NETBEANS-5043] Turning on lexer.nbbridge enables Go to declaration in VSCode

### DIFF
--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -250,7 +250,6 @@ disabled.modules=\
     org.netbeans.modules.languages.ini,\
     org.netbeans.modules.languages.manifest,\
     org.netbeans.modules.languages.yaml,\
-    org.netbeans.modules.lexer.nbbridge,\
     org.netbeans.modules.localhistory,\
     org.netbeans.modules.localtasks,\
     org.netbeans.modules.lsp.client,\


### PR DESCRIPTION
Well piggybacking on #2546 is a nasty thing to do.