### PR TITLE
[NETBEANS-5545] ParentProject and RootProject query support for Maven projects

### DIFF
--- a/java/maven/.gitignore
+++ b/java/maven/.gitignore
@@ -1,0 +1,1 @@
+test/unit/data/parent-projects/**/target/

--- a/java/maven/manifest.mf
+++ b/java/maven/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven/2
-OpenIDE-Module-Specification-Version: 2.145
+OpenIDE-Module-Specification-Version: 2.146
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/maven/layer.xml
 AutoUpdate-Show-In-Client: false

--- a/java/maven/src/org/netbeans/modules/maven/queries/MavenParentRootImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/queries/MavenParentRootImpl.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.queries;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.spi.project.ParentProjectProvider;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.netbeans.spi.project.RootProjectProvider;
+import org.openide.filesystems.FileObject;
+
+/**
+ *
+ * @author sdedic
+ */
+@ProjectServiceProvider(service = {ParentProjectProvider.class, RootProjectProvider.class}, projectType="org-netbeans-modules-maven")
+public class MavenParentRootImpl implements ParentProjectProvider, RootProjectProvider {
+    private final Project project;
+    
+    /**
+     * Cached parent project, or {@link #NO_PROJECT} if none.
+     */
+    // @GuardedBy(this)
+    private Reference<Project>  parent = new WeakReference<>(null);
+
+    /**
+     * Cached root project, in worst case this project itself.
+     */
+    // @GuardedBy(this)
+    private Reference<Project>  root = new WeakReference<>(null);
+    
+    public MavenParentRootImpl(Project proj) {
+        this.project = proj;
+    }
+    
+    @Override
+    public Project getPartentProject() {
+        synchronized (this) {
+            if (parent == NO_PROJECT) {
+                return null;
+            }
+            Project fromCache = parent.get();
+            if (fromCache != null) {
+                return fromCache;
+            }
+        }
+        Project found = findParentProject(project, project);
+        synchronized (this) {
+            parent = found == null ? NO_PROJECT : new WeakReference<>(found);
+        }
+        return found;
+    }
+    
+    private static Project findParentProject(Project from, Project toFind) {
+        FileObject dir = from.getProjectDirectory();
+        FileObject findDir = toFind.getProjectDirectory();
+        if (dir == null) {
+            // ??
+            return null;
+        }
+        FileObject parentDir = dir.getParent();
+        if (parentDir == null) {
+            return null;
+        }
+        Project parentProj = FileOwnerQuery.getOwner(parentDir);
+        if (parentProj == null) {
+            return null;
+        }
+        FileObject parentProjDir = parentProj.getProjectDirectory();
+        NbMavenProject parentMaven = parentProj.getLookup().lookup(NbMavenProject.class);
+        if (parentMaven == null) {
+            return null;
+        }
+        // verify that the parent project lists the child as a module
+        for (String s : parentMaven.getMavenProject().getModules()) {
+            FileObject child = parentProjDir.getFileObject(s);
+            if (findDir.equals(child)) {
+                return parentProj;
+            }
+        }
+        
+        return findParentProject(parentProj, toFind);
+    }
+
+    @Override
+    public Project getRootProject() {
+        synchronized (this) {
+            if (root == NO_PROJECT) {
+                return null;
+            }
+            Project r = root.get();
+            if (r != null) {
+                return r;
+            }
+        }
+        Project that = project;
+        while (true) {
+            Project parent = findParentProject(that, that);
+            if (parent == null || parent == that) {
+                break;
+            }
+            that = parent;
+        }
+        
+        synchronized (this) {
+            root = new WeakReference<>(that);
+        }
+        return that;
+    }
+    
+    private static final WeakReference<Project> NO_PROJECT = new WeakReference<>(null);
+}

--- a/java/maven/test/unit/data/parent-projects/basic/child/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/basic/child/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>child</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/java/maven/test/unit/data/parent-projects/basic/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/basic/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>basic</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  
+  <modules>
+      <module>child</module>
+  </modules>
+</project>

--- a/java/maven/test/unit/data/parent-projects/multi/first/child/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/multi/first/child/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>multi-grandchild</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/java/maven/test/unit/data/parent-projects/multi/first/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/multi/first/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>multi-first</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <modules>
+    <module>child</module>
+  </modules>
+</project>

--- a/java/maven/test/unit/data/parent-projects/multi/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/multi/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>nested</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+      <module>first</module>
+      <module>second</module>
+  </modules>
+</project>

--- a/java/maven/test/unit/data/parent-projects/multi/second/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/multi/second/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>nested-second</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/java/maven/test/unit/data/parent-projects/nested/first/child/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/nested/first/child/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>nested-grandchild</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/java/maven/test/unit/data/parent-projects/nested/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/nested/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>nested</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+      <module>first/child</module>
+      <module>second</module>
+  </modules>
+</project>

--- a/java/maven/test/unit/data/parent-projects/nested/second/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/nested/second/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>nested-second</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/java/maven/test/unit/data/parent-projects/single/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/single/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>single</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/java/maven/test/unit/data/parent-projects/skipped/first/child/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/skipped/first/child/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>skipped-child</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/java/maven/test/unit/data/parent-projects/skipped/first/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/skipped/first/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>skipped-first</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/java/maven/test/unit/data/parent-projects/skipped/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/skipped/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>skipped</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  
+  <modules>
+      <module>first</module>
+      <module>first/child</module>
+      <module>second</module>
+  </modules>
+</project>

--- a/java/maven/test/unit/data/parent-projects/skipped/second/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/skipped/second/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>skipped-second</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/java/maven/test/unit/data/parent-projects/unrelated/child/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/unrelated/child/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>unrelated-child</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>

--- a/java/maven/test/unit/data/parent-projects/unrelated/pom.xml
+++ b/java/maven/test/unit/data/parent-projects/unrelated/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.netbeans.projects.test</groupId>
+  <artifactId>unrelated</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+</project>

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenParentRootImplTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/queries/MavenParentRootImplTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.queries;
+
+import java.io.File;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.spi.project.ParentProjectProvider;
+import org.netbeans.spi.project.RootProjectProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+/**
+ *
+ * @author sdedic
+ */
+public class MavenParentRootImplTest extends NbTestCase {
+
+    public MavenParentRootImplTest(String name) {
+        super(name);
+    }
+    
+    private FileObject  rootFolder;
+    private Project  rootProject;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        String s = getName();
+        int under = s.lastIndexOf('_');
+        if (under == -1) {
+            return;
+        }
+        FileObject fo = FileUtil.toFileObject(getDataDir());
+        rootFolder = fo.getFileObject("parent-projects/" + s.substring(under + 1));
+        rootProject = FileOwnerQuery.getOwner(rootFolder);
+    }
+    
+    public void testProject_single() throws Exception {
+        Project p = FileOwnerQuery.getOwner(rootFolder);
+        assertNotNull(p);
+        
+        ParentProjectProvider ppp = p.getLookup().lookup(ParentProjectProvider.class);
+        assertNotNull(ppp);
+        
+        Project parent = ppp.getPartentProject();
+        assertNull(parent);
+        
+        
+        RootProjectProvider rpp = p.getLookup().lookup(RootProjectProvider.class);
+        assertNotNull(rpp);
+        assertSame(p, rpp.getRootProject());
+    }
+
+    public void testProject_basic() throws Exception {
+        FileObject subDir = rootFolder.getFileObject("child");
+        Project p = FileOwnerQuery.getOwner(subDir);
+        assertNotNull(p);
+        
+        ParentProjectProvider ppp = p.getLookup().lookup(ParentProjectProvider.class);
+        assertNotNull(ppp);
+        
+        Project parent = ppp.getPartentProject();
+        assertSame(rootProject, parent);
+        
+        
+        RootProjectProvider rpp = p.getLookup().lookup(RootProjectProvider.class);
+        assertNotNull(rpp);
+        assertSame(rootProject, rpp.getRootProject());
+    }
+
+    public void testProject_unrelated() throws Exception {
+        FileObject subDir = rootFolder.getFileObject("child");
+        Project p = FileOwnerQuery.getOwner(subDir);
+        assertNotNull(p);
+        
+        ParentProjectProvider ppp = p.getLookup().lookup(ParentProjectProvider.class);
+        assertNotNull(ppp);
+        
+        Project parent = ppp.getPartentProject();
+        assertNull(parent);
+        
+        
+        RootProjectProvider rpp = p.getLookup().lookup(RootProjectProvider.class);
+        assertNotNull(rpp);
+        assertSame(p, rpp.getRootProject());
+    }
+
+    public void testProject_nested() throws Exception {
+        FileObject childDir = rootFolder.getFileObject("first/child");
+        
+        Project p = FileOwnerQuery.getOwner(childDir);
+        assertNotNull(p);
+        
+        ParentProjectProvider ppp = p.getLookup().lookup(ParentProjectProvider.class);
+        assertNotNull(ppp);
+        
+        Project parent = ppp.getPartentProject();
+        assertSame(rootProject, parent);
+        
+        
+        RootProjectProvider rpp = p.getLookup().lookup(RootProjectProvider.class);
+        assertNotNull(rpp);
+        assertSame(rootProject, rpp.getRootProject());
+    }
+
+    public void testProject_multi() throws Exception {
+        FileObject childDir = rootFolder.getFileObject("first/child");
+        FileObject firstDir = rootFolder.getFileObject("first");
+        
+        Project p = FileOwnerQuery.getOwner(childDir);
+        Project fp = FileOwnerQuery.getOwner(firstDir);
+        assertNotNull(p);
+        assertNotNull(fp);
+        
+        ParentProjectProvider ppp = p.getLookup().lookup(ParentProjectProvider.class);
+        assertNotNull(ppp);
+        
+        Project parent = ppp.getPartentProject();
+        assertSame(fp, parent);
+        
+        
+        RootProjectProvider rpp = p.getLookup().lookup(RootProjectProvider.class);
+        assertNotNull(rpp);
+        assertSame(rootProject, rpp.getRootProject());
+    }
+
+    public void testProject_skipped() throws Exception {
+        FileObject childDir = rootFolder.getFileObject("first/child");
+        
+        Project p = FileOwnerQuery.getOwner(childDir);
+        assertNotNull(p);
+        
+        ParentProjectProvider ppp = p.getLookup().lookup(ParentProjectProvider.class);
+        assertNotNull(ppp);
+        
+        Project parent = ppp.getPartentProject();
+        assertSame(rootProject, parent);
+        
+        
+        RootProjectProvider rpp = p.getLookup().lookup(RootProjectProvider.class);
+        assertNotNull(rpp);
+        assertSame(rootProject, rpp.getRootProject());
+    }
+
+}


### PR DESCRIPTION
Simple, but somewhat caching implementation of `ParentProjectProvider` and `RootProjectProvider` for maven projects. Works strictly by containment - does not uses `parent` inheritance relationship.

Let `q = p.parentProject`, `r = p.rootProject`. Then `p` will be built if either `r` or `p` is built.