### PR TITLE
Avoid NPE when executing some Maven projects.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/runjar/MavenExecuteUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/runjar/MavenExecuteUtils.java
@@ -615,9 +615,9 @@ public final class MavenExecuteUtils {
      * @return
      */
     public static String[] splitAll(String argline, boolean filterClassPath) {
-        String jvm = splitJVMParams(argline, false);
-        String mainClazz = splitMainClass(argline);
-        String args = splitParams(argline);
+        String jvm = argline == null ? null : splitJVMParams(argline, false);
+        String mainClazz = argline == null ? null : splitMainClass(argline);
+        String args = argline == null ? null : splitParams(argline);
         if (filterClassPath && jvm != null && jvm.contains("-classpath %classpath")) {
             jvm = jvm.replace("-classpath %classpath", "");
         }

--- a/java/maven/src/org/netbeans/modules/maven/runjar/RunJarStartupArgs.java
+++ b/java/maven/src/org/netbeans/modules/maven/runjar/RunJarStartupArgs.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.maven.runjar;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -136,7 +137,7 @@ public class RunJarStartupArgs implements LateBoundPrerequisitesChecker {
             if (mainClass.length == 0) {
                 // accept userargs, since we don't know where the division is, make it fixed in the processing.
                 joinedArgs.addAll(appArgsValue);
-                appArgsValue = null;
+                appArgsValue = Collections.emptyList();
             } else {
                 joinedArgs.addAll(Arrays.asList(mainClass));
             }


### PR DESCRIPTION
Looks like that after #2731 I cannot execute my [talk2compiler](https://github.com/jaroslavtulach/talk2compiler) project:
```
java.lang.NullPointerException: Cannot invoke "String.length()" because "this.line" is null
	at org.netbeans.modules.maven.runjar.PropertySplitter.nextPair(PropertySplitter.java:65)
	at org.netbeans.modules.maven.runjar.MavenExecuteUtils.splitJVMParams(MavenExecuteUtils.java:642)
	at org.netbeans.modules.maven.runjar.MavenExecuteUtils.splitAll(MavenExecuteUtils.java:618)
	at org.netbeans.modules.maven.runjar.RunJarStartupArgs.checkRunConfig(RunJarStartupArgs.java:130)
	at org.netbeans.modules.maven.execute.MavenCommandLineExecutor.run(MavenCommandLineExecutor.java:238)
	at org.netbeans.core.execution.RunClassThread.doRun(RunClassThread.java:132)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
[catch] at org.netbeans.core.execution.RunClassThread.run(RunClassThread.java:81)
java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "params" is null
	at org.netbeans.modules.maven.runjar.MavenExecuteUtils.joinParameters(MavenExecuteUtils.java:555)
	at org.netbeans.modules.maven.runjar.RunJarStartupArgs.checkRunConfig(RunJarStartupArgs.java:207)
	at org.netbeans.modules.maven.execute.MavenCommandLineExecutor.run(MavenCommandLineExecutor.java:238)
	at org.netbeans.core.execution.RunClassThread.doRun(RunClassThread.java:132)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
```
CCing @sdedic.