### PR TITLE
[NETBEANS-5319] Always do save modified files when used through LSP.

### DIFF
--- a/java/java.lsp.server/nbcode/branding/modules/org-openide-loaders.jar/org/netbeans/modules/openide/loaders/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-openide-loaders.jar/org/netbeans/modules/openide/loaders/Bundle.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 # yes/no/ask
-ASK_OnSaving=no
+ASK_OnSaving=yes
 # yes/no/ask
 ASK_OnClosing=no


### PR DESCRIPTION
As described in NETBEANS-5319, when new files are added through LSP (e.g. in a VSCode extension), breakpoints do not work in these files at all.
If a file is modified, then breakpoints are submitted to wrong locations depending on the scope of the modification.

The reason is that NetBeans LSP backend is holding modified documents and VSCode updates files on disk at the same time. But breakpoints are resolved to disk locations that correspond to the sate before the files were modified. Until the files are saved through the NetBeans, breakpoints will resolve to wrong locations.

This fix allows to save modifications it got through the LSP protocol, which synchronizes the content and allows breakpoints to resolve as expected.