### PR TITLE
Use Java 11 to Build NetBeans dev Snap

### DIFF
--- a/nbbuild/packaging/netbeans-dev_snap/snap/snapcraft.yaml
+++ b/nbbuild/packaging/netbeans-dev_snap/snap/snapcraft.yaml
@@ -53,18 +53,18 @@ parts:
     build-attributes: [ no-patchelf ]
     build-packages:
       - unzip
-      - openjdk-8-jdk-headless
+      - openjdk-11-jdk-headless
     plugin: ant
     source: ../../../
     filesets:
         netbeans: [ netbeans/*, -netbeans/*.built ]
     override-build: |
-        export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+        export JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
         ant -quiet -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dbuildnumber=$(date +%Y%m%d)
         mv nbbuild/netbeans $SNAPCRAFT_PART_INSTALL/netbeans
         # Make the default cache and data directory relative to Snap user directory
-        sed -i 's/${HOME}\/.netbeans/${SNAP_USER_COMMON}\/data/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
-        sed -i 's/${HOME}\/.cache\/netbeans/${SNAP_USER_COMMON}\/cache/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
+        sed -i 's/${HOME}\/.netbeans\/dev/${SNAP_USER_DATA}\/data/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
+        sed -i 's/${HOME}\/.cache\/netbeans\/dev/${SNAP_USER_DATA}\/cache/' $SNAPCRAFT_PART_INSTALL/netbeans/bin/netbeans
         sed -i 's/-J-Dapple.laf.useScreenMenuBar=true/-J-Dplugin.manager.install.global=false/' $SNAPCRAFT_PART_INSTALL/netbeans/etc/netbeans.conf
     stage:
         - $netbeans


### PR DESCRIPTION
This is a small experimental patch affects ~10 people using netbeans-dev Snap
It set the build to Java 11, and also have the experiment to use the SNAP_USER_DATA directory copy feature of Snap. If it goes well, I'm going to have something like that for the netbeans Snap as well. That would actually mean, there would be no upgrade dialog to be displayed when the software is updated, snap would copy the previous user/cache dir over. Also when switching back a release the old userdir would be used.

As this change does not affect anything else in NB, I'm going to merge it without approval, reviewers were added for notification purposes only. 