### PR TITLE
[NETBEANS-5318] Temporary script trust.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
@@ -265,9 +265,8 @@ public final class RunUtils {
             TrustProjectPanel trust = new TrustProjectPanel(project);
             DialogDescriptor dsc = new DialogDescriptor(trust, Bundle.ProjectTrustDlg_TITLE(), true, null);
             if (DialogDisplayer.getDefault().notify(dsc) == DialogDescriptor.OK_OPTION) {
-                if (trust.getTrustInFuture()) {
-                    ProjectTrust.getDefault().trustProject(project);
-                }
+                // trust just temporarily, or record the decision:
+                ProjectTrust.getDefault().trustProject(project, trust.getTrustInFuture());
                 ret = true;
             }
         }


### PR DESCRIPTION
If the user acknowledges run of the gradle build script in the IDE, the script may be reloaded from time to time, for example as result of __Fix project problems__ or other occasions. If the user did not check "Trust permanently" in the question, the IDE would ask the user repeatedly even during the same IDE session.
This change in 932c71c will change the behaviour that after user's acknowledgement, the IDE trust the buildscript within this IDE run only - and won't ask again.

The other commits that were originally part of this PR were separated to PR #2765 per @lkishalmi request.