### PR TITLE
LSP: Test Explorer essential fixes

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -52,8 +52,6 @@ import org.netbeans.modules.java.lsp.server.progress.OperationContext;
 import org.netbeans.modules.java.lsp.server.progress.ProgressOperationEvent;
 import org.netbeans.modules.java.lsp.server.progress.ProgressOperationListener;
 import org.netbeans.modules.java.lsp.server.progress.TestProgressHandler;
-import org.netbeans.modules.progress.spi.InternalHandle;
-import org.netbeans.spi.extexecution.base.ProcessParameters;
 import org.netbeans.spi.project.ActionProgress;
 import org.netbeans.spi.project.ActionProvider;
 import org.netbeans.spi.project.SingleMethod;
@@ -252,7 +250,7 @@ public abstract class NbLaunchDelegate {
         Collection<ActionProvider> actionProviders = findActionProviders(toRun);
         Lookup testLookup = Lookups.singleton(toRun);
         String[] actions;
-        if (mainSource && singleMethod != null) {
+        if (!mainSource && singleMethod != null) {
             actions = debug ? new String[] {SingleMethod.COMMAND_DEBUG_SINGLE_METHOD}
                             : new String[] {SingleMethod.COMMAND_RUN_SINGLE_METHOD};
         } else {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -144,7 +144,7 @@ public abstract class NbLaunchDelegate {
                     context.setProcessExecutorHandle(e.getProgressHandle());
                 }
             });
-            TestProgressHandler testProgressHandler = ctx.getClient().getNbCodeCapabilities().hasTestResultsSupport() ? new TestProgressHandler(ctx.getClient(), Utils.toUri(toRun)) : null;
+            TestProgressHandler testProgressHandler = ctx.getClient().getNbCodeCapabilities().hasTestResultsSupport() ? new TestProgressHandler(ctx.getClient(), context.getClient(), Utils.toUri(toRun)) : null;
             Lookup launchCtx = new ProxyLookup(
                     testProgressHandler != null ? Lookups.fixed(toRun, ioContext, progress, testProgressHandler) : Lookups.fixed(toRun, ioContext, progress),
                     Lookup.getDefault()

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchRequestHandler.java
@@ -123,7 +123,7 @@ public final class NbLaunchRequestHandler {
         } else {
             context.setSourcePaths((String[]) launchArguments.get("sourcePaths"));
         }
-        String singleMethod = (String)launchArguments.get("singleMethod");
+        String singleMethod = (String)launchArguments.get("methodName");
         boolean testRun = (Boolean) launchArguments.getOrDefault("testRun", Boolean.FALSE);
         activeLaunchHandler.nbLaunch(file, singleMethod, launchArguments, context, !noDebug, testRun, new OutputListener(context)).thenRun(() -> {
             activeLaunchHandler.postLaunch(launchArguments, context);

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/progress/TestProgressHandlerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/progress/TestProgressHandlerTest.java
@@ -27,6 +27,8 @@ import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.debug.OutputEventArguments;
+import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 import org.junit.Test;
 import org.netbeans.api.extexecution.print.LineConvertors;
 import org.netbeans.api.project.Project;
@@ -71,7 +73,7 @@ public class TestProgressHandlerTest extends NbTestCase {
         assertNotNull(fo);
         List<TestProgressParams> msgs = new ArrayList<>();
         MockLanguageClient mlc = new MockLanguageClient(msgs);
-        TestProgressHandler progressHandler = new TestProgressHandler(mlc, fo.toURI().toString());
+        TestProgressHandler progressHandler = new TestProgressHandler(mlc, new IDebugProtocolClient() {}, fo.toURI().toString());
         progressHandler.displaySuiteRunning(progressHandler, "TestSuiteName");
         FileObject projectDir = fo;
         Project project = new Project() {

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -228,16 +228,15 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             ]);
         }
     }));
-    const runDebug = async (noDebug : boolean, testRun: boolean, uri : any, methodName? : string) => {
-        const editor = window.activeTextEditor;
-        if (editor) {
-            const docUri = editor.document.uri;
+    const runDebug = async (noDebug : boolean, testRun: boolean, uri : vscode.Uri, methodName? : string) => {
+        const docUri = uri ? uri : window.activeTextEditor?.document.uri;
+        if (docUri) {
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(docUri);
             const debugConfig : vscode.DebugConfiguration = {
                 type: "java8+",
                 name: "Java Single Debug",
                 request: "launch",
-                mainClass: uri,
+                mainClass: uri.toString(),
                 methodName,
                 testRun
             };

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -228,15 +228,15 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             ]);
         }
     }));
-    const runDebug = async (noDebug : boolean, testRun: boolean, uri : vscode.Uri, methodName? : string) => {
-        const docUri = uri ? uri : window.activeTextEditor?.document.uri;
+    const runDebug = async (noDebug: boolean, testRun: boolean, uri: string, methodName?: string) => {
+        const docUri = uri ? vscode.Uri.file(uri) : window.activeTextEditor?.document.uri;
         if (docUri) {
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(docUri);
             const debugConfig : vscode.DebugConfiguration = {
                 type: "java8+",
                 name: "Java Single Debug",
                 request: "launch",
-                mainClass: uri.toString(),
+                mainClass: uri,
                 methodName,
                 testRun
             };

--- a/java/java.lsp.server/vscode/src/protocol.ts
+++ b/java/java.lsp.server/vscode/src/protocol.ts
@@ -79,7 +79,7 @@ export interface TestSuite {
     suiteName: string;
     file?: string;
     line?: number;
-    state: 'running' | 'completed' | 'errored';
+    state: 'loaded' | 'running' | 'completed' | 'errored';
     tests?: TestCase[];
 }
 
@@ -89,7 +89,7 @@ export interface TestCase {
     fullName: string;
     file?: string;
     line?: number;
-    state: 'running' | 'passed' | 'failed' | 'skipped' | 'errored';
+    state: 'loaded' | 'running' | 'passed' | 'failed' | 'skipped' | 'errored';
     stackTrace?: string[];
 }
 

--- a/java/java.lsp.server/vscode/src/testAdapter.ts
+++ b/java/java.lsp.server/vscode/src/testAdapter.ts
@@ -62,14 +62,18 @@ export class NbTestAdapter implements TestAdapter {
                 this.children.push({ type: 'suite', id: suite.suiteName, label: suite.suiteName, file: suite.file ? Uri.parse(suite.file)?.path : undefined, line: suite.line, children });
             });
         }
-		this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: this.testSuite });
+        if (this.children.length > 0) {
+            this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished', suite: this.testSuite });
+        } else {
+            this.testsEmitter.fire(<TestLoadFinishedEvent>{ type: 'finished' });
+        }
     }
 
     async run(tests: string[]): Promise<void> {
 		this.statesEmitter.fire(<TestRunStartedEvent>{ type: 'started', tests });
 		if (tests.length === 1) {
             if (tests[0] === '*') {
-                await commands.executeCommand('java.run.test', this.workspaceFolder.uri.toString());
+                await commands.executeCommand('java.run.test', this.workspaceFolder.uri);
                 this.statesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
             } else {
                 const idx = tests[0].indexOf(':');
@@ -78,9 +82,9 @@ export class NbTestAdapter implements TestAdapter {
                 if (current && current.file) {
                     const methodName = idx < 0 ? undefined : tests[0].slice(idx + 1);
                     if (methodName) {
-                        await commands.executeCommand('java.run.single', Uri.file(current.file).toString(), methodName);
+                        await commands.executeCommand('java.run.single', Uri.file(current.file), methodName);
                     } else {
-                        await commands.executeCommand('java.run.single', Uri.file(current.file).toString());
+                        await commands.executeCommand('java.run.single', Uri.file(current.file));
                     }
                     this.statesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
                 } else {
@@ -101,9 +105,9 @@ export class NbTestAdapter implements TestAdapter {
             if (current && current.file) {
                 const methodName = idx < 0 ? undefined : tests[0].slice(idx + 1);
                 if (methodName) {
-                    await commands.executeCommand('java.debug.single', Uri.file(current.file).toString(), methodName);
+                    await commands.executeCommand('java.debug.single', Uri.file(current.file), methodName);
                 } else {
-                    await commands.executeCommand('java.debug.single', Uri.file(current.file).toString());
+                    await commands.executeCommand('java.debug.single', Uri.file(current.file));
                 }
                 this.statesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
             } else {

--- a/java/java.lsp.server/vscode/src/testAdapter.ts
+++ b/java/java.lsp.server/vscode/src/testAdapter.ts
@@ -23,7 +23,6 @@ import * as path from 'path';
 import { TestAdapter, TestSuiteEvent, TestEvent, TestLoadFinishedEvent, TestLoadStartedEvent, TestRunFinishedEvent, TestRunStartedEvent, TestSuiteInfo, TestInfo } from "vscode-test-adapter-api";
 import { TestSuite } from "./protocol";
 import { LanguageClient } from "vscode-languageclient";
-import { getVSCodeDownloadUrl } from "vscode-test/out/util";
 
 export class NbTestAdapter implements TestAdapter {
 

--- a/java/java.lsp.server/vscode/src/testAdapter.ts
+++ b/java/java.lsp.server/vscode/src/testAdapter.ts
@@ -72,7 +72,7 @@ export class NbTestAdapter implements TestAdapter {
 		this.statesEmitter.fire(<TestRunStartedEvent>{ type: 'started', tests });
 		if (tests.length === 1) {
             if (tests[0] === '*') {
-                await commands.executeCommand('java.run.test', this.workspaceFolder.uri);
+                await commands.executeCommand('java.run.test', this.workspaceFolder.uri.toString());
                 this.statesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
             } else {
                 const idx = tests[0].indexOf(':');
@@ -81,9 +81,9 @@ export class NbTestAdapter implements TestAdapter {
                 if (current && current.file) {
                     const methodName = idx < 0 ? undefined : tests[0].slice(idx + 1);
                     if (methodName) {
-                        await commands.executeCommand('java.run.single', Uri.file(current.file), methodName);
+                        await commands.executeCommand('java.run.single', Uri.file(current.file).toString(), methodName);
                     } else {
-                        await commands.executeCommand('java.run.single', Uri.file(current.file));
+                        await commands.executeCommand('java.run.single', Uri.file(current.file).toString());
                     }
                     this.statesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
                 } else {
@@ -104,9 +104,9 @@ export class NbTestAdapter implements TestAdapter {
             if (current && current.file) {
                 const methodName = idx < 0 ? undefined : tests[0].slice(idx + 1);
                 if (methodName) {
-                    await commands.executeCommand('java.debug.single', Uri.file(current.file), methodName);
+                    await commands.executeCommand('java.debug.single', Uri.file(current.file).toString(), methodName);
                 } else {
-                    await commands.executeCommand('java.debug.single', Uri.file(current.file));
+                    await commands.executeCommand('java.debug.single', Uri.file(current.file).toString());
                 }
                 this.statesEmitter.fire(<TestRunFinishedEvent>{ type: 'finished' });
             } else {

--- a/java/java.lsp.server/vscode/src/testAdapter.ts
+++ b/java/java.lsp.server/vscode/src/testAdapter.ts
@@ -133,7 +133,7 @@ export class NbTestAdapter implements TestAdapter {
         this.updateTests(suite, true);
         if (suite.state === 'running') {
             this.statesEmitter.fire(<TestSuiteEvent>{ type: 'suite', suite: suite.suiteName, state: suite.state });
-        } else {
+        } else if (suite.state !== 'loaded') {
             if (suite.tests) {
                 suite.tests.forEach(test => {
                     let message;

--- a/platform/api.progress/src/org/netbeans/modules/progress/spi/Controller.java
+++ b/platform/api.progress/src/org/netbeans/modules/progress/spi/Controller.java
@@ -344,6 +344,10 @@ public class Controller {
                         if (lastEvent.isSwitched()) {
                             event.markAsSwitched();
                         }
+                        // preserve finish type
+                        if (lastEvent.getType() == ProgressEvent.TYPE_FINISH) {
+                            event.markAsFinished();
+                        }
                         LOG.log(Level.FINER, "Event merged with {0} to {1}", 
                                 new Object [] { lastEvent, event} );
                     }

--- a/platform/api.progress/src/org/netbeans/modules/progress/spi/ProgressEvent.java
+++ b/platform/api.progress/src/org/netbeans/modules/progress/spi/ProgressEvent.java
@@ -157,4 +157,8 @@ public final class ProgressEvent {
         sb.append("]");
         return sb.toString();
     }
+
+    void markAsFinished() {
+        type = TYPE_FINISH;
+    }
 }


### PR DESCRIPTION
A set of essential fixes for 12.4 Beta:
- Test Explorer support should show standard output in debug console
- Test Explorer support for multi projects
- Test Explorer should prevent duplicate classes in UI
- Test Explorer should support for junit ParameterizedTests
- Failing ServerTest fixed
- Fixed deadlock in Java code completion over LSP
- Fixed run single method over LSP