### PR TITLE
[NETBEANS-5025] Fix wheel/trackpad scrolling in Options > Fonts & Colors > Syntax > Preview area

### DIFF
--- a/ide/options.editor/src/org/netbeans/modules/options/colors/SyntaxColoringPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/colors/SyntaxColoringPanel.java
@@ -171,6 +171,9 @@ public class SyntaxColoringPanel extends JPanel implements ActionListener,
                 }
             }
         );
+
+        spPreview.getVerticalScrollBar().setUnitIncrement(10);
+        spPreview.getHorizontalScrollBar().setUnitIncrement(10);
     }
     
     private void updateLanguageCombobox() {


### PR DESCRIPTION
Scrolling using mouse wheel (or scroll arrow buttons) in "Options > Fonts & Colors > Syntax > Preview area" (select language "Yaml") is very slow (1-3 pixel) because a `JPanel` is used as view in a `JScrollPane`. Since `JPanel` does not implement the `javax.swing.Scrollable` interface, the scrollpane uses a unit increment of 1. So clicking scroll arrow arrows (or rotating mouse wheel one tick) scrolls only 1-3 pixel (depending on OS and scroll amount specified in OS settings).

This fix simply sets unit increment to 10.

This is similar to other code in NB:
https://github.com/apache/netbeans/search?q=setUnitIncrement

This affects all Lafs.

For FlatLaf, this also improves smooth scrolling (using trackpad) reported here:
https://issues.apache.org/jira/browse/NETBEANS-5025