### PR TITLE
[NETBEANS-3409] Missing popup menu for sql editor tabs

### DIFF
--- a/platform/openide.filesystems.compat8/manifest.mf
+++ b/platform/openide.filesystems.compat8/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.filesystems.compat8
 OpenIDE-Module-Localizing-Bundle: org/openide/filesystems/compat8/Bundle.properties
-OpenIDE-Module-Specification-Version: 9.17
+OpenIDE-Module-Specification-Version: 9.17.1
 OpenIDE-Module-Fragment-Host: org.openide.filesystems
 

--- a/platform/openide.filesystems.compat8/src/org/openide/filesystems/FileSystemCompat.java
+++ b/platform/openide.filesystems.compat8/src/org/openide/filesystems/FileSystemCompat.java
@@ -43,6 +43,9 @@ import org.openide.util.actions.SystemAction;
  */
 @PatchFor(FileSystem.class)
 public abstract class FileSystemCompat {
+    /** system actions for this FS */
+    private static final SystemAction[] NO_SYSTEM_ACTIONS = new SystemAction[0];
+
     /** Property name giving capabilities state. @deprecated No more capabilities. */
     static final String PROP_CAPABILITIES = "capabilities"; // NOI18N    
 
@@ -67,7 +70,14 @@ public abstract class FileSystemCompat {
     *
     * @return array of available actions
     */
-    public abstract SystemAction[] getActions();
+    @SuppressWarnings("ReturnOfCollectionOrArrayField")
+    public SystemAction[] getActions() {
+        // If implementations don't override getActions, an empty array is
+        // returned to satisfy the FileSystem#getActions contract. As the
+        // empty array is immutable, it is save to return a singleton in this
+        // case
+        return NO_SYSTEM_ACTIONS;
+    }
 
     /**
      * Get actions appropriate to a certain file selection.


### PR DESCRIPTION
The Filesystems API compatibility module provides implementations for
Filesystem#getActions for several filesystems. Most filesystem
implementations are covered by the implementation in
AbstractFileSystemCompat, but this does not cover implementations
directly inheriting from Filesystem.

One such filesystem is BinaryFS.

In the SQL Editor the command window function (temp files for SQL
execution) is backed by a file in the SystemFileSystem, which delegates
in the end to BinaryFS:

SystemFileSystem->
  ModuleLayeredFileSystem ->
    BinaryFS

As BinaryFS does not implement getActions and no patch is provided for
this class, an AbstractMethodError is raised.

Instead of bailing out with an Error, the compatibility implementation
now returns an empty array to satisfy the Filesystem#getActions contract.