### PR TITLE
[NETBEANS-5185] - cleanup imports in the Enterprise Web.Monitor module

### DIFF
--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/ClientData.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/ClientData.java
@@ -19,10 +19,14 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class ClientData extends BaseBean {
 
@@ -34,7 +38,7 @@ public class ClientData extends BaseBean {
     }
 
     public ClientData(int options) {
-	super(ClientData.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(ClientData.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.initialize(options);
     }

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/ContextAttributes.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/ContextAttributes.java
@@ -29,10 +29,17 @@
  */
 
 package org.netbeans.modules.web.monitor.data;
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+
+import java.beans.PropertyChangeListener;
+import java.util.Hashtable;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class ContextAttributes extends BaseBean {
 
@@ -45,7 +52,7 @@ public class ContextAttributes extends BaseBean {
     }
 
     public ContextAttributes(int options) {
-	super(ContextAttributes.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(ContextAttributes.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.createProperty("Param", PARAM,  // NOI18N
 			    Common.TYPE_0_N | Common.TYPE_BEAN | Common.TYPE_KEY, 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/ContextData.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/ContextData.java
@@ -27,14 +27,17 @@
  * @version
  */
 
-
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
 
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class ContextData extends BaseBean {
 
@@ -49,7 +52,7 @@ public class ContextData extends BaseBean {
     }
 
     public ContextData(int options) {
-	super(ContextData.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(ContextData.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.createProperty("Param", PARAM, //NOI18N
 			    Common.TYPE_0_N | Common.TYPE_BEAN | Common.TYPE_KEY, 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/CookieIn.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/CookieIn.java
@@ -19,35 +19,38 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
 import javax.servlet.http.Cookie;
+
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class CookieIn extends BaseBean {
 
     static Vector comparators = new Vector();
-
 
     public CookieIn() {
 	this(Common.USE_DEFAULT_VALUES);
     }
 
     public CookieIn(Cookie cookie) {
-	super(comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 5));
+	super(comparators, new Version(1, 0, 5));
 	this.setAttributeValue("name", cookie.getName());//NOI18N
 	this.setAttributeValue("value", cookie.getValue());//NOI18N
     }
 
     public CookieIn(String name, String value) {
-	super(comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 5));
+	super(comparators, new Version(1, 0, 5));
 	this.setAttributeValue("name", name);//NOI18N
 	this.setAttributeValue("value", value);//NOI18N
     }
 
     public CookieIn(int options) {
-	super(comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.initialize(options);
     }

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/CookieOut.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/CookieOut.java
@@ -19,11 +19,14 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
 import javax.servlet.http.Cookie;
+
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
 
 public class CookieOut extends BaseBean
 {

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/CookiesData.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/CookiesData.java
@@ -19,10 +19,15 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
+import org.netbeans.modules.schema2beans.AttrProp;
+
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class CookiesData extends BaseBean {
 
@@ -37,7 +42,7 @@ public class CookiesData extends BaseBean {
     }
 
     public CookiesData(int options) {
-	super(RequestData.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(RequestData.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.createProperty("CookieIn", COOKIEIN, // NOI18N
 			    Common.TYPE_0_N | Common.TYPE_BEAN | Common.TYPE_KEY, 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/DispatchData.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/DispatchData.java
@@ -19,13 +19,15 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.xml.sax.InputSource;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
-import java.io.*;
-import org.netbeans.modules.web.monitor.client.TransactionNode;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class DispatchData extends BaseBean implements DataRecord {
 
@@ -47,7 +49,7 @@ public class DispatchData extends BaseBean implements DataRecord {
     }
     
     public DispatchData(int options) {
-	super(comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(comparators, new Version(1, 0, 6));
 	this.createProperty("ClientData", CLIENTDATA,  // NOI18N
 			    Common.TYPE_1 | Common.TYPE_BEAN | Common.TYPE_KEY, 
 			    ClientData.class);

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/Dispatches.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/Dispatches.java
@@ -19,10 +19,12 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.util.Vector;
+import org.netbeans.modules.schema2beans.AttrProp;
+
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.Common;
 
 public class Dispatches extends BaseBean {
 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/EngineData.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/EngineData.java
@@ -19,10 +19,14 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class EngineData extends BaseBean {
 
@@ -35,7 +39,7 @@ public class EngineData extends BaseBean {
 
 
     public EngineData(int options) {
-	super(EngineData.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(EngineData.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.initialize(options);
     }

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/Headers.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/Headers.java
@@ -24,10 +24,18 @@
  */
 
 package org.netbeans.modules.web.monitor.data;
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+
+import java.beans.PropertyChangeListener;
+import java.util.Enumeration;
+import java.util.StringTokenizer;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class Headers extends BaseBean {
 
@@ -40,7 +48,7 @@ public class Headers extends BaseBean {
     }
 
     public Headers(int options) {
-	super(Headers.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(Headers.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.createProperty("Param", PARAM,  // NOI18N
 			    Common.TYPE_0_N | Common.TYPE_BEAN | Common.TYPE_KEY, 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/MonitorData.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/MonitorData.java
@@ -19,12 +19,26 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.GraphManager;
+import org.netbeans.modules.schema2beans.Version;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
-import java.io.*;
+
 
 public class MonitorData extends BaseBean implements DataRecord {
 
@@ -66,7 +80,7 @@ public class MonitorData extends BaseBean implements DataRecord {
     }
     
     public MonitorData(int options) {
-	super(MonitorData.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(MonitorData.comparators, new Version(1, 0, 6));
 	// The graph manager is allocated in the bean root
 	this.graphManager = new GraphManager(this);
 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/Param.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/Param.java
@@ -19,10 +19,14 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class Param extends BaseBean {
 
@@ -34,13 +38,13 @@ public class Param extends BaseBean {
     }
 
     public Param(String name, String value) {
-	super(Param.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(Param.comparators, new Version(1, 0, 6));
 	setAttributeValue("name", name); //NOI18N
 	setAttributeValue("value", value); //NOI18N
     }
 
     public Param(int options) {
-	super(Param.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(Param.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.initialize(options);
     }

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/RequestAttributesIn.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/RequestAttributesIn.java
@@ -29,10 +29,17 @@
  */
 
 package org.netbeans.modules.web.monitor.data;
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+
+import java.beans.PropertyChangeListener;
+import java.util.Hashtable;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class RequestAttributesIn extends BaseBean {
 
@@ -45,7 +52,7 @@ public class RequestAttributesIn extends BaseBean {
     }
 
     public RequestAttributesIn(int options) {
-	super(RequestAttributesIn.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(RequestAttributesIn.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.createProperty("Param", PARAM,  // NOI18N
 			    Common.TYPE_0_N | Common.TYPE_BEAN | Common.TYPE_KEY, 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/RequestAttributesOut.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/RequestAttributesOut.java
@@ -29,10 +29,17 @@
  */
 
 package org.netbeans.modules.web.monitor.data;
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+
+import java.beans.PropertyChangeListener;
+import java.util.Hashtable;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class RequestAttributesOut extends BaseBean {
 
@@ -45,7 +52,7 @@ public class RequestAttributesOut extends BaseBean {
     }
 
     public RequestAttributesOut(int options) {
-	super(RequestAttributesOut.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(RequestAttributesOut.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.createProperty("Param", PARAM,  // NOI18N
 			    Common.TYPE_0_N | Common.TYPE_BEAN | Common.TYPE_KEY, 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/RequestData.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/RequestData.java
@@ -19,11 +19,20 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
-import java.io.*;
+import java.beans.PropertyChangeListener;
+import java.io.InputStream;
+import java.util.StringTokenizer;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.GraphManager;
+import org.netbeans.modules.schema2beans.Version;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 public class RequestData extends BaseBean {
 
@@ -48,7 +57,7 @@ public class RequestData extends BaseBean {
 
 
     public RequestData(Node doc, int options) {
-	super(RequestData.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(RequestData.comparators, new Version(1, 0, 6));
 	if (doc == null) {
 	    doc = GraphManager.createRootElementNode(REQUESTDATA); 
 		
@@ -67,7 +76,7 @@ public class RequestData extends BaseBean {
     }
 
     public RequestData(int options)	{
-	super(RequestData.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(RequestData.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 
 	this.createProperty("Headers", HEADERS, //NOI18N

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/ServletData.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/ServletData.java
@@ -19,10 +19,15 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
+import org.netbeans.modules.schema2beans.AttrProp;
+
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class ServletData extends BaseBean {
 
@@ -35,7 +40,7 @@ public class ServletData extends BaseBean {
     }
 
     public ServletData(int options) {
-	super(ServletData.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(ServletData.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.createProperty("Param", PARAM, //NOI18N
 			    Common.TYPE_0_N | Common.TYPE_BEAN | Common.TYPE_KEY, 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/SessionData.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/SessionData.java
@@ -19,10 +19,15 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class SessionData extends BaseBean {
 
@@ -36,7 +41,7 @@ public class SessionData extends BaseBean {
     }
 
     public SessionData(int options) {
-	super(SessionData.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(SessionData.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.createProperty("SessionIn", SESSIONIN, //NOI18N
 			    Common.TYPE_1 | Common.TYPE_BEAN | Common.TYPE_KEY, 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/SessionIn.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/SessionIn.java
@@ -32,10 +32,15 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class SessionIn extends BaseBean {
 
@@ -48,7 +53,7 @@ public class SessionIn extends BaseBean {
     }
 
     public SessionIn(int options) {
-	super(SessionIn.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(SessionIn.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.createProperty("Param", PARAM, //NOI18N
 			    Common.TYPE_0_N | Common.TYPE_BEAN | Common.TYPE_KEY, 

--- a/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/SessionOut.java
+++ b/enterprise/web.monitor/src/org/netbeans/modules/web/monitor/data/SessionOut.java
@@ -33,10 +33,15 @@
 
 package org.netbeans.modules.web.monitor.data;
 
-import org.w3c.dom.*;
-import org.netbeans.modules.schema2beans.*;
-import java.beans.*;
-import java.util.*;
+import java.beans.PropertyChangeListener;
+import java.util.Vector;
+
+import org.netbeans.modules.schema2beans.AttrProp;
+import org.netbeans.modules.schema2beans.BaseBean;
+import org.netbeans.modules.schema2beans.BeanComparator;
+import org.netbeans.modules.schema2beans.BeanProp;
+import org.netbeans.modules.schema2beans.Common;
+import org.netbeans.modules.schema2beans.Version;
 
 public class SessionOut extends BaseBean {
 
@@ -49,7 +54,7 @@ public class SessionOut extends BaseBean {
     }
 
     public SessionOut(int options) {
-	super(SessionOut.comparators, new org.netbeans.modules.schema2beans.Version(1, 0, 6));
+	super(SessionOut.comparators, new Version(1, 0, 6));
 	// Properties (see root bean comments for the bean graph)
 	this.createProperty("Param", PARAM,  //NOI18N
 			    Common.TYPE_0_N | Common.TYPE_BEAN | Common.TYPE_KEY, 


### PR DESCRIPTION
In cleaning up Vector raw types, I noticed a bunch of imports in the
Enterprise Web.Monitor module that could use some cleanup.

It's bad form to use the "*" when importing. It's pulls in every class in the import.

In addition, it can break  modularization.