### PR TITLE
[NETBEANS-5362] Update FlatLaf from 1.0-rc2 to 1.0 to fix NPE in Jvi plugin when showing popup

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-5507827B39B40EED2942652D4792A51A5C49D67C com.formdev:flatlaf:1.0-rc2
+A807C984F00B683C65503803720821F12E136E93 com.formdev:flatlaf:1.0

--- a/platform/libs.flatlaf/external/flatlaf-1.0-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-1.0-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 1.0-rc2
-Files: flatlaf-1.0-rc2.jar
+Version: 1.0
+Files: flatlaf-1.0.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/org-netbeans-libs-flatlaf.sig
+++ b/platform/libs.flatlaf/nbproject/org-netbeans-libs-flatlaf.sig
@@ -312,6 +312,7 @@ CLSS public static com.formdev.flatlaf.util.ColorFunctions$Fade
 cons public init(float)
 fld public final float amount
 intf com.formdev.flatlaf.util.ColorFunctions$ColorFunction
+meth public java.lang.String toString()
 meth public void apply(float[])
 supr java.lang.Object
 
@@ -325,6 +326,7 @@ fld public final float amount
 fld public final int hslIndex
 intf com.formdev.flatlaf.util.ColorFunctions$ColorFunction
 meth protected boolean shouldInverse(float[])
+meth public java.lang.String toString()
 meth public void apply(float[])
 supr java.lang.Object
 
@@ -344,6 +346,7 @@ CLSS public com.formdev.flatlaf.util.DerivedColor
 cons public !varargs init(java.awt.Color,com.formdev.flatlaf.util.ColorFunctions$ColorFunction[])
 meth public com.formdev.flatlaf.util.ColorFunctions$ColorFunction[] getFunctions()
 meth public java.awt.Color derive(java.awt.Color)
+meth public java.lang.String toString()
 supr javax.swing.plaf.ColorUIResource
 hfds baseOfDefaultColorRGB,functions,hasBaseOfDefaultColor
 

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-1.0-rc2.jar=modules/ext/flatlaf-1.0-rc2.jar
+release.external/flatlaf-1.0.jar=modules/ext/flatlaf-1.0.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-1.0-rc2.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-1.0-rc2.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-1.0.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-1.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
This FlatLaf update fixes a regression in FlatLaf 1.0-rc2 (and older)
that breaks the Jvi plugin as soon as a popup should be shown. 
E.g. pressing `:w` in editor.
https://issues.apache.org/jira/browse/NETBEANS-5362

FlatLaf 0.31, which was used in NB 12.2 (and before), did not have this issue.
So only NB 12.3 betas are affected.

The NPE occurs when invoking `PopupFactory.getSharedInstance().getPopup( owner, contents, x, y )`
with `null` as `owner`, which is actually unusual.
`PopupFactory` is e.g. used to show popups for code completion.

There are about 30 source files in NB repo that use `PopupFactory`:
https://github.com/apache/netbeans/search?q=popupfactory

So it is possible that also some popups in NB core are affected by this Flatlaf bug.

Hope we can get this fix into 12.3 beta 3.