### PR TITLE
[NETBEANS-5090] fix missing Serializable interface when a @ViewScoped  CDI bean is created via JSF CDI Bean Wizard

### DIFF
--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/ManagedBeanIterator.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/ManagedBeanIterator.java
@@ -174,6 +174,7 @@ public class ManagedBeanIterator implements TemplateWizard.Iterator {
                 switch (namedScope) {
                     case SESSION:
                     case CONVERSATION:
+                    case VIEW:
                         templateProperties.put("passivationCapable", "true");    //NOI18N
                         break;
                     default:


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/NETBEANS-5090