### PR TITLE
Improving appearance and behavior of the prepended virtual text.

### DIFF
--- a/ide/editor.lib/src/org/netbeans/editor/BaseKit.java
+++ b/ide/editor.lib/src/org/netbeans/editor/BaseKit.java
@@ -2992,7 +2992,9 @@ public class BaseKit extends DefaultEditorKit {
                                 editorCaret.moveCarets(new CaretMoveHandler() {
                                     @Override
                                     public void moveCarets(CaretMoveContext context) {
+                                        Position.Bias[] biasRet = new Position.Bias[1];
                                         for (CaretInfo caretInfo : context.getOriginalSortedCarets()) {
+                                            biasRet[0] = Position.Bias.Forward; // Initial value in case it would stay non-updated
                                             try {
                                                 if (!select && caretInfo.isSelection()) {
                                                     int offset = caretInfo.getSelectionEnd();
@@ -3000,12 +3002,12 @@ public class BaseKit extends DefaultEditorKit {
                                                 } else {
                                                     int offset = caretInfo.getDot();
                                                     offset = target.getUI().getNextVisualPositionFrom(target,
-                                                            offset, Position.Bias.Forward, SwingConstants.EAST, null);
+                                                            offset, caretInfo.getDotBias(), SwingConstants.EAST, biasRet);
                                                     Position dotPos = doc.createPosition(offset);
                                                     if (select) {
-                                                        context.moveDot(caretInfo, dotPos, Position.Bias.Forward);
+                                                        context.moveDot(caretInfo, dotPos, biasRet[0]);
                                                     } else {
-                                                        context.setDot(caretInfo, dotPos, Position.Bias.Forward);
+                                                        context.setDot(caretInfo, dotPos, biasRet[0]);
                                                     }
                                                 }
                                             } catch (BadLocationException ex) {
@@ -3283,7 +3285,9 @@ public class BaseKit extends DefaultEditorKit {
                                 editorCaret.moveCarets(new CaretMoveHandler() {
                                     @Override
                                     public void moveCarets(CaretMoveContext context) {
+                                        Position.Bias[] biasRet = new Position.Bias[1];
                                         for (CaretInfo caretInfo : context.getOriginalSortedCarets()) {
+                                            biasRet[0] = Position.Bias.Forward; // Initial value in case it would stay non-updated
                                             try {
                                                 if (!select && caretInfo.isSelection()) {
                                                     int offset = caretInfo.getSelectionStart();
@@ -3291,12 +3295,12 @@ public class BaseKit extends DefaultEditorKit {
                                                 } else {
                                                     int offset = caretInfo.getDot();
                                                     offset = target.getUI().getNextVisualPositionFrom(target,
-                                                            offset, Position.Bias.Backward, SwingConstants.WEST, null);
+                                                            offset, caretInfo.getDotBias(), SwingConstants.WEST, biasRet);
                                                     Position dotPos = doc.createPosition(offset);
                                                     if (select) {
-                                                        context.moveDot(caretInfo, dotPos, Position.Bias.Forward);
+                                                        context.moveDot(caretInfo, dotPos, biasRet[0]);
                                                     } else {
-                                                        context.setDot(caretInfo, dotPos, Position.Bias.Forward);
+                                                        context.setDot(caretInfo, dotPos, biasRet[0]);
                                                     }
                                                 }
                                             } catch (BadLocationException ex) {

--- a/ide/editor.lib2/src/org/netbeans/api/editor/caret/CaretItem.java
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/caret/CaretItem.java
@@ -203,8 +203,16 @@ final class CaretItem implements Comparable {
         this.dotPos = dotPos;
     }
 
+    public void setDotBias(Position.Bias dotBias) {
+        this.dotBias = dotBias;
+    }
+
     void setMarkPos(Position markPos) {
         this.markPos = markPos;
+    }
+
+    public void setMarkBias(Position.Bias markBias) {
+        this.markBias = markBias;
     }
 
     void setMagicCaretPosition(Point newMagicCaretPosition) { // [TODO] move to transaction context

--- a/ide/editor.lib2/src/org/netbeans/api/editor/caret/CaretMoveContext.java
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/caret/CaretMoveContext.java
@@ -94,7 +94,7 @@ public final class CaretMoveContext {
         NavigationFilter naviFilter = transaction.getCaret().getNavigationFilterNoDefault(transaction.getOrigin());
         if (naviFilter != null) {
             FilterBypassImpl fbi = new FilterBypassImpl(transaction, caret, transaction.getDocument());
-            naviFilter.setDot(fbi, dotPos.getOffset(), Position.Bias.Forward);
+            naviFilter.setDot(fbi, dotPos.getOffset(), Position.Bias.Forward);//XXX: forward!
             return fbi.getResult();
         } else {
             return setDotAndMark(caret, dotPos, dotBias, dotPos, dotBias);

--- a/ide/editor.lib2/src/org/netbeans/api/editor/caret/CaretTransaction.java
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/caret/CaretTransaction.java
@@ -180,11 +180,13 @@ final class CaretTransaction {
                 }
                 if (dotChanged) {
                     caretItem.setDotPos(dotPos);
+                    caretItem.setDotBias(dotBias);
                     expandFoldPositions.add(dotPos);
                     anyDotChanged = true;
                 }
                 if (markChanged) {
                     caretItem.setMarkPos(markPos);
+                    caretItem.setMarkBias(markBias);
                     expandFoldPositions.add(markPos);
                     anyMarkChanged = true;
                 }

--- a/ide/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
+++ b/ide/editor.lib2/src/org/netbeans/api/editor/caret/EditorCaret.java
@@ -1099,7 +1099,8 @@ public final class EditorCaret implements Caret {
                     // since they were not visible up to this moment.
                     if (caretItem.getAndClearUpdateCaretBounds()) {
                         int dot = caretItem.getDot();
-                        Rectangle newCaretBounds = lvh.modelToViewBounds(dot, Position.Bias.Forward);
+                        Position.Bias dotBias = caretItem.getDotBias();
+                        Rectangle newCaretBounds = lvh.modelToViewBounds(dot, dotBias);
                         Rectangle oldBounds = caretItem.setCaretBoundsWithRepaint(newCaretBounds, c, "EditorCaret.paint()", i);
                         if (caretItem == lastCaret && oldBounds != null) {
                             maybeSaveCaretOffset(oldBounds);
@@ -1638,7 +1639,7 @@ public final class EditorCaret implements Caret {
                                 setRectangularSelectionToDotAndMark();
                             } else {
                                 try {
-                                    Rectangle r = c.modelToView(getLastCaretItem().getDot());
+                                    Rectangle r = c.modelToView(getLastCaretItem().getDot()); //TODO: bias?
                                     if (rsDotRect != null) {
                                         rsDotRect.y = r.y;
                                         rsDotRect.height = r.height;
@@ -2037,7 +2038,7 @@ public final class EditorCaret implements Caret {
                         Rectangle caretBounds;
                         Rectangle oldCaretBounds;
                         if (lastCaretItem.getAndClearUpdateCaretBounds()) {
-                            caretBounds = lvh.modelToViewBounds(lastCaretItem.getDot(), Position.Bias.Forward);
+                            caretBounds = lvh.modelToViewBounds(lastCaretItem.getDot(), lastCaretItem.getDotBias());
                             oldCaretBounds = lastCaretItem.setCaretBoundsWithRepaint(caretBounds, c, "update()-last-for-scroll", -2);
                         } else {
                             caretBounds = lastCaretItem.getCaretBounds();
@@ -2163,7 +2164,7 @@ public final class EditorCaret implements Caret {
                         CaretItem caretItem = caretInfo.getCaretItem();
                         Rectangle caretBounds = null;
                         if (caretItem.getAndClearUpdateCaretBounds()) {
-                            caretBounds = lvh.modelToViewBounds(caretItem.getDot(), Position.Bias.Forward);
+                            caretBounds = lvh.modelToViewBounds(caretItem.getDot(), caretItem.getDotBias());
                             caretItem.setCaretBoundsWithRepaint(caretBounds, c, "EditorCaret.update()", i);                            
                         }
                         if (i > 0) {

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsViewFactory.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/HighlightsViewFactory.java
@@ -190,7 +190,7 @@ public final class HighlightsViewFactory extends EditorViewFactory implements Hi
         }
         if (startOffset == lineEndOffset - 1) {
             AttributeSet attrs = hList.cutSingleChar();
-            return wrapWithPrependedText(new NewlineView(attrs), attrs);
+            return wrapWithPrependedText(new NewlineView(attrs), attrs, true);
         } else { // Regular view with possible highlight(s) or tab view
             updateTabsAndHighlightsAndRTL(startOffset);
             if (charType == TAB_CHAR_TYPE) {
@@ -200,7 +200,7 @@ public final class HighlightsViewFactory extends EditorViewFactory implements Hi
                     limitOffset = tabsEndOffset;
                 }
                 attrs = hList.cut(limitOffset);
-                return wrapWithPrependedText(new TabView(limitOffset - startOffset, attrs), attrs);
+                return wrapWithPrependedText(new TabView(limitOffset - startOffset, attrs), attrs, false);
 
             } else { // Create regular view with either LTR or RTL text
                 limitOffset = Math.min(limitOffset, nextTabOrRTLOffset); // nextTabOrRTLOffset < lineEndOffset 
@@ -221,7 +221,7 @@ public final class HighlightsViewFactory extends EditorViewFactory implements Hi
                 boolean inlineHints = documentView().op.isInlineHintsEnable();
                 AttributeSet attrs = hList.cutSameFont(defaultFont, limitOffset, wsEndOffset, docText, inlineHints);
                 int length = hList.startOffset() - startOffset;
-                EditorView view = wrapWithPrependedText(new HighlightsView(length, attrs), attrs);
+                EditorView view = wrapWithPrependedText(new HighlightsView(length, attrs), attrs, false);
                 EditorView origViewUnwrapped = origView instanceof PrependedTextView ? ((PrependedTextView) origView).getDelegate() : origView;
                 if (origViewUnwrapped != null && origViewUnwrapped.getClass() == HighlightsView.class && origViewUnwrapped.getLength() == length) {
                     HighlightsView origHView = (HighlightsView) origViewUnwrapped;
@@ -254,11 +254,11 @@ public final class HighlightsViewFactory extends EditorViewFactory implements Hi
         }
     }
 
-    private @NonNull EditorView wrapWithPrependedText(@NonNull EditorView origView, @NullAllowed AttributeSet attrs) {
+    private @NonNull EditorView wrapWithPrependedText(@NonNull EditorView origView, @NullAllowed AttributeSet attrs, boolean newLineView) {
         boolean inlineHints = documentView().op.isInlineHintsEnable();
 
         if (attrs != null && inlineHints && attrs.getAttribute(ViewUtils.KEY_VIRTUAL_TEXT_PREPEND) instanceof String) {
-            return new PrependedTextView(documentView().op, attrs, origView);
+            return new PrependedTextView(documentView().op, attrs, origView, newLineView);
         }
 
         return origView;

--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/PrependedTextView.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/view/PrependedTextView.java
@@ -26,10 +26,18 @@ import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.font.TextLayout;
 import java.awt.geom.Rectangle2D;
+import java.util.Objects;
+import javax.swing.SwingConstants;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.Position;
 import javax.swing.text.Position.Bias;
+import javax.swing.text.StyleConstants;
 import javax.swing.text.View;
+import org.netbeans.api.editor.settings.AttributesUtilities;
+import org.netbeans.api.editor.settings.EditorStyleConstants;
+import org.netbeans.modules.editor.lib2.highlighting.DirectMergeContainer;
+import org.netbeans.modules.editor.lib2.highlighting.HighlightingManager;
+import org.netbeans.spi.editor.highlighting.HighlightsContainer;
 import org.netbeans.spi.editor.highlighting.HighlightsSequence;
 
 /**
@@ -39,14 +47,16 @@ public final class PrependedTextView extends EditorView {
 
     private final AttributeSet attributes;
     private final EditorView delegate;
+    private final boolean newLineView;
     private final TextLayout prependedTextLayout;
     private final double leftShift;
     private final double prependedTextWidth;
 
-    public PrependedTextView(DocumentViewOp op, AttributeSet attributes, EditorView delegate) {
+    public PrependedTextView(DocumentViewOp op, AttributeSet attributes, EditorView delegate, boolean newLineView) {
         super(null);
         this.attributes = attributes;
         this.delegate = delegate;
+        this.newLineView = newLineView;
         Font font = ViewUtils.getFont(attributes, op.getDefaultHintFont());
         prependedTextLayout = op.createTextLayout((String) attributes.getAttribute(ViewUtils.KEY_VIRTUAL_TEXT_PREPEND), font);
         Rectangle2D textBounds = prependedTextLayout.getBounds(); //TODO: allocation!
@@ -73,7 +83,11 @@ public final class PrependedTextView extends EditorView {
     public Shape modelToViewChecked(int offset, Shape alloc, Bias bias) {
         Shape res = delegate.modelToViewChecked(offset, alloc, bias);
         Rectangle2D rect = ViewUtils.shapeAsRect(res);
-        rect.setRect(rect.getX() + prependedTextWidth, rect.getY(), rect.getWidth(), rect.getHeight());
+        if (newLineView) {
+            rect.setRect(rect.getX(), rect.getY(), rect.getWidth() + prependedTextWidth, rect.getHeight());
+        } else {
+            rect.setRect(rect.getX() + (bias == Bias.Backward ? 0 : prependedTextWidth), rect.getY(), rect.getWidth() + (bias == Bias.Backward ? prependedTextWidth : 0), rect.getHeight());
+        }
         return rect;
     }
 
@@ -81,15 +95,64 @@ public final class PrependedTextView extends EditorView {
     public void paint(Graphics2D g, Shape hViewAlloc, Rectangle clipBounds) {
         Rectangle2D span = ViewUtils.shapeAsRect(hViewAlloc);
         span.setRect(span.getX() + prependedTextWidth, span.getY(), span.getWidth() - prependedTextWidth, span.getHeight());
+        PaintState saved = PaintState.save(g);
         delegate.paint(g, span, clipBounds);
+        saved.restore();
         span.setRect(span.getX() - prependedTextWidth, span.getY(), prependedTextWidth, span.getHeight());
 
-        HighlightsSequence highlights = getDocumentView().getPaintHighlights(this, 0);
+        HighlightsSequence thisViewHighlights = getDocumentView().getPaintHighlights(this, 0);
 
-        if (highlights.moveNext()) {
-            AttributeSet attrs = highlights.getAttributes();
-            HighlightsViewUtils.fillBackground(g, span, attrs, getDocumentView().getTextComponent());
-            HighlightsViewUtils.paintBackgroundHighlights(g, span, attrs, getDocumentView()); //TODO: clear some attributes (like boxes)???
+        if (thisViewHighlights.moveNext()) {
+            int thisIndex = getParagraphView().children.indexOf(this);
+            EditorView previousView = thisIndex > 0 ? getParagraphView().children.get(thisIndex - 1) : null;
+            AttributeSet attrs = thisViewHighlights.getAttributes();
+            AttributeSet prevAttrs;
+            if (previousView != null) {
+                HighlightsSequence prevViewHighlights = getDocumentView().getPaintHighlights(previousView, previousView.getLength() - 1);
+                if (prevViewHighlights.moveNext()) {
+                    prevAttrs = prevViewHighlights.getAttributes();
+                } else {
+                    prevAttrs = AttributesUtilities.createImmutable();
+                }
+            } else {
+                prevAttrs = AttributesUtilities.createImmutable();
+            }
+            Color thisBackground = (Color) attrs.getAttribute(StyleConstants.Background);
+            Color prevBackground = (Color) prevAttrs.getAttribute(StyleConstants.Background);
+            Color background;
+
+            if (!newLineView && !Objects.equals(thisBackground, prevBackground)) {
+                background = null;
+                HighlightsContainer[] layers = ((DirectMergeContainer) HighlightingManager.getInstance(getDocumentView().getTextComponent()).
+                        getTopHighlights()).getLayers();
+                for (HighlightsContainer l : layers) {
+                    int min = Math.max(delegate.getStartOffset() - 1, getParagraphView().getStartOffset());
+                    int max = delegate.getStartOffset() + 1;
+                    HighlightsSequence backgroundHighlight = l.getHighlights(min, max);
+                    if (backgroundHighlight.moveNext() &&
+                        backgroundHighlight.getStartOffset()== min &&
+                        backgroundHighlight.getEndOffset() == max) {
+                        AttributeSet backgroundAttrs = backgroundHighlight.getAttributes();
+                        if (backgroundAttrs != null && Boolean.TRUE.equals(backgroundAttrs.getAttribute(HighlightsContainer.ATTR_EXTENDS_EOL))) {
+                            Color thisContainerBackground = (Color) backgroundAttrs.getAttribute(StyleConstants.Background);
+                            if (thisContainerBackground != null) {
+                                background = thisContainerBackground;
+                            }
+                        }
+                    }
+                }
+            } else {
+                background = thisBackground;
+            }
+
+            //TODO: borders, underline, strike-through?
+            Color thisWaveUnderline = (Color) attrs.getAttribute(EditorStyleConstants.WaveUnderlineColor);
+            Color prevWaveUnderline = (Color) prevAttrs.getAttribute(EditorStyleConstants.WaveUnderlineColor);
+            Color waveUnderline = Objects.equals(thisWaveUnderline, prevWaveUnderline) ? thisWaveUnderline : null;
+
+            AttributeSet real = AttributesUtilities.createImmutable(StyleConstants.Background, background, EditorStyleConstants.WaveUnderlineColor, waveUnderline);
+            HighlightsViewUtils.fillBackground(g, span, real, getDocumentView().getTextComponent());
+            HighlightsViewUtils.paintBackgroundHighlights(g, span, real, getDocumentView());
         }
 
         g.setColor(Color.gray);
@@ -150,6 +213,25 @@ public final class PrependedTextView extends EditorView {
 
     EditorView getDelegate() {
         return delegate;
+    }
+
+    @Override
+    public int getNextVisualPositionFromChecked(int offset, Bias bias, Shape alloc, int direction, Bias[] biasRet) {
+        if (!newLineView) {
+            if (offset == getStartOffset() && bias == Bias.Forward && direction == SwingConstants.WEST) {
+                biasRet[0] = Bias.Backward;
+                return offset;
+            }
+            if (offset == -1 && bias == Bias.Forward && direction == SwingConstants.EAST) {
+                biasRet[0] = Bias.Backward;
+                return getStartOffset();
+            }
+            if (offset == getStartOffset() && bias == Bias.Backward && direction == SwingConstants.EAST) {
+                biasRet[0] = Bias.Forward;
+                return offset;
+            }
+        }
+        return super.getNextVisualPositionFromChecked(offset, bias, alloc, direction, biasRet);
     }
 
 }


### PR DESCRIPTION
With the prepended text (like inline parameter names in Java editor), there are several appearance and behavior issues, like:
-mark occurrences highlight will be painted under the prepended text, not only for the actual identifier, which I think does not look good.
-when navigating with left/right arrows around the prepended text, the cursor jumps weirdly.

The patch here is trying to solve that, but using only basic background highlights for the prepended text (which, to me, looks better when used; even though the implementation is not so nice), and cursor should now have an ability to stop before and after the prepended text.

Feedback/experience with this are welcome!

Thanks!