### PR TITLE
[NETBEANS-5075] Remove consecutive empty lines when formatting PHP code

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/CodeStyle.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/CodeStyle.java
@@ -236,6 +236,10 @@ public final class CodeStyle {
         return preferences.getInt(BLANK_LINES_BEFORE_CLOSE_PHP_TAG, getDefaultAsInt(BLANK_LINES_BEFORE_CLOSE_PHP_TAG));
     }
 
+    public int getBlankLinesMaxPreserved() {
+        return preferences.getInt(BLANK_LINES_MAX_PRESERVED, getDefaultAsInt(BLANK_LINES_MAX_PRESERVED));
+    }
+
     // Spaces ------------------------------------------------------------------
 
     public boolean spaceBeforeWhile() {

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FmtOptions.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FmtOptions.java
@@ -108,6 +108,7 @@ public final class FmtOptions {
     public static final String BLANK_LINES_AFTER_OPEN_PHP_TAG = "blankLinesAfterOpenPHPTag"; //NOI18N
     public static final String BLANK_LINES_AFTER_OPEN_PHP_TAG_IN_HTML = "blankLinesAfterOpenPHPTagInHTML"; //NOI18N
     public static final String BLANK_LINES_BEFORE_CLOSE_PHP_TAG = "blankLinesBeforeClosePHPTag"; //NOI18N
+    public static final String BLANK_LINES_MAX_PRESERVED = "blankLinesMaxPreserved"; //NOI18N
     public static final String SPACE_BEFORE_WHILE = "spaceBeforeWhile"; //NOI18N
     public static final String SPACE_BEFORE_ELSE = "spaceBeforeElse"; //NOI18N
     public static final String SPACE_BEFORE_CATCH = "spaceBeforeCatch"; //NOI18N
@@ -284,6 +285,7 @@ public final class FmtOptions {
             {BLANK_LINES_AFTER_OPEN_PHP_TAG, "1"}, //NOI18N
             {BLANK_LINES_AFTER_OPEN_PHP_TAG_IN_HTML, "0"}, //NOI18N
             {BLANK_LINES_BEFORE_CLOSE_PHP_TAG, "0"}, //NOI18N
+            {BLANK_LINES_MAX_PRESERVED, "1"}, //NOI18N
 
             {SPACE_BEFORE_WHILE, TRUE},
             {SPACE_BEFORE_ELSE, TRUE},

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/TokenFormatter.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/TokenFormatter.java
@@ -161,6 +161,7 @@ public class TokenFormatter {
         public int blankLinesAfterOpenPHPTag;
         public int blankLinesAfterOpenPHPTagInHTML;
         public int blankLinesBeforeClosePHPTag;
+        public int blankLinesMaxPreserved;
         public CodeStyle.WrapStyle wrapGroupUseList;
         public CodeStyle.WrapStyle wrapExtendsImplementsKeyword;
         public CodeStyle.WrapStyle wrapExtendsImplementsList;
@@ -312,6 +313,7 @@ public class TokenFormatter {
             blankLinesAfterOpenPHPTag = codeStyle.getBlankLinesAfterOpenPHPTag();
             blankLinesAfterOpenPHPTagInHTML = codeStyle.getBlankLinesAfterOpenPHPTagInHTML();
             blankLinesBeforeClosePHPTag = codeStyle.getBlankLinesBeforeClosePHPTag();
+            blankLinesMaxPreserved = codeStyle.getBlankLinesMaxPreserved();
 
             wrapGroupUseList = codeStyle.wrapGroupUseList();
             wrapExtendsImplementsKeyword = codeStyle.wrapExtendsImplementsKeyword();
@@ -1829,6 +1831,7 @@ public class TokenFormatter {
                                     } else {
                                         if (!indentRule) {
                                             newLines = countOfNewLines(oldText);
+                                            newLines = docOptions.blankLinesMaxPreserved + 1 < newLines ? docOptions.blankLinesMaxPreserved + 1 : newLines;
                                         }
                                     }
                                 }

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/Bundle.properties
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/Bundle.properties
@@ -430,3 +430,6 @@ FmtWrapping.groupUseListLabel.text=G&roup Use List:
 FmtWrapping.groupUseBracesCheckBox.text_1=Group &Use Braces
 FmtBraces.groupUseLabel.text=G&roup Use:
 FmtAlignment.noteLabel.text=<html><i>Note: These options depend on Wrapping settings</i></html>
+FmtBlankLines.maxPreservedBlankLabel.AccessibleContext.accessibleDescription=Maximal preserved consecutive empty lines
+FmtBlankLines.maxPreservedBlankLabel.AccessibleContext.accessibleName=Maximal Preserved Lines
+FmtBlankLines.maxPreservedBlankLabel.text=Max Preserved Lines:

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtBlankLines.form
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtBlankLines.form
@@ -47,7 +47,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-12,0,0,1,13"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,2,100,0,0,1,17"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
@@ -97,7 +97,6 @@
                                   <Group type="103" groupAlignment="0" attributes="0">
                                       <Group type="103" alignment="1" groupAlignment="0" attributes="0">
                                           <Component id="bClosePHPTagLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                                          <Component id="bUseTraitLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                                           <Component id="aOpenPHPTagHTMLLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                                       </Group>
                                       <Component id="bMethodsLabel" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -115,30 +114,42 @@
                                   <Component id="bUseLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                                   <Component id="aNamespaceLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                                   <Component id="bNamespaceLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                                  <Component id="bUseTraitLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                                  <Component id="maxPreservedBlankLabel" alignment="0" min="-2" max="-2" attributes="0"/>
                               </Group>
-                              <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Group type="103" alignment="0" groupAlignment="1" attributes="0">
-                                      <Component id="aMethodsField" linkSize="1" alignment="1" min="-2" max="-2" attributes="3"/>
-                                      <Component id="bMethodsField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="aFieldsField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="bFunctionEndField" linkSize="1" alignment="1" min="-2" max="-2" attributes="3"/>
-                                      <Component id="betweenFields" linkSize="1" alignment="0" min="-2" max="-2" attributes="1"/>
-                                      <Component id="bFieldsField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="aClassField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="bClassEndField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="aClassHeaderField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="bClassField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="aUseField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="bUseField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="aNamespaceField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="bNamespaceField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                  <Group type="102" attributes="0">
+                                      <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
+                                      <Group type="103" groupAlignment="0" attributes="0">
+                                          <Group type="103" alignment="0" groupAlignment="1" attributes="0">
+                                              <Component id="aMethodsField" linkSize="1" alignment="1" min="-2" max="-2" attributes="3"/>
+                                              <Component id="bMethodsField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="aFieldsField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="bFunctionEndField" linkSize="1" alignment="1" min="-2" max="-2" attributes="3"/>
+                                              <Component id="betweenFields" linkSize="1" alignment="0" min="-2" max="-2" attributes="1"/>
+                                              <Component id="bFieldsField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="aClassField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="bClassEndField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="aClassHeaderField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="bClassField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="aUseField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="bUseField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="aNamespaceField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="bNamespaceField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                          </Group>
+                                          <Component id="aOpenPHPTagField" linkSize="1" min="-2" max="-2" attributes="3"/>
+                                          <Group type="103" alignment="1" groupAlignment="0" max="-2" attributes="0">
+                                              <Component id="bClosePHPTagField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                              <Component id="aOpenPHPTagHTMLField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                          </Group>
+                                      </Group>
                                   </Group>
-                                  <Component id="aOpenPHPTagField" linkSize="1" min="-2" max="-2" attributes="3"/>
-                                  <Group type="103" alignment="1" groupAlignment="0" max="-2" attributes="0">
-                                      <Component id="bUseTraitField" linkSize="1" min="-2" max="-2" attributes="0"/>
-                                      <Component id="bClosePHPTagField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
-                                      <Component id="aOpenPHPTagHTMLField" linkSize="1" alignment="0" min="-2" max="-2" attributes="3"/>
+                                  <Group type="102" alignment="1" attributes="0">
+                                      <EmptySpace max="-2" attributes="0"/>
+                                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                                          <Component id="maxPreservedBlankField" max="32767" attributes="0"/>
+                                          <Component id="bUseTraitField" linkSize="1" max="32767" attributes="0"/>
+                                      </Group>
                                   </Group>
                               </Group>
                           </Group>
@@ -236,12 +247,17 @@
                           <Component id="bClosePHPTagLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="bClosePHPTagField" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="3" attributes="0">
-                          <Component id="bUseTraitLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="bUseTraitField" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="bUseTraitLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="3" attributes="0">
+                          <Component id="maxPreservedBlankLabel" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="maxPreservedBlankField" alignment="3" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                      <EmptySpace max="-2" attributes="0"/>
                       <Component id="cbGroupFields" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="32767" attributes="0"/>
                   </Group>
@@ -742,6 +758,23 @@
                   <ResourceString bundle="org/netbeans/modules/php/editor/indent/ui/Bundle.properties" key="FmtBlankLines.bUseTraitField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
                 </Property>
               </Properties>
+            </Component>
+            <Component class="javax.swing.JTextField" name="maxPreservedBlankField">
+            </Component>
+            <Component class="javax.swing.JLabel" name="maxPreservedBlankLabel">
+              <Properties>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/netbeans/modules/php/editor/indent/ui/Bundle.properties" key="FmtBlankLines.maxPreservedBlankLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+              <AccessibilityProperties>
+                <Property name="AccessibleContext.accessibleName" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/netbeans/modules/php/editor/indent/ui/Bundle.properties" key="FmtBlankLines.maxPreservedBlankLabel.AccessibleContext.accessibleName" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+                <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/netbeans/modules/php/editor/indent/ui/Bundle.properties" key="FmtBlankLines.maxPreservedBlankLabel.AccessibleContext.accessibleDescription" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+              </AccessibilityProperties>
             </Component>
           </SubComponents>
         </Container>

--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtBlankLines.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/ui/FmtBlankLines.java
@@ -57,6 +57,7 @@ public class FmtBlankLines extends javax.swing.JPanel {
         aOpenPHPTagField.putClientProperty(OPTION_ID, BLANK_LINES_AFTER_OPEN_PHP_TAG);
         aOpenPHPTagHTMLField.putClientProperty(OPTION_ID, BLANK_LINES_AFTER_OPEN_PHP_TAG_IN_HTML);
         bClosePHPTagField.putClientProperty(OPTION_ID, BLANK_LINES_BEFORE_CLOSE_PHP_TAG);
+        maxPreservedBlankField.putClientProperty(OPTION_ID, BLANK_LINES_MAX_PRESERVED);
 
         bNamespaceField.addKeyListener(new NumericKeyListener());
         aNamespaceField.addKeyListener(new NumericKeyListener());
@@ -139,6 +140,8 @@ public class FmtBlankLines extends javax.swing.JPanel {
         cbGroupFields = new javax.swing.JCheckBox();
         bUseTraitLabel = new javax.swing.JLabel();
         bUseTraitField = new javax.swing.JTextField();
+        maxPreservedBlankField = new javax.swing.JTextField();
+        maxPreservedBlankLabel = new javax.swing.JLabel();
 
         setName(org.openide.util.NbBundle.getMessage(FmtBlankLines.class, "LBL_BlankLines")); // NOI18N
         setOpaque(false);
@@ -235,6 +238,8 @@ public class FmtBlankLines extends javax.swing.JPanel {
 
         bUseTraitField.setText(org.openide.util.NbBundle.getMessage(FmtBlankLines.class, "FmtBlankLines.bUseTraitField.text")); // NOI18N
 
+        org.openide.awt.Mnemonics.setLocalizedText(maxPreservedBlankLabel, org.openide.util.NbBundle.getMessage(FmtBlankLines.class, "FmtBlankLines.maxPreservedBlankLabel.text")); // NOI18N
+
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
@@ -248,7 +253,6 @@ public class FmtBlankLines extends javax.swing.JPanel {
                             .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                                 .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                                     .addComponent(bClosePHPTagLabel)
-                                    .addComponent(bUseTraitLabel)
                                     .addComponent(aOpenPHPTagHTMLLabel))
                                 .addComponent(bMethodsLabel)
                                 .addComponent(bFunctionEndLabel)
@@ -263,29 +267,37 @@ public class FmtBlankLines extends javax.swing.JPanel {
                             .addComponent(aUseLabel)
                             .addComponent(bUseLabel)
                             .addComponent(aNamespaceLabel)
-                            .addComponent(bNamespaceLabel))
-                        .addGap(12, 12, 12)
+                            .addComponent(bNamespaceLabel)
+                            .addComponent(bUseTraitLabel)
+                            .addComponent(maxPreservedBlankLabel))
                         .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                .addComponent(aMethodsField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(bMethodsField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(aFieldsField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(bFunctionEndField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(betweenFields, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(bFieldsField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(aClassField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(bClassEndField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(aClassHeaderField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(bClassField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(aUseField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(bUseField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(aNamespaceField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(bNamespaceField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                            .addComponent(aOpenPHPTagField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                                .addComponent(bUseTraitField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(bClosePHPTagField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addComponent(aOpenPHPTagHTMLField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                            .addGroup(jPanel1Layout.createSequentialGroup()
+                                .addGap(12, 12, 12)
+                                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                                        .addComponent(aMethodsField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(bMethodsField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(aFieldsField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(bFunctionEndField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(betweenFields, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(bFieldsField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(aClassField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(bClassEndField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(aClassHeaderField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(bClassField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(aUseField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(bUseField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(aNamespaceField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(bNamespaceField, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                    .addComponent(aOpenPHPTagField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                                        .addComponent(bClosePHPTagField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addComponent(aOpenPHPTagHTMLField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                                    .addComponent(maxPreservedBlankField)
+                                    .addComponent(bUseTraitField)))))
                     .addComponent(cbGroupFields))
                 .addContainerGap())
         );
@@ -363,11 +375,15 @@ public class FmtBlankLines extends javax.swing.JPanel {
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(bClosePHPTagLabel)
                     .addComponent(bClosePHPTagField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(bUseTraitLabel)
-                    .addComponent(bUseTraitField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                    .addComponent(bUseTraitField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(bUseTraitLabel))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(maxPreservedBlankLabel)
+                    .addComponent(maxPreservedBlankField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(cbGroupFields)
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
@@ -425,6 +441,8 @@ public class FmtBlankLines extends javax.swing.JPanel {
         aUseField.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(FmtBlankLines.class, "FmtBlankLines.aUseField.AccessibleContext.accessibleDescription")); // NOI18N
         aUseLabel.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(FmtBlankLines.class, "FmtBlankLines.aUseLabel.AccessibleContext.accessibleName")); // NOI18N
         aUseLabel.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(FmtBlankLines.class, "FmtBlankLines.aUseLabel.AccessibleContext.accessibleDescription")); // NOI18N
+        maxPreservedBlankLabel.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(FmtBlankLines.class, "FmtBlankLines.maxPreservedBlankLabel.AccessibleContext.accessibleName")); // NOI18N
+        maxPreservedBlankLabel.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(FmtBlankLines.class, "FmtBlankLines.maxPreservedBlankLabel.AccessibleContext.accessibleDescription")); // NOI18N
 
         scrollPane1.setViewportView(jPanel1);
         jPanel1.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(FmtBlankLines.class, "FmtBlankLines.jPanel1.AccessibleContext.accessibleName")); // NOI18N
@@ -478,6 +496,8 @@ public class FmtBlankLines extends javax.swing.JPanel {
     private javax.swing.JLabel betweenFieldsLabel;
     private javax.swing.JCheckBox cbGroupFields;
     private javax.swing.JPanel jPanel1;
+    private javax.swing.JTextField maxPreservedBlankField;
+    private javax.swing.JLabel maxPreservedBlankLabel;
     private javax.swing.JScrollPane scrollPane1;
     // End of variables declaration//GEN-END:variables
 

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines01.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines01.php
@@ -1,0 +1,18 @@
+<?php
+
+function start() {
+    echo "Ready\n";
+    
+    
+    echo "Set\n";
+    
+    
+    
+    echo "Go!\n";
+}
+
+start();
+sleep(1);
+
+
+start();

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines01.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines01.php.formatted
@@ -1,0 +1,11 @@
+<?php
+
+function start() {
+    echo "Ready\n";
+    echo "Set\n";
+    echo "Go!\n";
+}
+
+start();
+sleep(1);
+start();

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines02.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines02.php
@@ -1,0 +1,18 @@
+<?php
+
+function start() {
+    echo "Ready\n";
+    
+    
+    echo "Set\n";
+    
+    
+    
+    echo "Go!\n";
+}
+
+start();
+sleep(1);
+
+
+start();

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines02.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines02.php.formatted
@@ -1,0 +1,14 @@
+<?php
+
+function start() {
+    echo "Ready\n";
+
+    echo "Set\n";
+
+    echo "Go!\n";
+}
+
+start();
+sleep(1);
+
+start();

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines03.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines03.php
@@ -1,0 +1,18 @@
+<?php
+
+function start() {
+    echo "Ready\n";
+    
+    
+    echo "Set\n";
+    
+    
+    
+    echo "Go!\n";
+}
+
+start();
+sleep(1);
+
+
+start();

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines03.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/MaxPreservedLines03.php.formatted
@@ -1,0 +1,17 @@
+<?php
+
+function start() {
+    echo "Ready\n";
+
+
+    echo "Set\n";
+
+
+    echo "Go!\n";
+}
+
+start();
+sleep(1);
+
+
+start();

--- a/php/php.editor/test/unit/data/testfiles/formatting/issue176453.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/issue176453.php.formatted
@@ -4,7 +4,6 @@ echo preg_replace_callback('~-([a-z])~', function ($match) {
   return strtoupper($match[1]);
 }, 'hello-world');
 
-
 $greet = function($name) {
   printf("Hello %s\r\n", $name);
 };

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterBlankLinesTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterBlankLinesTest.java
@@ -147,6 +147,7 @@ public class PHPFormatterBlankLinesTest extends PHPFormatterTestBase {
 
     public void testAlternativeSyntaxPlacement01() throws Exception {
         HashMap<String, Object> options = new HashMap<String, Object>(FmtOptions.getDefaults());
+        options.put(FmtOptions.BLANK_LINES_MAX_PRESERVED, 2);
         reformatFileContents("testfiles/formatting/blankLines/AlternativeSyntaxPlacement01.php", options);
     }
 
@@ -166,6 +167,7 @@ public class PHPFormatterBlankLinesTest extends PHPFormatterTestBase {
     public void testBLAnonymousClass01() throws Exception {
         HashMap<String, Object> options = new HashMap<>(FmtOptions.getDefaults());
         options.put(FmtOptions.INITIAL_INDENT, 0);
+        options.put(FmtOptions.BLANK_LINES_MAX_PRESERVED, 6);
         reformatFileContents("testfiles/formatting/blankLines/AnonymousClass01.php", options);
     }
 
@@ -1029,6 +1031,24 @@ public class PHPFormatterBlankLinesTest extends PHPFormatterTestBase {
         HashMap<String, Object> options = new HashMap<String, Object>(FmtOptions.getDefaults());
         options.put(FmtOptions.INITIAL_INDENT, 4);
         reformatFileContents("testfiles/formatting/blankLines/OpenClosePHPTag05.php", options);
+    }
+
+    public void testMaxPreservedBlankLines01() throws Exception {
+        HashMap<String, Object> options = new HashMap<String, Object>(FmtOptions.getDefaults());
+        options.put(FmtOptions.BLANK_LINES_MAX_PRESERVED, 0);
+        reformatFileContents("testfiles/formatting/blankLines/MaxPreservedLines01.php", options);
+    }
+
+    public void testMaxPreservedBlankLines02() throws Exception {
+        HashMap<String, Object> options = new HashMap<String, Object>(FmtOptions.getDefaults());
+        options.put(FmtOptions.BLANK_LINES_MAX_PRESERVED, 1);
+        reformatFileContents("testfiles/formatting/blankLines/MaxPreservedLines02.php", options);
+    }
+
+    public void testMaxPreservedBlankLines03() throws Exception {
+        HashMap<String, Object> options = new HashMap<String, Object>(FmtOptions.getDefaults());
+        options.put(FmtOptions.BLANK_LINES_MAX_PRESERVED, 2);
+        reformatFileContents("testfiles/formatting/blankLines/MaxPreservedLines03.php", options);
     }
 
     public void testIssue229703() throws Exception {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5075

Removes multiple empty lines from PHP code.
Adds setting under Formatting/PHP/Blank Lines.

Formatting options:
![netbeans-5075](https://user-images.githubusercontent.com/4249184/100777756-84f48e80-3406-11eb-9fd5-9e77ac406aba.png)
