### PR TITLE
Use JSON parser to understand java.mx.projects.

### DIFF
--- a/java/java.mx.project/nbproject/project.xml
+++ b/java/java.mx.project/nbproject/project.xml
@@ -60,11 +60,12 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.api.scripting</code-name-base>
+                    <code-name-base>org.netbeans.libs.json_simple</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.0</specification-version>
+                        <release-version>1</release-version>
+                        <specification-version>0.24</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/Compliance.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/Compliance.java
@@ -18,6 +18,9 @@
  */
 package org.netbeans.modules.java.mx.project;
 
+import java.util.logging.Level;
+import org.openide.util.Exceptions;
+
 public final class Compliance {
 
     final int max;
@@ -65,7 +68,17 @@ public final class Compliance {
         if (comma != -1) {
             spec = spec.substring(0, comma);
         }
-        int version = Integer.parseInt(spec);
+        if (spec.endsWith("-loom")) {
+            spec = spec.substring(0, spec.length() - 5);
+        }
+        int version;
+        try {
+            version = Integer.parseInt(spec);
+        } catch (NumberFormatException numberFormatException) {
+            Exceptions.attachSeverity(numberFormatException, Level.INFO);
+            Exceptions.printStackTrace(numberFormatException);
+            return plus(8);
+        }
         return plus ? Compliance.plus(version) : Compliance.exact(version);
     }
 

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/ComplianceTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/ComplianceTest.java
@@ -18,13 +18,55 @@
  */
 package org.netbeans.modules.java.mx.project;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ComplianceTest {
+    private static List<LogRecord> collected = new ArrayList<>();
+    
+    @BeforeClass
+    public static void mockLogger() {
+        Logger l = Logger.getLogger("org.openide.util.Exceptions");
+        l.setUseParentHandlers(false);
+        l.addHandler(new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                collected.add(record);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() throws SecurityException {
+            }
+        });
+    }
+    
+    @Before
+    public void clearUpLogs() {
+        collected.clear();
+    }
+    
+    @After
+    public void failWhenThereIsAnError() {
+        if (collected.size() > 0) {
+            fail("Expecting no logs: " + collected);
+        }
+    }
     @Test
     public void defaultNull() {
         Compliance eightPlusByDefault = Compliance.parse(null);
@@ -35,6 +77,25 @@ public class ComplianceTest {
         Compliance elevenPlus = Compliance.parse("11+");
         assertMinMax(elevenPlus, 11, null);
         assertEquals("11+", elevenPlus.toString());
+    }
+    
+    @Test
+    public void loom() {
+        Compliance loom = Compliance.parse("17-loom");
+        assertMinMax(loom, 17, 17);
+        assertEquals("17", loom.toString());
+    }
+    
+    @Test
+    public void nonsenseFallsbackToEightPlus() {
+        Compliance wrong = Compliance.parse("17-nonsense");
+        assertMinMax(wrong, 8, null);
+        assertEquals("8+", wrong.toString());
+        
+        assertEquals("One error reported", 1, collected.size());
+        assertNotNull("Exception is there", collected.get(0).getThrown());
+        assertEquals("Number parsing error", NumberFormatException.class, collected.get(0).getThrown().getClass());
+        collected.clear();
     }
     
     @Test

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/ParseSuitesTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/ParseSuitesTest.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.java.mx.project;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -36,11 +37,22 @@ public final class ParseSuitesTest extends NbTestCase {
     }
 
     public void testParseThemAll() throws IOException {
+        assertSuitePys(getDataDir(), 14);
+    }
+
+    public static void main(String... args) throws IOException {
+        if (args.length == 0) {
+            throw new IOException("Specify parameter to directory with suite.py files you want to verify!");
+        }
+        assertSuitePys(new File(args[0]), -1);
+    }
+
+    private static void assertSuitePys(final File dir, final int expected) throws IOException {
         StringWriter s = new StringWriter();
         PrintWriter pw = new PrintWriter(s);
         int cnt[] = { 0 };
         int error[] = { 0 };
-        Files.walkFileTree(getDataDir().toPath(), new FileVisitor<Path>() {
+        Files.walkFileTree(dir.toPath(), new FileVisitor<Path>() {
             @Override
             public FileVisitResult preVisitDirectory(Path t, BasicFileAttributes bfa) throws IOException {
                 return FileVisitResult.CONTINUE;
@@ -75,6 +87,8 @@ public final class ParseSuitesTest extends NbTestCase {
         });
 
         assertEquals(s.toString(), 0, error[0]);
-        assertEquals("Parsed all suites", 14, cnt[0]);
+        if (expected >= 0) {
+            assertEquals(s.toString(), expected, cnt[0]);
+        }
     }
 }

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/ParseSuitesTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/ParseSuitesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.mx.project;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.java.mx.project.suitepy.MxSuite;
+
+public final class ParseSuitesTest extends NbTestCase {
+
+    public ParseSuitesTest(String name) {
+        super(name);
+    }
+
+    public void testParseThemAll() throws IOException {
+        StringWriter s = new StringWriter();
+        PrintWriter pw = new PrintWriter(s);
+        int cnt[] = { 0 };
+        int error[] = { 0 };
+        Files.walkFileTree(getDataDir().toPath(), new FileVisitor<Path>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path t, BasicFileAttributes bfa) throws IOException {
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path t, BasicFileAttributes bfa) throws IOException {
+                if (!t.getFileName().toString().equals("suite.py")) {
+                    return FileVisitResult.CONTINUE;
+                }
+                cnt[0]++;
+                try {
+                    pw.println("Parsing " + t);
+                    MxSuite.parse(t.toUri().toURL());
+                } catch (IOException ex) {
+                    error[0]++;
+                    pw.println("Failure " + t);
+                    ex.printStackTrace(pw);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path t, IOException ioe) throws IOException {
+                throw new AssertionError("Failed at " + t, ioe);
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path t, IOException ioe) throws IOException {
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        assertEquals(s.toString(), 0, error[0]);
+        assertEquals("Parsed all suites", 14, cnt[0]);
+    }
+}

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SdkSuiteTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SdkSuiteTest.java
@@ -28,7 +28,6 @@ import static junit.framework.TestCase.assertTrue;
 import org.netbeans.api.java.queries.SourceForBinaryQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
-import org.netbeans.junit.NbModuleSuite;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
@@ -38,11 +37,7 @@ public class SdkSuiteTest extends SuiteCheck {
     }
 
     public static junit.framework.Test suite() {
-        DumpStack.start();
-        return NbModuleSuite.emptyConfiguration().
-            gui(false).
-            addTest(SdkSuiteTest.class).
-            suite();
+        return suite(SdkSuiteTest.class);
     }
 
     public void testParseSdkSourcesWithoutError() throws Exception {

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SuiteCheck.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SuiteCheck.java
@@ -30,6 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import javax.tools.Diagnostic;
+import junit.framework.Test;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertSame;
@@ -50,16 +51,25 @@ import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.Sources;
 import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.junit.NbModuleSuite;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.parsing.api.indexing.IndexingManager;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
-import org.openide.util.Utilities;
 
 abstract class SuiteCheck extends NbTestCase {
     SuiteCheck(String name) {
         super(name);
         log(Level.INFO, "Test created by %s classloader", getClass().getClassLoader());
+    }
+
+    static Test suite(final Class<? extends Test> clazz) {
+        DumpStack.start();
+        return NbModuleSuite.emptyConfiguration().
+                gui(false).
+                enableClasspathModules(true).
+                addTest(clazz).
+                suite();
     }
 
     @Override

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/TrufleSuiteTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/TrufleSuiteTest.java
@@ -18,19 +18,13 @@
  */
 package org.netbeans.modules.java.mx.project;
 
-import org.netbeans.junit.NbModuleSuite;
-
 public class TrufleSuiteTest extends SuiteCheck {
     public TrufleSuiteTest(String n) {
         super(n);
     }
 
     public static junit.framework.Test suite() {
-        DumpStack.start();
-        return NbModuleSuite.emptyConfiguration().
-            gui(false).
-            addTest(TrufleSuiteTest.class).
-            suite();
+        return SuiteCheck.suite(TrufleSuiteTest.class);
     }
 
     public void testParseTruffleSourcesWithoutError() throws Exception {


### PR DESCRIPTION
`java.mx.projects` module is using JavaScript engine to parse the `suite.py` files (after transforming them to JSON format). This is no longer working on JDKs that don't carry JavaScript implementation - e.g. JDK15+.

This PR replaces usage of JavaScript with existing NetBeans parsing library `json_simple`.