### PR TITLE
[NETBEANS-5270] Multiple CustomIndexer same Mime-Type: priority ignored

### DIFF
--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerCache.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexerCache.java
@@ -464,7 +464,7 @@ public abstract class IndexerCache <T extends SourceIndexerFactory> {
 
                 // the comparator instance must not be cached, because it uses data
                 // from the default lookup
-                Collections.sort(_orderedInfos, new C());
+                Collections.sort(_orderedInfos, new C().thenComparing(IIC));
                 sortInfosByMimeType(_infosByMimeType);
                 if (transientUpdate) {
                     return new Object [] {


### PR DESCRIPTION
If you have multiple CustomIndexer with the same Mime-Type and you override the method "getPriority" in the corresponding IndexerFactory, this priority is ignored/never used.
So there is the bug, that sometimes it can be that this CustomIndexers are executed in the wrong order.