### PR TITLE
Let Mutex.EVENT methods co-operate with Lookups.executeWith(...)

### DIFF
--- a/platform/openide.util.ui/src/org/netbeans/modules/openide/util/NbMutexEventProvider.java
+++ b/platform/openide.util.ui/src/org/netbeans/modules/openide/util/NbMutexEventProvider.java
@@ -24,9 +24,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.openide.util.BaseUtilities;
+import org.openide.util.Lookup;
 import org.openide.util.Mutex;
 import org.openide.util.MutexException;
 import org.openide.util.Union2;
+import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.spi.MutexEventProvider;
 import org.openide.util.spi.MutexImplementation;
@@ -94,7 +96,10 @@ public class NbMutexEventProvider implements MutexEventProvider {
            if (EventQueue.isDispatchThread()) {
                run.run();
            } else {
-               EventQueue.invokeLater(run);
+               Lookup inherit = Lookup.getDefault();
+               EventQueue.invokeLater(() -> {
+                   Lookups.executeWith(inherit, run);
+               });
            }
        }
 
@@ -102,7 +107,10 @@ public class NbMutexEventProvider implements MutexEventProvider {
         * @param run runabble to post later
         */
         private static void doEventRequest(Runnable run) {
-            EventQueue.invokeLater(run);
+            Lookup inherit = Lookup.getDefault();
+            EventQueue.invokeLater(() -> {
+                Lookups.executeWith(inherit, run);
+            });
         }
 
         /** Methods for access to event queue and waiting for result.
@@ -124,22 +132,25 @@ public class NbMutexEventProvider implements MutexEventProvider {
             final AtomicBoolean started = new AtomicBoolean(); // #210991
             final AtomicBoolean finished = new AtomicBoolean();
             final AtomicBoolean invoked = new AtomicBoolean();
+            final Lookup inherit = Lookup.getDefault();
             try {
                 class AWTWorker implements Runnable {
                     @Override
                     public void run() {
                         started.set(true);
-                        try {
-                            res.set(Union2.<T,Throwable>createFirst(run.run()));
-                        } catch (Exception e) {
-                            res.set(Union2.<T,Throwable>createSecond(e));
-                        } catch (LinkageError e) {
-                            // #20467
-                            res.set(Union2.<T,Throwable>createSecond(e));
-                        } catch (StackOverflowError e) {
-                            // #20467
-                            res.set(Union2.<T,Throwable>createSecond(e));
-                        }
+                        Lookups.executeWith(inherit, () -> {
+                            try {
+                                res.set(Union2.<T,Throwable>createFirst(run.run()));
+                            } catch (Exception e) {
+                                res.set(Union2.<T,Throwable>createSecond(e));
+                            } catch (LinkageError e) {
+                                // #20467
+                                res.set(Union2.<T,Throwable>createSecond(e));
+                            } catch (StackOverflowError e) {
+                                // #20467
+                                res.set(Union2.<T,Throwable>createSecond(e));
+                            }
+                        });
                         finished.set(true);
                     }
                 }

--- a/platform/openide.util.ui/test/unit/src/org/netbeans/modules/openide/util/NbMutexEventProviderTest.java
+++ b/platform/openide.util.ui/test/unit/src/org/netbeans/modules/openide/util/NbMutexEventProviderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.openide.util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Consumer;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.openide.util.Lookup;
+import org.openide.util.Mutex;
+import org.openide.util.Mutex.Action;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ProxyLookup;
+
+public class NbMutexEventProviderTest {
+
+    public NbMutexEventProviderTest() {
+    }
+
+    @Test
+    public void lookupPropagationReadAccessRunnable() throws Exception {
+        performTest(Mutex.EVENT::readAccess);
+    }
+
+    @Test
+    public void lookupPropagationReadAccessAction() throws Exception {
+        performTest((r) -> {
+            Mutex.EVENT.readAccess((Action) () -> {
+                r.run();
+                return null;
+            });
+        });
+    }
+
+    @Test
+    public void lookupPropagationWriteAccessRunnable() throws Exception {
+        performTest(Mutex.EVENT::writeAccess);
+    }
+
+    @Test
+    public void lookupPropagationWriteAccessAction() throws Exception {
+        performTest((r) -> {
+            Mutex.EVENT.writeAccess((Action) () -> {
+                r.run();
+                return null;
+            });
+        });
+    }
+
+    @Test
+    public void lookupPropagationPostReadRequest() throws Exception {
+        performTest(Mutex.EVENT::postReadRequest);
+    }
+
+    @Test
+    public void lookupPropagationPostWriteRequest() throws Exception {
+        performTest(Mutex.EVENT::postWriteRequest);
+    }
+
+    private void performTest(Consumer<Runnable> enterEventQueue) throws InterruptedException {
+        Token token = new Token();
+        CountDownLatch cdl = new CountDownLatch(1);
+        Error[] observedError = { null };
+        assertLookupGlobalToken("No token yet", null);
+        final Lookup compound = new ProxyLookup(Lookups.singleton(token), Lookup.getDefault());
+        Lookups.executeWith(compound, () -> {
+            assertLookupGlobalToken("Set now", token);
+            enterEventQueue.accept(() -> {
+                try {
+                    assertLookupGlobalToken("availableInReadAccess", token);
+                } catch (Error err) {
+                    observedError[0] = err;
+                } finally {
+                    cdl.countDown();
+                }
+            });
+        });
+        assertLookupGlobalToken("No token again", null);
+        cdl.await();
+        if (observedError[0] != null) {
+            throw observedError[0];
+        }
+        assertLookupGlobalToken("No token still", null);
+    }
+
+    private void assertLookupGlobalToken(String msg, Token expected) {
+        Token actual = Lookup.getDefault().lookup(Token.class);
+        assertSame(msg, expected, actual);
+    }
+
+    private static final class Token {
+    }
+}

--- a/platform/openide.util/apichanges.xml
+++ b/platform/openide.util/apichanges.xml
@@ -26,6 +26,23 @@
         <apidef name="xml_base">XML API</apidef>
     </apidefs>
     <changes>
+        <change id="lookup-mutex-event">
+            <api name="util_base"/>
+            <summary>Propagate current Lookup via Mutex.EVENT</summary>
+            <version major="9" minor="18"/>
+            <date year="2021" month="1" day="10"/>
+            <author login="jtulach"/>
+            <compatibility addition="yes" binary="compatible" source="compatible"/>
+            <description>
+                <p>
+                    <a href="@TOP@/org/openide/util/Mutex.html#EVENT">Mutex.EVENT</a>
+                    methods have been enhanced to work well with
+                    <a href="@org-openide-util-lookup@/org/openide/util/lookup/Lookups.html#executeWith-org.openide.util.Lookup-java.lang.Runnable-">Lookups.executeWith(...)</a>.
+                </p>
+            </description>
+            <class package="org.openide.util" name="Mutex"/>
+            <issue number="188604"/>
+        </change>
     <change id="weak-listen-on-specific-property">
         <api name="util_base"/>
         <summary>Weak property and vetoable listeners for a specific property name.</summary>

--- a/platform/openide.util/manifest.mf
+++ b/platform/openide.util/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.util
 OpenIDE-Module-Localizing-Bundle: org/openide/util/base/Bundle.properties
-OpenIDE-Module-Specification-Version: 9.17
+OpenIDE-Module-Specification-Version: 9.18
 

--- a/platform/openide.util/src/org/openide/util/Mutex.java
+++ b/platform/openide.util/src/org/openide/util/Mutex.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 import org.openide.util.MutexException;
 import org.netbeans.modules.openide.util.DefaultMutexImplementation;
 import org.netbeans.modules.openide.util.LazyMutexImplementation;
+import org.openide.util.lookup.Lookups;
 import org.openide.util.spi.MutexEventProvider;
 import org.openide.util.spi.MutexImplementation;
 
@@ -113,6 +114,11 @@ public final class Mutex {
      *  unless the current thread is the event dispatch thread, in which case
      *  <code>action.run()</code> is immediately executed.
      * </UL>
+     * <p>
+     * Since version 9.18 the methods of the {@code EVENT} instance properly
+     * understand semantics of {@link Lookups#executeWith(org.openide.util.Lookup, java.lang.Runnable)}
+     * method and propagate the effective {@link Lookup} to the event dispatch
+     * thread.
      */
     public static final Mutex EVENT;
     static {


### PR DESCRIPTION
While working on #2652 it turned out that `OpenProjectList` class is using `Mutex.EVENT` to deliver changes and that the call disassociates the event deliver from the originating request. One option is to modify `OpenProjectList` to deliver events synchronously (at least in `GraphicsEnvironment.isHeadless()` mode, the other is to make sure effective lookup set by `Lookups.executeWith` is properly propagated through `Mutext.EVENT` methods. That's what this PR proposes.