### PR TITLE
[NETBEANS-5261] Shared settings for PHP code generators

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSGenerator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/codegen/CGSGenerator.java
@@ -418,7 +418,8 @@ public final class CGSGenerator implements CodeGenerator {
         Preferences preferences = null;
         Project project = FileOwnerQuery.getOwner(fo);
         if (project != null) {
-            preferences = ProjectUtils.getPreferences(project, CGSGenerator.class, false);
+            // Share settings because style of generated code is part of project coding standard.
+            preferences = ProjectUtils.getPreferences(project, CGSGenerator.class, true);
             try {
                 cgsInfo.setHowToGenerate(GenWay.valueOf(preferences.get(GETTER_SETTER_PROJECT_PROPERTY, GenWay.AS_JAVA.name())));
             } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5261

Changes settings of PHP code generators to shared in project.
Style of generated getters/setters/constructors is part of coding standard so it should be part of shared settings.