### PR TITLE
[NETBEANS-5485] cnd-rfs-1.0.zip compile fix

### DIFF
--- a/cnd/cnd.remote/tools/Makefile
+++ b/cnd/cnd.remote/tools/Makefile
@@ -38,11 +38,11 @@ CFLAGS-Linux := ${CFLAGS-COMMON} -Wreturn-type -Wimplicit -Werror -std=c99 ${PRE
 CFLAGS-SunOS := ${CFLAGS-COMMON} -xc99 -errwarn ${PREVISE_FLAG}
 CFLAGS-Mac_OS_X := ${CFLAGS-COMMON}
 
-LDFLAGS-LIB-Linux := -shared -ldl -lrt
+LDFLAGS-LIB-Linux := -shared -lpthread -ldl -lrt
 LDFLAGS-LIB-SunOS := -shared -ldl -lrt -lsocket
 LDFLAGS-LIB-Mac_OS_X := -G -ldl -lrt
 
-LDFLAGS-APP-Linux := -lrt -lnsl -lresolv
+LDFLAGS-APP-Linux := -lrt -lpthread -lnsl -lresolv
 LDFLAGS-APP-SunOS := -lrt -lnsl -lsocket -lresolv
 LDFLAGS-APP-Mac_OS_X := -lrt -lnsl -lsocket -lresolv
 

--- a/cnd/cnd.remote/tools/rfs_controller.c
+++ b/cnd/cnd.remote/tools/rfs_controller.c
@@ -417,7 +417,7 @@ static void calc_fs_skew(struct timeval *skew) {
     
     char path[PATH_MAX+1];
     getcwd(path, sizeof path);
-    strncat(path, "/tmpXXXXXX", sizeof path);
+    strncat(path, "/tmpXXXXXX", (sizeof path)-1);
 
     int fd;
 


### PR DESCRIPTION
Fixes some compiler flags and a bug in the source code of cnd-rfs-1.0.zip (that is required to build cnd.remote).