### PR TITLE
Don't use local .m2 cache in build by default.

### DIFF
--- a/nbbuild/binaries-default-properties.xml
+++ b/nbbuild/binaries-default-properties.xml
@@ -22,4 +22,5 @@
 <project name="binaries-default-properties" default="netbeans" basedir=".">
   <property name="binaries.cache" location="${user.home}/.hgexternalcache"/>
   <property name="binaries.server" value="https://netbeans.osuosl.org/binaries/"/>
+  <property name="binaries.repos" value="https://repo1.maven.org/maven2/"/>
 </project>

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -69,7 +69,7 @@
     <taskdef name="downloadbinaries" classname="org.netbeans.nbbuild.extlibs.DownloadBinaries" classpath="${build.ant.classes.dir}"/>
     <taskdef name="configureproxy" classname="org.netbeans.nbbuild.extlibs.ConfigureProxy" classpath="${build.ant.classes.dir}"/>
     <property name="have-downloadbinaries-task" value="true" />
-    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
+    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" repos="${binaries.repos}">
         <manifest dir="${nb_all}">
             <include name="nbbuild/external/binaries-list"/>
             <include name="platform/libs.junit4/external/binaries-list"/>
@@ -198,7 +198,7 @@ metabuild.hash=${metabuild.hash}</echo>
   <target name="download-all-extbins" unless="ext.binaries.downloaded" depends="bootstrap">
     <echo>Downloading external binaries (*/external/ directories)...</echo>
     <!-- optionnal reporttofile used to speed resolving artefacts resolution for maven artefacts -->
-    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" >
+    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" repos="${binaries.repos}"  >
         <manifest dir="${nb_all}">
             <include name="**/external/binaries-list"/>
         </manifest>
@@ -235,7 +235,7 @@ metabuild.hash=${metabuild.hash}</echo>
         <map from="${nb_all}/" to=""/>
         <globmapper from="*" to="*/external/binaries-list"/>
     </pathconvert>
-    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
+    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" repos="${binaries.repos}">
         <manifest dir="${nb_all}" includes="${modules.binaries-list}"/>
     </downloadbinaries>
   </target>
@@ -468,7 +468,7 @@ metabuild.hash=${metabuild.hash}</echo>
   </target>
   
   <target name="-download-nb-windows-launchers" depends="init,-check-nb-cluster" if="has.nb.cluster" unless="do.build.windows.launchers">
-    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
+    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" repos="${binaries.repos}">
         <manifest dir="${nb_all}" includes="nb/ide.launcher/external/binaries-list"/>
     </downloadbinaries>
 
@@ -1310,7 +1310,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
       </fileset>
     </subant>
     <taskdef name="downloadbinaries" classname="org.netbeans.nbbuild.extlibs.DownloadBinaries" classpath="${nbantext.jar}"/>
-    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" clean="true">
+    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" repos="${binaries.repos}" clean="true">
         <manifest dir="${nb_all}">
             <include name="*/external/binaries-list"/>
             <include name="contrib/*/external/binaries-list"/>
@@ -1689,7 +1689,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
     <pathconvert property="source.dirs" pathsep="," refid="source.dirset">
       <regexpmapper from="${nb_all}/(.*)$" to="\1/**/*" handledirsep="yes"/>
     </pathconvert>
-    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}"> <!--XXX-->
+    <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" repos="${binaries.repos}"> <!--XXX-->
         <manifest dir="${nb_all}">
             <include name="libs.antlr3.devel/external/binaries-list"/>
         </manifest>
@@ -2172,7 +2172,7 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
         <taskdef name="exclusionsfromlicenseinfo" classname="org.netbeans.nbbuild.extlibs.ExclusionsFromLicenseInfo" classpath="${nbantext.jar}"/>
         <taskdef name="reportFromLicenseinfo" classname="org.netbeans.nbbuild.extlibs.ReportFromLicenseinfo" classpath="${nbantext.jar}"/>
         
-        <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
+        <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" repos="${binaries.repos}">
             <manifest dir="${nb_all}">
                 <include name="nbbuild/external/binaries-list"/>
             </manifest>


### PR DESCRIPTION
Always download Maven binaries by default rather than relying on local .m2 cache (issues with Jenkins builds).
Expose binaries.repos property so source repositories of binaries can be configured, including local .m2 if desired.

Passing eg. `-Dbinaries.repos="file:///<HOME>/.m2/repository/ https://repo1.maven.org/maven2/"`to ant still allows use of local binaries if necessary.