### PR TITLE
[NETBEANS-4783] Unselect added files from CDNJS by default

### DIFF
--- a/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/ui/FilesNode.java
+++ b/webcommon/javascript.cdnjs/src/org/netbeans/modules/javascript/cdnjs/ui/FilesNode.java
@@ -101,7 +101,7 @@ public class FilesNode extends AbstractNode {
 
         @Override
         protected Node[] createNodes(String key) {
-            boolean install = (installedFiles == null) || installedFiles.contains(key);
+            boolean install = (installedFiles != null) && installedFiles.contains(key);
             return new Node[] {new FileNode(key, install)};
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-4783

When adding new files from CDNJS new files are not selected by default.