### PR TITLE
[NETBEANS-5299] Update FlatLaf from 1.0-rc1 to 1.0-rc2

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-6D2AEA7D59BB99C278A32256B17753C4F8507B3C com.formdev:flatlaf:1.0-rc1
+5507827B39B40EED2942652D4792A51A5C49D67C com.formdev:flatlaf:1.0-rc2

--- a/platform/libs.flatlaf/external/flatlaf-1.0-rc2-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-1.0-rc2-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 1.0-rc1
-Files: flatlaf-1.0-rc1.jar
+Version: 1.0-rc2
+Files: flatlaf-1.0-rc2.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/org-netbeans-libs-flatlaf.sig
+++ b/platform/libs.flatlaf/nbproject/org-netbeans-libs-flatlaf.sig
@@ -8,6 +8,7 @@ fld public final static java.lang.String BUTTON_TYPE_ROUND_RECT = "roundRect"
 fld public final static java.lang.String BUTTON_TYPE_SQUARE = "square"
 fld public final static java.lang.String BUTTON_TYPE_TAB = "tab"
 fld public final static java.lang.String BUTTON_TYPE_TOOLBAR_BUTTON = "toolBarButton"
+fld public final static java.lang.String COMPONENT_FOCUS_OWNER = "JComponent.focusOwner"
 fld public final static java.lang.String COMPONENT_ROUND_RECT = "JComponent.roundRect"
 fld public final static java.lang.String MENU_BAR_EMBEDDED = "JRootPane.menuBarEmbedded"
 fld public final static java.lang.String MINIMUM_HEIGHT = "JComponent.minimumHeight"
@@ -65,6 +66,8 @@ fld public final static java.lang.String TABBED_PANE_TRAILING_COMPONENT = "JTabb
 fld public final static java.lang.String TAB_BUTTON_SELECTED_BACKGROUND = "JToggleButton.tab.selectedBackground"
 fld public final static java.lang.String TAB_BUTTON_UNDERLINE_COLOR = "JToggleButton.tab.underlineColor"
 fld public final static java.lang.String TAB_BUTTON_UNDERLINE_HEIGHT = "JToggleButton.tab.underlineHeight"
+fld public final static java.lang.String TREE_PAINT_SELECTION = "JTree.paintSelection"
+fld public final static java.lang.String TREE_WIDE_SELECTION = "JTree.wideSelection"
 meth public static boolean clientPropertyBoolean(javax.swing.JComponent,java.lang.String,boolean)
 meth public static boolean clientPropertyEquals(javax.swing.JComponent,java.lang.String,java.lang.Object)
 meth public static int clientPropertyInt(javax.swing.JComponent,java.lang.String,int)

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-1.0-rc1.jar=modules/ext/flatlaf-1.0-rc1.jar
+release.external/flatlaf-1.0-rc2.jar=modules/ext/flatlaf-1.0-rc2.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-1.0-rc1.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-1.0-rc1.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-1.0-rc2.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-1.0-rc2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Updates FlatLaf to latest version to fix `Enter` key regression:
https://issues.apache.org/jira/browse/NETBEANS-5299

https://github.com/JFormDesigner/FlatLaf/releases/tag/1.0-rc2
