### PR TITLE
[NETBEANS-5540] Workaround for 12.4 beta: disable lazy-load by default.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/options/GradleExperimentalSettings.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/options/GradleExperimentalSettings.java
@@ -50,7 +50,7 @@ public final class GradleExperimentalSettings {
     }
 
     public boolean isOpenLazy() {
-        return getPreferences().getBoolean(PROP_LAZY_OPEN_GROUPS, true);
+        return getPreferences().getBoolean(PROP_LAZY_OPEN_GROUPS, false);
     }
 
     public void setCacheDisabled(boolean b) {


### PR DESCRIPTION
This does not solve loading issues reported in [NETBEANS-5540](https://issues.apache.org/jira/browse/NETBEANS-5540), but disables the newer code for 12.4, while retaining the possibility to test it.

