### PR TITLE
[NETBEANS-5057] fix for indexing JSF composite components

### DIFF
--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/index/CompositeComponentModel.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/index/CompositeComponentModel.java
@@ -270,7 +270,7 @@ public class CompositeComponentModel extends JsfPageModel {
             if (folder.getName().equalsIgnoreCase("resources")) { //NOI18N
                 //check if its parent is META-INF
                 FileObject parent = folder.getParent();
-                if (parent != null && parent.getNameExt().startsWith("META-INF")) { //NOI18N
+                if (parent != null && parent.getName().startsWith("META-INF")) { //NOI18N
                     //the folder seems to be the right resources folder
                     return folder;
                 }

--- a/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/index/JsfBinaryIndexer.java
+++ b/enterprise/web.jsf.editor/src/org/netbeans/modules/web/jsf/editor/index/JsfBinaryIndexer.java
@@ -48,14 +48,14 @@ import org.openide.util.Exceptions;
  * @author marekfukala
  */
 @ConstrainedBinaryIndexer.Registration(
-namePattern = ".*\\.tld|.*\\.taglib\\.xml",
+namePattern = ".*\\.tld|.*\\.taglib\\.xml|.*\\.xhtml",
 indexVersion = JsfBinaryIndexer.INDEXER_VERSION,
 indexerName = JsfBinaryIndexer.INDEXER_NAME)
 public class JsfBinaryIndexer extends ConstrainedBinaryIndexer {
 
     private static final Logger LOGGER = Logger.getLogger(JsfBinaryIndexer.class.getSimpleName());
     private static final String CONTENT_UNKNOWN = "content/unknown";    //NOI18N
-    static final int INDEXER_VERSION = 10; //NOI18N
+    static final int INDEXER_VERSION = 11; //NOI18N
     static final String INDEXER_NAME = "jsfBinary"; //NOI18N
 
     @Override


### PR DESCRIPTION
We have several JSF libraries that contain both JSF components and JSF composite components.
When the JSF library is open in NetBeans, all JSF components are found within the editor.
When the JSF library is referenced as external JAR, only the JSF components are recognised by the editor, not the JSF composite components.

The fix as suggested in:
https://stackoverflow.com/questions/21607320/jsf-composite-components-in-jar-not-recognised-in-netbeans
works for us.

https://issues.apache.org/jira/browse/NETBEANS-5057