### PR TITLE
[NETBEANS-5234] PHP debugger - fix display of long strings

### DIFF
--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/Property.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/Property.java
@@ -32,6 +32,7 @@ import org.netbeans.modules.php.dbgp.SessionId;
 import org.netbeans.modules.php.dbgp.SessionManager;
 import org.netbeans.modules.php.dbgp.UnsufficientValueException;
 import org.openide.util.Exceptions;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 /**
@@ -39,6 +40,7 @@ import org.w3c.dom.Node;
  *
  */
 public class Property extends BaseMessageChildElement {
+
     static final String PROPERTY = "property"; // NOI18N
     private static final String NUMCHILDREN = "numchildren"; // NOI18N
     static final String ENCODING = "encoding"; // NOI18N
@@ -64,12 +66,11 @@ public class Property extends BaseMessageChildElement {
     }
 
     public void setName(String value) {
-        Node node = getNode().getAttributes().getNamedItem(NAME);
-        if (node == null) {
-            node = getNode().getOwnerDocument().createAttribute(NAME);
-            getNode().appendChild(node);
+        Node node = getNode();
+        if (node instanceof Element) {
+            Element element = (Element) node;
+            element.setAttribute(NAME, value);
         }
-        node.setNodeValue(value);
     }
 
     public String getFullName() {

--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/PropertyValueResponse.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/packets/PropertyValueResponse.java
@@ -33,7 +33,7 @@ public class PropertyValueResponse extends DbgpResponse {
     }
 
     public Property getProperty() {
-        Node node = getChild(getNode(), Property.PROPERTY);
+        Node node = getNode();
         if (node != null) {
             return new Property(node);
         }
@@ -42,13 +42,17 @@ public class PropertyValueResponse extends DbgpResponse {
 
     @Override
     public void process(DebugSession session, DbgpCommand command) {
+        if (!(command instanceof PropertyValueCommand)) {
+            return;
+        }
         DebugSession currentSession = SessionManager.getInstance().getSession(session.getSessionId());
         if (currentSession == session) {
             // perform update local view only if response appears in current session
             Property property = getProperty();
             if (property != null) {
-                session.getBridge().getVariablesModel().updateProperty(
-                        getProperty());
+                // response does not contain variable name so it is taken from command
+                property.setName(((PropertyValueCommand) command).getName());
+                session.getBridge().getVariablesModel().updateProperty(property);
             }
         }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5234

Fixed processing of `property_value` command response.
Because response does not contain variable name, it has to be copied from command.
For details see [Xdebug documentation](https://xdebug.org/docs/dbgp#property-get-property-set-property-value) 

Fixed `Property.setName()` because code for adding attribute did not work.