### PR TITLE
Profiler lib native binaries: use ASF binaries with fix for NETBEANS-1428

### DIFF
--- a/profiler/lib.profiler/build.xml
+++ b/profiler/lib.profiler/build.xml
@@ -26,8 +26,13 @@
     <property name="profiler.cluster" value="./release"/>
     <property name="header.dir" value="${basedir}/native/build"/>
     <target name="-process.release.files">
+        <!-- CDDL licensed binaries, from the Oracle days -->
         <unzip src="external/profiler-external-binaries-8.2.zip" 
                overwrite="false"
+               dest="${profiler.cluster}"/>
+        <!-- AL2 licensed binaries, build from ASF code (overwrites CDDL binaries) -->
+        <unzip src="external/profiler-external-binaries-ASF.zip"
+               overwrite="true"
                dest="${profiler.cluster}"/>
     </target>
 

--- a/profiler/lib.profiler/external/binaries-list
+++ b/profiler/lib.profiler/external/binaries-list
@@ -15,3 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 45225DCFC94A9782419E95C70957822A0C44612D profiler-external-binaries-8.2.zip
+B1C1B951F79716EFFAB9BEC96A611844B038E2E2 profiler-external-binaries-ASF.zip

--- a/profiler/lib.profiler/external/profiler-external-binaries-ASF.txt
+++ b/profiler/lib.profiler/external/profiler-external-binaries-ASF.txt
@@ -1,0 +1,6 @@
+Name: Profiler Binaries
+Description: Profiler Binaries for a large variety of platforms, superseds older CDDL binaries where applicable.
+Version: ASF-v1 (first version released under ASF hospice)
+License: Apache License v2
+Source: https://netbeans.apache.org
+Origin: Apache NetBeans


### PR DESCRIPTION
Use ASF-created binaries for Windows X86, Windows X64, MacOS X64, Linux X86 and Linux X64. The ASF-binaries includes the fix for [NETBEANS-1428](https://issues.apache.org/jira/browse/NETBEANS-1428). For the rest of the platforms that were supported in the past (for example HP-UX, Solaris, Linux ARM) we keep these binaries in the distribution but they are no longer receiving bug fixes and they therefore _don't_ have the fix [NETBEANS-1428](https://issues.apache.org/jira/browse/NETBEANS-1428).

This PR continues (for now) to use the "external binaries" mechanism even if this mechanism was never intended for binaries originating from Apache NetBeans itself (duh!, they are not 'external'). In this light I probably didn't need to create the file `external/profiler-external-binaries-ASF.txt` but I did so for completeness.

