### PR TITLE
[NETBEANS-5318] Prevent unnecessary Gradle model reloads

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
@@ -110,7 +110,10 @@ public final class GradleProjectCache {
         if (aim == FALLBACK) {
             return fallbackProject(files);
         }
-        GradleProject prev = project.project != null ? project.project : fallbackProject(files);
+        GradleProject prev = project.getProjectInternal();
+        if (prev == null) {
+            prev = fallbackProject(files);
+        }
 
         // Try to turn to the cache
         if (!ignoreCache  && (prev.getQuality() == FALLBACK)) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectProblemProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectProblemProvider.java
@@ -103,8 +103,9 @@ public class GradleProjectProblemProvider implements ProjectProblemsProvider {
         @Override
         public Result call() throws Exception {
             NbGradleProjectImpl impl = project.getLookup().lookup(NbGradleProjectImpl.class);
+            GradleProject original = impl.getGradleProject();
             GradleProject gradleProject = GradleProjectCache.loadProject(impl, FULL_ONLINE, true, true);
-            impl.fireProjectReload(false);
+            impl.recordOrReloadProject(original, gradleProject, true);
             Quality q = gradleProject.getQuality();
             Status st = q.worseThan(SIMPLE) ? Status.UNRESOLVED
                     : q.worseThan(FULL) ? Status.RESOLVED_WITH_WARNING : Status.RESOLVED;

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -188,7 +188,7 @@ public final class NbGradleProjectImpl implements Project {
         }
         p = loadProject();
         synchronized (this) {
-            // avod unnecessary project replacements.
+            // avoid unnecessary project replacements.
             if (project != null) {
                 return project;
             }

--- a/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
@@ -77,8 +77,8 @@ public class ReloadAction  extends AbstractAction implements ContextAwareAction 
                 NbGradleProjectImpl.RELOAD_RP.submit(() -> {
                     // A bit low level calls, just to allow UI interaction to
                     // Trust the project.
-                    impl.project = GradleProjectCache.loadProject(impl, FULL_ONLINE, true, true);
-                    NbGradleProjectImpl.ACCESSOR.doFireReload(NbGradleProject.get(impl));
+                    GradleProject newProject = GradleProjectCache.loadProject(impl, FULL_ONLINE, true, true);
+                    impl.recordOrReloadProject(null, newProject, false);
                 });
             }
         }

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
@@ -84,8 +84,8 @@ public class AbstractGradleProjectTestCase extends NbTestCase {
         NbGradleProjectImpl.RELOAD_RP.submit(() -> {
             // A bit low level calls, just to allow UI interaction to
             // Trust the project.
-            impl.project = GradleProjectCache.loadProject(impl, FULL_ONLINE, true, true);
-            NbGradleProjectImpl.ACCESSOR.doFireReload(NbGradleProject.get(impl));
+            GradleProject newProject = GradleProjectCache.loadProject(impl, FULL_ONLINE, true, true);
+            impl.recordOrReloadProject(null, newProject, false);
         }).get();
     }
     


### PR DESCRIPTION
Originally submitted in PR #2764, but separated for easier integration into its own PR.

## Prevent unnecessary reloads
When the project problem is being fixed, the project model is loaded again, but then the model is thrown away and loaded once again (unnecessarily). In 22424fb I've changed the behaviour to reuse the model - if another action did not alter the model in the meantime.

## Synchronization fixes
The `project` variable is accessed from several threads, at least from RELOAD_RP and any random thread that calls `NbGradleProjectImpl` getters. I've tried to synchronize that so the reference is replaced, but the `loadProject` is still executed outside mutexes and events are fired in RELOAD_RP.