### PR TITLE
[NETBEANS-2665] Gradle Project Loading Improvements

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/gradle.properties
+++ b/extide/gradle/netbeans-gradle-tooling/gradle.properties
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 netbeans.license=apache20-asf

--- a/extide/gradle/netbeans-gradle-tooling/gradle.properties
+++ b/extide/gradle/netbeans-gradle-tooling/gradle.properties
@@ -1,0 +1,1 @@
+netbeans.license=apache20-asf

--- a/extide/gradle/netbeans-gradle-tooling/src/main/groovy/org/netbeans/modules/gradle/api/ModelFetcher.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/groovy/org/netbeans/modules/gradle/api/ModelFetcher.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.api;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.gradle.api.Action;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildActionExecuter;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.ProjectConnection;
+import org.gradle.tooling.model.gradle.BasicGradleProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public final class ModelFetcher {
+    private static final AtomicInteger REQUEST_SEQUENCER = new AtomicInteger();
+
+    final ExecutorService executor;
+    final transient CountDownLatch lock = new CountDownLatch(1);
+    final MultiModelAction action = new MultiModelAction();
+    final Map<Integer, ModelResult> modelResults = new HashMap<>();
+
+    public ModelFetcher() {
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    public ModelFetcher(ExecutorService executor) {
+        this.executor = executor;
+    }
+
+    public boolean isAcceptingRequests() {
+        return !executor.isShutdown();
+    }
+
+    public <T> Future<T> requestModel(Class<T> modelType) throws RejectedExecutionException {
+        return requestModel(null, modelType, null, null);
+    }
+
+    public <T> Future<T> requestModel(String target, Class<T> modelType) throws RejectedExecutionException {
+        return requestModel(target, modelType, null, null);
+    }
+
+    public <T,P> Future<T> requestModel(Class<T> modelType, Class<P> parameterType, Action<? super P> parameterInitializer) throws RejectedExecutionException {
+        return requestModel(null, modelType, parameterType, parameterInitializer);
+    }
+
+    public <T,P> Future<T> requestModel(String target, Class<T> modelType, Class<P> parameterType, Action<? super P> parameterInitializer) throws RejectedExecutionException {
+        ModelRequest req = new ModelRequest(target, modelType, parameterType, parameterInitializer);
+        Future ret = executor.submit(() -> {
+            lock.await();
+            ModelResult result = modelResults.get(req.sequenceId);
+            if (result != null) {
+                if (result.problem == null) {
+                    return (T) result.model;
+                } else {
+                    throw new Exception(result.problem);
+                }
+            } else {
+                throw new Exception("Model not found");
+            }
+        });
+        action.modelRequests.add(req);
+        return ret;
+    }
+
+    public void fetchModels(ProjectConnection pconn, Action<? super BuildActionExecuter> config) {
+        executor.shutdown();
+        try {
+            if (!action.modelRequests.isEmpty()) {
+                BuildActionExecuter<Map<Integer, ModelResult>> exec = pconn.action(action);
+                if (config != null) {
+                    config.execute(exec);
+                }
+                modelResults.putAll(exec.run());
+            }
+        } finally {
+            lock.countDown();
+        }
+    }
+
+    static class MultiModelAction implements BuildAction<Map<Integer, ModelResult>> {
+
+        final List<ModelRequest> modelRequests = new LinkedList<>();
+
+        @Override
+        public Map<Integer, ModelResult> execute(BuildController bc) {
+            Map<Integer,ModelResult> ret = new HashMap<>();
+            List<ModelRequest> reqs = new LinkedList<>(modelRequests);
+            Iterator<ModelRequest> it = reqs.iterator();
+            while (it.hasNext()) {
+                ModelRequest req = it.next();
+                if (req.targetProjectId == null) {
+                    it.remove();
+                    if (req.parameterType != null) {
+                        try {
+                            ret.put(req.sequenceId, new ModelResult(bc.getModel(req.modelType, req.parameterType, req.parameterInitializer)));
+                        } catch (Throwable ex) {
+                            ret.put(req.sequenceId, new ModelResult(ex));
+                        }
+                    } else {
+                        try {
+                            ret.put(req.sequenceId, new ModelResult(bc.getModel(req.modelType)));
+                        } catch (Throwable ex) {
+                            ret.put(req.sequenceId, new ModelResult(ex));
+                        }
+                    }
+                }
+            }
+            if (!reqs.isEmpty()) {
+                GradleBuild build = bc.getBuildModel();
+                Map<String, BasicGradleProject> projects = new HashMap<>();
+                for (BasicGradleProject prj : build.getProjects()) {
+                    projects.put(prj.getPath(), prj);
+                }
+                for (ModelRequest req : reqs) {
+                    BasicGradleProject target = projects.get(req.targetProjectId);
+                    if (target != null) {
+                        if (req.parameterType != null) {
+                            try {
+                                ret.put(req.sequenceId, new ModelResult(bc.getModel(target, req.modelType, req.parameterType, req.parameterInitializer)));
+                            } catch (Throwable ex) {
+                                ret.put(req.sequenceId, new ModelResult(ex));
+                            }
+                        } else {
+                            try {
+                                ret.put(req.sequenceId, new ModelResult(bc.getModel(target, req.modelType)));
+                            } catch (Throwable ex) {
+                                ret.put(req.sequenceId, new ModelResult(ex));
+                            }
+                        }
+                    } else {
+                        ret.put(req.sequenceId, new ModelResult(new NullPointerException(req.targetProjectId)));
+                    }
+                }
+            }
+            return ret;
+        }
+    }
+    
+    static class ModelRequest<T,P> implements Serializable {
+        final int sequenceId = REQUEST_SEQUENCER.getAndIncrement();
+        String targetProjectId;
+        Class<T> modelType;
+        Class<P> parameterType;
+        Action<? super P> parameterInitializer;
+
+        public ModelRequest(String targetProjectId, Class<T> modelType, Class<P> parameterType, Action<? super P> parameterInitializer) {
+            this.targetProjectId = targetProjectId;
+            this.modelType = modelType;
+            this.parameterType = parameterType;
+            this.parameterInitializer = parameterInitializer;
+        }
+    }
+
+    static class ModelResult<T> implements Serializable {
+        T model;
+        Throwable problem;
+
+        public ModelResult(T model) {
+            this.model = model;
+        }
+
+        public ModelResult(Throwable problem) {
+            this.problem = problem;
+        }
+    }
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleAuxiliaryPropertiesImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleAuxiliaryPropertiesImpl.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.gradle;
 
+import org.netbeans.modules.gradle.loaders.LegacyProjectLoader;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import java.io.File;
 import java.io.FileInputStream;
@@ -124,6 +125,6 @@ public class GradleAuxiliaryPropertiesImpl implements AuxiliaryProperties {
 
     private File getPropFile(boolean shared) {
         GradleFiles gf = project.getGradleFiles();
-        return new File(shared ? gf.getProjectDir() : GradleProjectCache.getCacheDir(gf), GradleFiles.GRADLE_PROPERTIES_NAME);
+        return new File(shared ? gf.getProjectDir() : LegacyProjectLoader.getCacheDir(gf), GradleFiles.GRADLE_PROPERTIES_NAME);
     }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleAuxiliaryPropertiesImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleAuxiliaryPropertiesImpl.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.gradle;
 
-import org.netbeans.modules.gradle.loaders.LegacyProjectLoader;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import java.io.File;
 import java.io.FileInputStream;
@@ -28,8 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Set;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.spi.project.AuxiliaryProperties;
@@ -125,6 +122,6 @@ public class GradleAuxiliaryPropertiesImpl implements AuxiliaryProperties {
 
     private File getPropFile(boolean shared) {
         GradleFiles gf = project.getGradleFiles();
-        return new File(shared ? gf.getProjectDir() : LegacyProjectLoader.getCacheDir(gf), GradleFiles.GRADLE_PROPERTIES_NAME);
+        return new File(shared ? gf.getProjectDir() : NbGradleProjectImpl.getCacheDir(gf), GradleFiles.GRADLE_PROPERTIES_NAME);
     }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectErrorNotifications.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectErrorNotifications.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import javax.swing.JLabel;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.openide.awt.Notification;
+import org.openide.awt.NotificationDisplayer;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class GradleProjectErrorNotifications {
+    private final Set<Notification> notifictions = new HashSet<>();
+
+    public synchronized void openNotification(String title, String problem, String details) {
+        StringBuilder sb = new StringBuilder(details.length());
+        sb.append("<html>");
+        String[] lines = details.split("\n");
+        for (String line : lines) {
+            sb.append(line).append("<br/>");
+        }
+        Notification ntn = NotificationDisplayer.getDefault().notify(title,
+                NbGradleProject.getWarningIcon(),
+                new JLabel(problem),
+                new JLabel(sb.toString()),
+                NotificationDisplayer.Priority.LOW, NotificationDisplayer.Category.WARNING);
+        notifictions.add(ntn);
+    }
+
+    public synchronized void clear() {
+        Iterator<Notification> it = notifictions.iterator();
+        while(it.hasNext()) {
+            it.next().clear();
+            it.remove();
+        }
+    }
+
+    public static String bulletedList(Collection<? extends Object> elements) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<ul>");
+        for (Object element : elements) {
+            sb.append("<li>");
+            String[] lines = element.toString().split("\n");
+            for (int i = 0; i < lines.length; i++) {
+                String line = lines[i];
+                sb.append(line);
+                if (i < lines.length - 1) {
+                    sb.append("<br/>");
+                }
+            }
+            sb.append("</li>");
+        }
+        sb.append("</ul>");
+        return sb.toString();
+    }
+
+
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectLoader.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle;
+
+import org.netbeans.modules.gradle.api.NbGradleProject;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public interface GradleProjectLoader {
+
+    GradleProject loadProject(NbGradleProject.Quality aim, boolean ignoreCache, boolean interactive, String... args);
+    
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectProblemProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectProblemProvider.java
@@ -100,6 +100,6 @@ public class GradleProjectProblemProvider implements ProjectProblemsProvider {
                         : q.worseThan(FULL) ? Status.RESOLVED_WITH_WARNING : Status.RESOLVED;
                 return Result.create(st);
             });
-        }
+       }
     }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectStructure.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectStructure.java
@@ -16,30 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.netbeans.modules.gradle;
 
-package org.netbeans.modules.gradle.api;
-
-import org.netbeans.modules.gradle.tooling.Model;
-import java.util.Map;
+import java.io.File;
 import java.util.Set;
 
 /**
  *
- * @author Laszlo Kishalmi
+ * @author lkishalmi
  */
-public interface NbProjectInfo extends Model, org.gradle.tooling.model.Model {
-    
-    /**
-     * Project information which shall be cached.
-     * @return the important project data.
-     */
-    Map<String, Object> getInfo();
-    
-    /**
-     * Additional project information which could be thrown away.
-     * @return the not-that-important project data.
-     */    
-    Map<String, Object> getExt();
-    Set<String> getProblems();
-    boolean getMiscOnly();
+public interface GradleProjectStructure {
+
+    Set<String> getProjectPaths();
+    File getProjectDir(String path);
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -327,7 +327,8 @@ public final class NbGradleProjectImpl implements Project {
                 // this was explicitly invoked as project action, or problem resolution. Same level as
                 // Build project, so trust the project.
                 ProjectTrust.getDefault().trustProject(this, true);
-                GradleProject gradleProject = GradleProjectCache.loadProject(this, FULL_ONLINE, true, true);
+                GradleProjectLoader loader = getLookup().lookup(GradleProjectLoader.class);
+                GradleProject gradleProject = loader.loadProject(FULL_ONLINE, true, true);
                 LOG.log(Level.FINER, "Priming finished, reloading {0}: {1}", project);
                 fireProjectReload(false);
                 ret.complete(gradleProject);

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.gradle;
 
 import org.netbeans.modules.gradle.loaders.GradleProjectLoaderImpl;
-import org.netbeans.modules.gradle.loaders.LegacyProjectLoader;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
@@ -396,7 +395,7 @@ public final class NbGradleProjectImpl implements Project {
 
         @Override
         public FileObject getCacheDirectory() throws IOException {
-            return FileUtil.createFolder(LegacyProjectLoader.getCacheDir(gradleFiles));
+            return FileUtil.createFolder(getCacheDir(gradleFiles));
         }
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -19,6 +19,8 @@
 
 package org.netbeans.modules.gradle;
 
+import org.netbeans.modules.gradle.loaders.GradleProjectLoaderImpl;
+import org.netbeans.modules.gradle.loaders.LegacyProjectLoader;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
@@ -172,6 +174,8 @@ public final class NbGradleProjectImpl implements Project {
                 UILookupMergerSupport.createPrivilegedTemplatesMerger(),
                 LookupProviderSupport.createSourcesMerger(),
                 LookupProviderSupport.createSharabilityQueryMerger(),
+                new GradleProjectLoaderImpl(this),
+                new GradleProjectErrorNotifications(),
                 state
         );
     }
@@ -252,7 +256,8 @@ public final class NbGradleProjectImpl implements Project {
     }
 
     private GradleProject loadProject(boolean ignoreCache, Quality aim, String... args) {
-        GradleProject prj = GradleProjectCache.loadProject(this, aim, ignoreCache, false, args);
+        GradleProjectLoader loader = getLookup().lookup(GradleProjectLoader.class);
+        GradleProject prj = loader != null ? loader.loadProject(aim, ignoreCache, false, args) : null;
         return prj;
     }
 
@@ -338,6 +343,22 @@ public final class NbGradleProjectImpl implements Project {
         return ret;
     }
     
+    public static File getCacheDir(GradleFiles gf) {
+        return getCacheDir(gf.getRootDir(), gf.getProjectDir());
+    }
+
+    public static File getCacheDir(GradleProject gp) {
+        GradleBaseProject base = gp.getBaseProject();
+        return getCacheDir(base.getRootDir(), base.getProjectDir());
+    }
+
+    private static File getCacheDir(File rootDir, File projectDir) {
+        int code = Math.abs(projectDir.getAbsolutePath().hashCode());
+        String dirName = projectDir.getName() + "-" + code; //NOI18N
+        File dir = new File(rootDir, ".gradle/nb-cache/" + dirName); //NOI18N
+        return dir;
+    }
+
     private class ProjectOpenedHookImpl extends ProjectOpenedHook {
 
         @Override
@@ -362,6 +383,7 @@ public final class NbGradleProjectImpl implements Project {
             detachAllUpdater();
             dumpProject();
             getLookup().lookup(ProjectConnection.class).close();
+            getLookup().lookup(GradleProjectErrorNotifications.class).clear();
         }
     }
 
@@ -374,7 +396,7 @@ public final class NbGradleProjectImpl implements Project {
 
         @Override
         public FileObject getCacheDirectory() throws IOException {
-            return FileUtil.createFolder(GradleProjectCache.getCacheDir(gradleFiles));
+            return FileUtil.createFolder(LegacyProjectLoader.getCacheDir(gradleFiles));
         }
     }
 
@@ -390,7 +412,7 @@ public final class NbGradleProjectImpl implements Project {
             watcherRef = new WeakReference<>(watcher);
             Lookup general = Lookups.forPath("Projects/" + NbGradleProject.GRADLE_PROJECT_TYPE + "/Lookup"); //NOI18N
             pluginLookups.put(NB_GENERAL, general); //NOI18N
-            check();
+            setLookups(general);
             watcher.addPropertyChangeListener(WeakListeners.propertyChange(this, watcher));
         }
 
@@ -399,25 +421,27 @@ public final class NbGradleProjectImpl implements Project {
             NbGradleProject watcher = watcherRef.get();
             if (watcher != null) {
                 lookupsChanged = !watcher.isGradleProjectLoaded();
-                GradleBaseProject prj = watcher.projectLookup(GradleBaseProject.class);
-                Set<String> currentPlugins = new HashSet<>(prj.getPlugins());
-                if (prj.isRoot()) {
-                    currentPlugins.add(NB_ROOT_PLUGIN);
-                }
-                for (String cp : currentPlugins) {
-                    //Add Lookups for new plugins
-                    if (!pluginLookups.containsKey(cp)) {
-                        Lookup pluginLookup = Lookups.forPath("Projects/" + NbGradleProject.GRADLE_PLUGIN_TYPE + "/" + cp + "/Lookup"); //NOI18N
-                        pluginLookups.put(cp, pluginLookup);
-                        lookupsChanged = true;
+                if (watcher.isGradleProjectLoaded()) {
+                    GradleBaseProject prj = watcher.projectLookup(GradleBaseProject.class);
+                    Set<String> currentPlugins = new HashSet<>(prj.getPlugins());
+                    if (prj.isRoot()) {
+                        currentPlugins.add(NB_ROOT_PLUGIN);
                     }
-                }
-                Iterator<String> it = pluginLookups.keySet().iterator();
-                while (it.hasNext()) {
-                    String oldPlugin = it.next();
-                    if (!currentPlugins.contains(oldPlugin) && !NB_GENERAL.equals(oldPlugin)) {
-                        it.remove();
-                        lookupsChanged = true;
+                    for (String cp : currentPlugins) {
+                        //Add Lookups for new plugins
+                        if (!pluginLookups.containsKey(cp)) {
+                            Lookup pluginLookup = Lookups.forPath("Projects/" + NbGradleProject.GRADLE_PLUGIN_TYPE + "/" + cp + "/Lookup"); //NOI18N
+                            pluginLookups.put(cp, pluginLookup);
+                            lookupsChanged = true;
+                        }
+                    }
+                    Iterator<String> it = pluginLookups.keySet().iterator();
+                    while (it.hasNext()) {
+                        String oldPlugin = it.next();
+                        if (!currentPlugins.contains(oldPlugin) && !NB_GENERAL.equals(oldPlugin)) {
+                            it.remove();
+                            lookupsChanged = true;
+                        }
                     }
                 }
             }

--- a/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
@@ -77,7 +77,8 @@ public class ReloadAction  extends AbstractAction implements ContextAwareAction 
                 NbGradleProjectImpl.RELOAD_RP.submit(() -> {
                     // A bit low level calls, just to allow UI interaction to
                     // Trust the project.
-                    impl.project = GradleProjectCache.loadProject(impl, FULL_ONLINE, true, true);
+                    GradleProjectLoader loader = impl.getLookup().lookup(GradleProjectLoader.class);
+                    impl.project = loader.loadProject(FULL_ONLINE, true, true);
                     NbGradleProjectImpl.ACCESSOR.doFireReload(NbGradleProject.get(impl));
                 });
             }

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
@@ -33,6 +33,9 @@ import java.util.Map;
 import java.util.Set;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.GradleModuleFileCache21;
+import org.netbeans.modules.gradle.cache.AbstractDiskCache.CacheEntry;
+import org.netbeans.modules.gradle.cache.SubProjectDiskCache;
+import org.netbeans.modules.gradle.cache.SubProjectDiskCache.SubProjectInfo;
 
 /**
  * This object holds the basic information of the Gradle project.
@@ -329,19 +332,28 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
         ret.buildDir = new File(files.getProjectDir(), "build");
         ret.rootDir = files.getRootDir();
         ret.version = "unspecified";
-        StringBuilder path = new StringBuilder(":");       //NOI18N
-        if (!files.isRootProject()) {
-            Path prjPath = files.getProjectDir().toPath();
-            Path rootPath = files.getRootDir().toPath();
-            String separator = "";
-            Path relPath = rootPath.relativize(prjPath);
-            for(int i = 0; i < relPath.getNameCount() ; i++) {
-                path.append(separator);
-                path.append(relPath.getName(i));
-                separator = ":"; //NOI18N
-            }
+        CacheEntry<SubProjectInfo> structureCache = SubProjectDiskCache.get(files.getRootDir()).loadEntry();
+        if (structureCache != null) {
+            SubProjectInfo info = structureCache.getData();
+            ret.path = info.getProjectPath(files.getProjectDir());
+            ret.description = info.getProjectDescription(files.getProjectDir());
+            ret.name = info.getProjectName(files.getProjectDir());
         }
-        ret.path = path.toString();
+        if (ret.path == null) {
+            StringBuilder path = new StringBuilder(":");       //NOI18N
+            if (!files.isRootProject()) {
+                Path prjPath = files.getProjectDir().toPath();
+                Path rootPath = files.getRootDir().toPath();
+                String separator = "";
+                Path relPath = rootPath.relativize(prjPath);
+                for(int i = 0; i < relPath.getNameCount() ; i++) {
+                    path.append(separator);
+                    path.append(relPath.getName(i));
+                    separator = ":"; //NOI18N
+                }
+            }
+            ret.path = path.toString();
+        }
         ret.status = "release";
         ret.parentName = files.isRootProject() ? null : files.getRootDir().getName();
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProject.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Set;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.GradleModuleFileCache21;
-import org.netbeans.modules.gradle.cache.AbstractDiskCache.CacheEntry;
 import org.netbeans.modules.gradle.cache.SubProjectDiskCache;
 import org.netbeans.modules.gradle.cache.SubProjectDiskCache.SubProjectInfo;
 
@@ -332,12 +331,12 @@ public final class GradleBaseProject implements Serializable, ModuleSearchSuppor
         ret.buildDir = new File(files.getProjectDir(), "build");
         ret.rootDir = files.getRootDir();
         ret.version = "unspecified";
-        CacheEntry<SubProjectInfo> structureCache = SubProjectDiskCache.get(files.getRootDir()).loadEntry();
-        if (structureCache != null) {
-            SubProjectInfo info = structureCache.getData();
-            ret.path = info.getProjectPath(files.getProjectDir());
-            ret.description = info.getProjectDescription(files.getProjectDir());
-            ret.name = info.getProjectName(files.getProjectDir());
+        SubProjectInfo structure = SubProjectDiskCache.get(files.getRootDir()).loadData();
+        if (structure != null) {
+            // Note: The structure information might be invalid, though we are just guessing here
+            ret.path = structure.getProjectPath(files.getProjectDir());
+            ret.description = structure.getProjectDescription(files.getProjectDir());
+            ret.name = structure.getProjectName(files.getProjectDir());
         }
         if (ret.path == null) {
             StringBuilder path = new StringBuilder(":");       //NOI18N

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleBaseProjectBuilder.java
@@ -20,7 +20,7 @@
 package org.netbeans.modules.gradle.api;
 
 import org.netbeans.modules.gradle.spi.GradleFiles;
-import org.netbeans.modules.gradle.GradleArtifactStore;
+import org.netbeans.modules.gradle.loaders.GradleArtifactStore;
 import static org.netbeans.modules.gradle.api.GradleDependency.*;
 import org.netbeans.modules.gradle.spi.ProjectInfoExtractor;
 import java.io.File;

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleProjects.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleProjects.java
@@ -19,7 +19,7 @@
 
 package org.netbeans.modules.gradle.api;
 
-import org.netbeans.modules.gradle.GradleArtifactStore;
+import org.netbeans.modules.gradle.loaders.GradleArtifactStore;
 import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.WeakHashMap;
 import org.netbeans.modules.gradle.NbGradleProjectImpl;
 import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache.QualifiedProjectInfo;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
@@ -40,8 +41,18 @@ public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, Q
     // Increase this number if new info is gathered from the projects.
     private static final int COMPATIBLE_CACHE_VERSION = 18;
     private static final String INFO_CACHE_FILE_NAME = "project-info.ser"; //NOI18N
+    private static final Map<GradleFiles, ProjectInfoDiskCache> DISK_CACHES = new WeakHashMap<>();
 
-    public ProjectInfoDiskCache(GradleFiles gf) {
+    public static ProjectInfoDiskCache get(GradleFiles gf) {
+        ProjectInfoDiskCache ret = DISK_CACHES.get(gf);
+        if (ret == null) {
+            ret = new ProjectInfoDiskCache(gf);
+            DISK_CACHES.put(gf, ret);
+        }
+        return ret;
+    }
+    
+    private ProjectInfoDiskCache(GradleFiles gf) {
         super(gf);
     }
     

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
@@ -25,7 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import org.netbeans.modules.gradle.GradleProjectCache;
+import org.netbeans.modules.gradle.NbGradleProjectImpl;
 import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache.QualifiedProjectInfo;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
 import org.netbeans.modules.gradle.api.NbProjectInfo;
@@ -52,7 +52,7 @@ public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, Q
 
     @Override
     protected File cacheFile() {
-        return new File(GradleProjectCache.getCacheDir(key), INFO_CACHE_FILE_NAME);
+        return new File(NbGradleProjectImpl.getCacheDir(key), INFO_CACHE_FILE_NAME);
     }
 
     @Override

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/SubProjectDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/SubProjectDiskCache.java
@@ -75,6 +75,7 @@ public class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo>
         String rootProjectName;
         Map<String, String> path2Name;
         Map<File, String> file2Path;
+        Map<String, String> path2Description;
 
         protected SubProjectInfo() {}
 
@@ -83,8 +84,12 @@ public class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo>
             rootProjectName = prj.getName();
             path2Name = new HashMap<>();
             file2Path = new HashMap<>();
+            path2Description = new HashMap<>();
             for (GradleProject child : prj.getChildren()) {
                 path2Name.put(child.getPath(), child.getName());
+                if (child.getDescription() != null) {
+                    path2Description.put(child.getPath(), child.getDescription());
+                }
                 File dir = child.getProjectDirectory();
                 if (!dir.isAbsolute()) {
                     dir = new File(prj.getProjectDirectory(), dir.toString());
@@ -98,6 +103,7 @@ public class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo>
             rootProjectName = gbp.getName();
             path2Name = new HashMap<>();
             file2Path = new HashMap<>();
+            path2Description = Collections.emptyMap();
             for (Map.Entry<String, File> sprj : gbp.getSubProjects().entrySet()) {
                 file2Path.put(sprj.getValue(), sprj.getKey());
                 path2Name.put(sprj.getKey(), sprj.getKey());
@@ -115,6 +121,15 @@ public class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo>
         public String getProjectName(File dir) {
             String path = file2Path.get(dir);
             return path != null ? path2Name.get(path) : null;
+        }
+
+        public String getProjectDescription(String path) {
+            return path2Description.get(path);
+        }
+
+        public String getProjectDescription(File dir) {
+            String path = file2Path.get(dir);
+            return path != null ? path2Description.get(path) : null;
         }
 
         public String getProjectPath(File dir) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/SubProjectDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/SubProjectDiskCache.java
@@ -28,6 +28,7 @@ import java.util.WeakHashMap;
 import org.netbeans.modules.gradle.cache.SubProjectDiskCache.SubProjectInfo;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import org.gradle.tooling.model.GradleProject;
+import org.netbeans.modules.gradle.GradleProjectStructure;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 
 /**
@@ -37,9 +38,9 @@ import org.netbeans.modules.gradle.api.GradleBaseProject;
 public class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo> {
 
     private static final String SUBPROJECT_CACHE_FILE_NAME = ".gradle/nb-cache/subprojects.ser"; //NOI18N
-    private static final int COMPATIBLE_CACHE_VERSION = 1;
+    private static final int COMPATIBLE_CACHE_VERSION = 2;
 
-    private static Map<File, SubProjectDiskCache> diskCaches = new WeakHashMap<>();
+    private static final Map<File, SubProjectDiskCache> DISK_CACHES = new WeakHashMap<>();
 
     protected SubProjectDiskCache() {}
 
@@ -63,55 +64,81 @@ public class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo>
     }
 
     public static SubProjectDiskCache get(File key) {
-        SubProjectDiskCache ret = diskCaches.get(key);
+        SubProjectDiskCache ret = DISK_CACHES.get(key);
         if (ret == null) {
             ret = new SubProjectDiskCache(key);
-            diskCaches.put(key, ret);
+            DISK_CACHES.put(key, ret);
         }
         return ret;
     }
 
-    public static final class SubProjectInfo implements Serializable {
-        String rootProjectName;
-        Map<String, String> path2Name;
-        Map<File, String> file2Path;
-        Map<String, String> path2Description;
+    public static final class SubProjectInfo implements GradleProjectStructure, Serializable {
+        public static final String ROOT_PATH = ":"; //NOI18N
+
+        private Map<String, String> path2Name;
+        private Map<File, String> file2Path;
+        private Map<String, File> path2File;
+        private Map<String, String> path2Description;
 
         protected SubProjectInfo() {}
 
         public SubProjectInfo(GradleProject prj) {
             assert prj.getParent() == null : "This shall be called only on a root project!";
-            rootProjectName = prj.getName();
-            path2Name = new HashMap<>();
-            file2Path = new HashMap<>();
-            path2Description = new HashMap<>();
-            for (GradleProject child : prj.getChildren()) {
-                path2Name.put(child.getPath(), child.getName());
-                if (child.getDescription() != null) {
-                    path2Description.put(child.getPath(), child.getDescription());
+            if (prj.getChildren().isEmpty()) {
+                path2Name = Collections.singletonMap(ROOT_PATH, prj.getName());
+                file2Path = Collections.singletonMap(prj.getProjectDirectory(), ROOT_PATH);
+                path2File = Collections.singletonMap(ROOT_PATH, prj.getProjectDirectory());
+                path2Description = Collections.singletonMap(ROOT_PATH, prj.getDescription());
+            } else {
+                path2Name = new HashMap<>();
+                file2Path = new HashMap<>();
+                path2File = new HashMap<>();
+                path2Description = new HashMap<>();
+
+                path2Name.put(ROOT_PATH, prj.getName());
+                file2Path.put(prj.getProjectDirectory(), ROOT_PATH);
+                path2File.put(ROOT_PATH, prj.getProjectDirectory());
+                if (prj.getDescription() != null) {
+                    path2Description.put(ROOT_PATH, prj.getDescription());
                 }
-                File dir = child.getProjectDirectory();
-                if (!dir.isAbsolute()) {
-                    dir = new File(prj.getProjectDirectory(), dir.toString());
+
+                for (GradleProject child : prj.getChildren()) {
+                    path2Name.put(child.getPath(), child.getName());
+                    if (child.getDescription() != null) {
+                        path2Description.put(child.getPath(), child.getDescription());
+                    }
+                    File dir = child.getProjectDirectory();
+                    if (!dir.isAbsolute()) {
+                        dir = new File(prj.getProjectDirectory(), dir.toString());
+                    }
+                    file2Path.put(dir, child.getPath());
+                    path2File.put(child.getPath(), dir);
                 }
-                file2Path.put(dir, child.getPath());
             }
         }
 
         public SubProjectInfo(GradleBaseProject gbp) {
             assert gbp.isRoot() : "This shall be called only on a root project!";
-            rootProjectName = gbp.getName();
-            path2Name = new HashMap<>();
-            file2Path = new HashMap<>();
-            path2Description = Collections.emptyMap();
-            for (Map.Entry<String, File> sprj : gbp.getSubProjects().entrySet()) {
-                file2Path.put(sprj.getValue(), sprj.getKey());
-                path2Name.put(sprj.getKey(), sprj.getKey());
-            }
-        }
+            if (gbp.getSubProjects().isEmpty()) {
+                path2Name = Collections.singletonMap(ROOT_PATH, gbp.getName());
+                file2Path = Collections.singletonMap(gbp.getProjectDir(), ROOT_PATH);
+                path2File = Collections.singletonMap(ROOT_PATH, gbp.getProjectDir());
+                path2Description = Collections.singletonMap(ROOT_PATH, gbp.getDescription());
+            } else {
+                path2Name = new HashMap<>();
+                file2Path = new HashMap<>();
+                path2File = new HashMap<>();
+                path2Description = Collections.emptyMap();
 
-        public String gerRootProjectName() {
-            return rootProjectName;
+                path2Name.put(ROOT_PATH, gbp.getName());
+                file2Path.put(gbp.getProjectDir(), ROOT_PATH);
+                path2File.put(ROOT_PATH, gbp.getProjectDir());
+                for (Map.Entry<String, File> sprj : gbp.getSubProjects().entrySet()) {
+                    file2Path.put(sprj.getValue(), sprj.getKey());
+                    path2File.put(sprj.getKey(), sprj.getValue());
+                    path2Name.put(sprj.getKey(), sprj.getKey());
+                }
+            }
         }
 
         public String getProjectName(String path) {
@@ -141,9 +168,20 @@ public class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo>
         }
 
         @Override
-        public String toString() {
-            return "SubProjects of [" + rootProjectName + "]: " + file2Path.keySet();
+        public Set<String> getProjectPaths() {
+            return path2Name.keySet();
         }
+
+        @Override
+        public File getProjectDir(String path) {
+            return path2File.get(path);
+        }
+
+        @Override
+        public String toString() {
+            return "SubProjects of [" + path2Name.get(ROOT_PATH) + "]: " + file2Path.keySet();
+        }
+
 
     }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/SubProjectDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/SubProjectDiskCache.java
@@ -28,6 +28,7 @@ import java.util.WeakHashMap;
 import org.netbeans.modules.gradle.cache.SubProjectDiskCache.SubProjectInfo;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import org.gradle.tooling.model.GradleProject;
+import org.netbeans.api.project.ProjectManager;
 import org.netbeans.modules.gradle.GradleProjectStructure;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 
@@ -35,7 +36,7 @@ import org.netbeans.modules.gradle.api.GradleBaseProject;
  *
  * @author lkishalmi
  */
-public class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo> {
+public final class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo> {
 
     private static final String SUBPROJECT_CACHE_FILE_NAME = ".gradle/nb-cache/subprojects.ser"; //NOI18N
     private static final int COMPATIBLE_CACHE_VERSION = 2;
@@ -71,6 +72,14 @@ public class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo>
         }
         return ret;
     }
+
+    @Override
+    protected boolean doStoreEntry(CacheEntry<SubProjectInfo> entry) {
+        boolean ret = super.doStoreEntry(entry);
+        ProjectManager.getDefault().clearNonProjectCache();
+        return ret;
+    }
+    
 
     public static final class SubProjectInfo implements GradleProjectStructure, Serializable {
         public static final String ROOT_PATH = ":"; //NOI18N

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/SubProjectDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/SubProjectDiskCache.java
@@ -103,20 +103,28 @@ public class SubProjectDiskCache extends AbstractDiskCache<File, SubProjectInfo>
                 }
 
                 for (GradleProject child : prj.getChildren()) {
-                    path2Name.put(child.getPath(), child.getName());
-                    if (child.getDescription() != null) {
-                        path2Description.put(child.getPath(), child.getDescription());
-                    }
-                    File dir = child.getProjectDirectory();
-                    if (!dir.isAbsolute()) {
-                        dir = new File(prj.getProjectDirectory(), dir.toString());
-                    }
-                    file2Path.put(dir, child.getPath());
-                    path2File.put(child.getPath(), dir);
+                    processGradleProject(child);
                 }
             }
         }
 
+        private void processGradleProject(GradleProject prj) {
+            String path = prj.getPath();
+            path2Name.put(path, prj.getName());
+            File dir = prj.getProjectDirectory();
+            if (!dir.isAbsolute()) {
+                dir = new File(prj.getProjectDirectory(), dir.toString());
+            }
+            file2Path.put(dir, path);
+            path2File.put(path, dir);
+            if (prj.getDescription() != null) {
+                path2Description.put(path, prj.getDescription());
+            }
+            for (GradleProject child : prj.getChildren()) {
+                processGradleProject(child);
+            }
+        }
+        
         public SubProjectInfo(GradleBaseProject gbp) {
             assert gbp.isRoot() : "This shall be called only on a root project!";
             if (gbp.getSubProjects().isEmpty()) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
@@ -19,7 +19,7 @@
 
 package org.netbeans.modules.gradle.execute;
 
-import org.netbeans.modules.gradle.GradleDaemon;
+import org.netbeans.modules.gradle.loaders.GradleDaemon;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 import org.netbeans.modules.gradle.api.execute.RunConfig;

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDistributionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDistributionProviderImpl.java
@@ -34,7 +34,7 @@ import java.util.prefs.PreferenceChangeListener;
 import javax.swing.event.ChangeListener;
 import org.gradle.internal.impldep.com.google.common.base.Objects;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.NbGradleProjectImpl;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.GradleDistributionManager;
 import org.netbeans.modules.gradle.api.execute.GradleDistributionManager.GradleDistribution;
@@ -72,13 +72,13 @@ public class GradleDistributionProviderImpl implements GradleDistributionProvide
         }
     };
 
-    final Project project;
+    final NbGradleProjectImpl project;
     private GradleDistribution dist;
     private PropertyChangeListener pcl;
     private URI distributionURI;
 
     public GradleDistributionProviderImpl(Project project) {
-        this.project = project;
+        this.project = (NbGradleProjectImpl) project;
         pcl = (evt) -> {
             if (NbGradleProject.PROP_RESOURCES.endsWith(evt.getPropertyName())) {
                 URI uri = (URI) evt.getNewValue();
@@ -101,11 +101,9 @@ public class GradleDistributionProviderImpl implements GradleDistributionProvide
 
             GradleDistributionManager mgr = GradleDistributionManager.get(settings.getGradleUserHome());
 
-            GradleBaseProject gbp = GradleBaseProject.get(project);
-
-            if ((gbp != null) && settings.isWrapperPreferred()) {
+            if (settings.isWrapperPreferred()) {
                 try {
-                    dist = mgr.distributionFromWrapper(gbp.getRootDir());
+                    dist = mgr.distributionFromWrapper(project.getGradleFiles().getRootDir());
                 } catch (Exception ex) {
                     LOGGER.log(Level.FINE, "Cannot evaulate Gradle Wrapper", ex); //NOI18N
                 }
@@ -135,10 +133,7 @@ public class GradleDistributionProviderImpl implements GradleDistributionProvide
     private URI getWrapperDistributionURI() {
         URI ret = null;
         try {
-            GradleBaseProject gbp = GradleBaseProject.get(project);
-            if (gbp != null) {
-                ret = GradleDistributionManager.getWrapperDistributionURI(gbp.getRootDir());
-            }
+            ret = GradleDistributionManager.getWrapperDistributionURI(project.getGradleFiles().getRootDir());
         } catch (IOException | URISyntaxException ex) {}
         return ret;
     }
@@ -161,8 +156,7 @@ public class GradleDistributionProviderImpl implements GradleDistributionProvide
 
     @Override
     public Set<File> getWatchedResources() {
-        GradleBaseProject gbp = GradleBaseProject.get(project);
-        return gbp != null ? Collections.singleton(new File(gbp.getRootDir(), GradleFiles.WRAPPER_PROPERTIES)) : Collections.emptySet();
+        return Collections.singleton(project.getGradleFiles().getWrapperProperties());
     }
 
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDistributionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDistributionProviderImpl.java
@@ -84,14 +84,13 @@ public class GradleDistributionProviderImpl implements GradleDistributionProvide
                 URI uri = (URI) evt.getNewValue();
                 if ((uri != null) && (uri.getPath() != null) && uri.getPath().endsWith(GradleFiles.WRAPPER_PROPERTIES)) {
                     URI newDistURI = getWrapperDistributionURI();
-                    if (GradleSettings.getDefault().isWrapperPreferred() && ! Objects.equal(distributionURI, newDistURI)) {
+                    if (GradleSettings.getDefault().isWrapperPreferred() && (distributionURI != null) && !Objects.equal(distributionURI, newDistURI)) {
                         distributionURI = newDistURI;
                         distributionChanged();
                     }
                 }
             }
         };
-        distributionURI = getWrapperDistributionURI();
         NbGradleProject.addPropertyChangeListener(project, WeakListeners.propertyChange(pcl, project));
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDistributionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDistributionProviderImpl.java
@@ -156,7 +156,7 @@ public class GradleDistributionProviderImpl implements GradleDistributionProvide
 
     @Override
     public Set<File> getWatchedResources() {
-        return Collections.singleton(project.getGradleFiles().getWrapperProperties());
+        return Collections.singleton(new File(project.getGradleFiles().getRootDir(), GradleFiles.WRAPPER_PROPERTIES));
     }
 
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -70,7 +70,7 @@ public abstract class AbstractProjectLoader {
 
         public ReloadContext(NbGradleProjectImpl project, NbGradleProject.Quality aim, GradleCommandLine cmd) {
             this.project = project;
-            this.previous = project.isGradleProjectLoaded() ? project.getGradleProject() : null;
+            this.previous = project.isGradleProjectLoaded() ? project.getGradleProject() : FallbackProjectLoader.createFallbackProject(project.getGradleFiles());
             this.aim = aim;
             this.cmd = cmd;
         }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.netbeans.modules.gradle.GradleProject;
+import org.netbeans.modules.gradle.GradleProjectLoader;
+import org.netbeans.modules.gradle.NbGradleProjectImpl;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.EVALUATED;
+import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FALLBACK;
+import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache;
+import org.netbeans.modules.gradle.cache.SubProjectDiskCache;
+import org.netbeans.modules.gradle.spi.GradleFiles;
+import org.netbeans.modules.gradle.spi.ProjectInfoExtractor;
+import org.openide.util.Lookup;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public abstract class AbstractProjectLoader implements GradleProjectLoader {
+
+    final ReloadContext ctx;
+
+    protected AbstractProjectLoader(ReloadContext ctx) {
+        this.ctx = ctx;
+    }
+
+    public abstract boolean isEnabled();
+
+    static final class ReloadContext {
+
+        final NbGradleProjectImpl project;
+        final GradleProject previous;
+        final NbGradleProject.Quality aim;
+        String[] args = new String[0];
+
+        public ReloadContext(NbGradleProjectImpl project, NbGradleProject.Quality aim) {
+            this.project = project;
+            this.previous = project.isGradleProjectLoaded() ? project.getGradleProject() : null;
+            this.aim = aim;
+        }
+
+        public GradleProject getPrevious() {
+            return previous;
+        }
+
+        public NbGradleProject.Quality getAim() {
+            return aim;
+        }
+    }
+
+    static GradleProject createGradleProject(ProjectInfoDiskCache.QualifiedProjectInfo info) {
+        Collection<? extends ProjectInfoExtractor> extractors = Lookup.getDefault().lookupAll(ProjectInfoExtractor.class);
+        Map<Class, Object> results = new HashMap<>();
+        Set<String> problems = new LinkedHashSet<>(info.getProblems());
+
+        Map<String, Object> projectInfo = new HashMap<>(info.getInfo());
+        projectInfo.putAll(info.getExt());
+
+        for (ProjectInfoExtractor extractor : extractors) {
+            ProjectInfoExtractor.Result result = extractor.extract(projectInfo, Collections.unmodifiableMap(results));
+            problems.addAll(result.getProblems());
+            for (Object extract : result.getExtract()) {
+                results.put(extract.getClass(), extract);
+            }
+
+        }
+        return new GradleProject(info.getQuality(), problems, results.values());
+
+    }
+
+    static void updateSubDirectoryCache(GradleProject gp) {
+        if (gp.getQuality().atLeast(EVALUATED)) {
+            GradleBaseProject baseProject = gp.getBaseProject();
+            if (baseProject.isRoot()) {
+                SubProjectDiskCache spCache = SubProjectDiskCache.get(baseProject.getRootDir());
+                spCache.storeData(new SubProjectDiskCache.SubProjectInfo(baseProject));
+            }
+        }
+    }
+
+    static void saveCachedProjectInfo(ProjectInfoDiskCache.QualifiedProjectInfo data, GradleProject gp) {
+        assert gp.getQuality().betterThan(FALLBACK) : "Never attempt to cache FALLBACK projects."; //NOi18N
+        GradleFiles gf = new GradleFiles(gp.getBaseProject().getProjectDir(), true);
+        new ProjectInfoDiskCache(gf).storeData(data);
+    }
+
+
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -31,6 +31,7 @@ import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.EVALUATED;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FALLBACK;
+import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache;
 import org.netbeans.modules.gradle.cache.SubProjectDiskCache;
 import org.netbeans.modules.gradle.spi.GradleFiles;
@@ -41,27 +42,34 @@ import org.openide.util.Lookup;
  *
  * @author lkishalmi
  */
-public abstract class AbstractProjectLoader implements GradleProjectLoader {
+public abstract class AbstractProjectLoader {
 
     final ReloadContext ctx;
 
-    protected AbstractProjectLoader(ReloadContext ctx) {
+    AbstractProjectLoader(ReloadContext ctx) {
         this.ctx = ctx;
     }
 
-    public abstract boolean isEnabled();
+    abstract GradleProject load();
+ 
+    abstract boolean isEnabled();
 
+    boolean needsTrust() {
+        return true;
+    }
+    
     static final class ReloadContext {
 
         final NbGradleProjectImpl project;
         final GradleProject previous;
         final NbGradleProject.Quality aim;
-        String[] args = new String[0];
+        final GradleCommandLine cmd;
 
-        public ReloadContext(NbGradleProjectImpl project, NbGradleProject.Quality aim) {
+        public ReloadContext(NbGradleProjectImpl project, NbGradleProject.Quality aim, GradleCommandLine cmd) {
             this.project = project;
             this.previous = project.isGradleProjectLoaded() ? project.getGradleProject() : null;
             this.aim = aim;
+            this.cmd = cmd;
         }
 
         public GradleProject getPrevious() {

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import org.netbeans.modules.gradle.GradleProject;
-import org.netbeans.modules.gradle.GradleProjectLoader;
 import org.netbeans.modules.gradle.NbGradleProjectImpl;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.NbGradleProject;
@@ -36,6 +35,7 @@ import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache;
 import org.netbeans.modules.gradle.cache.SubProjectDiskCache;
 import static org.netbeans.modules.gradle.loaders.GradleDaemon.INIT_SCRIPT;
 import static org.netbeans.modules.gradle.loaders.GradleDaemon.TOOLING_JAR;
+import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import org.netbeans.modules.gradle.spi.GradleSettings;
 import org.netbeans.modules.gradle.spi.ProjectInfoExtractor;
@@ -117,7 +117,8 @@ public abstract class AbstractProjectLoader {
     static void updateSubDirectoryCache(GradleProject gp) {
         if (gp.getQuality().atLeast(EVALUATED)) {
             GradleBaseProject baseProject = gp.getBaseProject();
-            if (baseProject.isRoot()) {
+            if (baseProject.isRoot() && !GradleExperimentalSettings.getDefault().isBundledLoading()) {
+                // Bundled Gradle Project loading saves better information, do not overwrite that
                 SubProjectDiskCache spCache = SubProjectDiskCache.get(baseProject.getRootDir());
                 spCache.storeData(new SubProjectDiskCache.SubProjectInfo(baseProject));
             }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/BundleProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/BundleProjectLoader.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.io.File;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import org.gradle.tooling.ProjectConnection;
+import org.netbeans.modules.gradle.GradleProject;
+import org.netbeans.modules.gradle.api.ModelFetcher;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.api.NbProjectInfo;
+import org.netbeans.modules.gradle.cache.AbstractDiskCache.CacheEntry;
+import org.netbeans.modules.gradle.cache.SubProjectDiskCache;
+import org.netbeans.modules.gradle.cache.SubProjectDiskCache.SubProjectInfo;
+import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
+import org.openide.util.Exceptions;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class BundleProjectLoader extends AbstractProjectLoader {
+
+
+    private CacheEntry<SubProjectInfo> structureCache;
+    BundleProjectLoader(ReloadContext ctx) {
+        super(ctx);
+    }
+
+
+    @Override
+    GradleProject load() {
+        File rootDir = ctx.project.getGradleFiles().getRootDir();
+        if (structureCache == null) {
+            SubProjectDiskCache spCache = SubProjectDiskCache.get(rootDir);
+            structureCache = spCache.loadEntry();
+        }
+        if (structureCache == null || !structureCache.isValid()) {
+            ModelCache modelCache = ModelCacheManager.getModelCache(rootDir, org.gradle.tooling.model.GradleProject.class, () -> new ModelCache(ctx.project, new ProjectStructureCachingDescriptor(rootDir)));
+            try {
+                modelCache.refreshAndWait();
+            } catch (InterruptedException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+            SubProjectDiskCache spCache = SubProjectDiskCache.get(rootDir);
+            structureCache = spCache.loadEntry();
+        }
+        if (structureCache != null) {
+            ModelCache modelCache = ModelCacheManager.getModelCache(rootDir, NbProjectInfo.class, () -> new ModelCache(ctx.project, new NbProjectInfoCachingDescriptor(structureCache.getData())));
+            try {
+                modelCache.refreshAndWait();
+            } catch (InterruptedException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    boolean isEnabled() {
+        return ctx.getAim().betterThan(NbGradleProject.Quality.FALLBACK) && GradleExperimentalSettings.getDefault().isBundledLoading();
+    }
+
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.gradle.loaders;
 
 import org.netbeans.modules.gradle.GradleProject;
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FALLBACK;
 import org.netbeans.modules.gradle.cache.AbstractDiskCache;
 import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache;
@@ -31,15 +30,12 @@ import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
  */
 public class DiskCacheProjectLoader extends AbstractProjectLoader {
 
-    public DiskCacheProjectLoader(ReloadContext ctx) {
+    DiskCacheProjectLoader(ReloadContext ctx) {
         super(ctx);
     }
 
     @Override
-    public GradleProject loadProject(NbGradleProject.Quality aim, boolean ignoreCache, boolean interactive, String... args) {
-        if ((aim == FALLBACK) || ignoreCache || GradleExperimentalSettings.getDefault().isCacheDisabled()) {
-            return null;
-        }
+    public GradleProject load() {
         AbstractDiskCache.CacheEntry<ProjectInfoDiskCache.QualifiedProjectInfo> cacheEntry = new ProjectInfoDiskCache(ctx.project.getGradleFiles()).loadEntry();
         if (cacheEntry != null) {
             if (cacheEntry.isCompatible()) {
@@ -54,8 +50,12 @@ public class DiskCacheProjectLoader extends AbstractProjectLoader {
     }
 
     @Override
-    public boolean isEnabled() {
-        return true;
+    boolean isEnabled() {
+        return ctx.aim.betterThan(FALLBACK) && !GradleExperimentalSettings.getDefault().isCacheDisabled();
     }
 
+    @Override
+    boolean needsTrust() {
+        return false;
+    }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
@@ -36,7 +36,7 @@ public class DiskCacheProjectLoader extends AbstractProjectLoader {
 
     @Override
     public GradleProject load() {
-        AbstractDiskCache.CacheEntry<ProjectInfoDiskCache.QualifiedProjectInfo> cacheEntry = new ProjectInfoDiskCache(ctx.project.getGradleFiles()).loadEntry();
+        AbstractDiskCache.CacheEntry<ProjectInfoDiskCache.QualifiedProjectInfo> cacheEntry = ProjectInfoDiskCache.get(ctx.project.getGradleFiles()).loadEntry();
         if (cacheEntry != null) {
             if (cacheEntry.isCompatible()) {
                 GradleProject prev = createGradleProject(cacheEntry.getData());

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
@@ -36,14 +36,12 @@ public class DiskCacheProjectLoader extends AbstractProjectLoader {
 
     @Override
     public GradleProject load() {
-        AbstractDiskCache.CacheEntry<ProjectInfoDiskCache.QualifiedProjectInfo> cacheEntry = ProjectInfoDiskCache.get(ctx.project.getGradleFiles()).loadEntry();
-        if (cacheEntry != null) {
-            if (cacheEntry.isCompatible()) {
-                GradleProject prev = createGradleProject(cacheEntry.getData());
-                if (cacheEntry.isValid()) {
-                    updateSubDirectoryCache(prev);
-                    return prev;
-                }
+        ProjectInfoDiskCache cache = ProjectInfoDiskCache.get(ctx.project.getGradleFiles());
+        if (cache.isCompatible()) {
+            GradleProject prev = createGradleProject(cache.loadData());
+            if (cache.isValid()) {
+                updateSubDirectoryCache(prev);
+                return prev;
             }
         }
         return null;

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
@@ -39,13 +39,13 @@ public class FallbackProjectLoader extends AbstractProjectLoader {
 
     final GradleFiles files;
 
-    public FallbackProjectLoader(ReloadContext ctx) {
+    FallbackProjectLoader(ReloadContext ctx) {
         super(ctx);
         this.files = ctx.project.getGradleFiles();
     }
 
     @Override
-    public GradleProject loadProject(NbGradleProject.Quality aim, boolean ignoreCache, boolean interactive, String... args) {
+    public GradleProject load() {
         Collection<? extends ProjectInfoExtractor> extractors = Lookup.getDefault().lookupAll(ProjectInfoExtractor.class);
         Map<Class, Object> infos = new HashMap<>();
         Set<String> problems = new LinkedHashSet<>();
@@ -62,8 +62,12 @@ public class FallbackProjectLoader extends AbstractProjectLoader {
     }
 
     @Override
-    public boolean isEnabled() {
+    boolean isEnabled() {
         return true;
     }
 
+    @Override
+    boolean needsTrust() {
+        return false;
+    }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
@@ -46,6 +46,10 @@ public class FallbackProjectLoader extends AbstractProjectLoader {
 
     @Override
     public GradleProject load() {
+        return createFallbackProject(files);
+    }
+
+    public static GradleProject createFallbackProject(GradleFiles files) {
         Collection<? extends ProjectInfoExtractor> extractors = Lookup.getDefault().lookupAll(ProjectInfoExtractor.class);
         Map<Class, Object> infos = new HashMap<>();
         Set<String> problems = new LinkedHashSet<>();
@@ -58,9 +62,9 @@ public class FallbackProjectLoader extends AbstractProjectLoader {
             }
 
         }
-        return new GradleProject(NbGradleProject.Quality.FALLBACK, problems, infos.values());
+        return new GradleProject(NbGradleProject.Quality.FALLBACK, problems, infos.values());        
     }
-
+    
     @Override
     boolean isEnabled() {
         return true;

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
@@ -23,14 +23,10 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.GradleProject;
-import org.netbeans.modules.gradle.GradleProjectLoader;
-import org.netbeans.modules.gradle.NbGradleProjectImpl;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 import org.netbeans.modules.gradle.spi.ProjectInfoExtractor;
-import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.util.Lookup;
 
 /**
@@ -38,12 +34,14 @@ import org.openide.util.Lookup;
  * @author lkishalmi
  */
 //@ProjectServiceProvider(service = GradleProjectLoader.class, projectType = NbGradleProject.GRADLE_PROJECT_TYPE)
-public class FallbackProjectLoader implements GradleProjectLoader {
+public class FallbackProjectLoader extends AbstractProjectLoader {
+
 
     final GradleFiles files;
 
-    public FallbackProjectLoader(Project project) {
-        this.files = ((NbGradleProjectImpl) project).getGradleFiles();
+    public FallbackProjectLoader(ReloadContext ctx) {
+        super(ctx);
+        this.files = ctx.project.getGradleFiles();
     }
 
     @Override
@@ -61,6 +59,11 @@ public class FallbackProjectLoader implements GradleProjectLoader {
 
         }
         return new GradleProject(NbGradleProject.Quality.FALLBACK, problems, infos.values());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
     }
 
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/FallbackProjectLoader.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.GradleProject;
+import org.netbeans.modules.gradle.GradleProjectLoader;
+import org.netbeans.modules.gradle.NbGradleProjectImpl;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.spi.GradleFiles;
+import org.netbeans.modules.gradle.spi.ProjectInfoExtractor;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.util.Lookup;
+
+/**
+ *
+ * @author lkishalmi
+ */
+//@ProjectServiceProvider(service = GradleProjectLoader.class, projectType = NbGradleProject.GRADLE_PROJECT_TYPE)
+public class FallbackProjectLoader implements GradleProjectLoader {
+
+    final GradleFiles files;
+
+    public FallbackProjectLoader(Project project) {
+        this.files = ((NbGradleProjectImpl) project).getGradleFiles();
+    }
+
+    @Override
+    public GradleProject loadProject(NbGradleProject.Quality aim, boolean ignoreCache, boolean interactive, String... args) {
+        Collection<? extends ProjectInfoExtractor> extractors = Lookup.getDefault().lookupAll(ProjectInfoExtractor.class);
+        Map<Class, Object> infos = new HashMap<>();
+        Set<String> problems = new LinkedHashSet<>();
+
+        for (ProjectInfoExtractor extractor : extractors) {
+            ProjectInfoExtractor.Result result = extractor.fallback(files);
+            problems.addAll(result.getProblems());
+            for (Object extract : result.getExtract()) {
+                infos.put(extract.getClass(), extract);
+            }
+
+        }
+        return new GradleProject(NbGradleProject.Quality.FALLBACK, problems, infos.values());
+    }
+
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleArtifactStore.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleArtifactStore.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.netbeans.modules.gradle;
+package org.netbeans.modules.gradle.loaders;
 
 import org.netbeans.modules.gradle.api.GradleConfiguration;
 import org.netbeans.modules.gradle.api.GradleDependency;
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.swing.event.ChangeListener;
+import org.netbeans.modules.gradle.GradleProject;
 import org.openide.modules.OnStart;
 import org.openide.modules.Places;
 import org.openide.util.ChangeSupport;

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleDaemon.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleDaemon.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.netbeans.modules.gradle;
+package org.netbeans.modules.gradle.loaders;
 
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import org.netbeans.modules.gradle.loaders.FallbackProjectLoader;
+import org.netbeans.modules.gradle.loaders.LegacyProjectLoader;
+import java.util.Arrays;
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.GradleProject;
+import org.netbeans.modules.gradle.GradleProjectLoader;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class GradleProjectLoaderImpl implements GradleProjectLoader {
+
+    final Project project;
+
+    public GradleProjectLoaderImpl(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public GradleProject loadProject(NbGradleProject.Quality aim, boolean ignoreCache, boolean interactive, String... args) {
+        List<GradleProjectLoader> loaders = Arrays.asList(
+                new LegacyProjectLoader(project),
+                new FallbackProjectLoader(project)
+        );
+
+        GradleProject ret = null;
+        for (GradleProjectLoader loader : loaders) {
+            ret = loader.loadProject(aim, ignoreCache, interactive, args);
+            if (ret != null) {
+                break;
+            }
+        }
+        return ret;
+    }
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -47,6 +47,7 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
         List<AbstractProjectLoader> loaders = new LinkedList<>();
 
         if (!ignoreCache) loaders.add(new DiskCacheProjectLoader(ctx));
+        loaders.add(new BundleProjectLoader(ctx));
         loaders.add(new LegacyProjectLoader(ctx));
         loaders.add(new FallbackProjectLoader(ctx));
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
@@ -51,7 +51,6 @@ import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FULL_ONLIN
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.SIMPLE;
 import org.netbeans.modules.gradle.api.NbProjectInfo;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
-import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache;
 import org.netbeans.modules.gradle.spi.GradleSettings;
 import org.openide.util.Cancellable;
@@ -82,18 +81,11 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
     }
 
     @Override
-    public GradleProject loadProject(NbGradleProject.Quality aim, boolean ignoreCache, boolean interactive, String... args) {
-
-        ctx.args = args;
-
+    public GradleProject load() {
         GradleProject ret;
         try {
-            if (RunUtils.isProjectTrusted(ctx.project, interactive)) {
-                ret = GRADLE_LOADER_RP.submit(new ProjectLoaderTask(ctx)).get();
-                updateSubDirectoryCache(ret);
-            } else {
-                ret = ctx.previous.invalidate();
-            }
+            ret = GRADLE_LOADER_RP.submit(new ProjectLoaderTask(ctx)).get();
+            updateSubDirectoryCache(ret);
         } catch (InterruptedException | ExecutionException ex) {
             ret = null;
         }
@@ -121,7 +113,7 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
         GradleProjectErrorNotifications errors = ctx.project.getLookup().lookup(GradleProjectErrorNotifications.class);
 
 
-        GradleCommandLine cmd = new GradleCommandLine(ctx.args);
+        GradleCommandLine cmd = new GradleCommandLine(ctx.cmd);
         cmd.setFlag(GradleCommandLine.Flag.CONFIGURE_ON_DEMAND, GradleSettings.getDefault().isConfigureOnDemand());
         cmd.addParameter(GradleCommandLine.Parameter.INIT_SCRIPT, INIT_SCRIPT);
         cmd.setStackTrace(GradleCommandLine.StackTrace.SHORT);

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/ModelCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/ModelCache.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.gradle.tooling.ProjectConnection;
+import org.gradle.tooling.model.Model;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.ModelFetcher;
+import static org.netbeans.modules.gradle.loaders.ModelCache.State.*;
+import org.openide.util.RequestProcessor;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class ModelCache <T extends Model> {
+
+    enum State { FREE, BUSY }
+
+    static final RequestProcessor RP = new RequestProcessor(ModelCache.class);
+    
+    private static final Logger LOG = Logger.getLogger(ModelCache.class.getName());
+    
+    private State state = FREE;
+    final ModelCachingDescriptor<T> descriptor;
+    final Project project;
+
+    private CountDownLatch barrier;
+
+    public ModelCache(Project project, ModelCachingDescriptor<T> descriptor) {
+        this.project = project;
+        this.descriptor = descriptor;
+    }
+
+    public void refreshAndWait() throws InterruptedException {
+        synchronized (this) {
+            if (state == FREE) {
+                barrier = new CountDownLatch(1);
+                RP.submit(() -> load());
+            }
+        }
+        barrier.await();
+    }
+
+    private void load() {
+        synchronized (this) {
+            if (state == State.BUSY) {
+                throw new IllegalStateException("Chache is BUSY");
+            } else {
+                state = BUSY;
+            }
+        }
+        try {
+            List<String> filteredTargets = descriptor.getTargets().stream().filter((String target) -> descriptor.needsRefresh(target)).collect(Collectors.toList());
+            if (!filteredTargets.isEmpty()) {
+                ProjectConnection pconn = project.getLookup().lookup(ProjectConnection.class);
+                ModelFetcher fetcher = new ModelFetcher();
+                for (String target : filteredTargets) {
+                     fetcher.modelAction(target, descriptor.getModelClass(), (T model) -> descriptor.onLoad(target, model));
+                }
+                long startTime = System.currentTimeMillis();
+                fetcher.fetchModels(pconn, (launcher) -> {
+                    descriptor.gradleCommandLine().configure(launcher);
+                });
+                fetcher.awaitTermination(10, TimeUnit.MINUTES);
+                long endTime = System.currentTimeMillis();
+                LOG.info("Loaded " + filteredTargets.size() + " targets for " + project + " in " + (endTime - startTime));
+            }
+        } catch (Exception ex) {
+        } finally {
+            synchronized (this) {
+                state = FREE;
+            }
+            barrier.countDown();
+        }
+    }
+
+    public synchronized State getState() {
+        return state;
+    }
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/ModelCacheManager.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/ModelCacheManager.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.io.File;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import org.gradle.tooling.model.Model;
+import org.openide.util.Pair;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class ModelCacheManager {
+
+    static Map<File, List<Pair<Class, ModelCache>>> CACHES = new ConcurrentHashMap<>();
+
+    public static <T extends Model> ModelCache<T> getModelCache(File rootDir, Class<T> clazz, Supplier<ModelCache<T>> supplier) {
+        List<Pair<Class, ModelCache>> caches = CACHES.get(rootDir);
+        if (caches == null) {
+            caches = new LinkedList<>();
+            CACHES.put(rootDir, caches);
+        }
+        ModelCache<T> c = null;
+        for (Pair<Class, ModelCache> cache : caches) {
+            if (cache.first().isAssignableFrom(clazz)) {
+                c = cache.second();
+            }
+        }
+        if (c == null) {
+            c = supplier.get();
+            caches.add(Pair.of(clazz, c));
+        }
+        return c;
+    }
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/ModelCachingDescriptor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/ModelCachingDescriptor.java
@@ -16,30 +16,27 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.netbeans.modules.gradle.loaders;
 
-package org.netbeans.modules.gradle.api;
-
-import org.netbeans.modules.gradle.tooling.Model;
-import java.util.Map;
 import java.util.Set;
+import org.gradle.tooling.model.Model;
+import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 
 /**
  *
- * @author Laszlo Kishalmi
+ * @author lkishalmi
  */
-public interface NbProjectInfo extends Model, org.gradle.tooling.model.Model {
-    
-    /**
-     * Project information which shall be cached.
-     * @return the important project data.
-     */
-    Map<String, Object> getInfo();
-    
-    /**
-     * Additional project information which could be thrown away.
-     * @return the not-that-important project data.
-     */    
-    Map<String, Object> getExt();
-    Set<String> getProblems();
-    boolean getMiscOnly();
+public interface ModelCachingDescriptor <T extends Model> {
+
+    Class<T> getModelClass();
+
+    Set<String> getTargets();
+
+    GradleCommandLine gradleCommandLine();
+
+    void onLoad(String target, T model);
+    void onError(String target, Exception ex);
+
+    boolean needsRefresh(String target);
+
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/NbProjectInfoCachingDescriptor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/NbProjectInfoCachingDescriptor.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.util.Set;
+import org.netbeans.modules.gradle.GradleProjectStructure;
+import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
+import org.netbeans.modules.gradle.api.NbProjectInfo;
+import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
+import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache;
+import org.netbeans.modules.gradle.spi.GradleFiles;
+
+import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.*;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public final class NbProjectInfoCachingDescriptor implements ModelCachingDescriptor<NbProjectInfo> {
+
+    final GradleProjectStructure structure;
+
+    public NbProjectInfoCachingDescriptor(GradleProjectStructure structure) {
+        this.structure = structure;
+    }
+
+
+    @Override
+    public Class<NbProjectInfo> getModelClass() {
+        return NbProjectInfo.class;
+    }
+
+    @Override
+    public Set<String> getTargets() {
+        return structure.getProjectPaths();
+    }
+
+    @Override
+    public GradleCommandLine gradleCommandLine() {
+        return AbstractProjectLoader.injectNetBeansTooling(new GradleCommandLine());
+    }
+
+    @Override
+    public void onLoad(String target, NbProjectInfo model) {
+        Quality quality = model.hasException() ? SIMPLE : FULL_ONLINE;
+        ProjectInfoDiskCache.QualifiedProjectInfo qinfo = new ProjectInfoDiskCache.QualifiedProjectInfo(quality, model);
+        GradleFiles gf = new GradleFiles(structure.getProjectDir(target), true);
+        ProjectInfoDiskCache.get(gf).storeData(qinfo);
+    }
+
+    @Override
+    public void onError(String target, Exception ex) {
+    }
+
+    @Override
+    public boolean needsRefresh(String target) {
+        GradleFiles gf = new GradleFiles(structure.getProjectDir(target), true);
+        return ! ProjectInfoDiskCache.get(gf).isValid();
+    }
+
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/ProjectStructureCachingDescriptor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/ProjectStructureCachingDescriptor.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.loaders;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+import org.gradle.tooling.model.GradleProject;
+import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
+import org.netbeans.modules.gradle.cache.SubProjectDiskCache;
+import org.netbeans.modules.gradle.cache.SubProjectDiskCache.SubProjectInfo;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class ProjectStructureCachingDescriptor implements ModelCachingDescriptor<GradleProject>{
+
+    final File rootDir;
+
+    public ProjectStructureCachingDescriptor(File rootDir) {
+        this.rootDir = rootDir;
+    }
+
+
+    @Override
+    public Class<GradleProject> getModelClass() {
+        return GradleProject.class;
+    }
+
+    @Override
+    public Set<String> getTargets() {
+        return Collections.singleton(SubProjectInfo.ROOT_PATH);
+    }
+
+    @Override
+    public GradleCommandLine gradleCommandLine() {
+        return new GradleCommandLine();
+    }
+
+    @Override
+    public void onLoad(String target, GradleProject model) {
+        SubProjectDiskCache cache = SubProjectDiskCache.get(rootDir);
+        SubProjectInfo info = new SubProjectInfo(model);
+        cache.storeData(info);
+    }
+
+    @Override
+    public void onError(String target, Exception ex) {
+    }
+
+    @Override
+    public boolean needsRefresh(String target) {
+        SubProjectDiskCache cache = SubProjectDiskCache.get(rootDir);
+        return ! cache.isValid();
+    }
+
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/nodes/ConfigurationsNode.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/nodes/ConfigurationsNode.java
@@ -20,7 +20,7 @@
 package org.netbeans.modules.gradle.nodes;
 
 import org.netbeans.modules.gradle.ActionProviderImpl;
-import org.netbeans.modules.gradle.GradleArtifactStore;
+import org.netbeans.modules.gradle.loaders.GradleArtifactStore;
 import org.netbeans.modules.gradle.NbGradleProjectImpl;
 import org.netbeans.modules.gradle.api.GradleDependency;
 import org.netbeans.modules.gradle.GradleProject;

--- a/extide/gradle/src/org/netbeans/modules/gradle/options/Bundle.properties
+++ b/extide/gradle/src/org/netbeans/modules/gradle/options/Bundle.properties
@@ -54,3 +54,5 @@ SettingsPanel.cbDownloadSources.toolTipText=Not implemented yet.
 SettingsPanel.cbSilentInstall.text=Install Gradle Runtime Silently
 SettingsPanel.btDefaultHome.text=Default
 SettingsPanel.lbAllowExecution.text=Allow Gradle Execution:
+SettingsPanel.cbBundledLoading.text=Load Projects in Bundles
+SettingsPanel.cbBundledLoading.toolTipText=Instead of loading  sub-projects of a multi-project build individually, try fetch the sub-project details in one run.

--- a/extide/gradle/src/org/netbeans/modules/gradle/options/GradleExperimentalSettings.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/options/GradleExperimentalSettings.java
@@ -19,7 +19,6 @@
 package org.netbeans.modules.gradle.options;
 
 import java.util.prefs.Preferences;
-import org.netbeans.modules.gradle.spi.GradleSettings;
 import org.openide.util.NbPreferences;
 
 /**
@@ -29,6 +28,7 @@ import org.openide.util.NbPreferences;
 public final class GradleExperimentalSettings {
     public static final String PROP_DISABLE_CACHE = "disableCache";
     public static final String PROP_LAZY_OPEN_GROUPS = "lazyOpen";
+    public static final String PROP_BUNDLED_LOADING = "bundledLoading";
 
     private static final GradleExperimentalSettings INSTANCE = new GradleExperimentalSettings(NbPreferences.forModule(GradleExperimentalSettings.class));
     private final Preferences preferences;
@@ -61,4 +61,11 @@ public final class GradleExperimentalSettings {
         return getPreferences().getBoolean(PROP_DISABLE_CACHE, false);
     }
 
+    public void setBundledLoading(boolean b) {
+        getPreferences().putBoolean(PROP_BUNDLED_LOADING, b);
+    }
+
+    public boolean isBundledLoading() {
+        return getPreferences().getBoolean(PROP_BUNDLED_LOADING, false);
+    }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.form
+++ b/extide/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.form
@@ -834,6 +834,7 @@
                               <Group type="103" groupAlignment="0" attributes="0">
                                   <Component id="cbOpenLazy" min="-2" max="-2" attributes="0"/>
                                   <Component id="cbEnableCache" min="-2" max="-2" attributes="0"/>
+                                  <Component id="cbBundledLoading" alignment="0" min="-2" max="-2" attributes="0"/>
                               </Group>
                           </Group>
                       </Group>
@@ -850,7 +851,9 @@
                       <Component id="cbEnableCache" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="cbOpenLazy" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace pref="362" max="32767" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="cbBundledLoading" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace pref="334" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -880,6 +883,16 @@
                 </Property>
                 <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                   <ResourceString bundle="org/netbeans/modules/gradle/options/Bundle.properties" key="SettingsPanel.cbOpenLazy.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="cbBundledLoading">
+              <Properties>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/netbeans/modules/gradle/options/Bundle.properties" key="SettingsPanel.cbBundledLoading.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+                <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/netbeans/modules/gradle/options/Bundle.properties" key="SettingsPanel.cbBundledLoading.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
                 </Property>
               </Properties>
             </Component>

--- a/extide/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/options/SettingsPanel.java
@@ -136,6 +136,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         jLabel1 = new javax.swing.JLabel();
         cbEnableCache = new javax.swing.JCheckBox();
         cbOpenLazy = new javax.swing.JCheckBox();
+        cbBundledLoading = new javax.swing.JCheckBox();
 
         setPreferredSize(new java.awt.Dimension(723, 417));
         setLayout(new java.awt.BorderLayout());
@@ -576,6 +577,9 @@ public class SettingsPanel extends javax.swing.JPanel {
         org.openide.awt.Mnemonics.setLocalizedText(cbOpenLazy, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.cbOpenLazy.text")); // NOI18N
         cbOpenLazy.setToolTipText(org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.cbOpenLazy.toolTipText")); // NOI18N
 
+        org.openide.awt.Mnemonics.setLocalizedText(cbBundledLoading, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.cbBundledLoading.text")); // NOI18N
+        cbBundledLoading.setToolTipText(org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.cbBundledLoading.toolTipText")); // NOI18N
+
         javax.swing.GroupLayout pnlExperimentalLayout = new javax.swing.GroupLayout(pnlExperimental);
         pnlExperimental.setLayout(pnlExperimentalLayout);
         pnlExperimentalLayout.setHorizontalGroup(
@@ -588,7 +592,8 @@ public class SettingsPanel extends javax.swing.JPanel {
                         .addGap(6, 6, 6)
                         .addGroup(pnlExperimentalLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(cbOpenLazy)
-                            .addComponent(cbEnableCache))))
+                            .addComponent(cbEnableCache)
+                            .addComponent(cbBundledLoading))))
                 .addContainerGap(423, Short.MAX_VALUE))
         );
         pnlExperimentalLayout.setVerticalGroup(
@@ -600,7 +605,9 @@ public class SettingsPanel extends javax.swing.JPanel {
                 .addComponent(cbEnableCache)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(cbOpenLazy)
-                .addContainerGap(362, Short.MAX_VALUE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(cbBundledLoading)
+                .addContainerGap(334, Short.MAX_VALUE))
         );
 
         pnlCards.add(pnlExperimental, "Experimental");
@@ -723,6 +730,7 @@ public class SettingsPanel extends javax.swing.JPanel {
 
         cbEnableCache.setSelected(!experimental.isCacheDisabled());
         cbOpenLazy.setSelected(experimental.isOpenLazy());
+        cbBundledLoading.setSelected(experimental.isBundledLoading());
 
         cbPreferMaven.setSelected(settings.isPreferMaven());
 
@@ -789,6 +797,7 @@ public class SettingsPanel extends javax.swing.JPanel {
 
         experimental.setCacheDisabled(!cbEnableCache.isSelected());
         experimental.setOpenLazy(cbOpenLazy.isSelected());
+        experimental.setBundledLoading(cbBundledLoading.isSelected());
 
         settings.setDownloadLibs((GradleSettings.DownloadLibsRule) cbDownloadLibs.getSelectedItem());
         settings.setDownloadSources((GradleSettings.DownloadMiscRule) cbDownloadSources.getSelectedItem());
@@ -835,6 +844,7 @@ public class SettingsPanel extends javax.swing.JPanel {
 
         isChanged |= experimental.isCacheDisabled() == cbEnableCache.isSelected();
         isChanged |= experimental.isOpenLazy() != cbOpenLazy.isSelected();
+        isChanged |= experimental.isBundledLoading() != cbBundledLoading.isSelected();
 
         isChanged |= settings.isPreferMaven() != cbPreferMaven.isSelected();
 
@@ -902,6 +912,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     private javax.swing.JButton btUseCustomGradle;
     private javax.swing.JComboBox<GradleSettings.GradleExecutionRule> cbAllowExecution;
     private javax.swing.JCheckBox cbAlwaysShowOutput;
+    private javax.swing.JCheckBox cbBundledLoading;
     private javax.swing.JCheckBox cbConfigureOnDemand;
     private javax.swing.JCheckBox cbDisplayDescription;
     private javax.swing.JComboBox<GradleSettings.DownloadMiscRule> cbDownloadJavadoc;

--- a/extide/gradle/src/org/netbeans/modules/gradle/queries/ProjectContainerProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/queries/ProjectContainerProviderImpl.java
@@ -30,7 +30,6 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
-import org.netbeans.modules.gradle.api.GradleProjects;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.spi.project.ProjectContainerProvider;
 import org.netbeans.spi.project.ProjectServiceProvider;

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.netbeans.api.annotations.common.NonNull;
@@ -64,6 +65,8 @@ public final class GradleFiles implements Serializable {
         public static final Set<Kind> PROJECT_FILES = EnumSet.of(ROOT_SCRIPT, BUILD_SCRIPT, SETTINGS_SCRIPT, PROJECT_PROPERTIES, ROOT_PROPERTIES);
     }
 
+    private static final Logger LOG = Logger.getLogger(GradleFiles.class.getName());
+    
     public static final String SETTINGS_FILE_NAME     = "settings.gradle"; //NOI18N
     public static final String SETTINGS_FILE_NAME_KTS = "settings.gradle.kts"; //NOI18N
     public static final String BUILD_FILE_NAME        = "build.gradle"; //NOI18N
@@ -85,6 +88,7 @@ public final class GradleFiles implements Serializable {
     }
     
     public GradleFiles(File dir, boolean knownProject) {
+        LOG.fine("Gradle Files for: " + dir.getAbsolutePath());
         this.knownProject = knownProject;
         try {
             dir = dir.getCanonicalFile();

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.gradle.spi.newproject;
 
-import org.netbeans.modules.gradle.GradleProjectCache;
 import org.netbeans.modules.gradle.NbGradleProjectImpl;
 import java.io.File;
 import java.io.IOException;
@@ -52,6 +51,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
+import org.netbeans.modules.gradle.GradleProjectLoader;
 import org.netbeans.modules.gradle.ProjectTrust;
 import org.netbeans.modules.gradle.api.GradleProjects;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
@@ -263,7 +263,10 @@ public final class TemplateOperation implements Runnable {
                         NbGradleProjectImpl nbProject = project.getLookup().lookup(NbGradleProjectImpl.class);
                         if (nbProject != null) {
                             //Just load the project into the cache.
-                            GradleProjectCache.loadProject(nbProject, Quality.FULL_ONLINE, true, false);
+                            GradleProjectLoader loader = nbProject.getLookup().lookup(GradleProjectLoader.class);
+                            if (loader != null) {
+                                loader.loadProject(Quality.FULL_ONLINE, true, false);
+                            }
                         }
                         return Collections.singleton(projectDir);
                     }

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
@@ -84,7 +84,8 @@ public class AbstractGradleProjectTestCase extends NbTestCase {
         NbGradleProjectImpl.RELOAD_RP.submit(() -> {
             // A bit low level calls, just to allow UI interaction to
             // Trust the project.
-            impl.project = GradleProjectCache.loadProject(impl, FULL_ONLINE, true, true);
+            GradleProjectLoader loader = impl.getLookup().lookup(GradleProjectLoader.class);
+            impl.project = loader.loadProject(FULL_ONLINE, true, true);
             NbGradleProjectImpl.ACCESSOR.doFireReload(NbGradleProject.get(impl));
         }).get();
     }


### PR DESCRIPTION
This is a massive change, I've been working for a while. The main goal would be to retrieve the subproject configuration in one or two passes from Gradle, instead of one-by-one. I do not know how the pieces would come together yet, but this PR has the following changes:

1. Adds a new ModelFetcher which can retrieve multiple model objects from Gradle in one run.
2. Refactor the GradleProjectCache as several functionalities are gobbling there:
  - Make a difference between Gradle involved and heuristic based project loading. Move out the notification handling as well.