### PR TITLE
[NETBEANS-5141] Support Gradle Source Groups from Alien Projects

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
@@ -381,9 +381,6 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
                     // #67450: avoid actually loading the nested project.
                     return false;
                 }
-                if (FileOwnerQuery.getOwner(file) != proj) {
-                    return false;
-                }
             }
             return true;
         }


### PR DESCRIPTION
This change allows Gradle Source groups to display a source group from another project ownership. Previously an error node was created in this case, as having such entities in a project is generally a bad practice. With this change such source groups are coming with an error badge and some warning text.
I was thinking about putting this under an experimental feature flag, though I hope the number of such Gradle projects are really low.