### PR TITLE
[NETBEANS-5541] Upgrade Gradle Tooling to 7.0

### DIFF
--- a/extide/gradle/nbproject/project.xml
+++ b/extide/gradle/nbproject/project.xml
@@ -29,8 +29,8 @@
                     <code-name-base>org.netbeans.modules.libs.gradle</code-name-base>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>6</release-version>
-                        <specification-version>6.3</specification-version>
+                        <release-version>7</release-version>
+                        <specification-version>7.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/extide/libs.gradle/external/binaries-list
+++ b/extide/libs.gradle/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-566891D3FE72F69C9038A921BBE6CE255A77D4A1 gradle-tooling-api-6.7.jar
+DFC57AE4562914B649BF530C2D9BB22EC9677CF1 gradle-tooling-api-7.0.jar

--- a/extide/libs.gradle/external/gradle-tooling-api-7.0-license.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-7.0-license.txt
@@ -1,7 +1,7 @@
 Name: Gradle Wrapper
 Description: Gradle Tooling API
-Version: 6.7
-Files: gradle-tooling-api-6.7.jar
+Version: 7.0
+Files: gradle-tooling-api-7.0.jar
 License: Apache-2.0
 Origin: Gradle Inc.
 URL: https://gradle.org/

--- a/extide/libs.gradle/external/gradle-tooling-api-7.0-notice.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-7.0-notice.txt
@@ -1,5 +1,5 @@
 Gradle Inc.'s Gradle Tooling API
-Copyright 2007-2020 Gradle Inc.
+Copyright 2007-2021 Gradle Inc.
 
 This product includes software developed at
 Gradle Inc. (https://gradle.org/).

--- a/extide/libs.gradle/manifest.mf
+++ b/extide/libs.gradle/manifest.mf
@@ -1,6 +1,5 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-OpenIDE-Module: org.netbeans.modules.libs.gradle/6
+OpenIDE-Module: org.netbeans.modules.libs.gradle/7
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/libs/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 6.8
-
+OpenIDE-Module-Specification-Version: 7.0

--- a/extide/libs.gradle/nbproject/project.properties
+++ b/extide/libs.gradle/nbproject/project.properties
@@ -22,4 +22,4 @@ javac.compilerargs=-Xlint -Xlint:-serial
 # For more information, please see http://wiki.netbeans.org/SignatureTest
 sigtest.gen.fail.on.error=false
 
-release.external/gradle-tooling-api-6.7.jar=modules/gradle/gradle-tooling-api.jar
+release.external/gradle-tooling-api-7.0.jar=modules/gradle/gradle-tooling-api.jar

--- a/extide/libs.gradle/nbproject/project.xml
+++ b/extide/libs.gradle/nbproject/project.xml
@@ -39,7 +39,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>gradle/gradle-tooling-api.jar</runtime-relative-path>
-                <binary-origin>external/gradle-tooling-api-6.7.jar</binary-origin>
+                <binary-origin>external/gradle-tooling-api-7.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/gradle.java/apichanges.xml
+++ b/java/gradle.java/apichanges.xml
@@ -83,6 +83,21 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="gradle-7.0-deprecation">
+            <api name="gradle.java.api"/>
+            <summary>Deprecating Gradle 7.0 removed API-s</summary>
+            <version major="1" minor="13"/>
+            <date day="10" month="4" year="2021"/>
+            <author login="lkishalmi"/>
+            <compatibility semantic="incompatible" deprecation="yes"/>
+            <description>
+                <code><a href="@TOP@/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.html">GradleJavaSourceSet</a></code> 
+                methods <code>getCompileConfigurationName()</code> and <code>getRuntimeConfigurationName()</code> 
+                were deprecated as Gradle 7.0 does no longer supports them. They return <code>null</code> on Gradle 7.0.
+            </description>
+            <class package="org.netbeans.modules.gradle.java.api" name="GradleJavaSourceSet"/>
+            <issue number="NETBEANS-5541"/>            
+        </change>
         <change id="run.argument.properties">
             <api name="gradle.java.api"/>
             <summary>Support for explicit commandline arguments</summary>

--- a/java/gradle.java/manifest.mf
+++ b/java/gradle.java/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle.java
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/java/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/java/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.12
+OpenIDE-Module-Specification-Version: 1.13

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/api/GradleJavaSourceSet.java
@@ -160,10 +160,26 @@ public final class GradleJavaSourceSet implements Serializable {
         return targetCompatibility.getOrDefault(type, getSourcesCompatibility(type));
     }
 
+    /**
+     * Returns the name of the configuration used by this SourceSet for compile.
+     * This method returns an <code>null</code> from Gradle 7.0 as the
+     * corresponding method has been removed in that version. 
+     * @return the name of the configuration or <code>null</code> if that's not available.
+     * @deprecated No replacement.
+     */
+    @Deprecated
     public String getRuntimeConfigurationName() {
         return runtimeConfigurationName;
     }
 
+    /**
+     * Returns the name of the configuration used by this SourceSet for runtime.
+     * This method returns an <code>null</code> from Gradle 7.0 as the
+     * corresponding method has been removed in that version. 
+     * @return the name of the configuration or <code>null</code> if that's not available.
+     * @deprecated No replacement.
+     */
+    @Deprecated
     public String getCompileConfigurationName() {
         return compileConfigurationName;
     }

--- a/java/gradle.test/nbproject/project.xml
+++ b/java/gradle.test/nbproject/project.xml
@@ -29,8 +29,8 @@
                     <code-name-base>org.netbeans.modules.libs.gradle</code-name-base>
                     <compile-dependency/>
                     <run-dependency>
-                        <release-version>6</release-version>
-                        <specification-version>6.3</specification-version>
+                        <release-version>7</release-version>
+                        <specification-version>7.0</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
Well, let's prepare for this. As it happened before the Gradle and NetBeans release come really close again.
This upgrade is required, if someone would like to use NetBeans on Java 16, even if the target project is using an older JDK.