### PR TITLE
Maven: Fixed failing test.

### DIFF
--- a/java/maven/test/unit/src/org/netbeans/modules/maven/problems/PrimingActionTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/problems/PrimingActionTest.java
@@ -80,14 +80,6 @@ public class PrimingActionTest extends NbTestCase {
             + "  <artifactId>m</artifactId>" 
             + "  <groupId>g</groupId>"
             + "    <version>0</version>"
-            + "  <dependencies>"
-            + "    <dependency>"
-            + "      <groupId>io.micronaut</groupId>"
-            + "      <artifactId>micronaut-validation</artifactId>"
-            + "      <version>2.3.3</version>"
-            + "      <scope>compile</scope>"
-            + "    </dependency>"
-            + "  </dependencies>"
             + "</project>");
         
     }


### PR DESCRIPTION
I passed a failing test into master :( sorry, it succeeded on my local machine and I overlooked it among spurious error produced regularly by Travis. We should stabilize the testsuites somehow so they give **reliable** assesment of the PR ...

The culprit was the `dependency` in the project, which was satisfied on my local machine (from local M2 repo), but apparently is not at the build VM. For the test purposes, I only need project that is in a good shape, so project w/o any dependencies should do it.