### PR TITLE
Priming build action support

### DIFF
--- a/ide/projectapi/apichanges.xml
+++ b/ide/projectapi/apichanges.xml
@@ -83,6 +83,21 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="project-priming-action">
+            <api name="general"/>
+            <summary>Added <code>ActionProvider.COMMAND_PRIME</code> that initializes the project for IDE use.</summary>
+            <version major="1" minor="80"/>
+            <date day="5" month="3" year="2021"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes"/>
+            <description>
+                <p>
+                    <code><a href="@TOP@/org/netbeans/spi/project/ActionProvider.html">ActionProvider.COMMAND_PRIME</a></code> was introduced, so that
+                    projects can declare (and enable/disable as needed) an action that "primes" or initializes the project for the IDE. That often includes
+                    downloads, or partial build, which may produce messages, and could be automated by project-opening code.
+                </p>
+            </description>
+        </change>
         <change id="parent-and-root-project-provider">
             <api name="general"/>
             <summary>Added <code>ParentProjectProvider</code> and <code>RootProjectProvider</code> to improve project hierarchy discovery</summary>

--- a/ide/projectapi/manifest.mf
+++ b/ide/projectapi/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.projectapi/1
-OpenIDE-Module-Specification-Version: 1.79
+OpenIDE-Module-Specification-Version: 1.80
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/projectapi/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/projectapi/layer.xml
 OpenIDE-Module-Needs: org.netbeans.spi.project.ProjectManagerImplementation

--- a/ide/projectapi/src/org/netbeans/spi/project/ActionProvider.java
+++ b/ide/projectapi/src/org/netbeans/spi/project/ActionProvider.java
@@ -150,6 +150,13 @@ public interface ActionProvider {
     String COMMAND_RENAME = "rename"; // NOI18N
     
     /**
+     * Standard command for priming / initializing
+     * the project.
+     * @since 1.80
+     */
+    String COMMAND_PRIME = "prime"; // NOI18N
+    
+    /**
      * Get a list of all commands which this project supports.
      * @return a list of command names suitable for {@link #invokeAction}
      * @see #COMMAND_BUILD

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -343,7 +343,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.71</specification-version>
+                        <specification-version>1.80</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspServerState.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspServerState.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.netbeans.api.project.Project;
+import org.openide.filesystems.FileObject;
+
+/**
+ *
+ * @author sdedic
+ */
+public interface LspServerState {
+    /**
+     * Returns a Future that completes on initial project open. Use to shortcut
+     * service responses during server's initialization:
+     * <pre><code>
+     * if (serverState.openedProjects().getNow(null)) {
+     *      // the shortcut, e.g. return an empty result
+     * }
+     * </code></pre>
+     * or chain on project open.
+     * @return Future that completes when initial projects are opened.
+     */
+    public CompletableFuture<Project[]>   openedProjects();
+    
+    /**
+     * Asynchronously opens projects that contain the passed files. Completes with the list
+     * of opened projects, in no particular order.
+     * @param fileCandidates reference / owned files
+     * @return opened projects.
+     */
+    public CompletableFuture<Project[]>   asyncOpenSelectedProjects(List<FileObject> fileCandidates);
+    
+    /**
+     * Accesses TextDocumentService instance.
+     * @return TextDocumentService
+     */
+    public TextDocumentService getTextDocumentService();
+}

--- a/java/maven/manifest.mf
+++ b/java/maven/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven/2
-OpenIDE-Module-Specification-Version: 2.144
+OpenIDE-Module-Specification-Version: 2.145
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/maven/layer.xml
 AutoUpdate-Show-In-Client: false

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -308,7 +308,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.64</specification-version>
+                        <specification-version>1.80</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven/src/org/netbeans/modules/maven/ActionProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/ActionProviderImpl.java
@@ -98,7 +98,6 @@ import org.openide.util.NbBundle.Messages;
 import org.openide.util.NbPreferences;
 import org.openide.util.RequestProcessor;
 import org.openide.util.Task;
-import org.openide.util.TaskListener;
 import org.openide.util.actions.Presenter;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ProxyLookup;
@@ -145,7 +144,10 @@ public class ActionProviderImpl implements ActionProvider {
         COMMAND_DELETE,
         COMMAND_RENAME,
         COMMAND_MOVE,
-        COMMAND_COPY
+        COMMAND_COPY,
+        
+        // infrastructure
+        COMMAND_PRIME
     };
     
     private static final RequestProcessor RP = new RequestProcessor(ActionProviderImpl.class.getName(), 3);
@@ -241,7 +243,7 @@ public class ActionProviderImpl implements ActionProvider {
             Operations.renameProject(proj.getLookup().lookup(NbMavenProjectImpl.class));
             return;
         }
-
+        
         if (SwingUtilities.isEventDispatchThread()) {
             RP.post(new Runnable() {
                 @Override
@@ -263,9 +265,16 @@ public class ActionProviderImpl implements ActionProvider {
         if (convertedAction == null) {
             convertedAction = action;
         }
-
-        Lookup enhanced = new ProxyLookup(lookup, Lookups.fixed(replacements(proj, convertedAction, lookup)));
         
+        for (InternalActionDelegate del : proj.getLookup().lookupAll(InternalActionDelegate.class)) {
+            ActionProvider ap = del.getActionProvider();
+            if (Arrays.asList(ap.getSupportedActions()).contains(action)) {
+                ap.invokeAction(action, lookup);
+                return;
+            }
+        }
+        Lookup enhanced = new ProxyLookup(lookup, Lookups.fixed(replacements(proj, convertedAction, lookup)));
+
         RunConfig rc = ActionToGoalUtils.createRunConfig(convertedAction, proj.getLookup().lookup(NbMavenProjectImpl.class), enhanced);
         if (rc == null) {
             Logger.getLogger(ActionProviderImpl.class.getName()).log(Level.INFO, "No handling for action: {0}. Ignoring.", action); //NOI18N
@@ -466,6 +475,13 @@ public class ActionProviderImpl implements ActionProvider {
         if (convertedAction == null) {
             convertedAction = action;
         }
+        
+        for (InternalActionDelegate ap : proj.getLookup().lookupAll(InternalActionDelegate.class)) {
+            if (ap.getActionProvider().isActionEnabled(action, lookup)) {
+                return true;
+            }
+        }
+
         return ActionToGoalUtils.isActionEnable(convertedAction, proj.getLookup().lookup(NbMavenProjectImpl.class), lookup);
     }
 

--- a/java/maven/src/org/netbeans/modules/maven/InternalActionDelegate.java
+++ b/java/maven/src/org/netbeans/modules/maven/InternalActionDelegate.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven;
+
+import org.netbeans.spi.project.ActionProvider;
+
+/**
+ * The same as ActionProvider, but won't be exported outside the module.
+ * @author sdedic
+ */
+public interface InternalActionDelegate {
+    ActionProvider getActionProvider();
+}

--- a/java/maven/src/org/netbeans/modules/maven/problems/SanityBuildAction.java
+++ b/java/maven/src/org/netbeans/modules/maven/problems/SanityBuildAction.java
@@ -20,9 +20,8 @@
 package org.netbeans.modules.maven.problems;
 
 import java.util.Arrays;
-import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.maven.TestChecker;
 import org.netbeans.modules.maven.api.NbMavenProject;
@@ -46,38 +45,75 @@ import org.openide.util.NbBundle.Messages;
 public class SanityBuildAction implements ProjectProblemResolver {
 
     private final Project nbproject;
+    
+    /**
+     * The priming build, which is currently pending or recently completed.
+     * Initially empty.
+     */
+    private volatile CompletableFuture<ProjectProblemsProvider.Result> pendingResult;
 
     public SanityBuildAction(Project nbproject) {
         this.nbproject = nbproject;
     }
 
+    public SanityBuildAction(Project nbproject, Future<ProjectProblemsProvider.Result> otherResult) {
+        this.nbproject = nbproject;
+    }
+    
+    public Future<ProjectProblemsProvider.Result> getPendingResult() {
+        return this.pendingResult;
+    }
+
     @Override
-    public Future<ProjectProblemsProvider.Result> resolve() {
-        FutureTask<ProjectProblemsProvider.Result> toRet = new FutureTask<ProjectProblemsProvider.Result>(new Callable<ProjectProblemsProvider.Result>() {
+    public CompletableFuture<ProjectProblemsProvider.Result> resolve() {
+        CompletableFuture<ProjectProblemsProvider.Result> pr = pendingResult;
+        if (pr != null && !pr.isDone()) {
+            return pendingResult;
+        }
+        final CompletableFuture<ProjectProblemsProvider.Result> publicResult = new CompletableFuture<>();
+        
+        Runnable toRet = new Runnable() {
             @Override
-            public ProjectProblemsProvider.Result call() throws Exception {
-                BeanRunConfig config = new BeanRunConfig();
-                config.setExecutionDirectory(FileUtil.toFile(nbproject.getProjectDirectory()));
-                NbMavenProject mavenPrj = nbproject.getLookup().lookup(NbMavenProject.class);
-                if (mavenPrj != null
-                        && mavenPrj.getMavenProject().getVersion() != null 
-                        && mavenPrj.getMavenProject().getVersion().endsWith("SNAPSHOT")) {
-                    config.setGoals(Arrays.asList("--fail-at-end", "install")); // NOI18N
-                } else {
-                    config.setGoals(Arrays.asList("--fail-at-end", "package")); // NOI18N
+            public void run() {
+                try {
+                    BeanRunConfig config = new BeanRunConfig();
+                    config.setExecutionDirectory(FileUtil.toFile(nbproject.getProjectDirectory()));
+                    NbMavenProject mavenPrj = nbproject.getLookup().lookup(NbMavenProject.class);
+                    if (mavenPrj != null
+                            && mavenPrj.getMavenProject().getVersion() != null 
+                            && mavenPrj.getMavenProject().getVersion().endsWith("SNAPSHOT")) {
+                        config.setGoals(Arrays.asList("--fail-at-end", "install")); // NOI18N
+                    } else {
+                        config.setGoals(Arrays.asList("--fail-at-end", "package")); // NOI18N
+                    }
+                    config.setReactorStyle(ReactorStyle.ALSO_MAKE);
+                    config.setProperty(TestChecker.PROP_SKIP_TEST, "true"); //priming doesn't need test execution, just compilation
+                    config.setProject(nbproject);
+                    String label = build_label(nbproject.getProjectDirectory().getNameExt());
+                    config.setExecutionName(label);
+                    config.setTaskDisplayName(label);
+                    ExecutorTask et = RunUtils.run(config);
+                    et.addTaskListener(t -> {
+                        ProjectProblemsProvider.Result r = ProjectProblemsProvider.Result.create(ProjectProblemsProvider.Status.RESOLVED, ACT_start_validate());
+                        publicResult.complete(r);
+                    });
+                } catch (RuntimeException | Error e) {
+                    // always report completness, otherwise tasks that wait on priming build could block indefinitely.
+                    publicResult.completeExceptionally(e);
+                    throw e;
                 }
-                config.setReactorStyle(ReactorStyle.ALSO_MAKE);
-                config.setProperty(TestChecker.PROP_SKIP_TEST, "true"); //priming doesn't need test execution, just compilation
-                config.setProject(nbproject);
-                String label = build_label(nbproject.getProjectDirectory().getNameExt());
-                config.setExecutionName(label);
-                config.setTaskDisplayName(label);
-                RunUtils.run(config);
-                return ProjectProblemsProvider.Result.create(ProjectProblemsProvider.Status.RESOLVED, ACT_start_validate());
             }
-        });
-        MavenModelProblemsProvider.RP.execute(toRet);
-        return toRet;
+        };
+        synchronized (this) {
+            if (pendingResult != pr) {
+                // someone has started or completed the pending result before us: back off, use the
+                // existing one.
+                return pendingResult;
+            }
+            pendingResult = publicResult;
+        }
+        MavenModelProblemsProvider.RP.submit(toRet);
+        return publicResult;
     }
 
     @Override

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/problems/PrimingActionTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/problems/PrimingActionTest.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.problems;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.maven.InternalActionDelegate;
+import org.netbeans.modules.maven.api.execute.RunConfig;
+import org.netbeans.modules.maven.execute.AbstractMavenExecutor;
+import org.netbeans.modules.maven.execute.MavenCommandLineExecutor;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ui.ProjectProblemsProvider;
+import org.openide.execution.ExecutorTask;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.test.MockLookup;
+import org.openide.util.test.TestFileUtils;
+import org.openide.windows.InputOutput;
+
+/**
+ *
+ * @author sdedic
+ */
+public class PrimingActionTest extends NbTestCase {
+
+    public PrimingActionTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        System.getProperties().remove("test.reload.sync");
+        super.tearDown(); 
+    }
+
+    private void setupBrokenProject() throws Exception {
+        TestFileUtils.writeFile(new File(getWorkDir(), "pom.xml"), 
+             "<project xmlns='http://maven.apache.org/POM/4.0.0'>"
+            + "  <modelVersion>4.0.0</modelVersion>" 
+            + "  <parent>"
+            + "    <groupId>g</groupId>"
+            + "    <artifactId>par</artifactId>"
+            + "    <version>0</version>"
+            + "  </parent>" 
+            + "  <artifactId>m</artifactId>" 
+            + "  <groupId>g</groupId>"
+            + "</project>");
+        
+    }
+    
+    private void setupOKProject() throws Exception {
+        TestFileUtils.writeFile(new File(getWorkDir(), "pom.xml"), 
+             "<project xmlns='http://maven.apache.org/POM/4.0.0'>"
+            + "  <modelVersion>4.0.0</modelVersion>" 
+            + "  <artifactId>m</artifactId>" 
+            + "  <groupId>g</groupId>"
+            + "    <version>0</version>"
+            + "  <dependencies>"
+            + "    <dependency>"
+            + "      <groupId>io.micronaut</groupId>"
+            + "      <artifactId>micronaut-validation</artifactId>"
+            + "      <version>2.3.3</version>"
+            + "      <scope>compile</scope>"
+            + "    </dependency>"
+            + "  </dependencies>"
+            + "</project>");
+        
+    }
+    
+    public void testActionPresent() throws Exception {
+        setupBrokenProject();
+        Project p = ProjectManager.getDefault().findProject(FileUtil.toFileObject(getWorkDir()));
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        assertTrue(Arrays.asList(ap.getSupportedActions()).contains(ActionProvider.COMMAND_PRIME));
+    }
+    
+    private Collection<? extends ProjectProblemsProvider.ProjectProblem> collectProblems(Project p) {
+        Collection<? extends ProjectProblemsProvider.ProjectProblem> res = p.getLookup().lookupAll(ProjectProblemsProvider.class).stream().
+                map(ProjectProblemsProvider::getProblems).
+                flatMap(Collection::stream).
+                collect(Collectors.toList());
+        return res;
+    }
+    
+    public void testLookupNotBroken() throws Exception {
+        setupBrokenProject();
+        Project p = ProjectManager.getDefault().findProject(FileUtil.toFileObject(getWorkDir()));
+        Collection<? extends ActionProvider> provs = p.getLookup().lookupAll(ActionProvider.class);
+        assertEquals(1, provs.size());
+        
+        p.getLookup().lookupAll(ProjectProblemsProvider.class).toArray();
+        InternalActionDelegate[] deles = p.getLookup().lookupAll(InternalActionDelegate.class).toArray(new InternalActionDelegate[0]);
+        assertTrue(deles.length >= 1);
+        // still single
+        Collection<? extends ActionProvider> newProvs = p.getLookup().lookupAll(ActionProvider.class);
+        assertEquals(1, newProvs.size());
+        
+        assertSame(provs.iterator().next(), newProvs.iterator().next());
+    }
+    
+    /**
+     * Checks that the action is enabled even though problems are not evaluated yet.
+     */
+    public void testActionEnabledConservatively() throws Exception {
+        CountDownLatch cdl = new CountDownLatch(1);
+        MavenModelProblemsProvider.RP.submit(() -> {
+            try {
+                cdl.await();
+            } catch (InterruptedException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        });
+        setupBrokenProject();
+        Project p = ProjectManager.getDefault().findProject(FileUtil.toFileObject(getWorkDir()));
+        // no problems yet, and the resolution is blocked.
+        assertTrue(collectProblems(p).isEmpty());
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        boolean enabled = ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY);
+        cdl.countDown();
+        assertTrue(enabled);
+    }
+    
+    /**
+     * Checks that action is still enabled if the problems contains problems solvable by
+     * priming.
+     */
+    public void testActionEnabledWithBrokenProject() throws Exception {
+        setupBrokenProject();
+        System.setProperty("test.reload.sync", "true");
+        
+        Project p = ProjectManager.getDefault().findProject(FileUtil.toFileObject(getWorkDir()));
+        // we've identified problems
+        assertFalse(collectProblems(p).isEmpty());
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        
+        boolean enabled = ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY);
+        assertTrue(enabled);
+    }
+
+    /**
+     * Checks that the action is not enabled unnecessarily after the problems are
+     * collected.
+     */
+    public void testActionNotEnabledOnOKProject() throws Exception {
+        setupOKProject();
+        System.setProperty("test.reload.sync", "true");
+        
+        Project p = ProjectManager.getDefault().findProject(FileUtil.toFileObject(getWorkDir()));
+        // no problems at all
+        assertTrue(collectProblems(p).isEmpty());
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        
+        boolean enabled = ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY);
+        assertFalse(enabled);
+    }
+    
+    /**
+     * Block the actual maven execution, but pretend that the task has been completed
+     */
+    class MockMavenExec extends MavenCommandLineExecutor.ExecuteMaven {
+        volatile boolean executed;
+
+        @Override
+        public ExecutorTask execute(RunConfig config, InputOutput io, AbstractMavenExecutor.TabContext tc) {
+            executed = true;
+            ExecutorTask t = new ExecutorTask(() -> {}) {
+                @Override
+                public void stop() {
+                }
+
+                @Override
+                public int result() {
+                    return 0;
+                }
+
+                @Override
+                public InputOutput getInputOutput() {
+                    return null;
+                }
+
+            };
+            t.run();
+            return t;
+        }
+    }
+    
+    /**
+     * Checks that the priming build does not actually run on OK project, although
+     * the action may be temporarily enabled.
+     */
+    public void testPrimingBuildNotRunOnOK() throws Exception {
+        MockMavenExec mme = new MockMavenExec();
+        MockLookup.setLayersAndInstances(mme);
+        CountDownLatch cdl = new CountDownLatch(1);
+        MavenModelProblemsProvider.RP.submit(() -> {
+            try {
+                cdl.await();
+            } catch (InterruptedException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        });
+        setupOKProject();
+        Project p = ProjectManager.getDefault().findProject(FileUtil.toFileObject(getWorkDir()));
+        // no problems yet, and the resolution is blocked.
+        Collection<? extends ProjectProblemsProvider.ProjectProblem> probs = collectProblems(p);
+        assertEquals(0, probs.size());
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        boolean enabled = ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY);
+        
+        // the actual detection is still broken.
+        assertTrue(enabled);
+        
+        // release the problem analysis
+        cdl.countDown();
+        
+        class Prog extends ActionProgress {
+            CountDownLatch finish = new CountDownLatch(1);
+            volatile boolean started;
+            volatile boolean finished;
+            
+            @Override
+            protected void started() {
+                started = true;
+            }
+
+            @Override
+            public void finished(boolean success) {
+                finished = true;
+                finish.countDown();
+            }
+        }
+        
+        Prog progress = new Prog();
+
+        ap.invokeAction(ActionProvider.COMMAND_PRIME, Lookups.fixed(progress));
+        progress.finish.await();
+        
+        assertTrue(progress.started);
+        assertTrue(progress.finished);
+        
+        // but the execution was NOT really done
+        assertFalse(mme.executed);
+        
+        // check that the action is now disabled.
+        assertFalse(ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY));
+    }
+    
+    /**
+     * Checks that broken build will really execute maven, but block the execution,
+     * using mock service in Lookup.
+     */
+    public void testPrimingBuildExecutes() throws Exception {
+        MockMavenExec mme = new MockMavenExec();
+        MockLookup.setLayersAndInstances(mme);
+
+        System.setProperty("test.reload.sync", "true");
+
+        setupBrokenProject();
+        Project p = ProjectManager.getDefault().findProject(FileUtil.toFileObject(getWorkDir()));
+        Collection<? extends ProjectProblemsProvider.ProjectProblem> probs = collectProblems(p);
+        assertEquals(1, probs.size());
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        boolean enabled = ap.isActionEnabled(ActionProvider.COMMAND_PRIME, Lookup.EMPTY);
+        assertTrue(enabled);
+        class Prog extends ActionProgress {
+            CountDownLatch finish = new CountDownLatch(1);
+            volatile boolean started;
+            volatile boolean finished;
+            
+            @Override
+            protected void started() {
+                started = true;
+            }
+
+            @Override
+            public void finished(boolean success) {
+                finished = true;
+                finish.countDown();
+            }
+        }
+        
+        Prog progress = new Prog();
+
+        ap.invokeAction(ActionProvider.COMMAND_PRIME, Lookups.fixed(progress));
+        progress.finish.await();
+
+        // but the execution was NOT really done
+        assertTrue(mme.executed);
+    }
+}


### PR DESCRIPTION
Sometimes it is good idea to **automate** the priming build. So far, the only way how to do it is to  `ProjectProblemsProvider`s and "somehow" detect a priming build is required. So I have defined `COMMAND_PRIME` Project action to be implemented by specific project types that require some sort of 'initialization' before they can be fully used. Currently they are `maven` and `gradle`. 

Maven support comes in the second commit. I tried to avoid multiple runs of the 'priming build', so if the build is run, an additional request will just piggyback on the execution. But once the execution completes, another ProblemResolver invocation will re-build the project.

In maven, I didn't want to pollute even more `ActionProviderImpl` that already has very complex dependencies. At the same time, I didn't want to break the closure of `ActionProvider`s: since Maven does not use LookupMerger for `ActionProvider`s, there can be only that single one (maven core - provided) and others may only plug through providing configurations for maven executions, not by custom `invokeActions`.
So I have decided to make `InternalActionProvider` for use strictly within Maven module. May be used to decompose `ActionProviderImpl` in the future.

Last, in LSP, I have little optimized project opening: if a project **is being** opened, a new request to open the project will wait on the 1st one to complete. Since priming build is now part of the project open task, it may take a little longer.
It was necessary to prime the projects **before project-open event is fired**: otherwise NB support would kick in and start to display dialogs (Project XYZ has problems, ...). These dialogs will be still displayed, if the priming build fails.
