### PR TITLE
[NETBEANS-5326] LSP codelens output fixes

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbSourceProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbSourceProvider.java
@@ -118,11 +118,14 @@ public final class NbSourceProvider {
         String uri = sourceProvider.getSourceFileURI(fullyQualifiedName, relativeSourcePath);
 
         if (uri == null || uri.isEmpty()) {
-            for (String path : context.getSourcePaths()) {
-                Path fullpath = Paths.get(path, relativeSourcePath);
-                if (Files.isRegularFile(fullpath)) {
-                    uri = fullpath.toString();
-                    break;
+            String[] sourcePaths = context.getSourcePaths();
+            if (sourcePaths != null) {
+                for (String path : sourcePaths) {
+                    Path fullpath = Paths.get(path, relativeSourcePath);
+                    if (Files.isRegularFile(fullpath)) {
+                        uri = fullpath.toString();
+                        break;
+                    }
                 }
             }
         }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbThreads.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbThreads.java
@@ -27,7 +27,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 
-import org.eclipse.lsp4j.debug.TerminatedEventArguments;
 import org.eclipse.lsp4j.debug.ThreadEventArguments;
 import org.netbeans.api.debugger.DebuggerEngine;
 import org.netbeans.api.debugger.DebuggerManager;
@@ -63,15 +62,6 @@ public final class NbThreads {
     }
 
     private void initThreads(DebugAdapterContext context, JPDADebugger debugger) {
-        debugger.addPropertyChangeListener(JPDADebugger.PROP_STATE, evt -> {
-            int newState = (int) evt.getNewValue();
-            switch (newState) {
-                case JPDADebugger.STATE_DISCONNECTED:
-                    //debugger.removePropertyChangeListener(this);
-                    context.getClient().terminated(new TerminatedEventArguments());
-                    break;
-            }
-        });
         DebuggerEngine engine = debugger.getSession().getCurrentEngine();
         if (engine == null) {
             debugger.getSession().addPropertyChangeListener(Session.PROP_CURRENT_LANGUAGE, new PropertyChangeListener() {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
@@ -58,8 +58,9 @@ public final class NbLaunchRequestHandler {
     public CompletableFuture<Void> launch(Map<String, Object> launchArguments, DebugAdapterContext context) {
         CompletableFuture<Void> resultFuture = new CompletableFuture<>();
         boolean noDebug = (Boolean) launchArguments.getOrDefault("noDebug", Boolean.FALSE);
-        activeLaunchHandler = noDebug ? new NbLaunchWithoutDebuggingDelegate((daContext) -> handleTerminatedEvent(daContext))
-                : new NbLaunchWithDebuggingDelegate();
+        Consumer<DebugAdapterContext> terminateHandle = (daContext) -> handleTerminatedEvent(daContext);
+        activeLaunchHandler = noDebug ? new NbLaunchWithoutDebuggingDelegate(terminateHandle)
+                : new NbLaunchWithDebuggingDelegate(terminateHandle);
         // validation
         List<String> modulePaths = (List<String>) launchArguments.getOrDefault("modulePaths", Collections.emptyList());
         List<String> classPaths = (List<String>) launchArguments.getOrDefault("classPaths", Collections.emptyList());

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchWithDebuggingDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchWithDebuggingDelegate.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.java.lsp.server.debugging.launch;
 
 import java.util.Map;
+import java.util.function.Consumer;
 import org.netbeans.modules.java.lsp.server.debugging.DebugAdapterContext;
 
 
@@ -27,6 +28,18 @@ import org.netbeans.modules.java.lsp.server.debugging.DebugAdapterContext;
  * @author martin
  */
 public final class NbLaunchWithDebuggingDelegate extends NbLaunchDelegate {
+
+    private final Consumer<DebugAdapterContext> onFinishCallback;
+
+    NbLaunchWithDebuggingDelegate(Consumer<DebugAdapterContext> onFinishCallback) {
+        this.onFinishCallback = onFinishCallback;
+    }
+
+    @Override
+    protected void notifyFinished(DebugAdapterContext ctx, boolean success) {
+        super.notifyFinished(ctx, success);
+        onFinishCallback.accept(ctx);
+    }
 
     @Override
     public void postLaunch(Map<String, Object> launchArguments, DebugAdapterContext context) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -322,8 +322,7 @@ public final class Server {
                 capabilities.setDocumentHighlightProvider(true);
                 capabilities.setReferencesProvider(true);
                 List<String> commands = new ArrayList<>(Arrays.asList(
-                        JAVA_BUILD_WORKSPACE, GRAALVM_PAUSE_SCRIPT,
-                        JAVA_TEST_SINGLE_METHOD, JAVA_RUN_MAIN_METHOD));
+                        JAVA_BUILD_WORKSPACE, GRAALVM_PAUSE_SCRIPT));
                 for (CodeGenerator codeGenerator : Lookup.getDefault().lookupAll(CodeGenerator.class)) {
                     commands.addAll(codeGenerator.getCommands());
                 }
@@ -419,8 +418,6 @@ public final class Server {
     }
     
     public static final String JAVA_BUILD_WORKSPACE =  "java.build.workspace";
-    public static final String JAVA_TEST_SINGLE_METHOD =  "java.test.single.method";
-    public static final String JAVA_RUN_MAIN_METHOD =  "java.run.main.method";
     public static final String GRAALVM_PAUSE_SCRIPT =  "graalvm.pause.script";
     static final String INDEXING_COMPLETED = "Indexing completed.";
     static final String NO_JAVA_SUPPORT = "Cannot initialize Java support on JDK ";

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1375,7 +1375,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                                                     Utils.createPosition(cc.getCompilationUnit(), method.end().getOffset()));
                             List<Object> arguments = Arrays.asList(new Object[]{method.method().getFile().toURI(), method.method().getMethodName()});
                             lens.add(new CodeLens(range,
-                                                  new Command("Run test", Server.JAVA_TEST_SINGLE_METHOD, arguments),
+                                                  new Command("Run test", "java.run.codelens", arguments),
                                                   null));
                             lens.add(new CodeLens(range,
                                                   new Command("Debug test", "java.debug.codelens", arguments),
@@ -1391,7 +1391,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                             Range range = Utils.treeRange(cc, tree);
                             List<Object> arguments = Collections.singletonList(params.getTextDocument().getUri());
                             lens.add(new CodeLens(range,
-                                                  new Command("Run main", Server.JAVA_RUN_MAIN_METHOD, arguments),
+                                                  new Command("Run main", "java.run.codelens", arguments),
                                                   null));
                             lens.add(new CodeLens(range,
                                                   new Command("Debug main", "java.debug.codelens", arguments),

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -112,33 +112,6 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
                 progressOfCompilation.checkStatus();
                 return progressOfCompilation.getFinishFuture();
             }
-            case Server.JAVA_TEST_SINGLE_METHOD:
-                CommandProgress progressOfCommand = new CommandProgress();
-                String uriStr = ((JsonPrimitive) params.getArguments().get(0)).getAsString();
-                FileObject file;
-                try {
-                    file = URLMapper.findFileObject(new URL(uriStr));
-                } catch (MalformedURLException ex) {
-                    Exceptions.printStackTrace(ex);
-                    return CompletableFuture.completedFuture(true);
-                }
-                String methodName = ((JsonPrimitive) params.getArguments().get(1)).getAsString();
-                SingleMethod method = new SingleMethod(file, methodName);
-                runSingleMethodCommand(method, SingleMethod.COMMAND_RUN_SINGLE_METHOD, progressOfCommand);
-                progressOfCommand.checkStatus();
-                return progressOfCommand.getFinishFuture();
-            case Server.JAVA_RUN_MAIN_METHOD:
-                progressOfCommand = new CommandProgress();
-                uriStr = ((JsonPrimitive) params.getArguments().get(0)).getAsString();
-                try {
-                    file = URLMapper.findFileObject(new URL(uriStr));
-                } catch (MalformedURLException ex) {
-                    Exceptions.printStackTrace(ex);
-                    return CompletableFuture.completedFuture(true);
-                }
-                runSingleFile(file, ActionProvider.COMMAND_RUN_SINGLE, progressOfCommand);
-                progressOfCommand.checkStatus();
-                return progressOfCommand.getFinishFuture();
             default:
                 for (CodeGenerator codeGenerator : Lookup.getDefault().lookupAll(CodeGenerator.class)) {
                     if (codeGenerator.getCommands().contains(command)) {
@@ -147,46 +120,6 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
                 }
         }
         throw new UnsupportedOperationException("Command not supported: " + params.getCommand());
-    }
-
-    @NbBundle.Messages("No_Method_Found=No method found")
-    private void runSingleMethodCommand(SingleMethod singleMethod, String command, CommandProgress progressOfCommand) {
-        if (singleMethod == null) {
-            StatusDisplayer.getDefault().setStatusText(Bundle.No_Method_Found());
-            progressOfCommand.getFinishFuture().complete(true);
-        } else {
-            Mutex.EVENT.readAccess(new Runnable() {
-                @Override
-                public void run() {
-                    Project owner = FileOwnerQuery.getOwner(singleMethod.getFile());
-                    if (owner != null) {
-                        ActionProvider ap = owner.getLookup().lookup(ActionProvider.class);
-                        if (ap != null) {
-                            if (Arrays.asList(ap.getSupportedActions()).contains(command) && ap.isActionEnabled(command, Lookups.singleton(singleMethod))) {
-                                ap.invokeAction(command, Lookups.fixed(singleMethod, progressOfCommand));
-                            }
-                        }
-                    }
-                }
-            });
-        }
-    }
-
-    private void runSingleFile(FileObject file, String command, CommandProgress progressOfCommand) {
-        Mutex.EVENT.readAccess(new Runnable() {
-            @Override
-            public void run() {
-                Project owner = FileOwnerQuery.getOwner(file);
-                if (owner != null) {
-                    ActionProvider ap = owner.getLookup().lookup(ActionProvider.class);
-                    if (ap != null) {
-                        if (Arrays.asList(ap.getSupportedActions()).contains(command) && ap.isActionEnabled(command, Lookups.singleton(file))) {
-                            ap.invokeAction(command, Lookups.fixed(file, progressOfCommand));
-                        }
-                    }
-                }
-            }
-        });
     }
 
     @Override

--- a/java/java.lsp.server/vscode/package-lock.json
+++ b/java/java.lsp.server/vscode/package-lock.json
@@ -38,9 +38,9 @@
 			"integrity": "sha512-HI5l+f38o93x81mbOWZ1IEzj87rGCHfN4A4QyCU1MuViT5Slvlo5F+YVvmBFHfZsEGi0Lo8TghWU2Ew6vBILNA=="
 		},
 		"@types/vscode": {
-			"version": "1.47.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
-			"integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
+			"version": "1.49.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
+			"integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
 			"dev": true
 		},
 		"agent-base": {

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -21,7 +21,7 @@
 		"multi-root ready"
 	],
 	"engines": {
-		"vscode": "^1.47.0"
+		"vscode": "^1.49.0"
 	},
 	"activationEvents": [
 		"onLanguage:java",
@@ -175,7 +175,7 @@
 		"nbjavac": "node ./out/nbcode.js -J-Dnetbeans.close=true --modules --install .*nbjavac.*"
 	},
 	"devDependencies": {
-		"@types/vscode": "^1.47.0",
+		"@types/vscode": "^1.49.0",
 		"@types/glob": "^7.1.1",
 		"@types/mocha": "^7.0.2",
 		"@types/node": "^13.11.0",

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -211,7 +211,7 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             ]);
         }
     }));
-    context.subscriptions.push(commands.registerCommand('java.debug.codelens', async (uri, methodName) => {
+    const runCodelens = async (uri, methodName, noDebug) => {
         const editor = window.activeTextEditor;
         if (editor) {
             const docUri = editor.document.uri;
@@ -223,8 +223,17 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
                 mainClass: uri,
                 singleMethod: methodName,
             };
-            await vscode.debug.startDebugging(workspaceFolder, debugConfig).then();
+            const debugOptions = {
+                noDebug: noDebug,
+            }
+            await vscode.debug.startDebugging(workspaceFolder, debugConfig, debugOptions).then();
         }
+    };
+    context.subscriptions.push(commands.registerCommand('java.run.codelens', async (uri, methodName) => {
+        await runCodelens(uri, methodName, true);
+    }));
+    context.subscriptions.push(commands.registerCommand('java.debug.codelens', async (uri, methodName) => {
+        await runCodelens(uri, methodName, false);
     }));
     return Object.freeze({
         version : API_VERSION

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -211,19 +211,19 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             ]);
         }
     }));
-    const runCodelens = async (uri, methodName, noDebug) => {
+    const runCodelens = async (uri : any, methodName : string, noDebug : boolean) => {
         const editor = window.activeTextEditor;
         if (editor) {
             const docUri = editor.document.uri;
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(docUri);
-            const debugConfig = {
+            const debugConfig : vscode.DebugConfiguration = {
                 type: "java8+",
                 name: "CodeLens Debug",
                 request: "launch",
                 mainClass: uri,
                 singleMethod: methodName,
             };
-            const debugOptions = {
+            const debugOptions : vscode.DebugSessionOptions = {
                 noDebug: noDebug,
             }
             await vscode.debug.startDebugging(workspaceFolder, debugConfig, debugOptions).then();


### PR DESCRIPTION
This is a fix of NETBEANS-5326

If Run test/Debug test code lenses are used through LSP protocol, the actual test output is not visible. In case of Debug tes, the output is visible when it succeeds, however, it is significantly cut when it fails, preventing from seeing the test failure.

Correction of output from Run/Debug code lens actions.
- In case of Debug, the TerminatedEvent was sent too soon. Now, similar to Run, the TerminatedEvent is sent when the application terminates.
- Run now runs in the same was as "Run Without Debug" - through startDebugger with noDebug = true. This is necessary for consistency and proper output display.
- A NPE associated with a missing source path in case of Run is addressed