### PR TITLE
Offer to trust and prime the project when it is being opened.

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/Bundle.properties
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/Bundle.properties
@@ -56,6 +56,7 @@ BTN_PrjChooser_ApproveButtonTooltipText=Opens the project located in the selecte
 MNM_PrjChooser_ApproveButtonText=O
 LBL_PrjChooser_ProjectDirectoryFilter_Name=Project Folder
 LBL_PrjChooser_ProjectName_Label=&Project Name\:
+LBL_PrjChooser_Prime_CheckBox=&Trust and prime the project
 LBL_PrjChooser_Subprojects_CheckBox=Open &Required Projects\:
 MSG_PrjChooser_WaitMessage=Please wait ...
 # {0} number of projects

--- a/ide/projectui/src/org/netbeans/modules/project/ui/Bundle.properties
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/Bundle.properties
@@ -56,7 +56,8 @@ BTN_PrjChooser_ApproveButtonTooltipText=Opens the project located in the selecte
 MNM_PrjChooser_ApproveButtonText=O
 LBL_PrjChooser_ProjectDirectoryFilter_Name=Project Folder
 LBL_PrjChooser_ProjectName_Label=&Project Name\:
-LBL_PrjChooser_Prime_CheckBox=&Trust and prime the project
+LBL_PrjChooser_Prime_CheckBox=&Trust Project Build Script
+LBL_PrjChooser_Prime_CheckBoxTooltipText=A project's build script might execute foreign code with full permissions.
 LBL_PrjChooser_Subprojects_CheckBox=Open &Required Projects\:
 MSG_PrjChooser_WaitMessage=Please wait ...
 # {0} number of projects

--- a/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
@@ -709,7 +709,7 @@ public final class OpenProjectList {
                 }
                 if (prime) {
                     ActionProvider ap = p2.getLookup().lookup(ActionProvider.class);
-                    if (ap.isActionEnabled(ActionProvider.COMMAND_PRIME, p2.getLookup())) {
+                    if (ap != null && ap.isActionEnabled(ActionProvider.COMMAND_PRIME, p2.getLookup())) {
                         ap.invokeAction(ActionProvider.COMMAND_PRIME, p2.getLookup());
                     }
                 }

--- a/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectListSettings.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectListSettings.java
@@ -28,8 +28,6 @@ import java.util.List;
 import java.io.File;
 import java.util.prefs.Preferences;
 import javax.swing.filechooser.FileSystemView;
-import org.netbeans.api.project.ui.OpenProjects;
-import org.netbeans.api.project.ui.ProjectGroup;
 import org.netbeans.modules.project.ui.groups.Group;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
@@ -52,6 +50,7 @@ public class OpenProjectListSettings {
     private static final String OPEN_PROJECTS_DISPLAY_NAMES = "openProjectsDisplayNames"; //NOI18N - List of names
     private static final String OPEN_PROJECTS_ICONS = "openProjectsIcons"; //NOI18N - List of icons
     private static final String OPEN_SUBPROJECTS = "openSubprojects"; //NOI18N - boolean
+    private static final String TRUST_AND_PRIME = "trustAndPrime"; //NOI18N - boolean
     private static final String PROP_PROJECTS_FOLDER = "projectsFolder"; //NOI18N - String
     private static final String RECENT_PROJECTS_URLS = "recentProjectsURLs"; //NOI18N List of URLs
     private static final String RECENT_TEMPLATES = "recentTemplates"; // NOI18N -List of Strings
@@ -238,7 +237,15 @@ public class OpenProjectListSettings {
     public void setOpenSubprojects( boolean openSubprojects ) {
         getPreferences().putBoolean(OPEN_SUBPROJECTS, openSubprojects);
     }
-    
+
+    public boolean isTrustAndPrime() {
+        return getPreferences().getBoolean(TRUST_AND_PRIME, true);
+    }
+
+    public void setTrustAndPrime( boolean openSubprojects ) {
+        getPreferences().putBoolean(TRUST_AND_PRIME, openSubprojects);
+    }
+
     public URL getMainProjectURL() {
         String str = getProperty(MAIN_PROJECT_URL);
         if (str != null) {

--- a/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectListSettings.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectListSettings.java
@@ -239,7 +239,7 @@ public class OpenProjectListSettings {
     }
 
     public boolean isTrustAndPrime() {
-        return getPreferences().getBoolean(TRUST_AND_PRIME, true);
+        return getPreferences().getBoolean(TRUST_AND_PRIME, false);
     }
 
     public void setTrustAndPrime( boolean openSubprojects ) {

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.form
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.form
@@ -84,6 +84,9 @@
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/project/ui/Bundle.properties" key="LBL_PrjChooser_Prime_CheckBox" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
+        <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/project/ui/Bundle.properties" key="LBL_PrjChooser_Prime_CheckBoxTooltipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
         <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
           <Insets value="[2, 0, 2, 2]"/>
         </Property>

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.form
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.form
@@ -79,6 +79,24 @@
         </Constraint>
       </Constraints>
     </Component>
+    <Component class="javax.swing.JCheckBox" name="jCheckBoxPrime">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/project/ui/Bundle.properties" key="LBL_PrjChooser_Prime_CheckBox" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+        <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
+          <Insets value="[2, 0, 2, 2]"/>
+        </Property>
+      </Properties>
+      <AuxValues>
+        <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
+      </AuxValues>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="-1" gridY="-1" gridWidth="0" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="2" insetsRight="0" anchor="18" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
     <Component class="javax.swing.JCheckBox" name="jCheckBoxSubprojects">
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
@@ -139,6 +139,7 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
         add(jTextFieldProjectName, gridBagConstraints);
 
         org.openide.awt.Mnemonics.setLocalizedText(jCheckBoxPrime, org.openide.util.NbBundle.getMessage(ProjectChooserAccessory.class, "LBL_PrjChooser_Prime_CheckBox")); // NOI18N
+        jCheckBoxPrime.setToolTipText(org.openide.util.NbBundle.getMessage(ProjectChooserAccessory.class, "LBL_PrjChooser_Prime_CheckBoxTooltipText")); // NOI18N
         jCheckBoxPrime.setMargin(new java.awt.Insets(2, 0, 2, 2));
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
@@ -73,7 +73,7 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
 
     private Map<Project,Set<? extends Project>> subprojectsCache = new HashMap<Project,Set<? extends Project>>(); // #59098
     /** Creates new form ProjectChooserAccessory */
-    public ProjectChooserAccessory(JFileChooser chooser, boolean isOpenSubprojects) {
+    public ProjectChooserAccessory(JFileChooser chooser, boolean isOpenSubprojects, boolean trustAndPrime) {
         initComponents();
 
         modelUpdater = new ModelUpdater();
@@ -86,6 +86,9 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
         // Listen on the subproject checkbox to change the option accordingly
         jCheckBoxSubprojects.setSelected( isOpenSubprojects );
         jCheckBoxSubprojects.addActionListener( this );
+
+        jCheckBoxPrime.setSelected(trustAndPrime);
+        jCheckBoxPrime.addActionListener(this);
 
         // Listen on the chooser to update the Accessory
         chooser.addPropertyChangeListener( this );
@@ -109,6 +112,7 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
 
         jLabelProjectName = new javax.swing.JLabel();
         jTextFieldProjectName = new javax.swing.JTextField();
+        jCheckBoxPrime = new javax.swing.JCheckBox();
         jCheckBoxSubprojects = new javax.swing.JCheckBox();
         jScrollPaneSubprojects = new javax.swing.JScrollPane();
         jListSubprojects = new javax.swing.JList();
@@ -133,6 +137,14 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 6, 0);
         add(jTextFieldProjectName, gridBagConstraints);
+
+        org.openide.awt.Mnemonics.setLocalizedText(jCheckBoxPrime, org.openide.util.NbBundle.getMessage(ProjectChooserAccessory.class, "LBL_PrjChooser_Prime_CheckBox")); // NOI18N
+        jCheckBoxPrime.setMargin(new java.awt.Insets(2, 0, 2, 2));
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridwidth = java.awt.GridBagConstraints.REMAINDER;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.insets = new java.awt.Insets(0, 0, 2, 0);
+        add(jCheckBoxPrime, gridBagConstraints);
 
         org.openide.awt.Mnemonics.setLocalizedText(jCheckBoxSubprojects, org.openide.util.NbBundle.getMessage(ProjectChooserAccessory.class, "LBL_PrjChooser_Subprojects_CheckBox")); // NOI18N
         jCheckBoxSubprojects.setMargin(new java.awt.Insets(2, 0, 2, 2));
@@ -160,6 +172,7 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
 
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private javax.swing.JCheckBox jCheckBoxPrime;
     private javax.swing.JCheckBox jCheckBoxSubprojects;
     private javax.swing.JLabel jLabelProjectName;
     private javax.swing.JList jListSubprojects;
@@ -173,6 +186,9 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
     public void actionPerformed( ActionEvent e ) {
         if ( e.getSource() == jCheckBoxSubprojects ) {
             OpenProjectListSettings.getInstance().setOpenSubprojects( jCheckBoxSubprojects.isSelected() );
+        }
+        if (e.getSource() == jCheckBoxPrime) {
+            OpenProjectListSettings.getInstance().setTrustAndPrime(jCheckBoxPrime.isSelected());
         }
     }
 
@@ -342,6 +358,7 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
         jTextFieldProjectName.setEnabled( enable );
         jTextFieldProjectName.setForeground(/* i.e. L&F default */null);
         jCheckBoxSubprojects.setEnabled( enable );
+        jCheckBoxPrime.setEnabled(enable);
         jScrollPaneSubprojects.setEnabled( enable );
     }
 
@@ -426,7 +443,7 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
 
 
         if ( defaultAccessory ) {
-            chooser.setAccessory(new ProjectChooserAccessory(chooser, opls.isOpenSubprojects()));
+            chooser.setAccessory(new ProjectChooserAccessory(chooser, opls.isOpenSubprojects(), opls.isTrustAndPrime()));
         }
 
         File currDir = null;

--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/NewProject.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/NewProject.java
@@ -196,7 +196,7 @@ public class NewProject extends AbstractAction {
                             mainProject = lastProject;
                         }
                         
-                        OpenProjectList.getDefault().open(projectsToOpen.toArray(new Project[0]), false, true, mainProject);
+                        OpenProjectList.getDefault().open(projectsToOpen.toArray(new Project[0]), false, false, true, mainProject);
                         
         EventQueue.invokeLater( new Runnable() {
             @Override public void run() {

--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/OpenProject.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/OpenProject.java
@@ -165,6 +165,7 @@ public class OpenProject extends BasicAction {
                             });
                             OpenProjectList.getDefault().open( 
                                 projectsArray,                    // Put the project into OpenProjectList
+                                opls.isTrustAndPrime(),
                                 opls.isOpenSubprojects(),         // And optionaly open subprojects
                                 true,                             // open asynchronously
                                 null);

--- a/ide/projectui/src/org/netbeans/modules/project/ui/groups/Group.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/groups/Group.java
@@ -587,7 +587,7 @@ public abstract class Group {
                 h.switchToIndeterminate();
                 h.progress(Group_progress_opening(toOpen.size()));
                 //open the projects with current group
-                opl.open(toOpen.toArray(new Project[toOpen.size()]), false, h, null);
+                opl.open(toOpen.toArray(new Project[toOpen.size()]), false, false, h, null);
                 
                 if(!isNewGroup) {
                     //for old and new group project intersection, save the old files list,

--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectChooserAccessoryTest.java
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/ProjectChooserAccessoryTest.java
@@ -66,7 +66,7 @@ public class ProjectChooserAccessoryTest extends NbTestCase {
         
         List<Project> result = new ArrayList<Project>();
         //#101227
-        ProjectChooserAccessory acc = new ProjectChooserAccessory(new JFileChooser(), false);
+        ProjectChooserAccessory acc = new ProjectChooserAccessory(new JFileChooser(), false, true);
         acc.modelUpdater.addSubprojects(p1, result, new HashMap<Project,Set<? extends Project>>());
         
         assertTrue(new HashSet<Project>(Arrays.asList(p1, p2)).equals(new HashSet<Project>(result)));

--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
@@ -247,7 +247,7 @@ final class SuiteActionProvider implements ActionProvider {
             case ActionProvider.COMMAND_DEBUG_SINGLE:
                 return fo != null;
             default:
-                return true;
+                return false;
         }
     }
 }

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/action/ClientSideProjectActionProvider.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ui/action/ClientSideProjectActionProvider.java
@@ -120,7 +120,8 @@ public class ClientSideProjectActionProvider implements ActionProvider {
             // debug can be supported only by browser or platform command (but see #addDebugCommands())
             return false;
         }
-        return getCommand(commandId).isActionEnabled(lookup);
+        Command cmd = commands.get(commandId);
+        return cmd != null && cmd.isActionEnabled(lookup);
     }
 
     @Override


### PR DESCRIPTION
Sváťa exposed existing Maven concept of priming build as an action in #2795. Support for such action is making its way throughout other project types (#2816) and I believe it is time to use the new API to improve user experience in NetBeans IDE! Let's add a _trust and prime_ checkbox to the following dialog:

![obrazek](https://user-images.githubusercontent.com/26887752/111897079-1de30000-8a1e-11eb-9fcf-48aa4614880d.png)

NetBeans pays quite a lot of attention to security of its users. NetBeans does its best to shield developers against attacks like [CVE-2020-11986](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-11986). Clearly a user consent is needed to execute anything from the build. The IDE cannot execute random scripts when users are searching directories (via Favorites window) or opening random text files (via CLI or _File/Open_).

However users of other IDEs are surprised by questions that usually arise after a project is opened - it seems that other IDEs consider adding a project into a workspace or opening new window with a project an enough consent to trust the project.

I believe we can do the same in NetBeans. The _File/Open Project_ dialog/action is explicit enough consent to start trusting the project and perform the `COMMAND_PRIME` to download necessary libraries on disk. To stress that the trust is being granted I propose to add a checkbox (selected by default) into the project open dialog.

