### PR TITLE
[NETBEANS-5484] Clear NB Non-Project cache when we have more info from Gradle

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectCache.java
@@ -63,6 +63,7 @@ import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 import java.util.WeakHashMap;
 import javax.swing.JLabel;
+import org.netbeans.api.project.ProjectManager;
 import org.netbeans.modules.gradle.cache.AbstractDiskCache.CacheEntry;
 import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache.QualifiedProjectInfo;
 import org.netbeans.modules.gradle.api.execute.RunUtils;
@@ -412,6 +413,7 @@ public final class GradleProjectCache {
             if (baseProject.isRoot()) {
                 SubProjectDiskCache spCache = SubProjectDiskCache.get(baseProject.getRootDir());
                 spCache.storeData(new SubProjectDiskCache.SubProjectInfo(baseProject));
+                ProjectManager.getDefault().clearNonProjectCache();
             }
         }
     }


### PR DESCRIPTION
This one is an additional fix for NETBEANS-5484. The root cause of NETBEANS-5484 is that NetBeans evaluates a directory as non-project, since the applied heuristics can't tell otherwise. However after NB turned to Gradle for the exact project information, Gradle updates it's sub project information.
So after all of these when the user clicks on the Sub projects node. Upon the full information in the Gradle Project NB can ask for a project on a directory which previously identified as non-project so returning null instead of evaluating that directory again.
This simple fix clears the NB non-project cache when more information is available from Gradle, so the re-evaluation would happen and identify the directory as a project.