### PR TITLE
[NETBEANS-5091] PHP - more improvements for constants in code completion

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/model/nodes/ConstantDeclarationInfo.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/model/nodes/ConstantDeclarationInfo.java
@@ -20,15 +20,10 @@ package org.netbeans.modules.php.editor.model.nodes;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.modules.php.editor.model.nodes.ASTNodeInfo.Kind;
-import org.netbeans.modules.php.editor.parser.astnodes.ArrayCreation;
-import org.netbeans.modules.php.editor.parser.astnodes.ArrayElement;
 import org.netbeans.modules.php.editor.parser.astnodes.ConstantDeclaration;
 import org.netbeans.modules.php.editor.parser.astnodes.Expression;
 import org.netbeans.modules.php.editor.parser.astnodes.Identifier;
-import org.netbeans.modules.php.editor.parser.astnodes.Scalar;
-import org.netbeans.modules.php.editor.parser.astnodes.UnaryOperation;
 
 /**
  * @author Radek Matous
@@ -49,20 +44,6 @@ public class ConstantDeclarationInfo extends ClassConstantDeclarationInfo {
                 if (value != null) {
                     break;
                 }
-                /*
-                if (expression instanceof Scalar) {
-                    value = ((Scalar) expression).getStringValue();
-                    break;
-                }
-                if (expression instanceof UnaryOperation) {
-                    UnaryOperation up = (UnaryOperation) expression;
-                    if (up.getOperator() == UnaryOperation.Operator.MINUS
-                            && up.getExpression() instanceof Scalar) {
-                        value = "-" + ((Scalar) up.getExpression()).getStringValue();
-                        break;
-                    }
-                }
-                 */
             }
             retval.add(new ConstantDeclarationInfo(identifier, value, constantDeclaration));
         }
@@ -72,54 +53,6 @@ public class ConstantDeclarationInfo extends ClassConstantDeclarationInfo {
     @Override
     public Kind getKind() {
         return Kind.CONSTANT;
-    }
-
-    @CheckForNull
-    private static String getConstantValue(Expression expr) {
-        if (expr instanceof Scalar) {
-            return ((Scalar) expr).getStringValue();
-        }
-        if (expr instanceof UnaryOperation) {
-            UnaryOperation up = (UnaryOperation) expr;
-            if (up.getOperator() == UnaryOperation.Operator.MINUS
-                    && up.getExpression() instanceof Scalar) {
-                return "-" + ((Scalar) up.getExpression()).getStringValue();
-            }
-        }
-        if (expr instanceof ArrayCreation) {
-            return getConstantValue((ArrayCreation) expr);
-        }
-        return null;
-    }
-
-    private static String getConstantValue(ArrayCreation expr) {
-        StringBuilder sb = new StringBuilder("["); //NOI18N
-        boolean itemAdded = false;
-        List<ArrayElement> elements = expr.getElements();
-        if (elements.size() > 0) {
-            ArrayElement firstElement = elements.get(0);
-            Expression key = firstElement.getKey();
-            if (key != null) {
-                String convertedKey = getConstantValue(key);
-                if (convertedKey != null) {
-                    sb.append(convertedKey);
-                    sb.append(" => "); //NOI18N
-                }
-            }
-            String convertedValue = getConstantValue(firstElement.getValue());
-            if (convertedValue != null) {
-                sb.append(convertedValue);
-                itemAdded = true;
-            } else {
-                // Case when element exist but value was not converted to output.
-                sb.append("..."); //NOI18N
-            }
-        }
-        if (itemAdded && elements.size() > 1) {
-            sb.append(",..."); //NOI18N
-        }
-        sb.append("]"); //NOI18N
-        return sb.toString();
     }
 
 }

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class Constants {
+
+    const INDEX = 123;
+    const ALICE = 'Alice';
+    const PLANET = "Earth";
+    const NO_KEYS = [ 44, 55, 66, 77 ];
+    const WITH_KEYS = [ 1 => 'A', 2 => 'B' ];
+    const LONG_ARRAY = [ 1 => 'Alice', 2 => 'Bob',  3 => 'Charlie', 4 => 'Dave', 5 => 'Eve', 6 => 'Frank' ];
+    const CONST_REF = [ 1 => self::ALICE, self::INDEX => 'Bob' ];
+
+    public function printConsts() {
+        echo self::INDEX;
+        echo self::ALICE;
+        echo self::PLANET;
+        echo self::NO_KEYS;
+        echo self::WITH_KEYS;
+        echo self::LONG_ARRAY;
+        echo self::CONST_REF;
+    }
+
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_01.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo self::INDEX|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   INDEX 123                       [PUBLIC]   Constants

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_02.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo self::ALICE|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   ALICE 'Alice'                   [PUBLIC]   Constants

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_03.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo self::PLANET|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   PLANET "Earth"                  [PUBLIC]   Constants

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_04.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo self::NO_KEYS|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   NO_KEYS [44, 55, 66, 77]        [PUBLIC]   Constants

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_05.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo self::WITH_KEYS|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   WITH_KEYS [1 => 'A', 2 => 'B']  [PUBLIC]   Constants

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_06.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo self::LONG_ARRAY|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   LONG_ARRAY [1 => 'Alice', 2 =>  [PUBLIC]   Constants

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/classConst.php.testClassConst_07.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo self::CONST_REF|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   CONST_REF [1 => ?, ? => 'Bob']  [PUBLIC]   Constants

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const INDEX = 123;
+const ALICE = 'Alice';
+const PLANET = "Earth";
+const NO_KEYS = [44, 55, 66, 77];
+const WITH_KEYS = [1 => 'A', 2 => 'B'];
+const LONG_ARRAY = [1 => 'Alice', 2 => 'Bob', 3 => 'Charlie', 4 => 'Dave', 5 => 'Eve', 6 => 'Frank'];
+const CONST_REF = [1 => ALICE, INDEX => 'Bob'];
+
+echo INDEX;
+echo ALICE;
+echo PLANET;
+echo NO_KEYS;
+echo WITH_KEYS;
+echo LONG_ARRAY;
+echo CONST_REF;

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_01.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo INDEX|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   INDEX 123                       [PUBLIC]   globalConst.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_02.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo ALICE|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   ALICE 'Alice'                   [PUBLIC]   globalConst.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_03.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo PLANET|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   PLANET "Earth"                  [PUBLIC]   globalConst.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_04.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo NO_KEYS|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   NO_KEYS [44, 55, 66, 77]        [PUBLIC]   globalConst.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_05.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_05.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo WITH_KEYS|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   WITH_KEYS [1 => 'A', 2 => 'B']  [PUBLIC]   globalConst.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_06.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo LONG_ARRAY|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   LONG_ARRAY [1 => 'Alice', 2 =>  [PUBLIC]   globalConst.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php56/globalConst.php.testGlobalConst_07.completion
@@ -1,0 +1,4 @@
+Code completion result for source line:
+echo CONST_REF|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+CONSTANT   CONST_REF [1 => ?, ? => 'Bob']  [PUBLIC]   globalConst.php

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php70/contextSensitiveLexer/contextSensitiveLexerInterface.php.testContextSensitiveLexerInterface02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php70/contextSensitiveLexer/contextSensitiveLexerInterface.php.testContextSensitiveLexerInterface02.completion
@@ -9,43 +9,43 @@ CONSTANT   __line__ 100                    [PUBLIC]   InterfaceExample
 CONSTANT   __method__ 100                  [PUBLIC]   InterfaceExample
 CONSTANT   __namespace__ 100               [PUBLIC]   InterfaceExample
 CONSTANT   __trait__ 100                   [PUBLIC]   InterfaceExample
-CONSTANT   abstract ?                      [PUBLIC]   InterfaceExample
-CONSTANT   and ?                           [PUBLIC]   InterfaceExample
+CONSTANT   abstract [1, 2]                 [PUBLIC]   InterfaceExample
+CONSTANT   and [1, 2]                      [PUBLIC]   InterfaceExample
 CONSTANT   array 100                       [PUBLIC]   InterfaceExample
 CONSTANT   as 100                          [PUBLIC]   InterfaceExample
 CONSTANT   break 100                       [PUBLIC]   InterfaceExample
-CONSTANT   callable ?                      [PUBLIC]   InterfaceExample
+CONSTANT   callable [1, 2]                 [PUBLIC]   InterfaceExample
 CONSTANT   case 100                        [PUBLIC]   InterfaceExample
 CONSTANT   catch 100                       [PUBLIC]   InterfaceExample
 CONSTANT   class \InterfaceExample         [PUBLIC]   Magic Constant
 CONSTANT   clone 100                       [PUBLIC]   InterfaceExample
-CONSTANT   const ?                         [PUBLIC]   InterfaceExample
+CONSTANT   const [1, 2]                    [PUBLIC]   InterfaceExample
 CONSTANT   continue 100                    [PUBLIC]   InterfaceExample
 CONSTANT   declare 100                     [PUBLIC]   InterfaceExample
 CONSTANT   default 100                     [PUBLIC]   InterfaceExample
-CONSTANT   define ?                        [PUBLIC]   InterfaceExample
+CONSTANT   define [1, 2]                   [PUBLIC]   InterfaceExample
 CONSTANT   die 100                         [PUBLIC]   InterfaceExample
 CONSTANT   do 100                          [PUBLIC]   InterfaceExample
 CONSTANT   echo 100                        [PUBLIC]   InterfaceExample
 CONSTANT   else 100                        [PUBLIC]   InterfaceExample
 CONSTANT   elseif 100                      [PUBLIC]   InterfaceExample
-CONSTANT   enddeclare ?                    [PUBLIC]   InterfaceExample
-CONSTANT   endfor ?                        [PUBLIC]   InterfaceExample
-CONSTANT   endforeach ?                    [PUBLIC]   InterfaceExample
-CONSTANT   endif ?                         [PUBLIC]   InterfaceExample
+CONSTANT   enddeclare [1, 2]               [PUBLIC]   InterfaceExample
+CONSTANT   endfor [1, 2]                   [PUBLIC]   InterfaceExample
+CONSTANT   endforeach [1, 2]               [PUBLIC]   InterfaceExample
+CONSTANT   endif [1, 2]                    [PUBLIC]   InterfaceExample
 CONSTANT   endswitch 100                   [PUBLIC]   InterfaceExample
-CONSTANT   endwhile ?                      [PUBLIC]   InterfaceExample
+CONSTANT   endwhile [1, 2]                 [PUBLIC]   InterfaceExample
 CONSTANT   exit 100                        [PUBLIC]   InterfaceExample
-CONSTANT   extends ?                       [PUBLIC]   InterfaceExample
-CONSTANT   final ?                         [PUBLIC]   InterfaceExample
+CONSTANT   extends [1, 2]                  [PUBLIC]   InterfaceExample
+CONSTANT   final [1, 2]                    [PUBLIC]   InterfaceExample
 CONSTANT   finally 100                     [PUBLIC]   InterfaceExample
 CONSTANT   for 100                         [PUBLIC]   InterfaceExample
 CONSTANT   foreach 100                     [PUBLIC]   InterfaceExample
 CONSTANT   function 100                    [PUBLIC]   InterfaceExample
-CONSTANT   global ?                        [PUBLIC]   InterfaceExample
-CONSTANT   goto ?                          [PUBLIC]   InterfaceExample
+CONSTANT   global [1, 2]                   [PUBLIC]   InterfaceExample
+CONSTANT   goto [1, 2]                     [PUBLIC]   InterfaceExample
 CONSTANT   if 100                          [PUBLIC]   InterfaceExample
-CONSTANT   implements ?                    [PUBLIC]   InterfaceExample
+CONSTANT   implements [1, 2]               [PUBLIC]   InterfaceExample
 CONSTANT   include 100                     [PUBLIC]   InterfaceExample
 CONSTANT   include_once 100                [PUBLIC]   InterfaceExample
 CONSTANT   instanceof 100                  [PUBLIC]   InterfaceExample
@@ -57,17 +57,17 @@ CONSTANT   new 100                         [PUBLIC]   InterfaceExample
 CONSTANT   or 100                          [PUBLIC]   InterfaceExample
 CONSTANT   parent 100                      [PUBLIC]   InterfaceExample
 CONSTANT   print 100                       [PUBLIC]   InterfaceExample
-CONSTANT   private ?                       [PUBLIC]   InterfaceExample
-CONSTANT   protected ?                     [PUBLIC]   InterfaceExample
-CONSTANT   public ?                        [PUBLIC]   InterfaceExample
+CONSTANT   private [1, 2]                  [PUBLIC]   InterfaceExample
+CONSTANT   protected [1, 2]                [PUBLIC]   InterfaceExample
+CONSTANT   public [1, 2]                   [PUBLIC]   InterfaceExample
 CONSTANT   require 100                     [PUBLIC]   InterfaceExample
 CONSTANT   require_once 100                [PUBLIC]   InterfaceExample
 CONSTANT   return 100                      [PUBLIC]   InterfaceExample
 CONSTANT   self 100                        [PUBLIC]   InterfaceExample
-CONSTANT   static ?                        [PUBLIC]   InterfaceExample
+CONSTANT   static [1, 2]                   [PUBLIC]   InterfaceExample
 CONSTANT   switch 100                      [PUBLIC]   InterfaceExample
 CONSTANT   throw 100                       [PUBLIC]   InterfaceExample
-CONSTANT   trait ?                         [PUBLIC]   InterfaceExample
+CONSTANT   trait [1, 2]                    [PUBLIC]   InterfaceExample
 CONSTANT   try 100                         [PUBLIC]   InterfaceExample
 CONSTANT   use 100                         [PUBLIC]   InterfaceExample
 CONSTANT   var 100                         [PUBLIC]   InterfaceExample

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02.completion
@@ -12,13 +12,13 @@ VARIABLE   array $array2                   [PUBLIC]   spreadOperatorInArrayExpre
 VARIABLE   array $array2_a                 [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array3                   [PUBLIC]   spreadOperatorInArrayExpression.php
 CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
-CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
-CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
-CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
-CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT [0, 1, 2, 3]           [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [?]                   [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [...[0, 1, 2, 3]]    [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100, ?, ?]           [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [?, 100 => 0, ?]      [PUBLIC]   Foo
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform
 VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02a.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_02a.completion
@@ -13,13 +13,13 @@ VARIABLE   array $array2_a                 [PUBLIC]   spreadOperatorInArrayExpre
 VARIABLE   array $array3                   [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array3_a                 [PUBLIC]   spreadOperatorInArrayExpression.php
 CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
-CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
-CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
-CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
-CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT [0, 1, 2, 3]           [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [?]                   [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [...[0, 1, 2, 3]]    [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100, ?, ?]           [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [?, 100 => 0, ?]      [PUBLIC]   Foo
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform
 VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_03.completion
@@ -14,13 +14,13 @@ VARIABLE   array $array3                   [PUBLIC]   spreadOperatorInArrayExpre
 VARIABLE   array $array3_a                 [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array4                   [PUBLIC]   spreadOperatorInArrayExpression.php
 CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
-CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
-CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
-CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
-CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT [0, 1, 2, 3]           [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [?]                   [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [...[0, 1, 2, 3]]    [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100, ?, ?]           [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [?, 100 => 0, ?]      [PUBLIC]   Foo
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform
 VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_04.completion
@@ -14,13 +14,13 @@ VARIABLE   array $array3                   [PUBLIC]   spreadOperatorInArrayExpre
 VARIABLE   array $array3_a                 [PUBLIC]   spreadOperatorInArrayExpression.php
 VARIABLE   array $array4                   [PUBLIC]   spreadOperatorInArrayExpression.php
 CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
-CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
-CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
-CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
-CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT [0, 1, 2, 3]           [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [?]                   [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [...[0, 1, 2, 3]]    [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100, ?, ?]           [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [?, 100 => 0, ?]      [PUBLIC]   Foo
 ------------------------------------
 VARIABLE   $GLOBALS                                   PHP Platform
 VARIABLE   $HTTP_RAW_POST_DATA                        PHP Platform

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_01.completion
@@ -5,12 +5,12 @@ PACKAGE    Bar                             [PUBLIC]   null
 PACKAGE    Foo                             [PUBLIC]   null
 CLASS      Qux                             [PUBLIC]   Bar
 CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
-CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
-CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
-CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
-CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT [0, 1, 2, 3]           [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [?]                   [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [...[0, 1, 2, 3]]    [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100, ?, ?]           [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [?, 100 => 0, ?]      [PUBLIC]   Foo
 ------------------------------------
 KEYWORD    array                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_02.completion
@@ -5,12 +5,12 @@ PACKAGE    Bar                             [PUBLIC]   null
 PACKAGE    Foo                             [PUBLIC]   null
 CLASS      Qux                             [PUBLIC]   Bar
 CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
-CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
-CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
-CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
-CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT [0, 1, 2, 3]           [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [?]                   [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [...[0, 1, 2, 3]]    [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100, ?, ?]           [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [?, 100 => 0, ?]      [PUBLIC]   Foo
 ------------------------------------
 KEYWORD    array                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_03.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_03.completion
@@ -1,10 +1,10 @@
 Code completion result for source line:
 const CONSTANT3 = [...CONSTANT2, 100 => 0, ...CONSTANT|];
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
-CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
-CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
-CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT [0, 1, 2, 3]           [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [?]                   [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [...[0, 1, 2, 3]]    [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100, ?, ?]           [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [?, 100 => 0, ?]      [PUBLIC]   Foo

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_09.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInArrayExpression/spreadOperatorInArrayExpression.php.testSpreadOperatorInArrayExpression_GlobalConst_09.completion
@@ -5,12 +5,12 @@ PACKAGE    Bar                             [PUBLIC]   null
 PACKAGE    Foo                             [PUBLIC]   null
 CLASS      Qux                             [PUBLIC]   Bar
 CONSTANT   BAR_CONSTANT []                 [PUBLIC]   Bar
-CONSTANT   CONSTANT [0,...]                [PUBLIC]   Foo
-CONSTANT   CONSTANT1 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT1a [[0,...]]            [PUBLIC]   Foo
-CONSTANT   CONSTANT2 [100,...]             [PUBLIC]   Foo
-CONSTANT   CONSTANT3 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT4 [...]                 [PUBLIC]   Foo
-CONSTANT   CONSTANT5 [...]                 [PUBLIC]   Foo
+CONSTANT   CONSTANT [0, 1, 2, 3]           [PUBLIC]   Foo
+CONSTANT   CONSTANT1 [?]                   [PUBLIC]   Foo
+CONSTANT   CONSTANT1a [...[0, 1, 2, 3]]    [PUBLIC]   Foo
+CONSTANT   CONSTANT2 [100, ?, ?]           [PUBLIC]   Foo
+CONSTANT   CONSTANT3 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT4 [?, 100 => 0, ?]      [PUBLIC]   Foo
+CONSTANT   CONSTANT5 [?, 100 => 0, ?]      [PUBLIC]   Foo
 ------------------------------------
 KEYWORD    array                                      null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_00.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_00.completion
@@ -6,12 +6,12 @@ PACKAGE    Foo                             [PUBLIC]   null
 CLASS      BarUnpackClass                  [PUBLIC]   Bar
 CLASS      UnpackChildClass                [PUBLIC]   Foo
 CLASS      UnpackClass                     [PUBLIC]   Foo
-CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT ["1", "2", "3"]        [PUBLIC]   \Foo\UnpackClass
 CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 [?]                   [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 [?, "4"]              [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ["0", ?, "4"]         [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ["0", ?, "4", ?]      [PUBLIC]   \Foo\UnpackClass
 CONSTANT   F_CONST "test"                  [PUBLIC]   Foo
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_01.completion
@@ -6,12 +6,12 @@ PACKAGE    Foo                             [PUBLIC]   null
 CLASS      BarUnpackClass                  [PUBLIC]   Bar
 CLASS      UnpackChildClass                [PUBLIC]   Foo
 CLASS      UnpackClass                     [PUBLIC]   Foo
-CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT ["1", "2", "3"]        [PUBLIC]   \Foo\UnpackClass
 CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 [?]                   [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 [?, "4"]              [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ["0", ?, "4"]         [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ["0", ?, "4", ?]      [PUBLIC]   \Foo\UnpackClass
 CONSTANT   F_CONST "test"                  [PUBLIC]   Foo
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_02.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_02.completion
@@ -1,10 +1,10 @@
 Code completion result for source line:
 public const CONSTANT2 = [...self::|CONSTANT];
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT ["1", "2", "3"]        [PUBLIC]   \Foo\UnpackClass
 CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 [?]                   [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 [?, "4"]              [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ["0", ?, "4"]         [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ["0", ?, "4", ?]      [PUBLIC]   \Foo\UnpackClass
 CONSTANT   class \Foo\UnpackClass          [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_04.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_04.completion
@@ -6,12 +6,12 @@ PACKAGE    Foo                             [PUBLIC]   null
 CLASS      BarUnpackClass                  [PUBLIC]   Bar
 CLASS      UnpackChildClass                [PUBLIC]   Foo
 CLASS      UnpackClass                     [PUBLIC]   Foo
-CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT ["1", "2", "3"]        [PUBLIC]   \Foo\UnpackClass
 CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 [?]                   [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 [?, "4"]              [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ["0", ?, "4"]         [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ["0", ?, "4", ?]      [PUBLIC]   \Foo\UnpackClass
 CONSTANT   F_CONST "test"                  [PUBLIC]   Foo
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_06.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_06.completion
@@ -1,9 +1,9 @@
 Code completion result for source line:
 public const CONSTANT5 = ["0", ...self::CONSTANT, "4", self::CONSTA|NT1];
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT ["1", "2", "3"]        [PUBLIC]   \Foo\UnpackClass
 CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 [?]                   [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 [?, "4"]              [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ["0", ?, "4"]         [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ["0", ?, "4", ?]      [PUBLIC]   \Foo\UnpackClass

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_07.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_07.completion
@@ -6,13 +6,13 @@ PACKAGE    Foo                             [PUBLIC]   null
 CLASS      BarUnpackClass                  [PUBLIC]   Bar
 CLASS      UnpackChildClass                [PUBLIC]   Foo
 CLASS      UnpackClass                     [PUBLIC]   Foo
-CONSTANT   CHILD_CONSTANT ?                [PUBLIC]   \Foo\UnpackChildClass
-CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CHILD_CONSTANT ["0", ?]         [PUBLIC]   \Foo\UnpackChildClass
+CONSTANT   CONSTANT ["1", "2", "3"]        [PUBLIC]   \Foo\UnpackClass
 CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 [?]                   [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 [?, "4"]              [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ["0", ?, "4"]         [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ["0", ?, "4", ?]      [PUBLIC]   \Foo\UnpackClass
 CONSTANT   F_CONST "test"                  [PUBLIC]   Foo
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_08.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_08.completion
@@ -1,10 +1,10 @@
 Code completion result for source line:
 public const CHILD_CONSTANT = ["0", ...parent::C|ONSTANT, ];
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT ["1", "2", "3"]        [PUBLIC]   \Foo\UnpackClass
 CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 [?]                   [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 [?, "4"]              [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ["0", ?, "4"]         [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ["0", ?, "4", ?]      [PUBLIC]   \Foo\UnpackClass
 CONSTANT   class \Foo\UnpackClass          [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_10.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_10.completion
@@ -1,10 +1,10 @@
 Code completion result for source line:
 private const CONST1 = [...UnpackClass::|CONSTANT];
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT ["1", "2", "3"]        [PUBLIC]   \Foo\UnpackClass
 CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 [?]                   [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 [?, "4"]              [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ["0", ?, "4"]         [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ["0", ?, "4", ?]      [PUBLIC]   \Foo\UnpackClass
 CONSTANT   class \Foo\UnpackClass          [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_11.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_11.completion
@@ -6,10 +6,10 @@ PACKAGE    Foo                             [PUBLIC]   null
 CLASS      BarUnpackClass                  [PUBLIC]   Bar
 CLASS      UnpackChildClass                [PUBLIC]   Foo
 CLASS      UnpackClass                     [PUBLIC]   Foo
-CONSTANT   CONST1 ?                        [PRIVATE]  \Bar\BarUnpackClass
-CONSTANT   CONST2 ?                        [PRIVATE]  \Bar\BarUnpackClass
-CONSTANT   CONST3 ?                        [PRIVATE]  \Bar\BarUnpackClass
-CONSTANT   CONST4 ?                        [PRIVATE]  \Bar\BarUnpackClass
+CONSTANT   CONST1 [?]                      [PRIVATE]  \Bar\BarUnpackClass
+CONSTANT   CONST2 [1, ?]                   [PRIVATE]  \Bar\BarUnpackClass
+CONSTANT   CONST3 [1, ?, 4]                [PRIVATE]  \Bar\BarUnpackClass
+CONSTANT   CONST4 [?]                      [PRIVATE]  \Bar\BarUnpackClass
 CONSTANT   F_CONST "test"                  [PUBLIC]   Foo
 KEYWORD    parent::                                   null
 KEYWORD    self::                                     null

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_12.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_12.completion
@@ -1,10 +1,10 @@
 Code completion result for source line:
 private const CONST2 = [1, ...UnpackClass::C|ONSTANT];
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT ["1", "2", "3"]        [PUBLIC]   \Foo\UnpackClass
 CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 [?]                   [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 [?, "4"]              [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ["0", ?, "4"]         [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ["0", ?, "4", ?]      [PUBLIC]   \Foo\UnpackClass
 CONSTANT   class \Foo\UnpackClass          [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_15.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/php74/testSpreadOperatorInClassConst/spreadOperatorInClassConst.php.testSpreadOperatorInClassConst_15.completion
@@ -1,10 +1,10 @@
 Code completion result for source line:
 private const CONST3 = [1, ...\Foo\UnpackClass::|CONSTANT, 4];
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
-CONSTANT   CONSTANT ?                      [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT ["1", "2", "3"]        [PUBLIC]   \Foo\UnpackClass
 CONSTANT   CONSTANT1 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT2 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT3 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT4 ?                     [PUBLIC]   \Foo\UnpackClass
-CONSTANT   CONSTANT5 ?                     [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT2 [?]                   [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT3 [?, "4"]              [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT4 ["0", ?, "4"]         [PUBLIC]   \Foo\UnpackClass
+CONSTANT   CONSTANT5 ["0", ?, "4", ?]      [PUBLIC]   \Foo\UnpackClass
 CONSTANT   class \Foo\UnpackClass          [PUBLIC]   Magic Constant

--- a/php/php.editor/test/unit/data/testfiles/index/testClassConstantVisibility/testClassConstantVisibility.php.indexed
+++ b/php/php.editor/test/unit/data/testfiles/index/testClassConstantVisibility/testClassConstantVisibility.php.indexed
@@ -10,7 +10,7 @@ Document 1
 Searchable Keys:
   clz : classconstantvisibility;ClassConstantVisibility;13;;;;1;;0;<TESTURL>/testClassConstantVisibility.php;;
   clz.const : implicit_public_const;IMPLICIT_PUBLIC_CONST;50;0;0;<TESTURL>/testClassConstantVisibility.php;32;
-  clz.const : private_bar;PRIVATE_BAR;225;?;0;<TESTURL>/testClassConstantVisibility.php;2;
+  clz.const : private_bar;PRIVATE_BAR;225;[1, 2];0;<TESTURL>/testClassConstantVisibility.php;2;
   clz.const : private_const;PRIVATE_CONST;130;2;0;<TESTURL>/testClassConstantVisibility.php;2;
   clz.const : private_foo;PRIVATE_FOO;208;1;0;<TESTURL>/testClassConstantVisibility.php;2;
   clz.const : protected_const;PROTECTED_CONST;169;3;0;<TESTURL>/testClassConstantVisibility.php;4;

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP56CodeCompletionTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHP56CodeCompletionTest.java
@@ -70,6 +70,62 @@ public class PHP56CodeCompletionTest extends PHPCodeCompletionTestBase {
         checkCompletion("testfiles/completion/lib/php56/useFuncAndConst.php", "use function Name\\Space\\f^nc as fnc2;", false);
     }
 
+    public void testClassConst_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/classConst.php", "       echo self::INDEX^;", false);
+    }
+
+    public void testClassConst_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/classConst.php", "        echo self::ALICE^;", false);
+    }
+
+    public void testClassConst_03() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/classConst.php", "        echo self::PLANET^;", false);
+    }
+
+    public void testClassConst_04() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/classConst.php", "        echo self::NO_KEYS^;", false);
+    }
+
+    public void testClassConst_05() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/classConst.php", "       echo self::WITH_KEYS^;", false);
+    }
+
+    public void testClassConst_06() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/classConst.php", "       echo self::LONG_ARRAY^;", false);
+    }
+
+    public void testClassConst_07() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/classConst.php", "       echo self::CONST_REF^;", false);
+    }
+
+    public void testGlobalConst_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/globalConst.php", "echo INDEX^;", false);
+    }
+
+    public void testGlobalConst_02() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/globalConst.php", "echo ALICE^;", false);
+    }
+
+    public void testGlobalConst_03() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/globalConst.php", "echo PLANET^;", false);
+    }
+
+    public void testGlobalConst_04() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/globalConst.php", "echo NO_KEYS^;", false);
+    }
+
+    public void testGlobalConst_05() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/globalConst.php", "echo WITH_KEYS^;", false);
+    }
+
+    public void testGlobalConst_06() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/globalConst.php", "echo LONG_ARRAY^;", false);
+    }
+
+    public void testGlobalConst_07() throws Exception {
+        checkCompletion("testfiles/completion/lib/php56/globalConst.php", "echo CONST_REF^;", false);
+    }
+
     @Override
     protected Map<String, ClassPath> createClassPathsForTest() {
         return Collections.singletonMap(


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5091

- Improved display of class constants (previous change affected only global constants).
- Display more values, not only the first one.
- Unsupported key or value is displayed as "?".
- Conversion code was moved to parent class (`ClassConstantDeclarationInfo`) and child class (`ConstantDeclarationInfo`) uses the same method.
- Added new tests and updated existing.

Example:
![class_constant-updated](https://user-images.githubusercontent.com/4249184/101273278-06944580-3794-11eb-83de-4147710a1eee.png)
