### PR TITLE
Display sources loaded from String and find their MIME type.

### DIFF
--- a/ide/spi.debugger.ui/apichanges.xml
+++ b/ide/spi.debugger.ui/apichanges.xml
@@ -261,6 +261,21 @@
         <class package="org.netbeans.spi.debugger.ui" name="DebuggingView"/>
     </change>
 
+    <change id="DVFrameSourceMimeType">
+        <api name="DebuggerCoreSPI"/>
+        <summary>Source MIME type added to DVFrame.</summary>
+        <version major="2" minor="67"/>
+        <date day="30" month="11" year="2020"/>
+        <author login="mentlicher"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" semantic="compatible"/>
+        <description>
+            <p>
+                <code>DebuggingView.DVFrame</code> provides source MIME type.
+            </p>
+        </description>
+        <class package="org.netbeans.spi.debugger.ui" name="DebuggingView"/>
+    </change>
+
 </changes>
 
   <!-- Now the surrounding HTML text and document structure: -->

--- a/ide/spi.debugger.ui/manifest.mf
+++ b/ide/spi.debugger.ui/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.spi.debugger.ui/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/debugger/ui/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/debugger/resources/mf-layer.xml
-OpenIDE-Module-Specification-Version: 2.66
+OpenIDE-Module-Specification-Version: 2.67
 OpenIDE-Module-Provides: org.netbeans.spi.debugger.ui
 OpenIDE-Module-Install: org/netbeans/modules/debugger/ui/DebuggerModule.class

--- a/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/DebuggingView.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/spi/debugger/ui/DebuggingView.java
@@ -477,11 +477,21 @@ public final class DebuggingView {
         void makeCurrent();
 
         /**
-         * Gen URI of the source file associated with this frame, if any.
+         * Get URI of the source file associated with this frame, if any.
          * @return a source URI, or <code>null</code> if the file is unknown.
          * @since 2.65
          */
         URI getSourceURI();
+
+        /**
+         * Get the source MIME type, if known.
+         * @return the source MIME type, or <code>null</code> if the source, or
+         * its MIME type is unknown.
+         * @since 2.67
+         */
+        default String getSourceMimeType() {
+            return null;
+        }
 
         /**
          * Line location of the frame in the source code at {@link #getSourceURI()}.

--- a/java/debugger.jpda.truffle/nbproject/project.xml
+++ b/java/debugger.jpda.truffle/nbproject/project.xml
@@ -130,7 +130,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>2.65</specification-version>
+                        <specification-version>2.67</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleAccess.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleAccess.java
@@ -89,6 +89,7 @@ public class TruffleAccess implements JPDABreakpointListener {
     private static final String VAR_FRAME = "frame";                            // NOI18N
     private static final String VAR_SRC_ID = "id";                              // NOI18N
     private static final String VAR_SRC_URI = "uri";                            // NOI18N
+    private static final String VAR_SRC_MIMETYPE = "mimeType";                  // NOI18N
     private static final String VAR_SRC_NAME = "name";                          // NOI18N
     private static final String VAR_SRC_PATH = "path";                          // NOI18N
     private static final String VAR_SRC_SOURCESECTION = "sourceSection";        // NOI18N
@@ -308,8 +309,9 @@ public class TruffleAccess implements JPDABreakpointListener {
             String name = (String) sourcePositionVar.getField(VAR_SRC_NAME).createMirrorObject();
             String path = (String) sourcePositionVar.getField(VAR_SRC_PATH).createMirrorObject();
             URI uri = (URI) sourcePositionVar.getField(VAR_SRC_URI).createMirrorObject();
+            String mimeType = (String) sourcePositionVar.getField(VAR_SRC_MIMETYPE).createMirrorObject();
             StringReference codeRef = (StringReference) ((JDIVariable) sourcePositionVar.getField(VAR_SRC_CODE)).getJDIValue();
-            src = Source.getSource(debugger, id, name, path, uri, codeRef);
+            src = Source.getSource(debugger, id, name, path, uri, mimeType, codeRef);
         }
         return new SourcePosition(debugger, id, src, sourceSection);
     }
@@ -408,6 +410,7 @@ public class TruffleAccess implements JPDABreakpointListener {
         String sourceName;
         String sourcePath;
         URI sourceURI;
+        String mimeType;
         String sourceSection;
         try {
             int i1 = 0;
@@ -428,6 +431,9 @@ public class TruffleAccess implements JPDABreakpointListener {
             }
             i1 = i2 + 1;
             i2 = sourceDef.indexOf('\n', i1);
+            mimeType = sourceDef.substring(i1, i2);
+            i1 = i2 + 1;
+            i2 = sourceDef.indexOf('\n', i1);
             if (i2 < 0) {
                 i2 = sourceDef.length();
             }
@@ -435,7 +441,7 @@ public class TruffleAccess implements JPDABreakpointListener {
         } catch (IndexOutOfBoundsException ioob) {
             throw new IllegalStateException("var source definition='"+sourceDef+"'", ioob);
         }
-        Source src = Source.getSource(debugger, sourceId, sourceName, sourcePath, sourceURI, codeRef);
+        Source src = Source.getSource(debugger, sourceId, sourceName, sourcePath, sourceURI, mimeType, codeRef);
         return new SourcePosition(debugger, sourceId, src, sourceSection);
     }
     

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/TruffleStackFrame.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/TruffleStackFrame.java
@@ -58,6 +58,7 @@ public final class TruffleStackFrame {
     private final String sourceName;
     private final String sourcePath;
     private final URI    sourceURI;
+    private final String mimeType;
     private final String sourceSection;
     private final StringReference codeRef;
     private TruffleScope[] scopes;
@@ -111,6 +112,9 @@ public final class TruffleStackFrame {
                 throw new IllegalStateException("Bad URI: "+frameDefinition.substring(i1, i2), usex);
             }
             i1 = i2 + 1;
+            i2 = frameDefinition.indexOf('\n', i1);
+            mimeType = frameDefinition.substring(i1, i2);
+            i1 = i2 + 1;
             if (includeInternal) {
                 i2 = frameDefinition.indexOf('\n', i1);
                 sourceSection = frameDefinition.substring(i1, i2);
@@ -163,7 +167,7 @@ public final class TruffleStackFrame {
     public SourcePosition getSourcePosition() {
         Source src = Source.getExistingSource(debugger, sourceId);
         if (src == null) {
-            src = Source.getSource(debugger, sourceId, sourceName, sourcePath, sourceURI, codeRef);
+            src = Source.getSource(debugger, sourceId, sourceName, sourcePath, sourceURI, mimeType, codeRef);
         }
         SourcePosition sp = new SourcePosition(debugger, sourceId, src, sourceSection);
         return sp;

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/TruffleDVFrame.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/TruffleDVFrame.java
@@ -19,9 +19,11 @@
 package org.netbeans.modules.debugger.jpda.truffle.frames.models;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import org.netbeans.modules.debugger.jpda.truffle.access.CurrentPCInfo;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleAccess;
 import org.netbeans.modules.debugger.jpda.truffle.frames.TruffleStackFrame;
+import org.netbeans.modules.debugger.jpda.truffle.source.Source;
 import org.netbeans.spi.debugger.ui.DebuggingView.DVFrame;
 import org.netbeans.spi.debugger.ui.DebuggingView.DVThread;
 
@@ -63,7 +65,22 @@ public final class TruffleDVFrame implements DVFrame {
 
     @Override
     public URI getSourceURI() {
-        return truffleFrame.getSourcePosition().getSource().getURI();
+        Source source = truffleFrame.getSourcePosition().getSource();
+        URI uri = source.getURI();
+        if (uri != null && "file".equalsIgnoreCase(uri.getScheme())) {
+            return uri;
+        }
+        try {
+            return source.getUrl().toURI();
+        } catch (URISyntaxException ex) {
+            return null;
+        }
+    }
+
+    @Override
+    public String getSourceMimeType() {
+        Source source = truffleFrame.getSourcePosition().getSource();
+        return source.getMimeType();
     }
 
     @Override

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/Source.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/Source.java
@@ -51,10 +51,11 @@ public final class Source {
     private final String name;
     private final URI uri;          // The original source URI
     private final URL url;          // The source
+    private final String mimeType;
     private final long hash;
     private String content;
     
-    private Source(JPDADebugger jpda, String name, URI uri, long hash, StringReference codeRef) {
+    private Source(JPDADebugger jpda, String name, URI uri, String mimeType, long hash, StringReference codeRef) {
         this.name = name;
         this.codeRef = codeRef;
         URL url = null;
@@ -76,6 +77,7 @@ public final class Source {
         }
         this.url = url;
         this.uri = uri;
+        this.mimeType = mimeType;
         this.hash = hash;
     }
     
@@ -119,6 +121,15 @@ public final class Source {
                                    String path,
                                    URI uri,
                                    StringReference codeRef) {
+        return getSource(debugger, id, name, path, uri, null, codeRef);
+    }
+
+    public static Source getSource(JPDADebugger debugger, long id,
+                                   String name,
+                                   String path,
+                                   URI uri,
+                                   String mimeType,
+                                   StringReference codeRef) {
         synchronized (KNOWN_SOURCES) {
             Map<Long, Source> dbgSources = KNOWN_SOURCES.get(debugger);
             if (dbgSources != null) {
@@ -128,16 +139,17 @@ public final class Source {
                 }
             }
         }
-        return getTheSource(debugger, id, name, path, uri, codeRef);
+        return getTheSource(debugger, id, name, path, uri, mimeType, codeRef);
     }
     
     private static Source getTheSource(JPDADebugger debugger, long id,
                                        String name,
                                        String path,
                                        URI uri,
+                                       String mimeType,
                                        StringReference codeRef) {
         
-        Source src = new Source(debugger, name, uri, id, codeRef);
+        Source src = new Source(debugger, name, uri, mimeType, id, codeRef);
         synchronized (KNOWN_SOURCES) {
             Map<Long, Source> dbgSources = KNOWN_SOURCES.get(debugger);
             if (dbgSources == null) {
@@ -159,6 +171,10 @@ public final class Source {
     
     public URI getURI() {
         return uri;
+    }
+    
+    public String getMimeType() {
+        return mimeType;
     }
     
     public long getHash() {

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/FrameInfo.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/FrameInfo.java
@@ -61,7 +61,7 @@ final class FrameInfo {
                    ((sfLang != null) ? sfLang.getId() + " " + sfLang.getName() : "") + "\n" +
                    DebuggerVisualizer.getSourceLocation(topSS) + "\n" +
                    position.id + "\n" + position.name + "\n" + position.path + "\n" +
-                   position.uri.toString() + "\n" + position.sourceSection +/* "," + position.startColumn + "," +
+                   position.uri.toString() + "\n" + position.mimeType + "\n" + position.sourceSection +/* "," + position.startColumn + "," +
                    position.endLine + "," + position.endColumn +*/ "\n" + isInternal(topStackFrame);
         topVariables = JPDATruffleAccessor.getVariables(topStackFrame);
     }

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/FrameInfo.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/FrameInfo.java
@@ -41,7 +41,7 @@ final class FrameInfo {
 
     FrameInfo(DebugStackFrame topStackFrame, Iterable<DebugStackFrame> stackFrames) {
         SourceSection topSS = topStackFrame.getSourceSection();
-        SourcePosition position = new SourcePosition(topSS);
+        SourcePosition position = new SourcePosition(topSS, topStackFrame.getLanguage());
         ArrayList<DebugStackFrame> stackFramesArray = new ArrayList<>();
         for (DebugStackFrame sf : stackFrames) {
             if (sf == topStackFrame) {

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/GuestObject.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/GuestObject.java
@@ -145,7 +145,7 @@ public final class GuestObject {
             SourceSection sourceLocation = value.getSourceLocation();
             //System.err.println("\nSOURCE of "+value.getName()+" is: "+sourceLocation);
             if (sourceLocation != null && sourceLocation.isAvailable()) {
-                sp = new SourcePosition(sourceLocation);
+                sp = new SourcePosition(sourceLocation, value.getOriginalLanguage());
             }
         } catch (ThreadDeath td) {
             throw td;
@@ -159,7 +159,7 @@ public final class GuestObject {
                 SourceSection sourceLocation = metaObject.getSourceLocation();
                 //System.err.println("\nSOURCE of metaobject "+metaObject+" is: "+sourceLocation);
                 if (sourceLocation != null && sourceLocation.isAvailable()) {
-                    sp = new SourcePosition(sourceLocation);
+                    sp = new SourcePosition(sourceLocation, value.getOriginalLanguage());
                 }
             } catch (ThreadDeath td) {
                 throw td;

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/JPDATruffleAccessor.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/JPDATruffleAccessor.java
@@ -261,6 +261,8 @@ public class JPDATruffleAccessor extends Object {
         str.append('\n');
         str.append(position.uri.toString());
         str.append('\n');
+        str.append(position.mimeType);
+        str.append('\n');
         str.append(position.sourceSection);
         return str.toString();
     }

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/JPDATruffleAccessor.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/JPDATruffleAccessor.java
@@ -231,7 +231,7 @@ public class JPDATruffleAccessor extends Object {
                 System.err.println("frameInfos = "+frameInfos);
                 *//*
             }*/
-            SourcePosition position = new SourcePosition(sf.getSourceSection());
+            SourcePosition position = new SourcePosition(sf.getSourceSection(), sf.getLanguage());
             frameInfos.append(createPositionIdentificationString(position));
             if (includeInternal) {
                 frameInfos.append('\n');

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/JPDATruffleDebugManager.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/JPDATruffleDebugManager.java
@@ -107,7 +107,7 @@ class JPDATruffleDebugManager implements SuspendedCallback {
         }
         suspendedEvents.set(event);
         try {
-            SourcePosition position = new SourcePosition(event.getSourceSection());
+            SourcePosition position = new SourcePosition(event.getSourceSection(), event.getTopStackFrame().getLanguage());
             int stepCmd = JPDATruffleAccessor.executionHalted(
                     this, position,
                     event.getSuspendAnchor() == SuspendAnchor.BEFORE,

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/SourcePosition.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/SourcePosition.java
@@ -41,6 +41,7 @@ final class SourcePosition {
     final String sourceSection;
     final String code;
     final URI uri;
+    final String mimeType;
 
     public SourcePosition(SourceSection sourceSection) {
         Source source = sourceSection.getSource();
@@ -54,6 +55,7 @@ final class SourcePosition {
         this.sourceSection = sourceSection.getStartLine() + "," + sourceSection.getStartColumn() + "," + sourceSection.getEndLine() + "," + sourceSection.getEndColumn();
         this.code = source.getCharacters().toString();
         this.uri = source.getURI();
+        this.mimeType = source.getMimeType();
     }
 
     private static synchronized long getId(Source s) {

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/SourcePosition.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/SourcePosition.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.debugger.jpda.backend.truffle;
 
+import com.oracle.truffle.api.nodes.LanguageInfo;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -43,7 +44,7 @@ final class SourcePosition {
     final URI uri;
     final String mimeType;
 
-    public SourcePosition(SourceSection sourceSection) {
+    public SourcePosition(SourceSection sourceSection, LanguageInfo languageInfo) {
         Source source = sourceSection.getSource();
         this.id = getId(source);
         this.name = source.getName();
@@ -55,7 +56,15 @@ final class SourcePosition {
         this.sourceSection = sourceSection.getStartLine() + "," + sourceSection.getStartColumn() + "," + sourceSection.getEndLine() + "," + sourceSection.getEndColumn();
         this.code = source.getCharacters().toString();
         this.uri = source.getURI();
-        this.mimeType = source.getMimeType();
+        this.mimeType = findMIMEType(source, languageInfo);
+    }
+
+    private String findMIMEType(Source source, LanguageInfo languageInfo) {
+        String mimeType = source.getMimeType();
+        if (mimeType == null && languageInfo != null) {
+            mimeType = languageInfo.getDefaultMimeType();
+        }
+        return mimeType;
     }
 
     private static synchronized long getId(Source s) {

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -292,7 +292,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>2.63</specification-version>
+                        <specification-version>2.67</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
@@ -18,7 +18,11 @@
  */
 package org.netbeans.modules.java.lsp.server.debugging;
 
+import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -286,11 +290,33 @@ public final class NbProtocolServer implements IDebugProtocolServer {
                     stackFrame.setId(frameId);
                     stackFrame.setName(frame.getName());
                     URI sourceURI = frame.getSourceURI();
-                    if (sourceURI != null && sourceURI.getPath() != null) {
+                    if (sourceURI != null) {
                         Source source = new Source();
-                        source.setName(Paths.get(sourceURI).getFileName().toString());
-                        source.setPath(sourceURI.getPath());
-                        source.setSourceReference(0);
+                        String scheme = sourceURI.getScheme();
+                        if (null == scheme || scheme.isEmpty() || "file".equalsIgnoreCase(scheme)) {
+                            source.setName(Paths.get(sourceURI).getFileName().toString());
+                            source.setPath(sourceURI.getPath());
+                            source.setSourceReference(0);
+                        } else {
+                            int ref = context.createSourceReference(sourceURI, frame.getSourceMimeType());
+                            String path = sourceURI.getPath();
+                            if (path == null) {
+                                path = sourceURI.getSchemeSpecificPart();
+                            }
+                            if (path != null) {
+                                int sepIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf(File.separatorChar));
+                                source.setName(path.substring(sepIndex + 1));
+                                if ("jar".equalsIgnoreCase(scheme)) {
+                                    try {
+                                        path = new URI(path).getPath();
+                                    } catch (URISyntaxException ex) {
+                                        // ignore, we just tried
+                                    }
+                                }
+                                source.setPath(path);
+                            }
+                            source.setSourceReference(ref);
+                        }
                         stackFrame.setSource(source);
                     }
                     stackFrame.setLine(line);
@@ -343,10 +369,10 @@ public final class NbProtocolServer implements IDebugProtocolServer {
         if (sourceReference <= 0) {
             ErrorUtilities.completeExceptionally(future, "SourceRequest: property 'sourceReference' is missing, null, or empty", ResponseErrorCode.InvalidParams);
         } else {
-            String uri = context.getSourceUri(sourceReference);
+            URI uri = context.getSourceUri(sourceReference);
             NbSourceProvider sourceProvider = context.getSourceProvider();
             SourceResponse response = new SourceResponse();
-            response.setMimeType("text/x-java"); // Set mimeType to tell clients to recognize the source contents as java source
+            response.setMimeType(context.getSourceMimeType(sourceReference));
             response.setContent(sourceProvider.getSourceContents(uri));
             future.complete(response);
         }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbSourceProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbSourceProvider.java
@@ -19,7 +19,13 @@
 package org.netbeans.modules.java.lsp.server.debugging;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -67,9 +73,25 @@ public final class NbSourceProvider {
         });
     }
 
-    public String getSourceContents(String arg0) {
-        LOG.log(Level.INFO, "SourceContent {0}", arg0);
-        throw new UnsupportedOperationException("Not supported yet.");
+    public String getSourceContents(URI uri) {
+        LOG.log(Level.INFO, "SourceContent {0}", uri);
+        URL url;
+        try {
+            url = uri.toURL();
+        } catch (MalformedURLException ex) {
+            return ex.getLocalizedMessage();
+        }
+        StringBuilder content = new StringBuilder();
+        char[] buffer = new char[8192];
+        try (Reader r = new InputStreamReader(url.openConnection().getInputStream())) {
+            int l;
+            while ((l = r.read(buffer)) > 0) {
+                content.append(buffer, 0, l);
+            }
+        } catch (IOException ex) {
+            return ex.getLocalizedMessage();
+        }
+        return content.toString();
     }
     
     public Source getSource(String sourceName, String debuggerURI) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/breakpoints/NbBreakpoint.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/breakpoints/NbBreakpoint.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.java.lsp.server.debugging.breakpoints;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +36,7 @@ import org.netbeans.api.debugger.DebuggerManager;
 import org.netbeans.api.debugger.jpda.LineBreakpoint;
 import org.netbeans.modules.debugger.jpda.truffle.breakpoints.TruffleLineBreakpoint;
 import org.netbeans.modules.java.lsp.server.debugging.DebugAdapterContext;
+import org.openide.filesystems.URLMapper;
 
 /**
  *
@@ -56,6 +58,15 @@ public final class NbBreakpoint {
 
     public NbBreakpoint(Source source, String sourceURL, int line, int hitCount, String condition, String logMessage, DebugAdapterContext context) {
         this.source = source;
+        Integer ref = source.getSourceReference();
+        if (ref != null && ref != 0) {
+            URI uri = context.getSourceUri(ref);
+            if (uri != null) {
+                try {
+                    sourceURL = uri.toURL().toString();
+                } catch (MalformedURLException ex) {}
+            }
+        }
         this.sourceURL = sourceURL;
         this.line = line;
         this.hitCount = hitCount;
@@ -116,9 +127,9 @@ public final class NbBreakpoint {
         breakpoint.addPropertyChangeListener(Breakpoint.PROP_VALIDITY, evt -> {
             updateValid(breakpoint, true);
         });
-        updateValid(breakpoint, false);
         DebuggerManager d = DebuggerManager.getDebuggerManager();
         d.addBreakpoint(breakpoint);
+        updateValid(breakpoint, false);
         this.breakpoint = breakpoint;
         return CompletableFuture.completedFuture(this);
     }

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -163,7 +163,7 @@
 		"watch": "tsc -watch -p ./",
 		"test": "node ./out/test/runTest.js",
 		"nbcode": "node ./out/nbcode.js",
-		"nbjavac" : "node ./out/nbcode.js -J-Dnetbeans.close=true --modules --install .*nbjavac.*"
+		"nbjavac": "node ./out/nbcode.js -J-Dnetbeans.close=true --modules --install .*nbjavac.*"
 	},
 	"devDependencies": {
 		"@types/vscode": "^1.47.0",


### PR DESCRIPTION
Sources that have no File associated are put to a special virtual SourceFS filesystem. We add the MIME type information and use these files in NetBeans. It's also assured that breakpoints submitted into these files are resolved correctly.
A simple API change needs to be done: `DVFrame.getSourceMimeType()`.
