### PR TITLE
Trust priming build, as the user already saw the warning.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectProblemProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectProblemProvider.java
@@ -102,6 +102,7 @@ public class GradleProjectProblemProvider implements ProjectProblemsProvider {
 
         @Override
         public Result call() throws Exception {
+            ProjectTrust.getDefault().trustProject(project);
             NbGradleProjectImpl impl = project.getLookup().lookup(NbGradleProjectImpl.class);
             GradleProject gradleProject = GradleProjectCache.loadProject(impl, FULL_ONLINE, true, true);
             impl.fireProjectReload(false);


### PR DESCRIPTION
When the user triggers Priming Build from Project problems window, another "Trust the project" dialog appears immediately. The Project Problems window already warned about potential code execution done as part of the Gradle script.

This is inconsistent with manual Build action:
- open a fresh untrusted, unprimed gradle project
- dismis Project Problems window
- execute Project | Build or Build from project's context menu
=> no warning, no dialog, project becomes trusted.

This PR let the Priming Build behave just as a regular build: mark the project as trusted.