### PR TITLE
Properly stop Maven execution from LSP/DAP

### DIFF
--- a/java/java.lsp.server/nbcode/integration/manifest.mf
+++ b/java/java.lsp.server/nbcode/integration/manifest.mf
@@ -4,3 +4,4 @@ OpenIDE-Module: org.netbeans.modules.nbcode.integration
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/nbcode/integration/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.0
 OpenIDE-Module-Recommends: cnb.org.netbeans.modules.gradle.java
+OpenIDE-Module-Requires: org.openide.execution.ExecutionEngine.defaultLookup

--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -147,8 +147,6 @@ disabled.modules=\
     org.netbeans.modules.editor.tools.storage,\
     org.netbeans.modules.extbrowser.chrome,\
     org.netbeans.modules.extexecution.impl,\
-    org.netbeans.modules.extexecution.process,\
-    org.netbeans.modules.extexecution.process.jdk9,\
     org.netbeans.modules.findbugs.installer,\
     org.netbeans.modules.form,\
     org.netbeans.modules.form.kit,\

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/ProgressOperationEvent.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/ProgressOperationEvent.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.progress;
+
+import java.util.EventObject;
+import org.netbeans.modules.progress.spi.InternalHandle;
+import org.openide.util.Lookup;
+
+/**
+ * Contains information on the handle operation. Allows access to some runtime
+ * properties of the handle.
+ * 
+ * @author sdedic
+ */
+public final class ProgressOperationEvent extends EventObject {
+    private final LspInternalHandle progressHandle;
+
+    ProgressOperationEvent(LspInternalHandle progressHandle, Object source) {
+        super(source);
+        this.progressHandle = progressHandle;
+    }
+
+    /**
+     * @return the handle instance.
+     */
+    public InternalHandle getProgressHandle() {
+        return progressHandle;
+    }
+    
+    /**
+     * Identifies origin of the operation. Returns snapshot of the stacktrace
+     * from handle's creation time.
+     * @return 
+     */
+    public StackTraceElement[] getOperationOrigin() {
+        return progressHandle.getCreatorTrace();
+    }
+    
+    /**
+     * Provides access to the operation's Lookup. The Lookup is saved at the time when the
+     * Handle was created. The Lookup contents may help to select the appropriate
+     * handle from the active ones.
+     * @return 
+     */
+    public Lookup getOperationLookup() {
+        return progressHandle.getOperationLookup();
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/ProgressOperationListener.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/progress/ProgressOperationListener.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.progress;
+
+import java.util.EventListener;
+
+/**
+ * The Listener allows to intercept creation and finish of an operation that
+ * uses Progress API to report the progress.
+ * In JLS server, this can be used to control that operation on behalf of JLS client,
+ * or report to the client that the operation has finished. Useful where the original
+ * NB APIs do not provide feedback about start/stop (progress).
+ * 
+ * @author sdedic
+ */
+public interface ProgressOperationListener extends EventListener {
+    /**
+     * Called when the handle was created. The action may not be started yet at the
+     * time, just the operation handle was initialized. 
+     * @param e event instance
+     */
+    public default void progressHandleCreated(ProgressOperationEvent e) {}
+    
+    /**
+     * Called when the handle is called to report operation finish.
+     * @param e event instance.
+     */
+    public default void progressHandleFinished(ProgressOperationEvent e) {}
+}

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -151,6 +151,7 @@ public class ServerTest extends NbTestCase {
 
     @Override
     protected void setUp() throws Exception {
+        System.setProperty("java.awt.headless", Boolean.TRUE.toString());
         super.setUp();
         clearWorkDir();
         ServerSocket srv = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());

--- a/java/java.lsp.server/vscode/package-lock.json
+++ b/java/java.lsp.server/vscode/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "apache-netbeans-java",
-	"version": "0.1.0",
+	"version": "12.3.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -31,6 +31,11 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.15.tgz",
 			"integrity": "sha512-kwbcs0jySLxzLsa2nWUAGOd/s21WU1jebrEdtzhsj1D4Yps1EOuyI1Qcu+FD56dL7NRNIJtDDjcqIG22NwkgLw==",
 			"dev": true
+		},
+		"@types/ps-node": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ps-node/-/ps-node-0.1.0.tgz",
+			"integrity": "sha512-HI5l+f38o93x81mbOWZ1IEzj87rGCHfN4A4QyCU1MuViT5Slvlo5F+YVvmBFHfZsEGi0Lo8TghWU2Ew6vBILNA=="
 		},
 		"@types/vscode": {
 			"version": "1.47.0",
@@ -206,6 +211,12 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"connected-domain": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/connected-domain/-/connected-domain-1.0.0.tgz",
+			"integrity": "sha1-v+dyOMdL5FOnnwy2BY3utPI1jpM=",
 			"dev": true
 		},
 		"decamelize": {
@@ -780,6 +791,15 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
+		"ps-node": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/ps-node/-/ps-node-0.1.6.tgz",
+			"integrity": "sha1-mvZ6mdex0BMuUaUDCZ04qNKs4sM=",
+			"dev": true,
+			"requires": {
+				"table-parser": "^0.1.3"
+			}
+		},
 		"readdirp": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
@@ -871,6 +891,15 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
+			}
+		},
+		"table-parser": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/table-parser/-/table-parser-0.1.3.tgz",
+			"integrity": "sha1-BEHPzhallIFoTCfRtaZ/8VpDx7A=",
+			"dev": true,
+			"requires": {
+				"connected-domain": "^1.0.0"
 			}
 		},
 		"to-regex-range": {

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -179,13 +179,15 @@
 		"@types/glob": "^7.1.1",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.11.0",
+		"@types/ps-node": "^0.1.0",
 		"glob": "^7.1.6",
 		"mocha": "^7.1.2",
 		"typescript": "^3.8.3",
-		"vscode-test": "^1.3.0"
+		"vscode-test": "^1.3.0",
+		"ps-node": "^0.1.6"
 	},
 	"dependencies": {
-		"vscode-languageclient": "6.1.3",
-		"vscode-debugadapter": "1.42.1"
+		"vscode-debugadapter": "1.42.1",
+		"vscode-languageclient": "6.1.3"
 	}
 }

--- a/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as ps from 'ps-node';
 import { spawn, ChildProcessByStdio, spawnSync, SpawnSyncReturns } from 'child_process';
 import { Readable } from 'stream';
 
@@ -8,6 +9,7 @@ import { Readable } from 'stream';
 // as well as import your extension to test it
 import * as vscode from 'vscode';
 import * as myExtension from '../../extension';
+import { TextDocument, TextEditor, Uri } from 'vscode';
 
 suite('Extension Test Suite', () => {
     vscode.window.showInformationMessage('Cleaning up workspace.');
@@ -34,7 +36,7 @@ suite('Extension Test Suite', () => {
 
     test('Find clusters', async () => {
         let clusters = myExtension.findClusters('non-existent');
-        assert.strictEqual(clusters.length, 6, 'six clusters found: ' + clusters);
+        assert.strictEqual(clusters.length, 7, 'seven clusters found: ' + clusters);
         let nbcode = vscode.extensions.getExtension('asf.apache-netbeans-java');
         assert.ok(nbcode);
         for (let c of clusters) {
@@ -97,6 +99,88 @@ class Main {
     test("Compile workspace6", async() => demo(6));
 //    test("Compile workspace7", async() => demo(7));
 //    test("Compile workspace8", async() => demo(8));
+
+    /**
+     * Checks that maven-managed process can be started, and forcefully terminated by vscode
+     * although it does not run in debugging mode.
+     */
+    async function mavenTerminateWithoutDebugger() {
+        let folder: string = assertWorkspace();
+
+        await fs.promises.writeFile(path.join(folder, 'pom.xml'), `
+    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.netbeans.demo.vscode.t1</groupId>
+    <artifactId>basicapp</artifactId>
+    <version>1.0</version>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+    </project>
+        `);
+
+        let pkg = path.join(folder, 'src', 'main', 'java', 'pkg');
+        let mainJava = path.join(pkg, 'Main.java');
+
+        await fs.promises.mkdir(pkg, { recursive: true });
+
+        await fs.promises.writeFile(mainJava, `
+    package pkg;
+    class Main {
+    public static void main(String... args) throws Exception {
+        System.out.println("Endless wait...");
+        while (true) {
+            Thread.sleep(1000);
+        }
+    }
+    }
+        `);
+        vscode.workspace.saveAll();
+        let u : Uri = vscode.Uri.file(mainJava);
+        let doc : TextDocument = await vscode.workspace.openTextDocument(u);
+        let e : TextEditor = await vscode.window.showTextDocument(doc);
+
+        try {
+            let terminated = false;
+            let r = new Promise((resolve, reject) => {
+                function waitUserApplication(cnt : number, running: boolean, cb : () => void) {
+                    ps.lookup({
+                        command: "^.*[/\\\\]java",
+                        arguments: "pkg.Main"
+                    }, (err, list ) => {
+                        let success : boolean = (list && list.length > 0) == running;
+                        if (success) {
+                            cb();
+                        } else {
+                            if (cnt == 0) {
+                                reject("Timeout waiting for user application");
+                                return;
+                            }
+                            setTimeout(() => waitUserApplication(cnt - 1, running, cb), 100);
+                            return;
+                        }
+                    });
+                }
+                
+                function onProcessStarted() {
+                    console.log("Test: invoking debug.stop");
+                    // attempt to terminate:
+                    vscode.commands.executeCommand("workbench.action.debug.stop").
+                        then(() => waitUserApplication(5, false, () => resolve(true)));
+                }
+                console.log("Test: invoking debug debug.run");
+                vscode.commands.executeCommand("workbench.action.debug.run").then(
+                    () => waitUserApplication(5, true, onProcessStarted));
+            });
+            return r;
+        } catch (error) {
+            dumpJava();
+            throw error;
+        }
+    }
+
+    test("Maven run termination", async() => mavenTerminateWithoutDebugger());
 });
 
 function assertWorkspace(): string {

--- a/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
@@ -35,10 +35,14 @@ suite('Extension Test Suite', () => {
     });
 
     test('Find clusters', async () => {
-        let clusters = myExtension.findClusters('non-existent');
-        assert.strictEqual(clusters.length, 7, 'seven clusters found: ' + clusters);
-        let nbcode = vscode.extensions.getExtension('asf.apache-netbeans-java');
+        const nbcode = vscode.extensions.getExtension('asf.apache-netbeans-java');
         assert.ok(nbcode);
+
+        const extraCluster = path.join(nbcode.extensionPath, "nbcode", "extra");
+        let clusters = myExtension.findClusters('non-existent').
+            // ignore 'extra' cluster in the extension path, since nbjavac is there during development:
+            filter(s => !s.startsWith(extraCluster));
+        assert.strictEqual(clusters.length, 6, 'six required clusters found: ' + clusters);
         for (let c of clusters) {
             assert.ok(c.startsWith(nbcode.extensionPath), `All extensions are below ${nbcode.extensionPath}, but: ${c}`);
         }
@@ -154,7 +158,7 @@ class Main {
                             cb();
                         } else {
                             if (cnt == 0) {
-                                reject("Timeout waiting for user application");
+                                reject(new Error("Timeout waiting for user application"));
                                 return;
                             }
                             setTimeout(() => waitUserApplication(cnt - 1, running, cb), 100);

--- a/platform/core.execution/manifest.mf
+++ b/platform/core.execution/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.core.execution/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/core/execution/resources/Bundle.properties
-OpenIDE-Module-Provides: org.openide.execution.ExecutionEngine
+OpenIDE-Module-Provides: org.openide.execution.ExecutionEngine, org.openide.execution.ExecutionEngine.defaultLookup
 AutoUpdate-Essential-Module: true
-OpenIDE-Module-Specification-Version: 1.52
+OpenIDE-Module-Specification-Version: 1.53

--- a/platform/core.execution/src/org/netbeans/core/execution/ExecutionEngine.java
+++ b/platform/core.execution/src/org/netbeans/core/execution/ExecutionEngine.java
@@ -137,7 +137,7 @@ public final class
         ExecutorTaskImpl task = new ExecutorTaskImpl();
         synchronized (task.lock) {
             try {
-                new RunClassThread(g, name, number++, inout, this, task, run);
+                new RunClassThread(g, name, number++, inout, this, task, Lookup.getDefault(), run);
                 task.lock.wait();
             } catch (InterruptedException e) { // #171795
                 inout.closeInputOutput();

--- a/platform/core.execution/src/org/netbeans/core/execution/RunClassThread.java
+++ b/platform/core.execution/src/org/netbeans/core/execution/RunClassThread.java
@@ -19,12 +19,14 @@
 
 package org.netbeans.core.execution;
 
+import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
+import org.openide.util.lookup.Lookups;
 import org.openide.windows.InputOutput;
 
 /** Simple class for executing tasks in extra threads */
 final class RunClassThread extends Thread implements IOThreadIfc {
-
+    private final Lookup originalLookup;
     /** InputOutput that is to be used */
     private InputOutput io;
     /** name */
@@ -56,6 +58,7 @@ final class RunClassThread extends Thread implements IOThreadIfc {
                     InputOutput io,
                     org.netbeans.core.execution.ExecutionEngine engine,
                     ExecutorTaskImpl task,
+                    Lookup originalLookup,
                     Runnable run) {
         super(base, "exec_" + name + "_" + number); // NOI18N
         mygroup = base;
@@ -65,6 +68,7 @@ final class RunClassThread extends Thread implements IOThreadIfc {
         this.engine = engine;
         this.task = task;
         this.run = run;
+        this.originalLookup = originalLookup;
         // #33789 - this thread must not be daemon otherwise it is immediately destroyed
         setDaemon(false);
         this.start();
@@ -72,7 +76,12 @@ final class RunClassThread extends Thread implements IOThreadIfc {
 
     /** runs the thread
     */
+    @Override
     public void run() {
+        Lookups.executeWith(originalLookup, this::doRun);
+    }
+    
+    private void doRun() {
         mygroup.setFinalizable(); // mark it finalizable - after the completetion of the current thread it will be finalized
 
         boolean fire = true;
@@ -170,53 +179,6 @@ final class RunClassThread extends Thread implements IOThreadIfc {
     static String generateName() {
         return NbBundle.getMessage(RunClassThread.class, "CTL_GeneratedName", number++);
     }
-    
-    /**
-     * Workaround for a JRE bug that unstarted threads are not GC'd.
-     * @see http://www.netbeans.org/issues/show_bug.cgi?id=36395
-     * @see http://developer.java.sun.com/developer/bugParade/bugs/4533087.html
-     * /
-    private static void cleanUpHack(ThreadGroup tg) {
-        try {
-            Field f = ThreadGroup.class.getDeclaredField("threads"); // NOI18N
-            f.setAccessible(true);
-            Method m = ThreadGroup.class.getDeclaredMethod("remove", new Class[] {Thread.class}); // NOI18N
-            m.setAccessible(true);
-            Set stillborn = new HashSet(); // Set<Thread>
-            synchronized (tg) {
-                Thread[] ts = (Thread[])f.get(tg);
-                if (ts == null) {
-                    return;
-                }
-                for (int j = 0; j < ts.length; j++) {
-                    Thread t = ts[j];
-                    if (t == null) {
-                        continue;
-                    }
-                    if (!t.isAlive()) {
-                        stillborn.add(t);
-                    }
-                }
-            }
-            Iterator it = stillborn.iterator();
-            while (it.hasNext()) {
-                Thread t = (Thread)it.next();
-                m.invoke(tg, new Object[] {t});
-            }
-            // Handle child thread groups, too:
-            ThreadGroup[] kids = new ThreadGroup[tg.activeGroupCount()];
-            tg.enumerate(kids);
-            for (int i = 0; i < kids.length; i++) {
-                if (kids[i] != null) {
-                    cleanUpHack(kids[i]);
-                }
-            }
-        } catch (Exception e) {
-            // Oh well.
-            e.printStackTrace();
-        }
-    }
-    */
-    
+
 }
 

--- a/platform/core.execution/test/unit/src/org/netbeans/core/execution/CoreExecutionCompatibilityTest.java
+++ b/platform/core.execution/test/unit/src/org/netbeans/core/execution/CoreExecutionCompatibilityTest.java
@@ -21,6 +21,7 @@ package org.netbeans.core.execution;
 
 import junit.framework.Test;
 import org.openide.execution.ExecutionCompatibilityTest;
+import org.openide.execution.ExecutionEngineHid;
 
 /** Reuses ExecutionCompatibilityTest to check compatibility of the behaviour
  * of core implementation.
@@ -30,7 +31,7 @@ import org.openide.execution.ExecutionCompatibilityTest;
 public class CoreExecutionCompatibilityTest {
 
     public static Test suite() {
-        return ExecutionCompatibilityTest.suite(new ExecutionEngine());
+        return ExecutionCompatibilityTest.suite(new ExecutionEngine(), ExecutionEngineHid.WithLookup.class);
     }
 
 }

--- a/platform/openide.execution/nbproject/project.properties
+++ b/platform/openide.execution/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.main.page=org/openide/execution/doc-files/api.html

--- a/platform/openide.execution/src/org/openide/execution/ExecutionEngine.java
+++ b/platform/openide.execution/src/org/openide/execution/ExecutionEngine.java
@@ -25,13 +25,19 @@ import java.security.PermissionCollection;
 import java.security.Permissions;
 import org.openide.util.Lookup;
 import org.openide.util.RequestProcessor;
-import org.openide.windows.IOProvider;
+import org.openide.util.lookup.Lookups;
 import org.openide.windows.InputOutput;
 
 /**
  * Engine providing the environment necessary to run long-lived processes.
  * May perform tasks such as setting up thread groups, etc.
  * Modules should not implement this class.
+ * <p>
+ * <b>Note for implementors</b>: it is highly advised that the value {@code Lookup#getDefault} is saved,
+ * and established in the forked thread before the executed {@link Runnable} is called. This is
+ * done by OpenIDE libraries If the  ExecutionEngine implementation uses {@link RequestProcessor} for 
+ * planning the tasks.
+ * 
  * @author Jaroslav Tulach, Ales Novak
  */
 public abstract class ExecutionEngine extends Object {
@@ -117,6 +123,7 @@ public abstract class ExecutionEngine extends Object {
         }
         
         private static final class ET extends ExecutorTask {
+            private final Lookup originalLookup;
             private RequestProcessor.Task task;
             private int resultValue;
             private final String name;
@@ -124,6 +131,7 @@ public abstract class ExecutionEngine extends Object {
             
             public ET(Runnable run, String name, InputOutput io) {
                 super(run);
+                this.originalLookup = Lookup.getDefault();
                 this.resultValue = resultValue;
                 this.name = name;
                 task = RequestProcessor.getDefault().post(this);
@@ -143,12 +151,14 @@ public abstract class ExecutionEngine extends Object {
             }
             
             public void run() {
-                try {
-                    super.run();
-                } catch (RuntimeException x) {
-                    x.printStackTrace();
-                    resultValue = 1;
-                }
+                Lookups.executeWith(originalLookup, () -> {
+                    try {
+                        super.run();
+                    } catch (RuntimeException x) {
+                        x.printStackTrace();
+                        resultValue = 1;
+                    }
+                });
             }
             
         }

--- a/platform/openide.execution/test/unit/src/org/openide/execution/ExecutionCompatibilityTest.java
+++ b/platform/openide.execution/test/unit/src/org/openide/execution/ExecutionCompatibilityTest.java
@@ -22,7 +22,6 @@ package org.openide.execution;
 import junit.framework.Assert;
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import org.openide.execution.ExecutionEngine;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.AbstractLookup;
 import org.openide.util.lookup.InstanceContent;
@@ -41,13 +40,18 @@ public class ExecutionCompatibilityTest {
      * ExecutionEngine.
      */
     public static Test suite() {
-        return suite(null);
+        return suite(null, ExecutionEngineHid.WithLookup.class);
     }
     
     /** Executes the execution compatibility kit tests on the provided instance
-     * of execution engine.
+     * of execution engine. Consider to use {@link #suite(org.openide.execution.ExecutionEngine, java.lang.Class)}
+     * with the {@link ExecutionEngineHid.WithLookup}.class to check default Lookup propagation compatibility.
      */
     public static Test suite(ExecutionEngine engine) {
+        return suite(engine, ExecutionEngineHid.class);
+    }
+    
+    public static Test suite(ExecutionEngine engine, Class<? extends ExecutionEngineHid> testClass) {
         System.setProperty("org.openide.util.Lookup", ExecutionCompatibilityTest.class.getName() + "$Lkp");
         Object o = Lookup.getDefault();
         if (!(o instanceof Lkp)) {
@@ -66,7 +70,7 @@ public class ExecutionCompatibilityTest {
         }
         
         TestSuite ts = new TestSuite();
-        ts.addTestSuite(ExecutionEngineHid.class);
+        ts.addTestSuite(testClass);
         
         return ts;
     }

--- a/platform/openide.execution/test/unit/src/org/openide/execution/ExecutionEngineHid.java
+++ b/platform/openide.execution/test/unit/src/org/openide/execution/ExecutionEngineHid.java
@@ -19,15 +19,14 @@
 
 package org.openide.execution;
 
-import java.security.AllPermission;
-import java.security.CodeSource;
-import java.security.PermissionCollection;
-import java.security.Permissions;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
 import junit.framework.TestCase;
-import org.openide.execution.ExecutionEngine;
-import org.openide.execution.ExecutorTask;
+import static junit.framework.TestCase.assertSame;
 import org.openide.util.Lookup;
-import org.openide.windows.IOProvider;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ProxyLookup;
 import org.openide.windows.InputOutput;
 
 /** A piece of the test compatibility suite for the execution APIs.
@@ -80,4 +79,120 @@ public class ExecutionEngineHid extends TestCase {
         assertEquals("Default result is 0", 0, r);
     }
     
+    /**
+     * An extended version of compatibility test that checks the ExecutionEngine impl
+     * restores the contents of the default Lookup for the executing task. Recommended
+     * for all ExecutionEngine implementations.
+     */
+    public static class WithLookup extends ExecutionEngineHid {
+        
+        private static class Token {}
+        
+        Token check = new Token();
+        Token check2 = new Token();
+
+        public WithLookup(String testName) {
+            super(testName);
+        }
+        
+        /**
+         * Checks that the same contents of Lookup.getDefault() effective when the
+         * execution task is created is also in place when the task is run.
+         */
+        public void testExecutionMaintainLookup() throws Exception {
+            Worker w = new Worker();
+            
+            assertNull(Lookup.getDefault().lookup(Token.class));
+            w.checkInExecutedRunnable().get();
+        }
+        
+        /**
+         * Checks that the main Lookup's contents is not affected at the time
+         * the Runnable already reports the changed Lookup.
+         */
+        public void testRunnableAndMainDiffers() throws Exception {
+            Worker w = new Worker();
+            
+            assertNull(Lookup.getDefault().lookup(Token.class));
+            // stop the runnable after the first check.
+            w.s.drainPermits();
+            CompletableFuture<Token> cf = w.checkInExecutedRunnable();
+            
+            // wait until after the 1st assert
+            w.s2.acquire();
+            // check the main Lookup is still unaffected
+            assertNull(Lookup.getDefault().lookup(Token.class));
+            // release the runnable for 2nd check
+            w.s.release();
+            
+            assertSame(w.check, cf.get());
+        }
+        
+        /**
+         * Checks that two tasks running in parallel has separate Lookup contents
+         * and the main Lookup is unaffected.
+         * 
+         * @throws Exception 
+         */
+        public void testSeparateRunnableContexts() throws Exception {
+            Worker w = new Worker();
+            Worker w2 = new Worker();
+            
+            assertNull(Lookup.getDefault().lookup(Token.class));
+            // stop the runnable after the first check.
+            w.s.drainPermits();
+            CompletableFuture<Token> cf = w.checkInExecutedRunnable();
+            // wait until after the 1st assert
+            w.s2.acquire();
+            
+            CompletableFuture<Token> cf2 = w2.checkInExecutedRunnable();
+            // also stop after the 1st check
+            w2.s.drainPermits();
+            
+            // check the main Lookup is still unaffected
+            assertNull(Lookup.getDefault().lookup(Token.class));
+            
+            // release the runnable for 2nd check
+            w.s.release();
+            w2.s.release();
+            
+            assertSame(w.check, cf.get());
+            assertSame(w2.check, cf2.get());
+        }
+        
+        static class Worker {
+            Semaphore s = new Semaphore(1);
+            Semaphore s2 = new Semaphore(0);
+            CountDownLatch l = new CountDownLatch(1);
+            volatile Token check = new Token();
+            volatile Exception e = null;
+            volatile Error e2 = null;
+            volatile CompletableFuture<Token> future = new CompletableFuture<>();
+            
+            public CompletableFuture<Token> checkInExecutedRunnable() throws Exception {
+                Lookup newLkp = new ProxyLookup(Lookups.fixed(check), Lookup.getDefault());
+                Lookups.executeWith(newLkp, this::taskLauncher);
+                return future;
+            }
+
+            private void executedRunnable() {
+                Token t = null;
+                try {
+                    assertSame(check, t = Lookup.getDefault().lookup(Token.class));
+                    s2.release();
+                    s.acquire();
+                    assertSame(check, t = Lookup.getDefault().lookup(Token.class));
+                } catch (Exception | Error e) {
+                    future.completeExceptionally(e);
+                } finally {
+                    future.complete(t);
+                }
+            }
+
+            private void taskLauncher() {
+                assertSame(check, Lookup.getDefault().lookup(Token.class));
+                ExecutionEngine.getDefault().execute("Test", this::executedRunnable, InputOutput.NULL);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Maven executor forks the execution into a separate thread, and only then it creates a `ProgressHandle`. The handle is likely to be created **after** the _DAP_ call finishes, so it is not collected by the current code. I've implemented a event source  + listener interface to listen on create/finish of progress-generating tasks. _DAP_ operation can now establish a listener and receive a ProgressHandle even after the original launch request returns; it can connect the `ProgressHandle` to the `DebugContext`.

The default execution engine implementation should support default `Lookup` passing, so the threads it creates operate in the caller's context.

The tests of LSP server must run in headless mode; without that property, some code takes wrong path, blocking test execution on UI that nobody can click on.