### PR TITLE
[NETBEANS-5350] Improved Fix Uses dialog

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/actions/Bundle.properties
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/actions/Bundle.properties
@@ -33,14 +33,14 @@ ImportChoices=Import choices:
 ToggleCommentAction_shortDescription=Toggle Comment
 toggle-comment=Toggle Comment
 
-FixDupImportStmts_Title=Fix Uses in Current Namespace
-FixDupImportStmts_IntroLbl=<html>Select the fully qualified name to use in the use statement.</html>
-FixDupImportStmts_Header=Use Statements:
+FixDupImportStmts_Title=Fix Imports in Current Namespace
+FixDupImportStmts_IntroLbl=<html>Select the fully qualified name to import.</html>
+FixDupImportStmts_Header=Import:
 FixDupImportStmts_Combo_ACSD=Choose appropriate fully qualified name
 FixDupImportStmts_Combo_Name_ACSD=Fully Qualified Names
-FixDupImportStmts_UnusedImports=&Remove unused uses
+FixDupImportStmts_UnusedImports=&Remove unused imports
 FixDupImportStmts_CannotResolve=<html><font color='#FF0000'>&lt;cannot be resolved&gt;
 FixDupImportStmts_NothingToFix=<nothing to fix>
-FixDupImportStmts_checkUnusedImports_a11y=Remove unused uses checkbox
+FixDupImportStmts_checkUnusedImports_a11y=Remove unused imports checkbox
 
-Actions/Source/org-netbeans-modules-php-editor-actions-FixUsesAction$GlobalAction.instance=Fix Uses...
+Actions/Source/org-netbeans-modules-php-editor-actions-FixUsesAction$GlobalAction.instance=Fix Imports...

--- a/php/php.editor/src/org/netbeans/modules/php/editor/actions/FixUsesAction.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/actions/FixUsesAction.java
@@ -64,8 +64,8 @@ import org.openide.util.RequestProcessor;
  * @author Ondrej Brejla <obrejla@netbeans.org>
  */
 @Messages({
-    "FixUsesLabel=Fix Uses...",
-    "LongName=Fix Uses in Current Namespace"
+    "FixUsesLabel=Fix Imports...",
+    "LongName=Fix Imports in Current Namespace"
 })
 @EditorActionRegistration(
     name = FixUsesAction.ACTION_NAME,

--- a/php/php.editor/src/org/netbeans/modules/php/editor/actions/ImportDataCreator.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/actions/ImportDataCreator.java
@@ -49,7 +49,7 @@ import org.openide.util.NbBundle;
  *
  * @author Ondrej Brejla <obrejla@netbeans.org>
  */
-@NbBundle.Messages("DoNotUseType=Don't use type.")
+@NbBundle.Messages("DoNotUseType=Don't import.")
 public class ImportDataCreator {
     public static final String NS_SEPARATOR = "\\"; //NOI18N
     private final Map<String, List<UsedNamespaceName>> usedNames;

--- a/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_01.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_01.php.importData
@@ -16,18 +16,18 @@ Names:
 
 Variants:
  \Nette\Utils\Arrays
- Don't use type.
+ Don't import.
 
  \Nette\Utils\Html
- Don't use type.
+ Don't import.
 
  \Nette\Application\UI\Presenter
- Don't use type.
+ Don't import.
 
  \Nette\Application\Request
  \Nette\Http\Request
- Don't use type.
+ Don't import.
 
  \Nette\Utils\Strings
- Don't use type.
+ Don't import.
 

--- a/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_02.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_02.php.importData
@@ -16,17 +16,17 @@ Names:
 
 Variants:
  \Nette\Utils\Arrays
- Don't use type.
+ Don't import.
 
  <html><font color='#FF0000'>&lt;cannot be resolved&gt;
 
  \Nette\Utils\Html
- Don't use type.
+ Don't import.
 
  \Nette\Application\Request
  \Nette\Http\Request
- Don't use type.
+ Don't import.
 
  \Nette\Utils\Strings
- Don't use type.
+ Don't import.
 

--- a/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_03.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_03.php.importData
@@ -14,15 +14,15 @@ Names:
 
 Variants:
  \Nette\Utils\Html
- Don't use type.
+ Don't import.
 
  \Nette\Application\UI\Presenter
- Don't use type.
+ Don't import.
 
  \Nette\Application\Request
  \Nette\Http\Request
- Don't use type.
+ Don't import.
 
  \Nette\Utils\Strings
- Don't use type.
+ Don't import.
 

--- a/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_04.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_04.php.importData
@@ -10,9 +10,9 @@ Names:
 
 Variants:
  \Nette\Application\UI\Presenter
- Don't use type.
+ Don't import.
 
  \Nette\Application\Request
  \Nette\Http\Request
- Don't use type.
+ Don't import.
 

--- a/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_05.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_05.php.importData
@@ -5,7 +5,7 @@ Defaults:
  \Nette\Application\UI\Presenter
  \Nette\Http\Request
  \Nette\Utils\Strings
- Don't use type.
+ Don't import.
 
 Names:
  Html
@@ -16,18 +16,18 @@ Names:
 
 Variants:
  \Nette\Utils\Html
- Don't use type.
+ Don't import.
 
  \Nette\Application\UI\Presenter
- Don't use type.
+ Don't import.
 
  \Nette\Application\Request
  \Nette\Http\Request
- Don't use type.
+ Don't import.
 
  \Nette\Utils\Strings
- Don't use type.
+ Don't import.
 
  \Nette\Utils\Arrays
- Don't use type.
+ Don't import.
 

--- a/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_06.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_06.php.importData
@@ -16,18 +16,18 @@ Names:
 
 Variants:
  \Nette\Utils\Html
- Don't use type.
+ Don't import.
 
  \Nette\Application\UI\Presenter
- Don't use type.
+ Don't import.
 
  \Nette\Application\Request
  \Nette\Http\Request
- Don't use type.
+ Don't import.
 
  \Nette\Utils\Strings
- Don't use type.
+ Don't import.
 
  \Nette\Utils\Arrays
- Don't use type.
+ Don't import.
 

--- a/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_07.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_07.php.importData
@@ -8,5 +8,5 @@ Names:
 
 Variants:
  \GlobalClass
- Don't use type.
+ Don't import.
 

--- a/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_issue227304.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_issue227304.php.importData
@@ -1,7 +1,7 @@
 Caret position: 34
 Should show uses panel: true
 Defaults:
- Don't use type.
+ Don't import.
 
 Names:
  MyClass
@@ -9,5 +9,5 @@ Names:
 Variants:
  \Three\MyClass
  \Two\MyClass
- Don't use type.
+ Don't import.
 

--- a/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_issue246537a.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_issue246537a.php.importData
@@ -9,5 +9,5 @@ Names:
 Variants:
  \One\MyTrait
  \Two\MyTrait
- Don't use type.
+ Don't import.
 

--- a/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_issue246537b.php.importData
+++ b/php/php.editor/test/unit/data/testfiles/actions/testImportData/testImportData_issue246537b.php.importData
@@ -9,5 +9,5 @@ Names:
 Variants:
  \One\MyTrait
  \Two\MyTrait
- Don't use type.
+ Don't import.
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5350

Added buttons "Change Nothing" and "Restore Defaults" to Fix Uses dialog.
This is useful when user just wants to remove unused `use` statements or wants to fix only a few imports and dialog contains large number of items.

Initial state  and state after "Restore Defaults":
![netbeans-5350-defaults](https://user-images.githubusercontent.com/4249184/107558004-97dfc800-6bda-11eb-9505-d848de4a0bd9.png)

State after "Change Nothing":
![netbeans-5350-none](https://user-images.githubusercontent.com/4249184/107558011-99a98b80-6bda-11eb-8023-d1ffa8c02985.png)
