### PR TITLE
Fix ini values for Xdebug 3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,7 +157,7 @@ jobs:
           php-version: '7.4'
           tools: pecl
           extensions: xdebug
-          ini-values: xdebug.remote_enable=on, xdebug.remote_port=9003
+          ini-values: xdebug.mode=debug
 
       - name: Launch Xvfb
         run: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &


### PR DESCRIPTION
It seems that Xdebug 3 is installed via GitHub Actions. So, we have to fix the ini values. Let's wait for the build job result of this change. 

https://xdebug.org/docs/upgrade_guide

- `xdebug.remote_enable=on` to `xdebug.mode=debug`
- `xdebug.remote_port=9003`: This value is used by default