### PR TITLE
Fixing a mistake in ergonomics project detection, so that it can detect OpenJDK projects.

### DIFF
--- a/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureProjectFactory.java
+++ b/ergonomics/ide.ergonomics/src/org/netbeans/modules/ide/ergonomics/fod/FeatureProjectFactory.java
@@ -150,6 +150,8 @@ implements ProjectFactory, PropertyChangeListener, Runnable {
                 return false;
             }
 
+            relative = relative.substring(pos);
+
             if (relative.contains("*")) {
                 for (String segment : relative.split("/")) {
                     FOUND: if (segment.contains("*")) {

--- a/ergonomics/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/FeatureProjectFactoryTest.java
+++ b/ergonomics/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/fod/FeatureProjectFactoryTest.java
@@ -43,6 +43,20 @@ public class FeatureProjectFactoryTest {
         assertTrue(isProject(yes1, relative));
     }
 
+    @Test
+    public void recognizeParentPath() throws IOException {
+        FileObject root = FileUtil.createMemoryFileSystem().getRoot();
+        FileObject src = FileUtil.createFolder(root, "src");
+        FileObject marker = FileUtil.createFolder(src, "marker");
+        FileObject other = FileUtil.createFolder(src, "other");
+
+        final String relative = "../marker";
+
+        assertFalse(isProject(src, relative));
+        assertTrue(isProject(marker, relative));
+        assertTrue(isProject(other, relative));
+    }
+
     private static FileObject prj(FileObject root, String base, String mx, String file) throws IOException {
         return root.createFolder(base).createFolder(mx).createData(file).getParent().getParent();
     }


### PR DESCRIPTION
Basically, if the project marker file relative path contains `../`, we attempt to use the parent file. But, the `../` is never stripped from the marker file relative path. Trying to fix here.