### PR TITLE
[NETBEANS-4550] Handling tests that have a module-info overriding module-info from sources.

### DIFF
--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPaths.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/classpath/ModuleClassPaths.java
@@ -870,6 +870,7 @@ final class ModuleClassPaths {
                                     if (myModule != null) {
                                         dependsOnUnnamed = dependsOnUnnamed(myModule, true);
                                         requires.addAll(collectRequiredModules(myModule, myModuleTree, true, false, modulesByName));
+                                        requires.addAll(modulesByName.getOrDefault(myModule.getQualifiedName().toString(), Collections.emptyList()));
                                     } else if (base == systemModules) {
                                         //When module unresolvable add at least java.base to systemModules
                                         Optional.ofNullable(modulesByName.get(MOD_JAVA_BASE))

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/PatchModuleFileManager.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/PatchModuleFileManager.java
@@ -46,8 +46,10 @@ import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.modules.java.source.indexing.JavaIndex;
 import org.netbeans.modules.java.source.util.Iterators;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.BaseUtilities;
+import org.openide.util.Exceptions;
 import org.openide.util.Pair;
 
 /**
@@ -283,7 +285,7 @@ final class PatchModuleFileManager implements JavaFileManager {
     }
     //</editor-fold>
 
-    private Set<PatchLocation> moduleLocations(final Location baseLocation) {
+    private Set<PatchLocation> moduleLocations(final Location baseLocation) throws IOException {
         if (baseLocation != StandardLocation.PATCH_MODULE_PATH) {
             throw new IllegalStateException(baseLocation.toString());
         }
@@ -300,12 +302,13 @@ final class PatchModuleFileManager implements JavaFileManager {
     @NonNull
     private static PatchLocation createPatchLocation(
             @NonNull final String modName,
-            @NonNull final List<? extends URL> roots) {
+            @NonNull final List<? extends URL> roots) throws IOException {
         Collection<URL> bin = new ArrayList<>(roots.size());
         Collection<URL> src = new ArrayList<>(roots.size());
         for (URL root : roots) {
             if (JavaIndex.hasSourceCache(root, false)) {
                 src.add(root);
+                bin.add(FileUtil.urlForArchiveOrDir(JavaIndex.getClassFolder(root)));
             } else {
                 bin.add(root);
             }

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/queries/UnitTestsCompilerOptionsQueryImplTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/queries/UnitTestsCompilerOptionsQueryImplTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.maven.queries;
+
+import java.util.Arrays;
+import org.netbeans.api.java.queries.CompilerOptionsQuery;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.test.TestFileUtils;
+
+public class UnitTestsCompilerOptionsQueryImplTest extends NbTestCase {
+
+    public UnitTestsCompilerOptionsQueryImplTest(String name) {
+        super(name);
+    }
+
+    private FileObject wd;
+
+    protected @Override void setUp() throws Exception {
+        clearWorkDir();
+        wd = FileUtil.toFileObject(getWorkDir());
+    }
+
+    public void testNoCompilerPluginSpecified() throws Exception {
+        TestFileUtils.writeFile(wd,
+                                "pom.xml",
+                                "<project>\n" +
+                                "<modelVersion>4.0.0</modelVersion>\n" +
+                                "<groupId>test</groupId><artifactId>prj</artifactId>\n" +
+                                "<packaging>jar</packaging><version>1.0</version>\n" +
+                                "<build><plugins><plugin><artifactId>maven-compiler-plugin</artifactId><version>2.1</version>\n" +
+                                "<configuration><source>11</source></configuration></plugin></plugins></build>\n" +
+                                "</project>\n");
+        TestFileUtils.writeFile(wd,
+                                "src/main/java/module-info.java",
+                                "module test {}\n");
+        TestFileUtils.writeFile(wd,
+                                "src/main/java/test/API.java",
+                                "package test;\n" +
+                                "public class API {}\n");
+        TestFileUtils.writeFile(wd,
+                                "src/test/java/module-info.java",
+                                "module test { requires testng; }\n");
+        FileObject testSource =
+        TestFileUtils.writeFile(wd,
+                                "src/test/java/test/APITest.java",
+                                "package test;\n" +
+                                "public class APITest {}\n");
+        assertEquals(Arrays.asList("--patch-module",
+                                   "test=" + FileUtil.toFile(wd.getFileObject("src/main/java")).getAbsolutePath()),
+                     CompilerOptionsQuery.getOptions(testSource).getArguments());
+    }
+
+}


### PR DESCRIPTION
So, the problem here is that some Maven projects have a `module-info` for module `$m` in `src/main/java` and another for `$m` in `src/test/java`, which overrides the main one. (Note the module names are the same.) The `maven-compiler-plugin` will then put the `src/main/java` on patch path for (test) `$m`:
https://github.com/apache/maven-compiler-plugin/blob/1b206fe40156bb9814ed8b804a23362ec2b41daa/src/main/java/org/apache/maven/plugin/compiler/TestCompilerMojo.java#L335

This is an attempt to simulate this inside NetBeans, although I am by far not sure if it is correct. It:
-does the tweak in the module projects to include the `--patch-module` option
-tweaks `PatchModuleManager`, so that if we have caches for the main sources, we use the caches
-tweaks the `ClassPath` content so that the "IDE-view" classpath for tests was a reference to the main sources, so that navigation from tests to sources works.