### PR TITLE
[NETBEANS-5370] Prevent generating abstract methods with PHPDoc return array type

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/elements/BaseFunctionElementSupport.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/elements/BaseFunctionElementSupport.java
@@ -149,6 +149,7 @@ public class BaseFunctionElementSupport  {
                 }
                 break;
             case ReturnTypes:
+                boolean hasArray = false;
                 for (TypeResolver typeResolver : getReturnTypes()) {
                     if (typeResolver.isResolved()) {
                         QualifiedName typeName = typeResolver.getTypeName(false);
@@ -176,6 +177,16 @@ public class BaseFunctionElementSupport  {
                                         returnType = Type.PARENT;
                                     }
                                 }
+                            }
+                            // NETBEANS-5370: related to NETBEANS-4509
+                            if (returnType.endsWith("[]")) { // NOI18N
+                                returnType = Type.ARRAY;
+                            }
+                            if (returnType.equals(Type.ARRAY)) {
+                                if (hasArray) {
+                                    continue;
+                                }
+                                hasArray = true;
                             }
                             template.append(returnType);
                         }

--- a/php/php.editor/test/unit/data/testfiles/codegen/testNetbeans5370/testNetbeans5370.php
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testNetbeans5370/testNetbeans5370.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Netbeans5370;
+
+class TestClass1 extends TestAbstractClass {
+
+}
+
+abstract class TestAbstractClass
+{
+    /**
+     * @return string[]
+     */
+    abstract public function test(): array;
+}
+
+class TestClass2 implements TestInterface {
+
+}
+
+interface TestInterface
+{
+    /**
+     * @return string[]
+     */
+    public function test(): array;
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testNetbeans5370/testNetbeans5370.php.testNetbeans5370_01.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testNetbeans5370/testNetbeans5370.php.testNetbeans5370_01.codegen
@@ -1,0 +1,2 @@
+public function test(): array{
+}

--- a/php/php.editor/test/unit/data/testfiles/codegen/testNetbeans5370/testNetbeans5370.php.testNetbeans5370_02.codegen
+++ b/php/php.editor/test/unit/data/testfiles/codegen/testNetbeans5370/testNetbeans5370.php.testNetbeans5370_02.codegen
@@ -1,0 +1,2 @@
+public function test(): array{
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5370/testAbstract.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5370/testAbstract.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Netbeans5370;
+
+abstract class TestAbstractClass
+{
+    /**
+     * @return string[]
+     */
+    abstract public function testAbstract(): array;
+}
+
+class TestClass1 extends TestAbstractClass {
+    test
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5370/testAbstract.php.testAbstract.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5370/testAbstract.php.testAbstract.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testAbstract
+public function testAbstract(): array {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5370/testInterface.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5370/testInterface.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Netbeans5370;
+
+interface TestInterface
+{
+    /**
+     * @return string[]
+     */
+    public function testInterface(): array;
+}
+
+class TestClass2 implements TestInterface {
+    test
+}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5370/testInterface.php.testInterface.cccustomtpl
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5370/testInterface.php.testInterface.cccustomtpl
@@ -1,0 +1,4 @@
+Name: testInterface
+public function testInterface(): array {
+${cursor};
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testNetbeans5370.php
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testNetbeans5370.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Netbeans5370;
+
+class TestClass1 extends TestAbstractClass
+{
+
+}
+
+abstract class TestAbstractClass
+{
+    /**
+     * @return string[]
+     */
+    abstract public function test(): array;
+}
+
+class TestClass2 implements TestInterface
+{
+
+}
+
+interface TestInterface
+{
+    /**
+     * @return string[]
+     */
+    public function test(): array;
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testNetbeans5370.php.testNetbeans5370.hints
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testNetbeans5370.php.testNetbeans5370.hints
@@ -1,0 +1,10 @@
+class TestClass1 extends TestAbstractClass
+      ----------
+HINT:\Netbeans5370\TestClass1 is not abstract and does not override abstract method  test() in \Netbeans5370\TestAbstractClass
+FIX:Implement All Abstract Methods
+FIX:Declare Abstract Class
+class TestClass2 implements TestInterface
+      ----------
+HINT:\Netbeans5370\TestClass2 is not abstract and does not override abstract method  test() in \Netbeans5370\TestInterface
+FIX:Implement All Abstract Methods
+FIX:Declare Abstract Class

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testNetbeans5370.php.testNetbeans5370Fix_01.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testNetbeans5370.php.testNetbeans5370Fix_01.fixed
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Netbeans5370;
+
+class TestClass1 extends TestAbstractClass
+{
+    public function test(): array {
+        
+    }
+
+}
+
+abstract class TestAbstractClass
+{
+    /**
+     * @return string[]
+     */
+    abstract public function test(): array;
+}
+
+class TestClass2 implements TestInterface
+{
+
+}
+
+interface TestInterface
+{
+    /**
+     * @return string[]
+     */
+    public function test(): array;
+}

--- a/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testNetbeans5370.php.testNetbeans5370Fix_02.fixed
+++ b/php/php.editor/test/unit/data/testfiles/verification/ImplementAbstractMethodsHintError/testNetbeans5370.php.testNetbeans5370Fix_02.fixed
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace Netbeans5370;
+
+class TestClass1 extends TestAbstractClass
+{
+
+}
+
+abstract class TestAbstractClass
+{
+    /**
+     * @return string[]
+     */
+    abstract public function test(): array;
+}
+
+class TestClass2 implements TestInterface
+{
+    public function test(): array {
+        
+    }
+
+}
+
+interface TestInterface
+{
+    /**
+     * @return string[]
+     */
+    public function test(): array;
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/codegen/SelectedPropertyMethodsCreatorTest.java
@@ -639,4 +639,20 @@ public class SelectedPropertyMethodsCreatorTest extends PHPTestBase {
                 new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
         ));
     }
+
+    public void testNetbeans5370_01() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class TestClass1 extends TestAbstractClass {^", PhpVersion.PHP_70);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "test"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
+
+    public void testNetbeans5370_02() throws Exception {
+        CGSInfo cgsInfo = getCgsInfo("class TestClass2 implements TestInterface {^", PhpVersion.PHP_70);
+        checkResult(new SelectedPropertyMethodsCreator().create(
+                selectProperties(cgsInfo.getPossibleMethods(), "test"),
+                new SinglePropertyMethodCreator.InheritedMethodCreator(cgsInfo)
+        ));
+    }
 }

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb5370Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb5370Test.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.api.PhpVersion;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+
+public class PHPCodeCompletionNb5370Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionNb5370Test(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[]{
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/nb5370"))
+            })
+        );
+    }
+
+    public void testAbstract() throws Exception {
+        checkCompletionCustomTemplateResult("testfiles/completion/lib/nb5370/testAbstract.php", "    test^",
+                new DefaultFilter(PhpVersion.PHP_80, "test"), true);
+    }
+
+    public void testInterface() throws Exception {
+        checkCompletionCustomTemplateResult("testfiles/completion/lib/nb5370/testInterface.php", "    test^",
+                new DefaultFilter(PhpVersion.PHP_80, "test"), true);
+    }
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ImplementAbstractMethodsHintErrorTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/verification/ImplementAbstractMethodsHintErrorTest.java
@@ -217,6 +217,18 @@ public class ImplementAbstractMethodsHintErrorTest extends PHPHintsTestBase {
         applyHint(new ImplementAbstractMethodsHintError(), "testMixedTypeImplementMethod01.php", "class Chil^d implements MixedType {", "Implement");
     }
 
+    public void testNetbeans5370() throws Exception {
+        checkHints(new ImplementAbstractMethodsHintError(), "testNetbeans5370.php");
+    }
+
+    public void testNetbeans5370Fix_01() throws Exception {
+        applyHint(new ImplementAbstractMethodsHintError(), "testNetbeans5370.php", "class Test^Class1 extends TestAbstractClass", "Implement");
+    }
+
+    public void testNetbeans5370Fix_02() throws Exception {
+        applyHint(new ImplementAbstractMethodsHintError(), "testNetbeans5370.php", "class TestCl^ass2 implements TestInterface", "Implement");
+    }
+
     //~ Inner classes
     private static final class ImplementAbstractMethodsHintErrorStub extends ImplementAbstractMethodsHintError {
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5370

```php
<?php
namespace Netbeans5370;

abstract class TestAbstractClass
{
    /**
     * @return string[]
     */
    abstract public function testAbstract(): array;
}

// before
class TestClass1 extends TestAbstractClass {
    public function test(): string[] {
    }
}

// after
class TestClass1 extends TestAbstractClass {
    public function test(): array {
    }
}
```