### PR TITLE
[NETBEANS-5322] Removing IndexedClassDecl.

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -85,12 +85,14 @@ import com.sun.tools.javac.parser.ParserFactory;
 import com.sun.tools.javac.parser.ScannerFactory;
 import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
+import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.Log;
 import com.sun.tools.javac.util.Names;
 import com.sun.tools.javac.util.Warner;
+import java.lang.reflect.Method;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
@@ -102,7 +104,6 @@ import org.netbeans.lib.nbjavac.services.CancelService;
 import org.netbeans.lib.nbjavac.services.NBAttr;
 import org.netbeans.lib.nbjavac.services.NBParserFactory;
 import org.netbeans.lib.nbjavac.services.NBResolve;
-import org.netbeans.lib.nbjavac.services.NBTreeMaker.IndexedClassDecl;
 import org.netbeans.modules.java.source.TreeShims;
 import org.netbeans.modules.java.source.TreeUtilitiesAccessor;
 import org.netbeans.modules.java.source.builder.CommentHandlerService;
@@ -836,11 +837,12 @@ public final class TreeUtilities {
     /**Attribute the given tree in the given context.
      */
     public TypeMirror attributeTree(Tree tree, Scope scope) {
+        Env<AttrContext> env = getEnv(scope);
         if (scope instanceof NBScope && ((NBScope)scope).areAccessibilityChecksDisabled()) {
             NBResolve.instance(info.impl.getJavacTask().getContext()).disableAccessibilityChecks();
         }
         try {
-            return attributeTree(info.impl.getJavacTask(), (JCTree) tree, scope, new ArrayList<>());
+            return attributeTree(info.impl.getJavacTask(), env.toplevel, (JCTree) tree, scope, new ArrayList<>());
         } finally {
             NBResolve.instance(info.impl.getJavacTask().getContext()).restoreAccessbilityChecks();
         }
@@ -850,11 +852,12 @@ public final class TreeUtilities {
      * Returns scope valid at point when <code>to</code> is reached.
      */
     public Scope attributeTreeTo(Tree tree, Scope scope, Tree to) {
+        Env<AttrContext> env = getEnv(scope);
         if (scope instanceof NBScope && ((NBScope)scope).areAccessibilityChecksDisabled()) {
             NBResolve.instance(info.impl.getJavacTask().getContext()).disableAccessibilityChecks();
         }
         try {
-            return attributeTreeTo(info.impl.getJavacTask(), (JCTree)tree, scope, (JCTree)to, new ArrayList<>());
+            return attributeTreeTo(info.impl.getJavacTask(), env.toplevel, (JCTree)tree, scope, (JCTree)to, new ArrayList<>());
         } finally {
             NBResolve.instance(info.impl.getJavacTask().getContext()).restoreAccessbilityChecks();
         }
@@ -862,12 +865,11 @@ public final class TreeUtilities {
     
     public TypeMirror reattributeTree(Tree tree, Scope scope) {
         Env<AttrContext> env = getEnv(scope);
-        copyInnerClassIndexes(env.tree, tree);
         if (scope instanceof NBScope && ((NBScope)scope).areAccessibilityChecksDisabled()) {
             NBResolve.instance(info.impl.getJavacTask().getContext()).disableAccessibilityChecks();
         }
         try {
-            return attributeTree(info.impl.getJavacTask(), (JCTree)tree, scope, new ArrayList<>());
+            return attributeTree(info.impl.getJavacTask(), env.toplevel, (JCTree)tree, scope, new ArrayList<>());
         } finally {
             NBResolve.instance(info.impl.getJavacTask().getContext()).restoreAccessbilityChecks();
         }
@@ -875,19 +877,18 @@ public final class TreeUtilities {
     
     public Scope reattributeTreeTo(Tree tree, Scope scope, Tree to) {
         Env<AttrContext> env = getEnv(scope);
-        copyInnerClassIndexes(env.tree, tree);
         if (scope instanceof NBScope && ((NBScope)scope).areAccessibilityChecksDisabled()) {
             NBResolve.instance(info.impl.getJavacTask().getContext()).disableAccessibilityChecks();
         }
         try {
-            return attributeTreeTo(info.impl.getJavacTask(), (JCTree)tree, scope, (JCTree)to, new ArrayList<>());
+            return attributeTreeTo(info.impl.getJavacTask(), env.toplevel, (JCTree)tree, scope, (JCTree)to, new ArrayList<>());
         } finally {
             NBResolve.instance(info.impl.getJavacTask().getContext()).restoreAccessbilityChecks();
         }
     }
     
     //from org/netbeans/modules/java/hints/spiimpl/Utilities.java:
-    private static TypeMirror attributeTree(JavacTaskImpl jti, Tree tree, Scope scope, final List<Diagnostic<? extends JavaFileObject>> errors) {
+    private static TypeMirror attributeTree(JavacTaskImpl jti, CompilationUnitTree cut, Tree tree, Scope scope, final List<Diagnostic<? extends JavaFileObject>> errors) {
         Log log = Log.instance(jti.getContext());
         JavaFileObject prev = log.useSource(new DummyJFO());
         Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(log) {
@@ -912,11 +913,21 @@ public final class TreeUtilities {
             }
             return attr.attribStat((JCTree) tree,env);
         } finally {
+            unenter(jti.getContext(), (JCCompilationUnit) cut, (JCTree) tree);
 //            cacheContext.leave();
             log.useSource(prev);
             log.popDiagnosticHandler(discardHandler);
             resolve.restoreAccessbilityChecks();
 //            enter.shadowTypeEnvs(false);
+        }
+    }
+
+    private static void unenter(Context ctx, JCCompilationUnit cut, JCTree tree) {
+        try {
+            Method m = Enter.class.getDeclaredMethod("unenter", JCCompilationUnit.class, JCTree.class);
+            m.invoke(Enter.instance(ctx), cut, tree);
+        } catch (Throwable t) {
+            t.printStackTrace();
         }
     }
 
@@ -932,7 +943,7 @@ public final class TreeUtilities {
         VARIABLE_CAN_OWN_VARIABLES = result;
     }
 
-    private static Scope attributeTreeTo(JavacTaskImpl jti, Tree tree, Scope scope, Tree to, final List<Diagnostic<? extends JavaFileObject>> errors) {
+    private static Scope attributeTreeTo(JavacTaskImpl jti, CompilationUnitTree cut, Tree tree, Scope scope, Tree to, final List<Diagnostic<? extends JavaFileObject>> errors) {
         Log log = Log.instance(jti.getContext());
         JavaFileObject prev = log.useSource(new DummyJFO());
         Log.DiagnosticHandler discardHandler = new Log.DiscardDiagnosticHandler(log) {
@@ -959,6 +970,7 @@ public final class TreeUtilities {
                 throw new IllegalStateException(ex);
             }
         } finally {
+            unenter(jti.getContext(), (JCCompilationUnit) cut, (JCTree) tree);
 //            cacheContext.leave();
             log.useSource(prev);
             log.popDiagnosticHandler(discardHandler);
@@ -1745,52 +1757,6 @@ public final class TreeUtilities {
 
     }
     
-    private void copyInnerClassIndexes(Tree from, Tree to) {
-        final int[] fromIdx = {-3};
-        ErrorAwareTreeScanner<Void, Void> scanner = new ErrorAwareTreeScanner<Void, Void>() {
-            @Override
-            public Void scan(Tree node, Void p) {
-                return fromIdx[0] < -1 ? super.scan(node, p) : null;
-            }            
-            @Override
-            public Void visitClass(ClassTree node, Void p) {
-                if (fromIdx[0] < -2)
-                    return super.visitClass(node, p);
-                if (node instanceof IndexedClassDecl)
-                    fromIdx[0] = ((IndexedClassDecl)node).index;
-                return null;
-            }
-            @Override
-            public Void visitMethod(MethodTree node, Void p) {
-                return fromIdx[0] < -2 ? super.visitMethod(node, p) : null;
-            }
-
-            @Override
-            public Void visitBlock(BlockTree node, Void p) {
-                int old = fromIdx[0];
-                fromIdx[0] = -2;
-                try {
-                    return super.visitBlock(node, p);
-                } finally {
-                    if (fromIdx[0] < -1)
-                        fromIdx[0] = old;
-                }
-            }            
-        };
-        scanner.scan(from, null);
-        if (fromIdx[0] < -1)
-            return;
-        scanner = new ErrorAwareTreeScanner<Void, Void>() {
-            @Override
-            public Void visitClass(ClassTree node, Void p) {
-                if (node instanceof IndexedClassDecl)
-                    ((IndexedClassDecl)node).index = fromIdx[0]++;
-                return null;
-            }
-        };
-        scanner.scan(to, null);
-    }
-
     private static class UncaughtExceptionsVisitor extends ErrorAwareTreePathScanner<Void, Set<TypeMirror>> {
         
         private final CompilationInfo info;

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FindAnonymousVisitor.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/FindAnonymousVisitor.java
@@ -27,7 +27,6 @@ import org.netbeans.api.java.source.support.ErrorAwareTreeScanner;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import java.util.HashSet;
 import java.util.Set;
-import org.netbeans.lib.nbjavac.services.NBTreeMaker.IndexedClassDecl;
 
 /**
  * Partial reparse helper visitor.

--- a/java/java.source.nbjavac/src/org/netbeans/modules/java/source/nbjavac/parsing/FindAnonymousVisitor.java
+++ b/java/java.source.nbjavac/src/org/netbeans/modules/java/source/nbjavac/parsing/FindAnonymousVisitor.java
@@ -24,10 +24,8 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import org.netbeans.api.java.source.support.ErrorAwareTreeScanner;
-import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import java.util.HashSet;
 import java.util.Set;
-import org.netbeans.lib.nbjavac.services.NBTreeMaker.IndexedClassDecl;
 
 /**
  * Partial reparse helper visitor.
@@ -38,14 +36,12 @@ class FindAnonymousVisitor extends ErrorAwareTreeScanner<Void,Void> {
 
     private static enum Mode {COLLECT, CHECK};
 
-    int firstInner = -1;
     int noInner;
     boolean hasLocalClass;
     final Set<Tree> docOwners = new HashSet<Tree>();
     private Mode mode = Mode.COLLECT;            
     
     public final void reset () {
-        this.firstInner = -1;
         this.noInner = 0;
         this.hasLocalClass = false;
         this.mode = Mode.CHECK;
@@ -53,9 +49,6 @@ class FindAnonymousVisitor extends ErrorAwareTreeScanner<Void,Void> {
 
     @Override
     public Void visitClass(ClassTree node, Void p) {
-        if (firstInner == -1) {
-            firstInner = ((IndexedClassDecl)node).index;
-        }
         if (node.getSimpleName().length() != 0) {
             hasLocalClass = true;
         }

--- a/java/java.source.nbjavac/src/org/netbeans/modules/java/source/nbjavac/parsing/PartialReparserImpl.java
+++ b/java/java.source.nbjavac/src/org/netbeans/modules/java/source/nbjavac/parsing/PartialReparserImpl.java
@@ -25,9 +25,11 @@ import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.api.JavacTaskImpl;
 import com.sun.tools.javac.api.JavacTrees;
+import com.sun.tools.javac.comp.Enter;
 import com.sun.tools.javac.parser.LazyDocCommentTable;
 import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.CouplingAbort;
 import com.sun.tools.javac.util.Log;
@@ -108,7 +110,6 @@ public class PartialReparserImpl implements PartialReparser {
                 }
                 return false;
             }
-            final int firstInner = fav.firstInner;
             final int noInner = fav.noInner;
             final Context ctx = task.getContext();
             final TreeLoader treeLoader = TreeLoader.instance(ctx);
@@ -126,7 +127,8 @@ public class PartialReparserImpl implements PartialReparser {
                     ((CompilationInfoImpl.DiagnosticListenerImpl)dl).startPartialReparse(origStartPos, origEndPos);
                     long start = System.currentTimeMillis();
                     Map<JCTree,LazyDocCommentTable.Entry> docComments = new HashMap<>();
-                    block = pr.reparseMethodBody(cu, orig, newBody + " ", firstInner, docComments);
+                    Enter.instance(ctx).unenter((JCCompilationUnit) cu, ((JCTree.JCMethodDecl)orig).body);
+                    block = pr.reparseMethodBody(cu, orig, newBody + " ", docComments);
                     LOGGER.log(Level.FINER, "Reparsed method in: {0}", fo);     //NOI18N
                     if (block == null) {
                         LOGGER.log(

--- a/java/java.source.nbjavac/src/org/netbeans/modules/java/source/nbjavac/parsing/PartialReparserService.java
+++ b/java/java.source.nbjavac/src/org/netbeans/modules/java/source/nbjavac/parsing/PartialReparserService.java
@@ -80,12 +80,11 @@ public class PartialReparserService {
         this.context = context;
     }
 
-    public JCBlock reparseMethodBody(CompilationUnitTree topLevel, MethodTree methodToReparse, String newBodyText, int annonIndex,
+    public JCBlock reparseMethodBody(CompilationUnitTree topLevel, MethodTree methodToReparse, String newBodyText,
             final Map<? super JCTree,? super LazyDocCommentTable.Entry> docComments) {
         CharBuffer buf = CharBuffer.wrap((newBodyText+"\u0000").toCharArray(), 0, newBodyText.length());
         JavacParser parser = newParser(context, buf, ((JCBlock)methodToReparse.getBody()).pos, ((JCCompilationUnit)topLevel).endPositions);
         final JCStatement statement = parser.parseStatement();
-        NBParserFactory.assignAnonymousClassIndices(Names.instance(context), statement, Names.instance(context).empty, annonIndex);
         if (statement.getKind() == Tree.Kind.BLOCK) {
             if (docComments != null) {
                 docComments.putAll(((LazyDocCommentTable) parser.getDocComments()).table);

--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBEnter.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBEnter.java
@@ -29,7 +29,6 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.TreeInfo;
 import com.sun.tools.javac.util.Context;
-import org.netbeans.lib.nbjavac.services.NBTreeMaker.IndexedClassDecl;
 
 /**
  *
@@ -70,11 +69,6 @@ public class NBEnter extends Enter {
             return ;
         }
         super.visitTopLevel(tree);
-    }
-
-    //no @Override to ensure compatibility with ordinary javac:
-    protected int getIndex(JCClassDecl clazz) {
-        return clazz instanceof IndexedClassDecl ? ((IndexedClassDecl) clazz).index : -1;
     }
 
     @Override

--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBJavacTrees.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBJavacTrees.java
@@ -18,24 +18,15 @@
  */
 package org.netbeans.lib.nbjavac.services;
 
-import com.sun.source.doctree.DocCommentTree;
-import com.sun.source.tree.ClassTree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.api.JavacTrees;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.TreeInfo;
-import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.util.Context;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.lang.model.element.Element;
-import org.netbeans.lib.nbjavac.services.NBTreeMaker.IndexedClassDecl;
 
 /**
  *
@@ -55,29 +46,6 @@ public class NBJavacTrees extends JavacTrees {
     protected NBJavacTrees(Context context) {
         super(context);
     }
-
-    @Override
-    protected Copier createCopier(TreeMaker make) {
-        return new Copier(make) {
-            @Override public JCTree visitClass(ClassTree node, JCTree p) {
-                JCTree result;
-                try {
-                    MethodHandle superVisitClass = MethodHandles.lookup().findSpecial(Copier.class, "visitClass", MethodType.methodType(JCTree.class, new Class[]{ClassTree.class, JCTree.class}), getClass());
-                    result = (JCTree) superVisitClass.invokeExact(this, node, p);
-                } catch (Throwable ex) {
-                    Logger.getLogger(NBJavacTrees.class.getName()).log(Level.FINE, null, ex);
-                    result = super.visitClass(node, p);
-                }
-
-                if (node instanceof IndexedClassDecl && result instanceof IndexedClassDecl) {
-                    ((IndexedClassDecl) result).index = ((IndexedClassDecl) node).index;
-                }
-
-                return result;
-            }
-        };
-    }
-
     @Override
     public TreePath getPath(Element e) {
         TreePath path = super.getPath(e);

--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBTreeMaker.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBTreeMaker.java
@@ -70,30 +70,4 @@ public class NBTreeMaker extends TreeMaker {
         return new NBTreeMaker(toplevel, names, types, syms);
     }
 
-    @Override
-    public JCClassDecl ClassDef(JCModifiers mods, Name name, List<JCTypeParameter> typarams, JCExpression extending, List<JCExpression> implementing, List<JCTree> defs) {
-        try {
-            IndexedClassDecl result = new IndexedClassDecl(mods, name, typarams, extending, implementing, defs, null);
-
-            result.pos = pos;
-
-            return result;
-        } catch (NoSuchMethodError err) {
-            return super.ClassDef(mods, name, typarams, extending, implementing, defs);
-        }
-    }
-
-    public static class IndexedClassDecl extends JCClassDecl {
-        public int index;
-        protected IndexedClassDecl(JCModifiers mods,
-                                   Name name,
-                                   List<JCTypeParameter> typarams,
-                                   JCExpression extending,
-                                   List<JCExpression> implementing,
-                                   List<JCTree> defs,
-                                   ClassSymbol sym) {
-            super(mods, name, typarams, extending, implementing, defs, sym);
-            this.index = -1;
-        }
-    }
 }


### PR DESCRIPTION
Please see:
https://issues.apache.org/jira/browse/NETBEANS-5322
for the problem description

The issue is that when Trees.getScope() is called, for vanilla javac, it will assign new anonymous innerclass names to any anonymous innerclasses it encounters, and then drops them to revert back to the original state. But, with nb-javac, we use IndexedClassDecl to keep the anonymous innerclass names stable, and hence the real anonymous innerclasses are dropped at the end of getScope().

On one hand, this could be solved in nb-javac, but I believe we want (or must) avoid the tricks with IndexedClassDecl. These were done mostly for debugger, which needs to know the binary names of classes at least to set breakpoints at correct places. getScope() has been improved significantly and I hope it is good enough for the debugger, so my proposal here is to try to find out if things are working sufficiently OK without IndexedClassDecl by removing it.

(Note IndexedClassDecl does not do much without nb-javac, so this should, I believe, only be really relevant when running with nb-javac.)
