### PR TITLE
[NETBEANS-5511] Remove items via the iterator.

### DIFF
--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/FeatureUpdateElementImpl.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/FeatureUpdateElementImpl.java
@@ -496,7 +496,8 @@ public class FeatureUpdateElementImpl extends UpdateElementImpl {
                     }
                     Module m = Utilities.toModule(cnb, null);
                     if (m != null && ! m.getProblems().isEmpty()) {
-                        dependenciesToModulesOrFeatures.remove(depSpec);
+                        it.remove();
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Explicit removal of items during iteration is causing `ConcurrentModificationException`.
We use `Iterator.remove()` instead.