### PR TITLE
[NETBEANS-5499] Upgrade Felix library, works on JDK16.

### DIFF
--- a/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/EnabledAutoloadTest.java
+++ b/platform/core.netigso/test/unit/src/org/netbeans/core/netigso/EnabledAutoloadTest.java
@@ -20,6 +20,7 @@
 package org.netbeans.core.netigso;
 
 import java.io.File;
+import java.net.URL;
 import java.util.logging.Level;
 import junit.framework.Test;
 import org.netbeans.Module;
@@ -88,6 +89,10 @@ public class EnabledAutoloadTest extends NbTestCase {
 
             Module compat = mgr.get("org.openide.compat");
             assertTrue("Compat module is turned on too", compat.isEnabled());
+            
+            // OSGi installs URLStreamHandlers, check http(s) protocol parsing
+            new URL("http://localhost:10000");
+            new URL("https://localhost:10000");
         } finally {
             mgr.mutexPrivileged().exitWriteAccess();
         }
@@ -131,7 +136,7 @@ public class EnabledAutoloadTest extends NbTestCase {
             fail("m2 is turned on as module and listed on its own");
         }
     }
-
+    
     private void assertAsynchronousMessage(CharSequence log, String text) throws InterruptedException {
         for (int i = 0; i < 50; i++) {
             if (log.toString().contains(text)) {

--- a/platform/core.osgi/nbproject/project.properties
+++ b/platform/core.osgi/nbproject/project.properties
@@ -18,8 +18,8 @@ is.autoload=true
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 cp.extra=\
-    ${nb_all}/platform/libs.osgi/external/osgi.core-7.0.0.jar:\
-    ${nb_all}/platform/libs.osgi/external/osgi.cmpn-5.0.0.jar
+    ${nb_all}/platform/libs.osgi/external/osgi.core-8.0.0.jar:\
+    ${nb_all}/platform/libs.osgi/external/osgi.cmpn-7.0.0.jar
 test.unit.cp.extra=\
     ${ant.core.lib}:\
     ${nbantext.jar}:\

--- a/platform/libs.felix/external/binaries-list
+++ b/platform/libs.felix/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-9A6CBBA44A72BB04411EDF8B154C862E27209E8A org.apache.felix:org.apache.felix.main:6.0.3
+93763C923B93DE7BE39D987560A915A8A9A5099C org.apache.felix:org.apache.felix.main:7.0.0

--- a/platform/libs.felix/external/org.apache.felix.main-7.0.0-license.txt
+++ b/platform/libs.felix/external/org.apache.felix.main-7.0.0-license.txt
@@ -1,8 +1,8 @@
 Name: Felix
-Version: 6.0.3
+Version: 7.0.0
 Description: Apache Felix OSGi container.
 License: Apache-2.0
-Files: org.apache.felix.main-6.0.3.jar
+Files: org.apache.felix.main-7.0.0.jar
 Origin: Apache Software Foundation
 URL: http://archive.apache.org/dist/felix/
 

--- a/platform/libs.felix/external/org.apache.felix.main-7.0.0-notice.txt
+++ b/platform/libs.felix/external/org.apache.felix.main-7.0.0-notice.txt
@@ -1,10 +1,11 @@
+
 Apache Felix Main
-Copyright 2006-2013 The Apache Software Foundation
+Copyright 2006-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 This product includes software developed at
 The OSGi Alliance (http://www.osgi.org/).
-Copyright (c) OSGi Alliance (2000, 2012).
+Copyright (c) OSGi Alliance (2000, 2020).
 Licensed under the Apache License 2.0.

--- a/platform/libs.felix/nbproject/project.properties
+++ b/platform/libs.felix/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-release.external/org.apache.felix.main-6.0.3.jar=modules/ext/org.apache.felix.main-6.0.3.jar
+release.external/org.apache.felix.main-7.0.0.jar=modules/ext/org.apache.felix.main-7.0.0.jar
 javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/platform/libs.felix/nbproject/project.xml
+++ b/platform/libs.felix/nbproject/project.xml
@@ -36,8 +36,8 @@
             </module-dependencies>
             <public-packages/>
             <class-path-extension>
-                <runtime-relative-path>ext/org.apache.felix.main-6.0.3.jar</runtime-relative-path>
-                <binary-origin>external/org.apache.felix.main-6.0.3.jar</binary-origin>
+                <runtime-relative-path>ext/org.apache.felix.main-7.0.0.jar</runtime-relative-path>
+                <binary-origin>external/org.apache.felix.main-7.0.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/platform/libs.osgi/external/binaries-list
+++ b/platform/libs.osgi/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 4FA9F239A60AECA4A27648DF329D112D562A350C org.osgi:osgi.cmpn:7.0.0
-7545EAB9BD1F85E9F1162865A7281C8BECB417F2 org.osgi:osgi.core:7.0.0
+DAA42A0E96C3B881E8C330A413813983E92D2426 org.osgi:osgi.core:8.0.0

--- a/platform/libs.osgi/external/osgi-8.0-license.txt
+++ b/platform/libs.osgi/external/osgi-8.0-license.txt
@@ -1,10 +1,10 @@
 Name: OSGi
-Version: 7.0
-Files: osgi.cmpn-7.0.0.jar
-Description: OSGi specification (compendium).
+Version: 8.0
+Files: osgi.core-8.0.0.jar
+Description: OSGi specification (core & compendium).
 License: Apache-2.0
 Origin: OSGi
-URL: https://search.maven.org/artifact/org.osgi/osgi.cmpn/7.0.0/jar
+URL: https://search.maven.org/artifact/org.osgi/osgi.core/8.0.0/jar
 
                                  Apache License
                            Version 2.0, January 2004

--- a/platform/libs.osgi/nbproject/project.properties
+++ b/platform/libs.osgi/nbproject/project.properties
@@ -18,5 +18,5 @@ is.autoload=true
 javac.source=1.6
 javac.compilerargs=-Xlint -Xlint:-serial
 
-release.external/osgi.core-7.0.0.jar=modules/ext/osgi.core-7.0.0.jar
+release.external/osgi.core-8.0.0.jar=modules/ext/osgi.core-8.0.0.jar
 release.external/osgi.cmpn-7.0.0.jar=modules/ext/osgi.cmpn-7.0.0.jar

--- a/platform/libs.osgi/nbproject/project.xml
+++ b/platform/libs.osgi/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <subpackages>org.osgi</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/osgi.core-7.0.0.jar</runtime-relative-path>
-                <binary-origin>external/osgi.core-7.0.0.jar</binary-origin>
+                <runtime-relative-path>ext/osgi.core-8.0.0.jar</runtime-relative-path>
+                <binary-origin>external/osgi.core-8.0.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/osgi.cmpn-7.0.0.jar</runtime-relative-path>


### PR DESCRIPTION
I have tried Felix 7.0.0 with a minimal application and it seems that URL handling is fixed.