### PR TITLE
Fixing build for older ant versions.

### DIFF
--- a/ergonomics/ide.ergonomics/src-ant/org/netbeans/modules/ide/ergonomics/ant/ExtractLayer.java
+++ b/ergonomics/ide.ergonomics/src-ant/org/netbeans/modules/ide/ergonomics/ant/ExtractLayer.java
@@ -543,12 +543,10 @@ implements FileNameMapper, URIResolver, EntityResolver {
             return delegate.size();
         }
 
-        @Override
         public Stream<? extends Resource> stream() {
             return delegate.stream();
         }
 
-        @Override
         public boolean isEmpty() {
             return delegate.isEmpty();
         }


### PR DESCRIPTION
Master has failed to compile for me. It turned out that ant **1.10.1** I have been using does not support methods `stream()` and `isEmpty()` in that interface. ant **1.10.8** NetBeans itself is distributing is OK. But just removing the `@Override` may fix the build and allow earlier versions to be used.

Setting to WIP as the entire `commit-validation` failed for me once, but I wasn't able to verify whether it is some local problem or systematic problem with the method (i.e. isEmpty) actually not being called. Let's see what the CI says.