### PR TITLE
[NETBEANS-5053] - cleanup Set raw type warnings..

### DIFF
--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2OptionalFactory.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/Hk2OptionalFactory.java
@@ -232,7 +232,7 @@ public class Hk2OptionalFactory extends OptionalDeploymentManagerFactory {
 
         @Override
         public Set instantiate() throws IOException {
-            Set set = delegate.instantiate();
+            Set<?> set = delegate.instantiate();
             if(!set.isEmpty()) {
                 Object obj = set.iterator().next();
                 if(obj instanceof ServerInstance) {

--- a/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDWizardIterator.java
+++ b/enterprise/glassfish.javaee/src/org/netbeans/modules/glassfish/javaee/templates/WebLogicDDWizardIterator.java
@@ -90,7 +90,7 @@ public final class WebLogicDDWizardIterator implements WizardDescriptor.Instanti
     
     @Override
     public Set instantiate() throws IOException {
-        Set result = Collections.emptySet();
+        Set<FileObject> result = Collections.emptySet();
         WebLogicDDWizardPanel wizardPanel = (WebLogicDDWizardPanel) panels[0];
         
         File configDir = wizardPanel.getSelectedLocation();

--- a/enterprise/j2ee.ejbrefactoring/src/org/netbeans/modules/j2ee/ejbrefactoring/EjbRefactoringPlugin.java
+++ b/enterprise/j2ee.ejbrefactoring/src/org/netbeans/modules/j2ee/ejbrefactoring/EjbRefactoringPlugin.java
@@ -255,7 +255,7 @@ public class EjbRefactoringPlugin implements RefactoringPlugin {
                 //in this case J2eeApplicationprovider might provide the same results though.
                 Object obj = project.getLookup().lookup(SubprojectProvider.class);
                 if ((obj != null) && (obj instanceof SubprojectProvider)) {
-                    Set subprojects = ((SubprojectProvider) obj).getSubprojects();
+                    Set<? extends Project> subprojects = ((SubprojectProvider) obj).getSubprojects();
                     if (subprojects.contains(affectedProject)) {
                         org.netbeans.modules.j2ee.api.ejbjar.EjbJar em = org.netbeans.modules.j2ee.api.ejbjar.EjbJar
                                 .getEjbJar(project.getProjectDirectory());

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/J2eeVersionWarningPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/J2eeVersionWarningPanel.java
@@ -233,7 +233,7 @@ final class J2eeVersionWarningPanel extends javax.swing.JPanel {
         return spec.compareTo(new SpecificationVersion(sourceLevel)) >= 0;
     }
 
-    private static boolean isAcceptableSourceLevel(String minSourceLevel, String sourceLevel, Set acceptableSourceLevels) {
+    private static boolean isAcceptableSourceLevel(String minSourceLevel, String sourceLevel, Set<String> acceptableSourceLevels) {
         if (minSourceLevel.equals(sourceLevel)) {
             return true;
         }

--- a/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectServerPanel.java
+++ b/enterprise/javaee.project/src/org/netbeans/modules/javaee/project/api/ant/ui/wizard/ProjectServerPanel.java
@@ -604,7 +604,7 @@ private void serverLibraryCheckboxActionPerformed(java.awt.event.ActionEvent evt
         if (serverInstanceId != null) {
             try {
                 J2eePlatform j2eePlatform = Deployment.getDefault().getServerInstance(serverInstanceId).getJ2eePlatform();
-                Set jdks = j2eePlatform.getSupportedJavaPlatformVersions();
+                Set<String> jdks = j2eePlatform.getSupportedJavaPlatformVersions();
                 // make sure that chosen source level is suported by server:
                 if (jdks != null && !jdks.contains(sourceLevel)) { // workaround for #212146 when jdks == null
                     if ("1.7".equals(sourceLevel) && jdks.contains("1.6")) {
@@ -844,7 +844,7 @@ private void serverLibraryCheckboxActionPerformed(java.awt.event.ActionEvent evt
             cdiCheckbox.setVisible(false);
             return;
         }
-        Set jdks = Collections.emptySet();
+        Set<String> jdks = Collections.emptySet();
         String serverInstanceId = getSelectedServer();
         if (serverInstanceId != null) {
             try {

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDWizardIterator.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/wizard/PayaraDDWizardIterator.java
@@ -106,7 +106,7 @@ public final class PayaraDDWizardIterator implements WizardDescriptor.Instantiat
     
     @Override
     public Set instantiate() throws IOException {
-        Set result = Collections.emptySet();
+        Set<FileObject> result = Collections.emptySet();
         PayaraDDWizardPanel wizardPanel = (PayaraDDWizardPanel) panels[0];
         
         File configDir = wizardPanel.getSelectedLocation();

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceListModel.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceListModel.java
@@ -62,7 +62,7 @@ public class WebServiceListModel {
     private List<WebServiceData> webServices = Collections.synchronizedList(new ArrayList<WebServiceData>());
     private List<WebServiceGroup> webServiceGroups = Collections.synchronizedList(new ArrayList<WebServiceGroup>());
     // To maintain the display names for the webservice/port
-    private Set uniqueDisplayNames = Collections.synchronizedSet(new HashSet());
+    private Set<String> uniqueDisplayNames = Collections.synchronizedSet(new HashSet());
     private List<String> partnerServices = new ArrayList<String>();
     private static WebServiceListModel websvcNodeModel = new WebServiceListModel();
     private boolean initialized = false;

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java
@@ -72,7 +72,7 @@ public class SourceGroupSupport {
     public static SourceGroup[] getJavaSourceGroups(Project project) {
         SourceGroup[] sourceGroups = ProjectUtils.getSources(project).getSourceGroups(
                 JavaProjectConstants.SOURCES_TYPE_JAVA);
-        Set testGroups = getTestSourceGroups(sourceGroups);
+        Set<SourceGroup> testGroups = getTestSourceGroups(sourceGroups);
         List<SourceGroup> result = new ArrayList<>();
         for (int i = 0; i < sourceGroups.length; i++) {
             if (!testGroups.contains(sourceGroups[i])) {
@@ -180,9 +180,9 @@ public class SourceGroupSupport {
         return result;
     }
 
-    private static Set/*<SourceGroup>*/ getTestSourceGroups(SourceGroup[] sourceGroups) {
+    private static Set<SourceGroup> getTestSourceGroups(SourceGroup[] sourceGroups) {
         Map foldersToSourceGroupsMap = createFoldersToSourceGroupsMap(sourceGroups);
-        Set testGroups = new HashSet();
+        Set<SourceGroup> testGroups = new HashSet<>();
         for (int i = 0; i < sourceGroups.length; i++) {
             testGroups.addAll(getTestTargets(sourceGroups[i], foldersToSourceGroupsMap));
         }

--- a/harness/o.n.insane/src/org/netbeans/insane/scanner/ScannerUtils.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/scanner/ScannerUtils.java
@@ -244,7 +244,7 @@ public final class ScannerUtils {
     }
 
     @SuppressWarnings("deprecation")
-    private static void suspendAllThreads(Set except) {
+    private static void suspendAllThreads(Set<Thread> except) {
         Thread[] threads = getAllThreads();
         
         for (int i=0; i<threads.length; i++) {

--- a/ide/db/src/org/netbeans/api/db/explorer/support/DatabaseExplorerUIs.java
+++ b/ide/db/src/org/netbeans/api/db/explorer/support/DatabaseExplorerUIs.java
@@ -92,7 +92,7 @@ public final class DatabaseExplorerUIs {
 
         @Override
         public void newItemActionPerformed() {
-            Set oldConnections = new HashSet(Arrays.asList(connectionManager.getConnections()));
+            Set<DatabaseConnection> oldConnections = new HashSet<>(Arrays.<DatabaseConnection>asList(connectionManager.getConnections()));
             connectionManager.showAddConnectionDialog(null);
 
             // try to find the new connection

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/DebuggerManagerListener.java
@@ -332,7 +332,7 @@ public class DebuggerManagerListener extends DebuggerManagerAdapter {
             @Override
             public void run() {
                 List<? extends ActionsProvider> actionsProviderList = engine.lookup(null, ActionsProvider.class);
-                final Set engineActions = new HashSet();
+                final Set<?> engineActions = new HashSet<>();
                 for (ActionsProvider ap : actionsProviderList) {
                     engineActions.addAll(ap.getActions());
                 }

--- a/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/dtd/grammar/DTDGrammar.java
@@ -138,7 +138,7 @@ class DTDGrammar implements ExtendedGrammarQuery {
         
         NamedNodeMap existingAttributes = el.getAttributes();        
         
-        Set possibleAttributes = (Set) attrDecls.get(el.getTagName());
+        Set<String> possibleAttributes = (Set<String>) attrDecls.get(el.getTagName());
         if (possibleAttributes == null) return org.openide.util.Enumerations.empty();
         
         String prefix = ctx.getCurrentPrefix();
@@ -171,7 +171,7 @@ class DTDGrammar implements ExtendedGrammarQuery {
         if (elementDecls == null) return org.openide.util.Enumerations.empty();;
         
         Node node = ((Node)ctx).getParentNode();        
-        Set elements = null;
+        Set<String> elements = null;
         
         if (node instanceof Element) {
             Element el = (Element) node;
@@ -195,7 +195,7 @@ class DTDGrammar implements ExtendedGrammarQuery {
                 Enumeration en = ((ContentModel)model).whatCanFollow(new PreviousEnumeration(el, ctx));
                 if (en == null) return org.openide.util.Enumerations.empty();
                 String prefix = ctx.getCurrentPrefix();
-                elements = new TreeSet();
+                elements = new TreeSet<>();
                 while (en.hasMoreElements()) {
                     String next = (String) en.nextElement();
                     if (next.startsWith(prefix)) {

--- a/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
+++ b/ide/xml.tax/src/org/netbeans/modules/xml/tax/beans/editor/TreeNodeFilterCustomEditor.java
@@ -598,7 +598,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
         /** */
         private final NamedClass clazz;
         /** */
-        private final Set        layer;
+        private final Set<Item>  layer;
         /** */
         private final String     prefix;
 
@@ -663,7 +663,7 @@ public class TreeNodeFilterCustomEditor extends JPanel implements EnhancedCustom
 
         /**
          */
-        private static void insertItemIntoLayer (Set layer, Item newItem) {
+        private static void insertItemIntoLayer (Set<Item> layer, Item newItem) {
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("\n\nInsert newItem : " + newItem); // NOI18N
             if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug ("       Item : set = " + layer); // NOI18N
 

--- a/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
+++ b/ide/xsl/src/org/netbeans/modules/xsl/grammar/XSLGrammarQuery.java
@@ -55,22 +55,22 @@ public final class XSLGrammarQuery implements GrammarQuery{
      * allowed XSL children. Neither the element name keys nor the names in the
      * value set should contain the namespace prefix.
      */
-    private static Map<String, Set> elementDecls;
+    private static Map<String, Set<String>> elementDecls;
 
     /** Contains a mapping from XSL namespace element names to set of names of
      * allowed XSL attributes for that element.  The element name keys should
      * not contain the namespace prefix.
      */
-    private static Map<String, Set> attrDecls;
+    private static Map<String, Set<String>> attrDecls;
 
     /** A Set of XSL attributes which should be allowd for result elements*/
-    private static Set resultElementAttr;
+    private static Set<String> resultElementAttr;
 
     /** An object which indicates that result element should be allowed in a element Set */
     private static String resultElements = "RESULT_ELEMENTS_DUMMY_STRING"; // NOI18N
 
     /** A Set of elements which should be allowed at template level in XSL stylesheet */
-    private static Set template;
+    private static Set<String> template;
 
     /** Contains a mapping from XSL namespace element names to an attribute name which
      * should contain XPath expression.  The element name keys should
@@ -79,10 +79,10 @@ public final class XSLGrammarQuery implements GrammarQuery{
     private static Map<String, String> exprAttributes;
 
     /** A set containing all functions allowed in XSLT */
-    private static Set xslFunctions;
+    private static Set<String> xslFunctions;
 
     /** A set containing XPath axes */
-    private static Set xpathAxes;
+    private static Set<String> xpathAxes;
 
     /** A list of prefixes using the "http://www.w3.org/1999/XSL/Transform" namespace
      * defined in the context XSL document.  The first prefix in the list is the actual XSL
@@ -136,33 +136,33 @@ public final class XSLGrammarQuery implements GrammarQuery{
             // Commonly used variables
             Set emptySet = new TreeSet();
             String spaceAtt = "xml:space";  // NOI18N
-            Set tmpSet;
+            Set<String> tmpSet;
 
             ////////////////////////////////////////////////
             // Initialize common sets
 
-            Set charInstructions = new TreeSet(Arrays.asList(new String[]{"apply-templates", // NOI18N
+            Set<String> charInstructions = new TreeSet<>(Arrays.asList(new String[]{"apply-templates", // NOI18N
             "call-template","apply-imports","for-each","value-of", // NOI18N
             "copy-of","number","choose","if","text","copy", // NOI18N
             "variable","message","fallback"})); // NOI18N
 
-            Set instructions = new TreeSet(charInstructions);
+            Set<String> instructions = new TreeSet<>(charInstructions);
             instructions.addAll(Arrays.asList(new String[]{"processing-instruction", // NOI18N
             "comment","element","attribute"})); // NOI18N
 
-            Set charTemplate = charInstructions; // We don't care about PCDATA
+            Set<String> charTemplate = charInstructions; // We don't care about PCDATA
 
-            template = new TreeSet(instructions);
+            template = new TreeSet<>(instructions);
             template.add(resultElements);
 
-            Set topLevel = new TreeSet(Arrays.asList(new String[]{"import","include","strip-space", // NOI18N
+            Set<String> topLevel = new TreeSet<>(Arrays.asList(new String[]{"import","include","strip-space", // NOI18N
             "preserve-space","output","key","decimal-format","attribute-set", // NOI18N
             "variable","param","template","namespace-alias"})); // NOI18N
 
-            Set topLevelAttr = new TreeSet(Arrays.asList(new String[]{"extension-element-prefixes", // NOI18N
+            Set<String> topLevelAttr = new TreeSet<>(Arrays.asList(new String[]{"extension-element-prefixes", // NOI18N
             "exclude-result-prefixes","id","version",spaceAtt})); // NOI18N
 
-            resultElementAttr = new TreeSet(Arrays.asList(new String[]{"extension-element-prefixes", // NOI18N
+            resultElementAttr = new TreeSet<>(Arrays.asList(new String[]{"extension-element-prefixes", // NOI18N
             "exclude-result-prefixes","use-attribute-sets","version"})); // NOI18N
 
             ////////////////////////////////////////////////
@@ -214,7 +214,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
                 "stylesheet-prefix","result-prefix"}))); // NOI18N
 
             // xsl:template
-            tmpSet = new TreeSet(instructions);
+            tmpSet = new TreeSet<>(instructions);
             tmpSet.add(resultElements);
             tmpSet.add("param"); // NOI18N
             elementDecls.put("template", tmpSet); // NOI18N
@@ -365,7 +365,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
     private static Set getXslFunctions() {
         if (xslFunctions == null) {
-            xslFunctions = new TreeSet(Arrays.asList(new String[]{
+            xslFunctions = new TreeSet<>(Arrays.asList(new String[]{
                 "boolean(","ceiling(","concat(", "contains(","count(","current()","document(", // NOI18N
                 "false()", "floor(","format-number(","generate-id(", // NOI18N
                 "id(","local-name(","key(","lang(","last()","name(","namespace-uri(", "normalize-space(", // NOI18N
@@ -378,7 +378,7 @@ public final class XSLGrammarQuery implements GrammarQuery{
 
     private static Set getXPathAxes() {
         if (xpathAxes == null) {
-            xpathAxes = new TreeSet(Arrays.asList(new String[]{"ancestor::", "ancestor-or-self::", // NOI18N
+            xpathAxes = new TreeSet<>(Arrays.asList(new String[]{"ancestor::", "ancestor-or-self::", // NOI18N
             "attribute::", "child::", "descendant::", "descendant-or-self::", "following::", // NOI18N
             "following-sibling::", "namespace::", "parent::", "preceding::", // NOI18N
             "preceding-sibling::", "self::"})); // NOI18N

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
@@ -306,9 +306,8 @@ public class AntDebugger extends ActionsProviderSupport {
         updateUI();
         currentFile = event.getScriptLocation();
         // update variable values
-        Set properties = event.getPropertyNames ();
-        variables = (String[]) properties.toArray 
-            (new String [properties.size ()]);
+        Set<String> properties = event.getPropertyNames();
+        variables = properties.toArray(new String[properties.size()]);
         fireVariables ();
         fireWatches ();
         fireBreakpoints ();

--- a/java/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectIterator.java
+++ b/java/java.examples/src/org/netbeans/modules/java/examples/J2SESampleProjectIterator.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.java.examples;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import javax.swing.JComponent;
@@ -99,7 +100,7 @@ public class J2SESampleProjectIterator implements WizardDescriptor.AsynchronousI
         FileObject prjLoc = J2SESampleProjectGenerator.createProjectFromTemplate(
                               templateFO, projectLocation, name);
 
-        java.util.Set set = new java.util.HashSet();
+        Set<DataObject> set = new HashSet<>();
         set.add(DataObject.find(prjLoc));
 
         // open file from the project specified in the "defaultFileToOpen" attribute

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
@@ -583,7 +583,7 @@ public class InspectAndRefactorPanel extends javax.swing.JPanel implements Popup
         return toRet;
     }
     
-    private void storeFileList(Set files, String basekey) throws BackingStoreException {
+    private void storeFileList(Set<?> files, String basekey) throws BackingStoreException {
         Preferences pref = NbPreferences.forModule(JavaScopeBuilder.class).node(PREF_SCOPE).node(basekey);
         assert files != null;
         pref.clear();

--- a/java/java.platform.ui/src/org/netbeans/modules/java/platform/ui/PlatformsCustomizer.java
+++ b/java/java.platform.ui/src/org/netbeans/modules/java/platform/ui/PlatformsCustomizer.java
@@ -355,8 +355,8 @@ public class PlatformsCustomizer extends javax.swing.JPanel implements PropertyC
                         dlg.setVisible(true);
                         if (wiz.getValue() == WizardDescriptor.FINISH_OPTION) {
                             self.getChildren().refreshPlatforms();
-                            Set result = wiz.getInstantiatedObjects();
-                            self.expandPlatforms (result.isEmpty() ? null : (JavaPlatform)result.iterator().next());
+                            Set<JavaPlatform> result = wiz.getInstantiatedObjects();
+                            self.expandPlatforms (result.isEmpty() ? null : result.iterator().next());
                         }
                     } finally {
                         dlg.dispose();

--- a/java/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/TemplateWizardIterator.java
+++ b/java/java.source.queriesimpl/src/org/netbeans/modules/java/source/queriesimpl/TemplateWizardIterator.java
@@ -104,8 +104,8 @@ class TemplateWizardIterator implements WizardDescriptor.AsynchronousInstantiati
 
     @Override
     public Set instantiate() throws IOException, IllegalArgumentException {
-        Set set = delegateIterator.instantiate();
-        FileObject template = (FileObject) set.iterator().next();
+        Set<FileObject> set = delegateIterator.instantiate();
+        FileObject template = set.iterator().next();
         if (wiz instanceof TemplateWizard) {
             Logger logger = Logger.getLogger("org.netbeans.ui.metrics.form"); // NOI18N
             LogRecord rec = new LogRecord(Level.INFO, "USG_FORM_CREATED"); // NOI18N

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
@@ -65,7 +65,7 @@ public class SourceGroupSupport {
     public static SourceGroup[] getJavaSourceGroups(Project project) {
         SourceGroup[] sourceGroups = ProjectUtils.getSources(project).getSourceGroups(
                 JavaProjectConstants.SOURCES_TYPE_JAVA);
-        Set testGroups = getTestSourceGroups(sourceGroups);
+        Set<SourceGroup> testGroups = getTestSourceGroups(sourceGroups);
         List<SourceGroup> result = new ArrayList<>();
         for (int i = 0; i < sourceGroups.length; i++) {
             if (!testGroups.contains(sourceGroups[i])) {

--- a/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerationUtils.java
+++ b/java/xml.tools.java/src/org/netbeans/modules/xml/tools/java/generator/GenerationUtils.java
@@ -231,7 +231,7 @@ public final class GenerationUtils {
         if (constructor != null) {
             if (!constructor.getModifiers().contains(Modifier.PUBLIC)) {
                 ModifiersTree oldModifiersTree = constructorTree.getModifiers();
-                Set newModifiers = EnumSet.of(Modifier.PUBLIC);
+                Set<Modifier> newModifiers = EnumSet.of(Modifier.PUBLIC);
            //     for (Modifier modifier : oldModifiersTree.getFlags()) {
              //       if (!Modifier.PROTECTED.equals(modifier) && !Modifier.PRIVATE.equals(modifier)) {
                //         newModifiers.add(modifier);

--- a/platform/core.startup.base/src/org/netbeans/core/startup/layers/LocalFileSystemEx.java
+++ b/platform/core.startup.base/src/org/netbeans/core/startup/layers/LocalFileSystemEx.java
@@ -98,7 +98,7 @@ public final class LocalFileSystemEx extends LocalFileSystem {
         }
     }
 
-    private static Set<String> getInvalid (Set names) {
+    private static Set<String> getInvalid (Set<String> names) {
         LOGGER.finest("133616 - checking invalid");
         Set<String> invalid = new HashSet<String>();
         Iterator<String> i = names.iterator();

--- a/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
@@ -75,7 +75,7 @@ final class MultiFileObject extends AbstractFolder implements FileObject.Priorit
     /** list of objects that we delegate to and that already
     * has been created.
     */
-    private Set delegates;
+    private Set<FileObject> delegates;
 
     /** current delegate (the first object to delegate to), never null */
     private FileObject leader;
@@ -170,7 +170,7 @@ final class MultiFileObject extends AbstractFolder implements FileObject.Priorit
         MultiFileSystem mfs = getMultiFileSystem();
         FileSystem[] arr = mfs.getDelegates();
 
-        Set<FileObject> now = (delegates == null) ? Collections.emptySet(): delegates;
+        Set<FileObject> now = (delegates == null) ? Collections.emptySet() : delegates;
         Set<FileObject> del = new HashSet<FileObject>(arr.length * 2);
         Number maxWeight = 0;
         FileObject led = null;

--- a/platform/openide.util/src/org/openide/util/TopologicalSortException.java
+++ b/platform/openide.util/src/org/openide/util/TopologicalSortException.java
@@ -189,15 +189,15 @@ public final class TopologicalSortException extends Exception {
         // now connect vertexes that cannot be sorted into own
         // sets
         // map from the original objects to 
-        Map<Object,Set> objectsToSets = new HashMap<Object,Set>();
+        Map<Object, Set<Object>> objectsToSets = new HashMap<>();
 
-        ArrayList<Set> sets = new ArrayList<Set>();
+        List<Set<Object>> sets = new ArrayList<>();
 
         while (!dualGraph.isEmpty()) {
             Vertex v = dualGraph.pop();
 
             if (!v.visited) {
-                Set<Object> set = new HashSet<Object>();
+                Set<Object> set = new HashSet<>();
                 visitDualGraph(v, set);
 
                 if ((set.size() == 1) && v.edgesFrom.contains(v)) {
@@ -223,7 +223,7 @@ public final class TopologicalSortException extends Exception {
 
         // now topologically sort the sets
         // 1. prepare the map
-        HashMap<Set,Collection<Set>> edgesBetweenSets = new HashMap<Set,Collection<Set>>();
+        Map<Set, Collection<Set>> edgesBetweenSets = new HashMap<>();
         it = edges.entrySet().iterator();
 
         while (it.hasNext()) {

--- a/profiler/profiler.nbmodule/src/org/netbeans/modules/profiler/nbmodule/NbModuleProjectProfilingSupportProvider.java
+++ b/profiler/profiler.nbmodule/src/org/netbeans/modules/profiler/nbmodule/NbModuleProjectProfilingSupportProvider.java
@@ -83,7 +83,7 @@ public final class NbModuleProjectProfilingSupportProvider extends JavaProjectPr
                                                                                                     // ask first subproject for its JavaPlatform
 
             SubprojectProvider spp = project.getLookup().lookup(SubprojectProvider.class);
-            Set subProjects;
+            Set<? extends Project> subProjects;
 
             if (ProfilerLogger.isDebug()) {
                 ProfilerLogger.debug("NB Suite " + projectDir.getPath()); //NOI18N
@@ -99,7 +99,7 @@ public final class NbModuleProjectProfilingSupportProvider extends JavaProjectPr
                 return null;
             }
 
-            return getProjectJavaPlatform((Project) subProjects.iterator().next());
+            return getProjectJavaPlatform(subProjects.iterator().next());
         }
 
         ClassPath bootCp = ClassPath.getClassPath(projectDir, ClassPath.BOOT);

--- a/webcommon/web.webkit.tooling/src/org/netbeans/modules/web/webkit/tooling/networkmonitor/ModelItem.java
+++ b/webcommon/web.webkit.tooling/src/org/netbeans/modules/web/webkit/tooling/networkmonitor/ModelItem.java
@@ -340,16 +340,15 @@ class ModelItem implements PropertyChangeListener {
             StyledDocument doc, Style boldStyle, Style defaultStyle) throws BadLocationException {
 
         assert headers != null;
-        Set keys = new TreeSet(new Comparator<Object>() {
+        Set<String> keys = new TreeSet<>(new Comparator<String>() {
             @Override
-            public int compare(Object o1, Object o2) {
-                return ((String)o1).compareToIgnoreCase((String)o2);
+            public int compare(String o1, String o2) {
+                return o1.compareToIgnoreCase(o2);
             }
 
         });
         keys.addAll(headers.keySet());
-        for (Object oo : keys) {
-            String key = (String)oo;
+        for (String key : keys) {
             doc.insertString(doc.getLength(), key+": ", boldStyle);
             String value = (String)headers.get(key);
             doc.insertString(doc.getLength(), value+"\n", defaultStyle);


### PR DESCRIPTION
I am trying to cleanup a bunch of the Set raw type warnings.. They look like this..

   [repeat] /home/bwalker/src/netbeans/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/CPPLiteBreakpointActionProvider.java:50: warning: [rawtypes] found raw type: Set
   [repeat]     private static final Set actions = Collections.singleton (
   [repeat]                          ^
   [repeat]   missing type arguments for generic class Set<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in interface Set

This change reduces the warnings dramatically. The ones remaining are in public interfaces
and it's beyond the scope for me to tackle that.. Hopefully, in the future.