### PR TITLE
Allow "Attach sources/javadoc" UIs to be branded out.

### DIFF
--- a/java/java.j2seplatform/apichanges.xml
+++ b/java/java.j2seplatform/apichanges.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<?xml-stylesheet type="text/xml" href="../../nbbuild/javadoctools/apichanges.xsl"?>
+<!DOCTYPE apichanges PUBLIC "-//NetBeans//DTD API changes list 1.0//EN" "../../nbbuild/javadoctools/apichanges.dtd">
+
+<!--
+
+INFO FOR PEOPLE ADDING CHANGES:
+
+Check the DTD (apichanges.dtd) for details on the syntax. You do not
+need to regenerate the HTML, as this is part of Javadoc generation; just
+change the XML. Rough syntax of a change (several parts optional):
+
+<change>
+    <api name="compiler"/>
+    <summary>Some brief description here, can use <b>XHTML</b></summary>
+    <version major="1" minor="99"/>
+    <date day="13" month="6" year="2001"/>
+    <author login="jrhacker"/>
+    <compatibility addition="yes"/>
+    <description>
+        The main description of the change here.
+        Again can use full <b>XHTML</b> as needed.
+    </description>
+    <class package="org.openide.compiler" name="DoWhatIWantCompiler"/>
+    <issue number="14309"/>
+</change>
+
+Also permitted elements: <package>, <branch>. <version> is API spec
+version, recommended for all new changes. <compatibility> should say
+if things were added/modified/deprecated/etc. and give all information
+related to upgrading old code. List affected top-level classes and
+link to issue numbers if applicable. See the DTD for more details.
+
+Changes need not be in any particular order, they are sorted in various
+ways by the stylesheet anyway.
+
+Dates are assumed to mean "on the trunk". If you *also* make the same
+change on a stabilization branch, use the <branch> tag to indicate this
+and explain why the change was made on a branch in the <description>.
+
+Please only change this file on the trunk! Rather: you can change it
+on branches if you want, but these changes will be ignored; only the
+trunk version of this file is important.
+
+Deprecations do not count as incompatible, assuming that code using the
+deprecated calls continues to see their documented behavior. But do
+specify deprecation="yes" in <compatibility>.
+
+This file is not a replacement for Javadoc: it is intended to list changes,
+not describe the complete current behavior, for which ordinary documentation
+is the proper place.
+
+-->
+
+<apichanges>
+
+    <!-- First, a list of API names you may use: -->
+    <apidefs>
+        <apidef name="j2selibraries">Java SE Platforms and Libraries</apidef>
+    </apidefs>
+
+    <!-- ACTUAL CHANGES BEGIN HERE: -->
+
+    <changes>
+        <change id="ask.on.volume.attach">
+            <api name="j2selibraries"/>
+            <summary>Rebrand defaults for attach source and javaddoc user questions</summary>
+            <version major="1" minor="54"/>         
+            <date day="20" month="1" year="2021"/>
+            <author login="sdedic"/>
+            <compatibility modification="yes" binary="compatible" source="compatible"/>
+           <description>
+                A branding API to disable showing on source and javadoc attachment dialogs
+              - <a href="architecture-summary.html#group-branding">API_Ask_attachJavadocQuestion &amp; API_Ask_attachSourcesQuestion</a>.
+            </description>
+        </change>
+    </changes>
+
+    <!-- Now the surrounding HTML text and document structure: -->
+
+    <htmlcontents>
+        
+    <!-- Generated from apichanges.xml -->
+    <head>
+        <title>Change History for the Java SE Platforms and Libraries</title>
+        <link rel="stylesheet" href="prose.css" type="text/css"/>
+    </head>
+    <body>
+        <p class="overviewlink"><a href="@TOP@/overview-summary.html">Overview</a></p>
+        <h1>Introduction</h1>
+        <p>This document lists changes made to the <a href="@TOP@/overview-summary.html">Java SE Platforms and Libraries</a>.</p>
+        <!-- The actual lists of changes, as summaries and details: -->
+        <hr/>
+        <standard-changelists module-code-name="org.netbeans.modules.java.j2seplatform/1"/>
+        <hr/>
+        <p>@FOOTER@</p>
+    </body>
+    
+    </htmlcontents>
+
+</apichanges>

--- a/java/java.j2seplatform/arch.xml
+++ b/java/java.j2seplatform/arch.xml
@@ -340,9 +340,54 @@
     </api>
    </li>
   </ul>
+  
+  <api name="API_Ask_attachSourcesQuestion" group="branding" type="export" category="stable">
+      <p>
+        Controls interaction when <b>sources</b> are about to be attached to a Classpath root, in
+        <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation.html">SourceJavadocAttacherImplementation</a>
+        provided by this module. By setting <code>API_Ask_attachSourcesQuestion</code> key in 
+        <code>org/netbeans/modules/java/j2seplatform/api/Bundle.properties</code> one can control the function:
+      </p>
+      <ul>
+          <li>
+              <b>no</b> will disable the attachers. No source/javadoc will be attached, and no user interaction will be started.
+          </li>
+          <li>
+              <b>yes</b> will permit the registered <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation#Definer.html">
+                  SourceJavadocAttacherImplementation.Definer</a> to attach an appropriate resource(s). <b>User interaction will be skipped</b>
+          </li>
+          <li>
+              <b>ask</b> (the default) will ask the user to supply the resources.
+          </li>
+      </ul>
+      <p>
+          The key can be set by a branding file in your application build.
+      </p>
+  </api>
+  <api name="API_Ask_attachJavadocQuestion" group="branding" type="export" category="stable">
+      <p>
+        Controls interaction when <b>javadocs</b> are about to be attached to a Classpath root, in
+        <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation.html">SourceJavadocAttacherImplementation</a>
+        provided by this module. By setting <code>API_Ask_attachJavadocQuestion</code> key in 
+        <code>org/netbeans/modules/java/j2seplatform/api/Bundle.properties</code> one can control the function:
+      </p>
+      <ul>
+          <li>
+              <b>no</b> will disable the attachers. No source/javadoc will be attached, and no user interaction will be started.
+          </li>
+          <li>
+              <b>yes</b> will permit the registered <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation#Definer.html">
+                  SourceJavadocAttacherImplementation.Definer</a> to attach an appropriate resource(s). <b>User interaction will be skipped</b>
+          </li>
+          <li>
+              <b>ask</b> (the default) will ask the user to supply the resources.
+          </li>
+      </ul>
+      <p>
+          The key can be set by a branding file in your application build.
+      </p>
+  </api>  
  </answer>
-
-
 
 <!--
         <question id="dep-non-nb" when="init">

--- a/java/java.j2seplatform/arch.xml
+++ b/java/java.j2seplatform/arch.xml
@@ -341,7 +341,7 @@
    </li>
   </ul>
   
-  <api name="API_Ask_attachSourcesQuestion" group="branding" type="export" category="stable">
+  <api name="org.netbeans.modules.java.j2seplatform.api.API_Ask_attachSourcesQuestion" group="branding" type="export" category="stable">
       <p>
         Controls interaction when <b>sources</b> are about to be attached to a Classpath root, in
         <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation.html">SourceJavadocAttacherImplementation</a>
@@ -364,7 +364,7 @@
           The key can be set by a branding file in your application build.
       </p>
   </api>
-  <api name="API_Ask_attachJavadocQuestion" group="branding" type="export" category="stable">
+  <api name="org.netbeans.modules.java.j2seplatform.api.API_Ask_attachJavadocQuestion" group="branding" type="export" category="stable">
       <p>
         Controls interaction when <b>javadocs</b> are about to be attached to a Classpath root, in
         <a href="@org-netbeans-api-java@/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation.html">SourceJavadocAttacherImplementation</a>

--- a/java/java.j2seplatform/manifest.mf
+++ b/java/java.j2seplatform/manifest.mf
@@ -4,5 +4,5 @@ OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/j2seplatform/Bundle.
 OpenIDE-Module-Layer: org/netbeans/modules/java/j2seplatform/resources/layer.xml
 OpenIDE-Module-Install: org/netbeans/modules/java/j2seplatform/J2SEPlatformModule.class
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Specification-Version: 1.53
+OpenIDE-Module-Specification-Version: 1.54
 OpenIDE-Module-Provides: j2seplatform

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/api/Bundle.properties
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/api/Bundle.properties
@@ -15,19 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
-extra.module.files=modules/ext/org-netbeans-modules-java-j2seplatform-probe.jar
-jnlp.indirect.jars=modules/ext/org-netbeans-modules-java-j2seplatform-probe.jar
-
-javadoc.arch=${basedir}/arch.xml
-javadoc.apichanges=${basedir}/apichanges.xml
-
-#requires nb javac for unit tests
-requires.nb.javac=true
-
-test.config.stableBTD.includes=**/*Test.class
-test.config.stableBTD.excludes=\
-    **/DefaultClassPathProviderTest.class,\
-    **/DefaultSourceLevelQueryImplTest.class,\
-    **/JavadocForBinaryQueryPlatformImplTest.class
+# Select sources to attach to JAR files: yes/no/ask
+API_Ask_attachSourcesQuestion=ask
+API_Ask_attachJavadocQuestion=ask

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/SourceJavadocAttacherUtil.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/SourceJavadocAttacherUtil.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.java.j2seplatform.queries;
 
-import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -35,6 +34,8 @@ import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.java.queries.SourceJavadocAttacher.AttachmentListener;
+import org.netbeans.modules.java.j2seplatform.api.J2SEPlatformCreator;
+import org.netbeans.modules.java.j2seplatform.spi.J2SEPlatformDefaultJavadoc;
 import org.netbeans.spi.java.project.support.JavadocAndSourceRootDetection;
 import org.netbeans.spi.java.queries.SourceJavadocAttacherImplementation;
 import org.openide.DialogDescriptor;
@@ -77,23 +78,40 @@ public final class SourceJavadocAttacherUtil {
         assert root != null;
         assert browseCall != null;
         assert convertor != null;
-        final SelectRootsPanel selectJavadoc = new SelectRootsPanel(
-                SelectRootsPanel.JAVADOC,
-                root,
-                attachedRoots,
-                browseCall,
-                convertor,
-                plugin);
-        final DialogDescriptor dd = new DialogDescriptor(selectJavadoc, Bundle.TXT_SelectJavadoc());
-        dd.setButtonListener(selectJavadoc);
-        if (DialogDisplayer.getDefault().notify(dd) == DialogDescriptor.OK_OPTION) {
-            try {
-                return selectJavadoc.getRoots();
-            } catch (Exception e) {
-                DialogDisplayer.getDefault().notify(
-                        new NotifyDescriptor.Message(
-                            Bundle.TXT_InvalidJavadocRoot(),
-                            NotifyDescriptor.ERROR_MESSAGE));
+        String action = NbBundle.getMessage(J2SEPlatformCreator.class, "API_Ask_attachJavadocQuestion");
+        if ("yes".equalsIgnoreCase(action)) { // NOI18N
+            if (plugin == null) {
+                return null;
+            }
+            List<? extends URI> sources = plugin.getSources(root, () -> false).stream().map(url -> {
+                try {
+                    return url.toURI();
+                } catch (URISyntaxException ex) {
+                }
+                return null;
+            }).filter(uri -> uri != null).collect(Collectors.toList());
+            if (!sources.isEmpty()) {
+                return sources;
+            }
+        } else if ("ask".equalsIgnoreCase(action)) { // NOI18N
+            final SelectRootsPanel selectJavadoc = new SelectRootsPanel(
+                    SelectRootsPanel.JAVADOC,
+                    root,
+                    attachedRoots,
+                    browseCall,
+                    convertor,
+                    plugin);
+            final DialogDescriptor dd = new DialogDescriptor(selectJavadoc, Bundle.TXT_SelectJavadoc());
+            dd.setButtonListener(selectJavadoc);
+            if (DialogDisplayer.getDefault().notify(dd) == DialogDescriptor.OK_OPTION) {
+                try {
+                    return selectJavadoc.getRoots();
+                } catch (Exception e) {
+                    DialogDisplayer.getDefault().notify(
+                            new NotifyDescriptor.Message(
+                                Bundle.TXT_InvalidJavadocRoot(),
+                                NotifyDescriptor.ERROR_MESSAGE));
+                }
             }
         }
         return null;
@@ -113,7 +131,11 @@ public final class SourceJavadocAttacherUtil {
         assert root != null;
         assert browseCall != null;
         assert convertor != null;
-        if (GraphicsEnvironment.isHeadless()) {
+        String action = NbBundle.getMessage(J2SEPlatformCreator.class, "API_Ask_attachSourcesQuestion");
+        if ("yes".equalsIgnoreCase(action)) { // NOI18N
+            if (plugin == null) {
+                return null;
+            }
             List<? extends URI> sources = plugin.getSources(root, () -> false).stream().map(url -> {
                 try {
                     return url.toURI();
@@ -124,7 +146,7 @@ public final class SourceJavadocAttacherUtil {
             if (!sources.isEmpty()) {
                 return sources;
             }
-        } else {
+        } else if ("ask".equalsIgnoreCase(action)) { // NOI18N
             final SelectRootsPanel selectSources = new SelectRootsPanel(
                     SelectRootsPanel.SOURCES,
                     root,

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/AbstractJ2SEAttacherTestBase.java
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/AbstractJ2SEAttacherTestBase.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.j2seplatform;
+
+import org.netbeans.modules.java.j2seplatform.libraries.*;
+import java.awt.Dialog;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import static junit.framework.TestCase.fail;
+import org.netbeans.api.java.queries.SourceJavadocAttacher;
+import org.netbeans.junit.NbTestCase;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
+import org.openide.NotifyDescriptor;
+import org.openide.util.Mutex;
+import org.openide.util.Utilities;
+import org.openide.util.test.MockLookup;
+
+/**
+ *
+ * @author sdedic
+ */
+public class AbstractJ2SEAttacherTestBase extends NbTestCase {
+
+    public AbstractJ2SEAttacherTestBase(String name) {
+        super(name);
+    }
+
+    private Locale def;
+    protected URL classesRootURL;
+    
+    protected String getBase() throws Exception {
+        File dir = getWorkDir();
+        if (Utilities.isWindows()) {
+            dir = new File(dir.getCanonicalPath());
+        }
+        return dir.toString();
+    }
+    
+    protected List<Object> additionalServices() {
+        ArrayList<Object> obs = new ArrayList<>();
+        obs.add(TestLibraryProviderImpl.getDefault());
+        obs.add(new TestDisplayer());
+        return obs;
+    }
+    
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        def = Locale.getDefault();
+        List<Object> l = additionalServices();
+        MockLookup.setLayersAndInstances(l.toArray(new Object[l.size()]));
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        Locale.setDefault(def);
+        super.tearDown(); 
+    }
+    
+    protected volatile boolean permitUI;
+    protected final AtomicBoolean uiPresented = new AtomicBoolean();
+    
+    class TestDisplayer extends DialogDisplayer {
+
+        @Override
+        public Object notify(NotifyDescriptor descriptor) {
+            uiPresented.set(true);
+            if (permitUI) {
+                return NotifyDescriptor.CLOSED_OPTION;
+            } else {
+                fail("UI should not be presented");
+                return null;
+            }
+        }
+
+        @Override
+        public Dialog createDialog(DialogDescriptor descriptor) {
+            uiPresented.set(true);
+            if (permitUI) {
+                return new Dialog(null, false);
+            } else {
+                fail("UI should not be presented");
+                return null;
+            }
+        }
+    }
+    
+    protected void assertAttacherResults(boolean sources) throws Exception {
+        CountDownLatch cdl = new CountDownLatch(1);
+        AtomicBoolean b = new AtomicBoolean();
+        
+        SourceJavadocAttacher.AttachmentListener attachL = new SourceJavadocAttacher.AttachmentListener() {
+            @Override
+            public void attachmentSucceeded() {
+                fail("Library attacher should not auto-attach sources");
+            }
+
+            @Override
+            public void attachmentFailed() {
+                b.set(true);
+            }
+        };
+        
+        BiConsumer<URL, SourceJavadocAttacher.AttachmentListener> c = (sources ? SourceJavadocAttacher::attachSources : SourceJavadocAttacher::attachJavadoc);
+        c.accept(classesRootURL, attachL);
+        Mutex.EVENT.writeAccess(() -> {
+            cdl.countDown();
+        });
+        cdl.await();
+        assertTrue("Library sources not attached", b.get());
+        assertEquals(permitUI, uiPresented.get());
+    }
+
+    /**
+     * Library attacher should not assign anything in "yes" mode, the default attacher
+     * will do.
+     * @throws Exception 
+     */
+    public void testSourcesAttachedYes() throws Exception {
+        Locale.setDefault(new Locale("DA"));
+        assertAttacherResults(true);
+    }
+    
+    /**
+     * In No mode, no source should be attached.
+     * @throws Exception 
+     */
+    public void testSourceAttachedNo() throws Exception {
+        Locale.setDefault(new Locale("NO"));
+        assertAttacherResults(true);
+    }
+
+    /**
+     * Ask mode must enter UI interaction with DialogDisplayer
+     * @throws Exception 
+     */
+    public void testSourceAttachedWithUI() throws Exception {
+        permitUI = true;
+        assertAttacherResults(true);
+    }
+    
+    public void testJavadocAttachedNo() throws Exception {
+        Locale.setDefault(new Locale("NO"));
+        assertAttacherResults(false);
+    }
+
+    public void testJavadocAttachedWithUI() throws Exception {
+        permitUI = true;
+        assertAttacherResults(false);
+    }
+    
+    /**
+     * Library attacher should not assign anything in "yes" mode, the default attacher
+     * will do.
+     * @throws Exception 
+     */
+    public void testJavadocAttachedYes() throws Exception {
+        Locale.setDefault(new Locale("DA"));
+        assertAttacherResults(false);
+    }
+    
+}

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/api/Bundle_da.properties
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/api/Bundle_da.properties
@@ -14,20 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
-extra.module.files=modules/ext/org-netbeans-modules-java-j2seplatform-probe.jar
-jnlp.indirect.jars=modules/ext/org-netbeans-modules-java-j2seplatform-probe.jar
-
-javadoc.arch=${basedir}/arch.xml
-javadoc.apichanges=${basedir}/apichanges.xml
-
-#requires nb javac for unit tests
-requires.nb.javac=true
-
-test.config.stableBTD.includes=**/*Test.class
-test.config.stableBTD.excludes=\
-    **/DefaultClassPathProviderTest.class,\
-    **/DefaultSourceLevelQueryImplTest.class,\
-    **/JavadocForBinaryQueryPlatformImplTest.class
+API_Ask_attachSourcesQuestion=yes
+API_Ask_attachJavadocQuestion=yes

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/api/Bundle_no.properties
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/api/Bundle_no.properties
@@ -14,20 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+API_Ask_attachSourcesQuestion=no
+API_Ask_attachJavadocQuestion=no
 
-javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.8
-extra.module.files=modules/ext/org-netbeans-modules-java-j2seplatform-probe.jar
-jnlp.indirect.jars=modules/ext/org-netbeans-modules-java-j2seplatform-probe.jar
-
-javadoc.arch=${basedir}/arch.xml
-javadoc.apichanges=${basedir}/apichanges.xml
-
-#requires nb javac for unit tests
-requires.nb.javac=true
-
-test.config.stableBTD.includes=**/*Test.class
-test.config.stableBTD.excludes=\
-    **/DefaultClassPathProviderTest.class,\
-    **/DefaultSourceLevelQueryImplTest.class,\
-    **/JavadocForBinaryQueryPlatformImplTest.class

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceJavadocAttacherTest.java
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/J2SELibrarySourceJavadocAttacherTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.j2seplatform.libraries;
+
+import java.io.File;
+import org.netbeans.modules.java.j2seplatform.AbstractJ2SEAttacherTestBase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
+
+/**
+ *
+ * @author sdedic
+ */
+public class J2SELibrarySourceJavadocAttacherTest extends AbstractJ2SEAttacherTestBase {
+
+    public J2SELibrarySourceJavadocAttacherTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        setupLibraries();
+    }
+
+    private FileObject libraryClassRoot;
+    
+    private void setupLibraries() throws Exception {
+        File dir = new File(getBase());
+        
+        // create library1:
+        String libPath = dir.toString() + "/library1";
+        File library = LibraryTestUtils.createJar(new File(libPath), "library1.jar", new String[]{"Main.class"});
+        File src = new File(libPath+"/src1");
+        File javadoc = new File(libPath+"/javadoc1");
+        javadoc.mkdir();
+        LibraryTestUtils.registerLibrary("library1", library, src, javadoc);
+        libraryClassRoot = FileUtil.getArchiveRoot(FileUtil.toFileObject(library));
+        classesRootURL = URLMapper.findURL(libraryClassRoot, URLMapper.INTERNAL);
+    }
+}

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/JavadocForBinaryQueryLibraryImplTest.java
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/JavadocForBinaryQueryLibraryImplTest.java
@@ -22,15 +22,12 @@ package org.netbeans.modules.java.j2seplatform.libraries;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.jar.JarOutputStream;
 import java.util.zip.ZipEntry;
 import org.netbeans.api.java.queries.JavadocForBinaryQuery;
 import org.netbeans.core.startup.layers.ArchiveURLMapper;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.j2seplatform.platformdefinition.JavaPlatformProviderImpl;
-import org.netbeans.modules.project.libraries.DefaultLibraryImplementation;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Utilities;
 import org.netbeans.modules.masterfs.MasterURLMapper;
@@ -110,25 +107,7 @@ public class JavadocForBinaryQueryLibraryImplTest extends NbTestCase {
     }
     
     private void registerLibrary(final String libName, final File cp, final File javadoc) throws Exception {
-        DefaultLibraryImplementation lib;
-        lib = new DefaultLibraryImplementation("j2se", new String[]{"classpath", "javadoc"});
-        lib.setName(libName);
-        List<URL> l = new ArrayList<URL>();
-        URL u = Utilities.toURI(cp).toURL();
-        if (cp.getPath().endsWith(".jar")) {
-            u = FileUtil.getArchiveRoot(u);
-        }
-        l.add(u);
-        lib.setContent("classpath", l);
-        l = new ArrayList<URL>();
-        u = Utilities.toURI(javadoc).toURL();
-        if (javadoc.getPath().endsWith(".jar")) {
-            u = FileUtil.getArchiveRoot(u);
-        }
-        l.add(u);
-        lib.setContent("javadoc", l);
-        TestLibraryProviderImpl prov = TestLibraryProviderImpl.getDefault();
-        prov.addLibrary(lib);
+        LibraryTestUtils.registerLibrary(libName, cp, null, javadoc);
     }
     
     public void testQuery() throws Exception {

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/LibraryTestUtils.java
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/LibraryTestUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.j2seplatform.libraries;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarOutputStream;
+import java.util.zip.ZipEntry;
+import org.netbeans.modules.project.libraries.DefaultLibraryImplementation;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Utilities;
+
+/**
+ *
+ * @author sdedic
+ */
+public class LibraryTestUtils {
+    public static void registerLibrary(final String libName, final File cp, final File src, File javadoc) throws Exception {
+        DefaultLibraryImplementation lib;
+        lib = new DefaultLibraryImplementation("j2se", new String[]{"classpath", "src", "javadoc"});
+        lib.setName(libName);
+        List<URL> l = new ArrayList<URL>();
+        URL u = Utilities.toURI(cp).toURL();
+        if (cp.getPath().endsWith(".jar")) {
+            u = FileUtil.getArchiveRoot(u);
+        }
+        l.add(u);
+        lib.setContent("classpath", l);
+        if (src != null) {
+            l = new ArrayList<URL>();
+            u = Utilities.toURI(src).toURL();
+            if (src.getPath().endsWith(".jar")) {
+                u = FileUtil.getArchiveRoot(u);
+            }
+            l.add(u);
+            lib.setContent("src", l);
+        }
+        if (javadoc != null) {
+            l = new ArrayList<URL>();
+            u = Utilities.toURI(javadoc).toURL();
+            if (javadoc.getPath().endsWith(".jar")) {
+                u = FileUtil.getArchiveRoot(u);
+            }
+            l.add(u);
+            lib.setContent("javadoc", l);
+        }
+        TestLibraryProviderImpl prov = TestLibraryProviderImpl.getDefault();
+        prov.addLibrary(lib);
+    }
+
+
+    public static File createJar(File folder, String name, String resources[]) throws Exception {
+        folder.mkdirs();
+        File f = new File(folder,name);
+        if (!f.exists()) {
+            f.createNewFile();
+        }
+        JarOutputStream jos = new JarOutputStream(new FileOutputStream(f));
+        for (int i = 0; i < resources.length; i++) {
+            jos.putNextEntry(new ZipEntry(resources[i]));
+        }
+        jos.close();
+        return f;
+    }
+}

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/SourceForBinaryQueryLibraryImplTest.java
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/SourceForBinaryQueryLibraryImplTest.java
@@ -32,7 +32,6 @@ import org.netbeans.api.java.queries.SourceForBinaryQuery;
 import org.netbeans.core.startup.layers.ArchiveURLMapper;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.j2seplatform.platformdefinition.JavaPlatformProviderImpl;
-import org.netbeans.modules.project.libraries.DefaultLibraryImplementation;
 import org.netbeans.spi.project.libraries.LibraryImplementation;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -126,27 +125,7 @@ public class SourceForBinaryQueryLibraryImplTest extends NbTestCase {
     }
     
     private void registerLibrary(final String libName, final File cp, final File src) throws Exception {
-        DefaultLibraryImplementation lib;
-        lib = new DefaultLibraryImplementation("j2se", new String[]{"classpath", "src"});
-        lib.setName(libName);
-        List<URL> l = new ArrayList<URL>();
-        URL u = Utilities.toURI(cp).toURL();
-        if (cp.getPath().endsWith(".jar")) {
-            u = FileUtil.getArchiveRoot(u);
-        }
-        l.add(u);
-        lib.setContent("classpath", l);
-        if (src != null) {
-            l = new ArrayList<URL>();
-            u = Utilities.toURI(src).toURL();
-            if (src.getPath().endsWith(".jar")) {
-                u = FileUtil.getArchiveRoot(u);
-            }
-            l.add(u);
-            lib.setContent("src", l);
-        }
-        TestLibraryProviderImpl prov = TestLibraryProviderImpl.getDefault();
-        prov.addLibrary(lib);
+        LibraryTestUtils.registerLibrary(libName, cp, src, null);
     }
     
     private LibraryImplementation getLibrary (String name) {

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/TestLibraryProviderImpl.java
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/libraries/TestLibraryProviderImpl.java
@@ -23,10 +23,8 @@ import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import org.netbeans.spi.project.libraries.LibraryImplementation;
-import org.openide.util.Lookup;
 
 /**
  * Implementation of library provider for unit testing.

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformSourceJavadocAttacherTest.java
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformSourceJavadocAttacherTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.j2seplatform.platformdefinition;
+
+import java.util.Arrays;
+import org.netbeans.api.java.platform.JavaPlatform;
+import org.netbeans.modules.java.j2seplatform.AbstractJ2SEAttacherTestBase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.URLMapper;
+
+/**
+ *
+ * @author sdedic
+ */
+public class J2SEPlatformSourceJavadocAttacherTest extends AbstractJ2SEAttacherTestBase {
+
+    public J2SEPlatformSourceJavadocAttacherTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        
+        JavaPlatform p = JavaPlatform.getDefault();
+        classesRootURL = Arrays.stream(p.getBootstrapLibraries().getRoots()).map(
+                f -> URLMapper.findURL(f, URLMapper.INTERNAL)).
+                filter(
+                        u -> !u.toString().contains("nb-javac")
+                ).findAny().get();
+    }
+}

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceJavadocAttacherTest.java
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceJavadocAttacherTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.j2seplatform.queries;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+import org.netbeans.api.java.queries.SourceJavadocAttacher;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.j2seplatform.AbstractJ2SEAttacherTestBase;
+import org.netbeans.spi.java.queries.SourceJavadocAttacherImplementation;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
+import org.openide.util.Mutex;
+
+/**
+ *
+ * @author sdedic
+ */
+public class DefaultSourceJavadocAttacherTest extends AbstractJ2SEAttacherTestBase {
+
+    public DefaultSourceJavadocAttacherTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected List<Object> additionalServices() {
+        List<Object> l = super.additionalServices();
+        l.add(new Definer());
+        return l;
+    }
+    
+    URL sourceURL;
+    URL javadocURL;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        clearWorkDir();
+        
+        File f = getWorkDir();
+        FileObject fo = FileUtil.toFileObject(f);
+        
+        FileObject cl = fo.createFolder("classes");
+        FileObject src = fo.createFolder("src");
+        FileObject jd = fo.createFolder("javadoc");
+        
+        classesRootURL = URLMapper.findURL(cl, URLMapper.INTERNAL);
+        sourceURL = URLMapper.findURL(src, URLMapper.INTERNAL);
+        javadocURL = URLMapper.findURL(jd, URLMapper.INTERNAL);
+    }
+    
+    class Definer implements SourceJavadocAttacherImplementation.Definer {
+
+        @Override
+        public String getDisplayName() {
+            return "Test";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Test";
+        }
+
+        @Override
+        public List<? extends URL> getSources(URL root, Callable<Boolean> cancel) {
+            return Collections.singletonList(sourceURL);
+        }
+
+        @Override
+        public List<? extends URL> getJavadoc(URL root, Callable<Boolean> cancel) {
+            return Collections.singletonList(javadocURL);
+        }
+        
+    }
+    
+    protected void assertAttacherResults(boolean sources) throws Exception {
+        CountDownLatch cdl = new CountDownLatch(1);
+        AtomicReference<Boolean> b = new AtomicReference<>();
+        
+        boolean expectAttach = Locale.getDefault().getLanguage().compareToIgnoreCase("da") == 0;
+        
+        SourceJavadocAttacher.AttachmentListener attachL = new SourceJavadocAttacher.AttachmentListener() {
+            @Override
+            public void attachmentSucceeded() {
+                b.set(true);
+                if (!expectAttach) {
+                    fail("Must not attach to classes");
+                }
+            }
+
+            @Override
+            public void attachmentFailed() {
+                b.set(false);
+                if (expectAttach) {
+                    fail("Must process classes");
+                }
+            }
+        };
+        
+        BiConsumer<URL, SourceJavadocAttacher.AttachmentListener> c = (sources ? SourceJavadocAttacher::attachSources : SourceJavadocAttacher::attachJavadoc);
+        c.accept(classesRootURL, attachL);
+        Mutex.EVENT.writeAccess(() -> {
+            cdl.countDown();
+        });
+        cdl.await();
+        assertEquals(Boolean.valueOf(expectAttach), b.get());
+        assertEquals(permitUI, uiPresented.get());
+    }
+}

--- a/java/java.lsp.server/nbcode/branding/modules/org.netbeans.modules.java.j2seplatform.jar/org/netbeans/modules/java/j2seplatform/api/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org.netbeans.modules.java.j2seplatform.jar/org/netbeans/modules/java/j2seplatform/api/Bundle.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Select sources to attach to JAR files: yes/no/ask
+API_Ask_attachSourcesQuestion=yes
+API_Ask_attachJavadocQuestion=yes

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/j2seplatform/api/Bundle.properties
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/j2seplatform/api/Bundle.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Select sources to attach to JAR files: yes/no/ask
+API_Ask_attachSourcesQuestion=yes
+API_Ask_attachJavadocQuestion=yes
+


### PR DESCRIPTION
This PR is somewhat inspired by #2685: LSP tests now hang on displaying 'attach sources' for a Java platform, which is traditionally handled by `GraphicsEnvironment.isHeadless()`. But @JaroslavTulach approach shows a way how to do that more politely and allow the application to select which parts of the interaction are applicable in the final environment.

I have slightly modified the support made by @dbalek for 12.3; the `SourceJavadocAttacher.attachSources()` call could (IMHO) fail in a headless environment, since it got no `plugin` from the library + platform Attachers. @dbalek please review the behaviour: the other attachers now do nothing in 'yes' mode - they could possibly use the `Definer` SPI as well.

The actual bundle keys may still need to be modified based on discussion in #2685. After this PR merges, the headless property in #2679 can be replaced by branding out the dialogs.