### PR TITLE
[NETBEANS-5066] - cleanup usage of EMPTY_MAP warnings..

### DIFF
--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/facesmodel/JSFConfigComponentImpl.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/impl/facesmodel/JSFConfigComponentImpl.java
@@ -101,7 +101,7 @@ public abstract class JSFConfigComponentImpl extends AbstractDocumentComponent <
     }
     
     protected Map<String,Integer> getOrderedMapOfLocalNames(){
-        return Collections.EMPTY_MAP;
+        return Collections.<String,Integer>emptyMap();
     }
     
     protected void reorderChildren(){

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java
@@ -169,7 +169,7 @@ public class SourceGroupSupport {
     private static Map createFoldersToSourceGroupsMap(final SourceGroup[] sourceGroups) {
         Map<FileObject, SourceGroup> result;
         if (sourceGroups.length == 0) {
-            result = Collections.EMPTY_MAP;
+            result = Collections.<FileObject, SourceGroup>emptyMap();
         } else {
             result = new HashMap<>(2 * sourceGroups.length, .5f);
             for (int i = 0; i < sourceGroups.length; i++) {

--- a/ide/api.debugger/src/org/netbeans/spi/debugger/ContextAwareSupport.java
+++ b/ide/api.debugger/src/org/netbeans/spi/debugger/ContextAwareSupport.java
@@ -177,7 +177,7 @@ public final class ContextAwareSupport {
                 Proxy.newProxyInstance(
                     cl,
                     classes,
-                    new ContextAwareServiceHandler(serviceName, classes, Collections.EMPTY_MAP));
+                    new ContextAwareServiceHandler(serviceName, classes, Collections.emptyMap()));
     }
 
     private static String[] splitClasses(String classes) {

--- a/ide/schema2beans/src/org/netbeans/modules/schema2beans/JavaBeansUtil.java
+++ b/ide/schema2beans/src/org/netbeans/modules/schema2beans/JavaBeansUtil.java
@@ -536,7 +536,7 @@ public class JavaBeansUtil {
      * contents.
      */
     public static void copyBean(Object src, Object dest) throws java.beans.IntrospectionException {
-        copyBean(src, dest, Collections.EMPTY_MAP);
+        copyBean(src, dest, Collections.emptyMap());
     }
     
     /**

--- a/ide/xml.text/src/org/netbeans/modules/xml/text/structure/XMLDocumentModelProvider.java
+++ b/ide/xml.text/src/org/netbeans/modules/xml/text/structure/XMLDocumentModelProvider.java
@@ -306,7 +306,7 @@ public class XMLDocumentModelProvider implements DocumentModelProvider {
                     if(from == to) {
                         to++;
                     }
-                    addedElements.add(dtm.addDocumentElement(errorText, XML_ERROR, Collections.EMPTY_MAP,
+                    addedElements.add(dtm.addDocumentElement(errorText, XML_ERROR, Collections.emptyMap(),
                             from, to));
                 }
                 
@@ -391,7 +391,7 @@ public class XMLDocumentModelProvider implements DocumentModelProvider {
                 } else {
                     switch (sel.getType()) {
                         case Node.CDATA_SECTION_NODE:
-                            addedElements.add(dtm.addDocumentElement("cdata", XML_CDATA, Collections.EMPTY_MAP,
+                            addedElements.add(dtm.addDocumentElement("cdata", XML_CDATA, Collections.emptyMap(),
                                     sel.getElementOffset(), getSyntaxElementEndOffset(sel)));
                             break;
                         case Node.PROCESSING_INSTRUCTION_NODE: {
@@ -399,7 +399,7 @@ public class XMLDocumentModelProvider implements DocumentModelProvider {
                             String nodeName = ((ProcessingInstruction)sel.getNode()).getNodeName();
                             //if the nodename is not parsed, then the element is somehow broken => do not show it.
                             if(nodeName != null) {
-                                addedElements.add(dtm.addDocumentElement(nodeName, XML_PI, Collections.EMPTY_MAP,
+                                addedElements.add(dtm.addDocumentElement(nodeName, XML_PI, Collections.emptyMap(),
                                         sel.getElementOffset(), getSyntaxElementEndOffset(sel)));
                             }
                             break;
@@ -409,7 +409,7 @@ public class XMLDocumentModelProvider implements DocumentModelProvider {
                             String nodeName = ((DocumentType)sel.getNode()).getName();
                             //if the nodename is not parsed, then the element is somehow broken => do not show it.
                             if(nodeName != null) {
-                                addedElements.add(dtm.addDocumentElement(nodeName, XML_DOCTYPE, Collections.EMPTY_MAP,
+                                addedElements.add(dtm.addDocumentElement(nodeName, XML_DOCTYPE, Collections.emptyMap(),
                                         sel.getElementOffset(), getSyntaxElementEndOffset(sel)));
                             }
                             break;
@@ -417,7 +417,7 @@ public class XMLDocumentModelProvider implements DocumentModelProvider {
                         case Node.COMMENT_NODE:
                             //comment element <!-- xxx -->
                             //DO NOT CREATE ELEMENT FOR COMMENTS
-                            addedElements.add(dtm.addDocumentElement("comment", XML_COMMENT, Collections.EMPTY_MAP,
+                            addedElements.add(dtm.addDocumentElement("comment", XML_COMMENT, Collections.emptyMap(),
                                     sel.getElementOffset(), getSyntaxElementEndOffset(sel)));
                             break;
                         default:
@@ -433,7 +433,7 @@ public class XMLDocumentModelProvider implements DocumentModelProvider {
                                 //required is distinguishing elements after text deletion) and subsequently
                                 //the empty elements are added and removed all over again after each model
                                 //update which causes performance problems.
-                                addedElements.add(dtm.addDocumentElement("...", XML_CONTENT, Collections.EMPTY_MAP, from, to));
+                                addedElements.add(dtm.addDocumentElement("...", XML_CONTENT, Collections.emptyMap(), from, to));
                             }
                     }
                 }
@@ -508,7 +508,7 @@ public class XMLDocumentModelProvider implements DocumentModelProvider {
     
     private Map createAttributesMap(Node tag) {
         if(tag.getAttributes().getLength() == 0) {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         } else {
             HashMap map = new LinkedHashMap(tag.getAttributes().getLength());
             for(int i = 0; i < tag.getAttributes().getLength(); i++) {

--- a/java/form/src/org/netbeans/modules/form/layoutdesign/LayoutUtils.java
+++ b/java/form/src/org/netbeans/modules/form/layoutdesign/LayoutUtils.java
@@ -257,7 +257,7 @@ public class LayoutUtils implements LayoutConstants {
 
         // Calculate size of gap from sources and targets and their positions
         return getSizesOfDefaultGap(sources, targets, gapType,
-                                    visualMapper, null, Collections.EMPTY_MAP);
+                                    visualMapper, null, Collections.<String,LayoutRegion>emptyMap());
     }
 
     /**

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/JPQLExecutor.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/jpqleditor/JPQLExecutor.java
@@ -138,7 +138,7 @@ public class JPQLExecutor {
                 Method method2 = sessionFactoryImpl.getClass().getMethod(HIBERNATE_QUERY_SQL1);
                 Object qPlanCache = method2.invoke(sessionFactoryImpl);
                 Method method3 = qPlanCache.getClass().getMethod(HIBERNATE_QUERY_SQL2, String.class, boolean.class, Map.class);
-                Object cache = method3.invoke(qPlanCache, jpql, true, Collections.EMPTY_MAP);
+                Object cache = method3.invoke(qPlanCache, jpql, true, Collections.emptyMap());
                 Method method4 = cache.getClass().getMethod(HIBERNATE_QUERY_SQL3);
                 Object[] translators = (Object[]) method4.invoke(cache);
                 StringBuilder stringBuff = new StringBuilder();

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/DataNucleusProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/DataNucleusProvider.java
@@ -73,7 +73,7 @@ class DataNucleusProvider extends Provider{
     }
 
     public Map getUnresolvedVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
 
     public Map getDefaultVendorSpecificProperties() {

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/DefaultProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/DefaultProvider.java
@@ -44,10 +44,10 @@ public class DefaultProvider extends Provider{
     }
     
     public Map getUnresolvedVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
     
     public Map getDefaultVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
 }

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/EclipseLinkProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/EclipseLinkProvider.java
@@ -94,12 +94,12 @@ class EclipseLinkProvider extends Provider {
 
     @Override
     public Map getUnresolvedVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
 
     @Override
     public Map getDefaultVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
     
     private final HashMap<String,String[]> properties = new HashMap<>();

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/HibernateProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/HibernateProvider.java
@@ -81,7 +81,7 @@ class HibernateProvider extends Provider{
 
     @Override
     public Map getUnresolvedVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
     
     @Override

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/KodoProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/KodoProvider.java
@@ -67,11 +67,11 @@ class KodoProvider extends Provider{
     }
 
     public Map getUnresolvedVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
 
     public Map getDefaultVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
     
 }

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/OpenJPAProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/OpenJPAProvider.java
@@ -84,12 +84,12 @@ class OpenJPAProvider extends Provider{
 
     @Override
     public Map getUnresolvedVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
 
     @Override
     public Map getDefaultVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
 
 }

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/ToplinkProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/provider/ToplinkProvider.java
@@ -112,12 +112,12 @@ class ToplinkProvider extends Provider{
 
     @Override
     public Map getUnresolvedVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
 
     @Override
     public Map getDefaultVendorSpecificProperties() {
-        return Collections.EMPTY_MAP;
+        return Collections.emptyMap();
     }
     
     

--- a/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/pretty/VeryPretty.java
@@ -191,7 +191,7 @@ public final class VeryPretty extends JCTree.Visitor implements DocTreeVisitor<V
         out.addTrimObserver(this);
         this.indentSize = cs.getIndentSize();
         this.tree2Tag = tree2Tag;
-        this.tree2Doc = tree2Doc == null ? Collections.EMPTY_MAP : tree2Doc;
+        this.tree2Doc = tree2Doc == null ? Collections.<Tree, DocCommentTree>emptyMap(): tree2Doc;
         this.tag2Span = (Map<Object, int[]>) tag2Span;//XXX
         this.origText = origText;
         this.comments = CommentHandlerService.instance(context);

--- a/java/performance/actionsframework/src/org/netbeans/actions/spi/ContextProviderSupport.java
+++ b/java/performance/actionsframework/src/org/netbeans/actions/spi/ContextProviderSupport.java
@@ -72,7 +72,7 @@ public final class ContextProviderSupport implements ContextProvider {
     /** Get a map composed of the contributions of each contributor */
     public final Map getContext() {
         if (contributors == null || contributors.length == 0) {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         } else {
             Map[] m = new Map[contributors.length];
             for (int i=0; i < contributors.length; i++) {

--- a/java/performance/actionsframework/src/org/netbeans/actions/spi/ProxyContextProvider.java
+++ b/java/performance/actionsframework/src/org/netbeans/actions/spi/ProxyContextProvider.java
@@ -56,7 +56,7 @@ public final class ProxyContextProvider implements ContextProvider {
     
     public Map getContext() {
         if (providers == null || providers.length == 0) {
-            return Collections.EMPTY_MAP;
+            return Collections.emptyMap();
         }
         Map[] m = new Map[providers.length];
         for (int i=0; i < m.length; i++) {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/UnknownAnnotationLine.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/UnknownAnnotationLine.java
@@ -59,7 +59,7 @@ public class UnknownAnnotationLine implements AnnotationParsedLine {
 
     @Override
     public Map<OffsetRange, String> getTypes() {
-        return Collections.EMPTY_MAP;
+        return Collections.<OffsetRange, String>emptyMap();
     }
 
     @Override

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/annotation/LinkParsedLine.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/annotation/LinkParsedLine.java
@@ -46,7 +46,7 @@ public class LinkParsedLine implements AnnotationParsedLine {
 
     @Override
     public Map<OffsetRange, String> getTypes() {
-        return Collections.EMPTY_MAP;
+        return Collections.<OffsetRange, String>emptyMap();
     }
 
     @Override

--- a/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/PHPDocTag.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/parser/astnodes/PHPDocTag.java
@@ -59,7 +59,7 @@ public class PHPDocTag extends ASTNode {
         @Override
         public Map<OffsetRange, String> getTypes() {
             //types of these annotations are parsed by an editor parser itself
-            return Collections.EMPTY_MAP;
+            return Collections.<OffsetRange, String>emptyMap();
         }
 
         @Override

--- a/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/XMLMapAttr.java
@@ -1035,7 +1035,7 @@ final class XMLMapAttr implements Map {
         }
 
         static final Map wrapToMap(FileObject fo) {
-            return fo == null ? Collections.EMPTY_MAP : new FileMap(fo);
+            return fo == null ? Collections.emptyMap() : new FileMap(fo);
         }
 
         /**

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/StackTraceSnapshotBuilder.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/results/cpu/StackTraceSnapshotBuilder.java
@@ -259,7 +259,8 @@ public class StackTraceSnapshotBuilder {
     final Object stampLock = new Object();
     // @GuardedBy stampLock
     long currentDumpTimeStamp = -1L;
-    final AtomicReference<Map<Long, SampledThreadInfo>> lastStackTrace = new AtomicReference<Map<Long, SampledThreadInfo>>(Collections.EMPTY_MAP);
+    final AtomicReference<Map<Long, SampledThreadInfo>> lastStackTrace =
+          new AtomicReference<Map<Long, SampledThreadInfo>>(Collections.<Long, SampledThreadInfo>emptyMap());
     int stackTraceCount = 0;
     //    int builderBatchSize;
     final Set<String> ignoredThreadNames = new HashSet<String>();
@@ -619,7 +620,7 @@ public class StackTraceSnapshotBuilder {
             threadIds.clear();
             threadNames.clear();
             stackTraceCount = 0;
-            lastStackTrace.set(Collections.EMPTY_MAP);
+            lastStackTrace.set(Collections.<Long, SampledThreadInfo>emptyMap());
             registerNewMethodInfo(new MethodInfo("Thread","")); // NOI18N
             synchronized(stampLock) {
                 currentDumpTimeStamp = -1L;

--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsCompletionItem.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/JsCompletionItem.java
@@ -254,7 +254,7 @@ public class JsCompletionItem implements CompletionProposal {
         JsFunctionCompletionItem(ElementHandle element, CompletionRequest request, Set<String> resolvedReturnTypes, Map<String, Set<String>> parametersTypes) {
             super(element, request);
             this.returnTypes = resolvedReturnTypes != null ? resolvedReturnTypes : Collections.EMPTY_SET;
-            this.parametersTypes = parametersTypes != null ? parametersTypes : Collections.EMPTY_MAP;
+            this.parametersTypes = parametersTypes != null ? parametersTypes : Collections.<String, Set<String>>emptyMap();
         }
 
         @Override

--- a/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/webkit/knockout/unused/UnusedBindingsPanel.java
+++ b/webcommon/web.inspect/src/org/netbeans/modules/web/inspect/webkit/knockout/unused/UnusedBindingsPanel.java
@@ -56,7 +56,7 @@ public class UnusedBindingsPanel extends javax.swing.JPanel implements ExplorerM
     /** Tree with unused bindings. */
     private BeanTreeView treeView;
     /** Root node of the tree with unused bindings. */
-    private final UnusedRootNode rootNode = new UnusedRootNode(Collections.EMPTY_MAP);
+    private final UnusedRootNode rootNode = new UnusedRootNode(Collections.<String, Map<Integer, UnusedBinding>>emptyMap());
 
     /**
      * Creates a new {@code UnusedBindingsPanel}.


### PR DESCRIPTION
In many places there are unchecked conversion warnings.. This change reduces these errors
when using Collections.EMPTY_MAP to a bare minimum..

For example,

   [repeat] /tmp/netbeans/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/support/SourceGroupSupport.java:172: warning: [unchecked] unchecked conversion
   [repeat]             result = Collections.EMPTY_MAP;
   [repeat]                                 ^
   [repeat]   required: Map<FileObject,SourceGroup>
   [repeat]   found:    Map

Clean this up..