### PR TITLE
Return FileObject for non-existing JARs.

### DIFF
--- a/java/java.mx.project/nbproject/project.xml
+++ b/java/java.mx.project/nbproject/project.xml
@@ -158,7 +158,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.9</specification-version>
+                        <specification-version>9.23</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteSources.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteSources.java
@@ -625,11 +625,10 @@ final class SuiteSources implements Sources,
             if (SuiteSources.this.dir == null) {
                 return null;
             }
-            FileObject dists = SuiteSources.this.dir.getFileObject("mxbuild/dists");
-            if (dists == null) {
-                return null;
-            }
-            List<FileObject> dist = Arrays.stream(dists.getChildren()).filter((fo) -> fo.isFolder() && fo.getName().startsWith("jdk")).collect(Collectors.toList());
+            FileObject dists = getSubDir(SuiteSources.this.dir, "mxbuild/dists");
+            List<FileObject> dist = Arrays.stream(dists.getChildren()).
+                filter((fo) -> fo.isFolder() && fo.getName().startsWith("jdk")).
+                collect(Collectors.toList());
             dist.sort((fo1, fo2) -> fo2.getName().compareTo(fo1.getName()));
             for (FileObject jdkDir : dist) {
                 FileObject jar = jdkDir.getFileObject(name.toLowerCase().replace("_", "-") + ".jar");
@@ -637,11 +636,7 @@ final class SuiteSources implements Sources,
                     return jar;
                 }
             }
-            FileObject jar = dists.getFileObject(name.toLowerCase().replace("_", "-") + ".jar");
-            if (jar != null) {
-                return jar;
-            }
-            return null;
+            return dists.getFileObject(name.toLowerCase().replace("_", "-") + ".jar", false);
         }
 
         @Override

--- a/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/editor/JavaToCHyperlinkProvider.java
+++ b/java/java.openjdk.project/src/org/netbeans/modules/java/openjdk/editor/JavaToCHyperlinkProvider.java
@@ -91,27 +91,30 @@ public class JavaToCHyperlinkProvider implements HyperlinkProviderExt {
         final String[][] lookFor = new String[1][];
 
         try {
-            JavaSource.forDocument(doc).runUserActionTask(new Task<CompilationController>() {
-                @Override
-                public void run(CompilationController parameter) throws Exception {
-                    parameter.toPhase(Phase.PARSED);
+            final JavaSource source = JavaSource.forDocument(doc);
+            if (source != null) {
+                source.runUserActionTask(new Task<CompilationController>() {
+                    @Override
+                    public void run(CompilationController parameter) throws Exception {
+                        parameter.toPhase(Phase.PARSED);
 
-                    TreePath tp = parameter.getTreeUtilities().pathFor(offset);
+                        TreePath tp = parameter.getTreeUtilities().pathFor(offset);
 
-                    if (tp.getLeaf().getKind() != Kind.METHOD || !((MethodTree) tp.getLeaf()).getModifiers().getFlags().contains(Modifier.NATIVE))
-                        return ;
+                        if (tp.getLeaf().getKind() != Kind.METHOD || !((MethodTree) tp.getLeaf()).getModifiers().getFlags().contains(Modifier.NATIVE))
+                            return ;
 
-                    int[] nameSpan = parameter.getTreeUtilities().findNameSpan((MethodTree) tp.getLeaf());
+                        int[] nameSpan = parameter.getTreeUtilities().findNameSpan((MethodTree) tp.getLeaf());
 
-                    if (nameSpan[0] <= offset && offset <= nameSpan[1]) {
-                        parameter.toPhase(Phase.RESOLVED);
-                        Element el = parameter.getTrees().getElement(tp);
-                        if (el != null && el.getKind() == ElementKind.METHOD) {
-                            lookFor[0] = SourceUtils.getJVMSignature(ElementHandle.create(el));
+                        if (nameSpan[0] <= offset && offset <= nameSpan[1]) {
+                            parameter.toPhase(Phase.RESOLVED);
+                            Element el = parameter.getTrees().getElement(tp);
+                            if (el != null && el.getKind() == ElementKind.METHOD) {
+                                lookFor[0] = SourceUtils.getJVMSignature(ElementHandle.create(el));
+                            }
                         }
                     }
-                }
-            }, true);
+                }, true);
+            }
         } catch (IOException ex) {
             Exceptions.printStackTrace(ex);
         }

--- a/platform/masterfs/nbproject/project.xml
+++ b/platform/masterfs/nbproject/project.xml
@@ -39,7 +39,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.4</specification-version>
+                        <specification-version>9.23</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystem.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/FileBasedFileSystem.java
@@ -116,7 +116,7 @@ public class FileBasedFileSystem extends FileSystem {
             if (file.getParentFile() == null && BaseUtilities.isUnix()) {
                 retval = FileBasedFileSystem.getInstance().getRoot();
             } else {
-                retval = fs.getValidFileObject(file,caller);
+                retval = fs.getValidFileObject(file,caller, true);
             }                
         }         
         return retval;

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/BaseFileObj.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/BaseFileObj.java
@@ -591,7 +591,7 @@ public abstract class BaseFileObj extends FileObject {
                     final FileObjectFactory factory = getFactory();
                     final File file = parent.getFile();
                     retVal = factory.getCachedOnly(file);
-                    retVal = (retVal == null) ? factory.getFileObject(new FileInfo(file), FileObjectFactory.Caller.GetParent) : retVal;
+                    retVal = (retVal == null) ? factory.getFileObject(new FileInfo(file), FileObjectFactory.Caller.GetParent, true) : retVal;
                 }
             } else if ((parent != null)) {
                 final FileObjectFactory factory = getFactory();
@@ -600,7 +600,7 @@ public abstract class BaseFileObj extends FileObject {
                     retVal = FileBasedFileSystem.getInstance().getRoot();
                 } else {
                     retVal = factory.getCachedOnly(file);
-                    retVal = (retVal == null) ? factory.getFileObject(new FileInfo(file), FileObjectFactory.Caller.GetParent) : retVal;
+                    retVal = (retVal == null) ? factory.getFileObject(new FileInfo(file), FileObjectFactory.Caller.GetParent, true) : retVal;
                 }
             }
             assert retVal != null : "getParent should not return null for " + this;

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectKeeper.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FileObjectKeeper.java
@@ -137,7 +137,7 @@ final class FileObjectKeeper implements FileChangeListener {
                  if (lm > previous && factory != null && !recursive) {
                      final BaseFileObj prevFO = factory.getCachedOnly(f);
                      if (prevFO == null) {
-                         BaseFileObj who = factory.getValidFileObject(f, Caller.GetChildern);
+                         BaseFileObj who = factory.getValidFileObject(f, Caller.GetChildern, true);
                          if (who != null) {
                              LOG.log(Level.FINE, "External change detected {0}", who);  //NOI18N
                              if (who.isData()) {
@@ -235,7 +235,7 @@ final class FileObjectKeeper implements FileChangeListener {
             if (factory == null) {
                 factory = FileObjectFactory.getInstance(f);
             }
-            FileObject fo = factory.getValidFileObject(f, Caller.Others);
+            FileObject fo = factory.getValidFileObject(f, Caller.Others, true);
             LOG.log(Level.FINEST, "listenToAll, check {0} for stop {1}", new Object[] { fo, stop });
             if (fo instanceof FolderObj) {
                 FolderObj child = (FolderObj) fo;
@@ -314,7 +314,7 @@ final class FileObjectKeeper implements FileChangeListener {
             if (factory == null) {
                 factory = FileObjectFactory.getInstance(f);
             }
-            FileObject fo = factory.getValidFileObject(f, Caller.Others);
+            FileObject fo = factory.getValidFileObject(f, Caller.Others, true);
             if (fo instanceof FolderObj) {
                 fileFolderCreatedRecursion((FolderObj) fo, factory);
             }

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FolderObj.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FolderObj.java
@@ -80,7 +80,7 @@ public final class FolderObj extends BaseFileObj {
     }
 
     @Override
-    public FileObject getFileObject(String relativePath) {
+    public FileObject getFileObject(String relativePath, boolean onlyExisting) {
         if (relativePath.equals(".")) { // NOI18N
             return this;
         }
@@ -101,14 +101,14 @@ public final class FolderObj extends BaseFileObj {
         
         FileObjectFactory factory = getFactory();
         assert factory != null : "No factory for " + getPath() + " this: " + this;
-        return factory.getValidFileObject(file, FileObjectFactory.Caller.GetFileObject);
+        return factory.getValidFileObject(file, FileObjectFactory.Caller.GetFileObject, onlyExisting);
     }
 
 
     public final FileObject getFileObject(final String name, final String ext) {
         File file = BaseFileObj.getFile(getFileName().getFile(), name, ext);
         FileObjectFactory factory = getFactory();
-        return (name.indexOf("/") == -1) ? factory.getValidFileObject(file, FileObjectFactory.Caller.GetFileObject) : null;
+        return (name.indexOf("/") == -1) ? factory.getValidFileObject(file, FileObjectFactory.Caller.GetFileObject, true) : null;
     }
 
     @Override
@@ -165,7 +165,7 @@ public final class FolderObj extends BaseFileObj {
 
                 final FileObject fo = onlyExisting ?
                     lfs.getCachedOnly(fileName.getFile()) :
-                    lfs.getFileObject(fInfo, FileObjectFactory.Caller.GetChildern);
+                    lfs.getFileObject(fInfo, FileObjectFactory.Caller.GetChildern, true);
                 if (fo != null) {
                     final FileNaming foFileName = ((BaseFileObj)fo).getFileName();
                     if (!fo.isValid()) {
@@ -246,7 +246,7 @@ public final class FolderObj extends BaseFileObj {
 
         final FileObjectFactory factory = getFactory();
         if (factory != null) {
-            BaseFileObj exists = factory.getValidFileObject(folder2Create, FileObjectFactory.Caller.Others);
+            BaseFileObj exists = factory.getValidFileObject(folder2Create, FileObjectFactory.Caller.Others, true);
             if (exists instanceof FolderObj) {
                 retVal = (FolderObj)exists;
             } else {
@@ -337,7 +337,7 @@ public final class FolderObj extends BaseFileObj {
         final FileObjectFactory factory = getFactory();
         retVal = null;
         if (factory != null) {
-            final BaseFileObj fo = factory.getValidFileObject(file2Create, FileObjectFactory.Caller.Others);
+            final BaseFileObj fo = factory.getValidFileObject(file2Create, FileObjectFactory.Caller.Others, true);
             try {
                 retVal = (FileObj) fo;
             } catch (ClassCastException ex) {
@@ -466,7 +466,7 @@ public final class FolderObj extends BaseFileObj {
             final Integer operationId = entry.getValue();
 
             BaseFileObj newChild = (operationId == ChildrenCache.ADDED_CHILD) ? 
-                factory.getFileObject(new FileInfo(child.getFile()), FileObjectFactory.Caller.Refresh) 
+                factory.getFileObject(new FileInfo(child.getFile()), FileObjectFactory.Caller.Refresh, true) 
                 : 
                 factory.getCachedOnly(child.getFile());
             newChild = (BaseFileObj) ((newChild != null) ? newChild : getFileObject(child.getName()));

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/ReplaceForSerialization.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/ReplaceForSerialization.java
@@ -24,7 +24,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Date;
 import org.netbeans.modules.masterfs.filebasedfs.FileBasedFileSystem;
 import org.netbeans.modules.masterfs.providers.ProvidedExtensions;
 import org.openide.filesystems.FileLock;

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/BaseFileObjectTestHid.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/BaseFileObjectTestHid.java
@@ -263,7 +263,7 @@ public class BaseFileObjectTestHid extends TestBaseHid{
     public void testMoveOfAFolderDoesNotTouchSubhierarchy() throws Exception {
         FileObjectFactory fs = FileObjectFactory.getInstance(getWorkDir());
         assertNotNull(fs);
-        FileObject root1 = fs.getValidFileObject(getWorkDir(), FileObjectFactory.Caller.Others);
+        FileObject root1 = fs.getValidFileObject(getWorkDir(), FileObjectFactory.Caller.Others, true);
 
         FileObject where = root1.createFolder("else").createFolder("sub").createFolder("subsub");
         FileObject fo = root1.createFolder("something");
@@ -300,7 +300,7 @@ public class BaseFileObjectTestHid extends TestBaseHid{
         FileObjectFactory fs = FileObjectFactory.getInstance(getWorkDir());
         assertNotNull(fs);
         FileObject root1 = fs.getValidFileObject(getWorkDir(),
-                FileObjectFactory.Caller.Others);
+                FileObjectFactory.Caller.Others, true);
 
         FileObject where = root1.createFolder("else").createFolder("sub").createFolder(
                 "subsub");

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/WatcherDeadlockTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/WatcherDeadlockTest.java
@@ -109,7 +109,7 @@ public class WatcherDeadlockTest extends NbTestCase {
         @Override
         public long refreshRecursively(File dir, long lastTimeStamp, List<? super File> children) {
             fact = FileObjectFactory.getInstance(dir);
-            BaseFileObj obj = fact.getValidFileObject(dir, FileObjectFactory.Caller.Others);
+            BaseFileObj obj = fact.getValidFileObject(dir, FileObjectFactory.Caller.Others, true);
             assertNotNull("Obj found", obj);
             Object prev = STOP.get();
             if (prev == null) try {

--- a/platform/openide.filesystems/apichanges.xml
+++ b/platform/openide.filesystems/apichanges.xml
@@ -25,6 +25,24 @@
         <apidef name="filesystems">Filesystems API</apidef>
     </apidefs>
     <changes>
+        <change id="getFileObjectNonExisting">
+            <api name="filesystems"/>
+            <summary>getFileObject can return non-existing files</summary>
+            <version major="9" minor="23"/>
+            <date year="2021" month="3" day="5"/>
+            <author login="jtulach"/>
+            <compatibility addition="yes" source="compatible" semantic="compatible" binary="compatible"/>
+            <description>
+                <p>
+                    New method 
+                    <a href="@TOP@/org/openide/filesystems/FileObject.html#getFileObject-java.lang.String-boolean-"><code>getFileObject(relativePath, false)</code></a>
+                    in 
+                    <a href="@TOP@/org/openide/filesystems/FileObject.html"><code>FileObject</code></a>
+                    class to return a relative object even if it doesn't exist.
+                </p>
+            </description>
+            <class name="FileObject" package="org.openide.filesystems"/>
+        </change>
         <change id="LayerProcessorSupportedSource">
             <api name="filesystems"/>
             <summary>Declare support for all source levels.</summary>

--- a/platform/openide.filesystems/manifest.mf
+++ b/platform/openide.filesystems/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.openide.filesystems
 OpenIDE-Module-Localizing-Bundle: org/openide/filesystems/Bundle.properties
 OpenIDE-Module-Layer: org/openide/filesystems/resources/layer.xml
-OpenIDE-Module-Specification-Version: 9.22
+OpenIDE-Module-Specification-Version: 9.23
 
 

--- a/platform/openide.filesystems/src/org/openide/filesystems/AbstractFileObject.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/AbstractFileObject.java
@@ -548,7 +548,9 @@ final class AbstractFileObject extends AbstractFolder {
                       System.out.println ("Name: " + name);
                       System.out.println ("Old : " + oldName);
                 */
-                parent.refresh(name, oldName);
+                if (parent instanceof AbstractFolder) {
+                    ((AbstractFolder) parent).refresh(name, oldName);
+                }
 
                 if (hasAtLeastOneListeners()) {
                     fileRenamed0(new FileRenameEvent(this, on, oe));
@@ -597,7 +599,9 @@ final class AbstractFileObject extends AbstractFolder {
                 String n = name;
                 validFlag = false;
 
-                parent.refresh(null, n, true);
+                if (parent instanceof AbstractFolder) {
+                    ((AbstractFolder) parent).refresh(null, n, true);
+                }
             }
 
             getAbstractFileSystem().attr.deleteAttributes(fullName);
@@ -730,7 +734,9 @@ final class AbstractFileObject extends AbstractFolder {
                         validFlag = false;
 
                         // refresh the parent because this file has been deleted
-                        parent.refresh(null, oldN);
+                        if (parent instanceof AbstractFolder) {
+                            ((AbstractFolder) parent).refresh(null, oldN);
+                        }
 
                         // deletes all attributes asssociated with the moved file
                         // JST: I am not sure if this is the right behaviour, maybe this
@@ -861,8 +867,8 @@ final class AbstractFileObject extends AbstractFolder {
                 }
             }
 
-            if (refreshParent && (parent.getFileObject(getName(), getExt()) != null)) {
-                parent.refreshFolder(null, this.getNameExt(), fire, expected, null);
+            if (refreshParent && (parent.getFileObject(getName(), getExt()) != null) && parent instanceof AbstractFolder) {
+                ((AbstractFolder) parent).refreshFolder(null, this.getNameExt(), fire, expected, null);
             }
         } finally {
             getFileSystem().finishAtomicAction();

--- a/platform/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
@@ -60,7 +60,7 @@ abstract class AbstractFolder extends FileObject {
     protected String name;
 
     /** strong reference to parent (can be null for root) */
-    protected final AbstractFolder parent;
+    final FileObject parent;
 
     /** Stores the system name of the file system to test
     * validity later.
@@ -86,12 +86,12 @@ abstract class AbstractFolder extends FileObject {
     * @param parent the parent object (folder)
     * @param name name of the object (e.g. <code>filename.ext</code>)
     */
-    public AbstractFolder(FileSystem fs, AbstractFolder parent, String name) {
+    AbstractFolder(FileSystem fs, FileObject parent, String name) {
         this.system = fs;
         this.parent = parent;
         this.name = name;
         validFlag = true;
-        validRoot = (parent != null) ? (AbstractFolder) fs.getRoot() : null;
+        validRoot = (parent instanceof AbstractFolder) ? (AbstractFolder) fs.getRoot() : null;
     }
 
     /* Get the name without extension of this file or folder.
@@ -446,7 +446,7 @@ abstract class AbstractFolder extends FileObject {
         getFileSystem().waitRefreshed();
         return getFileObjectImpl(name, ext);
     }
-        
+
     private synchronized FileObject getFileObjectImpl(String name, String ext) {
         check();
 
@@ -505,7 +505,9 @@ abstract class AbstractFolder extends FileObject {
             FileEvent ev = new FileEvent(parent, fileevent.getFile(), fileevent.isExpected());
             try {
                 ev.inheritPostNotify(fileevent);
-                parent.fileDeleted0(ev);
+                if (parent instanceof AbstractFolder) {
+                    ((AbstractFolder) parent).fileDeleted0(ev);
+                }
             } finally {
                 ev.setPostNotify(null);
             }
@@ -526,7 +528,9 @@ abstract class AbstractFolder extends FileObject {
             FileEvent ev = new FileEvent(parent, fileevent.getFile(), fileevent.isExpected());
             try {
                 ev.inheritPostNotify(fileevent);
-                parent.fileCreated0(ev, isData);
+                if (parent instanceof AbstractFolder) {
+                    ((AbstractFolder) parent).fileCreated0(ev, isData);
+                }
             } finally {
                 ev.setPostNotify(null);
             }
@@ -546,7 +550,9 @@ abstract class AbstractFolder extends FileObject {
             FileEvent ev = new FileEvent(parent, fileevent.getFile(), fileevent.isExpected(), fileevent.getTime());
             try {
                 ev.inheritPostNotify(fileevent);
-                parent.fileChanged0(ev);
+                if (parent instanceof AbstractFolder) {
+                    ((AbstractFolder) parent).fileChanged0(ev);
+                }
             } finally {
                 ev.setPostNotify(null);
             }
@@ -569,7 +575,9 @@ abstract class AbstractFolder extends FileObject {
                 );
             try {
                 ev.inheritPostNotify(filerenameevent);
-                parent.fileRenamed0(ev);
+                if (parent instanceof AbstractFolder) {
+                    ((AbstractFolder) parent).fileRenamed0(ev);
+                }
             } finally {
                 ev.setPostNotify(null);
             }
@@ -587,7 +595,9 @@ abstract class AbstractFolder extends FileObject {
                 );
             try {
                 ev.inheritPostNotify(fileattributeevent);
-                parent.fileAttributeChanged0(ev);
+                if (parent instanceof AbstractFolder) {
+                    ((AbstractFolder) parent).fileAttributeChanged0(ev);
+                }
             } finally {
                 ev.setPostNotify(null);
             }
@@ -611,7 +621,7 @@ abstract class AbstractFolder extends FileObject {
     /** @return true if this folder or its parent have listeners
     */
     protected final boolean hasAtLeastOneListeners() {
-        return hasListeners() || ((parent != null) && parent.hasListeners());
+        return hasListeners() || ((parent instanceof AbstractFolder) && ((AbstractFolder) parent).hasListeners());
     }
 
     /** @return enumeration of all listeners.

--- a/platform/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/AbstractFolder.java
@@ -69,7 +69,7 @@ abstract class AbstractFolder extends FileObject {
 
     /** If root changes, all AbstractFolders in hierarchy are invalidated.
      *@see #isValid()*/
-    private final AbstractFolder validRoot;
+    private final FileObject validRoot;
 
     /** list of children */
     private String[] children;
@@ -90,8 +90,8 @@ abstract class AbstractFolder extends FileObject {
         this.system = fs;
         this.parent = parent;
         this.name = name;
-        validFlag = true;
-        validRoot = (parent instanceof AbstractFolder) ? (AbstractFolder) fs.getRoot() : null;
+        this.validFlag = true;
+        this.validRoot = (parent != null) ? fs.getRoot() : null;
     }
 
     /* Get the name without extension of this file or folder.

--- a/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/MultiFileObject.java
@@ -1292,8 +1292,10 @@ final class MultiFileObject extends AbstractFolder implements FileObject.Priorit
                       System.out.println ("Old : " + oldName);
                 */
 
-                /** [PENDING] expected to delete*/
-                parent.refresh(name, oldName);
+                if (parent instanceof AbstractFolder) {
+                    /** [PENDING] expected to delete*/
+                    ((AbstractFolder) parent).refresh(name, oldName);
+                }
 
                 //!!!      getMultiFileSystem ().attr.renameAttributes (oldFullName, newFullName);
                 if (hasAtLeastOneListeners()) {
@@ -1333,9 +1335,11 @@ final class MultiFileObject extends AbstractFolder implements FileObject.Priorit
                 String n = name;
                 validFlag = false;
 
-                /** [PENDING] expected rename of some refresh method */
-                //parent.internalRefresh (null, n, true, false, null);
-                parent.refresh(null, n, true, false);
+                if (parent instanceof AbstractFolder) {
+                    /** [PENDING] expected rename of some refresh method */
+                    //parent.internalRefresh (null, n, true, false, null);
+                    ((AbstractFolder) parent).refresh(null, n, true, false);
+                }
 
                 if (hasAtLeastOneListeners()) {
                     fileDeleted0(new FileEvent(this));

--- a/platform/openide.filesystems/src/org/openide/filesystems/VirtualFileObject.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/VirtualFileObject.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.filesystems;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Date;
+import java.util.Enumeration;
+import org.openide.util.Enumerations;
+
+final class VirtualFileObject extends AbstractFolder {
+    private final boolean folder;
+
+    public VirtualFileObject(FileSystem fileSystem, FileObject myObj, String nameExt, boolean folder) {
+        super(fileSystem, myObj, nameExt);
+        this.folder = folder;
+        this.validFlag = false;
+    }
+
+    @Override
+    void setAttribute(String attrName, Object value, boolean fire) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    protected String[] list() {
+        return new String[0];
+    }
+
+    @Override
+    protected AbstractFolder createFile(String name) {
+        return new VirtualFileObject(this.getFileSystem(), this, name, false);
+    }
+
+    @Override
+    void handleDelete(FileLock lock) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public void rename(FileLock lock, String name, String ext) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public boolean isFolder() {
+        return folder;
+    }
+
+    @Override
+    public Date lastModified() {
+        return getParent().lastModified();
+    }
+
+    @Override
+    public boolean isData() {
+        return !folder;
+    }
+
+    @Override
+    public Object getAttribute(String attrName) {
+        return null;
+    }
+
+    @Override
+    public void setAttribute(String attrName, Object value) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public Enumeration<String> getAttributes() {
+        return Enumerations.empty();
+    }
+
+    @Override
+    public long getSize() {
+        return 0;
+    }
+
+    @Override
+    public InputStream getInputStream() throws FileNotFoundException {
+        throw new FileNotFoundException();
+    }
+
+    @Override
+    public OutputStream getOutputStream(FileLock lock) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public FileLock lock() throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public void setImportant(boolean b) {
+    }
+
+    @Override
+    public FileObject createFolder(String name) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public FileObject createData(String name, String ext) throws IOException {
+        throw new IOException();
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean isVirtual() {
+        return true;
+    }
+
+    @Override
+    URL computeURL() {
+        URL url = getParent().computeURL();
+        try {
+            return new URL(url, getNameExt());
+        } catch (MalformedURLException ex) {
+            return super.computeURL();
+        }
+    }
+}

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
@@ -3465,7 +3465,35 @@ public class FileObjectTestHid extends TestBaseHid {
             // OK
         }
     }
- 
+
+    public void testNonExistingFileObject() throws Exception {
+        nonExistingFileObject("non-existing-child.xyz");
+    }
+
+    public void testNonExistingFileObjectInFolder() throws Exception {
+        nonExistingFileObject("non-existing-folder/non-existing-child.xyz");
+    }
+
+    private void nonExistingFileObject(String childName) throws Exception {
+        checkSetUp();
+        final FileObject fold = getTestFolder1(root);
+
+        FileObject ch1 = fold.getFileObject(childName);
+        assertNull("Not existing child", ch1);
+
+        FileObject ch2 = fold.getFileObject(childName, false);
+        assertNotNull("Non existing child created", ch2);
+        assertEquals("non-existing-child.xyz", ch2.getNameExt());
+        assertFalse("It is not valid to begin with", ch2.isValid());
+
+        URI foldUri = fold.toURI();
+        URI ch2Uri = ch2.toURI();
+
+        if (!ch2Uri.toString().startsWith(foldUri.toString())) {
+            fail("Expecting the child url:\n" + ch2Uri + "\nto begin with folder URL:\n" + foldUri);
+        }
+    }
+
     /*#46885: File not refreshed in editor if modified externally the first time after an internal modification*/
     public void testExternalChange () throws Exception {        
         checkSetUp();


### PR DESCRIPTION
@dougxc is working on changes in `mx` and they interfere with the way `java.mx.projects` deal with references to libraries. While debugging I realized that, ideally, one could clone [graal repository](https://github.com/oracle/graal) and open `truffle` suite without `mx build` - e.g. compiling anything. The IDE should handle that.

Well, it should, but it doesn't - if the JAR in `mxbuild` directory isn't present - no URL, but rather `null` was returned as its location. Then it was impossible to locate sources that produce that JAR. Commit 3387fc6 changes that - it returns (generic) JAR location even if it doesn't exist.

The change is based on long time needed, but never really implemented API change that now allows to create `FileObject` instances for files that don't exist: a19c3e3 - say farewell to `Pair<FileObject,URI>` as used elsewhere - create `FileObject` instances even for relative locations that don't exist.