### PR TITLE
Avoid autoupdating existing NetBeans modules.

### DIFF
--- a/java/java.lsp.server/build.xml
+++ b/java/java.lsp.server/build.xml
@@ -139,7 +139,11 @@
 
         <zip destfile="${build.dir}/apache-netbeans-java-${vsix.version}.vsix" basedir="${build.dir}/vscode-mandatory/" update="true" />
     </target>
-    <target name="test-vscode-ext" description="Tests the Visual Studio Code extension built by 'build-vscode-ext' target.">
+    <target name="test-lsp-server" description="Tests the LSP server behavior">
+        <ant dir="nbcode" target="test" inheritall="false" inheritrefs="false" />
+    </target>
+
+    <target name="test-vscode-ext" depends="test-lsp-server" description="Tests the Visual Studio Code extension built by 'build-vscode-ext' target.">
         <exec executable="npm" failonerror="true" dir="vscode">
             <arg value="--allow-same-version"/>
             <arg value="run" />

--- a/java/java.lsp.server/nbcode/integration/manifest.mf
+++ b/java/java.lsp.server/nbcode/integration/manifest.mf
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.nbcode.integration
+OpenIDE-Module-Layer: org/netbeans/modules/nbcode/integration/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/nbcode/integration/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.0
 OpenIDE-Module-Recommends: cnb.org.netbeans.modules.gradle.java

--- a/java/java.lsp.server/nbcode/integration/nbproject/project.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/project.xml
@@ -99,7 +99,24 @@
                         <specification-version>8.44</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.updatecenters</code-name-base>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.51</specification-version>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <compile-dependency/>
+                        <recursive/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
             <public-packages/>
         </data>
     </configuration>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
+<filesystem>
+    <folder name="Services">
+        <folder name="AutoupdateType">
+            <file name="82pluginportal-update-provider.instance_hidden"/>
+            <file name="distribution-update-provider.instance_hidden"/>
+            <file name="pluginportal-update-provider.instance_hidden"/>
+        </folder>
+    </folder>
+</filesystem>

--- a/java/java.lsp.server/nbcode/integration/test/unit/src/org/netbeans/modules/nbcode/integration/VerifyJustOneUpdateCenterTest.java
+++ b/java/java.lsp.server/nbcode/integration/test/unit/src/org/netbeans/modules/nbcode/integration/VerifyJustOneUpdateCenterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbcode.integration;
+
+import java.util.Arrays;
+import org.netbeans.junit.NbModuleSuite;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class VerifyJustOneUpdateCenterTest extends NbTestCase {
+
+    public VerifyJustOneUpdateCenterTest(String name) {
+        super(name);
+    }
+
+    public static junit.framework.Test suite() {
+        return NbModuleSuite.createConfiguration(VerifyJustOneUpdateCenterTest.class).
+            gui(true).
+            suite();
+    }
+
+    public void testUpdateCenters() {
+        FileObject services = FileUtil.getConfigRoot().getFileObject("Services");
+        assertNotNull("Services found", services);
+        FileObject au = services.getFileObject("AutoupdateType");
+        assertNotNull("AutoUpdate folder found", au);
+        FileObject[] arr = au.getChildren();
+        assertEquals("Just one AutoUpdate center registration: " + Arrays.toString(arr), 1, arr.length);
+        assertEquals("3rdparty.instance", arr[0].getNameExt());
+    }
+}

--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -22,6 +22,7 @@ cluster.path=\
     ${nbplatform.active.dir}/java:\
     ${nbplatform.active.dir}/nb:\
     ${nbplatform.active.dir}/platform:\
+    ${nbplatform.active.dir}/harness:\
     ${nbplatform.active.dir}/webcommon
 disabled.modules=\
     bcpg,\
@@ -82,6 +83,8 @@ disabled.modules=\
     org.netbeans.libs.jsr223,\
     org.netbeans.libs.jstestdriver,\
     org.netbeans.libs.jvyamlb,\
+    org.netbeans.libs.nbi.ant,\
+    org.netbeans.libs.nbi.engine,\
     org.netbeans.libs.plist,\
     org.netbeans.libs.smack,\
     org.netbeans.libs.springframework,\
@@ -94,6 +97,7 @@ disabled.modules=\
     org.netbeans.modules.ant.grammar,\
     org.netbeans.modules.ant.hints,\
     org.netbeans.modules.ant.kit,\
+    org.netbeans.modules.apisupport.harness,\
     org.netbeans.modules.applemenu,\
     org.netbeans.modules.autoupdate.pluginimporter,\
     org.netbeans.modules.beans,\
@@ -233,6 +237,8 @@ disabled.modules=\
     org.netbeans.modules.javawebstart,\
     org.netbeans.modules.jellytools.ide,\
     org.netbeans.modules.jellytools.java,\
+    org.netbeans.modules.jellytools.platform,\
+    org.netbeans.modules.jemmy,\
     org.netbeans.modules.jshell.support,\
     org.netbeans.modules.junit.ant,\
     org.netbeans.modules.junit.ant.ui,\

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -343,7 +343,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
             if (isOut) {
                 stdOut += text;
             }
-            if (stdOut.match(/org.netbeans.modules.java.lsp.server.*Enabled/)) {
+            if (stdOut.match(/org.netbeans.modules.java.lsp.server/)) {
                 resolve(text);
                 stdOut = null;
             }

--- a/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
@@ -42,8 +42,28 @@ suite('Extension Test Suite', () => {
         let clusters = myExtension.findClusters('non-existent').
             // ignore 'extra' cluster in the extension path, since nbjavac is there during development:
             filter(s => !s.startsWith(extraCluster));
-        assert.strictEqual(clusters.length, 6, 'six required clusters found: ' + clusters);
-        for (let c of clusters) {
+
+
+        let found : string[] = [];
+        function assertCluster(name : string) {
+            for (let c of clusters) {
+                if (c.endsWith('/' + name)) {
+                    found.push(c);
+                    return;
+                }
+            }
+            assert.fail(`Cannot find ${name} among ${clusters}`);
+        }
+
+        assertCluster('extide');
+        assertCluster('ide');
+        assertCluster('java');
+        assertCluster('nbcode');
+        assertCluster('platform');
+        assertCluster('webcommon');
+        assertCluster('harness');
+
+        for (let c of found) {
             assert.ok(c.startsWith(nbcode.extensionPath), `All extensions are below ${nbcode.extensionPath}, but: ${c}`);
         }
     });


### PR DESCRIPTION
Gregor Kováč [reported problems on subsequent start of VSNetBeans](https://lists.apache.org/thread.html/r07d0861858590e3a047d284d1443b8794912f4caeb231a3de19efedc%40%3Cusers.netbeans.apache.org%3E) and we have tracked down the problem to autoupdate!

There is `updatecenters` module in VSNetBeans since 90d2af9 - it is needed to install `nbjavac` on JDK8. However it also provides other update centers.

There is code checking whether Apache NetBeans `java.lsp.server` module is properly started. It [uses a regexp](https://github.com/apache/netbeans/blob/master/java/java.lsp.server/vscode/src/extension.ts#L350) to parse the output and searches for:

```ts
stdOut.match(/org.netbeans.modules.java.lsp.server.*Enabled/)
```

However, since recently there has been a release of updates and the output now says:
```
org.netbeans.modules.java.lsp.server 1.6.1.1.1.12.1.17.32.5.2.1.1.1.13 
Upgrade to 1.7.0.1.1.12.1.17.32.5.2.1.1.1.13
```

the existing regexp doesn't match this output and as such VSCode never connects to the Apache NetBeans LSP server now!

This PR disables the other update centers and changes the the regexp.