### PR TITLE
Avoid exception when tree parameter is null

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/TreeShims.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/TreeShims.java
@@ -61,7 +61,9 @@ public class TreeShims {
             Method getExpressions = CaseTree.class.getDeclaredMethod("getExpressions");
             return (List<? extends ExpressionTree>) getExpressions.invoke(node);
         } catch (NoSuchMethodException ex) {
-            return Collections.singletonList(node.getExpression());
+            ExpressionTree expression = node.getExpression();
+            // If null, return as an empty list, not a singleton list containing null.
+            return expression != null ? Collections.singletonList(expression) : Collections.emptyList();
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
             throw TreeShims.<RuntimeException>throwAny(ex);
         }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/save/FormatingTest.java
@@ -1963,6 +1963,12 @@ public class FormatingTest extends NbTestCase {
         preferences.putBoolean("indentCasesFromSwitch", true);
     }
     public void testRuleSwitch() throws Exception {
+        try {
+            SourceVersion.valueOf("RELEASE_13");
+        } catch (IllegalArgumentException ex) {
+            //OK, skip test
+            return ;
+        }
         testFile = new File(getWorkDir(), "Test.java");
         TestUtilities.copyStringToFile(testFile,
                 "package hierbas.del.litoral;\n\n"


### PR DESCRIPTION
This will happen when scanning the default: clause of a switch block.

This PR is intended to fix [NETBEANS-4569](https://issues.apache.org/jira/browse/NETBEANS-4569)