### PR TITLE
[NETBEANS-5587] Support SNAPSHOT versions of dependencies.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleModuleFileCache21.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleModuleFileCache21.java
@@ -244,15 +244,20 @@ public final class GradleModuleFileCache21 {
     }
 
     public static String[] gavSplit(String gav) {
-        int firstColon = gav.indexOf(':');
-        int lastColon = gav.lastIndexOf(':');
-        if (firstColon == -1 || firstColon == lastColon) {
+        // the general GAV format is - <group>:<artifact>:<version/snapshot>[:<classifier>][@extension]
+        int firstColon = gav.indexOf(':'); // NOI18N
+        int versionColon = gav.indexOf(':', firstColon + 1); // NOI18N
+        int versionEnd = gav.indexOf(':', versionColon + 1); // NO18N
+
+        int end = versionEnd == -1 ? gav.length() : versionEnd;
+
+        if (firstColon == -1 || firstColon == versionColon) {
             throw new IllegalArgumentException("Invalid GAV format: " + gav); //NOI18N
         }
-        return new String[] {
+        return new String[]{
             gav.substring(0, firstColon),
-            gav.substring(firstColon + 1, lastColon),
-            gav.substring(lastColon + 1)
+            gav.substring(firstColon + 1, versionColon),
+             gav.substring(versionColon + 1, end)
         };
     }
 }

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/GradleModuleFileCache21Test.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/GradleModuleFileCache21Test.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle;
+
+import org.netbeans.junit.NbTestCase;
+
+/**
+ *
+ * @author sdedic
+ */
+public class GradleModuleFileCache21Test extends NbTestCase {
+
+    public GradleModuleFileCache21Test(String name) {
+        super(name);
+    }
+    
+    /**
+     * Checks GAV split with regular fixed versions.
+     */
+    public void testGavSplitFixedVersion() throws Exception {
+        String[] parts = GradleModuleFileCache21.gavSplit("io.micronaut:micronaut-core:2.3.4"); // NOI18N
+        assertEquals(parts[0], "io.micronaut"); // NOI18N
+        assertEquals(parts[1], "micronaut-core"); // NOI18N
+        assertEquals(parts[2], "2.3.4"); // NOI18N
+    }
+
+    /**
+     * Checks GAV split with -SNAPSHOT and a maven-like timestamp/sequence as the
+     * snapshot unique id.
+     */
+    public void testGavSplitFixedSnapshotWithMavenTimestamp() throws Exception {
+        String[] parts = GradleModuleFileCache21.gavSplit("io.micronaut:micronaut-core:2.3.4-SNAPSHOT:20210302.164619-21"); // NOI18N
+        assertEquals(parts[0], "io.micronaut"); // NOI18N
+        assertEquals(parts[1], "micronaut-core"); // NOI18N
+        assertEquals(parts[2], "2.3.4-SNAPSHOT"); // NOI18N
+    }
+
+    public void testGavSplitFixedSnapshotWithoutUnqiueId() throws Exception {
+        String[] parts = GradleModuleFileCache21.gavSplit("io.micronaut:micronaut-core:2.3.4-SNAPSHOT"); // NOI18N
+        assertEquals(parts[0], "io.micronaut"); // NOI18N
+        assertEquals(parts[1], "micronaut-core"); // NOI18N
+        assertEquals(parts[2], "2.3.4-SNAPSHOT"); // NOI18N
+    }
+}


### PR DESCRIPTION
I have changed the `gavsplit`, since versions provided in the artifact ID contain 4th component, the `{timestamp}-{sequenceno}` for Mavenrepo SNAPSHOT artifacts.

I changed the code to search from the start, as the 'official' syntax for artifact ID is `group`:`artifact`:`version`[:`classifier`][@`ext`] ... so looking for 3rd `:` delimiter seems to satisfy both this and `group`:`artifact`:`version`:`timestamp`-`sequence` which comes to `gavSplit` for Maven SNAPSHOTs.