### PR TITLE
Inform VSCode that application/javascript is also a MIME type of JavaScript.

### DIFF
--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -32,6 +32,15 @@
 	],
 	"main": "./out/extension.js",
 	"contributes": {
+		"languages": [
+			{
+				"id": "javascript",
+				"mimetypes": [
+					"text/javascript",
+					"application/javascript"
+				]
+			}
+		],
 		"configuration": {
 			"title": "Java",
 			"properties": {


### PR DESCRIPTION
This change is necessary to have files with `application/javascript` MIME type recognized as JavaScript files. VSCode recognizes `text/javascript` only by default.
Sources that come from evaluations may have just `<eval>` name, without an extension. In that case just the associated MIME type defines the language of the source.