### PR TITLE
Change invokeLaters to Mutex.EVENT.

### DIFF
--- a/java/java.source/src/org/netbeans/api/java/source/UiUtils.java
+++ b/java/java.source/src/org/netbeans/api/java/source/UiUtils.java
@@ -34,7 +34,6 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 import javax.swing.Icon;
-import javax.swing.SwingUtilities;
 import javax.swing.text.StyledDocument;
 import org.netbeans.modules.java.source.pretty.VeryPretty;
 import org.netbeans.modules.java.source.save.DiffContext;
@@ -50,6 +49,7 @@ import org.openide.text.Line;
 import org.openide.text.Line.ShowOpenType;
 import org.openide.text.Line.ShowVisibilityType;
 import org.openide.text.NbDocument;
+import org.openide.util.Mutex;
 import org.openide.util.NbBundle;
 import org.openide.util.UserQuestionException;
 
@@ -377,27 +377,13 @@ public final class  UiUtils {
     }
     
     private static void doShow(final Line l, final int column) {
-        if (SwingUtilities.isEventDispatchThread()) {
-            l.show(ShowOpenType.OPEN, ShowVisibilityType.FOCUS, column);
-        } else {
-            SwingUtilities.invokeLater(new Runnable() {
-                public void run() {
-                    l.show(ShowOpenType.OPEN, ShowVisibilityType.FOCUS, column);
-                }
-            });
-        }
+        Mutex.EVENT.readAccess(() ->
+            l.show(ShowOpenType.OPEN, ShowVisibilityType.FOCUS, column)
+        );
     }
 
     private static void doOpen(final OpenCookie oc) {
-        if (SwingUtilities.isEventDispatchThread()) {
-            oc.open();
-        } else {
-            SwingUtilities.invokeLater(new Runnable() {
-                public void run() {
-                    oc.open();
-                }
-            });
-        }
+        Mutex.EVENT.readAccess(oc::open);
     }
     
     private static int getOffset(FileObject fo, final ElementHandle<? extends Element> handle) throws IOException {

--- a/java/java.source/test/unit/data/jdk/Table.java
+++ b/java/java.source/test/unit/data/jdk/Table.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package test;
+
+public class Table {
+
+}
+
+
+

--- a/java/java.source/test/unit/src/org/netbeans/api/java/source/UiUtilsTest.java
+++ b/java/java.source/test/unit/src/org/netbeans/api/java/source/UiUtilsTest.java
@@ -46,7 +46,7 @@ import org.openide.util.Utilities;
  * @author Tomas Zezula
  */
 public class UiUtilsTest extends NbTestCase {
-    private static final String JTABLE_DATA = "jdk/JTable.java";    //NOI18N
+    private static final String JTABLE_DATA = "jdk/Table.java";    //NOI18N
 
     public UiUtilsTest(String testName) {
         super(testName);
@@ -80,14 +80,14 @@ public class UiUtilsTest extends NbTestCase {
         ClasspathInfo cpInfo = js.getClasspathInfo();
         CompilationInfo ci = SourceUtilsTestUtil.getCompilationInfo(js, Phase.RESOLVED);
         Elements elements = ci.getElements();
-        Element ce = elements.getTypeElement("javax.swing.JTable");
+        Element ce = elements.getTypeElement("test.Table");
         assertNotNull(ce);
         Object[] result = UiUtils.getOpenInfo(cpInfo, ce);
         assertNotNull(result);
         assertTrue(result[0] instanceof FileObject);
         assertTrue(result[1] instanceof Integer);
         assertEquals(srcFile, result[0]);
-        assertEquals(7996, ((Integer) result[1]).intValue());
+        assertEquals(824, ((Integer) result[1]).intValue());
     }
 
     private static FileObject getSrcRoot(FileObject wrkRoot) throws IOException {
@@ -103,8 +103,8 @@ public class UiUtilsTest extends NbTestCase {
         assertNotNull(data);
         FileObject srcRoot = getSrcRoot(wrkRoot);
         assertNotNull(srcRoot);
-        FileObject pkg = FileUtil.createFolder(srcRoot, "javax/swing");        //NOI18N
-        FileObject src = pkg.createData("JTable.java");                //NOI18N
+        FileObject pkg = FileUtil.createFolder(srcRoot, "test");        //NOI18N
+        FileObject src = pkg.createData("Table.java");                //NOI18N
         FileLock lock = src.lock();
         try {
             BufferedReader in = new BufferedReader(new InputStreamReader(data.getInputStream()));

--- a/platform/openide.text/src/org/openide/text/CloneableEditorSupport.java
+++ b/platform/openide.text/src/org/openide/text/CloneableEditorSupport.java
@@ -59,7 +59,6 @@ import java.util.*;
 
 import javax.swing.JButton;
 import javax.swing.JEditorPane;
-import javax.swing.SwingUtilities;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -68,6 +67,7 @@ import javax.swing.undo.UndoableEdit;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.openide.util.Exceptions;
+import org.openide.util.Mutex;
 import org.openide.util.Parameters;
 import org.openide.util.UserCancelException;
 import org.openide.util.WeakSet;
@@ -803,7 +803,7 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
      */
     public JEditorPane[] getOpenedPanes() {
         // expected in AWT only
-        assert SwingUtilities.isEventDispatchThread()
+        assert Mutex.EVENT.isReadAccess()
                 : "CloneableEditorSupport.getOpenedPanes() must be called from AWT thread only"; // NOI18N
         CloneableEditorSupport redirect = CloneableEditorSupportRedirector.findRedirect(this);
         if (redirect != null) {
@@ -856,7 +856,7 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
      */
     JEditorPane getRecentPane () {
         // expected in AWT only
-        assert SwingUtilities.isEventDispatchThread()
+        assert Mutex.EVENT.isReadAccess()
                 : "CloneableEditorSupport.getRecentPane must be called from AWT thread only"; // NOI18N
         CloneableEditorSupport redirect = CloneableEditorSupportRedirector.findRedirect(this);
         if (redirect != null) {
@@ -1121,10 +1121,11 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
 			
 			
 			SafeAWTAccess safe = new SafeAWTAccess();
-            if (SwingUtilities.isEventDispatchThread()) {
+            if (Mutex.EVENT.isReadAccess()) {
                 safe.run(); 
             } else {
-                SwingUtilities.invokeLater(safe); 
+                // safe.run only blocks for a certain time, unlike Mutex.EVENT.readAccess().
+                Mutex.EVENT.postReadRequest(safe::run);
                 try {
                     safe.waitForResult();
                 } catch (InterruptedException ex) {
@@ -1937,7 +1938,7 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
             private boolean documentLocked = false;
 
             public void taskFinished(org.openide.util.Task t2) {
-                javax.swing.SwingUtilities.invokeLater(this);
+                Mutex.EVENT.postReadRequest(this);
                 t2.removeTaskListener(this);
             }
 
@@ -2250,7 +2251,7 @@ public abstract class CloneableEditorSupport extends CloneableOpenSupport {
                     // - post in AWT event thread because of possible dialog popup
                     // - acquire the write access before checking, so there is no
                     //   clash in-between and we're safe for potential reload.
-                    SwingUtilities.invokeLater(
+                    Mutex.EVENT.postReadRequest(
                         new Runnable() {
                             private boolean inRunAtomic;
                             

--- a/platform/openide.text/src/org/openide/text/DocumentOpenClose.java
+++ b/platform/openide.text/src/org/openide/text/DocumentOpenClose.java
@@ -23,11 +23,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.JEditorPane;
-import javax.swing.SwingUtilities;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.EditorKit;
 import javax.swing.text.Position;
@@ -363,7 +361,7 @@ final class DocumentOpenClose {
             // Initial part of reload runs in EDT (collects caret positions) but outside "lock"
             Mutex.EVENT.readAccess(reloadEDTTask);
         }
-    }
+    }   
     
     private StyledDocument retainExistingDocLA() { // Lock acquired mandatory
         switch (documentStatus) {
@@ -775,7 +773,7 @@ final class DocumentOpenClose {
                                 caretPositions[i] = null;
                             }
                         }
-                        SwingUtilities.invokeLater(new Runnable() {
+                        Mutex.EVENT.postReadRequest(new Runnable() {
                             @Override
                             public void run() {
                                 for (int i = 0; i < reloadOpenPanes.length; i++) {


### PR DESCRIPTION
During prototyping I wanted to pass dynamic context through Lookup.executeWith() to some code deeply burried in EditorSupport; and I discovered a few places where replanning to EDT broke the Lookup-passing logic. Since I've targeted real UI with the prototype, I've caught a few places in WindowManager as well.

The added test in UiUtils was probably omitted from the contribution, but the test source content does not matter, just the class name is tested, so I've provided a dummy test data (the original test data was copied from Swing, I believe).