### PR TITLE
[NETBEANS-5557] [CND] mime-resolver-hex-based.xml

### DIFF
--- a/cnd/cnd.utils/src/org/netbeans/modules/cnd/utils/resources/mime-resolver-hex-based.xml
+++ b/cnd/cnd.utils/src/org/netbeans/modules/cnd/utils/resources/mime-resolver-hex-based.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE MIME-Resolver PUBLIC "-//NetBeans//DTD MIME Resolver 1.0//EN"
+		    "http://www.netbeans.org/dtds/mime-resolver-1_0.dtd">
+<MIME-resolver>
+    <!--
+        MIME-resolver based on file signatures.
+        See https://en.wikipedia.org/wiki/List_of_file_signatures for a list.
+    -->
+    <file>
+        <magic hex="EDABEEDB"
+              mask="FFFFFFFF"/>
+        <!-- RPM file -->
+        <resolver mime="application/x-rpm" />
+    </file>
+    <file>
+        <magic hex="53514c69746520666f726d6174203300"
+              mask="ffffffffffffffffffffffffffffffff" />
+        <!-- SQLITE Database -->
+        <resolver mime="application/vnd.sqlite3" />
+    </file>
+    <file>
+        <magic hex="FEEDFACE"
+              mask="ffffffff" />
+        <!-- 32 bit -->
+        <resolver mime="application/x-mach-binary" />
+    </file>
+    <file>
+        <magic hex="CEFAEDFE"
+              mask="ffffffff" />
+        <!-- 32 bit reverse ordered -->
+        <resolver mime="application/x-mach-binary" />
+    </file>
+    <file>
+        <magic hex="CFFAEDFE"
+              mask="ffffffff" />
+        <!-- 64 bit reverse ordered -->
+        <resolver mime="application/x-mach-binary" />
+    </file>
+    <file>
+        <magic hex="6465780A30333500"
+              mask="ffffffffffffffff" />
+        <!-- Dalvik executable -->
+        <resolver mime="application/x-dex" />
+    </file>
+    <file>
+        <magic hex="7F454C46"
+              mask="ffffffff" />
+        <!-- ELF -->
+        <resolver mime="application/x-elf" />
+    </file>
+</MIME-resolver>


### PR DESCRIPTION
Adding a mime-resolver-hex-based.xml replacement to the cnd.utils module, that was missing from the 4th Oracle donation.