### PR TITLE
Branded in "Trust all gradle" button.

### DIFF
--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-gradle.jar/org/netbeans/modules/gradle/api/execute/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-gradle.jar/org/netbeans/modules/gradle/api/execute/Bundle.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+org.netbeans.modules.gradle.api.execute.TrustProjectOption.TrustOnce=1
+org.netbeans.modules.gradle.api.execute.TrustProjectOption.PermanentTrust=-2
+org.netbeans.modules.gradle.api.execute.TrustProjectOption.RunAlways=3


### PR DESCRIPTION
This is an option that is available in NetBeans IDE, but not accessible in LSP client.