### PR TITLE
[NETBEANS-5353] Use cleanTest instead of rerun-tasks to force test to run

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/action-mapping.xml
@@ -23,16 +23,16 @@
 <actions>
     <apply-for plugins="java">
         <action name="test.single">
-            <args>--rerun-tasks test --tests "${selectedClass}"</args>
+            <args>cleanTest test --tests "${selectedClass}"</args>
         </action>
         <action name="run.single.method">
-            <args>--rerun-tasks test --tests "${selectedMethod}"</args>
+            <args>cleanTest test --tests "${selectedMethod}"</args>
         </action>
         <action name="debug.single.method">
-            <args>--rerun-tasks test --debug-jvm --tests "${selectedMethod}"</args>
+            <args>cleanTest test --debug-jvm --tests "${selectedMethod}"</args>
         </action>
         <action name="debug.test.single">
-            <args>--rerun-tasks test --debug-jvm --tests "${selectedClass}"</args>
+            <args>cleanTest test --debug-jvm --tests "${selectedClass}"</args>
         </action>
 
         <action name="javadoc">


### PR DESCRIPTION
See [NETBEANS-5353](https://issues.apache.org/jira/browse/NETBEANS-5353) description; this PR attempts to use gradle's up-to-date checks so unnecessary compilations are avoided during test runs/debugs.

@lkishalmi  please review.