### PR TITLE
Branding API to disable Maven index download

### DIFF
--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-maven-indexer.jar/org/netbeans/modules/maven/indexer/api/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-maven-indexer.jar/org/netbeans/modules/maven/indexer/api/Bundle.properties
@@ -15,4 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
+DEFAULT_CREATE_INDEX=false
 DEFAULT_UPDATE_FREQ=3

--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-maven-indexer.jar/org/netbeans/modules/maven/indexer/api/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-maven-indexer.jar/org/netbeans/modules/maven/indexer/api/Bundle.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DEFAULT_UPDATE_FREQ=3

--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
@@ -106,8 +106,10 @@ final class SuiteActionProvider implements ActionProvider {
             }
             case SingleMethod.COMMAND_RUN_SINGLE_METHOD: {
                 SingleMethod m = context.lookup(SingleMethod.class);
-                if (m != null && fo == null) {
-                    fo = m.getFile();
+                if (m != null) {
+                    if (fo == null) {
+                        fo = m.getFile();
+                    }
                     testSuffix = "#" + m.getMethodName();
                 }
                 // fallthrough
@@ -122,8 +124,10 @@ final class SuiteActionProvider implements ActionProvider {
                 break;
             case SingleMethod.COMMAND_DEBUG_SINGLE_METHOD: {
                 SingleMethod m = context.lookup(SingleMethod.class);
-                if (m != null && fo == null) {
-                    fo = m.getFile();
+                if (m != null) {
+                    if (fo == null) {
+                        fo = m.getFile();
+                    }
                     testSuffix = "#" + m.getMethodName();
                 }
                 // fallthrough

--- a/java/maven.indexer/manifest.mf
+++ b/java/maven.indexer/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/indexer/Bundle.properties
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module-Specification-Version: 2.51
+OpenIDE-Module-Specification-Version: 2.52
 OpenIDE-Module: org.netbeans.modules.maven.indexer/2
 

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
@@ -335,7 +335,12 @@ public final class RepositoryPreferences {
     }
 
     public static int getIndexUpdateFrequency() {
-        int defaultFrequency = getDefaultIndexUpdateFrequency();
+        int defaultFrequency;
+        if (Boolean.getBoolean("netbeans.full.hack")) { // NOI18N
+            defaultFrequency = FREQ_NEVER;
+        } else {
+            defaultFrequency = getDefaultIndexUpdateFrequency();
+        }
         return getPreferences().getInt(PROP_INDEX_FREQ, defaultFrequency);
     }
 
@@ -344,13 +349,7 @@ public final class RepositoryPreferences {
         "DEFAULT_UPDATE_FREQ=0"
     })
     static int getDefaultIndexUpdateFrequency() throws NumberFormatException {
-        final int defaultFrequency;
-        if (Boolean.getBoolean("netbeans.full.hack")) { // NOI18N
-            defaultFrequency = FREQ_NEVER;
-        } else {
-            defaultFrequency = Integer.parseInt(Bundle.DEFAULT_UPDATE_FREQ());
-        }
-        return defaultFrequency;
+        return Integer.parseInt(Bundle.DEFAULT_UPDATE_FREQ());
     }
 
     /**
@@ -366,7 +365,15 @@ public final class RepositoryPreferences {
      * @return 
      */
     public static boolean isIndexRepositories() {
-        return getPreferences().getBoolean(PROP_INDEX, true);
+        return getPreferences().getBoolean(PROP_INDEX, getDefaultIndexRepositories());
+    }
+
+    @NbBundle.Messages({
+        "# true or false:",
+        "DEFAULT_CREATE_INDEX=true"
+    })
+    static boolean getDefaultIndexRepositories() {
+        return Boolean.valueOf(Bundle.DEFAULT_CREATE_INDEX());
     }
 
     public static Date getLastIndexUpdate(String repoId) {

--- a/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
+++ b/java/maven.indexer/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferences.java
@@ -53,6 +53,7 @@ import org.openide.util.NbPreferences;
 import org.eclipse.aether.repository.MirrorSelector;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.util.repository.DefaultMirrorSelector;
+import org.openide.util.NbBundle;
 
 /**
  * List of Maven repositories of interest.
@@ -334,8 +335,24 @@ public final class RepositoryPreferences {
     }
 
     public static int getIndexUpdateFrequency() {
-        return getPreferences().getInt(PROP_INDEX_FREQ, Boolean.getBoolean("netbeans.full.hack") ? FREQ_NEVER : FREQ_ONCE_WEEK);
+        int defaultFrequency = getDefaultIndexUpdateFrequency();
+        return getPreferences().getInt(PROP_INDEX_FREQ, defaultFrequency);
     }
+
+    @NbBundle.Messages({
+        "# FREQ_ONCE_WEEK = 0, FREQ_ONCE_DAY = 1, FREQ_STARTUP = 2, FREQ_NEVER = 3;",
+        "DEFAULT_UPDATE_FREQ=0"
+    })
+    static int getDefaultIndexUpdateFrequency() throws NumberFormatException {
+        final int defaultFrequency;
+        if (Boolean.getBoolean("netbeans.full.hack")) { // NOI18N
+            defaultFrequency = FREQ_NEVER;
+        } else {
+            defaultFrequency = Integer.parseInt(Bundle.DEFAULT_UPDATE_FREQ());
+        }
+        return defaultFrequency;
+    }
+
     /**
      * @since 2.27
      * @param bool 

--- a/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/Bundle_te_ST.properties
+++ b/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/Bundle_te_ST.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DEFAULT_UPDATE_FREQ=3
+

--- a/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/Bundle_te_ST.properties
+++ b/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/Bundle_te_ST.properties
@@ -16,4 +16,4 @@
 # under the License.
 
 DEFAULT_UPDATE_FREQ=3
-
+DEFAULT_CREATE_INDEX=false

--- a/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferencesTest.java
+++ b/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferencesTest.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.maven.indexer.api;
 import java.util.Date;
 import java.util.Locale;
 import org.apache.maven.settings.Mirror;
+import org.junit.Ignore;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.junit.NbTestSuite;
 import org.netbeans.modules.maven.embedder.EmbedderFactory;
@@ -31,19 +32,15 @@ public class RepositoryPreferencesTest extends NbTestCase {
     public RepositoryPreferencesTest(String name) {
         super(name);
     }
-    
+
     public static NbTestSuite suite() {
-        NbTestSuite suite = new NbTestSuite();
-        suite.addTest(new RepositoryPreferencesTest("testNoConsecutiveSlashesInRepositoryID"));
-        suite.addTest(new RepositoryPreferencesTest("testGetRepositoryInfos"));
-        suite.addTest(new RepositoryPreferencesTest("testGetMirrorRepositoryInfos"));
-        return suite;
+        return new NbTestSuite(RepositoryPreferencesTest.class);
     }
 
     @Override protected void setUp() throws Exception {
         System.setProperty("no.local.settings", "true");
     }
-    
+
     // issue http://netbeans.org/bugzilla/show_bug.cgi?id=239898
     public void testNoConsecutiveSlashesInRepositoryID() throws Exception {
         RepositoryPreferences rp = RepositoryPreferences.getInstance();
@@ -53,8 +50,8 @@ public class RepositoryPreferencesTest extends NbTestCase {
         RepositoryPreferences.getLastIndexUpdate("foo_http://nowhere.net");
         RepositoryPreferences.setLastIndexUpdate("foo_http://nowhere.net", new Date());
         rp.removeTransientRepositories(1);
-    }   
-    
+    }
+
     public void testGetRepositoryInfos() throws Exception {
         RepositoryPreferences rp = RepositoryPreferences.getInstance();
         assertEquals("[local, central]", rp.getRepositoryInfos().toString());
@@ -70,16 +67,17 @@ public class RepositoryPreferencesTest extends NbTestCase {
         rp.removeTransientRepositories(3);
         assertEquals("[local, central]", rp.getRepositoryInfos().toString());
     }
-    
-public void testNonHttpRepositoryInfos() throws Exception { //#227322
+
+    @Ignore
+    public void testNonHttpRepositoryInfos() throws Exception { //#227322
         RepositoryPreferences rp = RepositoryPreferences.getInstance();
         assertEquals("[local, central]", rp.getRepositoryInfos().toString());
         rp.addTransientRepository(1, "foo", "Foo", "scp://192.168.1.1/mkleint", RepositoryInfo.MirrorStrategy.NONE);
         assertEquals("[local, central]", rp.getRepositoryInfos().toString());
         rp.addTransientRepository(2, "bar", "bar", "ftp://192.168.1.1/mkleint", RepositoryInfo.MirrorStrategy.NONE);
         assertEquals("[local, central]", rp.getRepositoryInfos().toString());
-    }    
-    
+    }
+
     /** created in attempt of reproducing issue http://netbeans.org/bugzilla/show_bug.cgi?id=214980
      */
     public void testGetMirrorRepositoryInfos() throws Exception {
@@ -155,9 +153,9 @@ public void testNonHttpRepositoryInfos() throws Exception { //#227322
             assertTrue(m.isMirror());
             assertEquals("[eclipselink, central]", m.getMirroredRepositories().toString());
         } finally {
-           EmbedderFactory.getOnlineEmbedder().getSettings().removeMirror(mirror); 
+           EmbedderFactory.getOnlineEmbedder().getSettings().removeMirror(mirror);
         }
-    } 
+    }
 
     public void testDefaultFreqIsWeek() {
         Locale orig = Locale.getDefault();
@@ -176,6 +174,28 @@ public void testNonHttpRepositoryInfos() throws Exception { //#227322
             Locale.setDefault(new Locale("te", "ST"));
             int def = RepositoryPreferences.getDefaultIndexUpdateFrequency();
             assertEquals("Branded to never", RepositoryPreferences.FREQ_NEVER, def);
+        } finally {
+            Locale.setDefault(orig);
+        }
+    }
+
+    public void testDefaultCreateIndex() {
+        Locale orig = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.ENGLISH);
+            boolean def = RepositoryPreferences.getDefaultIndexRepositories();
+            assertTrue("Indexing is on", def);
+        } finally {
+            Locale.setDefault(orig);
+        }
+    }
+
+    public void testBrandingCreateIndex() {
+        Locale orig = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("te", "ST"));
+            boolean def = RepositoryPreferences.getDefaultIndexRepositories();
+            assertFalse("Never create index", def);
         } finally {
             Locale.setDefault(orig);
         }

--- a/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferencesTest.java
+++ b/java/maven.indexer/test/unit/src/org/netbeans/modules/maven/indexer/api/RepositoryPreferencesTest.java
@@ -20,7 +20,7 @@
 package org.netbeans.modules.maven.indexer.api;
 
 import java.util.Date;
-import static junit.framework.Assert.assertEquals;
+import java.util.Locale;
 import org.apache.maven.settings.Mirror;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.junit.NbTestSuite;
@@ -159,5 +159,25 @@ public void testNonHttpRepositoryInfos() throws Exception { //#227322
         }
     } 
 
+    public void testDefaultFreqIsWeek() {
+        Locale orig = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.ENGLISH);
+            int def = RepositoryPreferences.getDefaultIndexUpdateFrequency();
+            assertEquals("Once a week is default", RepositoryPreferences.FREQ_ONCE_WEEK, def);
+        } finally {
+            Locale.setDefault(orig);
+        }
+    }
 
+    public void testBrandingFreqToNever() {
+        Locale orig = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("te", "ST"));
+            int def = RepositoryPreferences.getDefaultIndexUpdateFrequency();
+            assertEquals("Branded to never", RepositoryPreferences.FREQ_NEVER, def);
+        } finally {
+            Locale.setDefault(orig);
+        }
+    }
 }

--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -83,6 +83,20 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="disable-maven-repo-indexing">
+            <api name="general"/>
+            <summary>Default for frequency of indexing</summary>
+            <version major="2" minor="147"/>
+            <date day="1" month="4" year="2021"/>
+            <author login="jtulach"/>
+            <compatibility semantic="compatible"/>
+            <description>
+                <p>
+                    Introducing <a href="@TOP@architecture-summary.html#group-branding">branding APIs</a>
+                    specify default frequency for downloading Maven index.
+                </p>
+            </description>
+        </change>
         <change id="ProjectLookup.fallback">
             <api name="general"/>
             <summary>Allow project services, that are ordered <b>after</b> specific packaging type</summary>

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -212,6 +212,13 @@
             ExplicitProcessParameters</a> instance(s) in the action's Lookup. See <a href="@org-netbeans-modules-extexecution-base@/org/netbeans/api/extexecution/base/ExplicitProcessParameters.html">
             ExplicitProcessParameters</a> javadoc for more details.
       </api>
+      <api category="devel" group="branding" name="org.netbeans.modules.maven.indexer.api.DEFAULT_CREATE_INDEX" type="export">
+          Brand the <code>DEFAULT_CREATE_INDEX</code> key in
+          <code>org.netbeans.modules.maven.indexer.api.Bundle</code> file
+          with one of the values <code>true</code> or <code>false</code>
+          to control (usually to disable with <code>DEFAULT_CREATE_INDEX=false</code>)
+          the default behavior automatic maven index downloading.
+      </api> 
       <api category="devel" group="branding" name="org.netbeans.modules.maven.indexer.api.DEFAULT_UPDATE_FREQ" type="export">
           Brand the <code>DEFAULT_UPDATE_FREQ</code> key in
           <code>org.netbeans.modules.maven.indexer.api.Bundle</code> file

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -212,6 +212,19 @@
             ExplicitProcessParameters</a> instance(s) in the action's Lookup. See <a href="@org-netbeans-modules-extexecution-base@/org/netbeans/api/extexecution/base/ExplicitProcessParameters.html">
             ExplicitProcessParameters</a> javadoc for more details.
       </api>
+      <api category="devel" group="branding" name="org.netbeans.modules.maven.indexer.api.DEFAULT_UPDATE_FREQ" type="export">
+          Brand the <code>DEFAULT_UPDATE_FREQ</code> key in
+          <code>org.netbeans.modules.maven.indexer.api.Bundle</code> file
+          with one of the values:
+          <ul>
+              <li><code>0</code> - once a week</li>
+              <li><code>1</code> - once a day</li>
+              <li><code>2</code> - on each startup</li>
+              <li><code>3</code> - never</li>
+          </ul>
+          to control (usually to disable with <code>DEFAULT_UPDATE_FREQ=3</code>)
+          the default behavior automatic maven index downloading.
+      </api> 
   </p>
   
  </answer>

--- a/java/maven/manifest.mf
+++ b/java/maven/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven/2
-OpenIDE-Module-Specification-Version: 2.146
+OpenIDE-Module-Specification-Version: 2.147
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/maven/layer.xml
 AutoUpdate-Show-In-Client: false

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -220,7 +220,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.40</specification-version>
+                        <specification-version>2.51</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven/src/org/netbeans/modules/maven/ProjectOpenedHookImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/ProjectOpenedHookImpl.java
@@ -181,17 +181,17 @@ public class ProjectOpenedHookImpl extends ProjectOpenedHook {
         //only check for the updates of index, if the indexing was already used.
         if (checkedIndices.compareAndSet(false, true) && existsDefaultIndexLocation() && RepositoryPreferences.isIndexRepositories()) {
             final int freq = RepositoryPreferences.getIndexUpdateFrequency();
-            new RequestProcessor("Maven Repo Index Transfer/Scan").post(new Runnable() { // #138102
-                public @Override void run() {
-                    List<RepositoryInfo> ris = RepositoryPreferences.getInstance().getRepositoryInfos();
-                    Set<String> doNotIndexRepos = getDoNotIndexRepos();
-                    for (final RepositoryInfo ri : ris) {
-                        //check this repo can be indexed
-                        if ( (!ri.isRemoteDownloadable() && !ri.isLocal()) || doNotIndexRepos.contains(ri.getId())) {
-                            LOGGER.log(Level.FINER, "Skipping Index At Startup for :{0}", ri.getId());//NOI18N
-                            continue;
-                        }
-                        if (freq != RepositoryPreferences.FREQ_NEVER) {
+            if (freq != RepositoryPreferences.FREQ_NEVER) {
+                new RequestProcessor("Maven Repo Index Transfer/Scan").post(new Runnable() { // #138102
+                    public @Override void run() {
+                        List<RepositoryInfo> ris = RepositoryPreferences.getInstance().getRepositoryInfos();
+                        Set<String> doNotIndexRepos = getDoNotIndexRepos();
+                        for (final RepositoryInfo ri : ris) {
+                            //check this repo can be indexed
+                            if ( (!ri.isRemoteDownloadable() && !ri.isLocal()) || doNotIndexRepos.contains(ri.getId())) {
+                                LOGGER.log(Level.FINER, "Skipping Index At Startup for :{0}", ri.getId());//NOI18N
+                                continue;
+                            }
                             boolean run = false;
                             if (freq == RepositoryPreferences.FREQ_STARTUP) {
                                 LOGGER.log(Level.FINER, "Index At Startup :{0}", ri.getId());//NOI18N
@@ -208,8 +208,8 @@ public class ProjectOpenedHookImpl extends ProjectOpenedHook {
                             }
                         }
                     }
-                }
-            }, 1000 * 60 * 2);
+                }, 1000 * 60 * 2);
+            }
         }
     }
 


### PR DESCRIPTION
Users of VSNetBeans complain about the Maven index download (some users of NetBeans IDE, like me, complain as well) and the fact that there is no UI to disable it. To address their complains right now, before some final solution[1] is implemented, I propose to introduce branding API and use it in the `nbcode` suite to disable the download in VSNetBeans.


[1] Ideally I'd like the queries to Maven to be handled online by sending a query to https://search.maven.org/#search|ga|1|guice & co.