### PR TITLE
[NETBEANS-4444] The selected text is not removed in the Find Combobox…

### DIFF
--- a/ide/editor.search/nbproject/project.properties
+++ b/ide/editor.search/nbproject/project.properties
@@ -16,4 +16,4 @@
 # under the License.
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
-spec.version.base=1.33.0
+spec.version.base=1.33.1

--- a/ide/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
+++ b/ide/editor.search/src/org/netbeans/modules/editor/search/SearchComboBoxEditor.java
@@ -123,6 +123,25 @@ public class SearchComboBoxEditor implements ComboBoxEditor {
                         DocumentUtilities.addDocumentListener(newDoc, manageViewListener, DocumentListenerPriority.AFTER_CARET_UPDATE);
                     }
                 }
+                // NETBEANS-4444
+                // selection is not removed when text is input via IME
+                // so, just remove it when the caret is changed
+                if ("caret".equals(evt.getPropertyName())) { // NOI18N
+                    if (evt.getOldValue() instanceof Caret) {
+                        Caret oldCaret = (Caret) evt.getOldValue();
+                        if (oldCaret != null) {
+                            int dotPosition = oldCaret.getDot();
+                            int markPosition = oldCaret.getMark();
+                            if (dotPosition != markPosition) {
+                                try {
+                                    editorPane.getDocument().remove(Math.min(markPosition, dotPosition), Math.abs(markPosition - dotPosition));
+                                } catch (BadLocationException ex) {
+                                    LOG.log(Level.WARNING, "Invalid removal offset: {0}", ex.offsetRequested()); // NOI18N
+                                }
+                            }
+                        }
+                    }
+                }
             }
         });
     }


### PR DESCRIPTION
… when text is input via IME

Selection is not removed when text is input via IME. So, just remove it when the caret is changed.