### PR TITLE
Reducing dependencies on Swing API when basic API exists.

### DIFF
--- a/extide/o.apache.tools.ant.module/nbproject/project.xml
+++ b/extide/o.apache.tools.ant.module/nbproject/project.xml
@@ -44,14 +44,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.api.progress.nb</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>1.40</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.api.xml</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/TargetExecutor.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/run/TargetExecutor.java
@@ -51,7 +51,6 @@ import org.apache.tools.ant.module.bridge.AntBridge;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.options.OptionsDisplayer;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
 import org.netbeans.modules.options.java.api.JavaOptions;
 import org.openide.ErrorManager;
 import org.openide.LifecycleManager;
@@ -555,7 +554,7 @@ public final class TargetExecutor implements Runnable {
         }
         
 	    // #58513, #87801: register a progress handle for the task too.
-        final ProgressHandle handle = ProgressHandleFactory.createHandle(displayName, new Cancellable() {
+        final ProgressHandle handle = ProgressHandle.createHandle(displayName, new Cancellable() {
             public boolean cancel() {
                 sa.actionPerformed(null);
                 return true;

--- a/ide/csl.api/nbproject/project.xml
+++ b/ide/csl.api/nbproject/project.xml
@@ -53,14 +53,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.api.progress.nb</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>1.40</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.core.multiview</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/ide/csl.api/src/org/netbeans/modules/csl/api/UiUtils.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/api/UiUtils.java
@@ -36,7 +36,7 @@ import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import org.netbeans.api.lexer.TokenHierarchy;
 import org.netbeans.api.lexer.TokenSequence;
-import org.netbeans.api.progress.ProgressUtils;
+import org.netbeans.api.progress.BaseProgressUtils;
 import org.netbeans.modules.csl.api.DeclarationFinder.DeclarationLocation;
 import org.netbeans.modules.csl.core.Language;
 import org.netbeans.modules.csl.core.LanguageRegistry;
@@ -301,7 +301,7 @@ public final class UiUtils {
                     return DeclarationLocation.NONE; //we are opening @ 0 position. Fix #160478
                 }
             } else if (SwingUtilities.isEventDispatchThread()) {
-                ProgressUtils.runOffEventDispatchThread(
+                BaseProgressUtils.runOffEventDispatchThread(
                     new Runnable() {
                         @Override
                         public void run() {

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/GoToSupport.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/GoToSupport.java
@@ -34,7 +34,7 @@ import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import org.netbeans.api.editor.EditorRegistry;
-import org.netbeans.api.progress.ProgressUtils;
+import org.netbeans.api.progress.BaseProgressUtils;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.csl.api.DataLoadersBridge;
 import org.netbeans.modules.csl.api.DeclarationFinder;
@@ -84,7 +84,7 @@ public class GoToSupport {
         final AtomicBoolean cancel = new AtomicBoolean();
         String name = NbBundle.getMessage(GoToSupport.class, "NM_GoToDeclaration");
 
-        ProgressUtils.runOffEventDispatchThread(new Runnable() {
+        BaseProgressUtils.runOffEventDispatchThread(new Runnable() {
 
             public void run() {
                 perform(doc, offset, false, cancel);

--- a/ide/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsPanelLogic.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/hints/infrastructure/HintsPanelLogic.java
@@ -52,9 +52,6 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
 import org.netbeans.api.editor.EditorRegistry;
-import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
-import org.netbeans.api.progress.ProgressUtils;
 import org.netbeans.modules.csl.api.HintSeverity;
 import org.netbeans.modules.csl.api.Rule;
 
@@ -63,11 +60,9 @@ import org.netbeans.modules.parsing.api.ResultIterator;
 import org.netbeans.modules.parsing.api.ParserManager;
 import org.netbeans.modules.parsing.api.Source;
 import org.netbeans.modules.parsing.api.UserTask;
-import org.netbeans.modules.parsing.impl.Utilities;
 import org.netbeans.modules.parsing.spi.ParseException;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
-import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 
 

--- a/java/debugger.jpda.ui/nbproject/project.xml
+++ b/java/debugger.jpda.ui/nbproject/project.xml
@@ -70,14 +70,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.api.progress.nb</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>1.40</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.libs.javacapi</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/ConnectPanel.java
+++ b/java/debugger.jpda.ui/src/org/netbeans/modules/debugger/jpda/ui/ConnectPanel.java
@@ -65,7 +65,6 @@ import org.netbeans.api.debugger.jpda.DebuggerStartException;
 import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.debugger.jpda.ListeningDICookie;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
 import org.netbeans.spi.debugger.ui.Controller;
 import org.netbeans.spi.debugger.ui.PersistentController;
 import org.openide.DialogDisplayer;
@@ -650,7 +649,7 @@ public class ConnectPanel extends JPanel implements ActionListener, HelpCtx.Prov
                 @Override
                 public void run() {
                     final Thread theCurrentThread = Thread.currentThread();
-                    ProgressHandle progress = ProgressHandleFactory.createHandle(
+                    ProgressHandle progress = ProgressHandle.createHandle(
                             NbBundle.getMessage(ConnectPanel.class, "CTL_connectProgress"),
                             new Cancellable() {
                                 @Override

--- a/platform/api.search/nbproject/project.xml
+++ b/platform/api.search/nbproject/project.xml
@@ -44,14 +44,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.api.progress.nb</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>1.40</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.queries</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/platform/api.search/src/org/netbeans/modules/search/GraphicalSearchListener.java
+++ b/platform/api.search/src/org/netbeans/modules/search/GraphicalSearchListener.java
@@ -29,7 +29,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.netbeans.api.actions.Savable;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
 import org.netbeans.api.search.provider.SearchListener;
 import org.netbeans.modules.search.ui.FileObjectPropertySet;
 import org.netbeans.modules.search.ui.UiUtils;
@@ -39,7 +38,6 @@ import org.openide.filesystems.FileObject;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
-import org.openide.util.Cancellable;
 import org.openide.util.NbBundle;
 
 /**
@@ -82,7 +80,7 @@ class GraphicalSearchListener extends SearchListener {
     }
 
     public void searchStarted() {
-        progressHandle = ProgressHandleFactory.createHandle(
+        progressHandle = ProgressHandle.createHandle(
                 NbBundle.getMessage(ResultView.class, "TEXT_SEARCHING___"), //NOI18N
                 () -> {
                     searchComposition.terminate();

--- a/platform/api.search/src/org/netbeans/modules/search/ReplaceTask.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ReplaceTask.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
 import org.netbeans.modules.search.MatchingObject.InvalidityStatus;
 import org.netbeans.modules.search.ui.BasicReplaceResultsPanel;
 import org.openide.filesystems.FileAlreadyLockedException;
@@ -71,7 +70,7 @@ public final class ReplaceTask implements Runnable {
         this.panel = panel;
         
         problems = new ArrayList<String>(4);
-        progressHandle = ProgressHandleFactory.createHandle(
+        progressHandle = ProgressHandle.createHandle(
                 NbBundle.getMessage(getClass(), "LBL_Replacing"), //NOI18N
                 null, null);
     }

--- a/platform/autoupdate.cli/nbproject/project.xml
+++ b/platform/autoupdate.cli/nbproject/project.xml
@@ -35,14 +35,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.api.progress.nb</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>1.40</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.autoupdate.services</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/platform/core.ui/nbproject/project.xml
+++ b/platform/core.ui/nbproject/project.xml
@@ -35,14 +35,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.api.progress.nb</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>1.40</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.core</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/platform/core.ui/src/org/netbeans/core/ui/warmup/MenuWarmUpTask.java
+++ b/platform/core.ui/src/org/netbeans/core/ui/warmup/MenuWarmUpTask.java
@@ -34,7 +34,6 @@ import javax.swing.JFrame;
 import javax.swing.JMenu;
 import javax.swing.SwingUtilities;
 import org.netbeans.api.progress.ProgressHandle;
-import org.netbeans.api.progress.ProgressHandleFactory;
 import static org.netbeans.core.ui.warmup.Bundle.*;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor.Message;
@@ -184,7 +183,7 @@ public final class MenuWarmUpTask implements Runnable {
                 LOG.fine("Refresh disabled, aborting");
                 return; // no file refresh
             }
-            final ProgressHandle h = ProgressHandleFactory.createHandle(MSG_Refresh(), this, null);
+            final ProgressHandle h = ProgressHandle.createHandle(MSG_Refresh(), this, null);
             if (!LOG.isLoggable(Level.FINE)) {
                 int delay = Integer.parseInt(MSG_RefreshDelay());
                 h.setInitialDelay(delay);


### PR DESCRIPTION
When I was prototyping for LSP, I stumbled upon some uses of Progress API that were unnecessarily tied to Swing. So replacing usage of `api.progress.nb` calls with equivalent `api.progress` + reducing dependencies between modules.