### PR TITLE
Reusing exiting (compact) profiles support for releases

### DIFF
--- a/java/api.java/manifest.mf
+++ b/java/api.java/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.java/1
-OpenIDE-Module-Specification-Version: 1.76
+OpenIDE-Module-Specification-Version: 1.80
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/java/queries/Bundle.properties
 AutoUpdate-Show-In-Client: false
 

--- a/java/api.java/src/org/netbeans/api/java/queries/SourceLevelQuery.java
+++ b/java/api.java/src/org/netbeans/api/java/queries/SourceLevelQuery.java
@@ -161,17 +161,70 @@ public class SourceLevelQuery {
         /**
          * The compact1 profile.
          */
-        COMPACT1("compact1", Bundle.NAME_Compact1(), JDK8),   //NOI18N
+        COMPACT1("compact1", Bundle.NAME_Compact1(), "-profile", null, JDK8),   //NOI18N
 
         /**
          * The compact2 profile.
          */
-        COMPACT2("compact2", Bundle.NAME_Compact2(), JDK8),   //NOI18N
+        COMPACT2("compact2", Bundle.NAME_Compact2(), "-profile", null, JDK8),   //NOI18N
 
         /**
          * The compact3 profile.
          */
-        COMPACT3("compact3", Bundle.NAME_Compact3(), JDK8),   //NOI18N
+        COMPACT3("compact3", Bundle.NAME_Compact3(), "-profile", null, JDK8),   //NOI18N
+
+        /**
+         * The release7 profile.
+         */
+        RELEASE7("release7", Bundle.NAME_Release7(), "--release", "7", new SpecificationVersion("9")),   //NOI18N
+
+        /**
+         * The release8 profile.
+         * @since 1.80
+         */
+        RELEASE8("release8", Bundle.NAME_Release8(), "--release", "8", new SpecificationVersion("9")),   //NOI18N
+
+        /**
+         * The release9 profile.
+         * @since 1.80
+         */
+        RELEASE9("release9", Bundle.NAME_Release9(), "--release", "9", new SpecificationVersion("9")),   //NOI18N
+
+        /**
+         * The release10 profile.
+         * @since 1.80
+         */
+        RELEASE10("release10", Bundle.NAME_Release10(), "--release", "10", new SpecificationVersion("10")),   //NOI18N
+
+        /**
+         * The release11 profile.
+         * @since 1.80
+         */
+        RELEASE11("release11", Bundle.NAME_Release11(), "--release", "11", new SpecificationVersion("11")),   //NOI18N
+
+        /**
+         * The release12 profile.
+         * @since 1.80
+         */
+        RELEASE12("release12", Bundle.NAME_Release12(), "--release", "12", new SpecificationVersion("12")),   //NOI18N
+
+        /**
+         * The release13 profile.
+         * @since 1.80
+         */
+        RELEASE13("release13", Bundle.NAME_Release13(), "--release", "13", new SpecificationVersion("13")),   //NOI18N
+
+        /**
+         * The release14 profile.
+         * @since 1.80
+         */
+        RELEASE14("release14", Bundle.NAME_Release14(), "--release", "14", new SpecificationVersion("14")),   //NOI18N
+
+        /**
+         * The release15 profile.
+         * @since 1.80
+         */
+        RELEASE15("release15", Bundle.NAME_Release8(), "--release", "15", new SpecificationVersion("15")),   //NOI18N
 
         /**
          * The default full JRE profile.
@@ -190,25 +243,58 @@ public class SourceLevelQuery {
             }
         }
 
+        /**
+         * Finds JDK9+ release profile by its name.
+         * 
+         * @param release name of the release {@code 8, 9, 11, 15}
+         * @return found release profile or {@code null}
+         * @since 1.80
+         */
+        public static Profile forRelease(String release) {
+            for (Profile p : values()) {
+                if ("--release".equals(p.getOptionName())) { // NO18N
+                    if (release.equals(p.release)) {
+                        return p;
+                    }
+                }
+            }
+            return null;
+        }
+
         private final String name;
         private final String displayName;
+        private final String optionName;
+        private final String release;
         private final SpecificationVersion supportedFrom;
 
         @NbBundle.Messages({
         "NAME_Compact1=Compact 1",
         "NAME_Compact2=Compact 2",
         "NAME_Compact3=Compact 3",
+        "NAME_Release7=Release 7",
+        "NAME_Release8=Release 8",
+        "NAME_Release9=Release 9",
+        "NAME_Release10=Release 10",
+        "NAME_Release11=Release 11",
+        "NAME_Release12=Release 12",
+        "NAME_Release13=Release 13",
+        "NAME_Release14=Release 14",
+        "NAME_Release15=Release 15",
         "NAME_FullJRE=Full JRE"
         })
         private Profile(
                 @NonNull final String name,
                 @NonNull final String displayName,
+                @NonNull final String optionName,
+                @NonNull final String release,
                 @NonNull final SpecificationVersion supportedFrom) {
             assert name != null;
             assert displayName != null;
             assert supportedFrom != null;
             this.name = name;
             this.displayName = displayName;
+            this.optionName = optionName;
+            this.release = release;
             this.supportedFrom = supportedFrom;
         }
 
@@ -216,6 +302,8 @@ public class SourceLevelQuery {
             assert displayName != null;
             this.name = "";   //NOI18N
             this.displayName = displayName;
+            this.optionName = ""; //NOI18N
+            this.release = null;
             this.supportedFrom = null;
         }
 
@@ -235,6 +323,27 @@ public class SourceLevelQuery {
         @NonNull
         public String getDisplayName() {
             return displayName;
+        }
+
+        /**
+         * Returns the name of {@code javac} option to enable the profile.
+         *
+         * @return the option name
+         * @since 1.80
+         */
+        @NonNull
+        public String getOptionName() {
+            return optionName;
+        }
+
+        /**
+         * Returns the value of {@code javac} option to choose the profile.
+         *
+         * @return the option value
+         * @since 1.80
+         */
+        public String getOptionValue() {
+            return release != null ? release : getName();
         }
 
         /**

--- a/java/java.source.base/nbproject/project.xml
+++ b/java/java.source.base/nbproject/project.xml
@@ -40,7 +40,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.64</specification-version>
+                        <specification-version>1.80</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -974,6 +974,12 @@ public class JavacParser extends Parser {
         if (lintOptions.length() > 0) {
             options.addAll(Arrays.asList(lintOptions.split(" ")));
         }
+        if (sourceProfile != null &&
+            sourceProfile != SourceLevelQuery.Profile.DEFAULT) {
+            options.add(sourceProfile.getOptionName()); // Limit JRE to required compact profile
+            options.add(sourceProfile.getOptionValue());
+        }
+        final boolean dontSpecifySourceAndTarget = options.contains("--release");
         if (!backgroundCompilation) {
             options.add("-Xjcov"); //NOI18N, Make the compiler store end positions
             options.add("-XDallowStringFolding=false"); //NOI18N
@@ -983,8 +989,10 @@ public class JavacParser extends Parser {
             options.add("-XDbackgroundCompilation");    //NOI18N
             options.add("-XDcompilePolicy=byfile");     //NOI18N
             options.add("-XD-Xprefer=source");     //NOI18N
-            options.add("-target");                     //NOI18N
-            options.add(validatedSourceLevel.requiredTarget().name);
+            if (!dontSpecifySourceAndTarget) {
+                options.add("-target");                     //NOI18N
+                options.add(validatedSourceLevel.requiredTarget().name);
+            }
         }
         options.add("-XDide");   // NOI18N, javac runs inside the IDE
         if (!DISABLE_PARAMETER_NAMES_READING) {
@@ -996,12 +1004,9 @@ public class JavacParser extends Parser {
         options.add("-g:source"); // NOI18N, Make the compiler to maintian source file info
         options.add("-g:lines"); // NOI18N, Make the compiler to maintain line table
         options.add("-g:vars");  // NOI18N, Make the compiler to maintain local variables table
-        options.add("-source");  // NOI18N
-        options.add(validatedSourceLevel.name);
-        if (sourceProfile != null &&
-            sourceProfile != SourceLevelQuery.Profile.DEFAULT) {
-            options.add("-profile");    //NOI18N, Limit JRE to required compact profile
-            options.add(sourceProfile.getName());
+        if (!dontSpecifySourceAndTarget) {
+            options.add("-source");  // NOI18N
+            options.add(validatedSourceLevel.name);
         }
         options.add("-XDdiags.formatterOptions=-source");  // NOI18N
         options.add("-XDdiags.layout=%L%m|%L%m|%L%m");  // NOI18N

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenSourceLevelImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenSourceLevelImpl.java
@@ -186,6 +186,17 @@ public class MavenSourceLevelImpl implements SourceLevelQueryImplementation2 {
                 }
             }
         }
+        String release = PluginPropertyUtils.getPluginProperty(project, Constants.GROUP_APACHE_PLUGINS, //NOI18N
+                Constants.PLUGIN_COMPILER, //NOI18N
+                "release", //NOI18N
+                goal,
+                null);
+        if (release != null) {
+            SourceLevelQuery.Profile p = SourceLevelQuery.Profile.forRelease(release);
+            if (p != null) {
+                return p;
+            }
+        }
         return SourceLevelQuery.Profile.DEFAULT;
     }
 


### PR DESCRIPTION
While investigating how to support the `--release` tag more in the NetBeans Javac infrastructure (tracked as [NETBEANS-5339](https://issues.apache.org/jira/browse/NETBEANS-5339)) I realized there already is support for `-profile` by @tzezula. As `release` is kinda `profile`, it seems easy to reuse it. With the changes in this PR I was able to see proper errors for:
```java
public class Main {
    public static final void main(String... args) {
        System.err.println("Hello " + Module.class);
    }
}
```
in a Maven project with following `pom.xml`:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>test</groupId>
    <artifactId>release8test</artifactId>
    <version>1.0-SNAPSHOT</version>
    <packaging>jar</packaging>
    <build>
        <plugins>
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
                <version>3.8.1</version>
                <configuration>
                    <release>8</release>
                </configuration>
            </plugin>
        </plugins>
    </build>
    <properties>
        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
        <maven.compiler.source>1.8</maven.compiler.source>
        <maven.compiler.target>1.8</maven.compiler.target>
    </properties>
</project>
```
Changing the value of `release` to `8` or `9` shows/hides the error in editor.