### PR TITLE
[NETBEANS-5155] retain fallback to file's MIME type.

### DIFF
--- a/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/hints/ErrorCheckingSupport.java
+++ b/webcommon/javascript2.editor/src/org/netbeans/modules/javascript2/editor/hints/ErrorCheckingSupport.java
@@ -85,6 +85,20 @@ public final class ErrorCheckingSupport {
     }
 
     public static String getMimeType(Parser.Result info) {
+        String mime = getWebPageMetadataMime(info);
+        if (mime != null) {
+            return mime;
+        }
+        FileObject fo = info.getSnapshot().getSource().getFileObject();
+        if (fo != null) {
+            return fo.getMIMEType();
+        } else {
+            // no fileobject?
+            return info.getSnapshot().getMimeType();
+        }
+    }
+    
+    private static String getWebPageMetadataMime(Parser.Result info) {
         String mime = WebPageMetadata.getContentMimeType(info, false);
         if (mime != null) {
             return mime;
@@ -116,16 +130,7 @@ public final class ErrorCheckingSupport {
             // XXX
             return null;
         }
-        if (res.get() != null) {
-            return res.get();
-        }
-        FileObject fo = info.getSnapshot().getSource().getFileObject();
-        if (fo != null) {
-            return fo.getMIMEType();
-        } else {
-            // no fileobject?
-            return info.getSnapshot().getMimeType();
-        }
+        return res.get();
     }
 
     public static HintFix createErrorFixForFile(Snapshot snapshot, boolean enable) {


### PR DESCRIPTION
When reviewing, please compare also the [original semantics (before the refactoring)](https://github.com/apache/netbeans/commit/580d925e0608690eb3462aad37de15cdf0259853#diff-37427eeda3bcf06f91cce8d11efead9489dbe75a90f4d7433c183846c8a43577L89) with this fixed behaviour. 
