### PR TITLE
[NETBEANS-5214] Fix handling of global values

### DIFF
--- a/ide/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarResolver.java
+++ b/ide/css.lib/src/org/netbeans/modules/css/lib/api/properties/GrammarResolver.java
@@ -287,12 +287,12 @@ public class GrammarResolver {
                     InputState beforeState = createInputState();
                     List<ValueGrammarElement> matching = new ArrayList<>(globalValues.length);
                     for(ValueGrammarElement vge: globalValues) {
-                        backupInputState(beforeState);
                         if(processValue(vge)) {
                             matching.add(vge);
                         } else {
                             valueNotAccepted(vge);
                         }
+                        backupInputState(beforeState);
                     }
                     if(! matching.isEmpty()) {
                         boolean matched = processValue(matching.get(0));

--- a/ide/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/GrammarResolverTest.java
+++ b/ide/css.lib/test/unit/src/org/netbeans/modules/css/lib/api/properties/GrammarResolverTest.java
@@ -852,4 +852,15 @@ public class GrammarResolverTest extends CssTestBase {
     }
     
 
+    public void testGlobalValuesAreResolved() {
+        String grammar = "a";
+
+        // Baseline matching - validate, that grammar works
+        assertResolve(grammar, "a");
+
+        // Verify that the global values unset, inherit and initial are matched
+        assertResolve(grammar, "unset");
+        assertResolve(grammar, "inherit");
+        assertResolve(grammar, "initial");
+    }
 }


### PR DESCRIPTION
When checking the global values, the input state needs to be reset after
the possible values are checked. Before this change the right grammar
element was found, but then could not be processed, because the state
of the input was already changed by the checking.