### PR TITLE
New from Template for VSCode.

### DIFF
--- a/ide/css.prep/src/org/netbeans/modules/css/prep/layer.xml
+++ b/ide/css.prep/src/org/netbeans/modules/css/prep/layer.xml
@@ -255,7 +255,7 @@
     <folder name="Templates">
         <folder name="ClientSide">
             <!-- position copied from web.clientproject -->
-            <attr name="position" intvalue="610"/>
+            <attr name="position" intvalue="1610"/>
         </folder>
     </folder>
     <folder name="OptionsExport">

--- a/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/layer.xml
+++ b/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/layer.xml
@@ -26,7 +26,7 @@
         <folder name="UnitTests">
             <attr name="displayName" bundlevalue="org.netbeans.modules.gsf.testrunner.Bundle#UnitTests_displayname"/>
             <attr name="position" intvalue="1200"/>
-
+            <attr name="templateWizardURL" urlvalue="nbresloc:/org/netbeans/modules/gsf/testrunner/resources/description.html"/>
         </folder>
     </folder>
 

--- a/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/resources/description.html
+++ b/ide/gsf.testrunner/src/org/netbeans/modules/gsf/testrunner/resources/description.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Licensed to the Apache Software Foundation (ASF) under one
@@ -19,18 +18,13 @@
     under the License.
 
 -->
-<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
-<filesystem>
-    <folder name="Services">
-        <folder name="AutoupdateType">
-            <file name="82pluginportal-update-provider.instance_hidden"/>
-            <file name="distribution-update-provider.instance_hidden"/>
-            <file name="pluginportal-update-provider.instance_hidden"/>
-        </folder>
-    </folder>
-    <folder name="Templates">
-        <folder name="XML">
-            <file name="XMLCatalog.xml_hidden"/>
-        </folder>
-    </folder>
-</filesystem>
+
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+</head>
+<body>
+JUnit3/4/5 and TestNG test templates.
+</body>
+</html>
+

--- a/ide/ide.kit/nbproject/project.properties
+++ b/ide/ide.kit/nbproject/project.properties
@@ -17,6 +17,10 @@
 
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
+
+test.config.commit.includes=\
+    org/netbeans/modules/ide/kit/Verify*.class
+
 test.config.installer.includes=\
     org/netbeans/test/ide/InstallationCompletenessTest.class
 test.config.au.includes=\

--- a/ide/ide.kit/test/qa-functional/src/org/netbeans/modules/ide/kit/VerifySimpleTemplatesTest.java
+++ b/ide/ide.kit/test/qa-functional/src/org/netbeans/modules/ide/kit/VerifySimpleTemplatesTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import junit.framework.Test;
+import org.netbeans.api.actions.Editable;
 import org.netbeans.api.actions.Openable;
 import org.netbeans.junit.NbModuleSuite;
 import org.netbeans.junit.NbTestCase;
@@ -41,6 +42,7 @@ public class VerifySimpleTemplatesTest extends NbTestCase {
 
     public static Test suite() {
         return NbModuleSuite.emptyConfiguration().
+            clusters("(extide|java).*").
             enableModules(".*", ".*").
             honorAutoloadEager(true).
             failOnException(Level.INFO).
@@ -68,12 +70,18 @@ public class VerifySimpleTemplatesTest extends NbTestCase {
             for (DataObject t : simpleTemplates) {
                 LOG.log(Level.WARNING, "Processing {0}", t.getPrimaryFile().getPath());
                 DataObject generated = t.createFromTemplate(scratch, "Test" + ++cnt);
-                Openable open = generated.getLookup().lookup(Openable.class);
-                if (open != null) {
-                    LOG.log(Level.WARNING, "Opening {0}", generated.getPrimaryFile().getPath());
-                    open.open();
+                Editable edit = generated.getLookup().lookup(Editable.class);
+                if (edit != null) {
+                    LOG.log(Level.WARNING, "Editing {0}", generated.getPrimaryFile().getPath());
+                    edit.edit();
                 } else {
-                    LOG.log(Level.WARNING, "Cannot open {0}", generated.getPrimaryFile().getPath());
+                    Openable open = generated.getLookup().lookup(Openable.class);
+                    if (open != null) {
+                        LOG.log(Level.WARNING, "Opening {0}", generated.getPrimaryFile().getPath());
+                        open.open();
+                    } else {
+                        LOG.log(Level.WARNING, "Cannot open {0}", generated.getPrimaryFile().getPath());
+                    }
                 }
             }
         }

--- a/ide/ide.kit/test/qa-functional/src/org/netbeans/modules/ide/kit/VerifySimpleTemplatesTest.java
+++ b/ide/ide.kit/test/qa-functional/src/org/netbeans/modules/ide/kit/VerifySimpleTemplatesTest.java
@@ -41,6 +41,11 @@ public class VerifySimpleTemplatesTest extends NbTestCase {
     }
 
     public static Test suite() {
+        String v = System.getProperty("java.version");
+        if (v == null || !v.startsWith("1.8")) {
+            return NbModuleSuite.emptyConfiguration().suite();
+        }
+
         return NbModuleSuite.emptyConfiguration().
             clusters("(extide|java).*").
             enableModules(".*", ".*").

--- a/ide/ide.kit/test/qa-functional/src/org/netbeans/modules/ide/kit/VerifySimpleTemplatesTest.java
+++ b/ide/ide.kit/test/qa-functional/src/org/netbeans/modules/ide/kit/VerifySimpleTemplatesTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.ide.kit;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import junit.framework.Test;
+import org.netbeans.api.actions.Openable;
+import org.netbeans.junit.NbModuleSuite;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileUtil;
+import org.openide.loaders.DataFolder;
+import org.openide.loaders.DataObject;
+
+public class VerifySimpleTemplatesTest extends NbTestCase {
+    private static Logger LOG = Logger.getLogger(VerifySimpleTemplatesTest.class.getName());
+
+    public VerifySimpleTemplatesTest(String name) {
+        super(name);
+    }
+
+    public static Test suite() {
+        return NbModuleSuite.emptyConfiguration().
+            enableModules(".*", ".*").
+            honorAutoloadEager(true).
+            failOnException(Level.INFO).
+            addTest(VerifySimpleTemplatesTest.class).
+            suite();
+    }
+
+    public void testAllTemplates() throws IOException {
+        clearWorkDir();
+
+        DataFolder scratch = DataFolder.findFolder(FileUtil.toFileObject(getWorkDir()));
+
+        DataFolder templates = DataFolder.findFolder(FileUtil.getConfigFile("Templates"));
+        List<DataObject> groups = new ArrayList<>();
+        quickPickTemplates(templates, groups);
+
+        int cnt = 0;
+        for (DataObject g : groups) {
+            assertTrue("It is a folder: " + g, g instanceof DataFolder);
+            DataFolder f = (DataFolder) g;
+
+            List<DataObject> simpleTemplates = new ArrayList<>();
+            quickPickTemplates(f, simpleTemplates);
+
+            for (DataObject t : simpleTemplates) {
+                LOG.log(Level.WARNING, "Processing {0}", t.getPrimaryFile().getPath());
+                DataObject generated = t.createFromTemplate(scratch, "Test" + ++cnt);
+                Openable open = generated.getLookup().lookup(Openable.class);
+                if (open != null) {
+                    LOG.log(Level.WARNING, "Opening {0}", generated.getPrimaryFile().getPath());
+                    open.open();
+                } else {
+                    LOG.log(Level.WARNING, "Cannot open {0}", generated.getPrimaryFile().getPath());
+                }
+            }
+        }
+    }
+
+    private void quickPickTemplates(DataFolder f, List<DataObject> collect) {
+        for (DataObject obj : f.getChildren()) {
+            if (obj instanceof DataFolder) {
+                Object o = obj.getPrimaryFile().getAttribute("simple"); // NOI18N
+                if (o == null || Boolean.TRUE.equals(o)) {
+                    collect.add(obj);
+                }
+                continue;
+            }
+            if (obj.isTemplate()) {
+                collect.add(obj);
+            }
+        }
+    }
+}

--- a/ide/projectuiapi/arch.xml
+++ b/ide/projectuiapi/arch.xml
@@ -529,6 +529,14 @@ Nothing.
    modules that seem to provide support for technologies used in the about 
    to be opened projects.
    </api>
+
+   <api name="templateCategory" category="stable" group="property" type="export">
+       <a href="@TOP@/org/netbeans/spi/project/ui/templates/support/package-summary.html">org.netbeans.spi.project.ui.templates.support</a>
+       package defines a special <code>templateCategory</code> property which
+       allows one to categorize templates. See
+       <a href="@TOP@/org/netbeans/spi/project/ui/templates/support/package-summary.html">package summary</a>
+       for detailed info.
+   </api>
   </p>
  </answer>
 

--- a/ide/projectuiapi/src/org/netbeans/spi/project/ui/templates/support/package.html
+++ b/ide/projectuiapi/src/org/netbeans/spi/project/ui/templates/support/package.html
@@ -21,7 +21,7 @@
 <html>
 <body>
 
-Support for providing own templates visible in <b>New File...</b> action.
+Support for providing own templates visible in <b>New File</b> action.
 
 <p>Project types may declare the templates for projects using {@link org.netbeans.api.templates.TemplateRegistration}
 with a path as a subfolder of <code>Projects/</code>.

--- a/ide/xml/src/org/netbeans/modules/xml/resources/templates/emptyXML.xml.template
+++ b/ide/xml/src/org/netbeans/modules/xml/resources/templates/emptyXML.xml.template
@@ -1,10 +1,24 @@
+<#if fileEncoding??>
 <?xml version="1.0" encoding="${fileEncoding}"?>
+<#else>
+<?xml version="1.0" encoding="UTF-8"?>
+</#if>
 <#assign licenseFirst = "<!--">
 <#assign licensePrefix = "">
 <#assign licenseLast = "-->">
 <#include "${project.licensePath}">
 
+<#if doctype??>
 ${doctype}
+</#if>
+<#if !rootTagNs??>
+  <#assign rootTagNs = "demo">
+  <#assign nsDeclarations = "">
+</#if>
+<#if !generatedContent??>
+  <#assign generatedContent = "Hello World!">
+</#if>
+
 <${rootTagNs}${nsDeclarations}>
     ${generatedContent}
 </${rootTagNs}>

--- a/ide/xml/src/org/netbeans/modules/xml/resources/templates/emptyXML.xml.template
+++ b/ide/xml/src/org/netbeans/modules/xml/resources/templates/emptyXML.xml.template
@@ -8,17 +8,9 @@
 <#assign licenseLast = "-->">
 <#include "${project.licensePath}">
 
-<#if doctype??>
-${doctype}
-</#if>
-<#if !rootTagNs??>
-  <#assign rootTagNs = "demo">
-  <#assign nsDeclarations = "">
-</#if>
-<#if !generatedContent??>
-  <#assign generatedContent = "Hello World!">
-</#if>
+${doctype!""}
 
-<${rootTagNs}${nsDeclarations}>
-    ${generatedContent}
-</${rootTagNs}>
+<${rootTagNs!"demo"}${nsDeclarations!""}>
+    ${generatedContent!"Hello World!"}
+</${rootTagNs!"demo"}>
+

--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -300,7 +300,6 @@ disabled.modules=\
     org.netbeans.modules.tasklist.ui,\
     org.netbeans.modules.team.commons,\
     org.netbeans.modules.team.ide,\
-    org.netbeans.modules.templates,\
     org.netbeans.modules.terminal.nb,\
     org.netbeans.modules.testng.ant,\
     org.netbeans.modules.testng.maven,\

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -252,6 +252,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.java.nativeimage.debugger</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>0</release-version>
+                        <specification-version>0.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.java.project</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -322,15 +331,6 @@
                 </dependency>
                 <dependency>
                     <code-name-base>org.netbeans.modules.nativeimage.api</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <release-version>0</release-version>
-                        <specification-version>0.1</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.modules.java.nativeimage.debugger</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
@@ -482,6 +482,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>1.54</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.loaders</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.81</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.logging.Level;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
@@ -203,8 +204,19 @@ class LspTemplateUI {
 
             boolean display;
             if (obj instanceof DataFolder) {
-                Object o = obj.getPrimaryFile ().getAttribute ("simple"); // NOI18N
-                display = o == null || Boolean.TRUE.equals (o);
+                Object simple = fo.getAttribute("simple"); // NOI18N
+                if (simple != null) {
+                    display = Boolean.TRUE.equals(simple);
+                } else {
+                    Object cathegory = fo.getAttribute("templateCategory"); // NOI18N
+                    if ("invisible".equals(cathegory)) { // NOI18N
+                        display = false;
+                    } else if ("helper-files".equals(cathegory)) { // NOI18N
+                        display = false;
+                    } else {
+                        display = fo.getChildren().length > 0;
+                    }
+                }
             } else {
                 display = obj.isTemplate();
             }
@@ -240,7 +252,7 @@ class LspTemplateUI {
                     descriptionText = null;
                 }
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                Exceptions.printStackTrace(Exceptions.attachSeverity(ex, Level.FINE));
                 return descriptionText;
             }
         }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import com.google.gson.JsonPrimitive;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.loaders.DataFolder;
+import org.openide.loaders.DataObject;
+import org.openide.loaders.DataObjectNotFoundException;
+import org.openide.nodes.Node;
+import org.openide.util.NbBundle;
+
+class LspTemplateUI {
+    private LspTemplateUI() {
+    }
+
+    static CompletableFuture<Object> createFromTemplate(String templates, NbCodeLanguageClient client, ExecuteCommandParams params) {
+        final FileObject fo = FileUtil.getConfigFile(templates);
+        final DataFolder folder = DataFolder.findFolder(fo);
+        return displayUI(folder, client, params);
+    }
+
+    @NbBundle.Messages({
+        "CTL_TemplateUI_SelectGroup=Select Group of Objects",
+        "CTL_TemplateUI_SelectTemplate=Select Object Template",
+        "CTL_TemplateUI_SelectTarget=Where to put the object?",
+        "CTL_TemplateUI_SelectName=Name of the object?",
+    })
+    private static CompletableFuture<Object> displayUI(DataFolder templates, NbCodeLanguageClient client, ExecuteCommandParams params) {
+        final FileObject[] group = { null };
+        final DataObject[] source = { null };
+        final DataFolder[] target = findTargetFolder(params);
+
+        final List<QuickPickItem> categories = quickPickTemplates(templates);
+        final CompletionStage<List<QuickPickItem>> pickGroup = client.showQuickPick(new ShowQuickPickParams(Bundle.CTL_TemplateUI_SelectGroup(), false, categories));
+        final CompletionStage<List<QuickPickItem>> pickProject = pickGroup.thenCompose(selectedGroups -> {
+            group[0] = templates.getPrimaryFile().getFileObject(singleSelection(selectedGroups));
+            List<QuickPickItem> projectTypes = quickPickTemplates(DataFolder.findFolder(group[0]));
+            return client.showQuickPick(new ShowQuickPickParams(Bundle.CTL_TemplateUI_SelectTemplate(), false, projectTypes));
+        });
+        final CompletionStage<DataObject> findTemplate = pickProject.thenApply((selectedTemplates) -> {
+            try {
+                final String templateName = singleSelection(selectedTemplates);
+                final FileObject templateFo = group[0].getFileObject(templateName);
+                source[0] = DataObject.find(templateFo);
+            } catch (DataObjectNotFoundException ex) {
+                throw raise(RuntimeException.class, ex);
+            }
+            return source[0];
+        });
+        final CompletionStage<DataFolder> findTarget;
+        if (target[0] == null) {
+            findTarget = findTemplate.thenCompose(any -> client.workspaceFolders()).thenCompose(folders -> {
+                return client.showInputBox(new ShowInputBoxParams(Bundle.CTL_TemplateUI_SelectTarget(), findWorkspaceRoot(folders)));
+            }).thenApply((path) -> {
+                target[0] = DataFolder.findFolder(FileUtil.toFileObject(new File(path)));
+                return target[0];
+            });
+        } else {
+            findTarget = findTemplate.thenApply(any -> target[0]);
+        }
+        CompletionStage<String> findTargetName = findTarget.thenCompose((t) -> {
+            return client.showInputBox(new ShowInputBoxParams(Bundle.CTL_TemplateUI_SelectName(), source[0].getName()));
+        }).thenApply((nameWithExtension) -> {
+            String templateExtension = source[0].getPrimaryFile().getExt();
+            return removeExtensionFromFileName(nameWithExtension, templateExtension);
+        });
+        return findTargetName.thenApply((name) -> {
+            try {
+                DataObject newPrj = source[0].createFromTemplate(target[0], name);
+                return (Object) newPrj.getPrimaryFile().toURI().toString();
+            } catch (IOException ex) {
+                throw raise(RuntimeException.class, ex);
+            }
+        }).toCompletableFuture();
+    }
+
+    private static String findWorkspaceRoot(List<WorkspaceFolder> folders) {
+        String root = System.getProperty("user.home"); // NOI18N
+        for (WorkspaceFolder f : folders) {
+            try {
+                File file = new File(new URI(f.getUri()));
+                if (file.exists()) {
+                    root = file.getPath();
+                    break;
+                }
+            } catch (URISyntaxException ex) {
+                continue;
+            }
+        }
+        return root;
+    }
+
+    private static String singleSelection(List<QuickPickItem> selectedGroups) throws IllegalStateException {
+        if (selectedGroups == null || selectedGroups.size() != 1) {
+            throw new IllegalStateException("Unexpected selection: " + selectedGroups);
+        }
+        return selectedGroups.get(0).getUserData().toString();
+    }
+
+    private static DataFolder[] findTargetFolder(ExecuteCommandParams params) {
+        final DataFolder[] target = { null };
+        for (Object arg : params.getArguments()) {
+            if (arg == null) {
+                continue;
+            }
+            String path;
+            if (arg instanceof JsonPrimitive) {
+                JsonPrimitive jp = (JsonPrimitive) arg;
+                path = jp.getAsString();
+            } else {
+                path = arg.toString();
+            }
+            File file = new File(path);
+            if (file.exists()) {
+                target[0] = DataFolder.findFolder(FileUtil.toFileObject(file));
+            }
+        }
+        return target;
+    }
+
+    private static String removeExtensionFromFileName(String nameWithExtension, String templateExtension) {
+        if (nameWithExtension.endsWith('.' + templateExtension)) {
+            return nameWithExtension.substring(0, nameWithExtension.length() - templateExtension.length() - 1);
+        } else {
+            return nameWithExtension;
+        }
+    }
+
+    private static List<QuickPickItem> quickPickTemplates(final DataFolder folder) {
+        Node[] arr = folder.getNodeDelegate().getChildren().getNodes(true);
+        List<QuickPickItem> categories = new ArrayList<>();
+        for (Node n : arr) {
+            FileObject fo = n.getLookup().lookup(FileObject.class);
+            DataObject obj = n.getLookup().lookup(DataObject.class);
+
+            boolean display;
+            if (obj instanceof DataFolder) {
+                Object o = obj.getPrimaryFile ().getAttribute ("simple"); // NOI18N
+                display = o == null || Boolean.TRUE.equals (o);
+            } else {
+                display = obj.isTemplate();
+            }
+
+            if (display) {
+                categories.add(new QuickPickItem(
+                        n.getDisplayName(),
+                        n.getShortDescription(),
+                        null,
+                        false,
+                        fo.getNameExt()
+                ));
+            }
+        }
+        return categories;
+    }
+
+    private static <T extends Exception> T raise(Class<T> aClass, Exception ex) throws T {
+        throw (T)ex;
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -608,8 +608,7 @@ public final class Server {
                 capabilities.setImplementationProvider(true);
                 capabilities.setDocumentHighlightProvider(true);
                 capabilities.setReferencesProvider(true);
-                List<String> commands = new ArrayList<>(Arrays.asList(
-                        JAVA_BUILD_WORKSPACE, JAVA_LOAD_WORKSPACE_TESTS, GRAALVM_PAUSE_SCRIPT, JAVA_SUPER_IMPLEMENTATION));
+                List<String> commands = new ArrayList<>(Arrays.asList(JAVA_NEW_FROM_TEMPLATE, JAVA_BUILD_WORKSPACE, JAVA_LOAD_WORKSPACE_TESTS, GRAALVM_PAUSE_SCRIPT, JAVA_SUPER_IMPLEMENTATION));
                 for (CodeGenerator codeGenerator : Lookup.getDefault().lookupAll(CodeGenerator.class)) {
                     commands.addAll(codeGenerator.getCommands());
                 }
@@ -721,6 +720,7 @@ public final class Server {
     }
     
     public static final String JAVA_BUILD_WORKSPACE =  "java.build.workspace";
+    public static final String JAVA_NEW_FROM_TEMPLATE =  "java.new.from.template";
     public static final String JAVA_LOAD_WORKSPACE_TESTS =  "java.load.workspace.tests";
     public static final String JAVA_SUPER_IMPLEMENTATION =  "java.super.implementation";
     public static final String GRAALVM_PAUSE_SCRIPT =  "graalvm.pause.script";

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -119,6 +119,8 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
                 ActionsManager am = DebuggerManager.getDebuggerManager().getCurrentEngine().getActionsManager();
                 am.doAction("pauseInGraalScript");
                 return CompletableFuture.completedFuture(true);
+            case Server.JAVA_NEW_FROM_TEMPLATE:
+                return LspTemplateUI.createFromTemplate("Templates", client, params);
             case Server.JAVA_BUILD_WORKSPACE: {
                 final CommandProgress progressOfCompilation = new CommandProgress();
                 final Lookup ctx = Lookups.singleton(progressOfCompilation);

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -250,7 +250,7 @@
 			"explorer/context": [
 				{
 					"command": "java.workspace.new",
-					"when": "nbJavaLSReady",
+					"when": "nbJavaLSReady && explorerResourceIsFolder",
 					"group": "navigation@3"
 				}
 			],

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -212,6 +212,11 @@
 				"category": "Java"
 			},
 			{
+				"command": "java.workspace.new",
+				"title": "New from Template...",
+				"category": "Java"
+			},
+			{
 				"command": "java.goto.super.implementation",
 				"title": "Go to Super Implementation",
 				"category": "Java"
@@ -242,7 +247,18 @@
 					"group": "navigation@100"
 				}
 			],
+			"explorer/context": [
+				{
+					"command": "java.workspace.new",
+					"when": "nbJavaLSReady",
+					"group": "navigation@3"
+				}
+			],
 			"commandPalette": [
+				{
+					"command": "java.workspace.new",
+					"when": "nbJavaLSReady"
+				},
 				{
 					"command": "java.workspace.compile",
 					"when": "nbJavaLSReady"

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -186,7 +186,15 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
         let c : LanguageClient = await client;
         const commands = await vscode.commands.getCommands();
         if (commands.includes('java.new.from.template')) {
-            const res = await vscode.commands.executeCommand('java.new.from.template', ctx?.fsPath);
+            function ctxUri(): vscode.Uri | undefined {
+                if (ctx && ctx.fsPath) {
+                    return ctx as vscode.Uri;
+                }
+                return vscode.window.activeTextEditor?.document?.uri;
+            }
+
+            const res = await vscode.commands.executeCommand('java.new.from.template', ctxUri()?.toString());
+
             if (typeof res === 'string') {
                 let newFile = vscode.Uri.parse(res as string);
                 await vscode.window.showTextDocument(newFile);

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -182,6 +182,19 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('nativeimage', debugDescriptionFactory));
 
     // register commands
+    context.subscriptions.push(commands.registerCommand('java.workspace.new', async (ctx) => {
+        let c : LanguageClient = await client;
+        const commands = await vscode.commands.getCommands();
+        if (commands.includes('java.new.from.template')) {
+            const res = await vscode.commands.executeCommand('java.new.from.template', ctx?.fsPath);
+            if (typeof res === 'string') {
+                let newFile = vscode.Uri.parse(res as string);
+                await vscode.window.showTextDocument(newFile);
+            }
+        } else {
+            throw `Client ${c} doesn't support new from template`;
+        }
+    }));
     context.subscriptions.push(commands.registerCommand('java.workspace.compile', () => {
         return window.withProgress({ location: ProgressLocation.Window }, p => {
             return new Promise(async (resolve, reject) => {

--- a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/resources/Classes.html
+++ b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/resources/Classes.html
@@ -21,10 +21,10 @@
 
 <html>
 <head>
-	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 </head>
 <BODY>
-This category has templates for various kinds of Java classes.
-Using these templates allows you to write Java code by hand. To design dialogs
-or Frames visually, use the templates in the Java GUI Forms category.
+Various kinds of Java classes. Using these templates allows you to write
+Java code by hand. To design dialogs or Frames visually, use the templates in 
+the Java GUI Forms category.
 </BODY></HTML>

--- a/java/java.source/src/org/netbeans/modules/java/JavaDataObject.java
+++ b/java/java.source/src/org/netbeans/modules/java/JavaDataObject.java
@@ -27,6 +27,7 @@ import org.netbeans.api.java.source.Task;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.api.java.source.JavaSource.Phase;
 import org.netbeans.api.java.loaders.JavaDataSupport;
+import org.netbeans.api.java.source.ModificationResult;
 import org.netbeans.api.java.source.TreeUtilities;
 import org.netbeans.api.java.source.WorkingCopy;
 import org.netbeans.api.java.source.TreeMaker;
@@ -100,6 +101,9 @@ public final class JavaDataObject extends MultiDataObject {
             final String originalName) throws IOException 
     {
         JavaSource javaSource = JavaSource.forFileObject (fileToUpdate);
+        if (javaSource == null) {
+            return;
+        }
 
         Task<WorkingCopy> task = new Task<WorkingCopy>() {
             
@@ -130,6 +134,7 @@ public final class JavaDataObject extends MultiDataObject {
                 }
             }                
         };
-        javaSource.runModificationTask(task).commit();
+        final ModificationResult taskResult = javaSource.runModificationTask(task);
+        taskResult.commit();
     }
 }

--- a/java/java.source/src/org/netbeans/modules/java/source/resources/OverriddenMethodBody.template
+++ b/java/java.source/src/org/netbeans/modules/java/source/resources/OverriddenMethodBody.template
@@ -14,5 +14,5 @@ ${simple_class_name}        simple name of the enclosing class
 <#if method_return_type?? && method_return_type != "void">
 return ${super_method_call}; //To change body of generated methods, choose Tools | Templates.
 <#else>
-${super_method_call}; //To change body of generated methods, choose Tools | Templates.
+${super_method_call!''}; //To change body of generated methods, choose Tools | Templates.
 </#if>

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/resources/JUnit3Suite.java.template
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/resources/JUnit3Suite.java.template
@@ -26,9 +26,11 @@ public class ${name} extends TestCase {
     <#-- classes:     "FooA.class,FooB.class" -->
     public static Test suite() {
         TestSuite suite = new TestSuite("${name}");
+<#if classes??>
         <#list "${classes}"?split(",") as class>
         suite.addTest(new TestSuite(${class}));
         </#list>
+</#if>
         return suite;
     }
 

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/resources/JUnit4Suite.java.template
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/resources/JUnit4Suite.java.template
@@ -18,7 +18,7 @@ import org.junit.runners.Suite;
 <#-- classNames:  "FooA,FooB" -->
 <#-- classes:     "FooA.class,FooB.class" -->
 @RunWith(Suite.class)
-@Suite.SuiteClasses({${classes}})
+@Suite.SuiteClasses({${classes!''}})
 public class ${name} {
 
 }

--- a/java/junit.ui/src/org/netbeans/modules/junit/ui/resources/JUnit5Suite.java.template
+++ b/java/junit.ui/src/org/netbeans/modules/junit/ui/resources/JUnit5Suite.java.template
@@ -18,7 +18,7 @@ import org.junit.runner.RunWith;
 <#-- classNames:  "FooA,FooB" -->
 <#-- classes:     "FooA.class,FooB.class" -->
 @RunWith(JUnitPlatform.class)
-@SelectClasses({${classes}})
+@SelectClasses({${classes!''}})
 public class ${name} {
 
 }

--- a/java/spring.beans/src/org/netbeans/modules/spring/beans/resources/templates/springXMLConfig.template
+++ b/java/spring.beans/src/org/netbeans/modules/spring/beans/resources/templates/springXMLConfig.template
@@ -1,19 +1,25 @@
+<#if project.encoding??>
 <?xml version="1.0" encoding="${project.encoding}"?>
+<#else>
+<?xml version="1.0" encoding="UTF-8"?>
+</#if>
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-<#list namespaces as namespace>
+<#if namespaces??>
+    <#list namespaces as namespace>
        xmlns:${namespace.prefix}="${namespace.namespace}"
-</#list>
+    </#list>
 
-<#if version??>
+    <#if version??>
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-${version}.xsd
-<#else>
+    <#else>
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.2.3.xsd
-</#if>
-<#list namespaces as namespace>
-    <#if namespace.hasSchemeLocation()>
-          ${namespace.namespace} ${namespace.namespace}/${namespace.fileName}
     </#if>
-</#list>">
+    <#list namespaces as namespace>
+        <#if namespace.hasSchemeLocation()>
+          ${namespace.namespace} ${namespace.namespace}/${namespace.fileName}
+        </#if>
+    </#list>">
+</#if>
 
 </beans>

--- a/java/testng.ui/src/org/netbeans/modules/testng/ui/resources/TestNGSuite.xml.template
+++ b/java/testng.ui/src/org/netbeans/modules/testng/ui/resources/TestNGSuite.xml.template
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8' ?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
-<suite name="${suiteName}">
+<suite name="${suiteName!'Suite name'}">
 
     <!--
     see examples at http://testng.org/doc/documentation-main.html#testng-xml
@@ -17,10 +17,10 @@
         </classes>
     </test>
     -->
-    
-    <test name="${testName}">
+
+    <test name="${testName!'testName'}">
         <packages>
-            <package name="${pkg}"/>
+            <package name="${pkg!'org.pkg'}"/>
         </packages>
     </test>
 

--- a/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/templates/FXML_java_1.template
+++ b/javafx/javafx2.project/src/org/netbeans/modules/javafx2/project/templates/FXML_java_1.template
@@ -21,7 +21,7 @@ public class ${name} extends Application {
 
     @Override
     public void start(Stage stage) throws Exception {
-        Parent root = FXMLLoader.load(getClass().getResource("${fxmlname}.fxml"));
+        Parent root = FXMLLoader.load(getClass().getResource("${fxmlname!name}.fxml"));
         
         Scene scene = new Scene(root);
 

--- a/platform/templates/src/org/netbeans/modules/templates/resources/layer.xml
+++ b/platform/templates/src/org/netbeans/modules/templates/resources/layer.xml
@@ -25,6 +25,7 @@
     <folder name="Templates">
         <folder name="Other">
             <attr name="displayName" bundlevalue="org.netbeans.modules.templates.resources.Bundle#Templates/Other"/>
+            <attr name="templateWizardURL" urlvalue="nbresloc:/org/netbeans/modules/templates/resources/templatesOther.html"/>
             <attr name="position" intvalue="2100"/>
             <folder name="Folder">
                 <attr name="displayName" bundlevalue="org.netbeans.modules.templates.resources.Bundle#Templates/Other/Folder"/>

--- a/platform/templates/src/org/netbeans/modules/templates/resources/templatesOther.html
+++ b/platform/templates/src/org/netbeans/modules/templates/resources/templatesOther.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Licensed to the Apache Software Foundation (ASF) under one
@@ -19,18 +18,12 @@
     under the License.
 
 -->
-<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
-<filesystem>
-    <folder name="Services">
-        <folder name="AutoupdateType">
-            <file name="82pluginportal-update-provider.instance_hidden"/>
-            <file name="distribution-update-provider.instance_hidden"/>
-            <file name="pluginportal-update-provider.instance_hidden"/>
-        </folder>
-    </folder>
-    <folder name="Templates">
-        <folder name="XML">
-            <file name="XMLCatalog.xml_hidden"/>
-        </folder>
-    </folder>
-</filesystem>
+
+<html>
+<head>
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+</head>
+<body>
+Uncathegorized templates.
+</body>
+</html>

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/resources/clientside-description.html
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/resources/clientside-description.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Licensed to the Apache Software Foundation (ASF) under one
@@ -19,18 +18,13 @@
     under the License.
 
 -->
-<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
-<filesystem>
-    <folder name="Services">
-        <folder name="AutoupdateType">
-            <file name="82pluginportal-update-provider.instance_hidden"/>
-            <file name="distribution-update-provider.instance_hidden"/>
-            <file name="pluginportal-update-provider.instance_hidden"/>
-        </folder>
-    </folder>
-    <folder name="Templates">
-        <folder name="XML">
-            <file name="XMLCatalog.xml_hidden"/>
-        </folder>
-    </folder>
-</filesystem>
+
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+</head>
+<body>
+HTML and JavaScript templates.
+</body>
+</html>
+

--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/resources/layer.xml
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/resources/layer.xml
@@ -32,8 +32,9 @@
         </folder>
 
         <folder name="ClientSide">
-            <attr name="position" intvalue="610"/>
+            <attr name="position" intvalue="1610"/>
             <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.web.clientproject.Bundle"/>
+            <attr name="templateWizardURL" urlvalue="nbresloc:/org/netbeans/modules/web/clientproject/resources/clientside-description.html"/>
 
             <file name="html.html" url="nbresloc:/org/netbeans/modules/html/templates/html.html">
                 <attr name="position" intvalue="100"/>


### PR DESCRIPTION
Exposes `DataObject.createFromTemplate` for _simple_ templates from `Templates` folder to VSCode users in a simple few step UI. CCing @Ondrej-Douda, @jisedlac

![obrazek](https://user-images.githubusercontent.com/26887752/114654246-0aa81500-9cea-11eb-996b-b8b7044e3a3f.png)

Select the _New from Template..._ item and:
* select the group - e.g. __Java__, __JUnit__, __HTML__, __Other__
* select the actual template
* if the action was invoked from palette (_Ctrl-Shift-P_) specify location
* specify name for the new object/file
 
At the end new file opens in the editor. Testing extension is available at its [jenkins builder](https://ci-builds.apache.org/job/Netbeans/job/netbeans-vscode-new-from-template/) and is updated with every change to this PR.