### PR TITLE
Various fixes for LSP codeAction and rename requests.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateClassFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/CreateClassFix.java
@@ -309,7 +309,7 @@ public abstract class CreateClassFix extends CreateFixBase implements EnhancedFi
                             source = make.Class(make.Modifiers(EnumSet.of(Modifier.PUBLIC)), simpleName, Collections.<TypeParameterTree>emptyList(), null, Collections.<Tree>emptyList(), Collections.<Tree>emptyList());
                             break;
                         case INTERFACE:
-                            source = make.Interface(make.Modifiers(EnumSet.of(Modifier.PUBLIC)), simpleName, Collections.<TypeParameterTree>emptyList(), null, Collections.<Tree>emptyList());
+                            source = make.Interface(make.Modifiers(EnumSet.of(Modifier.PUBLIC)), simpleName, Collections.<TypeParameterTree>emptyList(), Collections.<Tree>emptyList(), Collections.<Tree>emptyList());
                             break;
                         case ANNOTATION_TYPE:
                             source = make.AnnotationType(make.Modifiers(EnumSet.of(Modifier.PUBLIC)), simpleName, Collections.<Tree>emptyList());

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceExpressionBasedMethodFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceExpressionBasedMethodFix.java
@@ -200,7 +200,16 @@ final class IntroduceExpressionBasedMethodFix extends IntroduceFixBase implement
 
     @Override
     public ModificationResult getModificationResult() throws IOException {
-        return getModificationResult("method", targets.iterator().next(), true, EnumSet.of(Modifier.PRIVATE), false, null);
+        ModificationResult result = null;
+        int counter = 0;
+        do {
+            try {
+                result = getModificationResult("method" + (counter != 0 ? String.valueOf(counter) : ""), targets.iterator().next(), true, EnumSet.of(Modifier.PRIVATE), false, null);
+            } catch (Exception e) {
+                counter++;
+            }
+        } while (result == null && counter < 10);
+        return result;
     }
 
     private ModificationResult getModificationResult(final String name, final TargetDescription target, final boolean replaceOther, final Set<Modifier> access, final boolean redoReferences, final MemberSearchResult searchResult) throws IOException {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceExpressionBasedMethodFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceExpressionBasedMethodFix.java
@@ -27,6 +27,7 @@ import com.sun.source.tree.Tree;
 import com.sun.source.tree.TypeParameterTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
+import java.awt.GraphicsEnvironment;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -259,7 +260,7 @@ final class IntroduceExpressionBasedMethodFix extends IntroduceFixBase implement
                         TreePath firstLeaf = desc.getOccurrenceRoot();
                         int startOff = (int) copy.getTrees().getSourcePositions().getStartPosition(copy.getCompilationUnit(), firstLeaf.getLeaf());
                         int endOff = (int) copy.getTrees().getSourcePositions().getEndPosition(copy.getCompilationUnit(), firstLeaf.getLeaf());
-                        if (!IntroduceHint.shouldReplaceDuplicate(doc, startOff, endOff)) {
+                        if (!GraphicsEnvironment.isHeadless() && !IntroduceHint.shouldReplaceDuplicate(doc, startOff, endOff)) {
                             continue;
                         }
                         //XXX:

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodFix.java
@@ -439,7 +439,16 @@ public final class IntroduceMethodFix extends IntroduceFixBase implements Fix {
 
     @Override
     public ModificationResult getModificationResult() throws IOException {
-        return js.runModificationTask(new TaskImpl(EnumSet.of(Modifier.PRIVATE), "method", targets.iterator().next(), true, null, false));
+        ModificationResult result = null;
+        int counter = 0;
+        do {
+            try {
+                result = js.runModificationTask(new TaskImpl(EnumSet.of(Modifier.PRIVATE), "method" + (counter != 0 ? String.valueOf(counter) : ""), targets.iterator().next(), true, null, false));
+            } catch (Exception e) {
+                counter++;
+            }
+        } while (result == null && counter < 10);
+        return result;
     }
 
     static class OccurrencePositionComparator implements Comparator<Occurrence> {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/introduce/IntroduceMethodFix.java
@@ -35,6 +35,7 @@ import com.sun.source.tree.TypeParameterTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
+import java.awt.GraphicsEnvironment;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -863,7 +864,7 @@ public final class IntroduceMethodFix extends IntroduceFixBase implements Fix {
                     int startOff = (int) copy.getTrees().getSourcePositions().getStartPosition(copy.getCompilationUnit(), firstSt);
                     int endOff = (int) copy.getTrees().getSourcePositions().getEndPosition(copy.getCompilationUnit(), lastSt);
                     
-                    if (usedAfter || !IntroduceHint.shouldReplaceDuplicate(doc, startOff, endOff)) {
+                    if (usedAfter || !GraphicsEnvironment.isHeadless() && !IntroduceHint.shouldReplaceDuplicate(doc, startOff, endOff)) {
                         continue;
                     }
                     List<StatementTree> newStatements = new LinkedList<StatementTree>();

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspServerUtils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspServerUtils.java
@@ -85,7 +85,7 @@ public class LspServerUtils {
     public static final void avoidClientMessageThread(Lookup context) {
         NbCodeLanguageClient client = LspServerUtils.findLspClient(context);
         if (LspServerUtils.isClientResponseThread(client)) {
-            throw new IllegalStateException("Can not block LSP server message loop. Use RequestProcessor to run the calling code, or use notifyLater()");
+            throw new IllegalStateException("Cannot block LSP server message loop. Use RequestProcessor to run the calling code, or use notifyLater()");
         }
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -121,6 +121,7 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.TextDocumentService;
@@ -162,6 +163,7 @@ import org.netbeans.modules.java.hints.spiimpl.JavaFixImpl;
 import org.netbeans.modules.java.hints.spiimpl.hints.HintsInvoker;
 import org.netbeans.modules.java.hints.spiimpl.options.HintsSettings;
 import org.netbeans.modules.java.lsp.server.Utils;
+import org.netbeans.modules.java.lsp.server.debugging.utils.ErrorUtilities;
 import org.netbeans.modules.java.source.ElementHandleAccessor;
 import org.netbeans.modules.java.source.ui.ElementOpenAccessor;
 import org.netbeans.modules.parsing.api.ParserManager;
@@ -901,18 +903,18 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                 p = query[0].checkParameters();
                 if (cancel.get()) return ;
                 if (p != null && p.isFatal()) {
-                    result.completeExceptionally(new IllegalStateException(p.getMessage()));
+                    ErrorUtilities.completeExceptionally(result, p.getMessage(), ResponseErrorCode.UnknownErrorCode);
                     return ;
                 }
                 p = query[0].preCheck();
                 if (p != null && p.isFatal()) {
-                    result.completeExceptionally(new IllegalStateException(p.getMessage()));
+                    ErrorUtilities.completeExceptionally(result, p.getMessage(), ResponseErrorCode.UnknownErrorCode);
                     return ;
                 }
                 if (cancel.get()) return ;
                 p = query[0].prepare(refactoring);
                 if (p != null && p.isFatal()) {
-                    result.completeExceptionally(new IllegalStateException(p.getMessage()));
+                    ErrorUtilities.completeExceptionally(result, p.getMessage(), ResponseErrorCode.UnknownErrorCode);
                     return ;
                 }
                 for (RefactoringElement re : refactoring.getRefactoringElements()) {
@@ -1391,18 +1393,18 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                 p = refactoring[0].checkParameters();
                 if (cancel.get()) return ;
                 if (p != null && p.isFatal()) {
-                    result.completeExceptionally(new IllegalStateException(p.getMessage()));
+                    ErrorUtilities.completeExceptionally(result, p.getMessage(), ResponseErrorCode.UnknownErrorCode);
                     return ;
                 }
                 p = refactoring[0].preCheck();
                 if (p != null && p.isFatal()) {
-                    result.completeExceptionally(new IllegalStateException(p.getMessage()));
+                    ErrorUtilities.completeExceptionally(result, p.getMessage(), ResponseErrorCode.UnknownErrorCode);
                     return ;
                 }
                 if (cancel.get()) return ;
                 p = refactoring[0].prepare(session);
                 if (p != null && p.isFatal()) {
-                    result.completeExceptionally(new IllegalStateException(p.getMessage()));
+                    ErrorUtilities.completeExceptionally(result, p.getMessage(), ResponseErrorCode.UnknownErrorCode);
                     return ;
                 }
                 //TODO: check client capabilities!

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1198,32 +1198,35 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                     for (ErrorDescription err : IntroduceHint.computeError(cc, Utils.getOffset(doc, range.getStart()), Utils.getOffset(doc, range.getEnd()), new EnumMap<IntroduceKind, Fix>(IntroduceKind.class), new EnumMap<IntroduceKind, String>(IntroduceKind.class), new AtomicBoolean())) {
                         for (Fix fix : err.getFixes().getFixes()) {
                             if (fix instanceof IntroduceFixBase) {
-                                ModificationResult changes = ((IntroduceFixBase) fix).getModificationResult();
-                                if (changes != null) {
-                                    List<Either<TextDocumentEdit, ResourceOperation>> documentChanges = new ArrayList<>();
-                                    Set<? extends FileObject> fos = changes.getModifiedFileObjects();
-                                    if (fos.size() == 1) {
-                                        FileObject fileObject = fos.iterator().next();
-                                        List<? extends ModificationResult.Difference> diffs = changes.getDifferences(fileObject);
-                                        if (diffs != null) {
-                                            List<TextEdit> edits = new ArrayList<>();
-                                            for (ModificationResult.Difference diff : diffs) {
-                                                String newText = diff.getNewText();
-                                                edits.add(new TextEdit(new Range(Utils.createPosition(fileObject, diff.getStartPosition().getOffset()),
-                                                                                 Utils.createPosition(fileObject, diff.getEndPosition().getOffset())),
-                                                                       newText != null ? newText : ""));
+                                try {
+                                    ModificationResult changes = ((IntroduceFixBase) fix).getModificationResult();
+                                    if (changes != null) {
+                                        List<Either<TextDocumentEdit, ResourceOperation>> documentChanges = new ArrayList<>();
+                                        Set<? extends FileObject> fos = changes.getModifiedFileObjects();
+                                        if (fos.size() == 1) {
+                                            FileObject fileObject = fos.iterator().next();
+                                            List<? extends ModificationResult.Difference> diffs = changes.getDifferences(fileObject);
+                                            if (diffs != null) {
+                                                List<TextEdit> edits = new ArrayList<>();
+                                                for (ModificationResult.Difference diff : diffs) {
+                                                    String newText = diff.getNewText();
+                                                    edits.add(new TextEdit(new Range(Utils.createPosition(fileObject, diff.getStartPosition().getOffset()),
+                                                                                     Utils.createPosition(fileObject, diff.getEndPosition().getOffset())),
+                                                                           newText != null ? newText : ""));
+                                                }
+                                                documentChanges.add(Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(Utils.toUri(fileObject), -1), edits)));
                                             }
-                                            documentChanges.add(Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(Utils.toUri(fileObject), -1), edits)));
+                                            CodeAction codeAction = new CodeAction(fix.getText());
+                                            codeAction.setKind(CodeActionKind.RefactorExtract);
+                                            codeAction.setEdit(new WorkspaceEdit(documentChanges));
+                                            int renameOffset = ((IntroduceFixBase) fix).getNameOffset(changes);
+                                            if (renameOffset >= 0) {
+                                                codeAction.setCommand(new Command("Rename", "java.rename.element.at", Collections.singletonList(renameOffset)));
+                                            }
+                                            result.add(Either.forRight(codeAction));
                                         }
-                                        CodeAction codeAction = new CodeAction(fix.getText());
-                                        codeAction.setKind(CodeActionKind.RefactorExtract);
-                                        codeAction.setEdit(new WorkspaceEdit(documentChanges));
-                                        int renameOffset = ((IntroduceFixBase) fix).getNameOffset(changes);
-                                        if (renameOffset >= 0) {
-                                            codeAction.setCommand(new Command("Rename", "java.rename.element.at", Collections.singletonList(renameOffset)));
-                                        }
-                                        result.add(Either.forRight(codeAction));
                                     }
+                                } catch (GeneratorUtils.DuplicateMemberException dme) {
                                 }
                             }
                         }

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -29,7 +29,7 @@ import {
     Message,
     MessageType,
     LogMessageNotification,
-    HandlerResult
+    RevealOutputChannelOn
 } from 'vscode-languageclient';
 
 import * as net from 'net';
@@ -395,7 +395,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                 ]
             },
             outputChannel: log,
-            revealOutputChannelOn: 3, // error
+            revealOutputChannelOn: RevealOutputChannelOn.Never,
             progressOnInitialization: true,
             initializationOptions : {
                 'nbcodeCapabilities' : {


### PR DESCRIPTION
- [GR-28602] Request textDocument/codeAction failed when selecting source code for Introduce var refactor
- [GR-28596] Implementing an interface results in NullPointerException
- [GR-28601] GeneratorUtils$DuplicateMemberException: Class member already exists form Generate Constructor source action
- [GR-28604] GeneratorUtils$DuplicateMemberException: Class member already exists thrown from introduce element hints
- [GR-28614] IllegalStateException from Rename Symbol
