### PR TITLE
Delegates from TemplateWizardIterImpl.hasPrevious

### DIFF
--- a/platform/openide.loaders/src/org/openide/loaders/TemplateWizardIterImpl.java
+++ b/platform/openide.loaders/src/org/openide/loaders/TemplateWizardIterImpl.java
@@ -138,7 +138,7 @@ implements WizardDescriptor.Iterator, ChangeListener, Runnable {
      * @return <code>true</code> if so
      */
     public boolean hasPrevious() {
-        return !showingPanel;
+        return !showingPanel && getIterator().hasPrevious();
     }
 
     /** Move to the next panel.


### PR DESCRIPTION
As far as I can tell there is no way to disable a Previous button in the wizard because TemplateWizardIterImpl does not delegate the call to the wrapped iterator.

I think the current one-liner fixes that.

While searching I also found a thread talking about this from 2015 http://netbeans-org.1045718.n5.nabble.com/Re-how-to-disable-previous-button-in-one-of-wizards-td5741265.html where Graeme found the same fix.

draganknin had this closing statement there:

>I hope so that this will be fixed soon. Until it does I will stick with reflection. 

6 short years later I think this PR fixes it.

Most of the code seems to have been written by @JaroslavTulach, which is why I added him as a reviewer. I wouldn't have bothered him directly otherwise (and I do apologize if it's too much noise).