### PR TITLE
Fix versioning of external dependency cpplite-mi

### DIFF
--- a/cpplite/cpplite.debugger/external/binaries-list
+++ b/cpplite/cpplite.debugger/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-7E2B3E2AB5EBCABF3971F118A4D288A7E5DAC1DF cpplite-mi-1.0-SNAPSHOT.jar
+2BF984B5372F003D3E6C2E96A34F45D659168534 eu.doppel-helix.netbeans.lib:cpplite-mi:f8f8250283be

--- a/cpplite/cpplite.debugger/external/cpplite-mi-f8f8250283be-license.txt
+++ b/cpplite/cpplite.debugger/external/cpplite-mi-f8f8250283be-license.txt
@@ -1,6 +1,6 @@
 Name: CND Debugger parts
 Description: CND Debugger parts that didn't go through the Apache IP Clearance yet
-Version: 1.0-SNAPSHOT
+Version: f8f8250283be
 License: CDDL-1.0
 Origin: NetBeans
 

--- a/cpplite/cpplite.debugger/nbproject/project.properties
+++ b/cpplite/cpplite.debugger/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-release.external/cpplite-mi-1.0-SNAPSHOT.jar=modules/ext/cpplite-mi-1.0-SNAPSHOT.jar
-file.reference.cpplite-mi-1.0-SNAPSHOT.jar=release/modules/ext/cpplite-mi-1.0-SNAPSHOT.jar
+release.external/cpplite-mi-f8f8250283be.jar=modules/ext/cpplite-mi-f8f8250283be.jar
+file.reference.cpplite-mi-f8f8250283be.jar=release/modules/ext/cpplite-mi-f8f8250283be.jar
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/cpplite/cpplite.debugger/nbproject/project.xml
+++ b/cpplite/cpplite.debugger/nbproject/project.xml
@@ -190,8 +190,8 @@
                 <package>org.netbeans.modules.cpplite.debugger.api</package>
             </friend-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/cpplite-mi-1.0-SNAPSHOT.jar</runtime-relative-path>
-                <binary-origin>external/cpplite-mi-1.0-SNAPSHOT.jar</binary-origin>
+                <runtime-relative-path>ext/cpplite-mi-f8f8250283be.jar</runtime-relative-path>
+                <binary-origin>external/cpplite-mi-f8f8250283be.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Publishing fails with "-SNAPSHOT" dependencies. This PR uses the id of
the originating mercurial commit as version.