### PR TITLE
[NETBEANS-5052] Mark unused private constants

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/semantic/anonymousClass01.php
+++ b/php/php.editor/test/unit/data/testfiles/semantic/anonymousClass01.php
@@ -1,6 +1,8 @@
 <?php
 
 new class {
+    private const USED_PRIVATE_CONST = 1;
+    private const UNUSED_PRIVATE_CONST = 2;
     private $usedField;
     private $unusedField;
     private static $usedStaticField;
@@ -8,6 +10,7 @@ new class {
 
 
     public function publicMethod() {
+        self::USED_PRIVATE_CONST;
         $this->usedField = 10;
         self::$usedStaticField = 20;
         $this->usedPrivateMethod();

--- a/php/php.editor/test/unit/data/testfiles/semantic/anonymousClass01.php.semantic
+++ b/php/php.editor/test/unit/data/testfiles/semantic/anonymousClass01.php.semantic
@@ -1,6 +1,8 @@
 <?php
 
 new class {
+    private const |>FIELD,STATIC:USED_PRIVATE_CONST<| = 1;
+    private const |>FIELD,STATIC,UNUSED:UNUSED_PRIVATE_CONST<| = 2;
     private $|>FIELD:usedField<|;
     private $|>FIELD,UNUSED:unusedField<|;
     private static $|>FIELD,STATIC:usedStaticField<|;
@@ -8,6 +10,7 @@ new class {
 
 
     public function |>METHOD:publicMethod<|() {
+        self::|>FIELD,STATIC:USED_PRIVATE_CONST<|;
         $this->|>FIELD:usedField<| = 10;
         self::$|>FIELD,STATIC:usedStaticField<| = 20;
         $this->|>CUSTOM1:usedPrivateMethod<|();

--- a/php/php.editor/test/unit/data/testfiles/semantic/class005.php
+++ b/php/php.editor/test/unit/data/testfiles/semantic/class005.php
@@ -1,5 +1,9 @@
 <?php
 class person {                                // class name
+    public const MIN_AGE = 1;                 // public constant
+    protected const MAX_AGE = 150;            // protected constant
+    private const SETTING1 = 'abc';           // used private constant
+    private const SETTING2 = 5;               // unused private constant
     private $name;                            // class field declaration
     public $me = "mydefaultname";             // class field declaration
     private $you;                             // unused private class field
@@ -11,6 +15,7 @@ class person {                                // class name
         echo $this->$name."\n";               // $name is on class field
         echo $this->name."\n";                // usage of class field
         person::$count = person::$count + 1;
+        echo self::SETTING1."\n";
     }
 
     private function yourName() {             // unused method

--- a/php/php.editor/test/unit/data/testfiles/semantic/class005.php.semantic
+++ b/php/php.editor/test/unit/data/testfiles/semantic/class005.php.semantic
@@ -1,5 +1,9 @@
 <?php
 class |>CLASS:person<| {                                // class name
+    public const |>FIELD,STATIC:MIN_AGE<| = 1;                 // public constant
+    protected const |>FIELD,STATIC:MAX_AGE<| = 150;            // protected constant
+    private const |>FIELD,STATIC:SETTING1<| = 'abc';           // used private constant
+    private const |>FIELD,STATIC,UNUSED:SETTING2<| = 5;               // unused private constant
     private $|>FIELD:name<|;                            // class field declaration
     public $|>FIELD:me<| = "mydefaultname";             // class field declaration
     private $|>FIELD,UNUSED:you<|;                             // unused private class field
@@ -11,6 +15,7 @@ class |>CLASS:person<| {                                // class name
         echo $this->$name."\n";               // $name is on class field
         echo $this->|>FIELD:name<|."\n";                // usage of class field
         person::$|>FIELD,STATIC:count<| = person::$|>FIELD,STATIC:count<| + 1;
+        echo self::|>FIELD,STATIC:SETTING1<|."\n";
     }
 
     private function |>METHOD,UNUSED:yourName<|() {             // unused method

--- a/php/php.editor/test/unit/data/testfiles/semantic/unusedPrivateConst.php
+++ b/php/php.editor/test/unit/data/testfiles/semantic/unusedPrivateConst.php
@@ -1,0 +1,13 @@
+<?php
+
+class Foo {
+
+    public const PUBLIC_CONST = 1;
+    protected const PROTECTED_CONST = 2;
+    private const USED_PRIVATE = 3;
+    private const UNUSED_PRIVATE = 4;
+
+    function bar() {
+        return self::USED_PRIVATE;
+    }
+}

--- a/php/php.editor/test/unit/data/testfiles/semantic/unusedPrivateConst.php.semantic
+++ b/php/php.editor/test/unit/data/testfiles/semantic/unusedPrivateConst.php.semantic
@@ -1,0 +1,13 @@
+<?php
+
+class |>CLASS:Foo<| {
+
+    public const |>FIELD,STATIC:PUBLIC_CONST<| = 1;
+    protected const |>FIELD,STATIC:PROTECTED_CONST<| = 2;
+    private const |>FIELD,STATIC:USED_PRIVATE<| = 3;
+    private const |>FIELD,STATIC,UNUSED:UNUSED_PRIVATE<| = 4;
+
+    function |>METHOD:bar<|() {
+        return self::|>FIELD,STATIC:USED_PRIVATE<|;
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/SemanticAnalyzerTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/SemanticAnalyzerTest.java
@@ -47,6 +47,10 @@ public class SemanticAnalyzerTest extends SemanticAnalysisTestBase {
         checkSemantic("testfiles/semantic/class002.php");
     }
 
+    public void testAnalysisUnusedPrivateConstant() throws Exception {
+        checkSemantic("testfiles/semantic/unusedPrivateConst.php");
+    }
+
     public void testAnalysisUnusedPrivateField() throws Exception {
         checkSemantic("testfiles/semantic/class003.php");
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5052

Marks unused private constants in PHP Editor in same way as unused private fields and methods.

In following example `BAR3` is marked as unused:
![netbeans5052](https://user-images.githubusercontent.com/4249184/99908900-9f7f8700-2ce5-11eb-96c6-6f913deddee4.png)
