### PR TITLE
[NETBEANS-5096] Fix formatting in executable script

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/indent/FormatVisitor.java
@@ -2292,7 +2292,7 @@ public class FormatVisitor extends DefaultVisitor {
                 break;
             case T_INLINE_HTML:
                 FormatToken.InitToken token = (FormatToken.InitToken) formatTokens.get(0);
-                if (!token.hasHTML() && !isWhitespace(ts.token().text())) {
+                if (!token.hasHTML() && !isWhitespace(ts.token().text()) && !isShebang(ts.token().text())) {
                     token.setHasHTML(true);
                 }
                 int tokenStartOffset = ts.offset();
@@ -2716,6 +2716,10 @@ public class FormatVisitor extends DefaultVisitor {
             index++;
         }
         return index == text.length();
+    }
+
+    private boolean isShebang(final CharSequence text) {
+        return TokenUtilities.startsWith(text, "#!"); //NOI18N
     }
 
     private static boolean isAnonymousClass(ASTNode astNode) {

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/OpenClosePHPTag06.php
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/OpenClosePHPTag06.php
@@ -1,0 +1,6 @@
+#!/usr/bin/php
+<?php 
+
+
+
+echo "Hello World!\n";

--- a/php/php.editor/test/unit/data/testfiles/formatting/blankLines/OpenClosePHPTag06.php.formatted
+++ b/php/php.editor/test/unit/data/testfiles/formatting/blankLines/OpenClosePHPTag06.php.formatted
@@ -1,0 +1,4 @@
+#!/usr/bin/php
+<?php
+
+echo "Hello World!\n";

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterBlankLinesTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/indent/PHPFormatterBlankLinesTest.java
@@ -1033,6 +1033,11 @@ public class PHPFormatterBlankLinesTest extends PHPFormatterTestBase {
         reformatFileContents("testfiles/formatting/blankLines/OpenClosePHPTag05.php", options);
     }
 
+    public void testOpenClosePHPTag06() throws Exception {
+        HashMap<String, Object> options = new HashMap<String, Object>(FmtOptions.getDefaults());
+        reformatFileContents("testfiles/formatting/blankLines/OpenClosePHPTag06.php", options);
+    }
+
     public void testMaxPreservedBlankLines01() throws Exception {
         HashMap<String, Object> options = new HashMap<String, Object>(FmtOptions.getDefaults());
         options.put(FmtOptions.BLANK_LINES_MAX_PRESERVED, 0);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5096

Fixes blank lines formatting after open tag in script starting with shebang.
Setting for "After Open Tag" is applied instead of "After Open Tag in HTML".

Sample script:
```php
#!/usr/bin/php
<?php 

echo "Hello World!\n";

```