### PR TITLE
[NETBEANS-5524] Check for priming action before use.

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectList.java
@@ -713,7 +713,9 @@ public final class OpenProjectList {
                 }
                 if (prime) {
                     ActionProvider ap = p2.getLookup().lookup(ActionProvider.class);
-                    if (ap != null && ap.isActionEnabled(ActionProvider.COMMAND_PRIME, p2.getLookup())) {
+                    if (ap != null && 
+                        Arrays.asList(ap.getSupportedActions()).contains(ActionProvider.COMMAND_PRIME) &&
+                        ap.isActionEnabled(ActionProvider.COMMAND_PRIME, p2.getLookup())) {
                         final CountDownLatch[] await = new CountDownLatch[1];
                         ActionProgress awaitPriming = new ActionProgress() {
                             @Override

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
@@ -31,6 +31,7 @@ import java.net.URI;
 import java.text.Collator;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -346,7 +347,12 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
         for (Project p : projects) {
             final Lookup lkp = p.getLookup();
             final ActionProvider ap = lkp.lookup(ActionProvider.class);
-            if (ap != null && ap.isActionEnabled(ActionProvider.COMMAND_PRIME, lkp)) {
+            if (ap == null) {
+                // a Project without any actions ? Most probably ergonomics-proxy, count it in!
+                cnt++;
+            } else if (
+                Arrays.asList(ap.getSupportedActions()).contains(ActionProvider.COMMAND_PRIME) &&
+                ap.isActionEnabled(ActionProvider.COMMAND_PRIME, lkp)) {
                 cnt++;
             }
         }


### PR DESCRIPTION
I changed the Accessory panel so that it enables the checkbox when there's NO action provider at all. In reality that does not happen with well-behaved projects, as they have at least Build or Run actions. But Ergonomics-proxies have no actions on them (at least they appeared so).
Later, during open, the `getSupportedActions()` check is done again, to see whether the project really supports the action. Seemed to be working fine for PHP (and Maven, Ant, Gradle) on my clean setup.
