### PR TITLE
update default imports for JShell

### DIFF
--- a/java/jshell.support/src/org/netbeans/modules/jshell/tool/JShellTool.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/tool/JShellTool.java
@@ -215,13 +215,16 @@ public class JShellTool implements MessageHandler {
 
     static final String DEFAULT_STARTUP =
             "\n" +
-            "import java.util.*;\n" +
             "import java.io.*;\n" +
             "import java.math.*;\n" +
             "import java.net.*;\n" +
+            "import java.nio.file.*;\n" +
+            "import java.util.*;\n" +
             "import java.util.concurrent.*;\n" +
+            "import java.util.function.*;\n" +
             "import java.util.prefs.*;\n" +
             "import java.util.regex.*;\n" +
+            "import java.util.stream.*;\n" +
             "void printf(String format, Object... args) { System.out.printf(format, args); }\n";
 
     // Tool id (tid) mapping: the three name spaces


### PR DESCRIPTION
When I tried some code with JShell I found out that there were differencies in default imports between JShell from jdk and internal JShell from Netbeans. Default imports from JDK JShell :
jshell> /imports
|    import java.io.*
|    import java.math.*
|    import java.net.*
|    import java.nio.file.*
|    import java.util.*
|    import java.util.concurrent.*
|    import java.util.function.*
|    import java.util.prefs.*
|    import java.util.regex.*
|    import java.util.stream.*

Netbeans JShell :
[1]-> /imports
|    import java.util.*
|    import java.io.*
|    import java.math.*
|    import java.net.*
|    import java.util.concurrent.*
|    import java.util.prefs.*
|    import java.util.regex.*

I think it would be better if these default imports would be the same.