### PR TITLE
NETBEANS-5313 Payara Server not listed in the registered application servers list for Jakarta EE 8 profile

### DIFF
--- a/enterprise/j2ee.core/src/org/netbeans/api/j2ee/core/Profile.java
+++ b/enterprise/j2ee.core/src/org/netbeans/api/j2ee/core/Profile.java
@@ -61,9 +61,9 @@ public final class Profile {
 
     public static final Profile JAVA_EE_8_WEB  = new Profile(9, "1.8", "web", "JavaEE8Web.displayName");
 
-    public static final Profile JAKARTA_EE_8_WEB  = new Profile(10, "8.0", "web", "JakartaEE8Web.displayName");
+    public static final Profile JAKARTA_EE_8_FULL  = new Profile(10, "8.0", null, "JakartaEE8Full.displayName");
 
-    public static final Profile JAKARTA_EE_8_FULL  = new Profile(11, "8.0", null, "JakartaEE8Full.displayName");
+    public static final Profile JAKARTA_EE_8_WEB  = new Profile(11, "8.0", "web", "JakartaEE8Web.displayName");
 
     private final int order;
 

--- a/enterprise/payara.eecommon/nbproject/org-netbeans-modules-payara-eecommon.sig
+++ b/enterprise/payara.eecommon/nbproject/org-netbeans-modules-payara-eecommon.sig
@@ -1150,6 +1150,7 @@ fld public final static org.netbeans.modules.payara.eecommon.api.config.J2EEVers
 fld public final static org.netbeans.modules.payara.eecommon.api.config.J2EEVersion JAVAEE_6_0
 fld public final static org.netbeans.modules.payara.eecommon.api.config.J2EEVersion JAVAEE_7_0
 fld public final static org.netbeans.modules.payara.eecommon.api.config.J2EEVersion JAVAEE_8_0
+fld public final static org.netbeans.modules.payara.eecommon.api.config.J2EEVersion JAKARTAEE_8_0
 meth public int compareTo(java.lang.Object)
 meth public static org.netbeans.modules.payara.eecommon.api.config.J2EEVersion getJ2EEVersion(java.lang.String)
 supr org.netbeans.modules.payara.eecommon.api.config.J2EEBaseVersion

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/config/J2EEVersion.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/api/config/J2EEVersion.java
@@ -73,6 +73,12 @@ public final class J2EEVersion extends J2EEBaseVersion {
             "8.0", 8000, // NOI18N
             "8.0", 8000);   // NOI18N
 
+    /** Represents Jakarta EE version 8.0.0
+     */
+    public static final J2EEVersion JAKARTAEE_8_0 = new J2EEVersion(
+            "8.0.0", 80000,    // NOI18N
+            "8.0.0", 80000);   // NOI18N
+
     /**
      * -----------------------------------------------------------------------
      * Implementation
@@ -112,6 +118,8 @@ public final class J2EEVersion extends J2EEBaseVersion {
             result = JAVAEE_7_0;
         } else if(JAVAEE_8_0.toString().equals(version)) {
             result = JAVAEE_8_0;
+        } else if(JAKARTAEE_8_0.toString().equals(version)) {
+            result = JAKARTAEE_8_0;
         }
 
         return result;

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV5.xml
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/config/PayaraV5.xml
@@ -37,6 +37,8 @@ under the License.
         <profile version="1.7" type="full" check="full"/>
         <profile version="1.8" type="web"/>
         <profile version="1.8" type="full" check="full"/>
+        <profile version="8.0.0" type="web"/>
+        <profile version="8.0.0" type="full" check="full"/>
         <module type="war"/>
         <module type="car" check="full"/>
         <module type="ear" check="full"/>


### PR DESCRIPTION
This PR adds the Jakarta EE 8 profile support to Server config.

- J2EE 1.3 - Profile version 1.3 & J2EEVersion 1.3
- J2EE 1.4 - Profile version 1.4 & J2EEVersion 1.4
- Java EE 5 - Profile version 1.5 & J2EEVersion 5.0
- Java EE 6 - Profile version 1.6 & J2EEVersion 6.0
- Java EE 7 - Profile version 1.7 & J2EEVersion 7.0
- Java EE 8 - Profile version 1.8 & J2EEVersion 8.0
- Jakarta EE 8 - Profile version 8.0 & J2EEVersion 8.0.0 **(added by this PR)**