### PR TITLE
Avoid displaying unnecessary `<classLoader>` field.

### DIFF
--- a/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapUtils.java
+++ b/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapUtils.java
@@ -328,7 +328,6 @@ final class HeapUtils {
                         .dumpClass();
             }
             generator.generate(seg);
-            seg.close();
         }
 
         @Override
@@ -435,5 +434,5 @@ final class HeapUtils {
             return stringId;
         }
     }
-    
+
 }

--- a/profiler/profiler.heapwalker/nbproject/project.xml
+++ b/profiler/profiler.heapwalker/nbproject/project.xml
@@ -161,6 +161,21 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
+            <test-dependencies>
+                <test-type>
+                    <name>unit</name>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.nbjunit</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.lib.profiler</code-name-base>
+                        <compile-dependency/>
+                        <test/>
+                    </test-dependency>
+                </test-type>
+            </test-dependencies>
             <friend-packages>
                 <friend>com.sun.tools.visualvm.heapdump</friend>
                 <friend>com.sun.tools.visualvm.heapviewer</friend>

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ClassesController.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ClassesController.java
@@ -78,7 +78,7 @@ public class ClassesController extends AbstractTopLevelController implements Fie
         this.heapFragmentWalker = heapFragmentWalker;
 
         classesListController = new ClassesListController(this);
-        staticFieldsBrowserController = new FieldsBrowserController(this, FieldsBrowserController.ROOT_CLASS);
+        staticFieldsBrowserController = new FieldsBrowserController(this, FieldsBrowserController.ROOT_CLASS, true);
     }
 
     //~ Methods ------------------------------------------------------------------------------------------------------------------

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/FieldsBrowserController.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/FieldsBrowserController.java
@@ -42,6 +42,8 @@ import javax.swing.tree.TreePath;
     "FieldsBrowserController_NoneString=<none>"
 })
 public class FieldsBrowserController extends AbstractController {
+
+    private final boolean showClassLoaders;
     //~ Inner Interfaces ---------------------------------------------------------------------------------------------------------
 
     public static interface Handler {
@@ -136,11 +138,11 @@ public class FieldsBrowserController extends AbstractController {
         protected String computeValue() {
             return Bundle.FieldsBrowserController_NoneString();
         }
-        
+
         protected String computeSize() {
             return ""; // NOI18N
         }
-        
+
         protected String computeRetainedSize() {
             return ""; // NOI18N
         }
@@ -165,8 +167,13 @@ public class FieldsBrowserController extends AbstractController {
     //~ Constructors -------------------------------------------------------------------------------------------------------------
 
     public FieldsBrowserController(Handler instancesControllerHandler, int rootMode) {
+        this(instancesControllerHandler, rootMode, true);
+    }
+
+    public FieldsBrowserController(Handler instancesControllerHandler, int rootMode, boolean showClassLoaders) {
         this.instancesControllerHandler = instancesControllerHandler;
         this.rootMode = rootMode;
+        this.showClassLoaders = showClassLoaders;
     }
 
     //~ Methods ------------------------------------------------------------------------------------------------------------------
@@ -244,15 +251,15 @@ public class FieldsBrowserController extends AbstractController {
     protected AbstractButton createControllerPresenter() {
         return ((FieldsBrowserControllerUI) getPanel()).getPresenter();
     }
-    
+
     public List getExpandedPaths() {
         return ((FieldsBrowserControllerUI)getPanel()).getExpandedPaths();
     }
-    
+
     public TreePath getSelectedRow() {
         return ((FieldsBrowserControllerUI)getPanel()).getSelectedRow();
     }
-    
+
     public void restoreState(List expanded, TreePath selected) {
         ((FieldsBrowserControllerUI)getPanel()).restoreState(expanded, selected);
     }
@@ -263,10 +270,12 @@ public class FieldsBrowserController extends AbstractController {
     }
 
     private HeapWalkerNode getFields(final Instance instance) {
+        int fieldsMode = showClassLoaders ? HeapWalkerNode.MODE_FIELDS : HeapWalkerNode.MODE_FIELDS_NO_CLASSLOADER;
+
         return HeapWalkerNodeFactory.createRootInstanceNode(instance, "this",   // NOI18N
                 new Runnable() { public void run() { ((FieldsBrowserControllerUI) getPanel()).refreshView(); } },
                 new Runnable() { public void run() { getPanel().repaint(); } },
-                HeapWalkerNode.MODE_FIELDS, instancesControllerHandler.getHeapFragmentWalker().getHeapFragment());
+                fieldsMode, instancesControllerHandler.getHeapFragmentWalker().getHeapFragment());
     }
 
     private HeapWalkerNode getFields(final JavaClass javaClass) {
@@ -278,13 +287,13 @@ public class FieldsBrowserController extends AbstractController {
 
     private HeapWalkerNode getFilteredFields(HeapWalkerNode fields, String filterValue) {
         //    ArrayList filteredFields = new ArrayList();
-        //    
+        //
         //    Iterator fieldsIterator = fields.iterator();
         //    while (fieldsIterator.hasNext()) {
         //      FieldValue field = (FieldValue)fieldsIterator.next();
         //      if (matchesFilter(field)) filteredFields.add(field);
         //    }
-        //    
+        //
         //    return filteredFields;
         return fields;
     }

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapFragmentWalker.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapFragmentWalker.java
@@ -23,6 +23,7 @@ import org.netbeans.lib.profiler.heap.*;
 import org.netbeans.modules.profiler.heapwalk.ui.HeapFragmentWalkerUI;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -316,6 +317,25 @@ public class HeapFragmentWalker {
         }
 
         return null;
+    }
+
+    private Integer classLoaderCount;
+    public final int countClassLoaders() {
+        if (this.classLoaderCount != null) {
+            return this.classLoaderCount;
+        }
+        int nclassloaders = 0;
+        JavaClass cl = heapFragment.getJavaClassByName("java.lang.ClassLoader"); // NOI18N
+        if (cl != null) {
+            nclassloaders = cl.getInstancesCount();
+
+            Collection<JavaClass> jcs = cl.getSubClasses();
+
+            for (JavaClass jc : jcs) {
+                nclassloaders += jc.getInstancesCount();
+            }
+        }
+        return this.classLoaderCount = nclassloaders;
     }
 
 

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/InstancesController.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/InstancesController.java
@@ -98,7 +98,8 @@ public class InstancesController extends AbstractTopLevelController implements F
             public void refresh() { setJavaClass(selectedClass); }
         };
         instancesListController = new InstancesListController(this);
-        fieldsBrowserController = new FieldsBrowserController(this, FieldsBrowserController.ROOT_INSTANCE);
+        boolean showClassLoaders = heapFragmentWalker.countClassLoaders() > 1;
+        fieldsBrowserController = new FieldsBrowserController(this, FieldsBrowserController.ROOT_INSTANCE, showClassLoaders);
         referencesBrowserController = new ReferencesBrowserController(this);
 
         classPresenter.setHeapFragmentWalker(heapFragmentWalker);

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/InstancesListController.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/InstancesListController.java
@@ -487,6 +487,11 @@ public class InstancesListController extends AbstractController {
             return 0;
         }
 
+        @Override
+        public boolean isModeFields() {
+            return false;
+        }
+
         public int getNChildren() {
             return 0;
         }

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OverviewController.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OverviewController.java
@@ -137,21 +137,11 @@ public class OverviewController extends AbstractController {
         Heap heap = heapFragmentWalker.getHeapFragment();
         HeapSummary hsummary = heap.getSummary();
         long finalizers = computeFinalizers(heap);
-        int nclassloaders = 0;
-        JavaClass cl = heap.getJavaClassByName("java.lang.ClassLoader"); // NOI18N
         NumberFormat numberFormat = (NumberFormat)NumberFormat.getInstance().clone();
         numberFormat.setMaximumFractionDigits(1);
         
         oome = getOOMEThread(heap);
-        if (cl != null) {
-            nclassloaders = cl.getInstancesCount();
-            
-            Collection<JavaClass> jcs = cl.getSubClasses();
-            
-            for (JavaClass jc : jcs) {
-                nclassloaders += jc.getInstancesCount();
-            }
-        }
+        int nclassloaders = heapFragmentWalker.countClassLoaders();
         
         String filename = LINE_PREFIX
                 + Bundle.OverviewController_FileItemString(
@@ -202,7 +192,7 @@ public class OverviewController extends AbstractController {
                 + Bundle.OverviewController_SummaryString() + "</b><br><hr>" + dateTaken + "<br>" + filename + "<br>" + filesize + "<br><br>" + liveBytes // NOI18N
                 + "<br>" + liveClasses + "<br>" + liveInstances + "<br>" + classloaders + "<br>" + gcroots + "<br>" + finalizersInfo + oomeString; // NOI18N
     }
-    
+
     public String computeEnvironment() {
         String sysinfoRes = Icons.getResource(HeapWalkerIcons.SYSTEM_INFO);
         String header =  "<b><img border='0' align='bottom' src='nbresloc:/" + sysinfoRes + "'>&nbsp;&nbsp;" // NOI18N

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/AbstractHeapWalkerNode.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/AbstractHeapWalkerNode.java
@@ -41,7 +41,7 @@ public abstract class AbstractHeapWalkerNode extends HeapWalkerNode {
     private String size;
     private String retainedSize;
     private HeapWalkerNode[] children;
-    private int mode = HeapWalkerNode.MODE_FIELDS;
+    private final int mode;
 
     private Map<Object, Integer> indexes;
 
@@ -105,6 +105,10 @@ public abstract class AbstractHeapWalkerNode extends HeapWalkerNode {
     // Should be overridden for lazy populating children
     public boolean isLeaf() {
         return getNChildren() == 0;
+    }
+
+    public final boolean isModeFields() {
+        return mode != MODE_REFERENCES;
     }
 
     public int getMode() {

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/BrowserUtils.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/BrowserUtils.java
@@ -307,13 +307,13 @@ public class BrowserUtils {
     }
     
     private static String pathFromRoot(TreePath path) {
-        int m = ((HeapWalkerNode)path.getLastPathComponent()).getMode();
+        final HeapWalkerNode last = (HeapWalkerNode)path.getLastPathComponent();
         Object[] nodes = path.getPath();
         StringBuilder b = new StringBuilder();
         int s = nodes.length;
         for (int i = 0; i < s; i++) {
             HeapWalkerNode n = (HeapWalkerNode)nodes[i];
-            if (m == HeapWalkerNode.MODE_FIELDS) fieldFromRoot(n, b, i, s);
+            if (last.isModeFields()) fieldFromRoot(n, b, i, s);
             else referenceFromRoot(n, b, i, s);
             b.append("\n"); // NOI18N
         }

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerNode.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerNode.java
@@ -38,6 +38,7 @@ public abstract class HeapWalkerNode extends CCTNode {
 
     public static final int MODE_FIELDS = 1;
     public static final int MODE_REFERENCES = 2;
+    public static final int MODE_FIELDS_NO_CLASSLOADER = 3;
 
     //~ Methods ------------------------------------------------------------------------------------------------------------------
 
@@ -83,6 +84,7 @@ public abstract class HeapWalkerNode extends CCTNode {
      * There are two different algorithms for generating childs in both Browsers.
      */
     public abstract int getMode();
+    public abstract boolean isModeFields();
     
     
     public static TreePath fromNode(TreeNode node) {

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectArrayNode.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectArrayNode.java
@@ -127,7 +127,7 @@ public class ObjectArrayNode extends ArrayNode {
             public HeapWalkerNode[] computeChildren() {
                 HeapWalkerNode[] children = null;
 
-                if (getMode() == HeapWalkerNode.MODE_FIELDS) {
+                if (isModeFields()) {
                     int fieldsSize = getInstance().getLength();
 
                     if (fieldsSize == 0) {

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectFieldNode.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/ObjectFieldNode.java
@@ -40,7 +40,7 @@ public class ObjectFieldNode extends ObjectNode implements HeapWalkerFieldNode {
     }
 
     public ObjectFieldNode(ObjectFieldValue fieldValue, HeapWalkerNode parent, int mode) {
-        super((mode == HeapWalkerNode.MODE_FIELDS) ? fieldValue.getInstance() : fieldValue.getDefiningInstance(),
+        super((mode != HeapWalkerNode.MODE_REFERENCES) ? fieldValue.getInstance() : fieldValue.getDefiningInstance(),
               fieldValue.getField().getName(), parent, mode);
         this.fieldValue = fieldValue;
 

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/PrimitiveArrayNode.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/model/PrimitiveArrayNode.java
@@ -128,7 +128,7 @@ public class PrimitiveArrayNode extends ArrayNode {
             public HeapWalkerNode[] computeChildren() {
                 HeapWalkerNode[] children = null;
 
-                if (getMode() == HeapWalkerNode.MODE_FIELDS) {
+                if (isModeFields()) {
                     int fieldsSize = getInstance().getLength();
 
                     if (fieldsSize == 0) {

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/FieldsBrowserControllerUI.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/FieldsBrowserControllerUI.java
@@ -153,7 +153,7 @@ public class FieldsBrowserControllerUI extends JTitledPanel {
         }
 
         public void mouseClicked(MouseEvent e) {
-            if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2) {
+             if (SwingUtilities.isLeftMouseButton(e) && e.getClickCount() == 2) {
                 int row = fieldsListTable.rowAtPoint(e.getPoint());
                 if (e.getX() >= fieldsListTable.getTree().getRowBounds(row).x -
                                 fieldsListTable.getTreeCellOffsetX() && row != -1) {

--- a/profiler/profiler.heapwalker/test/unit/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerNodeTest.java
+++ b/profiler/profiler.heapwalker/test/unit/src/org/netbeans/modules/profiler/heapwalk/model/HeapWalkerNodeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.profiler.heapwalk.model;
+
+import java.io.File;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.lib.profiler.heap.Heap;
+import org.netbeans.lib.profiler.heap.HeapSegmentTest;
+import org.netbeans.modules.profiler.heapwalk.HeapFragmentWalker;
+
+public class HeapWalkerNodeTest extends NbTestCase {
+
+    public HeapWalkerNodeTest(String n) {
+        super(n);
+    }
+
+    private static void assertChildMode(ObjectNode on) {
+        ObjectNode ch = new ObjectNode(null, "any", on);
+        assertEquals("Same mode on child", on.getMode(), ch.getMode());
+    }
+
+    public void testModeFields1() {
+        ObjectNode on = new ObjectNode(null, "any", null, HeapWalkerNode.MODE_FIELDS);
+        assertTrue("Showing fields", on.isModeFields());
+        assertChildMode(on);
+    }
+
+
+    public void testModeFields2() {
+        ObjectNode on = new ObjectNode(null, "any", null, HeapWalkerNode.MODE_FIELDS_NO_CLASSLOADER);
+        assertTrue("Showing fields", on.isModeFields());
+        assertChildMode(on);
+    }
+
+    public void testModeFields3() {
+        ObjectNode on = new ObjectNode(null, "any", null, HeapWalkerNode.MODE_REFERENCES);
+        assertFalse("Not showing fields", on.isModeFields());
+        assertChildMode(on);
+    }
+
+    public void testSimpleHeapDumpAnalysis() throws Exception {
+        clearWorkDir();
+        File mydump = new File(getWorkDir(), "sample.hprof");
+        mydump.getParentFile().mkdirs();
+        Heap heap = HeapSegmentTest.generateSampleDump(mydump);
+
+        HeapFragmentWalker walker = new HeapFragmentWalker(heap, null);
+        assertEquals("No classloaders", 0, walker.countClassLoaders());
+    }
+
+    public void testComplexHeapDumpAnalysis() throws Exception {
+        clearWorkDir();
+        File mydump = new File(getWorkDir(), "complex.hprof");
+        mydump.getParentFile().mkdirs();
+        Heap heap = HeapSegmentTest.generateComplexDump(mydump);
+
+        HeapFragmentWalker walker = new HeapFragmentWalker(heap, null);
+        assertEquals("Heap dump uses some classloaders", 2, walker.countClassLoaders());
+    }
+}


### PR DESCRIPTION
Recently I was working on generating `.hprof` files manually, without dumping the Java heap by the JVM. I have created a [builder library](https://www.graalvm.org/tools/javadoc/org/graalvm/tools/insight/heap/HeapDump.html) to provide nice Java API around the [Java Profiler Heap Dump Format](http://hg.openjdk.java.net/jdk6/jdk6/jdk/raw-file/tip/src/share/demo/jvmti/hprof/manual.html) and I am using it in the [GraalVM Insight](https://github.com/oracle/graal/blob/master/tools/docs/Insight-Manual.md#Heap-Dumping) to heap dump JavaScript, Ruby, Python and other dynamic languages.

When analyzing the generated heap dump with NetBeans 12.3 I noticed `<classLoader> = null` almost every where - see the [original snapshot](https://github.com/oracle/graal/blob/04e2a3c014c524e8de804365cd5c17a11676e68b/tools/docs/Insight-HeapInspect.png) of the dump. The `<classLoader>` is an extra field added to the view useful only when there are some classloaders. However the dynamic languages may not need to expose `java.lang.ClassLoader` objects at all. With the changes in this PR I was able to [improve the snapshot](https://github.com/oracle/graal/blob/master/tools/docs/Insight-HeapInspect.png).

I tried to avoid changes in the `lib.profiler` library that would form a visible API change. Rather I handled everything in the `profiler.heapwalker` module (using a [magic string](http://wiki.apidesign.org/wiki/MagicalStrings) API check, alas). The number of `java.lang.ClassLoader` subclasses is counted when analyzing the heap and if there is no more than one classloader, information to remove the `classLoader` field is passed down through the heap walker nodes to remove the field named `<classLoader>`. I have created some tests to stiffen the intended behavior a bit.

With this PR am I donating this change to Apache NetBeans. I am making the same patch available under the original NetBeans 8.2 license - e.g. CDDL and GPLv2+CPex - should there be an interest to backport this change to previous version of NetBeans & derived apps.