### PR TITLE
Renaming modified src.java file leads to Cannot save src.java error. Hotfix.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayer.java
@@ -46,6 +46,22 @@ public class AbstractDialogDisplayer extends DialogDisplayer {
     @Override
     public Object notify(NotifyDescriptor descriptor) {
         LspServerUtils.avoidClientMessageThread(context);
+
+        // XXX: Subject to better fix
+        // XXX: Possibly use 3.16 protocol's willRename/didRename
+        // XXX: when available
+        StackTraceElement[] stack = new Exception().getStackTrace();
+        if (stack.length > 2 && stack[1] != null) {
+            if (
+                "org.openide.text.DataEditorSupport".equals(stack[1].getClassName()) &&
+                "canClose".equals(stack[1].getMethodName())
+            ) {
+                // when VSCode renames modified file, don't try to save the
+                // original
+                return NotifyDescriptor.CLOSED_OPTION;
+            }
+        }
+
         UIContext ctx = UIContext.find(context);
         NotifyDescriptorAdapter adapter = new NotifyDescriptorAdapter(descriptor, ctx);
         return adapter.clientNotify();


### PR DESCRIPTION
Using VSNB ext 12.2.252 and GraalVM 21.1.0 JDK8 CE build.

* Create Micronaut App project - see [wiki](https://cwiki.apache.org/confluence/display/NETBEANS/Apache+NetBeans+extension+for+Visual+Studio+Code)
* Click icon in Explorer to add file, name it e.g. "HellController.java"
* paste in content for HelloController.java sample.
* Rename the file in VSCode explorer to "HelloController.java"
* VSNetBeans complains file was changed on disk and has to be reloaded.
* Check the PROBLEMS window in VSCode it still lists "HellController.java" as having improperly named class.
* Press F5 for debugging the project it prints to console   :
```
        Info: Saving HellController ...
        Info: Save All finished.
        and dialog appears with "Cannot save HellController" message from VSNB ext
```
*    Close the folder with project and open again and it starts behave correctly

The PR workarounds the problem by not showing the "complains file was changed on disk and has to be reloaded". There may be better fixes, especially when `lsp4j` starts to fully support 3.16 protocol which contains notifications like `willRename`/`didRename`.
