### PR TITLE
Removing the need for a default JS engine in JDK to call ant tryme.

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/MergeTrymeArgs.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MergeTrymeArgs.java
@@ -19,6 +19,7 @@
 package org.netbeans.nbbuild;
 
 import java.util.Map.Entry;
+import java.util.TreeMap;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 
@@ -29,7 +30,7 @@ import org.apache.tools.ant.Task;
 public class MergeTrymeArgs extends Task {
     public @Override void execute() throws BuildException {
         StringBuilder tryMeArgs = new StringBuilder();
-        for(Entry<String,Object> e: getProject().getProperties().entrySet()) {
+        for(Entry<String,Object> e: new TreeMap<>(getProject().getProperties()).entrySet()) {
             if(e.getKey().startsWith("tryme.arg.")) {
                 tryMeArgs.append(" ");
                 tryMeArgs.append(e.getValue());

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MergeTrymeArgs.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MergeTrymeArgs.java
@@ -36,6 +36,6 @@ public class MergeTrymeArgs extends Task {
                 tryMeArgs.append(e.getValue());
             }
         }
-        getProject().setProperty("tryme.args", tryMeArgs.toString());
+        getProject().setNewProperty("tryme.args", tryMeArgs.toString());
     }
 }

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MergeTrymeArgs.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MergeTrymeArgs.java
@@ -24,8 +24,8 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Task;
 
 /**
- * Merge the arguments supplied via the tryme.arg.* properties into the
- * property tryme.args.
+ * Merge the arguments supplied via any {@code tryme.arg.*} properties into the
+ * property {@code tryme.args}.
  */
 public class MergeTrymeArgs extends Task {
     public @Override void execute() throws BuildException {

--- a/nbbuild/antsrc/org/netbeans/nbbuild/MergeTrymeArgs.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/MergeTrymeArgs.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.nbbuild;
+
+import java.util.Map.Entry;
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.Task;
+
+/**
+ * Merge the arguments supplied via the tryme.arg.* properties into the
+ * property tryme.args.
+ */
+public class MergeTrymeArgs extends Task {
+    public @Override void execute() throws BuildException {
+        StringBuilder tryMeArgs = new StringBuilder();
+        for(Entry<String,Object> e: getProject().getProperties().entrySet()) {
+            if(e.getKey().startsWith("tryme.arg.")) {
+                tryMeArgs.append(" ");
+                tryMeArgs.append(e.getValue());
+            }
+        }
+        getProject().setProperty("tryme.args", tryMeArgs.toString());
+    }
+}

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1193,7 +1193,6 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
     <mergetrymeargs />
     <property name="tryme.jdkhome" value="${nbjdk.home}"/>
     <property name="tryme.debug.args" value="" />
-    <property name="tryme.args" value="" />
     <property environment="env"/>
     <condition property="run.env.display" value="${env.NBDISPLAY}" else="${env.DISPLAY}">
 	<isset property="env.NBDISPLAY"/>

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1189,19 +1189,6 @@ PKGINST=${pkg.svr4.pkginst}</echo>
           description="Try running the IDE interactively.
 It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in debug mode" 
    >
-    <script language="javascript">
-        if (typeof Packages !== 'undefined') {
-            v = '';
-            i = new Packages.java.util.TreeMap(project.getProperties()).entrySet().iterator()
-            while (i.hasNext()) {
-                e = i.next()
-                if (e.getKey().startsWith('tryme.arg.')) {
-                    v += ' ' + e.getValue()
-                }
-            }
-            project.setNewProperty('tryme.args', v)
-        }
-    </script>
     <property name="tryme.jdkhome" value="${nbjdk.home}"/>
     <property name="tryme.debug.args" value="" />
     <property name="tryme.args" value="" />

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1189,6 +1189,8 @@ PKGINST=${pkg.svr4.pkginst}</echo>
           description="Try running the IDE interactively.
 It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in debug mode" 
    >
+    <taskdef name="mergetrymeargs" classname="org.netbeans.nbbuild.MergeTrymeArgs" classpath="${nbantext.jar}" />
+    <mergetrymeargs />
     <property name="tryme.jdkhome" value="${nbjdk.home}"/>
     <property name="tryme.debug.args" value="" />
     <property name="tryme.args" value="" />

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1189,8 +1189,8 @@ PKGINST=${pkg.svr4.pkginst}</echo>
           description="Try running the IDE interactively.
 It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in debug mode" 
    >
-    <taskdef name="mergetrymeargs" classname="org.netbeans.nbbuild.MergeTrymeArgs" classpath="${nbantext.jar}" />
-    <mergetrymeargs />
+    <taskdef name="mergetrymeargs" classname="org.netbeans.nbbuild.MergeTrymeArgs" classpath="${nbantext.jar}"/>
+    <mergetrymeargs/>
     <property name="tryme.jdkhome" value="${nbjdk.home}"/>
     <property name="tryme.debug.args" value="" />
     <property environment="env"/>


### PR DESCRIPTION
nbbuild/build.xml uses JavaScript to construct tryme.args property from tryme.arg.* properties. This, however, does not work for JDK 15+, as there is no default JS engine for it. I was thinking of various ways to fix it, but, in the end, this does not seem like a particularly important feature, and my proposal is to simple remove the feature to joing tryme.arg.* properties into tryme.args property.