### PR TITLE
Isolate userdirs used by different versions.

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -359,11 +359,18 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
         }, time);
     };
 
+    const ownName = "asf.apache-netbeans-java";
+    const ownExtension = vscode.extensions.getExtension(ownName);
+    if (!ownExtension) {
+        throw `Cannot find ${ownName} extension!`;
+    }
+    const version = ownExtension.packageJSON.version;
     const beVerbose : boolean = workspace.getConfiguration('netbeans').get('verbose', false);
     let info = {
         clusters : findClusters(context.extensionPath),
         extensionPath: context.extensionPath,
         storagePath : context.globalStoragePath,
+        version: version,
         jdkHome : specifiedJDK,
         verbose: beVerbose
     };

--- a/java/java.lsp.server/vscode/src/nbcode.ts
+++ b/java/java.lsp.server/vscode/src/nbcode.ts
@@ -28,6 +28,7 @@ export interface LaunchInfo {
     clusters: string[];
     extensionPath: string;
     storagePath: string;
+    version: string;
     jdkHome: string | unknown;
     verbose? : boolean;
 }
@@ -51,7 +52,7 @@ export function launch(
 ): ChildProcessByStdio<null, Readable, Readable> {
     let nbcodePath = find(info);
 
-    const userDir = path.join(info.storagePath, "userdir");
+    const userDir = path.join(info.storagePath, "userdir-" + info.version);
     fs.mkdirSync(userDir, {recursive: true});
     let userDirPerm = fs.statSync(userDir);
     if (!userDirPerm.isDirectory()) {
@@ -93,6 +94,7 @@ if (typeof process === 'object' && process.argv0 === 'node') {
     let info = {
         clusters : clusters,
         extensionPath: extension,
+        version: json.version,
         storagePath : globalStorage,
         jdkHome : null
     };


### PR DESCRIPTION
There are frequent user reports of _upgrading to new (development) version and nothing being working then_. 

Why that happens? One hypothesis suggests the problem is in sharing the same userdir between different versions. This PR avoids that by isolating the userdirs between different versions, by including the `.vsix` own version in the name of the _userdir_.
