### PR TITLE
[NETBEANS-4619][CND] Missing license headers

### DIFF
--- a/cnd/cnd.apt/src/org/netbeans/modules/cnd/apt/impl/support/aptBigIntegerExpr.g
+++ b/cnd/cnd.apt/src/org/netbeans/modules/cnd/apt/impl/support/aptBigIntegerExpr.g
@@ -1,47 +1,21 @@
-//
-// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-//
-// Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-//
-// Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-// Other names may be trademarks of their respective owners.
-//
-// The contents of this file are subject to the terms of either the GNU
-// General Public License Version 2 only ("GPL") or the Common
-// Development and Distribution License("CDDL") (collectively, the
-// "License"). You may not use this file except in compliance with the
-// License. You can obtain a copy of the License at
-// http://www.netbeans.org/cddl-gplv2.html
-// or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-// specific language governing permissions and limitations under the
-// License.  When distributing the software, include this License Header
-// Notice in each file and include the License file at
-// nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-// particular file as subject to the "Classpath" exception as provided
-// by Oracle in the GPL Version 2 section of the License file that
-// accompanied this code. If applicable, add the following below the
-// License Header, with the fields enclosed by brackets [] replaced by
-// your own identifying information:
-// "Portions Copyrighted [year] [name of copyright owner]"
-//
-// Contributor(s):
-//
-// The Original Software is NetBeans. The Initial Developer of the Original
-// Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-// Microsystems, Inc. All Rights Reserved.
-//
-// If you wish your version of this file to be governed by only the CDDL
-// or only the GPL Version 2, indicate your decision by adding
-// "[Contributor] elects to include this software in this distribution
-// under the [CDDL or GPL Version 2] license." If you do not indicate a
-// single choice of license, a recipient has the option to distribute
-// your version of this file under either the CDDL, the GPL Version 2 or
-// to extend the choice of license to its licensees as provided above.
-// However, if you add GPL Version 2 code and therefore, elected the GPL
-// Version 2 license, then the option applies only if the new code is
-// made subject to such option by the copyright holder.
-//
-
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /*
  *
  * Parser for preprocessor expressions based on Big Integers

--- a/cnd/cnd.apt/src/org/netbeans/modules/cnd/apt/impl/support/aptexpr.g
+++ b/cnd/cnd.apt/src/org/netbeans/modules/cnd/apt/impl/support/aptexpr.g
@@ -1,47 +1,21 @@
-//
-// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-//
-// Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-//
-// Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-// Other names may be trademarks of their respective owners.
-//
-// The contents of this file are subject to the terms of either the GNU
-// General Public License Version 2 only ("GPL") or the Common
-// Development and Distribution License("CDDL") (collectively, the
-// "License"). You may not use this file except in compliance with the
-// License. You can obtain a copy of the License at
-// http://www.netbeans.org/cddl-gplv2.html
-// or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-// specific language governing permissions and limitations under the
-// License.  When distributing the software, include this License Header
-// Notice in each file and include the License file at
-// nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-// particular file as subject to the "Classpath" exception as provided
-// by Oracle in the GPL Version 2 section of the License file that
-// accompanied this code. If applicable, add the following below the
-// License Header, with the fields enclosed by brackets [] replaced by
-// your own identifying information:
-// "Portions Copyrighted [year] [name of copyright owner]"
-//
-// Contributor(s):
-//
-// The Original Software is NetBeans. The Initial Developer of the Original
-// Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-// Microsystems, Inc. All Rights Reserved.
-//
-// If you wish your version of this file to be governed by only the CDDL
-// or only the GPL Version 2, indicate your decision by adding
-// "[Contributor] elects to include this software in this distribution
-// under the [CDDL or GPL Version 2] license." If you do not indicate a
-// single choice of license, a recipient has the option to distribute
-// your version of this file under either the CDDL, the GPL Version 2 or
-// to extend the choice of license to its licensees as provided above.
-// However, if you add GPL Version 2 code and therefore, elected the GPL
-// Version 2 license, then the option applies only if the new code is
-// made subject to such option by the copyright holder.
-//
-
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /*
  *
  * Parser for preprocessor expressions

--- a/cnd/cnd.apt/src/org/netbeans/modules/cnd/apt/impl/support/aptlexer.g
+++ b/cnd/cnd.apt/src/org/netbeans/modules/cnd/apt/impl/support/aptlexer.g
@@ -1,47 +1,21 @@
-//
-// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-//
-// Copyright 1997-2010 Oracle and/or its affiliates. All rights reserved.
-//
-// Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-// Other names may be trademarks of their respective owners.
-//
-// The contents of this file are subject to the terms of either the GNU
-// General Public License Version 2 only ("GPL") or the Common
-// Development and Distribution License("CDDL") (collectively, the
-// "License"). You may not use this file except in compliance with the
-// License. You can obtain a copy of the License at
-// http://www.netbeans.org/cddl-gplv2.html
-// or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-// specific language governing permissions and limitations under the
-// License.  When distributing the software, include this License Header
-// Notice in each file and include the License file at
-// nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-// particular file as subject to the "Classpath" exception as provided
-// by Oracle in the GPL Version 2 section of the License file that
-// accompanied this code. If applicable, add the following below the
-// License Header, with the fields enclosed by brackets [] replaced by
-// your own identifying information:
-// "Portions Copyrighted [year] [name of copyright owner]"
-//
-// Contributor(s):
-//
-// The Original Software is NetBeans. The Initial Developer of the Original
-// Software is Sun Microsystems, Inc. Portions Copyright 1997-2007 Sun
-// Microsystems, Inc. All Rights Reserved.
-//
-// If you wish your version of this file to be governed by only the CDDL
-// or only the GPL Version 2, indicate your decision by adding
-// "[Contributor] elects to include this software in this distribution
-// under the [CDDL or GPL Version 2] license." If you do not indicate a
-// single choice of license, a recipient has the option to distribute
-// your version of this file under either the CDDL, the GPL Version 2 or
-// to extend the choice of license to its licensees as provided above.
-// However, if you add GPL Version 2 code and therefore, elected the GPL
-// Version 2 license, then the option applies only if the new code is
-// made subject to such option by the copyright holder.
-//
-
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 // Start of APTLexer.cpp block
 header {
 

--- a/cnd/cnd.asm/licenseinfo.xml
+++ b/cnd/cnd.asm/licenseinfo.xml
@@ -1,4 +1,5 @@
-<#--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -18,8 +19,13 @@
     under the License.
 
 -->
-<#assign licenseFirst = "!">
-<#assign licensePrefix = "! ">
-<#assign licenseLast = "!">
-<#include "${project.licensePath}">
-
+<licenseinfo>
+    <fileset>
+        <!-- User templates -->
+        <file>src/org/netbeans/modules/cnd/asm/core/resources/AsmExample.s</file>
+        <file>src/org/netbeans/modules/cnd/asm/core/resources/AsmTemplate.s</file>
+        <file>src/org/netbeans/modules/cnd/asm/core/resources/InlineTemplate.il</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="TEMPLATE_MINIMAL_IP" />
+    </fileset>
+</licenseinfo>

--- a/cnd/cnd.asm/licenseinfo.xml
+++ b/cnd/cnd.asm/licenseinfo.xml
@@ -26,6 +26,6 @@
         <file>src/org/netbeans/modules/cnd/asm/core/resources/AsmTemplate.s</file>
         <file>src/org/netbeans/modules/cnd/asm/core/resources/InlineTemplate.il</file>
         <license ref="Apache-2.0-ASF" />
-        <comment type="TEMPLATE_MINIMAL_IP" />
+        <comment type="COMMENT_UNSUPPORTED" />
     </fileset>
 </licenseinfo>

--- a/cnd/cnd.asm/src/org/netbeans/modules/cnd/asm/base/AntlrTokenTypes.txt
+++ b/cnd/cnd.asm/src/org/netbeans/modules/cnd/asm/base/AntlrTokenTypes.txt
@@ -1,3 +1,20 @@
+#    Licensed to the Apache Software Foundation (ASF) under one
+#    or more contributor license agreements.  See the NOTICE file
+#    distributed with this work for additional information
+#    regarding copyright ownership.  The ASF licenses this file
+#    to you under the Apache License, Version 2.0 (the
+#    "License"); you may not use this file except in compliance
+#    with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing,
+#    software distributed under the License is distributed on an
+#    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#    KIND, either express or implied.  See the License for the
+#    specific language governing permissions and limitations
+#    under the License.
+
 DisScanner   
 LabelInst=4
 DigitLabel=5

--- a/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/cppunitrunner-cc.template
+++ b/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/cppunitrunner-cc.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/cppunittest-cc.template
+++ b/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/cppunittest-cc.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/cppunittest-h.template
+++ b/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/cppunittest-h.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/cppunittest.group
+++ b/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/cppunittest.group
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 Templates/cppFiles/__cppunittest__.h
 Templates/cppFiles/__cppunittest__.cc

--- a/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/test-cppunit-class-file-cpp.template
+++ b/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/test-cppunit-class-file-cpp.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/test-cppunit-class-file-h.template
+++ b/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/test-cppunit-class-file-h.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/test-cppunit-runner-file-cpp.template
+++ b/cnd/cnd.cncppunit/src/org/netbeans/modules/cnd/cncppunit/templates/cpp/test-cppunit-runner-file-cpp.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.completion/src/org/netbeans/modules/cnd/completion/templates/Bundle.properties
+++ b/cnd/cnd.completion/src/org/netbeans/modules/cnd/completion/templates/Bundle.properties
@@ -1,39 +1,18 @@
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# Copyright (c) 2014, 2016 Oracle and/or its affiliates. All rights reserved.
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
-#
-# Contributor(s):
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #JavaCodeTemplateProcessor
 CPP-init=Initializing code templates...

--- a/cnd/cnd.debugger.common2/src/org/netbeans/modules/cnd/debugger/common2/utils/ProcessListSupport.java
+++ b/cnd/cnd.debugger.common2/src/org/netbeans/modules/cnd/debugger/common2/utils/ProcessListSupport.java
@@ -1,6 +1,22 @@
 /*
- * Copyright (c) 2009, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 package org.netbeans.modules.cnd.debugger.common2.utils;
 
 

--- a/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/wizard/Bundle.properties
+++ b/cnd/cnd.discovery/src/org/netbeans/modules/cnd/discovery/wizard/Bundle.properties
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 WIZARD_TITLE_TXT=Configure Code Assistance Wizard
 ACTION_TITLE_TXT=Configure Code Assistance...

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-Linux-sparc_64.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-Linux-sparc_64.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-Linux-x86.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-Linux-x86.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-Linux-x86_64.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-Linux-x86_64.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-MacOSX-x86.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-MacOSX-x86.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-MacOSX-x86_64.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-MacOSX-x86_64.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-Previse.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-Previse.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-Previse_64.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-Previse_64.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-sparc.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-sparc.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-sparc_64.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-sparc_64.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-x86.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-x86.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-x86_64.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-SunOS-x86_64.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-impl.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-impl.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # 
 # Generated Makefile - do not edit! 
 # 

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-variables.mk
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Makefile-variables.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated - do not edit!
 #

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-Linux-sparc_64.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-Linux-sparc_64.bash
@@ -1,4 +1,22 @@
 #!/bin/bash -x
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-Linux-x86.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-Linux-x86.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-Linux-x86_64.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-Linux-x86_64.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-MacOSX-x86.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-MacOSX-x86.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-MacOSX-x86_64.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-MacOSX-x86_64.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-Previse.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-Previse.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-Previse_64.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-Previse_64.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-sparc.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-sparc.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-sparc_64.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-sparc_64.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-x86.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-x86.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-x86_64.bash
+++ b/cnd/cnd.discovery/tools/BuildTrace/nbproject/Package-SunOS-x86_64.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/BuildTrace/test.awk
+++ b/cnd/cnd.discovery/tools/BuildTrace/test.awk
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 BEGIN {
     R["called:"]=0; 

--- a/cnd/cnd.discovery/tools/ToolsWrapperUnix/wrapper
+++ b/cnd/cnd.discovery/tools/ToolsWrapperUnix/wrapper
@@ -1,4 +1,22 @@
 #!/bin/sh
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
 #set -x
 real_tool=echo
 if [ -n "${__CND_BUILD_LOG__}" ]; then

--- a/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Makefile-Unix_64.mk
+++ b/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Makefile-Unix_64.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Makefile-Windows_32.mk
+++ b/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Makefile-Windows_32.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated Makefile - do not edit!
 #

--- a/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Makefile-impl.mk
+++ b/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Makefile-impl.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # 
 # Generated Makefile - do not edit! 
 # 

--- a/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Makefile-variables.mk
+++ b/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Makefile-variables.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 # Generated - do not edit!
 #

--- a/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Package-Unix_64.bash
+++ b/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Package-Unix_64.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Package-Windows_32.bash
+++ b/cnd/cnd.discovery/tools/ToolsWrapperWidows/nbproject/Package-Windows_32.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.editor/l10n.list
+++ b/cnd/cnd.editor/l10n.list
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 # C/C++ Editor
 read global
 ${l10n-module}/src/**/*.gif

--- a/cnd/cnd.editor/licenseinfo.xml
+++ b/cnd/cnd.editor/licenseinfo.xml
@@ -1,4 +1,5 @@
-<#--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -18,8 +19,14 @@
     under the License.
 
 -->
-<#assign licenseFirst = "!">
-<#assign licensePrefix = "! ">
-<#assign licenseLast = "!">
-<#include "${project.licensePath}">
-
+<licenseinfo>
+    <fileset>
+        <!-- User templates -->
+        <file>src/org/netbeans/modules/cnd/editor/resources/cplusplus/CCExample</file>
+        <file>src/org/netbeans/modules/cnd/editor/resources/cplusplus/CExample</file>
+        <file>src/org/netbeans/modules/cnd/editor/resources/cplusplus/HExample</file>
+        <file>src/org/netbeans/modules/cnd/editor/resources/fortran/FExample</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="TEMPLATE_MINIMAL_IP" />
+    </fileset>
+</licenseinfo>

--- a/cnd/cnd.kit/hudson/master-email.template
+++ b/cnd/cnd.kit/hudson/master-email.template
@@ -1,4 +1,24 @@
 <html>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <head>
 <title>Hudson build report</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/cnd/cnd.kit/hudson/reporter.template
+++ b/cnd/cnd.kit/hudson/reporter.template
@@ -1,4 +1,24 @@
 <html>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <head>
 <title>Hudson test report</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/cnd/cnd.kit/hudson/slave-email.template
+++ b/cnd/cnd.kit/hudson/slave-email.template
@@ -1,4 +1,24 @@
 <html>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <head>
 <title>Hudson build report</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/cnd/cnd.kit/hudson/unstable.template
+++ b/cnd/cnd.kit/hudson/unstable.template
@@ -1,4 +1,24 @@
 <html>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <head>
 <title>Unstable tests report</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/cnd/cnd.kit/release/VERSION.txt
+++ b/cnd/cnd.kit/release/VERSION.txt
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # cluster incompatible release version
 13

--- a/cnd/cnd.makeproject/licenseinfo.xml
+++ b/cnd/cnd.makeproject/licenseinfo.xml
@@ -1,4 +1,5 @@
-<#--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -18,8 +19,13 @@
     under the License.
 
 -->
-<#assign licenseFirst = "!">
-<#assign licensePrefix = "! ">
-<#assign licenseLast = "!">
-<#include "${project.licensePath}">
-
+<licenseinfo>
+    <fileset>
+        <!-- User templates -->
+        <file>samples_src/hellocmake/CMakeLists.txt</file>
+        <file>samples_src/hellocmake/src/CMakeLists.txt</file>
+        <file>samples_src/helloqt/HelloForm.ui</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="TEMPLATE_MINIMAL_IP" />
+    </fileset>
+</licenseinfo>

--- a/cnd/cnd.makeproject/src/org/netbeans/modules/cnd/makeproject/launchers/resources/simple-launcher.template
+++ b/cnd/cnd.makeproject/src/org/netbeans/modules/cnd/makeproject/launchers/resources/simple-launcher.template
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 # Launchers File syntax:
 #
 # [Must-have property line] 

--- a/cnd/cnd.makeproject/src/org/netbeans/modules/cnd/makeproject/resources/MasterMakefile
+++ b/cnd/cnd.makeproject/src/org/netbeans/modules/cnd/makeproject/resources/MasterMakefile
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #
 #  There exist several targets which are by default empty and which can be 
 #  used for execution of your targets. These targets are usually executed 

--- a/cnd/cnd.makeproject/src/org/netbeans/modules/cnd/makeproject/resources/MasterMakefile-impl.mk
+++ b/cnd/cnd.makeproject/src/org/netbeans/modules/cnd/makeproject/resources/MasterMakefile-impl.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # 
 # Generated Makefile - do not edit! 
 # 

--- a/cnd/cnd.modelimpl/external/binaries-list
+++ b/cnd/cnd.modelimpl/external/binaries-list
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 C51780D99464CBF45B0495C7646B442AB3C7B463 open-fortran-parser-0.7.1.2.zip

--- a/cnd/cnd.modelimpl/src/org/netbeans/modules/cnd/modelimpl/csm/DeclTypeImpl.java
+++ b/cnd/cnd.modelimpl/src/org/netbeans/modules/cnd/modelimpl/csm/DeclTypeImpl.java
@@ -1,42 +1,20 @@
 /*
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright 2013 Oracle and/or its affiliates. All rights reserved.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Oracle and Java are registered trademarks of Oracle and/or its affiliates.
- * Other names may be trademarks of their respective owners.
- *
- * The contents of this file are subject to the terms of either the GNU
- * General Public License Version 2 only ("GPL") or the Common
- * Development and Distribution License("CDDL") (collectively, the
- * "License"). You may not use this file except in compliance with the
- * License. You can obtain a copy of the License at
- * http://www.netbeans.org/cddl-gplv2.html
- * or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
- * specific language governing permissions and limitations under the
- * License.  When distributing the software, include this License Header
- * Notice in each file and include the License file at
- * nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the GPL Version 2 section of the License file that
- * accompanied this code. If applicable, add the following below the
- * License Header, with the fields enclosed by brackets [] replaced by
- * your own identifying information:
- * "Portions Copyrighted [year] [name of copyright owner]"
- *
- * If you wish your version of this file to be governed by only the CDDL
- * or only the GPL Version 2, indicate your decision by adding
- * "[Contributor] elects to include this software in this distribution
- * under the [CDDL or GPL Version 2] license." If you do not indicate a * single choice of license, a recipient has the option to distribute
- * your version of this file under either the CDDL, the GPL Version 2 or
- * to extend the choice of license to its licensees as provided above.
- * However, if you add GPL Version 2 code and therefore, elected the GPL
- * Version 2 license, then the option applies only if the new code is
- * made subject to such option by the copyright holder.
- *
- * Contributor(s):
- *
- * Portions Copyrighted 2013 Sun Microsystems, Inc.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.netbeans.modules.cnd.modelimpl.csm;
 

--- a/cnd/cnd.navigation/src/org/netbeans/modules/cnd/navigation/resources/cnd_navigation.wsmode
+++ b/cnd/cnd.navigation/src/org/netbeans/modules/cnd/navigation/resources/cnd_navigation.wsmode
@@ -1,5 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
 
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <!DOCTYPE mode PUBLIC
           "-//NetBeans//DTD Mode Properties 2.0//EN"
           "http://www.netbeans.org/dtds/mode-properties2_0.dtd">

--- a/cnd/cnd.remote/licenseinfo.xml
+++ b/cnd/cnd.remote/licenseinfo.xml
@@ -1,4 +1,5 @@
-<#--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -18,8 +19,13 @@
     under the License.
 
 -->
-<#assign licenseFirst = "!">
-<#assign licensePrefix = "! ">
-<#assign licenseLast = "!">
-<#include "${project.licensePath}">
-
+<licenseinfo>
+    <fileset>
+        <!-- User templates -->
+        <file>tools/test/file_1</file>
+        <file>tools/test/file_2</file>
+        <file>tools/test/subdir/sub_1</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="TEMPLATE_MINIMAL_IP" />
+    </fileset>
+</licenseinfo>

--- a/cnd/cnd.remote/tools/nbproject/Package-Test_filedata_32.bash
+++ b/cnd/cnd.remote/tools/nbproject/Package-Test_filedata_32.bash
@@ -1,4 +1,21 @@
 #!/bin/bash -x
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 #
 # Generated - do not edit!

--- a/cnd/cnd.remote/tools/test/test1.sh
+++ b/cnd/cnd.remote/tools/test/test1.sh
@@ -1,41 +1,20 @@
 #/bin/sh -x
-# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-# Copyright (c) 2016 Oracle and/or its affiliates. All rights reserved.
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Oracle and Java are registered trademarks of Oracle and/or its affiliates.
-# Other names may be trademarks of their respective owners.
-#
-# The contents of this file are subject to the terms of either the GNU
-# General Public License Version 2 only ("GPL") or the Common
-# Development and Distribution License("CDDL") (collectively, the
-# "License"). You may not use this file except in compliance with the
-# License. You can obtain a copy of the License at
-# http://www.netbeans.org/cddl-gplv2.html
-# or nbbuild/licenses/CDDL-GPL-2-CP. See the License for the
-# specific language governing permissions and limitations under the
-# License.  When distributing the software, include this License Header
-# Notice in each file and include the License file at
-# nbbuild/licenses/CDDL-GPL-2-CP.  Oracle designates this
-# particular file as subject to the "Classpath" exception as provided
-# by Oracle in the GPL Version 2 section of the License file that
-# accompanied this code. If applicable, add the following below the
-# License Header, with the fields enclosed by brackets [] replaced by
-# your own identifying information:
-# "Portions Copyrighted [year] [name of copyright owner]"
-#
-# If you wish your version of this file to be governed by only the CDDL
-# or only the GPL Version 2, indicate your decision by adding
-# "[Contributor] elects to include this software in this distribution
-# under the [CDDL or GPL Version 2] license." If you do not indicate a
-# single choice of license, a recipient has the option to distribute
-# your version of this file under either the CDDL, the GPL Version 2 or
-# to extend the choice of license to its licensees as provided above.
-# However, if you add GPL Version 2 code and therefore, elected the GPL
-# Version 2 license, then the option applies only if the new code is
-# made subject to such option by the copyright holder.
-#
-# Contributor(s):
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 echo "### absolute"
 cat `pwd`/test/file_1

--- a/cnd/cnd.remote/tools/todo.txt
+++ b/cnd/cnd.remote/tools/todo.txt
@@ -1,19 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0. "
 
 TODO:
 

--- a/cnd/cnd.remote/tools/todo.txt
+++ b/cnd/cnd.remote/tools/todo.txt
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 TODO:
 
 - pass directory structure to the remote controller

--- a/cnd/cnd.script/licenseinfo.xml
+++ b/cnd/cnd.script/licenseinfo.xml
@@ -1,4 +1,5 @@
-<#--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -18,8 +19,14 @@
     under the License.
 
 -->
-<#assign licenseFirst = "!">
-<#assign licensePrefix = "! ">
-<#assign licenseLast = "!">
-<#include "${project.licensePath}">
-
+<licenseinfo>
+    <fileset>
+        <!-- User templates -->
+        <file>src/org/netbeans/modules/cnd/script/resources/batExample.bat</file>
+        <file>src/org/netbeans/modules/cnd/script/resources/makefileExample</file>
+        <file>src/org/netbeans/modules/cnd/script/resources/shellExample.sh</file>
+        <file>src/org/netbeans/modules/cnd/script/resources/simple-shell.template</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="TEMPLATE_MINIMAL_IP" />
+    </fileset>
+</licenseinfo>

--- a/cnd/cnd.simpleunit/licenseinfo.xml
+++ b/cnd/cnd.simpleunit/licenseinfo.xml
@@ -1,4 +1,5 @@
-<#--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
 
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -18,8 +19,14 @@
     under the License.
 
 -->
-<#assign licenseFirst = "!">
-<#assign licensePrefix = "! ">
-<#assign licenseLast = "!">
-<#include "${project.licensePath}">
-
+<licenseinfo>
+    <fileset>
+        <!-- User templates -->
+        <file>src/org/netbeans/modules/cnd/simpleunit/templates/cpp/simple-test-cc.template</file>
+        <file>src/org/netbeans/modules/cnd/simpleunit/templates/cpp/test-simple-file-cpp.template</file>
+        <file>src/org/netbeans/modules/cnd/simpleunit/templates/c/simple-test-c.template</file>
+        <file>src/org/netbeans/modules/cnd/simpleunit/templates/c/test-simple-file-c.template</file>
+        <license ref="Apache-2.0-ASF" />
+        <comment type="TEMPLATE_MINIMAL_IP" />
+    </fileset>
+</licenseinfo>

--- a/cnd/cnd.toolchain/test/unit/src/org/netbeans/modules/cnd/toolchain/api/toolchaindefinition.xsd
+++ b/cnd/cnd.toolchain/test/unit/src/org/netbeans/modules/cnd/toolchain/api/toolchaindefinition.xsd
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:tns="http://www.netbeans.org/ns/cnd-toolchain-definition/1"
            targetNamespace="http://www.netbeans.org/ns/cnd-toolchain-definition/1"

--- a/cnd/cnd.ui/licenseinfo.xml
+++ b/cnd/cnd.ui/licenseinfo.xml
@@ -22,10 +22,13 @@
 <licenseinfo>
     <fileset>
         <!-- User templates -->
-        <file>src/org/netbeans/modules/cnd/editor/resources/cplusplus/CCExample</file>
-        <file>src/org/netbeans/modules/cnd/editor/resources/cplusplus/CExample</file>
-        <file>src/org/netbeans/modules/cnd/editor/resources/cplusplus/HExample</file>
-        <file>src/org/netbeans/modules/cnd/editor/resources/fortran/FExample</file>
+        <file>src/org/netbeans/modules/cnd/resources/templates/qt/widget.template</file>
+        <file>src/org/netbeans/modules/cnd/resources/templates/qt/dialog-buttonsright.template</file>
+        <file>src/org/netbeans/modules/cnd/resources/templates/qt/resource.template</file>
+        <file>src/org/netbeans/modules/cnd/resources/templates/qt/translation.template</file>
+        <file>src/org/netbeans/modules/cnd/resources/templates/qt/dialog-buttonsbottom.template</file>
+        <file>src/org/netbeans/modules/cnd/resources/templates/qt/mainwindow.template</file>
+        <file>src/org/netbeans/modules/cnd/resources/templates/qt/dialog-nobuttons.template</file>
         <license ref="Apache-2.0-ASF" />
         <comment type="GUI_USABILITY" />
     </fileset>

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/empty-c.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/empty-c.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/file_header-c.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/file_header-c.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/file_header-h.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/file_header-h.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/file_header.group
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/file_header.group
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 Templates/cFiles/__file_header__.h
 Templates/cFiles/__file_header__.c

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/simple-c.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/simple-c.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/simple-h.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/c/simple-h.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/class-cc.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/class-cc.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/class-h.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/class-h.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/class.group
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/class.group
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 Templates/cppFiles/__class__.h
 Templates/cppFiles/__class__.cc

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/empty-cc.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/empty-cc.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/file_header-cc.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/file_header-cc.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/file_header-h.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/file_header-h.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/file_header.group
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/file_header.group
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 Templates/cFiles/__file_header__.h
 Templates/cFiles/__file_header__.cc

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/header-h.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/header-h.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/header.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/header.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 // -*- C++ -*-
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/simple-cc.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/cpp/simple-cc.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/fortran/fixed-fortran-f.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/fortran/fixed-fortran-f.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "C">
 <#assign licensePrefix = "C ">
 <#assign licenseLast = "C">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/fortran/free-fortran-f90.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/fortran/free-fortran-f90.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "!">
 <#assign licensePrefix = "! ">
 <#assign licenseLast = "!">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/fortran/module-f90.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/fortran/module-f90.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "!">
 <#assign licensePrefix = "! ">
 <#assign licenseLast = "!">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-buttonsbottom.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-buttonsbottom.template
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <ui version="4.0" >
  <class>%<%CLASSNAME%>%</class>
  <widget class="QDialog" name="%<%CLASSNAME%>%" >

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-buttonsbottom.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-buttonsbottom.template
@@ -1,23 +1,3 @@
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
 <ui version="4.0" >
  <class>%<%CLASSNAME%>%</class>
  <widget class="QDialog" name="%<%CLASSNAME%>%" >

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-buttonsright.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-buttonsright.template
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <ui version="4.0" >
  <class>%<%CLASSNAME%>%</class>
  <widget class="QDialog" name="%<%CLASSNAME%>%" >

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-buttonsright.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-buttonsright.template
@@ -1,23 +1,3 @@
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
 <ui version="4.0" >
  <class>%<%CLASSNAME%>%</class>
  <widget class="QDialog" name="%<%CLASSNAME%>%" >

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-nobuttons.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-nobuttons.template
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <ui version="4.0" >
  <class>%<%CLASSNAME%>%</class>
  <widget class="QDialog" name="%<%CLASSNAME%>%" >

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-nobuttons.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/dialog-nobuttons.template
@@ -1,23 +1,3 @@
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
 <ui version="4.0" >
  <class>%<%CLASSNAME%>%</class>
  <widget class="QDialog" name="%<%CLASSNAME%>%" >

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/form-cc.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/form-cc.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/form-h.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/form-h.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/mainwindow.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/mainwindow.template
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <ui version="4.0" >
  <class>%<%CLASSNAME%>%</class>
  <widget class="QMainWindow" name="%<%CLASSNAME%>%" >

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/mainwindow.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/mainwindow.template
@@ -1,23 +1,3 @@
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
 <ui version="4.0" >
  <class>%<%CLASSNAME%>%</class>
  <widget class="QMainWindow" name="%<%CLASSNAME%>%" >

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/resource.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/resource.template
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <RCC version="1.0">
     <qresource>
 <!--

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/resource.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/resource.template
@@ -1,24 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
 <RCC version="1.0">
     <qresource>
 <!--

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/simple-cc.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/simple-cc.template
@@ -1,3 +1,23 @@
+<#--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <#assign licenseFirst = "/*">
 <#assign licensePrefix = " * ">
 <#assign licenseLast = " */">

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/translation.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/translation.template
@@ -1,24 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
 <TS version="1.1">
 <context>
 </context>

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/translation.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/translation.template
@@ -1,4 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <TS version="1.1">
 <context>
 </context>

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/widget.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/widget.template
@@ -1,23 +1,3 @@
-<!--
-
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
-
--->
 <ui version="4.0" >
  <class>%<%CLASSNAME%>%</class>
  <widget class="QWidget" name="%<%CLASSNAME%>%" >

--- a/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/widget.template
+++ b/cnd/cnd.ui/src/org/netbeans/modules/cnd/resources/templates/qt/widget.template
@@ -1,3 +1,23 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
 <ui version="4.0" >
  <class>%<%CLASSNAME%>%</class>
  <widget class="QWidget" name="%<%CLASSNAME%>%" >

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/credits.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/credits.html
@@ -1,6 +1,23 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-*     Copyright © 1997, 2012, Oracle and/or its affiliates. All rights reserved.
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
 -->
 <html>
   <head>
@@ -12,57 +29,25 @@
     <title>Legal Notices</title>
   </head>
   <body>
-    <p>
-       DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
-    </p>
-    <p>
-       Copyright © 1997, 2012, Oracle and/or its affiliates. All rights reserved.
-    </p>
-    <p>
-       Oracle and Java are registered trademarks of Oracle and/or its affiliates. Other names may
-      be trademarks of their respective owners.
-    </p>
-    <p>
-       The contents of this file are subject to the terms of either the GNU General Public License
-      Version 2 only ("GPL") or the Common Development and Distribution License("CDDL")
-      (collectively, the "License"). You may not use this file except in compliance with the
-      License. You can obtain a copy of the License at <a href=
-      "http://www.netbeans.org/cddl-gplv2.html">http://www.netbeans.org/cddl-gplv2.html</a> or
-      nbbuild/licenses/CDDL-GPL-2-CP. See the License for the specific language governing
-      permissions and limitations under the License. When distributing the software, include this
-      License Header<br>
-       Notice in each file and include the License file at nbbuild/licenses/CDDL-GPL-2-CP. Oracle
-      designates this particular file as subject to the "Classpath" exception as provided by Oracle
-      in the GPL Version 2 section of the License file that accompanied this code. If applicable,
-      add the following below the License Header, with the fields enclosed by brackets [] replaced
-      by your own identifying information:<br>
-       "Portions Copyrighted [year] [name of copyright owner]"
-    </p>
-    <p>
-       Contributor(s):
-    </p>
-    <p>
-       The original software is NetBeans. The initial developer of the original software was Sun
-      Microsystems, Inc.; portions copyright 1997-2006 Sun Microsystems, Inc. All rights reserved.
-    </p>
-    <p>
-       If you wish your version of this file to be governed by only the CDDL or only the GPL
-      Version 2, indicate your decision by adding "[Contributor] elects to include this software in
-      this distribution under the [CDDL or GPL Version 2] license." If you do not indicate a<br>
-       single choice of license, a recipient has the option to distribute your version of this file
-      under either the CDDL, the GPL Version 2 or<br>
-       to extend the choice of license to its licensees as provided above. However, if you add GPL
-      Version 2 code and therefore, elected the GPL<br>
-       Version 2 license, then the option applies only if the new code is made subject to such
-      option by the copyright holder.
-    </p>
-    <p>
-       Oracle is not responsible for the availability of third-party Web sites mentioned in this
-      document. Oracle does not endorse and is not responsible or liable for any content,
-      advertising, products, or other materials on or available from such sites or resources.
-      Oracle will not be responsible or liable for any damage or loss caused or alleged to be
-      caused by or in connection with use of or reliance on any such content, goods, or services
-      available on or through any such sites or resources.
-    </p>
+      <pre>
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+      </pre>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/stopwords.swd
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/stopwords.swd
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+

--- a/cnd/cnd/l10n.list
+++ b/cnd/cnd/l10n.list
@@ -1,3 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 # cnd/core
 read global
 ${l10n-module}/src/**/*.png

--- a/cnd/libs.clank/external/binaries-list
+++ b/cnd/libs.clank/external/binaries-list
@@ -1,3 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#
 #changeset:   21704:717eaec19c30
 #branch:      jclank
 #tag:         tip

--- a/cnd/libs.clank/external/create_project_properties.sh
+++ b/cnd/libs.clank/external/create_project_properties.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 function get_public_packages() {
     prj=$1


### PR DESCRIPTION
Adding  missing license headers in different CND modules. In my box this clears the RAT report for the CND cluster.
Some cnd modules do not support FreeMarker templates, this can be improved in the future once CND compiles.