### PR TITLE
Execute commit validation on JDK15 and JDK11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,17 +87,6 @@ matrix:
             - ant $OPTS build
             - ant $OPTS test -Dtest.includes=NoTestsJustBuild
 
-        - name: Compile all modules with OpenJDK11
-          jdk: openjdk11
-          env:
-            - OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json -quiet -Dcluster.config=full -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false"
-          before_script:
-            - ant $OPTS clean
-          script:
-            - ant $OPTS build
-            - ant $OPTS test -Dtest.includes=NoTestsJustBuild
-            - ant $OPTS -f platform/o.n.core/ test -Dtest.includes=**/ValidateClassFilesTest.class
-
         - name: Test harness modules
           jdk: openjdk8
           env:
@@ -883,4 +872,33 @@ matrix:
             - ant $OPTS clean
             - ant $OPTS build
           script:
+            - hide-logs.sh ant $OPTS commit-validation
+
+        - name: commit-validation on Java 11
+          jdk: openjdk11
+          env:
+            - OPTS="-quiet -Dcluster.config=release -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true"
+          before_script:
+            - wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh
+            - export TEST_JDK=`bash install-jdk.sh --feature 11 --license GPL --emit-java-home --silent | tail -1`
+            - export JAVA_HOME=$TEST_JDK
+            - export OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json $OPTS -Dnbjdk.home=$TEST_JDK -Dtest.use.jdk.javac=true"
+            - ant $OPTS clean
+            - ant $OPTS build
+            - ant $OPTS test -Dtest.includes=NoTestsJustBuild
+          script:
+            - hide-logs.sh ant $OPTS commit-validation
+
+        - name: commit-validation on Java 15
+          jdk: openjdk8
+          env:
+            - OPTS="-quiet -Dcluster.config=release -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true"
+          before_script:
+            - wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh
+            - export TEST_JDK=`bash install-jdk.sh --feature 15 --license GPL --emit-java-home --silent | tail -1`
+            - export OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json $OPTS -Dtest.nbjdk.home=$TEST_JDK -Dtest.use.jdk.javac=true"
+            - ant $OPTS clean
+            - ant $OPTS build
+          script:
+            - export JAVA_HOME=$TEST_JDK
             - hide-logs.sh ant $OPTS commit-validation

--- a/ergonomics/ide.ergonomics/build.xml
+++ b/ergonomics/ide.ergonomics/build.xml
@@ -42,8 +42,8 @@
         </depend>
         <javac srcdir="src-ant" destdir="${src-ant.build}"
             deprecation="${build.compiler.deprecation}"
-            debug="true"
-            source="1.6" target="1.6" includeantruntime="false">
+            debug="true" release="8"
+            source="${javac.source}" target="${javac.target}" includeantruntime="false">
             <classpath>
                 <path path="${src-ant.cp}"/>
             </classpath>

--- a/ergonomics/ide.ergonomics/src-ant/org/netbeans/modules/ide/ergonomics/ant/ExtractLayer.java
+++ b/ergonomics/ide.ergonomics/src-ant/org/netbeans/modules/ide/ergonomics/ant/ExtractLayer.java
@@ -25,15 +25,19 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Spliterator;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import javax.imageio.ImageIO;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -527,10 +531,45 @@ implements FileNameMapper, URIResolver, EntityResolver {
         }
     }
 
-    private static final class ResArray extends ArrayList<Resource>
-    implements ResourceCollection {
+    private static final class ResArray implements ResourceCollection {
+        private final List<Resource> delegate = new ArrayList<>();
+
         public boolean isFilesystemOnly() {
             return false;
+        }
+
+        @Override
+        public int size() {
+            return delegate.size();
+        }
+
+        @Override
+        public Stream<? extends Resource> stream() {
+            return delegate.stream();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return delegate.isEmpty();
+        }
+
+        @Override
+        public Iterator<Resource> iterator() {
+            return delegate.iterator();
+        }
+
+        @Override
+        public void forEach(Consumer<? super Resource> action) {
+            delegate.forEach(action);
+        }
+
+        @Override
+        public Spliterator<Resource> spliterator() {
+            return delegate.spliterator();
+        }
+
+        public boolean add(Resource r) {
+            return delegate.add(r);
         }
     }
 

--- a/extra/libs.javafx.linux/manifest.mf
+++ b/extra/libs.javafx.linux/manifest.mf
@@ -5,5 +5,5 @@ OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/javafx/linux/Bundle.properti
 OpenIDE-Module-Fragment-Host: org.netbeans.libs.javafx
 OpenIDE-Module-Specification-Version: 13.7
 OpenIDE-Module-Java-Dependencies: Java > 11
-OpenIDE-Module-Needs: org.openide.modules.os.Linux
+OpenIDE-Module-Requires: org.openide.modules.os.Linux
 OpenIDE-Module-Provides: org.openide.modules.jre.JavaFX

--- a/extra/libs.javafx.macosx/manifest.mf
+++ b/extra/libs.javafx.macosx/manifest.mf
@@ -5,5 +5,5 @@ OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/javafx/macosx/Bundle.propert
 OpenIDE-Module-Fragment-Host: org.netbeans.libs.javafx
 OpenIDE-Module-Specification-Version: 13.7
 OpenIDE-Module-Java-Dependencies: Java > 11
-OpenIDE-Module-Needs: org.openide.modules.os.MacOSX
+OpenIDE-Module-Requires: org.openide.modules.os.MacOSX
 OpenIDE-Module-Provides: org.openide.modules.jre.JavaFX

--- a/extra/libs.javafx.win/manifest.mf
+++ b/extra/libs.javafx.win/manifest.mf
@@ -5,5 +5,5 @@ OpenIDE-Module-Localizing-Bundle: org/netbeans/libs/javafx/win/Bundle.properties
 OpenIDE-Module-Fragment-Host: org.netbeans.libs.javafx
 OpenIDE-Module-Specification-Version: 13.7
 OpenIDE-Module-Java-Dependencies: Java > 11
-OpenIDE-Module-Needs: org.openide.modules.os.Windows
+OpenIDE-Module-Requires: org.openide.modules.os.Windows
 OpenIDE-Module-Provides: org.openide.modules.jre.JavaFX

--- a/java/editor.htmlui/nbproject/project.properties
+++ b/java/editor.htmlui/nbproject/project.properties
@@ -18,4 +18,4 @@
 is.eager=true
 javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
-
+requires.nb.javac=true

--- a/java/form/src/org/netbeans/modules/form/resources/layer.xml
+++ b/java/form/src/org/netbeans/modules/form/resources/layer.xml
@@ -420,7 +420,6 @@
                 <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                 <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/form/resources/FormJApplet.html"/>
                 <attr name="SystemFileSystem.icon" urlvalue="nbresloc:/org/netbeans/modules/form/resources/palette/applet.gif"/>
-                <attr name="SystemFileSystem.icon32" urlvalue="nbresloc:/javax/swing/beaninfo/images/JAppletColor32.gif"/>
                 <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.java.source.queries.api.TemplateWizardFactory.create"/>
                 <attr name="templateCategory" stringvalue="java-forms"/>
                 <attr name="weight" intvalue="100"/>
@@ -584,7 +583,6 @@
                 <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                 <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/form/resources/FormApplet.html"/>
                 <attr name="SystemFileSystem.icon" urlvalue="nbresloc:/org/netbeans/modules/form/resources/palette/applet.gif"/>
-                <attr name="SystemFileSystem.icon32" urlvalue="nbresloc:/javax/swing/beaninfo/images/JAppletColor32.gif"/>
                 <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.java.source.queries.api.TemplateWizardFactory.create"/>
                 <attr name="templateCategory" stringvalue="java-forms,java-awt-forms"/>
                 <attr name="weight" intvalue="100"/>

--- a/java/java.source.base/src/org/netbeans/modules/java/source/PostFlowAnalysis.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/PostFlowAnalysis.java
@@ -28,7 +28,6 @@ import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.Enter;
 import com.sun.tools.javac.comp.Env;
-import com.sun.tools.javac.jvm.Pool;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
@@ -231,8 +230,9 @@ public class PostFlowAnalysis extends TreeScanner {
         outerThisStack = outerThisStack.prepend(outerThis);
     }
     
+    private static final int MAX_STRING_LENGTH = 65535;
     private void checkStringConstant(DiagnosticPosition pos, Object constValue) {
-        if (constValue instanceof String && ((String)constValue).length() >= Pool.MAX_STRING_LENGTH)
+        if (constValue instanceof String && ((String)constValue).length() >= MAX_STRING_LENGTH)
             log.error(pos, new Error("compiler", "limit.string")); //NOI18N
     }
 

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -86,7 +86,52 @@
         <property name="have-custom-javac-task" value="true" />
     </target>
 
-    <target name="build-init" depends="basic-init,jdk-8-check,set-buildnumber,-define-custom-javac-task">
+    <target name="-init-compile-bootclasspath-nb-vanilla" depends="basic-init,jdk-8-check,set-buildnumber,-define-custom-javac-task">
+        <property name="bootclasspath.prepend.nb" value="${nb_all}/java/libs.javacapi/external/nb-javac-15.0.0.2-api.jar${path.separator}${nb_all}/java/libs.javacimpl/external/nb-javac-15.0.0.2.jar" />
+        <property name="bootclasspath.prepend.vanilla" value="${nb_all}/nbbuild/external/vanilla-javac-api.jar${path.separator}${nb_all}/nbbuild/external/vanilla-javac-impl.jar" />
+    </target>
+    <target name="-init-bootclasspath-prepend-compile" depends="-init-compile-bootclasspath-nb-vanilla">
+        <condition property="bootclasspath.prepend" value="${bootclasspath.prepend.nb}">
+            <istrue value="${requires.nb.javac.impl}"/>
+        </condition>
+        <condition property="bootclasspath.prepend" value="${bootclasspath.prepend.vanilla}">
+            <istrue value="${requires.nb.javac}"/>
+        </condition>
+    </target>
+    <target name="-init-bootclasspath-prepend-run" depends="-init-bootclasspath-prepend-compile" unless="have-jdk-1.9">
+        <condition property="run.bootclasspath.prepend" value="${bootclasspath.prepend.nb}">
+            <istrue value="${requires.nb.javac.impl}"/>
+        </condition>
+        <condition property="run.bootclasspath.prepend" value="${bootclasspath.prepend.nb}">
+            <and>
+                <istrue value="${requires.nb.javac}"/>
+                <not>
+                    <istrue value="${test.use.jdk.javac}"/>
+                </not>
+            </and>
+        </condition>
+        <condition property="run.bootclasspath.prepend" value="${bootclasspath.prepend}">
+            <and>
+                <isset property="bootclasspath.prepend"/>
+                <not>
+                    <istrue value="${test.use.jdk.javac}"/>
+                </not>
+            </and>
+        </condition>
+        <condition property="test.extra.nb.javac.deps" value="${java.source.nbjavac.dir}/modules/org-netbeans-modules-java-source-nbjavac.jar">
+            <and>
+                <istrue value="${requires.nb.javac}"/>
+                <not>
+                    <istrue value="${test.use.jdk.javac}"/>
+                </not>
+            </and>
+        </condition>
+    </target>
+    <target name="-init-bootclasspath-prepend" depends="-init-bootclasspath-prepend-run,-init-bootclasspath-prepend-compile">
+        <!-- When requires.nb.javac property is true, prepend javac-api and javac-impl on bootclasspath to allow override the default annotation
+             processing API located in rt.jar. -->
+    </target>
+    <target name="build-init" depends="basic-init,jdk-8-check,set-buildnumber,-define-custom-javac-task,-init-bootclasspath-prepend">
         <property name="public.package.jar.dir" location="${nb.build.dir}/public-package-jars"/>
         <mkdir dir="${public.package.jar.dir}"/>
         <parseprojectxml
@@ -177,43 +222,6 @@
         <property name="locjhindexer.locales" value="${locales}"/>
         <property name="locmakenbm.locales" value="${locales}"/>
         <property name="locmakenbm.brands" value="${brandings}"/>
-        <!-- When requires.nb.javac property is true, prepend javac-api and javac-impl on bootclasspath to allow override the default annotation
-             processing API located in rt.jar. -->
-        <property name="bootclasspath.prepend.nb" value="${nb_all}/java/libs.javacapi/external/nb-javac-15.0.0.2-api.jar${path.separator}${nb_all}/java/libs.javacimpl/external/nb-javac-15.0.0.2.jar" />
-        <property name="bootclasspath.prepend.vanilla" value="${nb_all}/nbbuild/external/vanilla-javac-api.jar${path.separator}${nb_all}/nbbuild/external/vanilla-javac-impl.jar" />
-        <condition property="bootclasspath.prepend" value="${bootclasspath.prepend.nb}">
-            <istrue value="${requires.nb.javac.impl}"/>
-        </condition>
-        <condition property="bootclasspath.prepend" value="${bootclasspath.prepend.vanilla}">
-            <istrue value="${requires.nb.javac}"/>
-        </condition>
-        <condition property="run.bootclasspath.prepend" value="${bootclasspath.prepend.nb}">
-            <istrue value="${requires.nb.javac.impl}"/>
-        </condition>
-        <condition property="run.bootclasspath.prepend" value="${bootclasspath.prepend.nb}">
-            <and>
-                <istrue value="${requires.nb.javac}"/>
-                <not>
-                    <istrue value="${test.use.jdk.javac}"/>
-                </not>
-            </and>
-        </condition>
-        <condition property="run.bootclasspath.prepend" value="${bootclasspath.prepend}">
-            <and>
-                <isset property="bootclasspath.prepend"/>
-                <not>
-                    <istrue value="${test.use.jdk.javac}"/>
-                </not>
-            </and>
-        </condition>
-        <condition property="test.extra.nb.javac.deps" value="${java.source.nbjavac.dir}/modules/org-netbeans-modules-java-source-nbjavac.jar">
-            <and>
-                <istrue value="${requires.nb.javac}"/>
-                <not>
-                    <istrue value="${test.use.jdk.javac}"/>
-                </not>
-            </and>
-        </condition>
         <property name="test.extra.nb.javac.deps" value="" />
         <fail message="Delete standalone/suite-related metadata from netbeans.org modules">
             <condition>

--- a/platform/libs.javafx/manifest.mf
+++ b/platform/libs.javafx/manifest.mf
@@ -38,4 +38,4 @@ OpenIDE-Module-Provides: javafx.animation,
     javafx.util,
     javafx.util.converter,
     netscape.javascript
-Class-Path: %24%7Bjava.home%7D%2F/lib/ext/jfxrt.jar
+Class-Path: %24%7Bjava.home%7D/lib/ext/jfxrt.jar

--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -1698,7 +1698,8 @@ public final class ModuleManager extends Modules {
     private void maybeAddToEnableList(Set<Module> willEnable, Set<Module> mightEnable, Module m, boolean okToFail) {
         if (! missingDependencies(m).isEmpty()) {
             if (!okToFail) {
-                Util.err.warning("Module " + m + " had unexpected problems: " + missingDependencies(m) + " (willEnable: " + willEnable + " mightEnable: " + mightEnable + ")");
+                Util.err.warning("Module " + m + " had unexpected problems: " + missingDependencies(m));
+                Util.err.fine(" (willEnable: " + willEnable + " mightEnable: " + mightEnable + ")");
             }
             // Cannot satisfy its dependencies, exclude it.
             return;

--- a/platform/o.n.bootstrap/src/org/netbeans/Util.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/Util.java
@@ -139,9 +139,10 @@ public final class Util {
                 sampleName = packageName + '.' + sampleName;
             }
         }
+        Class<?> sampleClass = null;
         if (sampleName != null) {
             try {
-                cl.loadClass(sampleName);
+                sampleClass = cl.loadClass(sampleName);
             } catch (ClassNotFoundException cnfe) {
                 if (packageName == null) {
                     // This was all we were relying on, so it is an error.
@@ -169,6 +170,9 @@ public final class Util {
                 pkg = ((ProxyClassLoader) cl).getPackage(packageName);
             } else {
                 pkg = Package.getPackage(packageName);
+            }
+            if (pkg == null && sampleClass != null) {
+                pkg = sampleClass.getPackage();
             }
             if (pkg == null) {
                 err.fine("No package with the name " + packageName + " found");


### PR DESCRIPTION
I am in a need to test `java.mx.projects` module on JDK15+ and I realized that our testing framework isn't really easy to use on JDK11+. As such I decided to return back to basics and fix at least commit validation. The first commit enables `ant commit-validation` on JDK15. Subsequent commits will fix the failures.