### PR TITLE
Popup tab switcher should hide when another application steals focus

### DIFF
--- a/platform/o.n.swing.tabcontrol/nbproject/project.properties
+++ b/platform/o.n.swing.tabcontrol/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.7
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 


### PR DESCRIPTION
Fixes a problem I've run into several times on Mac OS - if another application steals focus
while the popup switcher is open, the switcher can wind up in a state where it is listening
twice, and is hidden as soon as you release the mouse button.

Fix is to add AWTEvent.WINDOW_EVENT_MASK to the set of AWTEvents listened for, check that
there really is no active window (to avoid confusion around heavyweight AWT popups) and
hide the popup in that case.