### PR TITLE
[NETBEANS-5004] Update macOS native launchers to call launcher shell script rather than nbexec

### DIFF
--- a/harness/apisupport.harness/macosx-launcher-src/Sources/AppLauncher/main.swift
+++ b/harness/apisupport.harness/macosx-launcher-src/Sources/AppLauncher/main.swift
@@ -19,150 +19,11 @@
 
 import Foundation
 
-func getDefaultDir(for directory: FileManager.SearchPathDirectory) -> String {
-    let urls = FileManager.default.urls(for: directory, in: .userDomainMask)
-    let defaultDir = URL(string: brandingToken!, relativeTo: urls[0])
-
-    return defaultDir!.path
-}
-
-func processClusters(file: String) -> String {
-    let appDir = Bundle.main.path(forResource: brandingToken, ofType: "")
-    var clusters = String()
-    do {
-        let contents = try String(contentsOfFile: file)
-        let lines = contents.components(separatedBy: .newlines)
-        for line in lines {
-            if (line.starts(with: "#")) {
-                continue;
-            }
-            clusters = clusters + appDir! + "/" + line + ":"
-        }
-    } catch {
-        print("error reading" + brandingToken! + ".clusters")
-    }
-
-    return clusters
-}
-
-func processConf(confFile: String, confDict: inout Dictionary<String, String> )  {
-    //set default userdir and cachedir
-    let userdir_root = getDefaultDir(for: .applicationSupportDirectory)
-    let cachedir_root = getDefaultDir(for: .cachesDirectory)
-    
-    do {
-        let contents = try String(contentsOfFile: confFile)
-        let lines = contents.components(separatedBy: .newlines)
-        for line in lines {
-            if (line.starts(with: "#")) {
-                continue;
-            }
-        
-            if let idx = line.firstIndex(of: "=") {
-                let varRange = line.startIndex..<idx
-                let idx2 = line.index(after: idx)
-                let valRange = idx2..<line.endIndex
-                let nbvar = String(line[varRange])
-                let nbval = String(line[valRange])
-                
-                // strip quotes
-                let start = nbval.index(after: nbval.startIndex)
-                let end = nbval.index(before: nbval.endIndex)
-                let val = nbval[start..<end]
-                
-                switch nbvar {
-                case "default_userdir":
-                    confDict["default_userdir"] = val.replacingOccurrences(of: "${DEFAULT_USERDIR_ROOT}", with: userdir_root)
-                case "default_cachedir":
-                    confDict["default_cachedir"] = val.replacingOccurrences(of: "${DEFAULT_CACHEDIR_ROOT}", with: cachedir_root)
-                case "default_options":
-                    confDict["default_options"] = String(val)
-                case "jdkhome":
-                    confDict["jdkhome"] = String(val)
-                case "extra_clusters":
-                    confDict["extra_clusters"] = String(val)
-                default:
-                    print("Unknown " + confFile + " variable: " + nbvar + "=" + nbval)
-                }
-            }
-        }
-    } catch {
-        print("error reading " + confFile)
-    }
-}
-
 let brandingToken = Bundle.main.object(forInfoDictionaryKey: "CFBundleExecutable") as? String
 let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
-let confFile = Bundle.main.path(forResource: brandingToken, ofType: "conf", inDirectory: brandingToken! + "/etc")
-let clustersFile = Bundle.main.path(forResource: brandingToken, ofType: "clusters", inDirectory: brandingToken! + "/etc")
-let iconFile = Bundle.main.path(forResource: brandingToken, ofType: "icns")
-let nbexecURL = Bundle.main.url(forResource: "nbexec", withExtension: "", subdirectory: brandingToken! + "/platform/lib")
-
-var confDict = Dictionary<String, String>()
-var clusters = processClusters(file: clustersFile!)
-var foundUserDir = false
-var foundCacheDir = false
-
-// process app.conf file
-processConf(confFile: confFile!, confDict: &confDict)
-
-// process user's app.conf
-if let userDir = confDict["default_userdir"] {
-    let userConfFile = userDir + "/etc/" + brandingToken! + ".conf"
-    if FileManager.default.fileExists(atPath: userConfFile) {
-        processConf(confFile: userConfFile, confDict: &confDict)
-    }
-}
-
-// check command line arguments for userdir or cachedir
-for argument in CommandLine.arguments {
-    switch argument {
-    case "--userdir":
-        foundUserDir = true
-    case "--cachedir":
-        foundCacheDir = true
-    default:
-        break
-    }
-}
+let launcherURL = Bundle.main.url(forResource: brandingToken, withExtension: "", subdirectory: brandingToken! + "/bin")
 
 var args = [String]()
-args.append("-J-Xdock:icon=" + iconFile!)
-args.append("-J-Xdock:name=" + appName!)
-
-
-// convert conf variables to command line arguments
-for (key, val) in confDict {
-    switch key {
-    case "default_userdir":
-        if (!foundUserDir) {
-            args.append("--userdir")
-            args.append(val)
-        }
-    case "default_cachedir":
-        if (!foundUserDir) {
-            args.append("--cachedir")
-            args.append(val)
-        }
-    case "default_options":
-        let nbargs = val.components(separatedBy: " ")
-        for arg in nbargs {
-            if !arg.trimmingCharacters(in: .whitespaces).isEmpty {
-                args.append(arg)
-            }
-        }
-    case "jdkhome":
-        args.append("--jdkhome")
-        args.append(val)
-    case "extra_clusters":
-        clusters = clusters + val
-    default:
-        print("Unknown netbeans.conf variable: " + key + "=" + val)
-    }
-}
-        
-args.append("--clusters")
-args.append(clusters)
 
 // add user's command line arguments
 for argument in Array(CommandLine.arguments.dropFirst()) {
@@ -172,10 +33,10 @@ for argument in Array(CommandLine.arguments.dropFirst()) {
 
 let launchNbexec = Process()
 var env = ProcessInfo.processInfo.environment
-env["DEFAULT_USERDIR_ROOT"] = getDefaultDir(for: .applicationSupportDirectory)
+env["APP_DOCK_NAME"] = appName
 launchNbexec.environment = env
 launchNbexec.arguments = args
-launchNbexec.executableURL = nbexecURL
+launchNbexec.executableURL = launcherURL
 try launchNbexec.run()
 
 // needed to keep Dock name based on CFBundleName from Info.plist

--- a/harness/apisupport.harness/release/launchers/app.sh
+++ b/harness/apisupport.harness/release/launchers/app.sh
@@ -35,6 +35,10 @@ done
 
 progdir=`dirname "$PRG"`
 APPNAME=`basename "$PRG"`
+if [ -z "$APP_DOCK_NAME" ] ; then
+  APP_DOCK_NAME="$APPNAME"
+fi
+
 case "`uname`" in
     Darwin*)
         # set default userdir and cachedir on Mac OS X
@@ -123,7 +127,7 @@ case "`uname`" in
     Darwin*)
         eval exec sh '"$nbexec"' \
             --jdkhome '"$jdkhome"' \
-            -J-Xdock:name='"$APPNAME"' \
+            -J-Xdock:name='"$APP_DOCK_NAME"' \
             '"-J-Xdock:icon=$progdir/../../$APPNAME.icns"' \
             --clusters '"$clusters"' \
             --userdir '"${userdir}"' \

--- a/nb/ide.launcher/macosx/Sources/NetBeansLauncher/main.swift
+++ b/nb/ide.launcher/macosx/Sources/NetBeansLauncher/main.swift
@@ -19,164 +19,20 @@
 
 import Foundation
 
-func getDefaultDir(for directory: FileManager.SearchPathDirectory) -> String {
-    let urls = FileManager.default.urls(for: directory, in: .userDomainMask)
-    let defaultDir = URL(string: "NetBeans", relativeTo: urls[0])
-    
-    return defaultDir!.path
-}
-
-func processClusters(file: String) -> String {
-    var clusters = String()
-    do {
-        let contents = try String(contentsOfFile: file)
-        let lines = contents.components(separatedBy: .newlines)
-        for line in lines {
-            if (line.starts(with: "#") || line == "platform") {
-                continue;
-            }
-            clusters = clusters + netBeansDir! + "/" + line + ":"
-        }
-    } catch {
-        print("error reading netbeans.clusters")
-    }
-    return clusters
-}
-
-func processConf(confFile: String, confDict: inout Dictionary<String, String> )  {
-    //set default userdir and cachedir
-    let userdir_root = getDefaultDir(for: .applicationSupportDirectory)
-    let cachedir_root = getDefaultDir(for: .cachesDirectory)
-    
-    do {
-        let contents = try String(contentsOfFile: confFile)
-        let lines = contents.components(separatedBy: .newlines)
-        for line in lines {
-            if (line.starts(with: "#")) {
-                continue;
-            }
-        
-            if let idx = line.firstIndex(of: "=") {
-                let varRange = line.startIndex..<idx
-                let idx2 = line.index(after: idx)
-                let valRange = idx2..<line.endIndex
-                let nbvar = String(line[varRange])
-                let nbval = String(line[valRange])
-                
-                // strip quotes
-                let start = nbval.index(after: nbval.startIndex)
-                let end = nbval.index(before: nbval.endIndex)
-                let val = nbval[start..<end]
-                
-                switch nbvar {
-                case "netbeans_default_userdir":
-                    confDict["netbeans_default_userdir"] = val.replacingOccurrences(of: "${DEFAULT_USERDIR_ROOT}", with: userdir_root)
-                case "netbeans_default_cachedir":
-                    confDict["netbeans_default_cachedir"] = val.replacingOccurrences(of: "${DEFAULT_CACHEDIR_ROOT}", with: cachedir_root)
-                case "netbeans_default_options":
-                    confDict["netbeans_default_options"] = String(val)
-                case "netbeans_jdkhome":
-                    confDict["netbeans_jdkhome"] = String(val)
-                case "netbeans_extraclusters":
-                    confDict["netbeans_extraclusters"] = String(val)
-                default:
-                    print("Unknown " + confFile + " variable: " + nbvar + "=" + nbval)
-                }
-            }
-        }
-    } catch {
-        print("error reading " + confFile)
-    }
-}
-
-let netBeansDir = Bundle.main.path(forResource: "netbeans", ofType: "", inDirectory: "NetBeans")
-let confFile = Bundle.main.path(forResource: "netbeans", ofType: "conf", inDirectory: "NetBeans/netbeans/etc")
-let clustersFile = Bundle.main.path(forResource: "netbeans", ofType: "clusters", inDirectory: "NetBeans/netbeans/etc")
-let iconFile = Bundle.main.path(forResource: "netbeans", ofType: "icns")
-let nbexecURL = Bundle.main.url(forResource: "nbexec", withExtension: "", subdirectory: "NetBeans/netbeans/platform/lib")
-
-var confDict = Dictionary<String, String>()
-var clusters = processClusters(file: clustersFile!)
-var foundUserDir = false
-var foundCacheDir = false
-
-// process netbeans.conf file
-processConf(confFile: confFile!, confDict: &confDict)
-
-// process user's netbeans.conf
-if let userDir = confDict["netbeans_default_userdir"] {
-    let userConfFile = userDir + "/etc/netbeans.conf"
-    if FileManager.default.fileExists(atPath: userConfFile) {
-        processConf(confFile: userConfFile, confDict: &confDict)
-    }
-}
-
-// check command line arguments for userdir or cachedir
-for argument in CommandLine.arguments {
-    switch argument {
-    case "--userdir":
-        foundUserDir = true
-    case "--cachedir":
-        foundCacheDir = true
-    default:
-        break
-    }
-}
+let netbeansURL = Bundle.main.url(forResource: "netbeans", withExtension: "", subdirectory: "NetBeans/netbeans/bin")
 
 var args = [String]()
-args.append("-J-Xdock:icon=" + iconFile!)
-args.append("-J-Xdock:name=Apache NetBeans")
-args.append("--branding")
-args.append("nb")
-args.append("-J-Dnetbeans.importclass=org.netbeans.upgrade.AutoUpgrade")
-
-// convert conf variables to command line arguments
-for (key, val) in confDict {
-    switch key {
-    case "netbeans_default_userdir":
-        if (!foundUserDir) {
-            args.append("--userdir")
-            args.append(val)
-        }
-    case "netbeans_default_cachedir":
-        if (!foundUserDir) {
-            args.append("--cachedir")
-            args.append(val)
-        }
-    case "netbeans_default_options":
-        let nbargs = val.components(separatedBy: " ")
-        for arg in nbargs {
-            if !arg.trimmingCharacters(in: .whitespaces).isEmpty {
-                args.append(arg)
-            }
-        }
-    case "netbeans_jdkhome":
-        args.append("--jdkhome")
-        args.append(val)
-    case "netbeans_extraclusters":
-        clusters = clusters + val
-    default:
-        print("Unknown netbeans.conf variable: " + key + "=" + val)
-    }
-}
-        
-args.append("--clusters")
-args.append(clusters)
 
 // add user's command line arguments
 for argument in Array(CommandLine.arguments.dropFirst()) {
     args.append(argument)
 }
 
-
-let launchNbexec = Process()
-var env = ProcessInfo.processInfo.environment
-env["DEFAULT_USERDIR_ROOT"] = getDefaultDir(for: .applicationSupportDirectory)
-launchNbexec.environment = env
-launchNbexec.arguments = args
-launchNbexec.executableURL = nbexecURL
-try launchNbexec.run()
+let launchNetbeans = Process()
+launchNetbeans.arguments = args
+launchNetbeans.executableURL = netbeansURL
+try launchNetbeans.run()
 
 // needed to keep Dock name based on CFBundleName from Info.plist
 // does not work if called from command line.
-launchNbexec.waitUntilExit()
+launchNetbeans.waitUntilExit()


### PR DESCRIPTION
Update macOS Native Launchers to call the unix launcher shell scripts instead of duplicating the logic in the scripts.

As @neilcsmith-net pointed out in https://github.com/apache/netbeans/pull/2563#issuecomment-765627457 this will avoid having to update the logic in yet another place as we do with the Windows Launcher. 
