### PR TITLE
[NETBEANS-5540] Workaround for 12.4 beta: disable lazy-load by default.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/options/GradleExperimentalSettings.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/options/GradleExperimentalSettings.java
@@ -50,7 +50,7 @@ public final class GradleExperimentalSettings {
     }
 
     public boolean isOpenLazy() {
-        return getPreferences().getBoolean(PROP_LAZY_OPEN_GROUPS, true);
+        return getPreferences().getBoolean(PROP_LAZY_OPEN_GROUPS, false);
     }
 
     public void setCacheDisabled(boolean b) {


### PR DESCRIPTION
Backport of commit cd6b246dc7 to 12.4 beta. 
Targetting `release124` as suggested by @geertjanw, but shouldn't it go to `delivery` instead, then merged to 12.4 release by RMs ?