### PR TITLE
[NETBEANS-5148] Added javafx:run to supported execgoals

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/output/ExecPluginOutputListenerProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/output/ExecPluginOutputListenerProvider.java
@@ -39,7 +39,8 @@ public class ExecPluginOutputListenerProvider implements OutputProcessor {
     
     private static final String[] EXECGOALS = new String[] {
         "mojo-execute#exec:exec", //NOI18N
-        "mojo-execute#exec:java" //NOI18N
+        "mojo-execute#exec:java", //NOI18N
+        "mojo-execute#javafx:run" //NOI18N
     };
     private final NbMavenProjectImpl project;
     


### PR DESCRIPTION
The Gluon JavaFX templates use the org.openjfx:javafx-maven-plugin maven plugin to run, as a result, the maven goal javafx:run was never treated the same as a normal Java application which uses the org.codehaus.mojo:exec-maven-plugin maven plugin.

I've added the goal javafx:run to the list of supported exec goals in `ExecPluginOutputListenerProvider.java`