### PR TITLE
[NETBEANS-5108] Use complete Composer package name

### DIFF
--- a/php/php.composer/src/org/netbeans/modules/php/composer/PhpProjectConvertor.java
+++ b/php/php.composer/src/org/netbeans/modules/php/composer/PhpProjectConvertor.java
@@ -103,12 +103,7 @@ public final class PhpProjectConvertor implements ProjectConvertor {
         assert content != null;
         Object name = content.get("name"); // NOI18N
         if (name instanceof String) {
-            String fullName = (String) name;
-            String[] parts = fullName.split("/", 2); // NOI18N
-            if (parts.length == 2) {
-                return parts[1];
-            }
-            return fullName;
+            return (String) name;
         }
         return null;
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5108

Full name of Composer package name is used in Usages window and File selector.

Before:
![netbeans-5108-before](https://user-images.githubusercontent.com/4249184/101399575-f2edf980-38cf-11eb-9af8-d81022197d92.png)

After:
![netbeans-5108-after](https://user-images.githubusercontent.com/4249184/101399590-f7b2ad80-38cf-11eb-95ae-e5a866e94f49.png)
