### PR TITLE
Make the --module --list CLI command more robust

### DIFF
--- a/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/ModuleOptions.java
+++ b/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/ModuleOptions.java
@@ -134,7 +134,7 @@ public class ModuleOptions extends OptionProcessor {
         "MSG_ListHeader_Version=Version",
         "MSG_ListHeader_State=State"
     })
-    private void listAllModules(PrintStream out) {
+    private void listAllModules(PrintStream out) throws IOException {
         List<UpdateUnit> modules = UpdateManager.getDefault().getUpdateUnits();
         
         PrintTable table = new PrintTable(
@@ -144,7 +144,9 @@ public class ModuleOptions extends OptionProcessor {
         for (UpdateUnit uu : modules) {
             table.addRow(Status.toArray(uu));
         }
-        table.write(out);
+        StringBuilder sb = new StringBuilder();
+        table.write(sb);
+        out.print(sb.toString());
         out.flush();
     }
 
@@ -156,22 +158,21 @@ public class ModuleOptions extends OptionProcessor {
     @Override
     protected void process(Env env, Map<Option, String[]> optionValues) throws CommandException {
         try {
-            if (optionValues.containsKey(extraUC)) {
-                extraUC(env, optionValues.get(extraUC));
-            }
-            if (optionValues.containsKey(refresh)) {
-                refresh(env);
-            }
-
-            if (optionValues.containsKey(list)) {
-                listAllModules(env.getOutputStream());
-            }
-
-            if (optionValues.containsKey(install)) {
-                install(env, optionValues.get(install));
-            }
-
             try {
+                if (optionValues.containsKey(extraUC)) {
+                    extraUC(env, optionValues.get(extraUC));
+                }
+                if (optionValues.containsKey(refresh)) {
+                    refresh(env);
+                }
+
+                if (optionValues.containsKey(list)) {
+                    listAllModules(env.getOutputStream());
+                }
+
+                if (optionValues.containsKey(install)) {
+                    install(env, optionValues.get(install));
+                }
 
                 if (optionValues.containsKey(disable)) {
                     changeModuleState(optionValues.get(disable), false);

--- a/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/PrintTable.java
+++ b/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/PrintTable.java
@@ -18,7 +18,7 @@
  */
 package org.netbeans.modules.autoupdate.cli;
 
-import java.io.PrintStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,7 +45,7 @@ final class PrintTable {
         data.add(fields);
     }
     
-    public void write(PrintStream ps) {
+    public void write(Appendable ps) throws IOException {
         int[] lengths = new int[names.length];
         length(names, lengths, limits);
         for (String[] arr : data) {
@@ -73,33 +73,33 @@ final class PrintTable {
         }
     }
 
-    private static void printRow(PrintStream ps, String[] data, int[] lengths, int[] limits) {
+    private static void printRow(Appendable ps, String[] data, int[] lengths, int[] limits) throws IOException {
         assert data.length == lengths.length;
         String sep = "";
         for (int i = 0; i < data.length; i++) {
-            ps.print(sep);
+            ps.append(sep);
             String d = data[i];
             if (limits != null && limits[i] >= 0 && d.length() > limits[i]) {
                 d = d.substring(0, limits[i]);
             }
-            ps.print(d);
+            ps.append(d);
             int missing = lengths[i] - d.length();
             while (missing-- > 0) {
-                ps.print(' ');
+                ps.append(' ');
             }
             sep = " ";
         }
-        ps.println();
+        ps.append('\n');
     }
-    private static void printSeparator(PrintStream ps, int[] lengths) {
+    private static void printSeparator(Appendable ps, int[] lengths) throws IOException {
         String sep = "";
         for (int i = 0; i < lengths.length; i++) {
-            ps.print(sep);
+            ps.append(sep);
             for (int j = 0; j < lengths[i]; j++) {
-                ps.print('-');
+                ps.append('-');
             }
             sep = " ";
         }
-        ps.println();
+        ps.append('\n');
     }
 }


### PR DESCRIPTION
There are problems with booting up `VSNetBeans` - @jisedlac reported problems on Windows:
```
java.io.EOFException
	at java.io.DataInputStream.readFully(DataInputStream.java:197)
	at org.netbeans.CLIHandler.initialize(CLIHandler.java:822)
	at org.netbeans.CLIHandler.initialize(CLIHandler.java:360)
	at org.netbeans.MainImpl.execute(MainImpl.java:168)
	at org.netbeans.MainImpl.main(MainImpl.java:60)
	at org.netbeans.Main.main(Main.java:58)
Exit code 4294967041
```
Also, if you have ever seen _Apache NetBeans Language Server not enabled!_ message  then [scanning just StdOut](https://github.com/apache/netbeans/pull/2576/commits/ad38e1d7b0c739d2d4f53e90c49e2683b6cd184c) shall help.

There is something wrong in `CLIHandler`. This PR isn't (yet) a fix for the problem, but it shall certainly make the behavior better.