### PR TITLE
Support executor ProgressHandle cancel over DAP protocol.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/DebugAdapterContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/DebugAdapterContext.java
@@ -33,6 +33,8 @@ import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 
 import org.netbeans.modules.java.lsp.server.debugging.breakpoints.BreakpointsManager;
 import org.netbeans.modules.java.lsp.server.debugging.launch.NbDebugSession;
+import org.netbeans.modules.java.lsp.server.progress.LspInternalHandle;
+import org.netbeans.modules.progress.spi.InternalHandle;
 import org.openide.util.Pair;
 
 public final class DebugAdapterContext {
@@ -50,6 +52,7 @@ public final class DebugAdapterContext {
     private Charset debuggeeEncoding;
     private boolean isVmStopOnEntry = false;
     private boolean isDebugMode = true;
+    private InternalHandle processExecutorHandle;
 
     private final AtomicInteger lastSourceReferenceId = new AtomicInteger(0);
     private final Map<Integer, Pair<URI, String>> sourcesById = new ConcurrentHashMap<>();
@@ -115,6 +118,19 @@ public final class DebugAdapterContext {
 
     void setClientPathsAreUri(boolean clientPathsAreUri) {
         this.clientPathsAreUri = clientPathsAreUri;
+    }
+    
+    public boolean requestProcessTermination() {
+        if (processExecutorHandle != null) {
+            ((LspInternalHandle)processExecutorHandle).forceRequestCancel();
+            return true;
+        } else {
+            return false;
+        }
+    }
+    
+    public void setProcessExecutorHandle(InternalHandle h) {
+        this.processExecutorHandle = h;
     }
 
     public String getClientPath(String debuggerPath) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/DebugAdapterContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/DebugAdapterContext.java
@@ -121,8 +121,12 @@ public final class DebugAdapterContext {
     }
     
     public boolean requestProcessTermination() {
-        if (processExecutorHandle != null) {
-            ((LspInternalHandle)processExecutorHandle).forceRequestCancel();
+        InternalHandle ih;
+        synchronized (this) {
+            ih = processExecutorHandle;
+        }
+        if (ih != null) {
+            ((LspInternalHandle)ih).forceRequestCancel();
             return true;
         } else {
             return false;
@@ -130,7 +134,9 @@ public final class DebugAdapterContext {
     }
     
     public void setProcessExecutorHandle(InternalHandle h) {
-        this.processExecutorHandle = h;
+        synchronized (this) {
+            this.processExecutorHandle = h;
+        }
     }
 
     public String getClientPath(String debuggerPath) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbDisconnectRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbDisconnectRequestHandler.java
@@ -45,6 +45,8 @@ public final class NbDisconnectRequestHandler {
             } else {
                 debugSession.detach();
             }
+        } else {
+            context.requestProcessTermination();
         }
     }
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -22,6 +22,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
@@ -41,6 +42,8 @@ import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.java.lsp.server.debugging.DebugAdapterContext;
 import org.netbeans.modules.java.lsp.server.debugging.NbSourceProvider;
+import org.netbeans.modules.java.lsp.server.progress.OperationContext;
+import org.netbeans.modules.progress.spi.InternalHandle;
 import org.netbeans.spi.project.ActionProgress;
 import org.netbeans.spi.project.ActionProvider;
 import org.openide.filesystems.FileObject;
@@ -114,6 +117,12 @@ public abstract class NbLaunchDelegate {
             );
             Lookups.executeWith(launchCtx, () -> {
                 providerAndCommand.first().invokeAction(providerAndCommand.second(), Lookups.fixed(toRun, ioContext, progress));
+                
+                OperationContext ctx = OperationContext.find(Lookup.getDefault());
+                List<InternalHandle> created = ctx.getOperationHandles();
+                if (!created.isEmpty()) {
+                    context.setProcessExecutorHandle(created.get(0));
+                }
             });
         }).exceptionally((t) -> {
             launchFuture.completeExceptionally(t);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/LspInternalHandle.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/LspInternalHandle.java
@@ -56,6 +56,8 @@ public class LspInternalHandle extends InternalHandle {
      */
     private boolean started;
     
+    private boolean explicitCancelRequest;
+    
     private static Field controllerField;
 
     public LspInternalHandle(OperationContext opContext, 
@@ -65,6 +67,19 @@ public class LspInternalHandle extends InternalHandle {
         this.lspClient = lspClient;
         this.opContext = opContext;
         this.controllerProvider = controllerProvider;
+        if (opContext != null) {
+            opContext.internalHandleCreated(this);
+        }
+    }
+
+    public void forceRequestCancel() {
+        explicitCancelRequest = true;
+        requestCancel();
+    }
+
+    @Override
+    public boolean isAllowCancel() {
+        return super.isAllowCancel() && (explicitCancelRequest || !opContext.isDisableCancels());
     }
 
     public OperationContext getContext() {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/OperationContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/OperationContext.java
@@ -190,9 +190,6 @@ public final class OperationContext {
     }
     
     private Either<String, Number> addHandle(Either<String, Number> token, InternalHandle h) {
-        synchronized (this) {
-            createdHandles.add(h);
-        }
         top.registerHandle(token, h);
         return token;
     }
@@ -265,5 +262,11 @@ public final class OperationContext {
     
     public synchronized List<InternalHandle> getOperationHandles() {
         return new ArrayList<>(createdHandles);
+    }
+    
+    void internalHandleCreated(InternalHandle h) {
+        synchronized (this) {
+            createdHandles.add(h);
+        }
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractProgressEnvironment.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractProgressEnvironment.java
@@ -82,7 +82,7 @@ public abstract class AbstractProgressEnvironment implements ProgressEnvironment
             }
             client = ctx.getClient();
         }
-        if (c != null && (ctx.isDisableCancels() || maskCancellablesPattern().matcher(c.getClass().getName()).matches())) {
+        if (c != null && maskCancellablesPattern().matcher(c.getClass().getName()).matches()) {
             c = null;
         }
         return new LspInternalHandle(


### PR DESCRIPTION
Followup to the previous ProgressHandle PRs. Changes the way `OperationContext` records created handles: they are recorded as soon as the `InternalHandle` instance is created (so it may not be started at the time someone calls `getHandles`).

The DAP server is then able to collect ProgressHandles created during the course of `invokeAction` call; hopefully the 1st will be the handle to the Executor.