### PR TITLE
[NETBEANS-5438] Fix incorrect PHP xdebug3 port config when copying to clipboard

### DIFF
--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/ConnectionErrMessage.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/ConnectionErrMessage.java
@@ -311,7 +311,7 @@ public class ConnectionErrMessage extends JPanel {
         StringBuilder sb = new StringBuilder();
         sb.append("xdebug.mode=debug").append(NEWLINE); // NOI18N
         sb.append("xdebug.client_host=localhost").append(NEWLINE); // NOI18N
-        sb.append("xdebug.remote_port=").append(String.valueOf(PhpOptions.getInstance().getDebuggerPort())).append(NEWLINE); // NOI18N
+        sb.append("xdebug.client_port=").append(String.valueOf(PhpOptions.getInstance().getDebuggerPort())).append(NEWLINE); // NOI18N
         sb.append(String.format("xdebug.idekey=\"%s\"", PhpOptions.getInstance().getDebuggerSessionId())); // NOI18N
         return sb.toString();
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5438

Fixes an issue in which Netbeans copies an incorrect configuration for the PHP xdebug port, despite showing the correct configuration to the user.

The xdebug `remote_port` configuration was replaced by `client_port`, as described in [the upgrade guidelines](https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_port). Netbeans suggests the configuration correctly and allows the user to copy it to the clipboard:

<img width="630" alt="Netbeans showing correct config" src="https://user-images.githubusercontent.com/5031156/110861198-8a326680-829c-11eb-8654-f2a0bdb17895.png">

However, when the user copies the values, the IDE copies the old value instead of the new one, as shown in the image below:
<img width="475" alt="Incorrectly copied values" src="https://user-images.githubusercontent.com/5031156/110861222-95859200-829c-11eb-9e15-f7b427499af7.png">

The current changes fix such behavior.
