### PR TITLE
[NETBEANS-2843] PHP debugger - support for resolved breakpoints

### DIFF
--- a/php/php.dbgp/manifest.mf
+++ b/php/php.dbgp/manifest.mf
@@ -3,5 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.php.dbgp
 OpenIDE-Module-Layer: org/netbeans/modules/php/dbgp/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/dbgp/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.52
+OpenIDE-Module-Specification-Version: 1.53
 

--- a/php/php.dbgp/nbproject/project.xml
+++ b/php/php.dbgp/nbproject/project.xml
@@ -180,7 +180,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>2.87</specification-version>
+                        <specification-version>2.149</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/DebuggerOptions.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/DebuggerOptions.java
@@ -26,6 +26,7 @@ import org.openide.util.Pair;
  * @author Radek Matous
  */
 public class DebuggerOptions {
+
     private static final DebuggerOptions GLOBAL_INSTANCE = new DefaultGlobal();
     int port = -1;
     int maxData = -2;
@@ -53,11 +54,11 @@ public class DebuggerOptions {
     }
 
     public int getPort() {
-        return (port != -1) ? port :  getGlobalInstance().getPort();
+        return (port != -1) ? port : getGlobalInstance().getPort();
     }
 
     public int getMaxData() {
-        return (maxData != -2) ? maxData :  getGlobalInstance().getMaxData();
+        return (maxData != -2) ? maxData : getGlobalInstance().getMaxData();
     }
 
     public int getMaxChildren() {
@@ -79,6 +80,11 @@ public class DebuggerOptions {
     public boolean showDebuggerConsole() {
         return getGlobalInstance().showDebuggerConsole();
     }
+
+    public boolean resolveBreakpoints() {
+        return getGlobalInstance().resolveBreakpoints();
+    }
+
     public boolean isDebuggerStoppedAtTheFirstLine() {
         return getGlobalInstance().isDebuggerStoppedAtTheFirstLine();
     }
@@ -92,6 +98,7 @@ public class DebuggerOptions {
     }
 
     private static class DefaultGlobal extends DebuggerOptions {
+
         public DefaultGlobal() {
         }
 
@@ -128,6 +135,11 @@ public class DebuggerOptions {
         @Override
         public boolean showDebuggerConsole() {
             return PhpOptions.getInstance().isDebuggerShowDebuggerConsole();
+        }
+
+        @Override
+        public boolean resolveBreakpoints() {
+            return PhpOptions.getInstance().isDebuggerResolveBreakpoints();
         }
 
         @Override

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/FeatureGetCommand.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/FeatureGetCommand.java
@@ -25,6 +25,7 @@ import java.util.Locale;
  *
  */
 public class FeatureGetCommand extends DbgpCommand {
+
     public enum Feature {
         LANGUAGE_SUPPORTS_THREADS,
         LANGUAGE_NAME,
@@ -42,6 +43,7 @@ public class FeatureGetCommand extends DbgpCommand {
         SUPPORTS_POSTMORTEM,
         SHOW_HIDDEN,
         NOTIFY_OK,
+        RESOLVED_BREAKPOINTS,
         /*
          * additional commands that could be supported
          */

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/InitMessage.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/InitMessage.java
@@ -33,6 +33,7 @@ import org.w3c.dom.Node;
  *
  */
 public class InitMessage extends DbgpMessage {
+
     private static final String IDEKEY = "idekey"; // NOI18N
     private static final String FILE = "fileuri"; // NOI18N
 
@@ -53,6 +54,7 @@ public class InitMessage extends DbgpMessage {
     public void process(DebugSession session, DbgpCommand command) {
         setId(session);
         setShowHidden(session);
+        setBreakpointResolution(session);
         setMaxDepth(session);
         setMaxChildren(session);
         setMaxDataSize(session);
@@ -78,6 +80,12 @@ public class InitMessage extends DbgpMessage {
 
     private void setShowHidden(DebugSession session) {
         setFeature(session, Feature.SHOW_HIDDEN, "1"); //NOI18N
+    }
+
+    private void setBreakpointResolution(DebugSession session) {
+        if (DebuggerOptions.getGlobalInstance().resolveBreakpoints()) {
+            setFeature(session, Feature.RESOLVED_BREAKPOINTS, "1"); // NOI18N
+        }
     }
 
     private void setMaxDepth(DebugSession session) {

--- a/php/php.project/manifest.mf
+++ b/php/php.project/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Specification-Version: 2.148
+OpenIDE-Module-Specification-Version: 2.149
 OpenIDE-Module: org.netbeans.modules.php.project
 OpenIDE-Module-Layer: org/netbeans/modules/php/project/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/project/resources/Bundle.properties

--- a/php/php.project/src/org/netbeans/modules/php/project/api/PhpOptions.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/api/PhpOptions.java
@@ -44,6 +44,7 @@ public final class PhpOptions {
     public static final String PROP_PHP_DEBUGGER_MAX_CHILDREN = "propPhpDebuggerMaxChildren"; // NOI18N
     public static final String PROP_PHP_DEBUGGER_SHOW_URLS = "propPhpDebuggerShowUrls"; // NOI18N
     public static final String PROP_PHP_DEBUGGER_SHOW_CONSOLE = "propPhpDebuggerShowConsole"; // NOI18N
+    public static final String PROP_PHP_DEBUGGER_RESOLVE_BREAKPOINTS = "propPhpDebuggerResolveBreakpoints"; // NOI18N
     public static final String PROP_PHP_GLOBAL_INCLUDE_PATH = "propPhpGlobalIncludePath"; // NOI18N
 
     private static final PhpOptions INSTANCE = new PhpOptions();
@@ -75,6 +76,8 @@ public final class PhpOptions {
                     propertyChangeSupport.firePropertyChange(PROP_PHP_DEBUGGER_SHOW_URLS, null, Boolean.valueOf(newValue));
                 } else if (PHP_DEBUGGER_SHOW_CONSOLE.equals(key)) {
                     propertyChangeSupport.firePropertyChange(PROP_PHP_DEBUGGER_SHOW_CONSOLE, null, Boolean.valueOf(newValue));
+                } else if (PHP_DEBUGGER_RESOLVE_BREAKPOINTS.equals(key)) {
+                    propertyChangeSupport.firePropertyChange(PROP_PHP_DEBUGGER_RESOLVE_BREAKPOINTS, null, Boolean.valueOf(newValue));
                 } else if (PHP_GLOBAL_INCLUDE_PATH.equals(key)) {
                     propertyChangeSupport.firePropertyChange(PROP_PHP_GLOBAL_INCLUDE_PATH, null, newValue);
                 }
@@ -183,6 +186,16 @@ public final class PhpOptions {
      */
     public boolean isDebuggerShowDebuggerConsole() {
         return getPhpOptions().isDebuggerShowConsole();
+    }
+
+    /**
+     * Check whether debugger requests breakpoint resolution. The default value is
+     * <code>{@value org.netbeans.modules.php.project.ui.options.PhpOptions#DEFAULT_DEBUGGER_RESOLVE_BREAKPOINTS}</code>.
+     * @return <code>true</code> if the debugger requests breakpoint resolution, <code>false</code> otherwise.
+     * @since 2.149
+     */
+    public boolean isDebuggerResolveBreakpoints() {
+        return getPhpOptions().isDebuggerResolveBreakpoints();
     }
 
     /**

--- a/php/php.project/src/org/netbeans/modules/php/project/ui/options/Bundle.properties
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/options/Bundle.properties
@@ -169,3 +169,5 @@ PhpDebuggerOptions.requestedUrlsCheckBox.AccessibleContext.accessibleName=Show R
 PhpDebuggerPanel.sessionIdTextField.AccessibleContext.accessibleName=Debugger Session ID
 PhpDebuggerPanel.maxStructuresDepthTextField.AccessibleContext.accessibleName=Maximum depth of structures
 PhpDebuggerPanel.maxChildrenTextField.AccessibleContext.accessibleName=Maximum number of children
+PhpDebuggerPanel.resolveBreakpointsCheckBox.text=&Resolve breakpoints
+PhpDebuggerPanel.resolveBreakpointsInfoLabel.text=<html>With breakpoint resolution Xdebug tries to find the line with executable code to stop on.<br>\nThis feature is available in Xdebug version 2.8 or newer.</html>

--- a/php/php.project/src/org/netbeans/modules/php/project/ui/options/PhpDebuggerPanel.form
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/options/PhpDebuggerPanel.form
@@ -52,6 +52,20 @@
                   <Component id="requestedUrlsCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="debuggerConsoleCheckBox" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="errorLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="portLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="sessionIdLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="maxDataLengthLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                          <Component id="portTextField" linkSize="2" min="-2" pref="50" max="-2" attributes="0"/>
+                          <Component id="sessionIdTextField" min="-2" pref="176" max="-2" attributes="0"/>
+                          <Component id="maxDataLengthTextField" linkSize="2" alignment="0" min="-2" pref="50" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
+                  <Component id="resolveBreakpointsCheckBox" min="-2" max="-2" attributes="0"/>
                   <Group type="102" attributes="0">
                       <EmptySpace min="21" pref="21" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
@@ -67,22 +81,7 @@
                                   <Component id="maxStructuresDepthTextField" linkSize="2" alignment="0" min="-2" pref="50" max="-2" attributes="1"/>
                               </Group>
                           </Group>
-                      </Group>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="portLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="sessionIdLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="maxDataLengthLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                          <Component id="portTextField" linkSize="2" min="-2" pref="50" max="-2" attributes="0"/>
-                          <Component id="sessionIdTextField" min="-2" pref="176" max="-2" attributes="0"/>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="maxDataLengthTextField" linkSize="2" min="-2" pref="50" max="-2" attributes="0"/>
-                              <EmptySpace min="-2" pref="97" max="-2" attributes="0"/>
-                          </Group>
+                          <Component id="resolveBreakpointsInfoLabel" min="-2" max="-2" attributes="0"/>
                       </Group>
                   </Group>
               </Group>
@@ -127,6 +126,10 @@
               <Component id="debuggerConsoleCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace min="-2" max="-2" attributes="0"/>
               <Component id="debuggerConsoleInfoLabel" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="resolveBreakpointsCheckBox" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="resolveBreakpointsInfoLabel" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="32767" attributes="0"/>
               <Component id="errorLabel" min="-2" max="-2" attributes="0"/>
           </Group>
@@ -348,6 +351,20 @@
           <ResourceString bundle="org/netbeans/modules/php/project/ui/options/Bundle.properties" key="PhpDebuggerOptions.errorLabel.AccessibleContext.accessibleDescription" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </AccessibilityProperties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="resolveBreakpointsCheckBox">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/project/ui/options/Bundle.properties" key="PhpDebuggerPanel.resolveBreakpointsCheckBox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="resolveBreakpointsInfoLabel">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/php/project/ui/options/Bundle.properties" key="PhpDebuggerPanel.resolveBreakpointsInfoLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
     </Component>
   </SubComponents>
 </Form>

--- a/php/php.project/src/org/netbeans/modules/php/project/ui/options/PhpDebuggerPanel.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/options/PhpDebuggerPanel.java
@@ -49,7 +49,7 @@ import org.openide.util.NbBundle;
 @OptionsPanelController.Keywords(keywords={"php", "debugger", "debugging", "xdebug", "#KW_DebuggerOptions"}, location=UiUtils.OPTIONS_PATH, tabTitle= "#LBL_DebuggerOptions")
 public class PhpDebuggerPanel extends JPanel {
 
-    private static final long serialVersionUID = 165768454654687L;
+    private static final long serialVersionUID = -6341327437203454463L;
 
     private final ChangeSupport changeSupport = new ChangeSupport(this);
     private final WatchesAndEvalListener watchesAndEvalListener;
@@ -149,6 +149,14 @@ public class PhpDebuggerPanel extends JPanel {
         debuggerConsoleCheckBox.setSelected(showConsole);
     }
 
+    public boolean isResolveBreakpoints() {
+        return resolveBreakpointsCheckBox.isSelected();
+    }
+
+    public void setResolveBreakpoints(boolean resolveBreakpoints) {
+        resolveBreakpointsCheckBox.setSelected(resolveBreakpoints);
+    }
+
     public void setError(String message) {
         errorLabel.setText(" "); // NOI18N
         errorLabel.setForeground(UIManager.getColor("nb.errorForeground")); // NOI18N
@@ -198,6 +206,8 @@ public class PhpDebuggerPanel extends JPanel {
         debuggerConsoleCheckBox = new JCheckBox();
         debuggerConsoleInfoLabel = new JLabel();
         errorLabel = new JLabel();
+        resolveBreakpointsCheckBox = new JCheckBox();
+        resolveBreakpointsInfoLabel = new JLabel();
 
         portLabel.setLabelFor(portTextField);
         Mnemonics.setLocalizedText(portLabel, NbBundle.getMessage(PhpDebuggerPanel.class, "PhpDebuggerPanel.portLabel.text")); // NOI18N
@@ -227,10 +237,13 @@ public class PhpDebuggerPanel extends JPanel {
         errorLabel.setLabelFor(debuggerConsoleCheckBox);
         Mnemonics.setLocalizedText(errorLabel, "ERROR"); // NOI18N
 
+        Mnemonics.setLocalizedText(resolveBreakpointsCheckBox, NbBundle.getMessage(PhpDebuggerPanel.class, "PhpDebuggerPanel.resolveBreakpointsCheckBox.text")); // NOI18N
+
+        Mnemonics.setLocalizedText(resolveBreakpointsInfoLabel, NbBundle.getMessage(PhpDebuggerPanel.class, "PhpDebuggerPanel.resolveBreakpointsInfoLabel.text")); // NOI18N
+
         GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addGroup(layout.createParallelGroup(Alignment.LEADING)
                     .addComponent(stopAtTheFirstLineCheckBox)
@@ -238,6 +251,17 @@ public class PhpDebuggerPanel extends JPanel {
                     .addComponent(requestedUrlsCheckBox)
                     .addComponent(debuggerConsoleCheckBox)
                     .addComponent(errorLabel)
+                    .addGroup(layout.createSequentialGroup()
+                        .addGroup(layout.createParallelGroup(Alignment.LEADING)
+                            .addComponent(portLabel)
+                            .addComponent(sessionIdLabel)
+                            .addComponent(maxDataLengthLabel))
+                        .addPreferredGap(ComponentPlacement.RELATED)
+                        .addGroup(layout.createParallelGroup(Alignment.LEADING, false)
+                            .addComponent(portTextField, GroupLayout.PREFERRED_SIZE, 50, GroupLayout.PREFERRED_SIZE)
+                            .addComponent(sessionIdTextField, GroupLayout.PREFERRED_SIZE, 176, GroupLayout.PREFERRED_SIZE)
+                            .addComponent(maxDataLengthTextField, GroupLayout.PREFERRED_SIZE, 50, GroupLayout.PREFERRED_SIZE)))
+                    .addComponent(resolveBreakpointsCheckBox)
                     .addGroup(layout.createSequentialGroup()
                         .addGap(21, 21, 21)
                         .addGroup(layout.createParallelGroup(Alignment.LEADING)
@@ -249,26 +273,14 @@ public class PhpDebuggerPanel extends JPanel {
                                 .addPreferredGap(ComponentPlacement.RELATED)
                                 .addGroup(layout.createParallelGroup(Alignment.LEADING, false)
                                     .addComponent(maxChildrenTextField)
-                                    .addComponent(maxStructuresDepthTextField, GroupLayout.PREFERRED_SIZE, 50, GroupLayout.PREFERRED_SIZE)))))
-                    .addGroup(layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(Alignment.LEADING)
-                            .addComponent(portLabel)
-                            .addComponent(sessionIdLabel)
-                            .addComponent(maxDataLengthLabel))
-                        .addPreferredGap(ComponentPlacement.RELATED)
-                        .addGroup(layout.createParallelGroup(Alignment.LEADING, false)
-                            .addComponent(portTextField, GroupLayout.PREFERRED_SIZE, 50, GroupLayout.PREFERRED_SIZE)
-                            .addComponent(sessionIdTextField, GroupLayout.PREFERRED_SIZE, 176, GroupLayout.PREFERRED_SIZE)
-                            .addGroup(layout.createSequentialGroup()
-                                .addComponent(maxDataLengthTextField, GroupLayout.PREFERRED_SIZE, 50, GroupLayout.PREFERRED_SIZE)
-                                .addGap(97, 97, 97)))))
+                                    .addComponent(maxStructuresDepthTextField, GroupLayout.PREFERRED_SIZE, 50, GroupLayout.PREFERRED_SIZE)))
+                            .addComponent(resolveBreakpointsInfoLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE))))
                 .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         layout.linkSize(SwingConstants.HORIZONTAL, new Component[] {maxChildrenTextField, maxDataLengthTextField, maxStructuresDepthTextField, portTextField});
 
-        layout.setVerticalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setVerticalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addGroup(layout.createParallelGroup(Alignment.BASELINE)
                     .addComponent(portLabel)
@@ -299,6 +311,10 @@ public class PhpDebuggerPanel extends JPanel {
                 .addComponent(debuggerConsoleCheckBox)
                 .addPreferredGap(ComponentPlacement.RELATED)
                 .addComponent(debuggerConsoleInfoLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(ComponentPlacement.RELATED)
+                .addComponent(resolveBreakpointsCheckBox)
+                .addPreferredGap(ComponentPlacement.RELATED)
+                .addComponent(resolveBreakpointsInfoLabel, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(ComponentPlacement.RELATED, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addComponent(errorLabel))
         );
@@ -349,6 +365,8 @@ public class PhpDebuggerPanel extends JPanel {
     private JLabel portLabel;
     private JTextField portTextField;
     private JCheckBox requestedUrlsCheckBox;
+    private JCheckBox resolveBreakpointsCheckBox;
+    private JLabel resolveBreakpointsInfoLabel;
     private JLabel sessionIdLabel;
     private JTextField sessionIdTextField;
     private JCheckBox stopAtTheFirstLineCheckBox;

--- a/php/php.project/src/org/netbeans/modules/php/project/ui/options/PhpDebuggerPanelController.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/options/PhpDebuggerPanelController.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.netbeans.modules.php.project.ui.options;
 
 import javax.swing.JComponent;
@@ -30,11 +29,11 @@ import org.openide.util.NbBundle;
  * Controller for {@link PhpDebuggerPanel}.
  */
 @OptionsPanelController.SubRegistration(
-    displayName="#LBL_DebuggerOptions",
-//    toolTip="#LBL_DebuggerOptionsTooltip",
-    id=PhpDebuggerPanelController.ID,
-    location=UiUtils.OPTIONS_PATH,
-    position=130
+        displayName = "#LBL_DebuggerOptions",
+        //    toolTip="#LBL_DebuggerOptionsTooltip",
+        id = PhpDebuggerPanelController.ID,
+        location = UiUtils.OPTIONS_PATH,
+        position = 130
 )
 public class PhpDebuggerPanelController extends BaseOptionsPanelController {
 
@@ -53,6 +52,7 @@ public class PhpDebuggerPanelController extends BaseOptionsPanelController {
         debuggerPanel.setMaxChildren(getPhpOptions().getDebuggerMaxChildren());
         debuggerPanel.setShowUrls(getPhpOptions().isDebuggerShowUrls());
         debuggerPanel.setShowConsole(getPhpOptions().isDebuggerShowConsole());
+        debuggerPanel.setResolveBreakpoints(getPhpOptions().isDebuggerResolveBreakpoints());
     }
 
     @Override
@@ -66,11 +66,12 @@ public class PhpDebuggerPanelController extends BaseOptionsPanelController {
         getPhpOptions().setDebuggerMaxChildren(parseInteger(debuggerPanel.getMaxChildren()));
         getPhpOptions().setDebuggerShowUrls(debuggerPanel.isShowUrls());
         getPhpOptions().setDebuggerShowConsole(debuggerPanel.isShowConsole());
+        getPhpOptions().setDebuggerResolveBreakpoints(debuggerPanel.isResolveBreakpoints());
     }
-    
+
     @Override
     protected boolean areOptionsChanged() {
-        if(parseInteger(debuggerPanel.getPort()) == null || parseInteger(debuggerPanel.getMaxDataLength()) == null
+        if (parseInteger(debuggerPanel.getPort()) == null || parseInteger(debuggerPanel.getMaxDataLength()) == null
                 || parseInteger(debuggerPanel.getMaxStructuresDepth()) == null || parseInteger(debuggerPanel.getMaxChildren()) == null) {
             return false;
         }
@@ -82,12 +83,13 @@ public class PhpDebuggerPanelController extends BaseOptionsPanelController {
                 || getPhpOptions().getDebuggerMaxChildren() != parseInteger(debuggerPanel.getMaxChildren())
                 || getPhpOptions().isDebuggerShowUrls() != debuggerPanel.isShowUrls()
                 || getPhpOptions().isDebuggerShowConsole() != debuggerPanel.isShowConsole()
+                || getPhpOptions().isDebuggerResolveBreakpoints() != debuggerPanel.isResolveBreakpoints()
                 || getPhpOptions().isDebuggerWatchesAndEval() != debuggerPanel.isWatchesAndEval();
     }
 
     @Override
     public JComponent getComponent(Lookup masterLookup) {
-         if (debuggerPanel == null) {
+        if (debuggerPanel == null) {
             debuggerPanel = new PhpDebuggerPanel();
             debuggerPanel.addChangeListener(this);
         }

--- a/php/php.project/src/org/netbeans/modules/php/project/ui/options/PhpOptions.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/options/PhpOptions.java
@@ -16,7 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.netbeans.modules.php.project.ui.options;
 
 import java.io.IOException;
@@ -32,12 +31,14 @@ import org.netbeans.spi.project.support.ant.PropertyUtils;
 import org.openide.util.Exceptions;
 
 /**
- * Helper class to get actual PHP properties like debugger port etc.
- * Use {@link #getInstance()} to get class instance.
+ * Helper class to get actual PHP properties like debugger port etc. Use
+ * {@link #getInstance()} to get class instance.
+ *
  * @author Tomas Mysik
  * @since 1.2
  */
 public final class PhpOptions {
+
     // Do not change arbitrary - consult with layer's folder OptionsExport
     // Path to Preferences node for storing these preferences
     private static final String PREFERENCES_PATH = "general"; // NOI18N
@@ -52,6 +53,7 @@ public final class PhpOptions {
     public static final boolean DEFAULT_DEBUGGER_SHOW_CONSOLE = false;
     public static final boolean DEFAULT_DEBUGGER_STOP_AT_FIRST_LINE = true;
     public static final boolean DEFAULT_DEBUGGER_WATCHES_AND_EVAL = false;
+    public static final boolean DEFAULT_DEBUGGER_RESOLVE_BREAKPOINTS = true;
     public static final boolean DEFAULT_ANNOTATIONS_RESOLVE_DEPRECATED_ELEMENTS = false;
     public static final boolean DEFAULT_ANNOTATIONS_UNKNOWN_ANNOTATIONS_AS_TYPE_ANNOTATIONS = false;
 
@@ -71,6 +73,7 @@ public final class PhpOptions {
     public static final String PHP_DEBUGGER_WATCHES_AND_EVAL = "phpDebuggerWatchesAndEval"; // NOI18N
     public static final String PHP_DEBUGGER_SHOW_URLS = "phpDebuggerShowUrls"; // NOI18N
     public static final String PHP_DEBUGGER_SHOW_CONSOLE = "phpDebuggerShowConsole"; // NOI18N
+    public static final String PHP_DEBUGGER_RESOLVE_BREAKPOINTS = "phpDebuggerResolveBreakpoints"; // NOI18N
 
     // annotations
     public static final String PHP_ANNOTATIONS_RESOLVE_DEPRECATED_ELEMENTS = "phpAnnottationsResolveDeprecetatedElements"; // NOI18N
@@ -220,6 +223,14 @@ public final class PhpOptions {
         getPreferences().putBoolean(PHP_DEBUGGER_SHOW_CONSOLE, debuggerShowConsole);
     }
 
+    public boolean isDebuggerResolveBreakpoints() {
+        return getPreferences().getBoolean(PHP_DEBUGGER_RESOLVE_BREAKPOINTS, DEFAULT_DEBUGGER_RESOLVE_BREAKPOINTS);
+    }
+
+    public void setDebuggerResolveBreakpoints(boolean debuggerResolveBreakpoints) {
+        getPreferences().putBoolean(PHP_DEBUGGER_RESOLVE_BREAKPOINTS, debuggerResolveBreakpoints);
+    }
+
     public boolean isAnnotationsResolveDeprecatedElements() {
         return getPreferences().getBoolean(PHP_ANNOTATIONS_RESOLVE_DEPRECATED_ELEMENTS, DEFAULT_ANNOTATIONS_RESOLVE_DEPRECATED_ELEMENTS);
     }
@@ -262,7 +273,8 @@ public final class PhpOptions {
 
     // #210057
     /**
-     * Ensure that the php.global.include.path is written in build.properties so Ant can see it.
+     * Ensure that the php.global.include.path is written in build.properties so
+     * Ant can see it.
      */
     public void ensurePhpGlobalIncludePath() {
         if (phpGlobalIncludePathEnsured) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-2843

- Adds PHP debugger option to enable/disable support of resolved breakpoints in Xdebug.
- Adds new Xdebug feature 'resolved_breakpoints'.
- Requests use of resolved breakpoints during debug session initialization.
- Supported by XDebug 2.8 or newer.