### PR TITLE
[NETBEANS-5478]: DownloadBinaries task: 5 secs connect time is not enough

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ConfigureProxy.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ConfigureProxy.java
@@ -114,7 +114,9 @@ public final class ConfigureProxy extends Task {
             for (Exception ex : errs) {
                 task.log(ex, Project.MSG_ERR);
             }
-            task.log(msgs.toString(), Project.MSG_ERR);
+            if (msgs.length() > 0) {
+                task.log(msgs.toString(), Project.MSG_ERR);
+            }
             throw new IOException("Cannot connect to " + url);
         } else {
             task.log(msgs.toString(), Project.MSG_DEBUG);

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ConfigureProxy.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ConfigureProxy.java
@@ -80,7 +80,7 @@ public final class ConfigureProxy extends Task {
     }
 
     static URLConnection openConnection(Task task, final URL url, URI[] connectedVia) throws IOException {
-        long connectTimeoutMs = getProjectPropertyInt(task, "downloadBinaries.connectTimeoutMs", 5000);
+        long connectTimeoutMs = getProjectPropertyInt(task, "downloadBinaries.connectTimeoutMs", 15000);
         task.log("Connect timeout set to " + connectTimeoutMs + " milliseconds prior to connecting to " + url, Project.MSG_DEBUG);
         final URLConnection[] conn = { null };
         final List<Exception> errs = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
This is an improvement on the NetBeans build system, specifically the task which downloads binary prerequisites from Central Maven or https://netbeans.osuosl.org/binaries.

As per the explanation in [NETBEANS-5478](https://issues.apache.org/jira/browse/NETBEANS-5478) a hard-coded connect timeout of 5 seconds will not work in some build environments because of the "network first touch penalty" (I'm looking at you GitHub Actions (= Azure)). This PR makes the connect timeout configurable so that it will be possible to do:


`ant -DdownloadBinaries.connectTimeoutMs=30000 ....`

(which will set the connect timeout to 30 seconds)

Current behavior is not changed, i.e the default is 5000 mseconds ... which I personally find low'ish, but admittedly has worked well for most users over the years. It just doesn't work in environments which need "warmup".


Note: This was very hard to track down. The reason is that `DownloadBinaries.java` swallows exceptions, see [line 212](https://github.com/apache/netbeans/blob/d0a9324230e37057a9e5a2b68d91be3e9f3fe618/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java#L212) and [line 309](https://github.com/apache/netbeans/blob/d0a9324230e37057a9e5a2b68d91be3e9f3fe618/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/DownloadBinaries.java#L309). This PR does not fix that in order to stay on a single topic for the PR.