### PR TITLE
Fix parsing of constraints if the current parser does not have source files.

### DIFF
--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/idebinding/HintsTaskTest.java
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/idebinding/HintsTaskTest.java
@@ -120,7 +120,27 @@ public class HintsTaskTest extends TestBase {
         
         assertFalse(new HashSet<String>(errors).contains("ERR_RemoveExpression"));
     }
-    
+
+    public void testTypeConditions() throws Exception {
+        prepareTest("test/Test.java", "");
+
+        FileObject hint = sourceRoot.createData("test.hint");
+        String code = "$1.length() :: $1 instanceof java.lang.String;;";
+
+        TestUtilities.copyStringToFile(hint, code);
+
+        TokenHierarchy<?> h = TokenHierarchy.create(code, DeclarativeHintTokenId.language());
+        DeclarativeHintsParser.Result res = new DeclarativeHintsParser().parse(hint, code, h.tokenSequence(DeclarativeHintTokenId.language()));
+        List<ErrorDescription> errorInstances = HintsTask.computeErrors(res, code, hint);
+        List<String> errors = new ArrayList<String>();
+
+        for (ErrorDescription ed : errorInstances) {
+            errors.add(ed.toString());
+        }
+
+        assertEquals(Arrays.asList(), errors);
+    }
+
     static {
         NbBundle.setBranding("test");
     }

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Hacks.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Hacks.java
@@ -20,44 +20,36 @@
 package org.netbeans.modules.java.hints.spiimpl;
 
 import com.sun.source.tree.BlockTree;
-import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Scope;
+import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
 import org.netbeans.api.java.source.support.ErrorAwareTreePathScanner;
-import com.sun.tools.javac.api.JavacTaskImpl;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.Enter;
 import com.sun.tools.javac.comp.Env;
-import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCErroneous;
-import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.Log;
-
-import java.io.File;
-import java.io.IOException;
 import java.util.Collections;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
-import javax.tools.JavaFileObject;
-
-import com.sun.tools.javac.parser.ParserFactory;
 import com.sun.tools.javac.tree.JCTree.JCLambda;
+import java.util.List;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.TreeUtilities;
 import org.netbeans.modules.java.hints.providers.spi.HintMetadata;
 import org.netbeans.modules.java.source.JavaSourceAccessor;
-import org.netbeans.modules.java.source.parsing.FileObjects;
-import org.openide.util.Exceptions;
 
 /**
  *
@@ -65,71 +57,9 @@ import org.openide.util.Exceptions;
  */
 public class Hacks {
 
-    //XXX: copied from Utilities, for declarative hints, different import management:
-    private static long inc;
-
-    public static Scope constructScope(CompilationInfo info, String... importedClasses) {
-        StringBuilder clazz = new StringBuilder();
-
-        clazz.append("package $$;\n");
-
-        for (String i : importedClasses) {
-            clazz.append("import ").append(i).append(";\n");
-        }
-
-        clazz.append("public class $$scopeclass$").append(inc++).append("{");
-
-        clazz.append("private void test() {\n");
-        clazz.append("}\n");
-        clazz.append("}\n");
-
-        JavacTaskImpl jti = JavaSourceAccessor.getINSTANCE().getJavacTask(info);
-        Context context = jti.getContext();
-
-        JavaCompiler jc = JavaCompiler.instance(context);
-        Log.instance(context).nerrors = 0;
-
-        JavaFileObject jfo = FileObjects.memoryFileObject("$$", "$", new File("/tmp/t.java").toURI(), System.currentTimeMillis(), clazz.toString());
-
-        try {
-            CompilationUnitTree cut = ParserFactory.instance(context).newParser(jfo.getCharContent(true), true, true, true).parseCompilationUnit();
-
-            jti.analyze(jti.enter(Collections.singletonList(cut)));
-
-            return new ScannerImpl().scan(cut, info);
-        } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
-            return null;
-        } finally {
-        }
-    }
-
     public static void copyLambdaKind(LambdaExpressionTree node, LambdaExpressionTree nue) {
         ((JCLambda) nue).paramKind = ((JCLambda) node).paramKind;
     }
-
-    private static final class ScannerImpl extends ErrorAwareTreePathScanner<Scope, CompilationInfo> {
-
-        @Override
-        public Scope visitBlock(BlockTree node, CompilationInfo p) {
-            return p.getTrees().getScope(getCurrentPath());
-        }
-
-        @Override
-        public Scope visitMethod(MethodTree node, CompilationInfo p) {
-            if (node.getReturnType() == null) {
-                return null;
-            }
-            return super.visitMethod(node, p);
-        }
-
-        @Override
-        public Scope reduce(Scope r1, Scope r2) {
-            return r1 != null ? r1 : r2;
-        }
-
-    }
-
 
     public static Tree createRenameTree(@NonNull Tree originalTree, @NonNull String newName) {
         return new RenameTree(originalTree, newName);
@@ -153,19 +83,31 @@ public class Hacks {
             return null;
         }
         
-        TypeElement jlObject = info.getElements().getTypeElement("java.lang.Object");
-        
-        //XXX:
-        TypeElement scope;
-
         if (info.getTopLevelElements().isEmpty()) {
-            scope = jlObject;
+            //TreeUtilities.parseType requires a type that originates in source, but we have none.
+            //so, use a synthetic scope (keeping the case where we have a type that originates in source,
+            //to keep compatibility:
+            StatementTree block = info.getTreeUtilities().parseStatement("{" + spec + " $;}", new SourcePositions[1]);
+
+            if (block.getKind() != Kind.BLOCK) {
+                return null;
+            }
+
+            List<? extends StatementTree> statements = ((BlockTree) block).getStatements();
+
+            if (statements.size() != 1 || statements.get(0).getKind() != Kind.VARIABLE) {
+                return null;
+            }
+
+            VariableTree var = (VariableTree) statements.get(0);
+            Scope scope = Utilities.constructScope(info, Collections.emptyMap());
+
+            info.getTreeUtilities().attributeTree(var, scope);
+
+            return info.getTrees().getTypeMirror(new TreePath(new TreePath(info.getCompilationUnit()), var.getType()));
         } else {
-            scope = info.getTopLevelElements().iterator().next();
+            return info.getTreeUtilities().parseType(spec, info.getTopLevelElements().iterator().next());
         }
-        //XXX end
-        
-        return info.getTreeUtilities().parseType(spec, /*XXX: jlObject*/scope);
     }
 
     public static VariableElement attributeThis(CompilationInfo info, TreePath tp) {


### PR DESCRIPTION
This fixes a problem where (without nb-javac), placing this into a `.hint` file:
```
$1.length() :: $1 instanceof java.lang.String;;
```

Will produce an error on $1.
