### PR TITLE
[NETBEANS-5176] Trivial NPE check on a NullAllowed field on GoTo Type

### DIFF
--- a/ide/jumpto/src/org/netbeans/modules/jumpto/common/ItemRenderer.java
+++ b/ide/jumpto/src/org/netbeans/modules/jumpto/common/ItemRenderer.java
@@ -286,7 +286,7 @@ public final class ItemRenderer<T> extends DefaultListCellRenderer implements Ch
                 if (shouldHighlight(isSelected)) {
                     JLabel highlightedTarget;
                     String textToFormat;
-                    if(searchFolders.isSelected()) {
+                    if ((searchFolders != null)  && searchFolders.isSelected()) {
                         highlightedTarget = jlOwner;
                         textToFormat = convertor.getOwnerName(item);
                     } else {
@@ -433,7 +433,7 @@ public final class ItemRenderer<T> extends DefaultListCellRenderer implements Ch
     
     private static HighlightingNameFormatter createNameFormatter(
             @NonNull final GoToSettings.HighlightingType type,
-            @NonNull final String separatorPattern) {
+            @NullAllowed final String separatorPattern) {
         switch (type) {
             case BACKGROUND:
                 Color back = new Color(236,235,163);


### PR DESCRIPTION
Also corrected a NotNull ->NullAllowed annotation, based on that ```HighlightingNameFormatter.Builder.create().setCamelCaseSeparator(separatorPattern)``` actually allows null.