### PR TITLE
Process test classes before executing single test

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/defaultActionMappings.xml
+++ b/java/maven/src/org/netbeans/modules/maven/execute/defaultActionMappings.xml
@@ -84,7 +84,7 @@
             <packaging>*</packaging>
         </packagings>
         <goals>
-            <goal>test-compile</goal>
+            <goal>process-test-classes</goal>
             <goal>surefire:test</goal>
         </goals>
         <properties>
@@ -158,7 +158,7 @@
             <packaging>*</packaging>
         </packagings>
         <goals>
-            <goal>process-classes</goal>
+            <goal>process-test-classes</goal>
             <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>
         </goals>
         <properties>
@@ -175,7 +175,7 @@
             <packaging>*</packaging>
         </packagings>
         <goals>
-            <goal>test-compile</goal>
+            <goal>process-test-classes</goal>
             <goal>surefire:test</goal>
         </goals>
         <properties>
@@ -254,7 +254,7 @@
             <packaging>*</packaging>
         </packagings>
         <goals>
-            <goal>test-compile</goal>
+            <goal>process-test-classes</goal>
             <goal>surefire:test</goal>
         </goals>
         <properties>


### PR DESCRIPTION
I cannot run/debug tests in [HTML/Java API](https://github.com/apache/netbeans-html4j/tree/master/generic) because they use `@JavaScriptBody` annotation and require post-processing. However, by default Maven doesn't invoke `process-test-classes` before execution. I was considering to fix it by writing `nbactions.xml` file, but it seems better to make it default, which is what this PR does.

![obrazek](https://user-images.githubusercontent.com/1842422/103293075-75f60180-49ef-11eb-9230-a3e48f79b82e.png)

Current failure is:
```
-------------------------------------------------------
Running org.netbeans.html.presenters.spi.test.GenericTest
Configuring TestNG with: TestNG652Configurator
SEVERE: When using @JavaScriptBody methods, one needs to either:
 - include asm-5.0.jar on runtime classpath
 - post process classes, see http://bits.netbeans.org/html+java/dev/net/java/html/js/package-summary.html#post-process
However following classes has not been processed from file:/home/devel/NetBeansProjects/netbeans-html4j/generic/target/test-classes/META-INF/net.java.html.js.classes
  org.netbeans.html.presenters.spi.test.Counter
Cannot initialize asm-5.0.jar!

java.lang.NoClassDefFoundError: org/objectweb/asm/ClassVisitor
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at org.netbeans.html.boot.impl.FnContext.newLoader(FnContext.java:57)
	at net.java.html.boot.BrowserBuilder.showAndWait(BrowserBuilder.java:288)
	at org.netbeans.html.presenters.spi.test.GenericTest$1.run(GenericTest.java:51)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: org.objectweb.asm.ClassVisitor
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	... 10 more
```

with the patch in this PR the "Test File" action works.