### PR TITLE
Options panel use GTK default colors

### DIFF
--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/LFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/LFCustoms.java
@@ -423,4 +423,11 @@ public abstract class LFCustoms {
     public static final String PROGRESS_CANCEL_BUTTON_ICON = "nb.progress.cancel.icon";
     public static final String PROGRESS_CANCEL_BUTTON_ROLLOVER_ICON = "nb.progress.cancel.icon.mouseover";
     public static final String PROGRESS_CANCEL_BUTTON_PRESSED_ICON = "nb.progress.cancel.icon.pressed";
+
+    /**
+     * Keys used by the options dialog module.
+     */
+    public static final String OPTIONS_USE_UI_DEFAULT_COLORS = "nb.options.useUIDefaultsColors";
+    public static final String OPTIONS_CATEGORIES_SEPARATOR_COLOR = "nb.options.categories.separatorColor";
+    public static final String OPTIONS_CATEGORIES_BUTTON_USE_NIMBUS = "nb.options.categories.button.useNimbusCategoryButton";
 }

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/GtkLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/gtk/GtkLFCustoms.java
@@ -136,6 +136,11 @@ public class GtkLFCustoms extends LFCustoms {
             "NbSlideBar.GroupSeparator.Gap.Before", 7,
             "NbSlideBar.GroupSeparator.Gap.After", 2,
             "NbSlideBar.RestoreButton.Gap", 5,
+            
+            // Options Panel
+            OPTIONS_USE_UI_DEFAULT_COLORS, true,
+            OPTIONS_CATEGORIES_SEPARATOR_COLOR, UIManager.getColor("Separator.foreground"),
+            OPTIONS_CATEGORIES_BUTTON_USE_NIMBUS, true,
         };
 
         //#108517 - turn off ctrl+page_up and ctrl+page_down mapping

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/MetalLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/metal/MetalLFCustoms.java
@@ -126,6 +126,9 @@ public final class MetalLFCustoms extends LFCustoms {
             //browser picker
             "Nb.browser.picker.background.light", new Color(249,249,249),
             "Nb.browser.picker.foreground.light", new Color(130,130,130),
+            
+            // Options Panel
+            OPTIONS_USE_UI_DEFAULT_COLORS, true,
         }; //NOI18N
 
         //#108517 - turn off ctrl+page_up and ctrl+page_down mapping

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/NimbusLFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/nimbus/NimbusLFCustoms.java
@@ -113,6 +113,10 @@ public final class NimbusLFCustoms extends LFCustoms {
             //browser picker
             "Nb.browser.picker.background.light", new Color(249,249,249),
             "Nb.browser.picker.foreground.light", new Color(130,130,130),
+            
+            // Options Panel
+            OPTIONS_USE_UI_DEFAULT_COLORS, true,
+            OPTIONS_CATEGORIES_BUTTON_USE_NIMBUS, true,
         };
         /*Object[] result = {
             DESKTOP_BORDER, new EmptyBorder(1, 1, 1, 1),

--- a/platform/options.api/nbproject/project.properties
+++ b/platform/options.api/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
@@ -78,7 +78,6 @@ import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
-import javax.swing.plaf.metal.MetalLookAndFeel;
 import javax.swing.text.JTextComponent;
 import org.netbeans.modules.options.CategoryModel.Category;
 import org.netbeans.modules.options.advanced.AdvancedPanel;
@@ -98,6 +97,10 @@ import org.openide.util.Utilities;
 import org.openide.windows.WindowManager;
 
 public class OptionsPanel extends JPanel {
+    private static final String OPTIONS_USE_UI_DEFAULT_COLORS = "nb.options.useUIDefaultsColors";  //NOI18N
+    private static final String OPTIONS_CATEGORIES_SEPARATOR_COLOR = "nb.options.categories.separatorColor"; //NOI18N
+    private static final String OPTIONS_CATEGORIES_BUTTON_USE_NIMBUS = "nb.options.categories.button.useNimbusCategoryButton"; //NOI18N
+    
     private JPanel pCategories;
     private JPanel pCategories2;
     private JScrollPane categoriesScrollPane;
@@ -116,20 +119,12 @@ public class OptionsPanel extends JPanel {
     private HashMap<String, HashMap<Integer, TabInfo>> categoryid2tabs = new HashMap<String, HashMap<Integer, TabInfo>>();
     private final ArrayList<String> disabledCategories = new ArrayList<String>();
 
-    //private final ArrayList<FileObject> advancedFOs = new ArrayList<FileObject>();
-    //private final HashMap<String, Integer> dublicateKeywordsFOs = new HashMap<String, Integer>();
-    //private final HashMap<FileObject, Integer> fo2index = new HashMap<FileObject, Integer>();
-
     private Map<String, CategoryButton> buttons = new LinkedHashMap<String, CategoryButton>();    
     private final boolean isMac = UIManager.getLookAndFeel ().getID ().equals ("Aqua");
-    private final boolean isNimbus = UIManager.getLookAndFeel ().getID ().equals ("Nimbus");
-    private final boolean isMetal = UIManager.getLookAndFeel() instanceof MetalLookAndFeel;
-    private final boolean isGTK = UIManager.getLookAndFeel ().getID ().equals ("GTK");
     private final Color selected = isMac ? new Color(221, 221, 221) : getSelectionBackground();
     private final Color selectedB = isMac ? new Color(183, 183, 183) : getUIColorOrDefault("nb.options.categories.selectionBorderColor", new Color (149, 106, 197));
     private final Color highlighted = isMac ? new Color(221, 221, 221) : getHighlightBackground();
     private final Color highlightedB = getUIColorOrDefault("nb.options.categories.highlightBorderColor", new Color (152, 180, 226));
-    //private final Color iconViewBorder = new Color (127, 157, 185);
     private final ControllerListener controllerListener = new ControllerListener ();
     
     private final Color borderMac = new Color(141, 141, 141);
@@ -393,8 +388,9 @@ public class OptionsPanel extends JPanel {
         showHint(true);
         
         pCategories = new JPanel (new BorderLayout ());
-        pCategories.setBorder (BorderFactory.createMatteBorder(0,0,1,0,getUIColorOrDefault("nb.options.categories.separatorColor", Color.lightGray))); //NOI18N
+        pCategories.setBorder (BorderFactory.createMatteBorder(0, 0, 1, 0, getUIColorOrDefault(OPTIONS_CATEGORIES_SEPARATOR_COLOR, Color.lightGray)));
         pCategories.setBackground (getTabPanelBackground());
+
         categoriesScrollPane = new JScrollPane(pCategories2, ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER, ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
         categoriesScrollPane.setBorder(null);
         categoriesScrollPane.getHorizontalScrollBar().setUnitIncrement(Utils.ScrollBarUnitIncrement);
@@ -877,7 +873,7 @@ public class OptionsPanel extends JPanel {
                 
     private CategoryButton addButton (CategoryModel.Category category) {
         int index = buttons.size ();
-        CategoryButton button = isNimbus || isGTK 
+        CategoryButton button = UIManager.getBoolean(OPTIONS_CATEGORIES_BUTTON_USE_NIMBUS)
                 ? new NimbusCategoryButton(category)
                 : new CategoryButton(category);
 
@@ -1027,8 +1023,13 @@ public class OptionsPanel extends JPanel {
         return new Color (224, 232, 246);
     }
 
+    /**
+     * Get if Options Panel uses UI default colors.
+     * Use property nb.options.useUIDefaultsColors to use modify it.
+     * @return boolean
+     */
     private boolean useUIDefaultsColors() {
-        return isMetal || isNimbus;
+        return UIManager.getBoolean(OPTIONS_USE_UI_DEFAULT_COLORS);
     }
 
     private Color getUIColorOrDefault(String uiKey, Color defaultColor) {


### PR DESCRIPTION
Use default colors in options panel when GTK laf is used.

Tested in Ubuntu 20.04 with default theme. 

Before:
![Screenshot from 2021-02-07 22-39-09](https://user-images.githubusercontent.com/4323228/107160276-9ffaf600-6995-11eb-877a-1058653fd33b.png)

After:
![Screenshot from 2021-02-07 22-40-04](https://user-images.githubusercontent.com/4323228/107160287-a8533100-6995-11eb-8675-1e2dccf2c871.png)
