### PR TITLE
[NETBEANS-5546] - Update asm from 8.0.1 to 9.2

### DIFF
--- a/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentFactory.java
+++ b/enterprise/javaee.wildfly/src/org/netbeans/modules/javaee/wildfly/WildflyDeploymentFactory.java
@@ -153,7 +153,7 @@ public class WildflyDeploymentFactory implements DeploymentFactory {
                                 return super.getCommonSuperClass(string, string1);
                             }
                         };
-                        ClassNode node = new ClassNode(Opcodes.ASM7);
+                        ClassNode node = new ClassNode(Opcodes.ASM9);
                         cr.accept(node, 0);
 
                         for (MethodNode m : (Collection<MethodNode>) node.methods) {

--- a/harness/apisupport.harness/build.xml
+++ b/harness/apisupport.harness/build.xml
@@ -39,13 +39,13 @@
                 <pathelement location="${cluster}/tasks.jar"></pathelement>
             </classpath>
         </taskdef>
-        <echo file="build/binaries-list">3F5199523FB95304B44563F5D56D9F5A07270669 org.ow2.asm:asm:8.0.1</echo>
+        <echo file="build/binaries-list">81A03F76019C67362299C40E0BA13405F5467BFF org.ow2.asm:asm:9.2</echo>
         <TestDownload>
             <manifest dir="build">
                 <include name="binaries-list"/>
             </manifest>
         </TestDownload>
-        <delete file="build/asm-8.0.1.jar"/>
+        <delete file="build/asm-9.2.jar"/>
     </target>
 
     <target name="compile-jnlp-launcher" depends="init,compile">

--- a/java/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/NbJShellAgent.java
+++ b/java/lib.jshell.agent/agentsrc/org/netbeans/lib/jshell/agent/NbJShellAgent.java
@@ -377,7 +377,7 @@ public class NbJShellAgent implements Runnable, ClassFileTransformer {
      */
     private void insertClassInit(String className, ClassNode target) {
         // method void static clinit()
-        MethodNode clinit = new MethodNode(Opcodes.ASM7,
+        MethodNode clinit = new MethodNode(Opcodes.ASM9,
             Opcodes.ACC_STATIC | Opcodes.ACC_SYNTHETIC,
             CLASS_INIT_NAME,
             CLASS_INIT_DESC,
@@ -400,7 +400,7 @@ public class NbJShellAgent implements Runnable, ClassFileTransformer {
             istm = new ByteArrayInputStream(classfileBuffer);
             ClassReader reader = new ClassReader(istm);
             ClassWriter wr = new ClassWriter(reader, 0);
-            ClassNode clazz = new ClassNode(Opcodes.ASM7);
+            ClassNode clazz = new ClassNode(Opcodes.ASM9);
             reader.accept(clazz, 0);
             
             boolean found = false;

--- a/java/lib.jshell.agent/nbproject/project.properties
+++ b/java/lib.jshell.agent/nbproject/project.properties
@@ -21,5 +21,5 @@ javac.compilerargs=-Xlint -Xlint:-serial
 extra.module.files=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 jnlp.indirect.jars=modules/ext/nb-custom-jshell-probe.jar,modules/ext/nb-mod-jshell-probe.jar
 
-agentsrc.asm.cp=${libs.asm.dir}/core/asm-8.0.1.jar
+agentsrc.asm.cp=${libs.asm.dir}/core/asm-9.2.jar
 agentsrc.jshell.cp=${nb_all}/java/libs.jshell.compile/external/jshell-9.jar

--- a/nbbuild/templates/common.xml
+++ b/nbbuild/templates/common.xml
@@ -79,10 +79,10 @@
         <tstamp>
             <format property="module.build.started.time" pattern="yyyy-MM-dd'T'HH:mm:ss.SSSZ"/>
         </tstamp>
-        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-8.0.1.jar">
-            <available file="${nbplatform.active.dir}/platform/core/asm-8.0.1.jar"/>
+        <condition property="asm.jar" value="${nbplatform.active.dir}/platform/core/asm-9.2.jar">
+            <available file="${nbplatform.active.dir}/platform/core/asm-9.2.jar"/>
         </condition>
-        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-8.0.1.jar"/>
+        <property name="asm.jar" location="${platform/libs.asm.dir}/core/asm-9.2.jar"/>
         <property name="tsaurl" value=""/>
         <property name="tsacert" value=""/>
     </target>

--- a/platform/core.startup/src/org/netbeans/core/startup/Asm.java
+++ b/platform/core.startup/src/org/netbeans/core/startup/Asm.java
@@ -57,7 +57,7 @@ final class Asm {
         // must analyze the extender class, as some annotations there may trigger
         ClassReader clr = new ClassReader(data);
         ClassWriter wr = new ClassWriter(clr, 0);
-        ClassNode theClass = new ClassNode(Opcodes.ASM7);
+        ClassNode theClass = new ClassNode(Opcodes.ASM9);
         
         clr.accept(theClass, 0);
         
@@ -74,7 +74,7 @@ final class Asm {
                 throw new IOException("Could not find classfile for extender class"); // NOI18N
             }
             ClassReader extenderReader = new ClassReader(istm);
-            ClassNode extenderClass = new ClassNode(Opcodes.ASM7);
+            ClassNode extenderClass = new ClassNode(Opcodes.ASM9);
             extenderReader.accept(extenderClass, ClassReader.SKIP_FRAMES);
             
             // search for a no-arg ctor, replace all invokespecial calls in ctors
@@ -145,7 +145,7 @@ final class Asm {
      */
     private static class NullSignVisitor extends SignatureVisitor {
         public NullSignVisitor() {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM9);
         }
     }
     
@@ -168,13 +168,13 @@ final class Asm {
          * @param firstSelf if true, assumes the first parameter is reference to self and will generate aload_0
          */
         public CallParametersWriter(MethodNode mn, boolean firstSelf) {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM9);
             this.mn = mn;
             this.paramIndex = firstSelf ? 0 : 1;
         }
         
         public CallParametersWriter(MethodNode mn, int[] indices) {
-            super(Opcodes.ASM7);
+            super(Opcodes.ASM9);
             this.mn = mn;
             this.paramIndices = indices;
         }
@@ -387,11 +387,11 @@ final class Asm {
         MethodNode noArgCtor
     ) {
         String desc = targetMethod.desc;
-        CtorDelVisitor v = new CtorDelVisitor(Opcodes.ASM7);
+        CtorDelVisitor v = new CtorDelVisitor(Opcodes.ASM9);
         an.accept(v);
         int nextPos = desc.indexOf(';', 2); // NOI18N
         desc = "(" + desc.substring(nextPos + 1); // NOI18N
-        MethodNode mn = new MethodNode(Opcodes.ASM7, 
+        MethodNode mn = new MethodNode(Opcodes.ASM9, 
                 targetMethod.access & (~Opcodes.ACC_STATIC), CONSTRUCTOR_NAME,
                 desc,
                 targetMethod.signature,

--- a/platform/libs.asm/external/asm-9.2-license.txt
+++ b/platform/libs.asm/external/asm-9.2-license.txt
@@ -1,6 +1,6 @@
 Name: OW2 ASM
-Version: 8.0.1
-Files: asm-tree-8.0.1.jar asm-commons-8.0.1.jar asm-8.0.1.jar
+Version: 9.2
+Files: asm-tree-9.2.jar asm-commons-9.2.jar asm-9.2.jar
 License: BSD-INRIA
 Origin: OW2 Consortium
 URL: https://repository.ow2.org/nexus/content/repositories/releases/org/ow2/asm/

--- a/platform/libs.asm/external/binaries-list
+++ b/platform/libs.asm/external/binaries-list
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-3F5199523FB95304B44563F5D56D9F5A07270669 org.ow2.asm:asm:8.0.1
-DFCAD5ABBCFF36F8BDAD5647FE6F4972E958AD59 org.ow2.asm:asm-tree:8.0.1
-019C7BA355F0737815205518E332A8DC08B417C6 org.ow2.asm:asm-commons:8.0.1
+81A03F76019C67362299C40E0BA13405F5467BFF org.ow2.asm:asm:9.2
+D96C99A30F5E1A19B0E609DBB19A44D8518AC01E org.ow2.asm:asm-tree:9.2
+F4D7F0FC9054386F2893B602454D48E07D4FBEAD org.ow2.asm:asm-commons:9.2

--- a/platform/libs.asm/nbproject/project.properties
+++ b/platform/libs.asm/nbproject/project.properties
@@ -19,7 +19,7 @@ javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 module.jar.dir=core
 
-release.external/asm-8.0.1.jar=core/asm-8.0.1.jar
-release.external/asm-tree-8.0.1.jar=core/asm-tree-8.0.1.jar
-release.external/asm-commons-8.0.1.jar=core/asm-commons-8.0.1.jar
-license.file=../external/asm-8.0.1-license.txt
+release.external/asm-9.2.jar=core/asm-9.2.jar
+release.external/asm-tree-9.2.jar=core/asm-tree-9.2.jar
+release.external/asm-commons-9.2.jar=core/asm-commons-9.2.jar
+license.file=../external/asm-9.2-license.txt

--- a/platform/libs.asm/nbproject/project.xml
+++ b/platform/libs.asm/nbproject/project.xml
@@ -29,16 +29,16 @@
                 <subpackages>org</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>asm-8.0.1.jar</runtime-relative-path>
-                <binary-origin>external/asm-8.0.1.jar</binary-origin>
+                <runtime-relative-path>asm-9.2.jar</runtime-relative-path>
+                <binary-origin>external/asm-9.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>asm-tree-8.0.1.jar</runtime-relative-path>
-                <binary-origin>external/asm-tree-8.0.1.jar</binary-origin>
+                <runtime-relative-path>asm-tree-9.2.jar</runtime-relative-path>
+                <binary-origin>external/asm-tree-9.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>asm-commons-8.0.1.jar</runtime-relative-path>
-                <binary-origin>external/asm-commons-8.0.1.jar</binary-origin>
+                <runtime-relative-path>asm-commons-9.2.jar</runtime-relative-path>
+                <binary-origin>external/asm-commons-9.2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Library Notes:
- JDK 18 support
- JDK 17 support
- JDK 16 support (sealed classes), new ASM9 api version
- Add some input validations in ClassReader
- Replace -debug flag in Printer with -nodebug (-debug continues to work)
- ClassReader.readStream() performance improvements
- Javadoc fixes
- 12 bug fixes

NetBeans Testing:
- Verify successfull execution of libraries and licenses Ant test
- Full build done
- Checked the files had been downloaded and placed at `/netbeans/platform/core/`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS


[ASM Web Page](https://asm.ow2.io/index.html)
[Release Notes](https://asm.ow2.io/versions.html)

Next version of Jacoco will [depend](https://github.com/jacoco/jacoco/blob/master/org.jacoco.doc/docroot/doc/changes.html#L40) on this version