### PR TITLE
Symbol.islocal has been renamed in JDK 16, avoiding the use of it

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/builder/ElementsService.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/builder/ElementsService.java
@@ -182,7 +182,16 @@ public class ElementsService {
     }
     
     public boolean isLocal(Element element) {
-        return ((Symbol)element).isLocal();
+        Element encl = element.getEnclosingElement();
+        if (encl == null ||
+            encl.getKind() == ElementKind.PACKAGE ||
+            encl.getKind() == ElementKind.MODULE) {
+            return false;
+        }
+        if (encl.getKind().isClass() || encl.getKind().isInterface()) {
+            return isLocal(encl);
+        }
+        return true;
     }
     
     public CharSequence getFullName(Element element) {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/usages/SourceAnalyzerFactory.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/usages/SourceAnalyzerFactory.java
@@ -57,6 +57,7 @@ import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.SourceUtils;
 import org.netbeans.modules.java.source.ElementHandleAccessor;
+import org.netbeans.modules.java.source.builder.ElementsService;
 import org.netbeans.modules.java.source.indexing.JavaCustomIndexer;
 import org.netbeans.modules.java.source.parsing.FileObjects;
 import org.netbeans.modules.java.source.parsing.OutputFileManager;
@@ -280,6 +281,7 @@ public final class SourceAnalyzerFactory {
         private final Stack<Pair<BinaryName,String>> activeClass;
         private final Names names;
         private final Trees trees;
+        private final ElementsService elementsService;
         private final CompilationUnitTree cu;
         private final URL siblingUrl;
         private final String sourceName;
@@ -364,6 +366,7 @@ public final class SourceAnalyzerFactory {
             this.packageAnnotations = new HashSet<>();
             this.names = Names.instance(jt.getContext());
             this.trees = Trees.instance(jt);
+            this.elementsService = ElementsService.instance(jt.getContext());
             this.state = State.OTHER;
             this.cu = cu;
             this.signatureFiles = sigFiles;
@@ -645,7 +648,7 @@ public final class SourceAnalyzerFactory {
                             resourceName = activeClass.peek().second();
                         }
                         name = Pair.<BinaryName,String>of(
-                                BinaryName.create(className, sym.getKind(), sym.isLocal(), simpleNameStart),
+                                BinaryName.create(className, sym.getKind(), elementsService.isLocal(sym), simpleNameStart),
                                 resourceName);
                         nameFrom = 2;
                     } else {


### PR DESCRIPTION
Symbol.islocal (internal javac API) has been renamed in JDK 16, re-implementing using standard API to avoid the dependency on the internal API.