### PR TITLE
[NETBEANS-5272] Fixed grouping of documents in document switcher

### DIFF
--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/DocumentSwitcherTable.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/DocumentSwitcherTable.java
@@ -237,6 +237,11 @@ class DocumentSwitcherTable extends SwitcherTable {
                     int res = project.getDisplayName().compareTo( otherProject.getDisplayName() );
                     if( res != 0 )
                         return res;
+
+                    res = project.getPath().compareTo(otherProject.getPath());
+                    if (res != 0) {
+                        return res;
+                    }
                 }
             }
             return super.compareTo( o );


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5272

Fixes issue when files from different projects with same name are not grouped correctly.
Adds sorting by project path to ensure files from same project are together.

Sample project reproducing the issue is available in JIRA.