### PR TITLE
[NETBEANS-5228] Enable 'return' breakpoint in PHP debugger

### DIFF
--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/ui/DbgpMethodBreakpointPanel.form
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/ui/DbgpMethodBreakpointPanel.form
@@ -53,16 +53,11 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="1" attributes="0">
-                  <Group type="102" attributes="0">
-                      <Component id="myStopOnLbl" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" pref="31" max="-2" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="1" attributes="0">
-                      <Component id="myMethodLbl" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                  </Group>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="myMethodLbl" min="-2" max="-2" attributes="0"/>
+                  <Component id="myStopOnLbl" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
+              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="myStopType" min="-2" max="-2" attributes="0"/>
                   <Component id="myMethodName" pref="189" max="32767" attributes="0"/>

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/ui/DbgpMethodBreakpointPanel.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/ui/DbgpMethodBreakpointPanel.java
@@ -41,8 +41,6 @@ public class DbgpMethodBreakpointPanel extends JPanel implements Controller {
 
     public DbgpMethodBreakpointPanel() {
         initComponents();
-        myStopOnLbl.setVisible(false);
-        myStopType.setVisible(false);
     }
 
     @Override
@@ -106,13 +104,10 @@ public class DbgpMethodBreakpointPanel extends JPanel implements Controller {
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(myStopOnLbl)
-                        .addGap(31, 31, 31))
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(myMethodLbl)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)))
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(myMethodLbl)
+                    .addComponent(myStopOnLbl))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(myStopType, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(myMethodName, javax.swing.GroupLayout.DEFAULT_SIZE, 189, Short.MAX_VALUE))


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5228

Enables support for breakpoint on return from function in PHP debugger.
Originally disabled in 2008 because of bug in Xdebug, the bug was fixed in 2009.