### PR TITLE
Don't show reload/save dialogs in VSNetBeans

### DIFF
--- a/extide/gradle/arch.xml
+++ b/extide/gradle/arch.xml
@@ -130,7 +130,7 @@
 
 
  <answer id="exec-property">
-     <api category="devel" group="branding" name="DEFAULT_REUSE_OUTPUT" type="export">
+     <api category="devel" group="branding" name="org.netbeans.modules.gradle.spi.DEFAULT_REUSE_OUTPUT" type="export">
          Brand the <code>DEFAULT_REUSE_OUTPUT</code> key in a 
          <code>org.netbeans.modules.gradle.spi.Bundle</code> file
          with one of the values <code>true</code> or <code>false</code>

--- a/ide/projectui/arch.xml
+++ b/ide/projectui/arch.xml
@@ -486,7 +486,7 @@
   <p>
       By default this module also opens all projects that were opened before
       shutting down. This behavior can however be disabled in application using
-      this module: <api name="LOAD_PROJECTS_ON_START" group="branding" type="export" category="stable">
+      this module: <api name="org.netbeans.modules.project.ui.LOAD_PROJECTS_ON_START" group="branding" type="export" category="stable">
         To disable loading of previously opened projects on startup
           set <code>LOAD_PROJECTS_ON_START=false</code> in
           <code>org/netbeans/modules/project/ui/Bundle.properties</code>

--- a/java/java.lsp.server/nbcode/branding/modules/org-openide-loaders.jar/org/netbeans/modules/openide/loaders/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-openide-loaders.jar/org/netbeans/modules/openide/loaders/Bundle.properties
@@ -15,13 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# DataEditorSupport
-# Cases when modified source file was changed to [read-only]
-MSG_FileReadOnlyClosing=File {0} was changed to read-only! All changes will be discarded.
-MSG_FileReadOnlySaving=File {0} was changed to read-only! Can not save it.
-MSG_FileReadOnlyChanging=File {0} was changed to read-only!
-
 # yes/no/ask
-ASK_OnSaving=ask
+ASK_OnSaving=no
 # yes/no/ask
-ASK_OnClosing=ask
+ASK_OnClosing=no

--- a/java/java.lsp.server/nbcode/integration/nbproject/project.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/project.xml
@@ -35,20 +35,20 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.api.templates</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>1.19</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
                         <specification-version>1.59</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.api.templates</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.19</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -73,6 +73,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>7.52</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.loaders</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.80</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/Bundle.properties
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/Bundle.properties
@@ -15,4 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-OpenIDE-Module-Name=NBCode Integration with VSCode
+OpenIDE-Module-Display-Category=Base IDE
+OpenIDE-Module-Long-Description=\
+    Integration of NetBeans into VS Code.
+OpenIDE-Module-Name=VSNetBeans
+OpenIDE-Module-Short-Description=Apache NetBeans Language Server

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -171,7 +171,7 @@
   </p>
   
   <p>
-      <api category="devel" group="branding" name="DEFAULT_REUSE_OUTPUT" type="export">
+      <api category="devel" group="branding" name="org.netbeans.modules.maven.options.DEFAULT_REUSE_OUTPUT" type="export">
           Brand the <code>DEFAULT_REUSE_OUTPUT</code> key in a 
           <code>org.netbeans.modules.maven.options.Bundle</code> file
           with one of the values <code>true</code> or <code>false</code>
@@ -179,7 +179,7 @@
           Use <code>never</code> value, if the reuse shall never be done,
           regardless of the settings value.
       </api> 
-      <api category="devel" group="branding" name="DEFAULT_COMPILE_ON_SAVE" type="export">
+      <api category="devel" group="branding" name="org.netbeans.modules.maven.api.execute.DEFAULT_COMPILE_ON_SAVE" type="export">
           Brand the <code>DEFAULT_COMPILE_ON_SAVE</code> key in a 
           <code>org.netbeans.modules.maven.api.execute.Bundle</code> file
           with one of the values <code>all</code> or <code>none</code>

--- a/nbbuild/javadoctools/links.xml
+++ b/nbbuild/javadoctools/links.xml
@@ -239,3 +239,4 @@
 <link href="${javadoc.docs.org-netbeans-modules-jumpto}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-jumpto"/>
 <link href="${javadoc.docs.org-netbeans-modules-java-editor-lib}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-java-editor-lib"/>
 <link href="${javadoc.docs.org-netbeans-modules-web-common}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-web-common"/>
+<link href="${javadoc.docs.org-netbeans-modules-db-core}" offline="true" packagelistloc="${netbeans.javadoc.dir}/org-netbeans-modules-db-core"/>

--- a/nbbuild/javadoctools/properties.xml
+++ b/nbbuild/javadoctools/properties.xml
@@ -236,3 +236,4 @@
 <property name="javadoc.docs.org-netbeans-modules-jumpto" value="${javadoc.web.root}/org-netbeans-modules-jumpto"/>
 <property name="javadoc.docs.org-netbeans-modules-java-editor-lib" value="${javadoc.web.root}/org-netbeans-modules-java-editor-lib"/>
 <property name="javadoc.docs.org-netbeans-modules-web-common" value="${javadoc.web.root}/org-netbeans-modules-web-common"/>
+<property name="javadoc.docs.org-netbeans-modules-db-core" value="${javadoc.web.root}/org-netbeans-modules-db-core"/>

--- a/nbbuild/javadoctools/replaces.xml
+++ b/nbbuild/javadoctools/replaces.xml
@@ -236,3 +236,4 @@
 <replacefilter token="@org-netbeans-modules-jumpto@" value="${javadoc.docs.org-netbeans-modules-jumpto}"/>
 <replacefilter token="@org-netbeans-modules-java-editor-lib@" value="${javadoc.docs.org-netbeans-modules-java-editor-lib}"/>
 <replacefilter token="@org-netbeans-modules-web-common@" value="${javadoc.docs.org-netbeans-modules-web-common}"/>
+<replacefilter token="@org-netbeans-modules-db-core@" value="${javadoc.docs.org-netbeans-modules-db-core}"/>

--- a/platform/core.multiview/arch.xml
+++ b/platform/core.multiview/arch.xml
@@ -881,7 +881,7 @@ No.
 -->
 <answer id="resources-read">
     <p>
-	<api category="devel" group="branding" name="MultiViewElement.Spliting.Enabled" type="export">
+	<api category="devel" group="branding" name="org.netbeans.core.multiview.MultiViewElement.Spliting.Enabled" type="export">
 	    By default a MultiViewElement allows the containing TopComponent to split it.
 	    Some systems may however find this not of any use. Then they should brand the
 	    <code>MultiViewElement.Spliting.Enabled</code> to <code>false</code>. NetBeans IDE

--- a/platform/core.network/arch.xml
+++ b/platform/core.network/arch.xml
@@ -107,7 +107,7 @@
       based on available JavaScript engine installed in the JVM.
       Execution of the downloaded JavaScript code is sandboxed.
   </p>
-  <api name="ALLOWED_PAC_ENGINES" type="export" category="stable" group="branding">
+  <api name="org.netbeans.core.network.proxy.pac.impl.ALLOWED_PAC_ENGINES" type="export" category="stable" group="branding">
       To further secure execution of downloaded scripts, it is possible
       to restrict the set of allowed 
       <a href="@JDK@/javax/script/ScriptEngine.html">ScriptEngine</a>s

--- a/platform/o.n.core/arch.xml
+++ b/platform/o.n.core/arch.xml
@@ -614,9 +614,9 @@
             implementation of <code>ProxySelector</code>.
         </api>
         
-    <api name="TimableEventQueue.install" category="friend" group="branding" type="export">
+    <api name="org.netbeans.core.TimableEventQueue.install" category="friend" group="branding" type="export">
         By default NetBeans based applications install their own <code>EventQueue</code>.
-        One can suppress that since versiong 3.27 of <code>org.netbeans.core</code> module
+        One can suppress that since version 3.27 of <code>org.netbeans.core</code> module
         by branding key <code>TimableEventQueue.install</code> in
         <code>org/netbeans/core/Bundle</code> to <code>false</code>.
     </api>

--- a/platform/openide.awt/arch.xml
+++ b/platform/openide.awt/arch.xml
@@ -453,7 +453,7 @@
     <api name="popupText" category="stable" type="export" group="property" url="@TOP@/org/openide/awt/Actions.html#connect-javax.swing.JMenuItem-javax.swing.Action-boolean-"/>
    </li>
    <li> 
-    <api name="USE_MNEMONICS" category="stable" type="export" group="branding">
+    <api name="org.openide.awt.USE_MNEMONICS" category="stable" type="export" group="branding">
         There is a way to enable mnemonics in popup menu items created via
         <a href="@TOP@/org/openide/awt/Actions.html">Actions</a> factory methods
         in your own application build on top of NetBeans Platform.

--- a/platform/openide.awt/src/org/openide/awt/Actions.java
+++ b/platform/openide.awt/src/org/openide/awt/Actions.java
@@ -65,7 +65,6 @@ import org.openide.util.LookupListener;
 import org.openide.util.Utilities;
 import org.openide.util.WeakListeners;
 import org.openide.util.actions.BooleanStateAction;
-import org.openide.util.actions.Presenter;
 import org.openide.util.actions.SystemAction;
 
 

--- a/platform/openide.loaders/apichanges.xml
+++ b/platform/openide.loaders/apichanges.xml
@@ -92,7 +92,7 @@ is the proper place.
           <date day="20" month="1" year="2021"/>
           <author login="jtulach"/>
           <compatibility addition="yes" binary="compatible" source="compatible"
-                         semantic="compatible" deprecation="no" deletion="no"
+                         semantic="incompatible" deletion="no"
                          modification="no"/>
           <description>
               A branding API to disable showing on close and on save editor dialogs

--- a/platform/openide.loaders/apichanges.xml
+++ b/platform/openide.loaders/apichanges.xml
@@ -85,6 +85,21 @@ is the proper place.
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
   <changes>
+      <change id="ask.on.save.close.defaults">
+          <api name="editor"/>
+          <summary>Rebrand defaults for Save/Close Editor Dialogs</summary>
+          <version major="7" minor="80"/>
+          <date day="20" month="1" year="2021"/>
+          <author login="jtulach"/>
+          <compatibility addition="yes" binary="compatible" source="compatible"
+                         semantic="compatible" deprecation="no" deletion="no"
+                         modification="no"/>
+          <description>
+              A branding API to disable showing on close and on save editor dialogs
+              - <a href="architecture-summary.html#group-branding">ASK_OnSaving &amp; ASK_OnClosing</a>.
+          </description>
+          <class package="org.openide.text" name="DataEditorSupport"/>
+      </change>
       <change id="org.openide.loaders.TemplateWizard.setTargetFolderLazy">
           <api name="loaders"/>
           <summary>Support lazy creation of TargetFolder.</summary>

--- a/platform/openide.loaders/arch.xml
+++ b/platform/openide.loaders/arch.xml
@@ -542,6 +542,21 @@ for more information about this.
         underlaying <a href="@TOP@/architecture-summary.html#script">scripting and templating
         engines</a>.
     </api>
+
+    <api name="ASK_OnSaving" group="branding" type="export" category="stable">
+        Control on save yes/no dialog in
+        <a href="@TOP@/org/openide/text/DataEditorSupport.html">DataEditorSupport</a>
+        by setting the <code>ASK_OnSaving</code> key in
+        <code>org/netbeans/modules/openide/loaders/Bundle.properties</code>
+        to <code>yes</code> or <code>no</code> in a branding file in your application.
+    </api>
+    <api name="ASK_OnClosing" group="branding" type="export" category="stable">
+        Control on close yes/no dialog in
+        <a href="@TOP@/org/openide/text/DataEditorSupport.html">DataEditorSupport</a>
+        by setting the <code>ASK_OnClosing</code> key in
+        <code>org/netbeans/modules/openide/loaders/Bundle.properties</code>
+        to <code>yes</code> or <code>no</code> in a branding file in your application.
+    </api>
 </answer>
 
 

--- a/platform/openide.loaders/arch.xml
+++ b/platform/openide.loaders/arch.xml
@@ -543,14 +543,14 @@ for more information about this.
         engines</a>.
     </api>
 
-    <api name="ASK_OnSaving" group="branding" type="export" category="stable">
+    <api name="org.netbeans.modules.openide.loaders.ASK_OnSaving" group="branding" type="export" category="stable">
         Control on save yes/no dialog in
         <a href="@TOP@/org/openide/text/DataEditorSupport.html">DataEditorSupport</a>
         by setting the <code>ASK_OnSaving</code> key in
         <code>org/netbeans/modules/openide/loaders/Bundle.properties</code>
         to <code>yes</code> or <code>no</code> in a branding file in your application.
     </api>
-    <api name="ASK_OnClosing" group="branding" type="export" category="stable">
+    <api name="org.netbeans.modules.openide.loaders.ASK_OnClosing" group="branding" type="export" category="stable">
         Control on close yes/no dialog in
         <a href="@TOP@/org/openide/text/DataEditorSupport.html">DataEditorSupport</a>
         by setting the <code>ASK_OnClosing</code> key in

--- a/platform/openide.loaders/manifest.mf
+++ b/platform/openide.loaders/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.loaders
-OpenIDE-Module-Specification-Version: 7.79
+OpenIDE-Module-Specification-Version: 7.80
 OpenIDE-Module-Localizing-Bundle: org/openide/loaders/Bundle.properties
 OpenIDE-Module-Provides: org.netbeans.modules.templates.v1_0
 OpenIDE-Module-Layer: org/netbeans/modules/openide/loaders/layer.xml

--- a/platform/openide.loaders/src/org/netbeans/modules/openide/loaders/AskEditorQuestions.java
+++ b/platform/openide.loaders/src/org/netbeans/modules/openide/loaders/AskEditorQuestions.java
@@ -44,6 +44,13 @@ public final class AskEditorQuestions {
     }
 
     public static boolean askUserQuestionExceptionOnSave(String localizedMessage) {
+        String ask = NbBundle.getMessage(AskEditorQuestions.class, "ASK_OnSaving"); // NOI18N
+        if ("yes".equals(ask)) { // NOI18N
+            return true;
+        }
+        if ("no".equals(ask)) { // NOI18N
+            return false;
+        }
         NotifyDescriptor nd = new NotifyDescriptor.Confirmation(localizedMessage, NotifyDescriptor.YES_NO_OPTION);
         Object res = DialogDisplayer.getDefault().notify(nd);
         if (NotifyDescriptor.OK_OPTION.equals(res)) {
@@ -54,6 +61,13 @@ public final class AskEditorQuestions {
     }
 
     public static boolean askFileReadOnlyOnClose(String fileName) {
+        String ask = NbBundle.getMessage(AskEditorQuestions.class, "ASK_OnClosing"); // NOI18N
+        if ("yes".equals(ask)) { // NOI18N
+            return true;
+        }
+        if ("no".equals(ask)) { // NOI18N
+            return false;
+        }
         Object result = DialogDisplayer.getDefault().notify(new NotifyDescriptor.Confirmation(
             NbBundle.getMessage(AskEditorQuestions.class, "MSG_FileReadOnlyClosing", 
             new Object[]{fileName}), 

--- a/platform/openide.loaders/src/org/netbeans/modules/openide/loaders/AskEditorQuestions.java
+++ b/platform/openide.loaders/src/org/netbeans/modules/openide/loaders/AskEditorQuestions.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.openide.loaders;
+
+import java.io.IOException;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
+import org.openide.filesystems.FileObject;
+import org.openide.util.NbBundle;
+
+public final class AskEditorQuestions {
+    private AskEditorQuestions() {
+    }
+
+    public static IOException throwableIsReadOnly(FileObject fo) {
+        IOException e = new IOException("File is read-only: " + fo); // NOI18N
+        UIException.annotateUser(e, null, NbBundle.getMessage(AskEditorQuestions.class, "MSG_FileReadOnlySaving", new Object[]{fo.getNameExt()}), null, null);
+        return e;
+    }
+
+    public static void notifyChangedToReadOnly(String fileName) {
+        // notify user if the object is modified and externally changed to read-only
+        DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(
+            NbBundle.getMessage(AskEditorQuestions.class, "MSG_FileReadOnlyChanging",
+            new Object[]{fileName}), 
+            NotifyDescriptor.WARNING_MESSAGE
+        ));
+    }
+
+    public static boolean askUserQuestionExceptionOnSave(String localizedMessage) {
+        NotifyDescriptor nd = new NotifyDescriptor.Confirmation(localizedMessage, NotifyDescriptor.YES_NO_OPTION);
+        Object res = DialogDisplayer.getDefault().notify(nd);
+        if (NotifyDescriptor.OK_OPTION.equals(res)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public static boolean askFileReadOnlyOnClose(String fileName) {
+        Object result = DialogDisplayer.getDefault().notify(new NotifyDescriptor.Confirmation(
+            NbBundle.getMessage(AskEditorQuestions.class, "MSG_FileReadOnlyClosing", 
+            new Object[]{fileName}), 
+            NotifyDescriptor.OK_CANCEL_OPTION, NotifyDescriptor.WARNING_MESSAGE
+        ));
+        return result == NotifyDescriptor.OK_OPTION;
+    }
+}

--- a/platform/openide.loaders/src/org/netbeans/modules/openide/loaders/Bundle.properties
+++ b/platform/openide.loaders/src/org/netbeans/modules/openide/loaders/Bundle.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# DataEditorSupport
+# Cases when modified source file was changed to [read-only]
+MSG_FileReadOnlyClosing=File {0} was changed to read-only! All changes will be discarded.
+MSG_FileReadOnlySaving=File {0} was changed to read-only! Can not save it.
+MSG_FileReadOnlyChanging=File {0} was changed to read-only!

--- a/platform/openide.loaders/src/org/openide/loaders/Bundle.properties
+++ b/platform/openide.loaders/src/org/openide/loaders/Bundle.properties
@@ -290,13 +290,6 @@ TIP_editor_ro=\ (read-only)
 # {2} line number 
 FMT_LineDisplayName2={1}:{2}
 
-# DataEditorSupport
-# Cases when modified source file was changed to [read-only]
-MSG_FileReadOnlyClosing=File {0} was changed to read-only! All changes will be discarded.
-MSG_FileReadOnlySaving=File {0} was changed to read-only! Can not save it.
-MSG_FileReadOnlyChanging=File {0} was changed to read-only!
-
-
 MSG_BinaryFileQuestion=\
     This file appears to contain binary data. \
     Are you sure you want to open it in the text editor?

--- a/platform/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/AskEditorQuestionsTest.java
+++ b/platform/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/AskEditorQuestionsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.openide.loaders;
+
+import java.awt.Dialog;
+import java.util.Locale;
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.netbeans.junit.MockServices;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
+
+public class AskEditorQuestionsTest {
+
+    public AskEditorQuestionsTest() {
+    }
+
+    @Before
+    public void setUp() {
+        Locale.setDefault(Locale.ENGLISH);
+        MockServices.setServices(MockDialogDisplayer.class);
+    }
+
+    public void testNotifyChangedToReadOnly() {
+        try {
+            AskEditorQuestions.notifyChangedToReadOnly("any.txt");
+            fail("Expecting dialog to be shown");
+        } catch (DisplayerException ex) {
+            assertTrue(ex.descriptor.getMessage().toString().contains("any.txt"));
+        }
+    }
+
+    @Test
+    public void testAskUserQuestionExceptionOnSave() {
+        try {
+            boolean result = AskEditorQuestions.askUserQuestionExceptionOnSave("any.txt");
+            fail("Expecting dialog not a result: " + result);
+        } catch (DisplayerException ex) {
+            assertTrue(ex.descriptor.getMessage().toString().contains("any.txt"));
+        }
+    }
+
+    @Test
+    public void testYesUserQuestionExceptionOnSave() {
+        Locale.setDefault(new Locale("DA"));
+        boolean result = AskEditorQuestions.askUserQuestionExceptionOnSave("any.txt");
+        assertTrue("Default answer is yes", result);
+    }
+
+    @Test
+    public void testNoUserQuestionExceptionOnSave() {
+        Locale.setDefault(new Locale("NO"));
+        boolean result = AskEditorQuestions.askUserQuestionExceptionOnSave("any.txt");
+        assertFalse("Default answer is no", result);
+    }
+
+    @Test
+    public void testAskFileReadOnlyOnClose() {
+        try {
+            boolean result = AskEditorQuestions.askFileReadOnlyOnClose("any.txt");
+            fail("Expecting dialog not a result: " + result);
+        } catch (DisplayerException ex) {
+            assertTrue(ex.descriptor.getMessage().toString().contains("any.txt"));
+        }
+    }
+
+    @Test
+    public void testYesFileReadOnlyOnClose() {
+        Locale.setDefault(new Locale("DA"));
+        boolean result = AskEditorQuestions.askFileReadOnlyOnClose("any.txt");
+        assertTrue("Default answer is yes", result);
+    }
+
+    @Test
+    public void testNoFileReadOnlyOnClose() {
+        Locale.setDefault(new Locale("NO"));
+        boolean result = AskEditorQuestions.askFileReadOnlyOnClose("any.txt");
+        assertFalse("Default answer is no", result);
+    }
+
+    private static final class DisplayerException extends RuntimeException {
+        final NotifyDescriptor descriptor;
+
+        public DisplayerException(NotifyDescriptor descriptor) {
+            this.descriptor = descriptor;
+        }
+    }
+
+    public final static class MockDialogDisplayer extends DialogDisplayer {
+        public MockDialogDisplayer() {
+        }
+
+        @Override
+        public Object notify(NotifyDescriptor nd) {
+            throw new DisplayerException(nd);
+        }
+
+        @Override
+        public Dialog createDialog(DialogDescriptor dd) {
+            throw new DisplayerException(dd);
+        }
+    }
+
+}

--- a/platform/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/Bundle_da.properties
+++ b/platform/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/Bundle_da.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ASK_OnSaving=yes
+ASK_OnClosing=yes

--- a/platform/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/Bundle_no.properties
+++ b/platform/openide.loaders/test/unit/src/org/netbeans/modules/openide/loaders/Bundle_no.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ASK_OnSaving=no
+ASK_OnClosing=no

--- a/platform/openide.windows/arch.xml
+++ b/platform/openide.windows/arch.xml
@@ -685,7 +685,7 @@ Yes. Component can control its persistence and way how they are displayed in con
          Or use -J-DNB.WinSys.Mode.Closing.Enabled=false command-line switch to override.
     </api>
     
-    <api type="export" group="branding" name="WinSys.Show.Hide.MainWindow.While.Switching.Role" category="stable">
+    <api type="export" group="branding" name="org.netbeans.core.windows.WinSys.Show.Hide.MainWindow.While.Switching.Role" category="stable">
          Name of resource bundle property which controls whether the main IDE
          window may hide temporarily (<code>true</code>) when switching window
          layout role or whether the main window should stay visible when switching
@@ -694,7 +694,7 @@ Yes. Component can control its persistence and way how they are displayed in con
          Or use -J-DNB.WinSys.WinSys.Show.Hide.MainWindow.While.Switching.Role=true command-line switch to override.
     </api>
     
-    <api type="export" group="branding" name="WinSys.Open.New.Editors.Docked" category="stable">
+    <api type="export" group="branding" name="org.netbeans.core.windows.WinSys.Open.New.Editors.Docked" category="stable">
          Name of resource bundle property which when set to <code>true</code> will
          force opening of new editor windows docked into the main IDE window.
          When set to <code>false</code> new editor windows will open tabbed
@@ -704,7 +704,7 @@ Yes. Component can control its persistence and way how they are displayed in con
          Or use -J-DNB.WinSys.WinSys.Open.New.Editors.Docked=true command-line switch to override.
     </api>
 
-    <api type="export" group="branding" name="WinSys.DragAndDrop.Sliding.Enabled" category="stable">
+    <api type="export" group="branding" name="org.netbeans.core.windows.WinSys.DragAndDrop.Sliding.Enabled" category="stable">
          Name of resource bundle property which enables/disables drag and drop
          of TopComponents into sliding Modes. When set to <code>true</code> then user can
          drag a TopComponent and drop it into a sliding bar to minimize it.
@@ -713,7 +713,7 @@ Yes. Component can control its persistence and way how they are displayed in con
          Or use -J-DNB.WinSys.WinSys.DragAndDrop.Sliding.Enabled=true command-line switch to override.
     </api>
 
-    <api type="export" group="branding" name="WinSys.TabControl.SimpleTabs.Enabled" category="stable">
+    <api type="export" group="branding" name="org.netbeans.core.windows.WinSys.TabControl.SimpleTabs.Enabled" category="stable">
          Name of resource bundle property which allows replacing the custom TabbedContainer
          with plain Swing JTabbedPane implementation when the property value is <code>true</code>.
          The default value is <code>false</code>.
@@ -721,7 +721,7 @@ Yes. Component can control its persistence and way how they are displayed in con
          Or use -J-DNB.WinSys.WinSys.TabControl.SimpleTabs.Enabled=true command-line switch to override.
     </api>
 
-    <api type="export" group="branding" name="WinSys.TabControl.SimpleTabs.Placement" category="stable">
+    <api type="export" group="branding" name="org.netbeans.core.windows.WinSys.TabControl.SimpleTabs.Placement" category="stable">
          Name of resource bundle property which defines the placement of window tabs.
          The possible values are <code>top</code> (default), <code>bottom</code>,
          <code>left</code>, <code>right</code>. Branding of this property has no effect when
@@ -729,7 +729,7 @@ Yes. Component can control its persistence and way how they are displayed in con
          The property value can be adjusted by branding of <code>org.netbeans.core.windows</code> module.
     </api>
 
-    <api type="export" group="branding" name="WinSys.TabControl.SimpleTabs.MultiRow" category="stable">
+    <api type="export" group="branding" name="org.netbeans.core.windows.WinSys.TabControl.SimpleTabs.MultiRow" category="stable">
          Name of resource bundle property which defines the tab layout when JTabbedPane
          implementation of tab control is being used. When set to <code>true</code>
          window tabs will be organized into multiple rows, when set to <code>false</code>
@@ -739,7 +739,7 @@ Yes. Component can control its persistence and way how they are displayed in con
          The property value can be adjusted by branding of <code>org.netbeans.core.windows</code> module.
     </api>
 
-    <api type="export" group="branding" name="WinSys.CtrlTabSwitching.In.JTable.Enabled" category="stable">
+    <api type="export" group="branding" name="org.netbeans.core.windows.WinSys.CtrlTabSwitching.In.JTable.Enabled" category="stable">
          Name of resource bundle property which can disable window switching 
          when the input focus is in JTable or JTabbedPane.<br/>
          Ctrl+Tab and Ctrl+Shift+Tab key strokes are hard-coded to switch between

--- a/platform/options.api/arch.xml
+++ b/platform/options.api/arch.xml
@@ -1120,7 +1120,7 @@
         can have the following structure
         <code>filePattern1#keyPattern1#|filePattern2|filePattern3#keyPattern3</code>.
    </api>
-   <api category="devel" group="branding" name="OPT_RestartAfterImport" type="export">
+   <api category="devel" group="branding" name="org.netbeans.modules.options.export.OPT_RestartAfterImport" type="export">
        By default importing settings (as described by <a href="#layer-OptionsExportLayers">OptionsExport</a>
        API does not require restart. Some systems may however support complex
        modifications to the installation structure. Then they should brand the 


### PR DESCRIPTION
VS Code manages files itself. Rename, copy, delete is handled by their UI and only later notified to the NetBeans backend. This PR provides branding API, to disable showing dialogs to the user and provide a default answer. This approach builds on previous branding APIs introduced for example in #2427, #2386, etc.