### PR TITLE
[NETBEANS-4739] CSS Go to Declaration , does not work

### DIFF
--- a/ide/css.editor/src/org/netbeans/modules/css/indexing/api/CssIndex.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/indexing/api/CssIndex.java
@@ -309,13 +309,7 @@ public class CssIndex {
         String keyName = type.getIndexKey();
         Map<FileObject, Collection<String>> map = new HashMap<>();
         try {
-            Collection<? extends IndexResult> results;
-            if(prefix.length() == 0) {
-                results = querySupport.query(keyName, "", QuerySupport.Kind.PREFIX, keyName);
-            } else {
-                String searchExpression = ".*("+encodeValueForRegexp(prefix)+").*"; //NOI18N
-                results = querySupport.query(keyName, searchExpression, QuerySupport.Kind.REGEXP, keyName);
-            }
+            Collection<? extends IndexResult> results = querySupport.query(keyName, prefix, QuerySupport.Kind.PREFIX, keyName);
             for (IndexResult result : results) {
                 String[] elements = result.getValues(keyName);
                 for(String e : elements) {
@@ -380,8 +374,8 @@ public class CssIndex {
      *
      * @param type
      * @param value
-     * @return returns a collection of files which contains the keyName key and the
-     * value matches the value regular expression
+     * @return returns a collection of files which contains elements with the
+     * given name and with the given type
      */
     public Collection<FileObject> find(RefactoringElementType type, String value) {
         return find(type, value, true);
@@ -391,13 +385,11 @@ public class CssIndex {
         String keyName = type.getIndexKey();
         try {
             StringBuilder searchExpression = new StringBuilder();
-            searchExpression.append(".*("); //NOI18N
             searchExpression.append(encodeValueForRegexp(value));
             if(includeVirtualElements) {
                 searchExpression.append(CssIndexer.VIRTUAL_ELEMENT_MARKER);
                 searchExpression.append('?'); //!?
             }
-            searchExpression.append(")[,;].*"); //NOI18N
 
             Collection<FileObject> matchedFiles = new LinkedList<>();
             Collection<? extends IndexResult> results = querySupport.query(keyName, searchExpression.toString(), QuerySupport.Kind.REGEXP, keyName);

--- a/ide/css.editor/test/unit/data/testProject/nbproject/project.properties
+++ b/ide/css.editor/test/unit/data/testProject/nbproject/project.properties
@@ -15,22 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-release.external/css21-spec.zip=docs/css21-spec.zip
-release.external/css3-spec.zip=docs/css3-spec.zip
-
-jnlp.indirect.files=\
-    docs/css21-spec.zip,\
-    docs/css3-spec.zip
-
-javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
-
-test.config.stableBTD.includes=**/*Test.class
-test.config.stableBTD.excludes=\
-    **/indent/CssIndenterTest.class,\
-    **/module/main/AnimationsModuleTest.class,\
-    **/module/main/StandardPropertiesHelpResolverTest.class,\
-    **/properties/parser/PropertyValueTest.class,\
-    **/CssBracketCompleterTest.class
-
-test-unit-sys-prop.netbeans.dirs=${netbeans.dest.dir}/${nb.cluster.ide.dir}
+config.folder=${file.reference.HTML5Application-config}
+file.reference.HTML5Application-config=config
+file.reference.HTML5Application-public_html=public_html
+file.reference.HTML5Application-test=test
+files.encoding=UTF-8
+site.root.folder=${file.reference.HTML5Application-public_html}
+test.folder=${file.reference.HTML5Application-test}

--- a/ide/css.editor/test/unit/data/testProject/nbproject/project.xml
+++ b/ide/css.editor/test/unit/data/testProject/nbproject/project.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.web.clientproject</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/clientside-project/1">
+            <name>CSS Editor Test Project</name>
+        </data>
+    </configuration>
+</project>

--- a/ide/css.editor/test/unit/data/testProject/public_html/test.html
+++ b/ide/css.editor/test/unit/data/testProject/public_html/test.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>GotoDeclaration Test</title>
+        <link rel="stylesheet" type="text/css" href="test1.css">
+        <link rel="stylesheet" type="text/css" href="test2.css">
+    </head>
+    <body>
+        <p class="classSelector1">test class</p>
+        <p class="classSelector3">test class</p>
+        <p id="yetAnotherId">test id</p>
+    </body>
+</html>

--- a/ide/css.editor/test/unit/data/testProject/public_html/test1.css
+++ b/ide/css.editor/test/unit/data/testProject/public_html/test1.css
@@ -1,0 +1,34 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+.classSelector1 {
+
+}
+
+.classSelector2 {
+
+}
+
+#dummyId {
+
+}
+
+#anotherId {
+
+}

--- a/ide/css.editor/test/unit/data/testProject/public_html/test2.css
+++ b/ide/css.editor/test/unit/data/testProject/public_html/test2.css
@@ -1,0 +1,42 @@
+/*
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+*/
+
+.classSelector3 {
+
+}
+
+#dummyId2 {
+
+}
+
+#dummyId3 {
+    color: #F1F1F1;
+}
+
+.anotherClassSelector {
+
+}
+
+h1 {
+
+}
+
+#yetAnotherId {
+
+}

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssGotoDeclarationTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/csl/CssGotoDeclarationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.css.editor.csl;
+
+import org.netbeans.modules.csl.spi.DefaultLanguageConfig;
+import org.netbeans.modules.css.editor.ProjectTestBase;
+import org.netbeans.modules.html.editor.gsf.HtmlLanguage;
+
+public class CssGotoDeclarationTest extends ProjectTestBase {
+
+    public CssGotoDeclarationTest(String testName) {
+        super(testName, "testProject");
+    }
+
+    @Override
+    protected DefaultLanguageConfig getPreferredLanguage() {
+        return new HtmlLanguage();
+    }
+
+    public void testClass_01() throws Exception {
+        checkDeclaration(getSourcesFolderName() + "/test.html", "<p class=\"classSelec^tor1\">test class</p>", "test1.css", 819);
+    }
+
+    public void testClass_02() throws Exception {
+        checkDeclaration(getSourcesFolderName() + "/test.html", "<p class=\"classSelec^tor3\">test class</p>", "test2.css", 819);
+    }
+
+    public void testId_01() throws Exception {
+        checkDeclaration(getSourcesFolderName() + "/test.html", "<p id=\"yetAnoth^erId\">test id</p>", "test2.css", 929);
+    }
+}

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/indexing/api/CssIndexTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/indexing/api/CssIndexTest.java
@@ -19,18 +19,32 @@
 
 package org.netbeans.modules.css.indexing.api;
 
-import org.netbeans.junit.NbTestCase;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.css.editor.ProjectTestBase;
+import org.netbeans.modules.css.refactoring.api.RefactoringElementType;
+import org.openide.filesystems.FileObject;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static junit.framework.TestCase.assertNotNull;
 
 /**
  *
  * @author mfukala@netbeans.org
  */
-public class CssIndexTest extends NbTestCase {
+public class CssIndexTest extends ProjectTestBase {
 
     public CssIndexTest(String name) {
-        super(name);
+        super(name, "testProject");
     }
-    
+
     public void testEncodeValueForRegexp() {
         assertEquals("", CssIndex.encodeValueForRegexp(""));
         assertEquals("a", CssIndex.encodeValueForRegexp("a"));
@@ -43,13 +57,13 @@ public class CssIndexTest extends NbTestCase {
     public void testCreateImpliedFileName() {
         //no change
         assertEquals("index.scss", CssIndex.createImpliedFileName("index.scss", null, false));
-        
+
         //imply underscope, keep ext
         assertEquals("_index.scss", CssIndex.createImpliedFileName("index.scss", null, true));
-        
+
         //add just ext
         assertEquals("index.scss", CssIndex.createImpliedFileName("index", "scss", false));
-        
+
         //mix
         assertEquals("_index.scss", CssIndex.createImpliedFileName("index", "scss", true));
         assertEquals("folder/index.scss", CssIndex.createImpliedFileName("folder/index", "scss", false));
@@ -58,12 +72,155 @@ public class CssIndexTest extends NbTestCase {
         assertEquals("folder1/folder2/_index.scss", CssIndex.createImpliedFileName("folder1/folder2/index", "scss", true));
         assertEquals("/folder/_index.scss", CssIndex.createImpliedFileName("/folder/index", "scss", true));
         assertEquals("/_index.scss", CssIndex.createImpliedFileName("/index", "scss", true));
-        
+
         //extension exists but not scss or sass
         assertEquals("_pa.rtial.scss", CssIndex.createImpliedFileName("pa.rtial", "scss", true));
         assertEquals("folder/_pa.rtial.scss", CssIndex.createImpliedFileName("folder/pa.rtial", "scss", true));
         assertEquals("folder/_pa.rtial.scss", CssIndex.createImpliedFileName("folder/pa.rtial.scss", null, true));
         assertEquals("folder/pa.rtial", CssIndex.createImpliedFileName("folder/pa.rtial", null, false));
-        
+    }
+
+    private CssIndex getTestCssIndex() throws IOException {
+        FileObject test1Css = getTestFile(getSourcesFolderName() + "/test1.css");
+        Project project = FileOwnerQuery.getOwner(test1Css);
+        assertNotNull(project);
+
+        CssIndex index = CssIndex.create(project);
+        assertNotNull(index);
+
+        return index;
+    }
+
+    public void testFindByTypeAndName() throws IOException {
+        FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+
+        Collection<FileObject> fileObjects = getTestCssIndex().find(RefactoringElementType.ID, "dummyId3");
+
+        assertNotNull(fileObjects);
+        assertEquals(1, fileObjects.size());
+        assertEquals(test2Css, fileObjects.iterator().next());
+    }
+
+    public void testFindAll() throws IOException {
+        assertEquals(
+            getTestCssIndex().findAll(RefactoringElementType.CLASS),
+            getTestCssIndex().findAllClassDeclarations()
+        );
+
+        assertEquals(
+            getTestCssIndex().findAll(RefactoringElementType.ID),
+            getTestCssIndex().findAllIdDeclarations()
+        );
+    }
+
+    public void testFindAllClassDeclarations() throws IOException {
+        FileObject test1Css = getTestFile(getSourcesFolderName() + "/test1.css");
+        FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+        Set<FileObject> testCssFiles = new HashSet<>(asList(test1Css, test2Css));
+
+        Map<FileObject,Collection<String>> allClassDeclarations = getTestCssIndex().findAllClassDeclarations();
+        assertNotNull(allClassDeclarations);
+        assertEquals(2, allClassDeclarations.size());
+        assertEquals(testCssFiles, allClassDeclarations.keySet());
+
+        assertEquals(new HashSet<>(asList("classSelector1", "classSelector2")), allClassDeclarations.get(test1Css));
+        assertEquals(new HashSet<>(asList("anotherClassSelector","classSelector3")), allClassDeclarations.get(test2Css));
+    }
+
+    public void testFindAllIdDeclarations() throws IOException {
+        FileObject test1Css = getTestFile(getSourcesFolderName() + "/test1.css");
+        FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+        Set<FileObject> testCssFiles = new HashSet<>(asList(test1Css, test2Css));
+
+        Map<FileObject,Collection<String>> allIdDeclarations = getTestCssIndex().findAllIdDeclarations();
+        assertNotNull(allIdDeclarations);
+        assertEquals(2, allIdDeclarations.size());
+        assertEquals(testCssFiles, allIdDeclarations.keySet());
+
+        assertEquals(new HashSet<>(asList("dummyId", "anotherId")), allIdDeclarations.get(test1Css));
+        assertEquals(new HashSet<>(asList("dummyId2", "dummyId3", "yetAnotherId")), allIdDeclarations.get(test2Css));
+    }
+
+    public void testFindByPrefix() throws IOException {
+        FileObject test1Css = getTestFile(getSourcesFolderName() + "/test1.css");
+        FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+        Set<FileObject> testCssFiles = new HashSet<>(asList(test1Css, test2Css));
+
+        Map<FileObject,Collection<String>> idPrefixResult = getTestCssIndex().findByPrefix(RefactoringElementType.ID, "another");
+        assertNotNull(idPrefixResult);
+        assertEquals(1, idPrefixResult.size());
+        assertEquals(singleton(test1Css), idPrefixResult.keySet());
+
+        assertEquals(new HashSet<>(asList("anotherId")), idPrefixResult.get(test1Css));
+
+        Map<FileObject,Collection<String>> classPrefixResult = getTestCssIndex().findByPrefix(RefactoringElementType.CLASS, "classSelector");
+        assertNotNull(classPrefixResult);
+        assertEquals(2, classPrefixResult.size());
+        assertEquals(testCssFiles, classPrefixResult.keySet());
+
+        assertEquals(new HashSet<>(asList("classSelector1", "classSelector2")), classPrefixResult.get(test1Css));
+        assertEquals(new HashSet<>(asList("classSelector3")), classPrefixResult.get(test2Css));
+    }
+
+    public void testFindClasses() throws IOException {
+        FileObject test1Css = getTestFile(getSourcesFolderName() + "/test1.css");
+        List<FileObject> result = new ArrayList<>(getTestCssIndex().findClasses("classSelector2"));
+        assertEquals(asList(test1Css), result);
+    }
+
+    public void testFindClassDeclaration() throws IOException {
+        FileObject test1Css = getTestFile(getSourcesFolderName() + "/test1.css");
+        List<FileObject> result = new ArrayList<>(getTestCssIndex().findClassDeclarations("classSelector2"));
+        assertEquals(asList(test1Css), result);
+    }
+
+    public void testFindClassesByPrefix() throws IOException {
+        FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+        Map<FileObject,Collection<String>> result = getTestCssIndex().findClassesByPrefix("another");
+        assertNotNull(result);
+        assertEquals(singleton(test2Css), result.keySet());
+        assertEquals(asList("anotherClassSelector"), new ArrayList<>(result.get(test2Css)));
+    }
+
+    public void testFindColorsByPrefix() throws IOException {
+        FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+        Map<FileObject,Collection<String>> result = getTestCssIndex().findColorsByPrefix("#F1");
+        assertNotNull(result);
+        assertEquals(singleton(test2Css), result.keySet());
+        assertEquals(asList("#F1F1F1"), new ArrayList<>(result.get(test2Css)));
+    }
+
+    public void testFindColor() throws IOException {
+        FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+        Collection<FileObject> result = getTestCssIndex().findColor("#F1F1F1");
+        assertNotNull(result);
+        assertEquals(singleton(test2Css), new HashSet<>(result));
+    }
+
+    public void testFindHtmlElement() throws IOException {
+        FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+        Collection<FileObject> result = getTestCssIndex().findHtmlElement("h1");
+        assertNotNull(result);
+        assertEquals(singleton(test2Css), new HashSet<>(result));
+    }
+
+    public void testFindIds() throws IOException {
+        FileObject test1Css = getTestFile(getSourcesFolderName() + "/test1.css");
+        List<FileObject> result = new ArrayList<>(getTestCssIndex().findIds("anotherId"));
+        assertEquals(asList(test1Css), result);
+    }
+
+    public void testFindIdDeclaration() throws IOException {
+        FileObject test1Css = getTestFile(getSourcesFolderName() + "/test1.css");
+        List<FileObject> result = new ArrayList<>(getTestCssIndex().findIdDeclarations("anotherId"));
+        assertEquals(asList(test1Css), result);
+    }
+
+    public void testFindIdsByPrefix() throws IOException {
+        FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+        Map<FileObject,Collection<String>> result = getTestCssIndex().findIdsByPrefix("yetAnother");
+        assertNotNull(result);
+        assertEquals(singleton(test2Css), result.keySet());
+        assertEquals(asList("yetAnotherId"), new ArrayList<>(result.get(test2Css)));
     }
 }

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/indexing/api/CssIndexTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/indexing/api/CssIndexTest.java
@@ -102,15 +102,33 @@ public class CssIndexTest extends ProjectTestBase {
     }
 
     public void testFindAll() throws IOException {
-        assertEquals(
-            getTestCssIndex().findAll(RefactoringElementType.CLASS),
-            getTestCssIndex().findAllClassDeclarations()
-        );
+        FileObject test1Css = getTestFile(getSourcesFolderName() + "/test1.css");
+        FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+        FileObject testHtml = getTestFile(getSourcesFolderName() + "/test.html");
+
+        Map<FileObject,Collection<String>> classIndex = getTestCssIndex().findAll(RefactoringElementType.CLASS);
 
         assertEquals(
-            getTestCssIndex().findAll(RefactoringElementType.ID),
-            getTestCssIndex().findAllIdDeclarations()
-        );
+            new HashSet<>(asList("classSelector1", "classSelector2")),
+            new HashSet<>(classIndex.get(test1Css)));
+        assertEquals(
+            new HashSet<>(asList("anotherClassSelector", "classSelector3")),
+            new HashSet<>(classIndex.get(test2Css)));
+        assertEquals(
+            new HashSet<>(asList("classSelector1", "classSelector3")),
+            new HashSet<>(classIndex.get(testHtml)));
+
+        Map<FileObject,Collection<String>> idIndex = getTestCssIndex().findAll(RefactoringElementType.ID);
+
+        assertEquals(
+            new HashSet<>(asList("anotherId", "dummyId")),
+            new HashSet<>(idIndex.get(test1Css)));
+        assertEquals(
+            new HashSet<>(asList("dummyId2", "dummyId3", "yetAnotherId")),
+            new HashSet<>(idIndex.get(test2Css)));
+        assertEquals(
+            new HashSet<>(asList("yetAnotherId")),
+            new HashSet<>(idIndex.get(testHtml)));
     }
 
     public void testFindAllClassDeclarations() throws IOException {
@@ -144,7 +162,8 @@ public class CssIndexTest extends ProjectTestBase {
     public void testFindByPrefix() throws IOException {
         FileObject test1Css = getTestFile(getSourcesFolderName() + "/test1.css");
         FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
-        Set<FileObject> testCssFiles = new HashSet<>(asList(test1Css, test2Css));
+        FileObject testHtml = getTestFile(getSourcesFolderName() + "/test.html");
+        Set<FileObject> testCssFiles = new HashSet<>(asList(test1Css, test2Css, testHtml));
 
         Map<FileObject,Collection<String>> idPrefixResult = getTestCssIndex().findByPrefix(RefactoringElementType.ID, "another");
         assertNotNull(idPrefixResult);
@@ -155,7 +174,7 @@ public class CssIndexTest extends ProjectTestBase {
 
         Map<FileObject,Collection<String>> classPrefixResult = getTestCssIndex().findByPrefix(RefactoringElementType.CLASS, "classSelector");
         assertNotNull(classPrefixResult);
-        assertEquals(2, classPrefixResult.size());
+        assertEquals(3, classPrefixResult.size());
         assertEquals(testCssFiles, classPrefixResult.keySet());
 
         assertEquals(new HashSet<>(asList("classSelector1", "classSelector2")), classPrefixResult.get(test1Css));
@@ -218,9 +237,12 @@ public class CssIndexTest extends ProjectTestBase {
 
     public void testFindIdsByPrefix() throws IOException {
         FileObject test2Css = getTestFile(getSourcesFolderName() + "/test2.css");
+        FileObject testHtml = getTestFile(getSourcesFolderName() + "/test.html");
+        Set<FileObject> testCssFiles = new HashSet<>(asList(test2Css, testHtml));
         Map<FileObject,Collection<String>> result = getTestCssIndex().findIdsByPrefix("yetAnother");
         assertNotNull(result);
-        assertEquals(singleton(test2Css), result.keySet());
+        assertEquals(testCssFiles, result.keySet());
         assertEquals(asList("yetAnotherId"), new ArrayList<>(result.get(test2Css)));
+        assertEquals(asList("yetAnotherId"), new ArrayList<>(result.get(testHtml)));
     }
 }

--- a/ide/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/CPCssIndexModelTest.java
+++ b/ide/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/CPCssIndexModelTest.java
@@ -18,12 +18,11 @@
  */
 package org.netbeans.modules.css.prep.editor;
 
-import org.netbeans.modules.css.prep.editor.CPCssIndexModel;
-import org.netbeans.modules.css.prep.editor.CPUtils;
 import java.io.IOException;
 import java.util.Collection;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
+import org.netbeans.modules.css.editor.ProjectTestBase;
 import org.netbeans.modules.css.indexing.api.CssIndex;
 import org.netbeans.modules.css.prep.editor.model.CPElementHandle;
 import org.netbeans.modules.css.prep.editor.model.CPElementType;
@@ -34,36 +33,36 @@ import org.openide.filesystems.FileObject;
  * @author marekfukala
  */
 public class CPCssIndexModelTest extends ProjectTestBase {
-    
+
     public CPCssIndexModelTest(String name) {
         super(name, "testProject");
     }
-    
+
     public void testIndexingAndQueryingOfVarsAndMixins() throws IOException {
         FileObject file = getTestFile(getSourcesFolderName() + "/lib1.scss");
         Project project = FileOwnerQuery.getOwner(file);
         assertNotNull(project);
-        
+
         CssIndex index = CssIndex.create(project);
         assertNotNull(index);
-        
+
         CPCssIndexModel indexModel = (CPCssIndexModel)index.getIndexModel(CPCssIndexModel.Factory.class, file);
         assertNotNull(indexModel);
-        
+
         Collection<CPElementHandle> variables = indexModel.getVariables();
         assertNotNull(variables);
-        
+
         assertEquals(2, CPUtils.filter(variables, CPElementType.VARIABLE_GLOBAL_DECLARATION).size());
         assertEquals(1, CPUtils.filter(variables, CPElementType.VARIABLE_DECLARATION_IN_BLOCK_CONTROL).size());
         assertEquals(2, CPUtils.filter(variables, CPElementType.VARIABLE_USAGE).size());
-        
+
         Collection<CPElementHandle> mixins = indexModel.getMixins();
         assertNotNull(mixins);
         assertEquals(2, CPUtils.filter(mixins, CPElementType.MIXIN_DECLARATION).size());
         assertEquals(1, CPUtils.filter(mixins, CPElementType.MIXIN_USAGE).size());
-        
+
     }
-    
+
     public void testEncodeDecodeElementId() {
         String elementId = "styleSheet/body/bodyItem|1/selectorsGroup/selector/elementName";
         String enc = CPCssIndexModel.encodeElementId(elementId);
@@ -72,5 +71,5 @@ public class CPCssIndexModelTest extends ProjectTestBase {
         assertFalse(enc.equals(dec));
         assertEquals(elementId, dec);
     }
-    
+
 }

--- a/ide/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/refactoring/CPWhereUsedQueryPluginTest.java
+++ b/ide/css.prep/test/unit/src/org/netbeans/modules/css/prep/editor/refactoring/CPWhereUsedQueryPluginTest.java
@@ -18,20 +18,16 @@
  */
 package org.netbeans.modules.css.prep.editor.refactoring;
 
-import org.netbeans.modules.css.prep.editor.refactoring.RefactoringElement;
-import org.netbeans.modules.css.prep.editor.refactoring.CPWhereUsedQueryPlugin;
-import org.netbeans.modules.css.prep.editor.refactoring.RefactoringElementContext;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.text.BadLocationException;
-import static junit.framework.Assert.assertNotNull;
 import org.netbeans.modules.csl.api.OffsetRange;
+import org.netbeans.modules.css.editor.ProjectTestBase;
 import org.netbeans.modules.css.lib.TestUtil;
 import org.netbeans.modules.css.lib.api.CssParserResult;
-import org.netbeans.modules.css.prep.editor.ProjectTestBase;
 import org.netbeans.modules.parsing.api.ParserManager;
 import org.netbeans.modules.parsing.api.ResultIterator;
 import org.netbeans.modules.parsing.api.Source;

--- a/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Queries.java
+++ b/ide/parsing.lucene/src/org/netbeans/modules/parsing/lucene/support/Queries.java
@@ -490,12 +490,19 @@ public final class Queries {
         }
     }
 
-    private static class RegexpFilter extends AbstractTCFilter {
+    static class RegexpFilter extends AbstractTCFilter {
         private static final BitSet SPECIAL_CHARS = new BitSet(126);
         static {
-            final char[] specials = new char[] {'{','}','[',']','(',')','\\','.','*','?'}; //NOI18N
+            final char[] specials = new char[] {'{','}','[',']','(',')','\\','.','*','?', '+'}; //NOI18N
             for (char c : specials) {
                 SPECIAL_CHARS.set(c);
+            }
+        }
+        private static final BitSet QUANTIFIER_CHARS = new BitSet(126);
+        static {
+            final char[] specials = new char[] {'{','*','?'}; //NOI18N
+            for (char c : specials) {
+                QUANTIFIER_CHARS.set(c);
             }
         }
 
@@ -518,6 +525,12 @@ public final class Queries {
             boolean quoted = false;
             for (int i = 0; i < regexp.length(); i++) {
                 char c = regexp.charAt(i);
+                if ((!quoted) && i < (regexp.length() - 1)) {
+                    char lookAhead = regexp.charAt(i + 1);
+                    if (QUANTIFIER_CHARS.get(lookAhead)) {
+                        break;
+                    }
+                }
                 if (c == '\\' && (i+1) < regexp.length()) { //NOI18N
                     char cn = regexp.charAt(i+1);
                     if (!quoted && cn == 'Q') { //NOI18N

--- a/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/support/QueriesTest.java
+++ b/ide/parsing.lucene/test/unit/src/org/netbeans/modules/parsing/lucene/support/QueriesTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.parsing.lucene.support;
+
+import java.lang.reflect.Field;
+import java.util.regex.Pattern;
+import org.netbeans.modules.parsing.lucene.support.Queries.RegexpFilter;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+
+public class QueriesTest {
+
+    public QueriesTest() {
+    }
+
+    @Test
+    public void testRegexpStartText() throws Exception {
+        // The first special char of the regexp ends the start text, in this
+        // case a group is introduced
+        assertEquals("base", getRegexpFilterPrefixForPattern("base(Query)"));
+        // Quoted parts of the regexp are extracted verbatim
+        assertEquals("base.*", getRegexpFilterPrefixForPattern(Pattern.quote("base.*")));
+        // Quantifiers that can become 0 need to remove the character they work
+        // on. Quantifiers on groups are handled by the group handling
+        assertEquals("base", getRegexpFilterPrefixForPattern("base+"));
+        assertEquals("bas", getRegexpFilterPrefixForPattern("base?"));
+        assertEquals("bas", getRegexpFilterPrefixForPattern("base*"));
+        assertEquals("bas", getRegexpFilterPrefixForPattern("base{0,5}"));
+    }
+
+    private String getRegexpFilterPrefixForPattern(String pattern) throws Exception {
+        RegexpFilter rf = new RegexpFilter("dummy", pattern, true);
+        Field startPrefix = RegexpFilter.class.getDeclaredField("startPrefix");
+        startPrefix.setAccessible(true);
+        return (String) startPrefix.get(rf);
+    }
+
+}


### PR DESCRIPTION
When the index storage of CSS grammar elements was modified to store values individually (74a5e17), not all use-sites were updated. This PR fixes this and adds unit tests for the CSS index functions.