### PR TITLE
[NETBEANS-5522] Minimal support for Gradle 7.0

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/groovy/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.groovy
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/groovy/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.groovy
@@ -258,8 +258,10 @@ class NbProjectInfoBuilder {
                             model.info["sourceset_${sourceSet.name}_classpath_annotation"] = storeSet(sourceSet.compileClasspath.files)
                         }
                     }
-                    model.info["sourceset_${sourceSet.name}_configuration_compile"] = sourceSet.compileConfigurationName;
-                    model.info["sourceset_${sourceSet.name}_configuration_runtime"] = sourceSet.runtimeConfigurationName;
+                    beforeGradle('7.0') {
+                        model.info["sourceset_${sourceSet.name}_configuration_compile"] = sourceSet.compileConfigurationName;
+                        model.info["sourceset_${sourceSet.name}_configuration_runtime"] = sourceSet.runtimeConfigurationName;
+                    }
                 }
             } else {
                 model.info.sourcesets = Collections.emptySet();

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
@@ -88,6 +88,7 @@ public final class GradleDistributionManager {
         GradleVersion.version("6.0"), // JDK-13
         GradleVersion.version("6.3"), // JDK-14
         GradleVersion.version("6.7"), // JDK-15
+        GradleVersion.version("7.0"), // JDK-16
     };
     private static final int JAVA_VERSION;
 


### PR DESCRIPTION
This patch allows the IDE to read projects that require Gradle 7.0.
I've created another PR #2861, that would bump the tooling version used in NetBeans to 7.0 (actually it is 7.0-rc-2), though not sure if that could fit for 12.4, that is needed for the IDE to be run on JDK 16 and have the Gradle integration work.

This one is safe for 12.4