### PR TITLE
Fixing codegen handling of both rewrite of an import and an adding of an import due to qual ident.

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
@@ -121,6 +121,7 @@ import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenSequence;
 import org.netbeans.api.queries.FileEncodingQuery;
 import org.netbeans.api.scripting.Scripting;
+import org.netbeans.modules.java.source.GeneratorUtilitiesAccessor;
 import org.netbeans.modules.java.source.TreeShims;
 import org.netbeans.modules.java.source.builder.CommentHandlerService;
 import org.netbeans.modules.java.source.builder.CommentSetImpl;
@@ -1068,6 +1069,10 @@ public final class GeneratorUtilities {
      * @since 0.86
      */
     public CompilationUnitTree addImports(CompilationUnitTree cut, Set<? extends Element> toImport) {
+        return addImports(cut, cut.getImports(), toImport);
+    }
+
+    private CompilationUnitTree addImports(CompilationUnitTree cut, List<? extends ImportTree> cutImports, Set<? extends Element> toImport) {
         assert cut != null && toImport != null && toImport.size() > 0;
 
         ArrayList<Element> elementsToImport = new ArrayList<Element>(toImport.size());
@@ -1175,7 +1180,7 @@ public final class GeneratorUtilities {
                 }
             }
         }
-        List<ImportTree> imports = new ArrayList<ImportTree>(cut.getImports());
+        List<ImportTree> imports = new ArrayList<ImportTree>(cutImports);
         for (ImportTree imp : imports) {
             Element e = getImportedElement(cut, imp);
             if (!elementsToImport.contains(e)) {
@@ -2246,5 +2251,14 @@ public final class GeneratorUtilities {
             }
         }.scan(tree, false);
         return b != null ? b : false;
+    }
+
+    static {
+        GeneratorUtilitiesAccessor.setInstance(new GeneratorUtilitiesAccessor() {
+            @Override
+            public CompilationUnitTree addImports(GeneratorUtilities gu, CompilationUnitTree cut, List<? extends ImportTree> cutImports, Set<? extends Element> toImport) {
+                return gu.addImports(cut, cutImports, toImport);
+            }
+        });
     }
 }

--- a/java/java.source.base/src/org/netbeans/modules/java/source/GeneratorUtilitiesAccessor.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/GeneratorUtilitiesAccessor.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.source;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ImportTree;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.Element;
+import org.netbeans.api.java.source.GeneratorUtilities;
+
+public abstract class GeneratorUtilitiesAccessor {
+
+    private static volatile GeneratorUtilitiesAccessor INSTANCE;
+
+    public static GeneratorUtilitiesAccessor getInstance() {
+        GeneratorUtilitiesAccessor result = INSTANCE;
+
+        if (result == null) {
+            synchronized (GeneratorUtilitiesAccessor.class) {
+                if (INSTANCE == null) {
+                    Class c = GeneratorUtilities.class;
+                    try {
+                        Class.forName(c.getName(), true, c.getClassLoader());
+                    } catch (Exception ex) {
+                        ex.printStackTrace();
+                    }
+
+                    assert INSTANCE != null;
+                }
+
+                return INSTANCE;
+            }
+        }
+
+        return result;
+    }
+
+    public static void setInstance(GeneratorUtilitiesAccessor instance) {
+        assert instance != null;
+        INSTANCE = instance;
+    }
+
+    protected GeneratorUtilitiesAccessor() {
+    }
+
+    public abstract CompilationUnitTree addImports(GeneratorUtilities gu, CompilationUnitTree cut, List<? extends ImportTree> cutImports, Set<? extends Element> toImport);
+
+}

--- a/java/java.source.base/src/org/netbeans/modules/java/source/transform/ImmutableTreeTranslator.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/transform/ImmutableTreeTranslator.java
@@ -24,6 +24,7 @@ import com.sun.source.tree.*;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.model.JavacElements;
+import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCLambda;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.util.Context;
@@ -39,6 +40,7 @@ import javax.lang.model.util.Elements;
 import org.netbeans.api.java.source.GeneratorUtilities;
 import org.netbeans.api.java.source.TreeMaker;
 import org.netbeans.api.java.source.WorkingCopy;
+import org.netbeans.modules.java.source.GeneratorUtilitiesAccessor;
 import org.netbeans.modules.java.source.TreeShims;
 import org.netbeans.modules.java.source.builder.ASTService;
 import org.netbeans.modules.java.source.builder.CommentHandlerService;
@@ -546,7 +548,9 @@ public class ImmutableTreeTranslator implements TreeVisitor<Tree,Object> {
         
         Set<? extends Element> newImports = importAnalysis.getImports();
         if (copy != null && newImports != null && !newImports.isEmpty()) {
-            imps = GeneratorUtilities.get(copy).addImports(tree, newImports).getImports();
+            imps = GeneratorUtilitiesAccessor.getInstance()
+                                             .addImports(GeneratorUtilities.get(copy), tree, imps, newImports)
+                                             .getImports();
         }
         
 	if (!annotations.equals(tree.getPackageAnnotations()) || pid!=tree.getPackageName() || !imps.equals(tree.getImports()) ||


### PR DESCRIPTION
This should fix the failing re-writes of import in the backporting nb-javac. Basically, without this patch, manual changes to import statements are thrown away when import analysis is adding any imports.