### PR TITLE
[NETBEANS-5074] - cleanup ArrayList warnings..

### DIFF
--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/app/EarDataObject.java
@@ -142,7 +142,7 @@ public class EarDataObject extends DD2beansDataObject
     }
 
     private void refreshSourceFolders () {
-        ArrayList srcRootList = new ArrayList ();
+        List<FileObject> srcRootList = new ArrayList<>();
         
         Project project = FileOwnerQuery.getOwner (getPrimaryFile ());
         if (project != null) {

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/client/ClientDataObject.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/client/ClientDataObject.java
@@ -119,7 +119,7 @@ public class ClientDataObject extends  DDMultiViewDataObject
     }
     
     private void refreshSourceFolders() {
-        ArrayList srcRootList = new ArrayList();
+        List<FileObject> srcRootList = new ArrayList<>();
         
         Project project = FileOwnerQuery.getOwner(getPrimaryFile());
         if (project != null) {

--- a/enterprise/web.core.syntax/nbproject/project.properties
+++ b/enterprise/web.core.syntax/nbproject/project.properties
@@ -21,7 +21,7 @@ release.external/generated-jstl11-doc-1.1.2.zip=docs/jstl11-doc.zip
 release.external/generated-jsf12-tlddoc-1.2-20.zip=docs/jsf12-tlddoc.zip
 release.external/generated-struts-tags-1.3.10.zip=docs/struts-tags.zip
 
-javac.source=1.6
+javac.source=1.8
 requires.nb.javac=true
 javadoc.arch=${basedir}/arch.xml
 

--- a/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/ErrorAnnotationImpl.java
+++ b/enterprise/web.core.syntax/src/org/netbeans/modules/web/core/syntax/ErrorAnnotationImpl.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.StyledDocument;
@@ -59,12 +60,12 @@ public class ErrorAnnotationImpl implements ErrorAnnotation {
     /** Jsp file, for which is the ErrorAnnotation */
     private FileObject jspFo;
     
-    private ArrayList annotations;
+    private List annotations;
     
     /** Creates a new instance of ErrorAnnotation */
     public ErrorAnnotationImpl(FileObject jspFo) {
         this.jspFo = jspFo;
-        annotations = new ArrayList();
+        annotations = new ArrayList<>();
     }
     
     /** Adds annotation for the errors. If the error is already annotated, does nothing. If there are 
@@ -74,7 +75,7 @@ public class ErrorAnnotationImpl implements ErrorAnnotation {
      */
     @Override
     public void annotate(ErrorInfo[] errors){
-        ArrayList added, removed, unchanged;
+        List added, removed, unchanged;
         Collection newAnnotations;
         
         // obtain data object
@@ -113,10 +114,10 @@ public class ErrorAnnotationImpl implements ErrorAnnotation {
         // create annotations from errors
         newAnnotations = getAnnotations(errors, document);
         // which annotations are really new
-        added=new ArrayList(newAnnotations);
+        added=new ArrayList<>(newAnnotations);
         added.removeAll(annotations);
         // which annotations were here before
-        unchanged=new ArrayList(annotations);
+        unchanged=new ArrayList<>(annotations);
         unchanged.retainAll(newAnnotations);
         // which annotations are obsolete
         removed = annotations;
@@ -125,7 +126,7 @@ public class ErrorAnnotationImpl implements ErrorAnnotation {
 
         // are there new annotations?
         if (!added.isEmpty()) {
-            final ArrayList finalAdded = added;
+            final List finalAdded = added;
             final DataObject doJsp2 = doJsp;
             Runnable docRenderer = new Runnable() {
                 @Override

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/NewWebFreeformProjectWizardIterator.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/NewWebFreeformProjectWizardIterator.java
@@ -74,7 +74,7 @@ public class NewWebFreeformProjectWizardIterator implements WizardDescriptor.Ins
     }
     
     private WizardDescriptor.Panel[] createPanels () {
-        List<WizardDescriptor.Panel> l = new ArrayList<WizardDescriptor.Panel>();
+        List<WizardDescriptor.Panel> l = new ArrayList<>();
         List<TargetDescriptor> extraTargets = new ArrayList<TargetDescriptor>();
         extraTargets.add(WebProjectNature.getExtraTarget());
         l.add(NewFreeformProjectSupport.createBasicProjectInfoWizardPanel());

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/ReflectionHelper.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/ui/ReflectionHelper.java
@@ -251,7 +251,7 @@ public class ReflectionHelper {
             } else {
                 Class<?> cls = Class.forName(className, true, loader);
                 if (cls.isInterface()) {
-                    return new ArrayList();
+                    return new ArrayList<Object>();
                 } else {
                     savedLoader = Thread.currentThread().getContextClassLoader();
                     Thread.currentThread().setContextClassLoader(loader);

--- a/ide/api.debugger/src/org/netbeans/api/debugger/ActionsManager.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/ActionsManager.java
@@ -21,7 +21,14 @@ package org.netbeans.api.debugger;
 
 import java.beans.*;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Vector;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -105,7 +112,7 @@ public final class ActionsManager {
     
     private final Vector<ActionsManagerListener>    listener = new Vector<ActionsManagerListener>();
     private final HashMap<String, List<ActionsManagerListener>> listeners = new HashMap<String, List<ActionsManagerListener>>();
-    private HashMap<Object, ArrayList<ActionsProvider>>  actionProviders;
+    private HashMap<Object, List<ActionsProvider>>  actionProviders;
     private final Object            actionProvidersLock = new Object();
     private final AtomicBoolean     actionProvidersInitialized = new AtomicBoolean(false);
     private MyActionListener        actionListener = new MyActionListener ();
@@ -137,7 +144,7 @@ public final class ActionsManager {
      */
     public final void doAction (final Object action) {
         doiingDo = true;
-        ArrayList<ActionsProvider> l = getActionProvidersForActionWithInit(action);
+        List<ActionsProvider> l = getActionProvidersForActionWithInit(action);
         boolean done = false;
         if (l != null) {
             int i, k = l.size ();
@@ -185,7 +192,8 @@ public final class ActionsManager {
         if (!inited && Mutex.EVENT.isReadAccess()) { // is EDT
             return postActionWithLazyInit(action);
         }
-        ArrayList<ActionsProvider> l = getActionProvidersForActionWithInit(action);
+        
+        List<ActionsProvider> l = getActionProvidersForActionWithInit(action);
         boolean posted = false;
         int k;
         if (l != null) {
@@ -193,7 +201,8 @@ public final class ActionsManager {
         } else {
             k = 0;
         }
-        List<ActionsProvider> postedActions = new ArrayList<ActionsProvider>(k);
+        
+        List<ActionsProvider> postedActions = new ArrayList<>(k);
         final AsynchActionTask task = new AsynchActionTask(postedActions);
         if (l != null) {
             int i;
@@ -356,7 +365,7 @@ public final class ActionsManager {
         boolean doInit = false;
         synchronized (actionProvidersLock) {
             if (actionProviders == null) {
-                actionProviders = new HashMap<Object, ArrayList<ActionsProvider>>();
+                actionProviders = new HashMap<>();
                 doInit = true;
             }
         }
@@ -374,7 +383,8 @@ public final class ActionsManager {
                 initActionImpls();
             }
         }
-        ArrayList<ActionsProvider> l = getActionProvidersForAction(action);
+
+        List<ActionsProvider> l = getActionProvidersForAction(action);
         if (l != null) {
             int i, k = l.size ();
             for (i = 0; i < k; i++) {
@@ -431,7 +441,7 @@ public final class ActionsManager {
         synchronized (listeners) {
             List<ActionsManagerListener> ls = listeners.get (propertyName);
             if (ls == null) {
-                ls = new ArrayList<ActionsManagerListener>();
+                ls = new ArrayList<>();
                 listeners.put (propertyName, ls);
             }
             ls.add(l);
@@ -498,12 +508,12 @@ public final class ActionsManager {
         final Object action
     ) {
         initListeners ();
-        List<ActionsManagerListener> l = new ArrayList<ActionsManagerListener>(listener);
+        List<ActionsManagerListener> l = new ArrayList<>(listener);
         List<ActionsManagerListener> l1;
         synchronized (listeners) {
             l1 = listeners.get(ActionsManagerListener.PROP_ACTION_PERFORMED);
             if (l1 != null) {
-                l1 = new ArrayList<ActionsManagerListener>(l1);
+                l1 = new ArrayList<>(l1);
             }
         }
         int i, k = l.size ();
@@ -533,12 +543,12 @@ public final class ActionsManager {
     ) {
         boolean enabled = isEnabled (action);
         initListeners ();
-        List<ActionsManagerListener> l = new ArrayList<ActionsManagerListener>(listener);
+        List<ActionsManagerListener> l = new ArrayList<>(listener);
         List<ActionsManagerListener> l1;
         synchronized (listeners) {
             l1 = listeners.get(ActionsManagerListener.PROP_ACTION_STATE_CHANGED);
             if (l1 != null) {
-                l1 = new ArrayList<ActionsManagerListener>(l1);
+                l1 = new ArrayList<>(l1);
             }
         }
         int i, k = l.size ();
@@ -556,22 +566,22 @@ public final class ActionsManager {
     
     // private support .........................................................
     
-    private ArrayList<ActionsProvider> getActionProvidersForAction(Object action) {
-        ArrayList<ActionsProvider> l;
+    private List<ActionsProvider> getActionProvidersForAction(Object action) {
+        List<ActionsProvider> l;
         synchronized (actionProvidersLock) {
             l = actionProviders.get(action);
             if (l != null) {
-                l = (ArrayList<ActionsProvider>) l.clone ();
+                l = new ArrayList<>(l);
             }
         }
         return l;
     }
     
-    private ArrayList<ActionsProvider> getActionProvidersForActionWithInit(Object action) {
+    private List<ActionsProvider> getActionProvidersForActionWithInit(Object action) {
         boolean doInit = false;
         synchronized (actionProvidersLock) {
             if (actionProviders == null) {
-                actionProviders = new HashMap<Object, ArrayList<ActionsProvider>>();
+                actionProviders = new HashMap<>();
                 doInit = true;
             }
         }
@@ -593,9 +603,9 @@ public final class ActionsManager {
     
     private void registerActionsProvider (Object action, ActionsProvider p) {
         synchronized (actionProvidersLock) {
-            ArrayList<ActionsProvider> l = actionProviders.get (action);
+            List<ActionsProvider> l = actionProviders.get(action);
             if (l == null) {
-                l = new ArrayList<ActionsProvider>();
+                l = new ArrayList<>();
                 actionProviders.put (action, l);
             }
             l.add (p);
@@ -721,8 +731,8 @@ public final class ActionsManager {
             }
         }
         synchronized (actionProvidersLock) {
-            Collection<ArrayList<ActionsProvider>> apsc = actionProviders.values();
-            for (ArrayList<ActionsProvider> aps : apsc) {
+            Collection<List<ActionsProvider>> apsc = actionProviders.values();
+            for (List<ActionsProvider> aps : apsc) {
                 for (ActionsProvider ap : aps) {
                     ap.removeActionsProviderListener(actionListener);
                 }

--- a/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueTable.java
+++ b/ide/bugtracking.commons/src/org/netbeans/modules/bugtracking/issuetable/IssueTable.java
@@ -444,7 +444,7 @@ public class IssueTable implements MouseListener, AncestorListener, KeyListener,
     }
 
     private void setFilterIntern(Filter filter) {
-        final List<IssueNode> filteredNodes = new ArrayList<IssueNode>(nodes.size());
+        final List<IssueNode> filteredNodes = new ArrayList<>(nodes.size());
         for (IssueNode node : nodes) {
             if (filter == null || filter.accept(node)) {
                 filteredNodes.add(node);
@@ -669,7 +669,7 @@ public class IssueTable implements MouseListener, AncestorListener, KeyListener,
     public void ancestorRemoved(AncestorEvent event) { }
 
     private void setModelProperties() {
-        List<ColumnDescriptor> properties = new ArrayList<ColumnDescriptor>(descriptors.length + (isSaved ? 2 : 0));
+        List<ColumnDescriptor> properties = new ArrayList<>(descriptors.length + (isSaved ? 2 : 0));
         int i = 0;
         for (; i < descriptors.length; i++) {
             ColumnDescriptor desc = descriptors[i];

--- a/ide/bugtracking/src/org/netbeans/modules/bugtracking/RepositoryImpl.java
+++ b/ide/bugtracking/src/org/netbeans/modules/bugtracking/RepositoryImpl.java
@@ -114,7 +114,7 @@ public final class RepositoryImpl<R, Q, I> {
                     if(LOG.isLoggable(Level.FINE)) {
                         LOG.log(Level.FINE, "firing query list change {0} - rImpl: {1} - r: {2}", new Object[]{getDisplayName(), this, r}); // NOI18N
                     }
-                    Collection<QueryImpl> queries = new ArrayList<QueryImpl>(getQueries());
+                    Collection<QueryImpl> queries = new ArrayList<>(getQueries());
                     synchronized(queryMap) {
                         List<Q> toRemove = new LinkedList<Q>();
                         for(Entry<Q, WeakReference<QueryImpl>> e : queryMap.entrySet()) {
@@ -218,7 +218,7 @@ public final class RepositoryImpl<R, Q, I> {
         if(is == null || is.isEmpty()) {
             return Collections.emptyList();
         }
-        List<IssueImpl> ret = new ArrayList<IssueImpl>(is.size());
+        List<IssueImpl> ret = new ArrayList<>(is.size());
         for (I i : is) {
             IssueImpl impl = getIssue(i);
             if(impl != null) {
@@ -255,7 +255,7 @@ public final class RepositoryImpl<R, Q, I> {
     
     public Collection<IssueImpl> simpleSearch(String criteria) {
         Collection<I> issues = repositoryProvider.simpleSearch(r, criteria);
-        List<IssueImpl> ret = new ArrayList<IssueImpl>(issues.size());
+        List<IssueImpl> ret = new ArrayList<>(issues.size());
         for (I i : issues) {
             ret.add(getIssue(i));
         }
@@ -428,7 +428,7 @@ public final class RepositoryImpl<R, Q, I> {
         if (issues == null || issues.isEmpty()) {
             return Collections.<IssueImpl>emptyList();
         }
-        List<IssueImpl> ret = new ArrayList<IssueImpl>(issues.size());
+        List<IssueImpl> ret = new ArrayList<>(issues.size());
         for (I i : issues) {
             IssueImpl impl = getIssue(i);
             if(impl != null) {

--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/storage/ui/CodeTemplatesModel.java
@@ -365,7 +365,7 @@ final class CodeTemplatesModel {
                         abbreviation,
                         getDescription(idx),
                         getText(idx),
-                        new ArrayList(getContexts(idx)),
+                        new ArrayList<String>(getContexts(idx)),
                         getUniqueId(idx),
                         mimeType
                 );

--- a/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/ActionFactory.java
+++ b/ide/editor.fold.nbui/src/org/netbeans/modules/editor/fold/ui/ActionFactory.java
@@ -221,7 +221,7 @@ final class ActionFactory {
                             if (fold == null) {
                                 return;
                             }
-                            List<Fold> allFolds = new ArrayList<>(FoldUtilities.findRecursive(fold));
+                            List<Fold> allFolds = new ArrayList<Fold>(FoldUtilities.findRecursive(fold));
                             Collections.reverse(allFolds);
                             allFolds.add(0, fold);
                             hierarchy.expand(allFolds);

--- a/ide/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/StorageImpl.java
+++ b/ide/editor.settings.lib/src/org/netbeans/modules/editor/settings/storage/StorageImpl.java
@@ -484,7 +484,7 @@ public final class StorageImpl <K extends Object, V extends Object> {
         private static boolean rebuilding = false;
         
         private final String storageDescriptionId;
-        private final List<StorageFilter> filtersForId = new ArrayList<StorageFilter>();
+        private final List<StorageFilter> filtersForId = new ArrayList<>();
         
         private static Set<String> rebuild() {
             filters.clear();

--- a/ide/html/nbproject/project.properties
+++ b/ide/html/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ViewModelListener.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/views/ViewModelListener.java
@@ -415,7 +415,7 @@ public class ViewModelListener extends DebuggerManagerAdapter {
         if (View.LOCALS_VIEW_NAME.equals(viewType) && (VariablesViewButtons.isResultsViewNested() ||
                 VariablesViewButtons.isWatchesViewNested())) {
 
-            hyperModels = new ArrayList();
+            hyperModels = new ArrayList<>();
             if (VariablesViewButtons.isResultsViewNested()) {
                 hyperModels.add(createCompound(View.RESULTS_VIEW_NAME));
             }

--- a/ide/versioning.util/src/org/netbeans/modules/turbo/Turbo.java
+++ b/ide/versioning.util/src/org/netbeans/modules/turbo/Turbo.java
@@ -73,7 +73,7 @@ public final class Turbo {
 
     private static WeakReference defaultInstance;
 
-    private List listeners = new ArrayList(100);
+    private List<TurboListener> listeners = new ArrayList<>(100);
 
     /** memory layer */
     private final Memory memory;

--- a/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
+++ b/ide/xml.core/src/org/netbeans/modules/xml/api/model/GrammarQueryManager.java
@@ -27,6 +27,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.List;
 import org.openide.ErrorManager;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
@@ -147,7 +148,7 @@ public abstract class GrammarQueryManager {
         public Enumeration enabled(GrammarEnvironment ctx) {
             Iterator<GrammarQueryManager> it = getRegistrations();
             transaction.set(null);
-            ArrayList list = new ArrayList(5);
+            List list = new ArrayList<>(5);
             {
                 Enumeration en = ctx.getDocumentChildren();
                 while (en.hasMoreElements()) {

--- a/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
+++ b/ide/xml.text.obsolete90/src/org/netbeans/modules/xml/text/syntax/XMLSyntaxSupport.java
@@ -361,7 +361,7 @@ public final class XMLSyntaxSupport extends ExtSyntaxSupport implements XMLToken
                     }
                 } else {                                                                // starttag
                     String name = text.substring( 1 );
-                    ArrayList attrs = new ArrayList();
+                    List<String> attrs = new ArrayList<>();
                     
                     // skip attributes
                     

--- a/ide/xml/src/org/netbeans/modules/xml/actions/CollectSystemAction.java
+++ b/ide/xml/src/org/netbeans/modules/xml/actions/CollectSystemAction.java
@@ -116,7 +116,7 @@ public abstract class CollectSystemAction extends SystemAction implements Presen
         if ( Util.THIS.isLoggable() ) /* then */ Util.THIS.debug (
             "\n--> CollectSystemAction.createMenu: ( " + coll + " )");
 
-        ArrayList items = new ArrayList ();
+        List<JMenuItem> items = new ArrayList<>();
 
         Iterator it = coll.iterator();
         while (it.hasNext ()) {

--- a/java/ant.freeform/nbproject/project.properties
+++ b/java/ant.freeform/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/java/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/TargetMappingPanel.java
+++ b/java/ant.freeform/src/org/netbeans/modules/ant/freeform/ui/TargetMappingPanel.java
@@ -77,7 +77,7 @@ public class TargetMappingPanel extends JPanel implements ActionListener, HelpCt
     private CustomTargetsModel customTargetsModel;
     private String antScript;
     
-    private List<JComboBox> combos = new ArrayList<JComboBox>();
+    private List<JComboBox> combos = new ArrayList<>();
     private List<TargetDescriptor> targetDescs = new ArrayList<TargetDescriptor>();
     
     /** Any change in standard tasks which needs to be persisted? */

--- a/java/dbschema/src/org/netbeans/modules/dbschema/DBMemoryCollection.java
+++ b/java/dbschema/src/org/netbeans/modules/dbschema/DBMemoryCollection.java
@@ -75,7 +75,7 @@ class DBMemoryCollection {
             switch (action) {
                 case DBElement.Impl.ADD:
                     if (newLength > 0) {
-                        list = ((oldLength == 0) ? new ArrayList() : new ArrayList(Arrays.asList(oldElements)));
+                        list = ((oldLength == 0) ? new ArrayList<DBElement>() : new ArrayList<DBElement>(Arrays.asList(oldElements)));
                         list.addAll(c);
                         hasChange = true;
                     }

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingMonitorModel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/models/DebuggingMonitorModel.java
@@ -361,7 +361,7 @@ NodeActionsProviderFilter, TableModel, Constants {
                     }
                     List<CallStackFrame> frames;
                     synchronized (framesAskedForMonitors) {
-                        frames = new ArrayList(framesAskedForMonitors);
+                        frames = new ArrayList<>(framesAskedForMonitors);
                     }
                     for (CallStackFrame frame : frames) {
                         modelEventSource.doRefreshCache(frame);

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/ThreadsCollectorImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/ThreadsCollectorImpl.java
@@ -61,7 +61,7 @@ public class ThreadsCollectorImpl extends ThreadsCollector {
     @Override
     public List<JPDAThread> getAllThreads() {
         synchronized (threads) {
-            return Collections.unmodifiableList(new ArrayList(threads));
+            return Collections.unmodifiableList(new ArrayList<JPDAThread>(threads));
         }
     }
 

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAClassTypeImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAClassTypeImpl.java
@@ -156,7 +156,7 @@ public class JPDAClassTypeImpl implements JPDAClassType {
             int ss = subinterfaces.size();
             int is = implementors.size();
             if (ss > 0 || is > 0) {
-                List<JPDAClassType> subClasses = new ArrayList(ss + is);
+                List<JPDAClassType> subClasses = new ArrayList<>(ss + is);
                 for (InterfaceType subclass : subinterfaces) {
                     subClasses.add(debugger.getClassType(subclass));
                 }
@@ -225,7 +225,7 @@ public class JPDAClassTypeImpl implements JPDAClassType {
     private List<JPDAClassType> getTypes(Collection<? extends ReferenceType> types) {
         if (types.size() > 0) {
             types = new LinkedHashSet<>(types); // To remove duplicities
-            List<JPDAClassType> interfaces = new ArrayList(types.size());
+            List<JPDAClassType> interfaces = new ArrayList<>(types.size());
             for (ReferenceType intrfc : types) {
                 interfaces.add(debugger.getClassType(intrfc));
             }

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAThreadImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAThreadImpl.java
@@ -2020,7 +2020,7 @@ public final class JPDAThreadImpl implements JPDAThread, Customizer, BeanContext
                 if (!submitMonitorEnteredFor(waitingMonitor)) {
                     submitCheckForMonitorEntered(waitingMonitor);
                 }
-                lockerThreadsList = new ThreadListDelegate(debugger, new ArrayList(lockedThreadsWithMonitors.keySet()));
+                lockerThreadsList = new ThreadListDelegate(debugger, new ArrayList<ThreadReference>(lockedThreadsWithMonitors.keySet()));
             } else {
                 //lockerThreads2 = null;
                 lockerThreadsMonitor = null;

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
@@ -260,7 +260,7 @@ public class ThreadsCache implements Executor {
         }
         List<ThreadReference> threads = threadMap.get(group);
         if (threads == null) {
-            threads = Collections.emptyList();
+            threads = Collections.<ThreadReference>emptyList();
         } else {
             threads = Collections.<List<ThreadReference>>unmodifiableList(new ArrayList(threads));
         }
@@ -283,7 +283,7 @@ public class ThreadsCache implements Executor {
             groupMap.put(group, groups);
         }
         if (groups == null) {
-            groups = Collections.emptyList();
+            groups = Collections.<ThreadGroupReference>emptyList();
         } else {
             groups = Collections.<List<ThreadReference>>unmodifiableList(new ArrayList(groups));
         }

--- a/java/java.graph/src/org/netbeans/modules/java/graph/DependencyGraphScene.java
+++ b/java/java.graph/src/org/netbeans/modules/java/graph/DependencyGraphScene.java
@@ -456,11 +456,11 @@ public class DependencyGraphScene<I extends GraphNodeImplementation> extends Gra
     }
     
     void highlightRelated (GraphNode<I> node) {
-        List<GraphNode> importantNodes = new ArrayList<GraphNode>();
-        List<GraphEdge> otherPathsEdges = new ArrayList<GraphEdge>();
-        List<GraphEdge> primaryPathEdges = new ArrayList<GraphEdge>();
-        List<GraphNode> childrenNodes = new ArrayList<GraphNode>();
-        List<GraphEdge> childrenEdges = new ArrayList<GraphEdge>();
+        List<GraphNode> importantNodes  = new ArrayList<>();
+        List<GraphEdge> otherPathsEdges = new ArrayList<>();
+        List<GraphEdge> primaryPathEdges = new ArrayList<>();
+        List<GraphNode> childrenNodes   = new ArrayList<>();
+        List<GraphEdge> childrenEdges   = new ArrayList<>();
 
         importantNodes.add(node);
 

--- a/java/java.sourceui/src/org/netbeans/modules/java/source/ui/OpenProjectFastIndex.java
+++ b/java/java.sourceui/src/org/netbeans/modules/java/source/ui/OpenProjectFastIndex.java
@@ -254,7 +254,7 @@ class OpenProjectFastIndex implements ClassIndexManagerListener {
     }
 
     private Collection<FileObject>  getFileRoots(Iterable<? extends URL> roots) {
-        Collection c = new ArrayList<FileObject>(5);
+        Collection<FileObject> c = new ArrayList<>(5);
         for (Iterator<? extends URL> it = roots.iterator(); it.hasNext(); ) {
             URL rootURL = it.next();
             FileObject fo = URLMapper.findFileObject(rootURL);
@@ -550,7 +550,7 @@ class OpenProjectFastIndex implements ClassIndexManagerListener {
         private final int         size;
         private final Project     project;
         
-        NameIndex(Project p, FileObject root, String files, ArrayList indices) {
+        NameIndex(Project p, FileObject root, String files, List<Object[]> indices) {
             this.project = p;
             this.root = new WeakReference(root);
             this.size = indices.size();
@@ -615,7 +615,7 @@ class OpenProjectFastIndex implements ClassIndexManagerListener {
         private Project             project;
         
         private Map<FileObject, NameIndex>  nameIndexes = new HashMap<FileObject, NameIndex>();
-        private ArrayList          dirPositions;
+        private List<Object[]>     dirPositions;
         private int                charPtr;
 
         public IndexBuilder(Project project, Collection<FileObject> rootsToScan, Collection<FileObject> removedRoots) {
@@ -626,7 +626,7 @@ class OpenProjectFastIndex implements ClassIndexManagerListener {
         
         private void reset() {
             filenames = new StringBuilder();
-            dirPositions = new ArrayList();
+            dirPositions = new ArrayList<>();
             charPtr = 0;
         }
         

--- a/java/maven.graph/src/org/netbeans/modules/maven/graph/MavenAction.java
+++ b/java/maven.graph/src/org/netbeans/modules/maven/graph/MavenAction.java
@@ -145,7 +145,7 @@ public abstract class MavenAction extends AbstractAction {
                 }
             }
         }
-        List<GraphEdge> edges2Exclude = new ArrayList<GraphEdge>();
+        List<GraphEdge> edges2Exclude = new ArrayList<>();
         Collection<GraphEdge<MavenDependencyNode>> incoming = scene.findNodeEdges(node, false, true);
         GraphNode<MavenDependencyNode> sourceNode = null;
         boolean primaryExcluded = false;

--- a/platform/openide.nodes/src/org/openide/nodes/BeanNode.java
+++ b/platform/openide.nodes/src/org/openide/nodes/BeanNode.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.Action;
@@ -448,9 +449,9 @@ public class BeanNode<T> extends AbstractNode {
     * @return three property lists
     */
     public static Descriptor computeProperties(Object bean, BeanInfo info) {
-        ArrayList<Node.Property> property = new ArrayList<Node.Property>();
-        ArrayList<Node.Property> expert = new ArrayList<Node.Property>();
-        ArrayList<Node.Property> hidden = new ArrayList<Node.Property>();
+        List<Node.Property> property = new ArrayList<>();
+        List<Node.Property> expert = new ArrayList<>();
+        List<Node.Property> hidden = new ArrayList<>();
 
         PropertyDescriptor[] propertyDescriptor = info.getPropertyDescriptors();
 
@@ -787,7 +788,7 @@ public class BeanNode<T> extends AbstractNode {
         public final Node.Property[] hidden;
 
         /** private constructor */
-        Descriptor(ArrayList<Node.Property> p, ArrayList<Node.Property> e, ArrayList<Node.Property> h) {
+        Descriptor(List<Node.Property> p, List<Node.Property> e, List<Node.Property> h) {
             property = new Node.Property[p.size()];
             p.toArray(property);
 

--- a/platform/openide.nodes/src/org/openide/nodes/CookieSetLkp.java
+++ b/platform/openide.nodes/src/org/openide/nodes/CookieSetLkp.java
@@ -68,7 +68,7 @@ final class CookieSetLkp extends AbstractLookup {
             isInReplaceInst.set(this);
             
             it = lookupResult(Object.class).allItems().iterator();
-            pairs = new ArrayList<AbstractLookup.Pair>();
+            pairs = new ArrayList<>();
         
             boolean change = false;
             int index = 0;

--- a/platform/openide.nodes/src/org/openide/nodes/FilterNode.java
+++ b/platform/openide.nodes/src/org/openide/nodes/FilterNode.java
@@ -2073,7 +2073,7 @@ public class FilterNode extends Node {
                     this.delegate = l;
 
                     if (results != null) {
-                        toCheck = new ArrayList<ProxyResult>(results).iterator();
+                        toCheck = new ArrayList<>(results).iterator();
                     }
                 }
             }

--- a/platform/openide.nodes/src/org/openide/nodes/NodeLookup.java
+++ b/platform/openide.nodes/src/org/openide/nodes/NodeLookup.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import org.openide.util.Lookup.Template;
@@ -44,7 +45,7 @@ final class NodeLookup extends AbstractLookup {
     private final AggregatingExecutor EXECUTOR = new AggregatingExecutor();
 
     /** Set of Classes that we have already queried <type>Class</type> */
-    private java.util.Collection<Class> queriedCookieClasses = new ArrayList<Class>();
+    private Collection<Class> queriedCookieClasses = new ArrayList<>();
 
     /** node we are associated with
      */
@@ -213,7 +214,7 @@ final class NodeLookup extends AbstractLookup {
             }
         }
 
-        java.util.ArrayList<AbstractLookup.Pair> list = new java.util.ArrayList<AbstractLookup.Pair>(instances);
+        List<AbstractLookup.Pair> list = new ArrayList<>(instances);
         java.util.Collections.sort(list, new Cmp());
 
         if (toAdd == null) {

--- a/platform/openide.util/src/org/openide/util/TopologicalSortException.java
+++ b/platform/openide.util/src/org/openide/util/TopologicalSortException.java
@@ -85,7 +85,7 @@ public final class TopologicalSortException extends Exception {
     public final Set[] unsortableSets() {
         Set[] all = topologicalSets();
 
-        ArrayList<Set> unsort = new ArrayList<Set>();
+        List<Set> unsort = new ArrayList<>();
 
         for (int i = 0; i < all.length; i++) {
             if ((all[i].size() > 1) || !(all[i] instanceof HashSet)) {

--- a/platform/openide.util/src/org/openide/util/io/NbObjectOutputStream.java
+++ b/platform/openide.util/src/org/openide/util/io/NbObjectOutputStream.java
@@ -54,7 +54,7 @@ public class NbObjectOutputStream extends ObjectOutputStream {
     }
 
     private static Map<String,Boolean> examinedClasses = new WeakHashMap<String,Boolean>(250);
-    private final List<Class> serializing = new ArrayList<Class>(50);
+    private final List<Class> serializing = new ArrayList<>(50);
 
     /** Create a new object output.
     * @param os the underlying output stream

--- a/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
+++ b/profiler/profiler.oql/src/org/netbeans/modules/profiler/oql/engine/api/impl/Snapshot.java
@@ -278,7 +278,7 @@ public class Snapshot {
         Instance queue = (Instance) clazz.getValueOfStaticField("queue"); // NOI18N
         Instance head = (Instance) queue.getValueOfField("head"); // NOI18N
 
-        List finalizables = new ArrayList();
+        List<Instance> finalizables = new ArrayList<>();
         if (head != null) {
             while (true) {
                 Instance referent = (Instance) head.getValueOfField("referent"); // NOI18N


### PR DESCRIPTION
This work cleans up a bunch of warnings surrounding the use of ArrayList..

For example:

   [repeat] /home/bwalker/src/netbeans/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabLayoutManager.java:245: warning: [unchecked] unchecked conversion
   [repeat]             List<Integer>[] rowIndexes = new ArrayList[rowCount];
   [repeat]                                          ^
   [repeat]   required: List<Integer>[]
   [repeat]   found:    ArrayList[]

ActionsManager.java was especially involved since one change would require another. And keeping track of
that, so as not to break things, was hard.