### PR TITLE
FlatLaf: update from 1.1.1 to 1.1.2 and fix/improve options

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-21EF33DBED3B07C5A9E2BB67118BBDF0E930ACCC com.formdev:flatlaf:1.1.1
+9ED8CDEA9AA43429EA26702F806D69D51655B0EF com.formdev:flatlaf:1.1.2

--- a/platform/libs.flatlaf/external/flatlaf-1.1.2-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-1.1.2-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 1.1.1
-Files: flatlaf-1.1.1.jar
+Version: 1.1.2
+Files: flatlaf-1.1.2.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-1.1.1.jar=modules/ext/flatlaf-1.1.1.jar
+release.external/flatlaf-1.1.2.jar=modules/ext/flatlaf-1.1.2.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-1.1.1.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-1.1.1.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-1.1.2.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-1.1.2.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/Bundle.properties
@@ -28,8 +28,7 @@ FlatLaf_DisplayName=FlatLaf
 KW_FlatLafOptions=FlatLaf, Look and Feel, Window decorations, Unified title bar, Embedded menu bar, underline menu, mnemonics
 
 FlatLafOptionsPanel.useWindowDecorationsCheckBox.text=&Window decorations
-FlatLafOptionsPanel.restartLabel.text=(needs restart)
-FlatLafOptionsPanel.unifiedTitleBarCheckBox.text=&Unified title bar background
+FlatLafOptionsPanel.unifiedTitleBarCheckBox.text=&Unified window title bar
 FlatLafOptionsPanel.menuBarEmbeddedCheckBox.text=&Embedded menu bar
 FlatLafOptionsPanel.underlineMenuSelectionCheckBox.text=Use underline menu &selection
 FlatLafOptionsPanel.alwaysShowMnemonicsCheckBox.text=Always show &mnemonics

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -183,3 +183,9 @@ Nb.browser.picker.foreground.light=rgb(192,192,192)
 # search in projects
 nb.search.sandbox.highlight=@selectionBackground
 nb.search.sandbox.regexp.wrong=rgb(255, 71, 71)
+
+
+#---- OptionsPanel ----
+
+nb.options.categories.selectionBackground = @selectionBackground
+nb.options.categories.highlightBackground = $TabbedPane.hoverColor

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
@@ -40,8 +40,12 @@ import org.netbeans.swing.tabcontrol.plaf.TabControlButton;
  */
 public class FlatLFCustoms extends LFCustoms {
 
+    private static final ModifiableColor unifiedBackground = new ModifiableColor();
+
     @Override
     public Object[] createApplicationSpecificKeysAndValues() {
+        updateUnifiedBackground();
+
         Color editorContentBorderColor = UIManager.getColor("TabbedContainer.editor.contentBorderColor"); // NOI18N
 
         Object[] removeCtrlPageUpDownKeyBindings = {
@@ -50,6 +54,9 @@ public class FlatLFCustoms extends LFCustoms {
         };
 
         return new Object[] {
+            // unified background
+            "nb.options.categories.tabPanelBackground", unifiedBackground,
+
             // options
             "TitlePane.useWindowDecorations", FlatLafPrefs.isUseWindowDecorations(),
             "TitlePane.unifiedBackground", FlatLafPrefs.isUnifiedTitleBar(),
@@ -111,6 +118,35 @@ public class FlatLFCustoms extends LFCustoms {
             "Table.ancestorInputMap.RightToLeft", new LazyModifyInputMap( "Table.ancestorInputMap.RightToLeft", removeCtrlPageUpDownKeyBindings ), // NOI18N
             "Tree.focusInputMap", new LazyModifyInputMap( "Tree.focusInputMap", removeCtrlPageUpDownKeyBindings ), // NOI18N
         };
+    }
+
+    static void updateUnifiedBackground() {
+        String key = FlatLafPrefs.isUnifiedTitleBar() && FlatLafPrefs.isUseWindowDecorations()
+                ? "Panel.background"
+                : "Tree.background";
+        unifiedBackground.setRGB(UIManager.getColor(key).getRGB());
+    }
+
+    //---- class ModifiableColor ----------------------------------------------
+
+    private static class ModifiableColor
+        extends Color
+    {
+        private int rgb;
+
+        public ModifiableColor() {
+            super(Color.red.getRGB());
+            rgb = super.getRGB();
+        }
+
+        @Override
+        public int getRGB() {
+            return rgb;
+        }
+
+        public void setRGB(int rgb) {
+            this.rgb = rgb;
+        }
     }
 
     //---- class LazyModifyInputMap -------------------------------------------

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -139,3 +139,11 @@ nb.popupswitcher.border=1,1,1,1,$PopupMenu.borderColor
 
 #---- Main Toolbar ----
 Nb.MainWindow.Toolbar.Dragger=org.netbeans.swing.laf.flatlaf.ui.FlatToolbarDragger
+
+
+#---- OptionsPanel ----
+
+nb.options.categories.tabPanelForeground = @foreground
+nb.options.categories.separatorColor = $Separator.foreground
+nb.options.categories.selectionBorderColor = $nb.options.categories.selectionBackground
+nb.options.categories.highlightBorderColor = $nb.options.categories.highlightBackground

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.form
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.form
@@ -46,27 +46,20 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" attributes="0">
-                      <Component id="useWindowDecorationsCheckBox" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace type="separate" max="-2" attributes="0"/>
-                      <Component id="restartLabel" min="-2" max="-2" attributes="0"/>
-                  </Group>
+                  <Component id="useWindowDecorationsCheckBox" min="-2" max="-2" attributes="0"/>
                   <Component id="unifiedTitleBarCheckBox" min="-2" max="-2" attributes="0"/>
                   <Component id="menuBarEmbeddedCheckBox" min="-2" max="-2" attributes="0"/>
                   <Component id="underlineMenuSelectionCheckBox" min="-2" max="-2" attributes="0"/>
                   <Component id="alwaysShowMnemonicsCheckBox" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="155" max="32767" attributes="0"/>
+              <EmptySpace pref="73" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="useWindowDecorationsCheckBox" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="restartLabel" alignment="3" min="-2" max="-2" attributes="0"/>
-              </Group>
+              <Component id="useWindowDecorationsCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="unifiedTitleBarCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
@@ -75,7 +68,7 @@
               <Component id="underlineMenuSelectionCheckBox" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="alwaysShowMnemonicsCheckBox" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="156" max="32767" attributes="0"/>
+              <EmptySpace pref="25" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -130,13 +123,6 @@
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="alwaysShowMnemonicsCheckBoxActionPerformed"/>
       </Events>
-    </Component>
-    <Component class="javax.swing.JLabel" name="restartLabel">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/swing/laf/flatlaf/Bundle.properties" key="FlatLafOptionsPanel.restartLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-      </Properties>
     </Component>
   </SubComponents>
 </Form>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanel.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.swing.laf.flatlaf;
 
+import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.util.SystemInfo;
 import org.netbeans.spi.options.OptionsPanelController;
 
@@ -43,13 +44,12 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
     }
 
     private void updateEnabled() {
-        boolean supportsWindowDecorations = SystemInfo.isWindows_10_orLater;
+        boolean supportsWindowDecorations = FlatLaf.supportsNativeWindowDecorations();
         useWindowDecorationsCheckBox.setEnabled(supportsWindowDecorations);
-        restartLabel.setEnabled(supportsWindowDecorations);
         unifiedTitleBarCheckBox.setEnabled(supportsWindowDecorations && useWindowDecorationsCheckBox.isSelected());
         menuBarEmbeddedCheckBox.setEnabled(supportsWindowDecorations && useWindowDecorationsCheckBox.isSelected());
 
-        restartLabel.setVisible(supportsWindowDecorations && FlatLafPrefs.isUseWindowDecorations() && !useWindowDecorationsCheckBox.isSelected());
+        underlineMenuSelectionCheckBox.setEnabled(!SystemInfo.isMacOS);
     }
 
     /**
@@ -66,7 +66,6 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
         unifiedTitleBarCheckBox = new javax.swing.JCheckBox();
         underlineMenuSelectionCheckBox = new javax.swing.JCheckBox();
         alwaysShowMnemonicsCheckBox = new javax.swing.JCheckBox();
-        restartLabel = new javax.swing.JLabel();
 
         setBorder(javax.swing.BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
@@ -105,30 +104,23 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
             }
         });
 
-        org.openide.awt.Mnemonics.setLocalizedText(restartLabel, org.openide.util.NbBundle.getMessage(FlatLafOptionsPanel.class, "FlatLafOptionsPanel.restartLabel.text")); // NOI18N
-
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(useWindowDecorationsCheckBox)
-                        .addGap(18, 18, 18)
-                        .addComponent(restartLabel))
+                    .addComponent(useWindowDecorationsCheckBox)
                     .addComponent(unifiedTitleBarCheckBox)
                     .addComponent(menuBarEmbeddedCheckBox)
                     .addComponent(underlineMenuSelectionCheckBox)
                     .addComponent(alwaysShowMnemonicsCheckBox))
-                .addContainerGap(155, Short.MAX_VALUE))
+                .addContainerGap(73, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(useWindowDecorationsCheckBox)
-                    .addComponent(restartLabel))
+                .addComponent(useWindowDecorationsCheckBox)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(unifiedTitleBarCheckBox)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -137,7 +129,7 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
                 .addComponent(underlineMenuSelectionCheckBox)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(alwaysShowMnemonicsCheckBox)
-                .addContainerGap(156, Short.MAX_VALUE))
+                .addContainerGap(25, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -201,7 +193,6 @@ public class FlatLafOptionsPanel extends javax.swing.JPanel {
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JCheckBox alwaysShowMnemonicsCheckBox;
     private javax.swing.JCheckBox menuBarEmbeddedCheckBox;
-    private javax.swing.JLabel restartLabel;
     private javax.swing.JCheckBox underlineMenuSelectionCheckBox;
     private javax.swing.JCheckBox unifiedTitleBarCheckBox;
     private javax.swing.JCheckBox useWindowDecorationsCheckBox;

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanelController.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafOptionsPanelController.java
@@ -31,8 +31,7 @@ import org.openide.util.HelpCtx;
 import org.openide.util.Lookup;
 
 /**
- *
- * @author charly
+ * @author Karl Tauber
  */
 @OptionsPanelController.SubRegistration(
     displayName="#FlatLaf_DisplayName",
@@ -69,22 +68,23 @@ public class FlatLafOptionsPanelController extends OptionsPanelController {
             changed = false;
 
             UIDefaults defaults = UIManager.getDefaults();
-            defaults.put("TitlePane.useWindowDecorations", FlatLafPrefs.isUseWindowDecorations());
             defaults.put("TitlePane.unifiedBackground", FlatLafPrefs.isUnifiedTitleBar());
             defaults.put("TitlePane.menuBarEmbedded", FlatLafPrefs.isMenuBarEmbedded());
             defaults.put("MenuItem.selectionType", FlatLafPrefs.isUnderlineMenuSelection() ? "underline" : null);
             defaults.put("Component.hideMnemonics", !FlatLafPrefs.isAlwaysShowMnemonics());
 
-            if (oldUseWindowDecorations != FlatLafPrefs.isUseWindowDecorations()
-                    || oldUnifiedTitleBar != FlatLafPrefs.isUnifiedTitleBar()) {
-                FlatLaf.updateUI();
-            } else if (oldMenuBarEmbedded != FlatLafPrefs.isMenuBarEmbedded()
+            FlatLFCustoms.updateUnifiedBackground();
+
+            if (oldUseWindowDecorations != FlatLafPrefs.isUseWindowDecorations()) {
+                FlatLaf.setUseNativeWindowDecorations(FlatLafPrefs.isUseWindowDecorations());
+            } 
+
+            if (oldMenuBarEmbedded != FlatLafPrefs.isMenuBarEmbedded()) {
+                FlatLaf.revalidateAndRepaintAllFramesAndDialogs();
+            } else if (oldUnifiedTitleBar != FlatLafPrefs.isUnifiedTitleBar()
                     || oldUnderlineMenuSelection != FlatLafPrefs.isUnderlineMenuSelection()
                     || oldAlwaysShowMnemonics != FlatLafPrefs.isAlwaysShowMnemonics()) {
-                for (Window w : Window.getWindows()) {
-                    w.revalidate();
-                    w.repaint();
-                }
+                FlatLaf.repaintAllFramesAndDialogs();
             }
         });
     }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafPrefs.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLafPrefs.java
@@ -44,11 +44,11 @@ class FlatLafPrefs {
     }
 
     static boolean isUnifiedTitleBar() {
-        return prefs.getBoolean(UNIFIED_TITLE_BAR, false);
+        return prefs.getBoolean(UNIFIED_TITLE_BAR, true);
     }
 
     static void setUnifiedTitleBar(boolean value) {
-        putBoolean(UNIFIED_TITLE_BAR, value, false);
+        putBoolean(UNIFIED_TITLE_BAR, value, true);
     }
 
     static boolean isMenuBarEmbedded() {

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
@@ -77,3 +77,9 @@ nb.quicksearch.border=1,1,1,1,@background
 
 # output
 nb.output.selectionBackground=#89BCED
+
+
+#---- OptionsPanel ----
+
+nb.options.categories.selectionBackground = rgb(193, 210, 238)
+nb.options.categories.highlightBackground = rgb(224, 232, 246)

--- a/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
+++ b/platform/options.api/src/org/netbeans/modules/options/OptionsPanel.java
@@ -124,12 +124,11 @@ public class OptionsPanel extends JPanel {
     private final boolean isMac = UIManager.getLookAndFeel ().getID ().equals ("Aqua");
     private final boolean isNimbus = UIManager.getLookAndFeel ().getID ().equals ("Nimbus");
     private final boolean isMetal = UIManager.getLookAndFeel() instanceof MetalLookAndFeel;
-    private final boolean isFlatLaf = UIManager.getLookAndFeel().getID().startsWith("FlatLaf");
     private final boolean isGTK = UIManager.getLookAndFeel ().getID ().equals ("GTK");
     private final Color selected = isMac ? new Color(221, 221, 221) : getSelectionBackground();
-    private final Color selectedB = isMac ? new Color(183, 183, 183) : (isFlatLaf ? selected : new Color (149, 106, 197));
+    private final Color selectedB = isMac ? new Color(183, 183, 183) : getUIColorOrDefault("nb.options.categories.selectionBorderColor", new Color (149, 106, 197));
     private final Color highlighted = isMac ? new Color(221, 221, 221) : getHighlightBackground();
-    private final Color highlightedB = isFlatLaf ? highlighted : new Color (152, 180, 226);
+    private final Color highlightedB = getUIColorOrDefault("nb.options.categories.highlightBorderColor", new Color (152, 180, 226));
     //private final Color iconViewBorder = new Color (127, 157, 185);
     private final ControllerListener controllerListener = new ControllerListener ();
     
@@ -394,7 +393,7 @@ public class OptionsPanel extends JPanel {
         showHint(true);
         
         pCategories = new JPanel (new BorderLayout ());
-        pCategories.setBorder (BorderFactory.createMatteBorder(0,0,1,0,isFlatLaf ? UIManager.getColor("Separator.foreground"): Color.lightGray)); //NOI18N
+        pCategories.setBorder (BorderFactory.createMatteBorder(0,0,1,0,getUIColorOrDefault("nb.options.categories.separatorColor", Color.lightGray))); //NOI18N
         pCategories.setBackground (getTabPanelBackground());
         categoriesScrollPane = new JScrollPane(pCategories2, ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER, ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
         categoriesScrollPane.setBorder(null);
@@ -965,6 +964,11 @@ public class OptionsPanel extends JPanel {
     }
 
     private Color getTabPanelBackground() {
+        Color uiColor = UIManager.getColor("nb.options.categories.tabPanelBackground"); //NOI18N
+        if (uiColor != null) {
+            return uiColor;
+        }
+
         if( useUIDefaultsColors() ) {
             Color res = UIManager.getColor( "Tree.background" ); //NOI18N
             if( null == res )
@@ -975,6 +979,11 @@ public class OptionsPanel extends JPanel {
     }
 
     private Color getTabPanelForeground() {
+        Color uiColor = UIManager.getColor("nb.options.categories.tabPanelForeground"); //NOI18N
+        if (uiColor != null) {
+            return uiColor;
+        }
+
         if( useUIDefaultsColors() ) {
             Color res = UIManager.getColor( "Tree.foreground" ); //NOI18N
             if( null == res )
@@ -985,6 +994,11 @@ public class OptionsPanel extends JPanel {
     }
 
     private Color getSelectionBackground() {
+        Color uiColor = UIManager.getColor("nb.options.categories.selectionBackground"); //NOI18N
+        if (uiColor != null) {
+            return uiColor;
+        }
+
         if( useUIDefaultsColors() ) {
             if( !Color.white.equals( getTabPanelBackground() ) ) {
                 Color res = UIManager.getColor( "Tree.selectionBackground" ); //NOI18N
@@ -997,6 +1011,11 @@ public class OptionsPanel extends JPanel {
     }
 
     private Color getHighlightBackground() {
+        Color uiColor = UIManager.getColor("nb.options.categories.highlightBackground"); //NOI18N
+        if (uiColor != null) {
+            return uiColor;
+        }
+
         if( useUIDefaultsColors() ) {
             if( !Color.white.equals( getTabPanelBackground() ) ) {
                 Color res = UIManager.getColor( "Tree.selectionBackground" ); //NOI18N
@@ -1009,7 +1028,12 @@ public class OptionsPanel extends JPanel {
     }
 
     private boolean useUIDefaultsColors() {
-        return isMetal || isNimbus || isFlatLaf;
+        return isMetal || isNimbus;
+    }
+
+    private Color getUIColorOrDefault(String uiKey, Color defaultColor) {
+        Color uiColor = UIManager.getColor(uiKey);
+        return (uiColor != null) ? uiColor : defaultColor;
     }
 
     // innerclasses ............................................................


### PR DESCRIPTION
This is a follow up to #2839, which unfortunately causes some problems in open editors when changing "Unified title bar" flag in FlatLaf Options: the line numbers ruler was hidden and sometimes I had the impression that some editing features no longer work. The problem was that `FlatLaf.updateUI()` was used to update all UI delegates. This PR no longer does this.

Changes:
- update from 1.1.1 to 1.1.2
- Options: option "Unified window title bar" is now enabled by default because this looks much better, especially in dark theme
- Options: disabling option "Window decorations" now works without restart
- Options: changing option "Unified window title bar" now works without `FlatLaf.updateUI()`, which fixes lost line numbers in editors
- Options: if option "Unified window title bar" is enabled, categories area gets same background as window title bar
- Options: moved categories area colors to FlatLaf properties files
  (this partially implements https://issues.apache.org/jira/browse/NETBEANS-3528 and removes all FlatLaf specific code from `OptionsPanel.java`, which was added in #1703)

Comparison of  "Unified window title bar" enabled/disabled:

![image](https://user-images.githubusercontent.com/5604048/113875999-9801db80-97b7-11eb-8e89-2566084395b2.png)

![image](https://user-images.githubusercontent.com/5604048/113876113-b7006d80-97b7-11eb-8622-a4ea44793b26.png)

![image](https://user-images.githubusercontent.com/5604048/113876138-bd8ee500-97b7-11eb-8892-4a89d69a9418.png)

![image](https://user-images.githubusercontent.com/5604048/113876167-c54e8980-97b7-11eb-82b6-7386b4371301.png)
