### PR TITLE
Restore original format of m2:/ URLs modified by aa256463dcefb3b95bec6b7ac74e04a960015bc9

### DIFF
--- a/nb/updatecenters/extras/nbjavac.api/release/modules/ext/nb-javac-15.0.0.2-api.jar.external
+++ b/nb/updatecenters/extras/nbjavac.api/release/modules/ext/nb-javac-15.0.0.2-api.jar.external
@@ -1,5 +1,5 @@
 CRC:3736270701
 SIZE:210532
-URL:m2:/com.dukescript.nbjavac:nb-javac:15.0.0.2:api
+URL:m2:/com.dukescript.nbjavac:nb-javac:15.0.0.2:jar:api
 MessageDigest: SHA-256 20dae9df239aa1d346c56b744aee741f753611e7470640ff1ff7b1731283ed1b
 MessageDigest: SHA-512 e12e603815159cbb348d8d3e73588d8ad549b41cac21831fa1228c0ab9bf23ce18d162b6fe7679de9d249fc2cb3a627edd35ebf2f3851dfd6d2513e1da741447

--- a/nb/updatecenters/extras/nbjavac.impl/release/modules/ext/nb-javac-15.0.0.2-impl.jar.external
+++ b/nb/updatecenters/extras/nbjavac.impl/release/modules/ext/nb-javac-15.0.0.2-impl.jar.external
@@ -1,5 +1,5 @@
 CRC:1851126890
 SIZE:3511612
-URL: m2:/com.dukescript.nbjavac:nb-javac:15.0.0.2
+URL: m2:/com.dukescript.nbjavac:nb-javac:15.0.0.2:jar
 MessageDigest: SHA-256 809b68535b8d5e564802deba7489308f01041acaf0731584544ffd96c6d385c1
 MessageDigest: SHA-512 e450cf9da202dee89ef79bff65fab1a287bd97d08ecc2ea19fbeedd8a16ce79371fbc0a72c68d353d8d13cae18e015ad862b28962cd2f6e43874f52767e99de7

--- a/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/AutoUpdate.java
@@ -188,7 +188,7 @@ public class AutoUpdate extends Task {
             List<String> info = installed.get(uu.getCodeName());
             if (info != null && !uu.isNewerThan(info.get(0))) {
                 log("Version " + info.get(0) + " of " + uu.getCodeName() + " is up to date", Project.MSG_VERBOSE);
-                    if (!force) {
+                if (!force) {
                     continue;
                 }
             }


### PR DESCRIPTION
m2:/ became a defacto API for the autoupdate mechanism. Both OpenJFX and
nb-javac rely on being able to be downloaded via the ".external" files
mechanism and third party modules could also rely on the exact syntax
of the URLs.

Instead of modifying the URL format, a new ad-hoc parser is introduced
to convert the m2 URL into maven coordinates.