### PR TITLE
[NETBEANS-4256] Fixed inconsistent xml fontcolor tag names.

### DIFF
--- a/ide/xml.lexer/src/org/netbeans/api/xml/lexer/XMLTokenId.java
+++ b/ide/xml.lexer/src/org/netbeans/api/xml/lexer/XMLTokenId.java
@@ -67,9 +67,9 @@ public enum XMLTokenId implements TokenId {
     /* PI target <sample>&lt;?<b>target</b> content of pi ?></sample> */
     PI_TARGET("xml-pi-target"),
     /* PI conetnt <sample>&lt;?target <b>content of pi </b>?></sample> */
-    PI_CONTENT("pi-content"),
+    PI_CONTENT("xml-pi-content"),
     /* PI end delimiter <sample>&lt;?target <content of pi <b>?></b></sample> */
-    PI_END("pi-end"),
+    PI_END("xml-pi-end"),
     /** Cdata section including its delimiters. */
     CDATA_SECTION("xml-cdata-section");
 

--- a/ide/xml.text/src/org/netbeans/modules/xml/text/resources/Bundle.properties
+++ b/ide/xml.text/src/org/netbeans/modules/xml/text/resources/Bundle.properties
@@ -38,8 +38,8 @@ xml-ws=Markup Whitespace
 xml-operator=Operators
 xml-EOL=New Line (deprecated)
 xml-pi-start=PI Start Delimiter
-pi-end=PI End Delimiter
-pi-target=PI Target
+xml-pi-end=PI End Delimiter
+xml-pi-target=PI Target
 xml-pi-content=PI Content
 xml-cdata-section=CDATA Section
 

--- a/ide/xml.text/src/org/netbeans/modules/xml/text/resources/XML-fontsColors.xml
+++ b/ide/xml.text/src/org/netbeans/modules/xml/text/resources/XML-fontsColors.xml
@@ -31,8 +31,8 @@
     </fontcolor>
     <fontcolor name="xml-error" default="error"/>
     <fontcolor name="xml-operator" default="operator"/>
-    <fontcolor name="pi-content" foreColor="ff00007c" default="default"/>
-    <fontcolor name="pi-end" foreColor="ff00007c" default="default">
+    <fontcolor name="xml-pi-content" foreColor="ff00007c" default="default"/>
+    <fontcolor name="xml-pi-end" foreColor="ff00007c" default="default">
         <font style="bold"/>
     </fontcolor>
     <fontcolor name="xml-pi-start" foreColor="ff00007c" default="default">

--- a/ide/xml.text/test/qa-functional/src/org/netbeans/modules/xml/text/syntax/data/goldenfiles/ColoringTest/testXMLColoring.pass
+++ b/ide/xml.text/test/qa-functional/src/org/netbeans/modules/xml/text/syntax/data/goldenfiles/ColoringTest/testXMLColoring.pass
@@ -1,168 +1,168 @@
-pi-start: <?
-pi-target: xml
-ws:  
-pi-content: version="1.0" encoding="UTF-8" standalone="no"
-pi-end: ?>
-text: 
+xml-pi-start: <?
+xml-pi-target: xml
+xml-ws:  
+xml-pi-content: version="1.0" encoding="UTF-8" standalone="no"
+xml-pi-end: ?>
+xml-text: 
 
 
-comment: <!-- Created by mschovanek on October 25, 2000, 3:49 PM -->
-text: 
+xml-comment: <!-- Created by mschovanek on October 25, 2000, 3:49 PM -->
+xml-text: 
 
 
-pi-start: <?
-pi-target: target
-ws:  
-pi-content: processing instruction data
-pi-end: ?>
-text: 
+xml-pi-start: <?
+xml-pi-target: target
+xml-ws:  
+xml-pi-content: processing instruction data
+xml-pi-end: ?>
+xml-text: 
 
 
-doctype: <!DOCTYPE Books PUBLIC 
-value: "+//XML Test//EN"
-doctype:  
-value: "any.dtd"
-doctype:  [
-text: 
+xml-doctype: <!DOCTYPE Books PUBLIC 
+xml-value: "+//XML Test//EN"
+xml-doctype:  
+xml-value: "any.dtd"
+xml-doctype:  [
+xml-text: 
     
-doctype: <!ELEMENT Books (Product+,Price?)*>
-text:          
-doctype: <!ELEMENT Product (#PCDATA|Descript)*>
-text: 
+xml-doctype: <!ELEMENT Books (Product+,Price?)*>
+xml-text:          
+xml-doctype: <!ELEMENT Product (#PCDATA|Descript)*>
+xml-text: 
     
-doctype: <!ELEMENT Price (#PCDATA)>
-text:                   
-doctype: <!ENTITY % states SYSTEM 
-value: "states.dtd"
-doctype: >
-text: 
+xml-doctype: <!ELEMENT Price (#PCDATA)>
+xml-text:                   
+xml-doctype: <!ENTITY % states SYSTEM 
+xml-value: "states.dtd"
+xml-doctype: >
+xml-text: 
     
-ref: %states;
-text:                                     
-doctype: <!NOTATION eps SYSTEM 
-value: "ghg"
-doctype: >
-text: 
+xml-ref: %states;
+xml-text:                                     
+xml-doctype: <!NOTATION eps SYSTEM 
+xml-value: "ghg"
+xml-doctype: >
+xml-text: 
     
-doctype: <!ENTITY % Y 
-value: "INCLUDE"
-doctype: >
-text:                      
-pi-start: <?
-pi-target: format
-ws:  
-pi-content: Bold!
-pi-end: ?>
-text: 
+xml-doctype: <!ENTITY % Y 
+xml-value: "INCLUDE"
+xml-doctype: >
+xml-text:                      
+xml-pi-start: <?
+xml-pi-target: format
+xml-ws:  
+xml-pi-content: Bold!
+xml-pi-end: ?>
+xml-text: 
     
-doctype: <!ELEMENT XMLwithDTD (#PCDATA|ANY)*>
-text:         
-comment: <!-- FULL ATTLIST -->
-text: 
+xml-doctype: <!ELEMENT XMLwithDTD (#PCDATA|ANY)*>
+xml-text:         
+xml-comment: <!-- FULL ATTLIST -->
+xml-text: 
     
-doctype: <!NOTATION pdf SYSTEM 
-value: "xpdf"
-doctype: >
-text:                
-doctype: <!ELEMENT Image EMPTY>
-text: 
+xml-doctype: <!NOTATION pdf SYSTEM 
+xml-value: "xpdf"
+xml-doctype: >
+xml-text:                
+xml-doctype: <!ELEMENT Image EMPTY>
+xml-text: 
     
-doctype: <!ATTLIST Image                             src       ENTITY      #REQUIRED
+xml-doctype: <!ATTLIST Image                             src       ENTITY      #REQUIRED
       descr     CDATA       #IMPLIED            visible   CDATA       #FIXED      
-value: "true"
-doctype: 
+xml-value: "true"
+xml-doctype: 
       format    (jpg | gif) #IMPLIED            os        (unix | os2)             
-value: "unix"
-doctype: 
+xml-value: "unix"
+xml-doctype: 
       entity    ENTITY      #IMPLIED            entities  ENTITIES    #IMPLIED
       id        ID          #IMPLIED            idref     IDREF       #IMPLIED
       idrefs    IDREFS      #IMPLIED            nmtoken   NMTOKEN     #IMPLIED
       nmtokens  NMTOKENS    #IMPLIED            notation  NOTATION    (pdf|dvi) #IMPLIED>
-text: 
+xml-text: 
     
-comment: <!-- GENERAL ENTITY -->
-text:                      
-doctype: <!ENTITY company 
-value: "Tisk &amp; spol."
-doctype: >
-text: 
+xml-comment: <!-- GENERAL ENTITY -->
+xml-text:                      
+xml-doctype: <!ENTITY company 
+xml-value: "Tisk &amp; spol."
+xml-doctype: >
+xml-text: 
     
-doctype: <!ENTITY thorn 
-value: "&#222;"
-doctype: >
-text:                     
-comment: <!-- EXTERNAL ENTITY -->
-text: 
+xml-doctype: <!ENTITY thorn 
+xml-value: "&#222;"
+xml-doctype: >
+xml-text:                     
+xml-comment: <!-- EXTERNAL ENTITY -->
+xml-text: 
     
-doctype: <!ENTITY extern SYSTEM 
-value: "externalEntity.xml"
-doctype: >
-comment: <!-- PARAMETR ENTITY -->
-text: 
+xml-doctype: <!ENTITY extern SYSTEM 
+xml-value: "externalEntity.xml"
+xml-doctype: >
+xml-comment: <!-- PARAMETR ENTITY -->
+xml-text: 
    
-doctype: <!ENTITY % sourceinfo 
-value: "lang   CDATA #REQUIRED cprght CDATA #IMPLIED"
-doctype: >
-doctype: 
+xml-doctype: <!ENTITY % sourceinfo 
+xml-value: "lang   CDATA #REQUIRED cprght CDATA #IMPLIED"
+xml-doctype: >
+xml-doctype: 
 ]>
-text: 
+xml-text: 
 
 
-pi-start: <?
-pi-target: target
-ws:  
-pi-content: processing instruction data
-pi-end: ?>
-text: 
+xml-pi-start: <?
+xml-pi-target: target
+xml-ws:  
+xml-pi-content: processing instruction data
+xml-pi-end: ?>
+xml-text: 
 
 
-tag: <Books
-tag: >
-pi-start: <?
-pi-target: pi
-ws:  
-pi-content: data
-pi-end: ?>
-text: 
+xml-tag: <Books
+xml-tag: >
+xml-pi-start: <?
+xml-pi-target: pi
+xml-ws:  
+xml-pi-content: data
+xml-pi-end: ?>
+xml-text: 
   
-tag: <Product
-tag: >
-text: Product 1 - 
-ref: &#100;
-text:  
-ref: &gt;
-text:  
-ref: &#x99;
-text:   
+xml-tag: <Product
+xml-tag: >
+xml-text: Product 1 - 
+xml-ref: &#100;
+xml-text:  
+xml-ref: &gt;
+xml-text:  
+xml-ref: &#x99;
+xml-text:   
     
-tag: <Descript
-ws:  
-attribute: lang
-operator: =
-value: "x 
-ref: &lt;
-value:  
-ref: &#100;
-value:  value'''"
-tag: >
-text: text data made in 
-ref: &cz;
-tag: </Descript
-tag: >
-text: 
+xml-tag: <Descript
+xml-ws:  
+xml-attribute: lang
+xml-operator: =
+xml-value: "x 
+xml-ref: &lt;
+xml-value:  
+xml-ref: &#100;
+xml-value:  value'''"
+xml-tag: >
+xml-text: text data made in 
+xml-ref: &cz;
+xml-tag: </Descript
+xml-tag: >
+xml-text: 
     
-cdata-section: <![CDATA[CDATA <a a='"""&#x23;'><!----> <?t d?><!DOCTYPE Books PUBLIC "+//XML Test//EN" "any.dtd" [
+xml-cdata-section: <![CDATA[CDATA <a a='"""&#x23;'><!----> <?t d?><!DOCTYPE Books PUBLIC "+//XML Test//EN" "any.dtd" [
       ]></a>section data]]>
-text: 
+xml-text: 
     `1234567890-=\qwertyuiop[]asdfghjkl;'zxcvbnm,./
     ~!@#$%^*()_+|QWERTYUIOP{}ASDFGHJKL:"ZXCVBNM?
   
-tag: </Product
-tag: >
-text: 
+xml-tag: </Product
+xml-tag: >
+xml-text: 
 
-tag: </Books
-tag: >
-text: 
+xml-tag: </Books
+xml-tag: >
+xml-text: 
 
 


### PR DESCRIPTION
**Recommended Retest**

1. Start netbeans
2. Enter Options->Fonts & Colors
3. Select XML for the language
4. Select Pi Content
5. Change the Foreground color to something other than the default [0,0,124] (Which is illegible in FlatLafDark)
6. Note that the color in the preview box changes.  (The text `version="1.0"`)
6. Exit netbeans
7. Repeat steps 1-3
8. Verify `version="1.0"` is the newly selected color.

Note 1:  In the master branch (and many versions before that), after restarting netbeans, the color will be restored to the original [0,0,124]

Note 2:  This fix also fixes the name styling for the PI  Target and PI End Delimiter.