### PR TITLE
Initial VSNetBeans extension integration tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 /nbi/engine/native/*/*/dist/
 /nb-javac/
 /java.source.nbjavac/test/test-nb-javac/nbproject/private/
+/java/java.lsp.server/vscode/.vscode-test/
 /harness/apisupport.harness/windows-launcher-src/*.exe
 /harness/apisupport.harness/windows-launcher-src/*.res
 /ide/versioning/test/qa-functional/data/tck.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -747,7 +747,7 @@ matrix:
         - name: Build the Visual Studio Code extension for Java
           jdk: openjdk8
           before_install:
-            - nvm install 8
+            - nvm install 12.14.1
           env:
             - OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json -quiet -Dcluster.config=java -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true"
           before_script:
@@ -755,6 +755,7 @@ matrix:
             - ant $OPTS build
           script:
             - (cd java/java.lsp.server; ant build-vscode-ext)
+            - (cd java/java.lsp.server; ant test-vscode-ext)
 
         - name: "GraalVM Tests (latest)"
           jdk: openjdk8

--- a/java/java.lsp.server/build.xml
+++ b/java/java.lsp.server/build.xml
@@ -129,4 +129,16 @@
 
         <zip destfile="${build.dir}/apache-netbeans-java-${vsix.version}.vsix" basedir="${build.dir}/vscode-mandatory/" update="true" />
     </target>
+    <target name="test-vscode-ext" description="Tests the Visual Studio Code extension built by 'build-vscode-ext' target.">
+        <exec executable="npm" failonerror="true" dir="vscode">
+            <arg value="--allow-same-version"/>
+            <arg value="run" />
+            <arg value="nbjavac" />
+        </exec>
+        <exec executable="npm" failonerror="true" dir="vscode">
+            <arg value="--allow-same-version"/>
+            <arg value="run" />
+            <arg value="test" />
+        </exec>
+    </target>
 </project>

--- a/java/java.lsp.server/vscode/.vscode/launch.json
+++ b/java/java.lsp.server/vscode/.vscode/launch.json
@@ -25,7 +25,8 @@
 			"runtimeExecutable": "${execPath}",
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index",
+				"${workspaceFolder}/out/test/ws"
 			],
 			"outFiles": [
 				"${workspaceFolder}/out/test/**/*.js"

--- a/java/java.lsp.server/vscode/BUILD.md
+++ b/java/java.lsp.server/vscode/BUILD.md
@@ -62,10 +62,32 @@ for running and debugging below.
 Often it is also important to properly clean everything. Use:
 
 ```bash
-java.lsp.server$ ant clean-vscode-server
+java.lsp.server$ ant clean-vscode-ext
 java.lsp.server$ cd ../..
 netbeans$ ant clean
 ```
+
+### Testing
+
+The `java.lsp.server` module has classical (as other NetBeans modules) tests.
+The most important one is [ServerTest](https://github.com/apache/netbeans/blob/master/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java)
+which simulates LSP communication and checks expected replies. In addition to
+that there are VS Code integration tests - those launch VS Code with the
+VSNetBeans extension and check behavior of the TypeScript integration code:
+
+```bash
+java.lsp.server$ ant build-vscode-ext # first and then
+java.lsp.server$ ant test-vscode-ext
+```
+
+In case you are behind a proxy, you may want to run the tests with
+
+```bash
+java.lsp.server$ npm_config_https_proxy=http://your.proxy.com:port ant test-vscode-ext
+```
+
+when executing the tests for the first time. That shall overcome the proxy
+and download an instance of `code` execute the tests on.
 
 ## Running and Debugging
 

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -160,11 +160,10 @@
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
-		"lint": "eslint src --ext ts",
 		"watch": "tsc -watch -p ./",
-		"pretest": "npm run compile && npm run lint",
 		"test": "node ./out/test/runTest.js",
-		"nbcode": "node ./out/nbcode.js"
+		"nbcode": "node ./out/nbcode.js",
+		"nbjavac" : "node ./out/nbcode.js -J-Dnetbeans.close=true --modules --install .*nbjavac.*"
 	},
 	"devDependencies": {
 		"@types/vscode": "^1.47.0",

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -28,6 +28,7 @@ import {
     StreamInfo,
     Message,
     MessageType,
+    LogMessageNotification
 } from 'vscode-languageclient';
 
 import * as net from 'net';
@@ -38,11 +39,32 @@ import * as vscode from 'vscode';
 import * as launcher from './nbcode';
 import { StatusMessageRequest, ShowStatusMessageParams  } from './protocol';
 
-let client: LanguageClient;
+const API_VERSION : string = "1.0";
+let client: Promise<LanguageClient>;
 let nbProcess : ChildProcess | null = null;
 let debugPort: number = -1;
+let consoleLog: boolean = !!process.env['ENABLE_CONSOLE_LOG'];
 
-function findClusters(myPath : string): string[] {
+function handleLog(log: vscode.OutputChannel, msg: string): void {
+    log.appendLine(msg);
+    if (consoleLog) {
+        console.log(msg);
+    }
+}
+
+function handleLogNoNL(log: vscode.OutputChannel, msg: string): void {
+    log.append(msg);
+    if (consoleLog) {
+        process.stdout.write(msg);
+    }
+}
+
+export function enableConsoleLog() {
+    consoleLog = true;
+    console.log("enableConsoleLog");
+}
+
+export function findClusters(myPath : string): string[] {
     let clusters = [];
     for (let e of vscode.extensions.all) {
         if (e.extensionPath === myPath) {
@@ -108,14 +130,18 @@ function findJDK(onChange: (path : string | null) => void): void {
     onChange(currentJdk);
 }
 
-export function activate(context: ExtensionContext) {
+interface VSNetBeansAPI {
+    version : string;
+}
+
+export function activate(context: ExtensionContext): VSNetBeansAPI {
     let log = vscode.window.createOutputChannel("Apache NetBeans Language Server");
 
     let conf = workspace.getConfiguration();
     if (conf.get("netbeans.conflict.check")) {
         let e = vscode.extensions.getExtension('redhat.java');
         function disablingFailed(reason: any) {
-            log.appendLine('Disabling some services failed ' + reason);
+            handleLog(log, 'Disabling some services failed ' + reason);
         }
         if (e && workspace.name) {
             vscode.window.showInformationMessage(`redhat.java found at ${e.extensionPath} - Suppressing some services to not clash with Apache NetBeans Language Server.`);
@@ -143,29 +169,33 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(commands.registerCommand('java.workspace.compile', () => {
         return window.withProgress({ location: ProgressLocation.Window }, p => {
             return new Promise(async (resolve, reject) => {
+                let c : LanguageClient = await client;
                 const commands = await vscode.commands.getCommands();
                 if (commands.includes('java.build.workspace')) {
                     p.report({ message: 'Compiling workspace...' });
-                    if (client != null) {
-                        client.outputChannel.show(true);
-                    }
+                    c.outputChannel.show(true);
                     const start = new Date().getTime();
+                    handleLog(log, `starting java.build.workspace`);
                     const res = await vscode.commands.executeCommand('java.build.workspace');
                     const elapsed = new Date().getTime() - start;
+                    handleLog(log, `finished java.build.workspace in ${elapsed} ms with result ${res}`);
                     const humanVisibleDelay = elapsed < 1000 ? 1000 : 0;
                     setTimeout(() => { // set a timeout so user would still see the message when build time is short
                         if (res) {
-                            resolve();
+                            resolve(res);
                         } else {
-                            reject();
+                            reject(res);
                         }
                     }, humanVisibleDelay);
                 } else {
-                    reject();
+                    reject(`cannot compile workspace; client is ${client}`);
                 }
             });
         });
     }));
+    return Object.freeze({
+        version : API_VERSION
+    });
 }
 
 /**
@@ -179,29 +209,33 @@ let maintenance : Promise<void> | null;
 let activationPending : boolean = false;
 
 function activateWithJDK(specifiedJDK: string | null, context: ExtensionContext, log : vscode.OutputChannel, notifyKill: boolean): void {
+    let setClient : [(c : LanguageClient) => void, (err : any) => void];
+    client = new Promise<LanguageClient>((clientOK, clientErr) => {
+        setClient = [ clientOK, clientErr ];
+    });
     const a : Promise<void> | null = maintenance;
     if (activationPending) {
         // do not activate more than once in parallel.
-        console.log("Server activation requested repeatedly, ignoring...");
+        handleLog(log, "Server activation requested repeatedly, ignoring...");
         return;
     }
     activationPending = true;
     // chain the restart after termination of the former process.
     if (a != null) {
-        console.log("Server activation initiated while in maintenance mode, scheduling after maintenance");
+        handleLog(log, "Server activation initiated while in maintenance mode, scheduling after maintenance");
         a.then(() => killNbProcess(notifyKill, log)).
-            then(() => doActivateWithJDK(specifiedJDK, context, log, notifyKill));
+            then(() => doActivateWithJDK(specifiedJDK, context, log, notifyKill, setClient));
     } else {
-        console.log("Initiating server activation");
+        handleLog(log, "Initiating server activation");
         killNbProcess(notifyKill, log).then(
-            () => doActivateWithJDK(specifiedJDK, context, log, notifyKill)
+            () => doActivateWithJDK(specifiedJDK, context, log, notifyKill, setClient)
         );
     }
 }
 
 function killNbProcess(notifyKill : boolean, log : vscode.OutputChannel, specProcess?: ChildProcess) : Promise<void> {
     const p = nbProcess;
-    console.log("Request to kill LSP server.");
+    handleLog(log, "Request to kill LSP server.");
     if (p && (!specProcess || specProcess == p)) {
         if (notifyKill) {
             vscode.window.setStatusBarMessage("Restarting Apache NetBeans Language Server.", 2000);
@@ -209,10 +243,10 @@ function killNbProcess(notifyKill : boolean, log : vscode.OutputChannel, specPro
         return new Promise((resolve, reject) => {
             nbProcess = null;
             p.on('close', function(code: number) {
-                console.log("LSP server closed: " + p.pid)
+                handleLog(log, "LSP server closed: " + p.pid)
                 resolve();
             });
-            console.log("Killing LSP server " + p.pid);
+            handleLog(log, "Killing LSP server " + p.pid);
             if (!p.kill()) {
                 reject("Cannot kill");
             }
@@ -222,15 +256,17 @@ function killNbProcess(notifyKill : boolean, log : vscode.OutputChannel, specPro
         if (specProcess) {
             msg += "Requested kill on " + specProcess.pid + ", ";
         }
-        console.log(msg + "current process is " + (p ? p.pid : "None"));
+        handleLog(log, msg + "current process is " + (p ? p.pid : "None"));
         return new Promise((res, rej) => { res(); });
     }
 }
 
-function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContext, log : vscode.OutputChannel, notifyKill: boolean): void {
+function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContext, log : vscode.OutputChannel, notifyKill: boolean,
+    setClient : [(c : LanguageClient) => void, (err : any) => void]
+): void {
     maintenance = null;
     let restartWithJDKLater : ((time: number, n: boolean) => void) = function restartLater(time: number, n : boolean) {
-        log.appendLine(`Restart of Apache Language Server requested in ${(time / 1000)} s.`);
+        handleLog(log, `Restart of Apache Language Server requested in ${(time / 1000)} s.`);
         setTimeout(() => {
             activateWithJDK(specifiedJDK, context, log, n);
         }, time);
@@ -245,7 +281,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
         verbose: beVerbose
     };
     let launchMsg = `Launching Apache NetBeans Language Server with ${specifiedJDK ? specifiedJDK : 'default system JDK'}`;
-    log.appendLine(launchMsg);
+    handleLog(log, launchMsg);
     vscode.window.setStatusBarMessage(launchMsg, 2000);
 
     let ideRunning = new Promise((resolve, reject) => {
@@ -254,7 +290,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
             if (p == nbProcess) {
                 activationPending = false;
             }
-            log.append(text);
+            handleLogNoNL(log, text);
             if (collectedText == null) {
                 return;
             }
@@ -265,7 +301,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
             }
         }
         let p = launcher.launch(info, "--modules", "--list");
-        console.log("LSP server launching: " + p.pid);
+        handleLog(log, "LSP server launching: " + p.pid);
         p.stdout.on('data', function(d: any) {
             logAndWaitForEnabled(d.toString());
         });
@@ -280,16 +316,16 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
             if (collectedText != null) {
                 let match = collectedText.match(/org.netbeans.modules.java.lsp.server[^\n]*/)
                 if (match?.length == 1) {
-                    log.appendLine(match[0]);
+                    handleLog(log, match[0]);
                 } else {
-                    log.appendLine("Cannot find org.netbeans.modules.java.lsp.server in the log!");
+                    handleLog(log, "Cannot find org.netbeans.modules.java.lsp.server in the log!");
                 }
                 log.show(false);
                 killNbProcess(false, log, p);
                 reject("Apache NetBeans Language Server not enabled!");
             } else {
-                console.log("LSP server " + p.pid + " terminated with " + code);
-                log.appendLine("Exit code " + code);
+                handleLog(log, "LSP server " + p.pid + " terminated with " + code);
+                handleLog(log, "Exit code " + code);
             }
         });
     });
@@ -358,7 +394,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                     return ErrorAction.Continue;
                 },
                 closed : function(): CloseAction {
-                    log.appendLine("Connection to Apache NetBeans Language Server closed.");
+                    handleLog(log, "Connection to Apache NetBeans Language Server closed.");
                     if (!activationPending) {
                         restartWithJDKLater(10000, false);
                     }
@@ -367,23 +403,24 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
             }
         }
 
-        if (client) {
-            client.stop();
-        }
-        client = new LanguageClient(
+        let c = new LanguageClient(
                 'java',
                 'NetBeans Java',
                 connection,
                 clientOptions
         );
-        client.start();
-        client.onReady().then(() => {
+        handleLog(log, 'Language Client: Starting');
+        c.start();
+        c.onReady().then(() => {
             commands.executeCommand('setContext', 'nbJavaLSReady', true);
-            client.onNotification(StatusMessageRequest.type, showStatusBarMessage);
-        });
+            c.onNotification(StatusMessageRequest.type, showStatusBarMessage);
+            c.onNotification(LogMessageNotification.type, (param) => handleLog(log, param.message));
+            handleLog(log, 'Language Client: Ready');
+            setClient[0](c);
+        }).catch(setClient[1]);
     }).catch((reason) => {
         activationPending = false;
-        log.append(reason);
+        handleLog(log, reason);
         window.showErrorMessage('Error initializing ' + reason);
     });
 
@@ -422,15 +459,15 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                 if (yes === reply) {
                     vscode.window.setStatusBarMessage("Preparing Apache NetBeans Language Server for additional installation", 2000);
                     restartWithJDKLater = function() {
-                        console.log("Ignoring request for restart of Apache NetBeans Language Server");
+                        handleLog(log, "Ignoring request for restart of Apache NetBeans Language Server");
                     };
                     maintenance = new Promise((resolve, reject) => {
                         const kill : Promise<void> = killNbProcess(false, log);
                         kill.then(() => {
                             let installProcess = launcher.launch(info, "-J-Dnetbeans.close=true", "--modules", "--install", ".*nbjavac.*");
-                            console.log("Launching installation process: " + installProcess.pid);
+                            handleLog(log, "Launching installation process: " + installProcess.pid);
                             let logData = function(d: any) {
-                                log.append(d.toString());
+                                handleLogNoNL(log, d.toString());
                             };
                             installProcess.stdout.on('data', logData);
                             installProcess.stderr.on('data', logData);
@@ -438,8 +475,8 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                             // MUST wait on 'close', since stdout is inherited by children. The installProcess dies but
                             // the inherited stream will be closed by the last child dying.
                             installProcess.on('close', function(code: number) {
-                                console.log("Installation completed: " + installProcess.pid);
-                                log.appendLine("Additional Java Support installed with exit code " + code);
+                                handleLog(log, "Installation completed: " + installProcess.pid);
+                                handleLog(log, "Additional Java Support installed with exit code " + code);
                                 // will be actually run after maintenance is resolve()d.
                                 activateWithJDK(specifiedJDK, context, log, notifyKill)
                                 resolve();
@@ -457,10 +494,7 @@ export function deactivate(): Thenable<void> {
     if (nbProcess != null) {
         nbProcess.kill();
     }
-    if (!client) {
-        return Promise.resolve();
-    }
-    return client.stop();
+    return client.then(c => c.stop());
 }
 
 class NetBeansDebugAdapterDescriptionFactory implements vscode.DebugAdapterDescriptorFactory {

--- a/java/java.lsp.server/vscode/src/test/runTest.ts
+++ b/java/java.lsp.server/vscode/src/test/runTest.ts
@@ -2,22 +2,39 @@ import * as path from 'path';
 
 import { runTests } from 'vscode-test';
 
+import * as os from 'os';
+import * as fs from 'fs';
+
 async function main() {
-	try {
-		// The folder containing the Extension Manifest package.json
-		// Passed to `--extensionDevelopmentPath`
-		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+    try {
+        // The folder containing the Extension Manifest package.json
+        // Passed to `--extensionDevelopmentPath`
+        const extensionDevelopmentPath = path.resolve(__dirname, '../../');
 
-		// The path to test runner
-		// Passed to --extensionTestsPath
-		const extensionTestsPath = path.resolve(__dirname, './suite/index');
+        // The path to test runner
+        // Passed to --extensionTestsPath
+        const extensionTestsPath = path.resolve(__dirname, './suite/index');
 
-		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
-	} catch (err) {
-		console.error('Failed to run tests');
-		process.exit(1);
-	}
+        const workspaceDir = path.join(extensionDevelopmentPath, 'out', 'test', 'ws');
+
+        if (!fs.statSync(workspaceDir).isDirectory()) {
+            throw `Expecting ${workspaceDir} to be a directory!`;
+        }
+
+        // Download VS Code, unzip it and run the integration test
+        await runTests({
+            version: "1.50.0",
+            extensionDevelopmentPath,
+            extensionTestsPath,
+            extensionTestsEnv: {
+                'ENABLE_CONSOLE_LOG' : 'true'
+            },
+            launchArgs: [workspaceDir, '--async-stack-traces']
+        });
+    } catch (err) {
+        console.error('Failed to run tests');
+        process.exit(1);
+    }
 }
 
 main();

--- a/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
@@ -1,15 +1,130 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawn, ChildProcessByStdio, spawnSync, SpawnSyncReturns } from 'child_process';
+import { Readable } from 'stream';
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
+import * as myExtension from '../../extension';
 
 suite('Extension Test Suite', () => {
-	vscode.window.showInformationMessage('Start all tests.');
+    vscode.window.showInformationMessage('Cleaning up workspace.');
+    let folder: string = assertWorkspace();
+    fs.rmdirSync(folder, { recursive: true });
+    fs.mkdirSync(folder, { recursive: true });
+    vscode.window.showInformationMessage('Start all tests.');
+    myExtension.enableConsoleLog();
 
-	test('Sample test', () => {
-		assert.equal(-1, [1, 2, 3].indexOf(5));
-		assert.equal(-1, [1, 2, 3].indexOf(0));
-	});
+    test('VSNetBeans is present', async () => {
+        let nbcode = vscode.extensions.getExtension('asf.apache-netbeans-java');
+        assert.ok(nbcode, "Apache NetBeans Extension is present");
+        let api = await nbcode.activate();
+        assert.ok(api.version, "Some version is specified");
+
+        let cannotReassignVersion = false;
+        try {
+            api.version = "different";
+        } catch (e) {
+            cannotReassignVersion = true;
+        }
+        assert.ok(cannotReassignVersion, "Cannot reassign value of version");
+    });
+
+    test('Find clusters', async () => {
+        let clusters = myExtension.findClusters('non-existent');
+        assert.strictEqual(clusters.length, 6, 'six clusters found: ' + clusters);
+        let nbcode = vscode.extensions.getExtension('asf.apache-netbeans-java');
+        assert.ok(nbcode);
+        for (let c of clusters) {
+            assert.ok(c.startsWith(nbcode.extensionPath), `All extensions are below ${nbcode.extensionPath}, but: ${c}`);
+        }
+    });
+
+    async function demo(where: number) {
+        let folder: string = assertWorkspace();
+
+        await fs.promises.writeFile(path.join(folder, 'pom.xml'), `
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.netbeans.demo.vscode.t1</groupId>
+    <artifactId>basicapp</artifactId>
+    <version>1.0</version>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+</project>
+		`);
+
+        let pkg = path.join(folder, 'src', 'main', 'java', 'pkg');
+        let mainJava = path.join(pkg, 'Main.java');
+
+        await fs.promises.mkdir(pkg, { recursive: true });
+
+        await fs.promises.writeFile(mainJava, `
+package pkg;
+class Main {
+	public static void main(String... args) {
+		System.out.println("Hello World!");
+	}
+}
+		`);
+
+        vscode.workspace.saveAll();
+
+        if (where === 6) return;
+
+        try {
+            console.log("Test: invoking compile");
+            let res = await vscode.commands.executeCommand("java.workspace.compile");
+            console.log(`Test: compile finished with ${res}`);
+        } catch (error) {
+            dumpJava();
+            throw error;
+        }
+
+        if (where === 7) return;
+
+        let mainClass = path.join(folder, 'target', 'classes', 'pkg', 'Main.class');
+
+        if (where === 8) return;
+
+        assert.ok(fs.statSync(mainClass).isFile(), "Class created by compilation: " + mainClass);
+    }
+
+    test("Compile workspace6", async() => demo(6));
+    test("Compile workspace7", async() => demo(7));
+    test("Compile workspace8", async() => demo(8));
 });
+
+function assertWorkspace(): string {
+    assert.ok(vscode.workspace, "workspace is defined");
+    const dirs = vscode.workspace.workspaceFolders;
+    assert.ok(dirs?.length, "There are some workspace folders: " + dirs);
+    assert.strictEqual(dirs.length, 1, "One folder provided");
+    let folder: string = dirs[0].uri.fsPath;
+    return folder;
+}
+
+async function dumpJava() {
+    const cmd = 'jps';
+    const args = [ '-v' ];
+    console.log(`Running: ${cmd} ${args.join(' ')}`);
+    let p : ChildProcessByStdio<null, Readable, Readable> = spawn(cmd, args, {
+        stdio : ["ignore", "pipe", "pipe"],
+    });
+    let n = await new Promise<number>((r, e) => {
+        p.stdout.on('data', function(d: any) {
+            console.log(d.toString());
+        });
+        p.stderr.on('data', function(d: any) {
+            console.log(d.toString());
+        });
+        p.on('close', function(code: number) {
+            r(code);
+        });
+    });
+    console.log(`${cmd} ${args.join(' ')} finished with code ${n}`);
+}

--- a/java/java.lsp.server/vscode/src/test/suite/index.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/index.ts
@@ -6,33 +6,36 @@ export function run(): Promise<void> {
 	// Create the mocha test
 	const mocha = new Mocha({
 		ui: 'tdd',
-		color: true
+		color: true,
+		timeout: 60000
 	});
 
 	const testsRoot = path.resolve(__dirname, '..');
 
 	return new Promise((c, e) => {
-		glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
-			if (err) {
-				return e(err);
-			}
+		setTimeout(function() {
+			glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+				if (err) {
+					return e(err);
+				}
 
-			// Add files to the test suite
-			files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
+				// Add files to the test suite
+				files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));
 
-			try {
-				// Run the mocha test
-				mocha.run(failures => {
-					if (failures > 0) {
-						e(new Error(`${failures} tests failed.`));
-					} else {
-						c();
-					}
-				});
-			} catch (err) {
-				console.error(err);
-				e(err);
-			}
-		});
+				try {
+					// Run the mocha test
+					mocha.run(failures => {
+						if (failures > 0) {
+							e(new Error(`${failures} tests failed.`));
+						} else {
+							c();
+						}
+					});
+				} catch (err) {
+					console.error(err);
+					e(err);
+				}
+			});
+		}, 3000);
 	});
 }

--- a/java/java.lsp.server/vscode/src/test/ws/empty.ts
+++ b/java/java.lsp.server/vscode/src/test/ws/empty.ts
@@ -1,0 +1,2 @@
+export function empty(): any {
+}


### PR DESCRIPTION
Executing some VS Code extension integration tests. The execution of the [first test failed](https://travis-ci.org/github/apache/netbeans/jobs/744801153) - e.g. the travis gate correctly verifies the behavior of our extension.

Next step is to initialize the extension and get its (programmatic) version: 9219db8 - that shall succeed.

The last test creates `pom.xml` and a `.java` source in a workspace and invokes its compilation. Then it checks the result. I guess that is enough for now and quite a bit of functionality is covered.

This was failing on the gate as the "compile" command was executed sooner than language client with its `java.build.workspace` action was really initialized. This should be [fixed now](https://github.com/apache/netbeans/pull/2549/commits/3dbed9d6b1f5855ce99cc227bff928568273b722). Please review.