### PR TITLE
Fixing failing build.

### DIFF
--- a/java/java.lsp.server/build.xml
+++ b/java/java.lsp.server/build.xml
@@ -87,6 +87,7 @@
         <delete dir="${build.dir}/bundles" />
         <mkdir dir="${build.dir}/bundles/package" />
         <copy file="vscode/package.json" todir="${build.dir}/bundles/package" />
+        <copy file="vscode/package-lock.json" todir="${build.dir}/bundles/package" />
 
         <exec executable="mvn" failonerror="true" dir="${nb_all}/nbbuild/misc/prepare-bundles">
             <arg value="package" />


### PR DESCRIPTION
- `PrepareBundles` task should use the same versions of NPMs as the extension itself
- stop LSP client before killing server while restarting NBLS 