### PR TITLE
[NETBEANS-5565] Disable running LSP servers for VCS diffs.

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
@@ -162,7 +162,9 @@ public class LSPBindings {
         if (prj == null) {
             dir = file.getParent();
             File dirFile = FileUtil.toFile(dir);
-            if (dirFile.getName().startsWith("vcs-") && dirFile.getAbsolutePath().startsWith(System.getProperty("java.io.tmpdir"))) {
+            if (dirFile != null &&
+                dirFile.getName().startsWith("vcs-") &&
+                dirFile.getAbsolutePath().startsWith(System.getProperty("java.io.tmpdir"))) {
                 //diff dir, don't start servers:
                 return null;
             }

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
@@ -161,6 +161,11 @@ public class LSPBindings {
 
         if (prj == null) {
             dir = file.getParent();
+            File dirFile = FileUtil.toFile(dir);
+            if (dirFile.getName().startsWith("vcs-") && dirFile.getAbsolutePath().startsWith(System.getProperty("java.io.tmpdir"))) {
+                //diff dir, don't start servers:
+                return null;
+            }
         } else {
             dir = prj.getProjectDirectory();
         }


### PR DESCRIPTION
Seems sensible to not run the LSP servers for diff windows. There does not seem to be a very clean way, so just looking at the directory names.