### PR TITLE
[NETBEANS-5304] CSS: Prevent UI blocking on undocumented properties

### DIFF
--- a/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/StandardPropertiesHelpResolver.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/module/main/StandardPropertiesHelpResolver.java
@@ -57,7 +57,7 @@ public class StandardPropertiesHelpResolver extends HelpResolver {
     private static final String W3C_SPEC_URL_PREFIX = "http://www.w3.org/TR/"; //NOI18N
     private static final String MODULE_ARCHIVE_PATH = "www.w3.org/TR/"; //NOI18N
     private static final String INDEX_HTML_FILE_NAME = "index.html"; //NOI18N
-    
+
     private static final String NO_HELP_MSG = NbBundle.getMessage(StandardPropertiesHelpResolver.class, "completion-help-no-documentation-found");
 
     @Override
@@ -171,24 +171,8 @@ public class StandardPropertiesHelpResolver extends HelpResolver {
 
                 } else {
                     //no pattern found, likely a bit different source
-                    LOGGER.warning(String.format("No property anchor section pattern found for property '%s'", property.getName())); //NOI18N
-                    
-                    //strip the <style>...</style> section from the source since it causes a garbage in the swingbrowser
-                    int styleSectionStart = urlContent.indexOf("<style type=\"text/css\">"); //NOI18N
-                    if(styleSectionStart >= 0) {
-                        final String styleEndTag = "</style>"; //NOI18N
-                        int styleSectionEnd = urlContent.indexOf(styleEndTag, styleSectionStart);
-                        if(styleSectionEnd >= 0) {
-                            StringBuilder buf = new StringBuilder();
-                            buf.append(urlContent.subSequence(0, styleSectionStart));
-                            buf.append(urlContent.subSequence(styleSectionEnd + styleEndTag.length(), urlContent.length()));
-                            
-                            return buf.toString();
-                        }
-                    }
-                    
-                    
-                    return urlContent;
+                    LOGGER.warning(String.format("No property anchor section pattern found for property '%s'", propertyUrl)); //NOI18N
+                    return NO_HELP_MSG;
                 }
             } catch (MalformedURLException ex) {
                 LOGGER.log(Level.WARNING, null, ex);


### PR DESCRIPTION
When the documentation for the target property could not be found, the
whole page of the CSS module was passed as help text. The rendering of
the HTML in combination with a popup menu caused problems on hide.

The documentation could be rendered, but on hide, the EDT is stuck in a
call to:

javax.swing.PopupFactory$MediumWeightPopup.hide()

Instead of rendering the whole documentation, the information "there is
no documenation" is rendered. While not optimal, it at least prevents a
heard freeze.