### PR TITLE
[NETBEANS-5062] PHPDoc static type incorrectly resolved when returned by another class

### DIFF
--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class Test1
+{
+
+    private function getTest2() {
+        return Test2::returnStatic();
+    }
+
+    private function getTest2ReturnType() {
+        return Test2::returnStaticReturnType();
+    }
+
+    private function getTest2PHPDoc() {
+        return Test2::returnStaticPHPDoc();
+    }
+
+    private function getTest2Self() {
+        return Test2::returnSelf();
+    }
+
+    private function getTest2SelfReturnType() {
+        return Test2::returnSelfReturnType();
+    }
+
+    private function getTest2SelfPHPDoc() {
+        return Test2::returnSelfPHPDoc();
+    }
+
+    public function testMethod() {
+        echo "Test1" . PHP_EOL;
+    }
+
+    public function test() {
+        $static1 = $this->getTest2();
+        $static1->testMethod();
+
+        $static2 = $this->getTest2ReturnType();
+        $static2->testMethod();
+
+        $static3 = $this->getTest2PHPDoc();
+        $static3->testMethod();
+
+        $self1 = $this->getTest2Self();
+        $self1->testMethod();
+
+        $self2 = $this->getTest2SelfReturnType();
+        $self2->testMethod();
+
+        $self3 = $this->getTest2SelfPHPDoc();
+        $self3->testMethod();
+    }
+
+}
+
+class Test2
+{
+
+    public static function returnStatic() {
+        return new static();
+    }
+
+    public static function returnStaticReturnType(): static {
+    }
+
+    /**
+     * @return static
+     */
+    public static function returnStaticPHPDoc() {
+    }
+
+    public static function returnSelf() {
+        return new self();
+    }
+
+    public static function returnSelfReturnType(): self {
+    }
+
+    /**
+     * @return self
+     */
+    public static function returnSelfPHPDoc() {
+    }
+
+    public function testMethod() {
+        echo "Test2" . PHP_EOL;
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Self_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Self_01.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+$self1->|testMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [STATIC]   Test2
+METHOD     returnSelfPHPDoc()              [STATIC]   Test2
+METHOD     returnSelfReturnType()          [STATIC]   Test2
+METHOD     returnStatic()                  [STATIC]   Test2
+METHOD     returnStaticPHPDoc()            [STATIC]   Test2
+METHOD     returnStaticReturnType()        [STATIC]   Test2
+METHOD     testMethod()                    [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Self_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Self_02.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+$self2->|testMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [STATIC]   Test2
+METHOD     returnSelfPHPDoc()              [STATIC]   Test2
+METHOD     returnSelfReturnType()          [STATIC]   Test2
+METHOD     returnStatic()                  [STATIC]   Test2
+METHOD     returnStaticPHPDoc()            [STATIC]   Test2
+METHOD     returnStaticReturnType()        [STATIC]   Test2
+METHOD     testMethod()                    [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Self_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Self_03.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+$self3->|testMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [STATIC]   Test2
+METHOD     returnSelfPHPDoc()              [STATIC]   Test2
+METHOD     returnSelfReturnType()          [STATIC]   Test2
+METHOD     returnStatic()                  [STATIC]   Test2
+METHOD     returnStaticPHPDoc()            [STATIC]   Test2
+METHOD     returnStaticReturnType()        [STATIC]   Test2
+METHOD     testMethod()                    [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Static_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Static_01.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+$static1->|testMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [STATIC]   Test2
+METHOD     returnSelfPHPDoc()              [STATIC]   Test2
+METHOD     returnSelfReturnType()          [STATIC]   Test2
+METHOD     returnStatic()                  [STATIC]   Test2
+METHOD     returnStaticPHPDoc()            [STATIC]   Test2
+METHOD     returnStaticReturnType()        [STATIC]   Test2
+METHOD     testMethod()                    [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Static_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Static_02.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+$static2->|testMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [STATIC]   Test2
+METHOD     returnSelfPHPDoc()              [STATIC]   Test2
+METHOD     returnSelfReturnType()          [STATIC]   Test2
+METHOD     returnStatic()                  [STATIC]   Test2
+METHOD     returnStaticPHPDoc()            [STATIC]   Test2
+METHOD     returnStaticReturnType()        [STATIC]   Test2
+METHOD     testMethod()                    [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Static_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5062/nb5062.php.testNb5062Static_03.completion
@@ -1,0 +1,10 @@
+Code completion result for source line:
+$static3->|testMethod();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+METHOD     returnSelf()                    [STATIC]   Test2
+METHOD     returnSelfPHPDoc()              [STATIC]   Test2
+METHOD     returnSelfReturnType()          [STATIC]   Test2
+METHOD     returnStatic()                  [STATIC]   Test2
+METHOD     returnStaticPHPDoc()            [STATIC]   Test2
+METHOD     returnStaticReturnType()        [STATIC]   Test2
+METHOD     testMethod()                    [PUBLIC]   Test2

--- a/php/php.editor/test/unit/data/testfiles/gotodeclaration/testNb5062/testNb5062.php
+++ b/php/php.editor/test/unit/data/testfiles/gotodeclaration/testNb5062/testNb5062.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class Test1
+{
+
+    private function getTest2() {
+        return Test2::returnStatic();
+    }
+
+    private function getTest2ReturnType() {
+        return Test2::returnStaticReturnType();
+    }
+
+    private function getTest2PHPDoc() {
+        return Test2::returnStaticPHPDoc();
+    }
+
+    private function getTest2Self() {
+        return Test2::returnSelf();
+    }
+
+    private function getTest2SelfReturnType() {
+        return Test2::returnSelfReturnType();
+    }
+
+    private function getTest2SelfPHPDoc() {
+        return Test2::returnSelfPHPDoc();
+    }
+
+    public function testMethod() {
+        echo "Test1" . PHP_EOL;
+    }
+
+    public function test() {
+        $static1 = $this->getTest2();
+        $static1->testMethod();
+
+        $static2 = $this->getTest2ReturnType();
+        $static2->testMethod();
+
+        $static3 = $this->getTest2PHPDoc();
+        $static3->testMethod();
+
+        $self1 = $this->getTest2Self();
+        $self1->testMethod();
+
+        $self2 = $this->getTest2SelfReturnType();
+        $self2->testMethod();
+
+        $self3 = $this->getTest2SelfPHPDoc();
+        $self3->testMethod();
+    }
+
+}
+
+class Test2
+{
+
+    public static function returnStatic() {
+        return new static();
+    }
+
+    public static function returnStaticReturnType(): static {
+    }
+
+    /**
+     * @return static
+     */
+    public static function returnStaticPHPDoc() {
+    }
+
+    public static function returnSelf() {
+        return new self();
+    }
+
+    public static function returnSelfReturnType(): self {
+    }
+
+    /**
+     * @return self
+     */
+    public static function returnSelfPHPDoc() {
+    }
+
+    public function testMethod() { // Test2
+        echo "Test2" . PHP_EOL;
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/markoccurences/testNb5062/testNb5062.php
+++ b/php/php.editor/test/unit/data/testfiles/markoccurences/testNb5062/testNb5062.php
@@ -1,0 +1,107 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class Test1
+{
+
+    private function getTest2() {
+        return Test2::returnStatic();
+    }
+
+    private function getTest2ReturnType() {
+        return Test2::returnStaticReturnType();
+    }
+
+    private function getTest2PHPDoc() {
+        return Test2::returnStaticPHPDoc();
+    }
+
+    private function getTest2Self() {
+        return Test2::returnSelf();
+    }
+
+    private function getTest2SelfReturnType() {
+        return Test2::returnSelfReturnType();
+    }
+
+    private function getTest2SelfPHPDoc() {
+        return Test2::returnSelfPHPDoc();
+    }
+
+    public function testMethod() {
+        echo "Test1" . PHP_EOL;
+    }
+
+    public function test() {
+        $static1 = $this->getTest2();
+        $static1->testMethod();
+
+        $static2 = $this->getTest2ReturnType();
+        $static2->testMethod();
+
+        $static3 = $this->getTest2PHPDoc();
+        $static3->testMethod();
+
+        $self1 = $this->getTest2Self();
+        $self1->testMethod();
+
+        $self2 = $this->getTest2SelfReturnType();
+        $self2->testMethod();
+
+        $self3 = $this->getTest2SelfPHPDoc();
+        $self3->testMethod();
+    }
+
+}
+
+class Test2
+{
+
+    public static function returnStatic() {
+        return new static();
+    }
+
+    public static function returnStaticReturnType(): static {
+    }
+
+    /**
+     * @return static
+     */
+    public static function returnStaticPHPDoc() {
+    }
+
+    public static function returnSelf() {
+        return new self();
+    }
+
+    public static function returnSelfReturnType(): self {
+    }
+
+    /**
+     * @return self
+     */
+    public static function returnSelfPHPDoc() {
+    }
+
+    public function testMethod() { // Test2
+        echo "Test2" . PHP_EOL;
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01a.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01a.occurrences
@@ -1,0 +1,7 @@
+        $static1->|>MARK_OCCURRENCES:testMe^thod<|();
+        $static2->|>MARK_OCCURRENCES:testMethod<|();
+        $static3->|>MARK_OCCURRENCES:testMethod<|();
+        $self1->|>MARK_OCCURRENCES:testMethod<|();
+        $self2->|>MARK_OCCURRENCES:testMethod<|();
+        $self3->|>MARK_OCCURRENCES:testMethod<|();
+    public function |>MARK_OCCURRENCES:testMethod<|() { // Test2

--- a/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01b.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01b.occurrences
@@ -1,0 +1,7 @@
+        $static1->|>MARK_OCCURRENCES:testMethod<|();
+        $static2->^|>MARK_OCCURRENCES:testMethod<|();
+        $static3->|>MARK_OCCURRENCES:testMethod<|();
+        $self1->|>MARK_OCCURRENCES:testMethod<|();
+        $self2->|>MARK_OCCURRENCES:testMethod<|();
+        $self3->|>MARK_OCCURRENCES:testMethod<|();
+    public function |>MARK_OCCURRENCES:testMethod<|() { // Test2

--- a/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01c.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01c.occurrences
@@ -1,0 +1,7 @@
+        $static1->|>MARK_OCCURRENCES:testMethod<|();
+        $static2->|>MARK_OCCURRENCES:testMethod<|();
+        $static3->|>MARK_OCCURRENCES:tes^tMethod<|();
+        $self1->|>MARK_OCCURRENCES:testMethod<|();
+        $self2->|>MARK_OCCURRENCES:testMethod<|();
+        $self3->|>MARK_OCCURRENCES:testMethod<|();
+    public function |>MARK_OCCURRENCES:testMethod<|() { // Test2

--- a/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01d.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01d.occurrences
@@ -1,0 +1,7 @@
+        $static1->|>MARK_OCCURRENCES:testMethod<|();
+        $static2->|>MARK_OCCURRENCES:testMethod<|();
+        $static3->|>MARK_OCCURRENCES:testMethod<|();
+        $self1->|>MARK_OCCURRENCES:testMetho^d<|();
+        $self2->|>MARK_OCCURRENCES:testMethod<|();
+        $self3->|>MARK_OCCURRENCES:testMethod<|();
+    public function |>MARK_OCCURRENCES:testMethod<|() { // Test2

--- a/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01e.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01e.occurrences
@@ -1,0 +1,7 @@
+        $static1->|>MARK_OCCURRENCES:testMethod<|();
+        $static2->|>MARK_OCCURRENCES:testMethod<|();
+        $static3->|>MARK_OCCURRENCES:testMethod<|();
+        $self1->|>MARK_OCCURRENCES:testMethod<|();
+        $self2->^|>MARK_OCCURRENCES:testMethod<|();
+        $self3->|>MARK_OCCURRENCES:testMethod<|();
+    public function |>MARK_OCCURRENCES:testMethod<|() { // Test2

--- a/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01f.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01f.occurrences
@@ -1,0 +1,7 @@
+        $static1->|>MARK_OCCURRENCES:testMethod<|();
+        $static2->|>MARK_OCCURRENCES:testMethod<|();
+        $static3->|>MARK_OCCURRENCES:testMethod<|();
+        $self1->|>MARK_OCCURRENCES:testMethod<|();
+        $self2->|>MARK_OCCURRENCES:testMethod<|();
+        $self3->|>MARK_OCCURRENCES:testMetho^d<|();
+    public function |>MARK_OCCURRENCES:testMethod<|() { // Test2

--- a/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01g.occurrences
+++ b/php/php.editor/test/unit/data/testfiles/testNb5062.php.testNb5062_01g.occurrences
@@ -1,0 +1,7 @@
+        $static1->|>MARK_OCCURRENCES:testMethod<|();
+        $static2->|>MARK_OCCURRENCES:testMethod<|();
+        $static3->|>MARK_OCCURRENCES:testMethod<|();
+        $self1->|>MARK_OCCURRENCES:testMethod<|();
+        $self2->|>MARK_OCCURRENCES:testMethod<|();
+        $self3->|>MARK_OCCURRENCES:testMethod<|();
+    public function |>MARK_OCCURRENCES:tes^tMethod<|() { // Test2

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb5062Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb5062Test.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+
+public class PHPCodeCompletionNb5062Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionNb5062Test(String testName) {
+        super(testName);
+    }
+
+    public void testNb5062Static_01() throws Exception {
+        testNb5062("$static1->^testMethod();");
+    }
+
+    public void testNb5062Static_02() throws Exception {
+        testNb5062("$static2->^testMethod();");
+    }
+
+    public void testNb5062Static_03() throws Exception {
+        testNb5062("$static3->^testMethod();");
+    }
+
+    public void testNb5062Self_01() throws Exception {
+        testNb5062("$self1->^testMethod();");
+    }
+
+    public void testNb5062Self_02() throws Exception {
+        testNb5062("$self2->^testMethod();");
+    }
+
+    public void testNb5062Self_03() throws Exception {
+        testNb5062("$self3->^testMethod();");
+    }
+
+    private void testNb5062(String caretLine) throws Exception {
+        checkCompletion("testfiles/completion/lib/nb5062/nb5062.php", caretLine, false);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/nb5062"))
+            })
+        );
+    }
+
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationNb5062Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/GotoDeclarationNb5062Test.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.csl;
+
+
+public class GotoDeclarationNb5062Test extends GotoDeclarationTestBase {
+
+    public GotoDeclarationNb5062Test(String testName) {
+        super(testName);
+    }
+
+    public void testNb5062_Static01() throws Exception {
+        checkDeclaration(getTestPath(), "$static1->te^stMethod();", "    public function ^testMethod() { // Test2");
+    }
+
+    public void testNb5062_Static02() throws Exception {
+        checkDeclaration(getTestPath(), "$static2->testMet^hod();", "    public function ^testMethod() { // Test2");
+    }
+
+    public void testNb5062_Static03() throws Exception {
+        checkDeclaration(getTestPath(), "$static3->^testMethod();", "    public function ^testMethod() { // Test2");
+    }
+
+    public void testNb5062_Self01() throws Exception {
+        checkDeclaration(getTestPath(), "$self1->te^stMethod();", "    public function ^testMethod() { // Test2");
+    }
+
+    public void testNb5062_Self02() throws Exception {
+        checkDeclaration(getTestPath(), "$self2->testMet^hod();", "    public function ^testMethod() { // Test2");
+    }
+
+    public void testNb5062_Self03() throws Exception {
+        checkDeclaration(getTestPath(), "$self3->^testMethod();", "    public function ^testMethod() { // Test2");
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplNb5062Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/OccurrencesFinderImplNb5062Test.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.csl;
+
+
+public class OccurrencesFinderImplNb5062Test extends OccurrencesFinderImplTestBase {
+
+    public OccurrencesFinderImplNb5062Test(String testName) {
+        super(testName);
+    }
+
+    public void testNb5062_01a() throws Exception {
+        checkOccurrences(getTestPath(), "$static1->testMe^thod();", true);
+    }
+
+    public void testNb5062_01b() throws Exception {
+        checkOccurrences(getTestPath(), "$static2->^testMethod();", true);
+    }
+
+    public void testNb5062_01c() throws Exception {
+        checkOccurrences(getTestPath(), "$static3->tes^tMethod();", true);
+    }
+
+    public void testNb5062_01d() throws Exception {
+        checkOccurrences(getTestPath(), "$self1->testMetho^d();", true);
+    }
+
+    public void testNb5062_01e() throws Exception {
+        checkOccurrences(getTestPath(), "$self2->^testMethod();", true);
+    }
+
+    public void testNb5062_01f() throws Exception {
+        checkOccurrences(getTestPath(), "$self3->testMetho^d();", true);
+    }
+
+    public void testNb5062_01g() throws Exception {
+        checkOccurrences(getTestPath(), "public function tes^tMethod() { // Test2", true);
+    }
+
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5062

```php

<?php
class Test1
{

    private function getTest2() {
        return Test2::returnStatic();
    }

    public function testMethod() {
        echo "Test1" . PHP_EOL;
    }

    public function test() {
        $static1 = $this->getTest2(); // Before: $static1 is recognized as Test1, After $static1 is recognized as Test2
        var_dump($static1); // object(Test2)#2 (0) {}
        $static1->testMethod();
    }
}

class Test2
{

    public static function returnStatic() {
        return new static();
    }

    public function testMethod() {
        echo "Test2" . PHP_EOL;
    }

}

$test = new Test1();
$test->test();
```