### PR TITLE
[NETBEANS-5210] Export code inspection settings

### DIFF
--- a/ide/code.analysis/manifest.mf
+++ b/ide/code.analysis/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module: org.netbeans.modules.code.analysis/0
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/analysis/Bundle.properties
 OpenIDE-Module-Recommends: org.openide.windows.WindowManager
 OpenIDE-Module-Specification-Version: 1.37
-
+OpenIDE-Module-Layer: org/netbeans/modules/analysis/resources/layer.xml

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/Bundle.properties
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/Bundle.properties
@@ -24,3 +24,4 @@ RunAnalysisPanel.singleInspectionRadio.text=&Single Inspection:
 RunAnalysisPanel.browse.text=&Browse...
 DN_Default=Default
 RequiredPluginsPanel.warning.text=Additional plugins required for the selected configuration.
+Options.Export.Inspections.displayName=Code Inspections

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/resources/layer.xml
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/resources/layer.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
+<filesystem>
+
+    <folder name="OptionsExport">
+        <folder name="Advanced">
+            <file name="Inspections">
+                <attr name="include" stringvalue="config/Preferences/org/netbeans/modules/code/analysis/.*"/>
+                <attr name="displayName" bundlevalue="org.netbeans.modules.analysis.Bundle#Options.Export.Inspections.displayName"/>
+            </file>
+        </folder>
+    </folder>
+
+</filesystem>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5210

Inspection settings (from Code > Inspect) can be exported from Tools > Options.
Settings are registered under Miscellaneous > Code Inspections.