### PR TITLE
[NETBEANS-4938] TestCase for a SourceGroup bug in Gradle Projects

### DIFF
--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
@@ -20,11 +20,14 @@ package org.netbeans.modules.gradle;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import static junit.framework.TestCase.assertNotNull;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FULL_ONLINE;
 import org.netbeans.modules.project.uiapi.ProjectOpenedTrampoline;
 import org.netbeans.spi.project.ui.ProjectOpenedHook;
 import org.openide.filesystems.FileObject;
@@ -74,6 +77,16 @@ public class AbstractGradleProjectTestCase extends NbTestCase {
         return prj;
     }
 
+    protected void reloadProject(Project project) throws InterruptedException, ExecutionException {
+        NbGradleProjectImpl impl = (NbGradleProjectImpl) project;
+        NbGradleProjectImpl.RELOAD_RP.submit(() -> {
+            // A bit low level calls, just to allow UI interaction to
+            // Trust the project.
+            impl.project = GradleProjectCache.loadProject(impl, FULL_ONLINE, true, true);
+            NbGradleProjectImpl.ACCESSOR.doFireReload(NbGradleProject.get(impl));
+        }).get();
+    }
+    
     protected FileObject createGradleProject(String path, String buildScript, String settingsScript) throws IOException {
         FileObject ret = FileUtil.toFileObject(getWorkDir());
         if (path != null) {

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaDebuggerImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaDebuggerImpl.java
@@ -30,12 +30,10 @@ import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.java.api.ProjectSourcesClassPathProvider;
 import org.netbeans.modules.gradle.java.execute.JavaRunUtils;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Lookup;
@@ -48,7 +46,6 @@ import org.netbeans.modules.gradle.java.spi.debug.GradleJavaDebugger;
  * 
  * @author lkishalmi
  */
-@ProjectServiceProvider(service = GradleJavaDebugger.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public final class GradleJavaDebuggerImpl implements GradleJavaDebugger {
 
     private final RequestProcessor RP = new RequestProcessor(GradleJavaDebuggerImpl.class);

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaProjectProblemProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaProjectProblemProvider.java
@@ -27,7 +27,6 @@ import java.util.List;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.java.execute.JavaRunUtils;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.netbeans.spi.project.ui.ProjectProblemsProvider;
 import static org.netbeans.spi.project.ui.ProjectProblemsProvider.PROP_PROBLEMS;
 import org.openide.util.NbBundle;
@@ -36,7 +35,6 @@ import org.openide.util.NbBundle;
  *
  * @author lkishalmi
  */
-@ProjectServiceProvider(service = ProjectProblemsProvider.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GradleJavaProjectProblemProvider implements ProjectProblemsProvider {
     private final Project project;
     private final PropertyChangeListener listener;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.gradle.java;
 
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.netbeans.modules.gradle.java.api.GradleJavaProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaSourceSet;
@@ -32,7 +31,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.netbeans.api.project.Project;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.netbeans.spi.project.SingleMethod;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -42,7 +40,6 @@ import org.openide.util.Lookup;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = ReplaceTokenProvider.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GradleJavaTokenProvider implements ReplaceTokenProvider {
 
     private static final String SELECTED_CLASS      = "selectedClass";     //NOI18N

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/LookupProviders.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/LookupProviders.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java;
+
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.spi.project.LookupProvider;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class LookupProviders {
+
+    @LookupProvider.Registration(projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
+    public static LookupProvider createJavaBaseProvider() {
+        return new LookupProvider() {
+            @Override
+            public Lookup createAdditionalLookup(Lookup baseContext) {
+                Project project = baseContext.lookup(Project.class);
+                return Lookups.fixed(
+                        new GradleJavaDebuggerImpl(project),
+                        new GradleJavaProjectProblemProvider(project),
+                        new GradleJavaTokenProvider(project),
+                        new RecommendedPrivilegedTemplatesImpl(),
+                        new SourceGroupResourceWatchList(project)
+                );
+            }
+        };
+    }
+
+}

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/RecommendedPrivilegedTemplatesImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/RecommendedPrivilegedTemplatesImpl.java
@@ -19,8 +19,6 @@
 
 package org.netbeans.modules.gradle.java;
 
-import org.netbeans.modules.gradle.api.NbGradleProject;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.netbeans.spi.project.ui.PrivilegedTemplates;
 import org.netbeans.spi.project.ui.RecommendedTemplates;
 
@@ -28,7 +26,6 @@ import org.netbeans.spi.project.ui.RecommendedTemplates;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = {RecommendedTemplates.class, PrivilegedTemplates.class}, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class RecommendedPrivilegedTemplatesImpl implements RecommendedTemplates, PrivilegedTemplates {
 
     // List of primarily supported templates categories

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/SourceGroupResourceWatchList.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/SourceGroupResourceWatchList.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.gradle.java;
 
 import org.netbeans.modules.gradle.java.api.GradleJavaSourceSet;
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaProject;
 import org.netbeans.modules.gradle.spi.WatchedResourceProvider;
 import java.io.File;
@@ -29,13 +28,11 @@ import java.util.HashSet;
 import java.util.Set;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.java.classpath.ClassPathProviderImpl;
-import org.netbeans.spi.project.ProjectServiceProvider;
 
 /**
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = {WatchedResourceProvider.class}, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class SourceGroupResourceWatchList implements WatchedResourceProvider {
 
     private final Project project;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/api/output/LocationOpener.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/api/output/LocationOpener.java
@@ -32,7 +32,6 @@ import javax.swing.SwingUtilities;
 import org.netbeans.api.java.classpath.GlobalPathRegistry;
 import org.netbeans.api.java.source.CompilationController;
 import org.netbeans.api.java.source.JavaSource;
-import org.netbeans.api.java.source.Task;
 import org.openide.cookies.LineCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
@@ -45,14 +44,7 @@ import org.openide.text.Line;
  */
 public final class LocationOpener {
 
-    public static final Location.Finder GLOBAL_FINDER = new Location.Finder() {
-
-        @Override
-        public FileObject findFileObject(Location loc) {
-            return GlobalPathRegistry.getDefault().findResource(loc.getFileName());
-        }
-
-    };
+    public static final Location.Finder GLOBAL_FINDER = (Location loc) -> GlobalPathRegistry.getDefault().findResource(loc.getFileName());
     final Location location;
     final Location.Finder finder;
 

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
@@ -41,7 +41,6 @@ import org.netbeans.api.project.Project;
 import org.netbeans.spi.java.classpath.ClassPathFactory;
 import org.netbeans.spi.java.classpath.ClassPathProvider;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.netbeans.spi.project.ui.ProjectOpenedHook;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -53,8 +52,6 @@ import static org.netbeans.api.java.classpath.JavaClassPathConstants.*;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = {ClassPathProvider.class, ProjectOpenedHook.class},
-        projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public final class ClassPathProviderImpl extends ProjectOpenedHook implements ClassPathProvider {
 
     public static final String MODULE_INFO_JAVA = "module-info.java"; // NOI18N

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GlobalClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GlobalClassPathProviderImpl.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.gradle.java.classpath;
 
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.java.api.ProjectSourcesClassPathProvider;
 import java.util.Arrays;
 import java.util.logging.Level;
@@ -28,14 +27,12 @@ import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.classpath.GlobalPathRegistry;
 import org.netbeans.api.project.Project;
 import static org.netbeans.spi.java.classpath.ClassPathFactory.createClassPath;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.netbeans.spi.project.ui.ProjectOpenedHook;
 
 /**
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = {ProjectSourcesClassPathProvider.class, ProjectOpenedHook.class}, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GlobalClassPathProviderImpl extends ProjectOpenedHook implements ProjectSourcesClassPathProvider {
 
     private static final Logger LOG = Logger.getLogger(GlobalClassPathProviderImpl.class.getName());

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
@@ -47,7 +47,6 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.Sources;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.netbeans.spi.project.SourceGroupModifierImplementation;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -59,7 +58,6 @@ import org.openide.util.Pair;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = {Sources.class, SourceGroupModifierImplementation.class}, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 @NbBundle.Messages({
     "# {0} - source group name",
     "# {1} - language",
@@ -146,8 +144,8 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
     private Map<String, Collection<File>> sourceGroups;
     private final Map<Pair<String, File>, SourceGroup> cache = new HashMap<>();
 
-    public GradleSourcesImpl(Project proj) {
-        this.proj = proj;
+    public GradleSourcesImpl(Project project) {
+        this.proj = project;
     }
 
     @Override

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/LookupProviders.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/LookupProviders.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.classpath;
+
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.spi.project.LookupProvider;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class LookupProviders {
+
+    @LookupProvider.Registration(projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
+    public static LookupProvider createJavaBaseProvider() {
+        return new LookupProvider() {
+            @Override
+            public Lookup createAdditionalLookup(Lookup baseContext) {
+                Project project = baseContext.lookup(Project.class);
+                return Lookups.fixed(
+                        new ClassPathProviderImpl(project),
+                        new GradleSourcesImpl(project),
+                        new GlobalClassPathProviderImpl(project)
+                );
+            }
+        };
+    }
+}

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/DebugFixHooks.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/DebugFixHooks.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.gradle.java.execute;
 
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaSourceSet;
 import org.netbeans.modules.gradle.spi.actions.AfterBuildActionHook;
@@ -36,7 +35,6 @@ import org.netbeans.api.debugger.DebuggerEngine;
 import org.netbeans.api.debugger.DebuggerManager;
 import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.java.classpath.ClassPath;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.util.Lookup;
 import org.netbeans.api.java.queries.SourceForBinaryQuery;
 import org.netbeans.api.project.Project;
@@ -51,10 +49,6 @@ import static org.netbeans.api.java.project.JavaProjectConstants.*;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(
-        service = {BeforeBuildActionHook.class, AfterBuildActionHook.class},
-        projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base"
-)
 public class DebugFixHooks implements BeforeBuildActionHook, AfterBuildActionHook {
 
     final Project project;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/GradleJavaPlatformProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/GradleJavaPlatformProviderImpl.java
@@ -22,9 +22,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.spi.execute.GradleJavaPlatformProvider;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Pair;
 
@@ -32,7 +30,6 @@ import org.openide.util.Pair;
  *
  * @author lkishalmi
  */
-@ProjectServiceProvider(service = GradleJavaPlatformProvider.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public final class GradleJavaPlatformProviderImpl implements GradleJavaPlatformProvider {
 
     final Project project;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/LookupProviders.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/LookupProviders.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.execute;
+
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.spi.project.LookupProvider;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class LookupProviders {
+    @LookupProvider.Registration(projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
+    public static LookupProvider createJavaBaseProvider() {
+        return new LookupProvider() {
+            @Override
+            public Lookup createAdditionalLookup(Lookup baseContext) {
+                Project project = baseContext.lookup(Project.class);
+                return Lookups.fixed(
+                        new DebugFixHooks(project),
+                        new GradleJavaPlatformProviderImpl(project),
+                        new ShowJavadocHook(project)
+                );
+            }
+        };
+    }
+
+}

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/ShowJavadocHook.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/execute/ShowJavadocHook.java
@@ -20,12 +20,10 @@
 package org.netbeans.modules.gradle.java.execute;
 
 import org.netbeans.modules.gradle.api.GradleBaseProject;
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.spi.actions.AfterBuildActionHook;
 import java.io.File;
 import java.io.PrintWriter;
 import org.netbeans.api.project.Project;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.util.Lookup;
 
 import static org.netbeans.api.java.project.JavaProjectConstants.*;
@@ -37,10 +35,6 @@ import org.openide.filesystems.FileUtil;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(
-        service = AfterBuildActionHook.class,
-        projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base"
-)
 public class ShowJavadocHook implements AfterBuildActionHook {
 
     final Project project;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/output/GatlingReportProcessorFactory.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/output/GatlingReportProcessorFactory.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.gradle.java.output;
 
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.RunConfig;
 import org.netbeans.modules.gradle.api.output.OutputDisplayer;
 import org.netbeans.modules.gradle.api.output.OutputListeners;
@@ -31,14 +30,12 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.util.Utilities;
 
 /**
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = OutputProcessorFactory.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/com.github.lkishalmi.gatling")
 public class GatlingReportProcessorFactory implements OutputProcessorFactory {
 
     static final OutputProcessor GATLING_OUTPUT_PROCESSOR = new GatlingOutputProcessor();

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/output/JDPAProcessorFactory.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/output/JDPAProcessorFactory.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.gradle.java.output;
 
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.RunConfig;
 import org.netbeans.modules.gradle.api.output.OutputDisplayer;
 import org.netbeans.modules.gradle.api.output.OutputProcessor;
@@ -29,7 +28,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.netbeans.modules.gradle.api.execute.RunUtils;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.windows.IOColors;
 import org.netbeans.modules.gradle.java.spi.debug.GradleJavaDebugger;
 
@@ -37,7 +35,6 @@ import org.netbeans.modules.gradle.java.spi.debug.GradleJavaDebugger;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = OutputProcessorFactory.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class JDPAProcessorFactory implements OutputProcessorFactory {
 
     @Override

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/output/JavaCompilerProcessorFactory.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/output/JavaCompilerProcessorFactory.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.gradle.java.output;
 
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.RunConfig;
 import org.netbeans.modules.gradle.api.output.OutputDisplayer;
 import org.netbeans.modules.gradle.api.output.OutputProcessor;
@@ -36,7 +35,6 @@ import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.queries.SourceForBinaryQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.awt.StatusDisplayer;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.URLMapper;
@@ -47,7 +45,6 @@ import org.netbeans.modules.gradle.java.api.ProjectSourcesClassPathProvider;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = OutputProcessorFactory.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public final class JavaCompilerProcessorFactory implements OutputProcessorFactory {
 
     @Override

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/output/LookupProviders.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/output/LookupProviders.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.output;
+
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.spi.project.LookupProvider;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class LookupProviders {
+
+    @LookupProvider.Registration(projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
+    public static LookupProvider createJavaBaseProvider() {
+        return new LookupProvider() {
+            @Override
+            public Lookup createAdditionalLookup(Lookup baseContext) {
+                return Lookups.fixed(
+                        new JavaCompilerProcessorFactory(),
+                        new JDPAProcessorFactory()
+                );
+            }
+        };
+    }
+
+    @LookupProvider.Registration(projectTypes = {
+        @LookupProvider.Registration.ProjectType(id = NbGradleProject.GRADLE_PLUGIN_TYPE + "/com.github.lkishalmi.gatling"),
+        @LookupProvider.Registration.ProjectType(id = NbGradleProject.GRADLE_PLUGIN_TYPE + "/io.gatling.gradle")
+    })
+    public static LookupProvider createGatlingProvider() {
+        return (baseContext) -> {
+            return Lookups.fixed(
+                    new JDPAProcessorFactory()
+            );
+        };
+    }
+}

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/FileBuiltQueryImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/FileBuiltQueryImpl.java
@@ -36,7 +36,6 @@ import org.netbeans.api.java.source.SourceUtils;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.queries.FileBuiltQuery;
 import static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet.SourceType.JAVA;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.netbeans.spi.project.ui.ProjectOpenedHook;
 import org.netbeans.spi.queries.FileBuiltQueryImplementation;
 import org.openide.filesystems.FileAttributeEvent;
@@ -54,8 +53,6 @@ import org.openide.util.WeakListeners;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = {FileBuiltQueryImplementation.class, ProjectOpenedHook.class},
-        projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class FileBuiltQueryImpl extends ProjectOpenedHook implements FileBuiltQueryImplementation {
 
     final Project project;
@@ -85,13 +82,9 @@ public class FileBuiltQueryImpl extends ProjectOpenedHook implements FileBuiltQu
 
     public FileBuiltQueryImpl(Project project) {
         this.project = project;
-        this.pcl = new PropertyChangeListener() {
-
-            @Override
-            public void propertyChange(PropertyChangeEvent evt) {
-                if (NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())) {
-                    cache.clear();
-                }
+        this.pcl = (PropertyChangeEvent evt) -> {
+            if (NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())) {
+                cache.clear();
             }
         };
     }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleAnnotationProcessorQueryImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleAnnotationProcessorQueryImpl.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.gradle.java.queries;
 
 import java.io.File;
 import java.net.MalformedURLException;
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,7 +40,6 @@ import org.netbeans.modules.gradle.java.api.GradleJavaProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaSourceSet;
 import static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet.SourceType.JAVA;
 import org.netbeans.spi.java.queries.AnnotationProcessingQueryImplementation;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.modules.SpecificationVersion;
@@ -50,7 +48,6 @@ import org.openide.modules.SpecificationVersion;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = AnnotationProcessingQueryImplementation.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GradleAnnotationProcessorQueryImpl implements AnnotationProcessingQueryImplementation {
 
     private static final SpecificationVersion VER16 = new SpecificationVersion("1.6");

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleBinaryForSource.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleBinaryForSource.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.gradle.java.queries;
 
 import org.netbeans.modules.gradle.java.api.GradleJavaSourceSet;
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaProject;
 import java.io.File;
 import java.net.URISyntaxException;
@@ -33,7 +32,6 @@ import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.queries.BinaryForSourceQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.spi.java.queries.BinaryForSourceQueryImplementation;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Utilities;
 
@@ -41,7 +39,6 @@ import org.openide.util.Utilities;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = BinaryForSourceQueryImplementation.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GradleBinaryForSource implements BinaryForSourceQueryImplementation {
 
     private final Project project;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleCompilerOptionsQuery.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleCompilerOptionsQuery.java
@@ -122,7 +122,7 @@ public final class GradleCompilerOptionsQuery implements CompilerOptionsQueryImp
 
         private List<String> checkArgs() {
             GradleJavaProject gjp = GradleJavaProject.get(project);
-            GradleJavaSourceSet ss = gjp.getSourceSets().get(sourceSetName);
+            GradleJavaSourceSet ss = gjp != null ? gjp.getSourceSets().get(sourceSetName) : null;
             return ss != null ? ss.getCompilerArgs(type) : Collections.emptyList();
         }
 

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleCompilerOptionsQuery.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleCompilerOptionsQuery.java
@@ -30,7 +30,6 @@ import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaSourceSet;
 import org.netbeans.spi.java.queries.CompilerOptionsQueryImplementation;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.ChangeSupport;
@@ -42,7 +41,6 @@ import static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet.SourceTyp
  *
  * @author lkishalmi
  */
-@ProjectServiceProvider(service = CompilerOptionsQueryImplementation.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public final class GradleCompilerOptionsQuery implements CompilerOptionsQueryImplementation {
 
     final Project project;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleFileLocator.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleFileLocator.java
@@ -38,14 +38,12 @@ import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.Sources;
 import org.netbeans.spi.java.classpath.ClassPathProvider;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.filesystems.FileObject;
 
 /**
  *
  * @author mkleint
  */
-@ProjectServiceProvider(service=LineConvertors.FileLocator.class, projectType=NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GradleFileLocator implements LineConvertors.FileLocator {
 
     private ClassPath classpath;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceForBinary.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceForBinary.java
@@ -41,9 +41,7 @@ import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.queries.SourceForBinaryQuery;
 import org.netbeans.api.project.Project;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.*;
-import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation;
 import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.ChangeSupport;
@@ -54,7 +52,6 @@ import org.openide.util.WeakListeners;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = {SourceForBinaryQueryImplementation.class, SourceForBinaryQueryImplementation2.class}, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GradleSourceForBinary implements SourceForBinaryQueryImplementation2 {
 
     private final Project project;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceLevelImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceLevelImpl.java
@@ -30,7 +30,6 @@ import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.queries.SourceLevelQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.spi.java.queries.SourceLevelQueryImplementation2;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.ChangeSupport;
@@ -40,8 +39,6 @@ import org.openide.util.WeakListeners;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service =  SourceLevelQueryImplementation2.class,
-        projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GradleSourceLevelImpl implements SourceLevelQueryImplementation2 {
 
     final Project project;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleTestForSourceImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleTestForSourceImpl.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.gradle.java.queries;
 
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaSourceSet;
 import org.netbeans.modules.gradle.java.api.GradleJavaSourceSet.SourceType;
 import org.netbeans.modules.gradle.java.api.GradleJavaProject;
@@ -33,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import org.netbeans.api.project.Project;
 import org.netbeans.spi.java.queries.MultipleRootsUnitTestForSourceQueryImplementation;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Utilities;
@@ -42,7 +40,6 @@ import org.openide.util.Utilities;
  *
  * @author Laszlo Kishalmi
  */
-@ProjectServiceProvider(service = MultipleRootsUnitTestForSourceQueryImplementation.class, projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
 public class GradleTestForSourceImpl implements MultipleRootsUnitTestForSourceQueryImplementation {
 
     private static final SourceType[] MAIN_SOURCES = new SourceType[]{

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/LookupProviders.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/LookupProviders.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.queries;
+
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.spi.project.LookupProvider;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class LookupProviders {
+    @LookupProvider.Registration(projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/java-base")
+    public static LookupProvider createJavaBaseProvider() {
+        return new LookupProvider() {
+            @Override
+            public Lookup createAdditionalLookup(Lookup baseContext) {
+                Project project = baseContext.lookup(Project.class);
+                return Lookups.fixed(
+                        new FileBuiltQueryImpl(project),
+                        new GradleAnnotationProcessorQueryImpl(project),
+                        new GradleBinaryForSource(project),
+                        new GradleCompilerOptionsQuery(project),
+                        new GradleFileLocator(project),
+                        new GradleSourceForBinary(project),
+                        new GradleSourceLevelImpl(project),
+                        new GradleTestForSourceImpl(project)
+                );
+            }
+        };
+    }
+}

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImplTest.java
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImplTest.java
@@ -27,6 +27,7 @@ import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.Sources;
 import org.netbeans.modules.gradle.AbstractGradleProjectTestCase;
+import org.netbeans.modules.gradle.ProjectTrust;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
@@ -41,9 +42,9 @@ public class GradleSourcesImplTest extends AbstractGradleProjectTestCase {
     }
 
     public void testGeneratedSources() throws Exception { // #187595
-        FileObject d = createGradleProject(
+        FileObject d = createGradleProject(null,
                 "apply plugin: 'java'\n" +
-                "sourceSets { main { java { srcDirs = [ 'src', 'build/gen-src' ] }}}");
+                "sourceSets { main { java { srcDirs = [ 'src', 'build/gen-src' ] }}}", "");
         FileObject src = FileUtil.createFolder(d, "src/");
         FileObject gsrc = FileUtil.createFolder(d, "build/gen-src");
         FileObject source = src.createData("Whatever.java");
@@ -59,11 +60,36 @@ public class GradleSourcesImplTest extends AbstractGradleProjectTestCase {
     }
 
     public void testRootProjectSourceGroup() throws IOException {
-        FileObject d = createGradleProject(
+        FileObject d = createGradleProject(null,
                 "apply plugin: 'java'\n" +
-                "sourceSets { main { java { srcDirs = [ 'src', 'build/gen-src' ] }}}");
+                "sourceSets { main { java { srcDirs = [ 'src', 'build/gen-src' ] }}}", "");
         Project p = ProjectManager.getDefault().findProject(d);
         SourceGroup[] groups = ProjectUtils.getSources(p).getSourceGroups(Sources.TYPE_GENERIC);
         assertEquals(1, groups.length);
+    }
+
+    public void testSourceProviderChange() throws Exception {
+        FileObject d = createGradleProject(null, "", "");
+        Project p = ProjectManager.getDefault().findProject(d);
+        ProjectTrust.getDefault().trustProject(p);
+        SourceGroup[] groups = ProjectUtils.getSources(p).getSourceGroups(Sources.TYPE_GENERIC);
+        assertEquals(1, groups.length);
+        groups = ProjectUtils.getSources(p).getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA);
+        assertEquals(0, groups.length);
+        FileObject src = FileUtil.createFolder(d, "src/");
+        FileObject gsrc = FileUtil.createFolder(d, "build/gen-src");
+        FileObject source = src.createData("Whatever.java");
+        FileObject generated = gsrc.createData("WhateverGen.java");
+        createGradleProject(null,
+                "apply plugin: 'java'\n" +
+                "sourceSets { main { java { srcDirs = [ 'src', 'build/gen-src' ] }}}", "");
+        reloadProject(p);
+        Sources srcs = ProjectUtils.getSources(p);
+        groups = srcs.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA);
+        assertEquals(2, groups.length);
+        assertTrue(groups[0].contains(source));
+        assertFalse(groups[0].contains(generated));
+        assertTrue(groups[1].contains(generated));
+        assertFalse(groups[1].contains(source));
     }
 }


### PR DESCRIPTION
This bug is haunting me for years, and I really need someone looking into it who is expert in the Lookup works. Fortunately it happens usually as an edge case, but I really would like to know what is the issue.

Let's imagine the following situation:
1. I create an empty Gradle project which could be a root project.
2. I open that in NetBeans
3. Later on I decide make a java project out of it by creating some source files and applying the Java plugin
4. The IDE won't show the Java Source Group till it is restarted. 

It could happen in a way that the IDE fails to detect the existence of the java plugin, as the heuristics miss that, then when the IDE got the correct information from Gradle. It still not able to show the SourceGroups.

More details later...