### PR TITLE
Let AutoUpdate task recognize m2:/ URL scheme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -793,7 +793,7 @@ matrix:
             - ant $OPTS clean
             - ant $OPTS build
           script:
-            - (cd java/java.lsp.server; ant build-vscode-ext)
+            - (cd java/java.lsp.server; ant build-vscode-ext -D3rdparty.modules=.*nbjavac.*)
             - (cd java/java.lsp.server; ant test-vscode-ext)
 
         - name: "GraalVM Tests (latest)"

--- a/nb/updatecenters/extras/nbjavac.api/release/modules/ext/nb-javac-15.0.0.2-api.jar.external
+++ b/nb/updatecenters/extras/nbjavac.api/release/modules/ext/nb-javac-15.0.0.2-api.jar.external
@@ -1,5 +1,5 @@
 CRC:3736270701
 SIZE:210532
-URL:m2:/com.dukescript.nbjavac:nb-javac:15.0.0.2:jar:api
+URL:m2:/com.dukescript.nbjavac:nb-javac:15.0.0.2:api
 MessageDigest: SHA-256 20dae9df239aa1d346c56b744aee741f753611e7470640ff1ff7b1731283ed1b
 MessageDigest: SHA-512 e12e603815159cbb348d8d3e73588d8ad549b41cac21831fa1228c0ab9bf23ce18d162b6fe7679de9d249fc2cb3a627edd35ebf2f3851dfd6d2513e1da741447

--- a/nb/updatecenters/extras/nbjavac.impl/release/modules/ext/nb-javac-15.0.0.2-impl.jar.external
+++ b/nb/updatecenters/extras/nbjavac.impl/release/modules/ext/nb-javac-15.0.0.2-impl.jar.external
@@ -1,5 +1,5 @@
 CRC:1851126890
 SIZE:3511612
-URL: m2:/com.dukescript.nbjavac:nb-javac:15.0.0.2:jar
+URL: m2:/com.dukescript.nbjavac:nb-javac:15.0.0.2
 MessageDigest: SHA-256 809b68535b8d5e564802deba7489308f01041acaf0731584544ffd96c6d385c1
 MessageDigest: SHA-512 e450cf9da202dee89ef79bff65fab1a287bd97d08ecc2ea19fbeedd8a16ce79371fbc0a72c68d353d8d13cae18e015ad862b28962cd2f6e43874f52767e99de7

--- a/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -57,6 +58,7 @@ import org.apache.tools.ant.taskdefs.Get;
 import org.apache.tools.ant.types.FileSet;
 import org.apache.tools.ant.util.FileUtils;
 import org.netbeans.nbbuild.AutoUpdateCatalogParser.ModuleItem;
+import org.netbeans.nbbuild.extlibs.DownloadBinaries;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.Attributes;
@@ -186,7 +188,7 @@ public class AutoUpdate extends Task {
             List<String> info = installed.get(uu.getCodeName());
             if (info != null && !uu.isNewerThan(info.get(0))) {
                 log("Version " + info.get(0) + " of " + uu.getCodeName() + " is up to date", Project.MSG_VERBOSE);
-                if (!force) {
+                    if (!force) {
                     continue;
                 }
             }
@@ -405,12 +407,17 @@ public class AutoUpdate extends Task {
                     }
                     url = url.substring(0, index) + propVal + url.substring(end + 1);
                 }
-                log("Trying external URL: " + url, Project.MSG_INFO);
                 try {
-                    conn = new URL(url).openConnection();
+                    URI u = new URI(url);
+                    if ("m2".equals(u.getScheme())) {
+                        log("Trying external Maven URL: " + u, Project.MSG_INFO);
+                        return DownloadBinaries.downloadMaven(this, u);
+                    }
+                    log("Trying external URL: " + u, Project.MSG_INFO);
+                    conn = u.toURL().openConnection();
                     conn.connect();
                     return conn.getInputStream();
-                } catch (IOException ex) {
+                } catch (URISyntaxException | IOException ex) {
                     log("Cannot connect to " + url, Project.MSG_WARN);
                     try {
                         logThrowable(ex);
@@ -423,7 +430,7 @@ public class AutoUpdate extends Task {
         throw new IOException("Cannot resolve external references");
     }
 
-    private void logThrowable(IOException ex) {
+    private void logThrowable(Exception ex) {
         log("Details", ex, Project.MSG_VERBOSE);
     }
 


### PR DESCRIPTION
Let `AutoUpdate` task recognize m2:/ URL scheme, so VSCode build can install additional nbjavac modules from Maven.

The [BUILD.md](https://github.com/apache/netbeans/blob/234392d4fc125d4e20a116598821b2cfd378dfc6/java/java.lsp.server/vscode/BUILD.md) file suggests to use:
```bash
java/java.lsp.server$ ant build-lsp-server -D3rdparty.modules=.*nbjavac.*
```
to build the LSP server with additionally installed `nbjavac` modules. The download no longer works since #2759 - the `AutoUpdate` task hasn't be updated to understand the `m2:/` protocol. This PR:
* calls from `AutoUpdate` task to `DownloadBinaries` to handle the `m2:/` protocol
* modifies the travis check to use the `-D3rdparty.modules` property, so we have some test coverage
* the [release job](https://ci-builds.apache.org/job/Netbeans/job/netbeans-vscode/) **is not** modified, ASF doesn't want to distribute nbjavac right now
* the `m2:/` URL definitions had to be adjusted to [gradle scheme](https://github.com/apache/netbeans/blob/234392d4fc125d4e20a116598821b2cfd378dfc6/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java#L424)

If this PR is accepted, then #2773 shall be adjusted accordingly.