### PR TITLE
Always display errors as an icon in bottom right corner

### DIFF
--- a/platform/o.n.core/src/org/netbeans/core/NotifyExcPanel.java
+++ b/platform/o.n.core/src/org/netbeans/core/NotifyExcPanel.java
@@ -601,9 +601,7 @@ public final class NotifyExcPanel extends JPanel implements ActionListener {
      */
     private static boolean shallNotify(Level level, boolean dialog) {
         int minAlert = Integer.getInteger("netbeans.exception.alert.min.level", 900); // NOI18N
-        boolean assertionsOn = false;
-        assert assertionsOn = true;
-        int defReport = assertionsOn ? 900 : 1001;
+        int defReport = 1001;
         int minReport = Integer.getInteger("netbeans.exception.report.min.level", defReport); // NOI18N
 
         if (dialog) {

--- a/platform/o.n.core/test/unit/src/org/netbeans/core/NotifyExceptionTest.java
+++ b/platform/o.n.core/test/unit/src/org/netbeans/core/NotifyExceptionTest.java
@@ -84,22 +84,14 @@ public class NotifyExceptionTest extends NbTestCase {
         NotifyExcPanel.cleanInstance();
     }
     
-    /**
-     * A simple test to ensure that error dialog window is not created modal
-     * until the MainWindow is visible.
-     */
-    public void testNoModalErrorDialog() throws Exception {
+    public void testNoErrorDialog() throws Exception {
         Frame mainWindow = WindowManager.getDefault().getMainWindow();
         final JDialog modalDialog = new HiddenDialog( mainWindow, true );
         DD.toReturn = modalDialog;
 
         Logger.global.log(Level.WARNING, "Something is wrong", new NullPointerException("npe"));
         waitEQ();
-        assertNotNull("Really returned", DD.lastDescriptor);
-        assertEquals("It is DialogDescriptor", DialogDescriptor.class, DD.lastDescriptor.getClass());
-        DialogDescriptor dd = (DialogDescriptor)DD.lastDescriptor;
-        assertFalse( "The request is for non-modal dialog", dd.isModal());
-        assertFalse("Main window is not visible", mainWindow.isVisible());
+        assertNull("No dialog shown", DD.lastDescriptor);
     }
 
     public void testExceptionWillGetTheLevelFromAnnoatation() throws Exception {
@@ -110,8 +102,7 @@ public class NotifyExceptionTest extends NbTestCase {
         Exceptions.printStackTrace(npe);
 
         waitEQ();
-        assertNotNull("We are going to display a warning", DD.lastDescriptor);
-
+        assertNull("No dialogs shown", DD.lastDescriptor);
     }
 
     public void testDirectlyLoggingAnExceptionWithALocalizedMessageAndTheRightLevelShowsItInADialog() throws Exception {


### PR DESCRIPTION
By default errors are displayed by blinking icon in bottom right corner in the production builds. Development builds (those with `-ea`) however display dialogs. That can be pretty annoying, especially when there is a lot of subsequent errors. I suggest to use the same mode as in production builds - e.g. to comment out the `assert use = true` check.