### PR TITLE
NETBEANS-5590] Support for assisted download of sources/javadocs for dependencies

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
@@ -126,6 +126,8 @@ public class ActionProviderImpl implements ActionProvider {
         }
         // add a fixed 'prime build' action
         actions.add(ActionProvider.COMMAND_PRIME);
+        actions.add(COMMAND_DL_SOURCES);
+        actions.add(COMMAND_DL_JAVADOC);
         return actions.toArray(new String[actions.size()]);
     }
     
@@ -263,7 +265,13 @@ public class ActionProviderImpl implements ActionProvider {
                 return;
             }
         }
-
+        
+        final String loadReason;
+        if  (mapping.getDisplayName() != null && !mapping.getDisplayName().equals(mapping.getName())) {
+            loadReason = mapping.getDisplayName();
+        } else {
+            loadReason = null;
+        }
 
         boolean reloadOnly = !showUI && (args.length == 0);
         if (!reloadOnly) {
@@ -293,7 +301,7 @@ public class ActionProviderImpl implements ActionProvider {
             if (needReload && canReload) {
                 String[] reloadArgs = RunUtils.evaluateActionArgs(project, mapping.getName(), mapping.getReloadArgs(), ctx);
                 final ActionProgress g = ActionProgress.start(context);
-                RequestProcessor.Task reloadTask = prj.reloadProject(true, maxQualily, reloadArgs);
+                RequestProcessor.Task reloadTask = prj.reloadProject(loadReason, true, maxQualily, reloadArgs);
                 reloadTask.addTaskListener((t) -> {
                     g.finished(true);
                 });

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectLoader.java
@@ -26,6 +26,5 @@ import org.netbeans.modules.gradle.api.NbGradleProject;
  */
 public interface GradleProjectLoader {
 
-    GradleProject loadProject(NbGradleProject.Quality aim, boolean ignoreCache, boolean interactive, String... args);
-    
+    GradleProject loadProject(NbGradleProject.Quality aim, String descriptionOpt, boolean ignoreCache, boolean interactive, String... args);
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
@@ -35,6 +35,7 @@ import org.openide.util.NbBundle;
 import org.netbeans.modules.gradle.api.GradleProjects;
 
 import static org.netbeans.modules.gradle.Bundle.*;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FULL_ONLINE;
 
 /**
@@ -65,6 +66,9 @@ public class ReloadAction  extends AbstractAction implements ContextAwareAction 
         }
     }
 
+    @NbBundle.Messages({
+        "ACT_ReloadingProject=Reloading"
+    })
     @Override public void actionPerformed(ActionEvent event) {
         Set<Project> reload = new LinkedHashSet<>();
         for (NbGradleProjectImpl prj : context.lookupAll(NbGradleProjectImpl.class)) {
@@ -78,7 +82,8 @@ public class ReloadAction  extends AbstractAction implements ContextAwareAction 
                     // A bit low level calls, just to allow UI interaction to
                     // Trust the project.
                     GradleProjectLoader loader = impl.getLookup().lookup(GradleProjectLoader.class);
-                    impl.project = loader.loadProject(FULL_ONLINE, true, true);
+                    GradleBaseProject gbp = GradleBaseProject.get(project);
+                    impl.project = loader.loadProject(FULL_ONLINE, ACT_ReloadingProject(), true, true);
                     NbGradleProjectImpl.ACCESSOR.doFireReload(NbGradleProject.get(impl));
                 });
             }

--- a/extide/gradle/src/org/netbeans/modules/gradle/action-mapping.xml
+++ b/extide/gradle/src/org/netbeans/modules/gradle/action-mapping.xml
@@ -37,18 +37,18 @@
         <args>clean</args>
         <reload rule="NEVER"/>
     </action>
-    <action name="download.javadoc">
+    <action displayName="Download Javadoc" name="download.javadoc">
         <!--
             We do not really execute any tasks here, rather just reload the project
             allowing it to go online and fetch some dependencies. So in this case
-            the action is forcing a project reload with some argiments.
+            the action is forcing a project reload with some arguments.
         -->
         <reload rule="ALWAYS_ONLINE">
             <args>-PdownloadJavadoc=${requestedComponent}</args>
         </reload>
     </action>
 
-    <action name="download.sources">
+    <action displayName="Download sources" name="download.sources">
         <reload rule="ALWAYS_ONLINE">
             <args>-PdownloadSources=${requestedComponent}</args>
         </reload>

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleProjects.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleProjects.java
@@ -51,6 +51,17 @@ public final class GradleProjects {
         GradleModuleFileCache21.CachedArtifactVersion.Entry sources = av != null ? av.getSources() : null;
         return sources != null ? sources.getPath().toFile() : GradleArtifactStore.getDefault().getSources(binary);
     }
+    
+    public static boolean isGradleCacheArtifact(File toCheck) {
+        try {
+            GradleModuleFileCache21 cache = GradleModuleFileCache21.getGradleFileCache();
+            GradleModuleFileCache21.CachedArtifactVersion av = cache.resolveCachedArtifactVersion(toCheck.toPath());
+            return av != null;
+        } catch (IllegalArgumentException ex) {
+            // expected: not an artifact
+            return false;
+        }
+    }
 
     /**
      * Get the JavaDoc artifact for the given binary if available.

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -67,12 +67,14 @@ public abstract class AbstractProjectLoader {
         final GradleProject previous;
         final NbGradleProject.Quality aim;
         final GradleCommandLine cmd;
+        final String description;
 
-        public ReloadContext(NbGradleProjectImpl project, NbGradleProject.Quality aim, GradleCommandLine cmd) {
+        public ReloadContext(NbGradleProjectImpl project, NbGradleProject.Quality aim, GradleCommandLine cmd, String description) {
             this.project = project;
             this.previous = project.isGradleProjectLoaded() ? project.getGradleProject() : FallbackProjectLoader.createFallbackProject(project.getGradleFiles());
             this.aim = aim;
             this.cmd = cmd;
+            this.description = description;
         }
 
         public GradleProject getPrevious() {

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -37,6 +37,7 @@ import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
 public class GradleProjectLoaderImpl implements GradleProjectLoader {
 
     final Project project;
+    private String actionDescription;
     private static final Logger LOGGER = Logger.getLogger(GradleProjectLoaderImpl.class.getName());
 
     public GradleProjectLoaderImpl(Project project) {
@@ -44,10 +45,10 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
     }
 
     @Override
-    public GradleProject loadProject(NbGradleProject.Quality aim, boolean ignoreCache, boolean interactive, String... args) {
+    public GradleProject loadProject(NbGradleProject.Quality aim, String descriptionOpt, boolean ignoreCache, boolean interactive, String... args) {
         LOGGER.info("Load aiming " +aim + " for "+ project);
         GradleCommandLine cmd = new GradleCommandLine(args);
-        AbstractProjectLoader.ReloadContext ctx = new AbstractProjectLoader.ReloadContext((NbGradleProjectImpl) project, aim, cmd);
+        AbstractProjectLoader.ReloadContext ctx = new AbstractProjectLoader.ReloadContext((NbGradleProjectImpl) project, aim, cmd, descriptionOpt);
         List<AbstractProjectLoader> loaders = new LinkedList<>();
 
         if (!ignoreCache) loaders.add(new DiskCacheProjectLoader(ctx));

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
@@ -267,12 +267,21 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
 
         @NbBundle.Messages({
             "# {0} - The project name",
-            "LBL_Loading=Loading {0}"
+            "LBL_Loading=Loading {0}",
+            "# {0} (re)load reason",
+            "# {1} project name",
+            "FMT_ProjectLoadReason={0} ({1})"
         })
         @Override
         public GradleProject call() throws Exception {
             tokenSource = GradleConnector.newCancellationTokenSource();
-            final ProgressHandle handle = ProgressHandle.createHandle(Bundle.LBL_Loading(ctx.previous.getBaseProject().getName()), this);
+            String msg;
+            if (ctx.description != null) {
+                msg = Bundle.FMT_ProjectLoadReason(ctx.description, ctx.previous.getBaseProject().getName());
+            } else {
+                msg = Bundle.LBL_Loading(ctx.previous.getBaseProject().getName());
+            }
+            final ProgressHandle handle = ProgressHandle.createHandle(msg, this);
             ProgressListener pl = (ProgressEvent pe) -> {
                 handle.progress(pe.getDescription());
             };

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
@@ -265,7 +265,7 @@ public final class TemplateOperation implements Runnable {
                             //Just load the project into the cache.
                             GradleProjectLoader loader = nbProject.getLookup().lookup(GradleProjectLoader.class);
                             if (loader != null) {
-                                loader.loadProject(Quality.FULL_ONLINE, true, false);
+                                loader.loadProject(Quality.FULL_ONLINE, null, true, false);
                             }
                         }
                         return Collections.singleton(projectDir);

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
@@ -85,7 +85,7 @@ public class AbstractGradleProjectTestCase extends NbTestCase {
             // A bit low level calls, just to allow UI interaction to
             // Trust the project.
             GradleProjectLoader loader = impl.getLookup().lookup(GradleProjectLoader.class);
-            impl.project = loader.loadProject(FULL_ONLINE, true, true);
+            impl.project = loader.loadProject(FULL_ONLINE, null, true, true);
             NbGradleProjectImpl.ACCESSOR.doFireReload(NbGradleProject.get(impl));
         }).get();
     }

--- a/java/api.java/apichanges.xml
+++ b/java/api.java/apichanges.xml
@@ -52,6 +52,20 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+        <change id="SourceAttacher.Definer2">
+            <api name="queries"/>
+            <summary>Allows <code>SourceJavadocAttacherImplementation.Definer</code> to reject a binary root.</summary>
+            <version major="1" minor="78"/>
+            <date day="16" month="4" year="2021"/>
+            <author login="sdedic"/>
+            <compatibility semantic="compatible" source="compatible" binary="compatible"/>
+            <description>
+                <p>
+                    When multiple Definers are defined, an implementation can opt out from the source/javadoc download.
+                </p>
+            </description>
+            <class package="org.netbeans.spi.java.queries" name="SourceJavadocAttacherImplementation"/>
+        </change>
         <change id="ModulePathsConstants">
             <api name="queries"/>
             <summary>Added constants for module paths into the <code>JavaClassPathConstants</code></summary>

--- a/java/api.java/manifest.mf
+++ b/java/api.java/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.java/1
-OpenIDE-Module-Specification-Version: 1.77
+OpenIDE-Module-Specification-Version: 1.78
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/java/queries/Bundle.properties
 AutoUpdate-Show-In-Client: false
 

--- a/java/api.java/nbproject/project.xml
+++ b/java/api.java/nbproject/project.xml
@@ -103,6 +103,8 @@
                     </test-dependency>
                     <test-dependency>
                         <code-name-base>org.openide.util.lookup</code-name-base>
+                        <compile-dependency/>
+                        <test/>
                     </test-dependency>
                 </test-type>
             </test-dependencies>

--- a/java/api.java/src/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation.java
+++ b/java/api.java/src/org/netbeans/spi/java/queries/SourceJavadocAttacherImplementation.java
@@ -30,7 +30,7 @@ import org.openide.util.lookup.ServiceProvider;
 
 /**
  * A SPI for attaching source roots and javadoc roots to binary roots.
- * The implementations of this interface are registered in global {@link Lookup}
+ * The implementations of this interface are registered in global {@link Lookup}.
  * @see ServiceProvider
  * @author Tomas Zezula
  * @since 1.35
@@ -59,7 +59,8 @@ public interface SourceJavadocAttacherImplementation {
 
     /**
      * Extension into the default {@link SourceJavadocAttacherImplementation} allowing to download or find sources and javadoc for given binary.
-     * The extension implementation is registered in the global {@link org.openide.util.Lookup}.
+     * The extension implementation is registered in the global {@link org.openide.util.Lookup}. Multiple Definers can be defined. Consider to implement
+     * {@link Definer2} to indicate the Definer is willing to handle the root.
      * @since 1.49
      */
     interface Definer {
@@ -96,5 +97,20 @@ public interface SourceJavadocAttacherImplementation {
          */
         @NonNull
         List<? extends URL> getJavadoc(@NonNull URL root, @NonNull Callable<Boolean> cancel);
+    }
+    
+    /**
+     * Extends the {@link Definer} interface to work better if several providers are defined.
+     * The Definer can indicate if it is willing to handle the artifact. For example, Maven may 
+     * reject artifacts that are outside of M2 local repository.
+     * @since 1.78
+     */
+    interface Definer2 extends Definer {
+        /**
+         * Determines if the binary root is acceptable for the Definer. Definers that use
+         * binary filename, path or some database to gather coordinates or location for download
+         * may reject roots that cannot be processed.
+         */
+        public boolean accepts(@NonNull URL root);
     }
 }

--- a/java/api.java/test/unit/src/org/netbeans/api/java/queries/SourceJavadocAttacherTest.java
+++ b/java/api.java/test/unit/src/org/netbeans/api/java/queries/SourceJavadocAttacherTest.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.java.queries;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.fail;
+import junit.framework.TestSuite;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.spi.java.queries.SourceJavadocAttacherImplementation;
+import org.openide.util.Lookup;
+import org.openide.util.RequestProcessor;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.test.MockLookup;
+
+/**
+ *
+ * @author sdedic
+ */
+public class SourceJavadocAttacherTest extends NbTestCase implements SourceJavadocAttacher.AttachmentListener {
+    private static final RequestProcessor TESTRP = new RequestProcessor(SourceJavadocAttacherTest.class);
+    
+    /**
+     * Attacher runs asynchronously, forks into RP
+     */
+    private boolean async;
+    
+    /**
+     * Blocks the attacher just at the time of its execution (potentially in the async thread) before it 
+     * calls to the listener.
+     */
+    private Semaphore processingBlock = new Semaphore(0);
+    
+    /**
+     * Released after the <b>AttacherImpl</b> calls the listener. Some of those
+     * calls should not reach the final listener.
+     */
+    private Semaphore listenerBlock = new Semaphore(0);
+    
+    /**
+     * Released when the attacher gets called. That means the prev attacher has
+     * completed somehow.
+     */
+    private Semaphore attacherReached = new Semaphore(0);
+    
+    /**
+     * Released when the final listener gets called.
+     */
+    private CountDownLatch finalListenerBlock = new CountDownLatch(1);
+
+    /**
+     * First attacher
+     */
+    private volatile AttacherImpl impl1;
+
+    /**
+     * Second attacher
+     */
+    private volatile AttacherImpl impl2;
+    
+     /**
+     * Contex for the attachJavadoc/Source. Defaults to null = default Lookup.
+     */
+    Lookup context = null;
+    
+    /**
+     * The first attacher, null (the default) means {@link #first}
+     */
+    AttacherImpl first;
+    
+   public SourceJavadocAttacherTest(String name) {
+        super(name);
+    }
+
+    public SourceJavadocAttacherTest(boolean async, String name) {
+        super(name);
+        this.async = async;
+    }
+    
+    public static class AsyncSource extends SourceJavadocAttacherTest {
+        public AsyncSource(String name) {
+            super(true, name);
+        }
+    }
+    
+    public static class Javadoc extends SourceJavadocAttacherTest {
+        public Javadoc(String name) {
+            super(false, name);
+        }
+
+        public Javadoc(boolean async, String name) {
+            super(async, name);
+        }
+
+        @Override
+        protected URL otherRes(AttacherImpl impl) {
+            return impl.source;
+        }
+
+        @Override
+        protected URL res(AttacherImpl impl) {
+            return impl.javadoc;
+        }
+
+        @Override
+        protected void doAttach(URL u) {
+            SourceJavadocAttacher.attachJavadoc(u, context, this);
+        }
+        
+        
+    }
+    public static class AsyncJavadoc extends Javadoc {
+        public AsyncJavadoc(String name) {
+            super(true, name);
+        }
+    }
+
+    URL u(String file) throws IOException {
+        return  new URL(getWorkDir().toURI().toURL(), file);
+    }
+    
+    AtomicInteger succeeded = new AtomicInteger(0);
+    AtomicInteger failed = new AtomicInteger(0);
+    
+    public static TestSuite suite() {
+        TestSuite s = new TestSuite();
+        s.addTestSuite(SourceJavadocAttacherTest.class);
+        s.addTestSuite(AsyncSource.class);
+        s.addTestSuite(Javadoc.class);
+        s.addTestSuite(AsyncJavadoc.class);
+        return s;
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        // give enough permits so all async Attachers complete, and do not block the RP.
+        processingBlock.release(100);
+        super.tearDown();
+    }
+
+    @Override
+    public void attachmentSucceeded() {
+        succeeded.incrementAndGet();
+        finalListenerBlock.countDown();
+    }
+
+    @Override
+    public void attachmentFailed() {
+        failed.incrementAndGet();
+        finalListenerBlock.countDown();
+    }
+    
+    protected URL res(AttacherImpl impl) {
+        return impl.source;
+    }
+    
+    protected URL otherRes(AttacherImpl impl) {
+        return impl.javadoc;
+    }
+    
+    /**
+     * Checks that first attacher is called, and the 2nd never gets even called,
+     * since the 1st accepts & succeeds.
+     */
+    public void testAttachFirst() throws Exception {
+        impl1 = new AttacherImpl(true, null);
+        impl2 = new AttacherImpl(true, null);
+        
+        MockLookup.setInstances(impl1, impl2);
+
+        assertAsyncReturnedAtStart(u("a"), true);
+        
+        finalListenerBlock.await();
+        
+        // first attacher contacted
+        assertNotNull(res(impl1));
+        assertNull(otherRes(impl1));
+
+        // 2nd attacher not reached
+        assertNull(res(impl2));
+        assertNull(otherRes(impl2));
+        
+        // listener called exactly once:
+        assertEquals(1, succeeded.get());
+        assertEquals(0, failed.get());
+    }
+    
+    protected void doAttach(URL u) {
+        SourceJavadocAttacher.attachSources(u, context, this);
+    }
+    
+    private void assertAsyncReturnedAtStart(URL u, boolean all) throws Exception {
+        if (first == null) {
+            first = impl1;
+        }
+        if (!async) {
+            processingBlock.release(3);
+        }
+        doAttach(u);
+        
+        if (async) {
+            // 1st already contacted
+            assertNotNull(res(first));
+            assertNull(otherRes(first));
+            
+            processingBlock.release(all ? 3 : 1);
+        }
+    }
+    
+    /**
+     * Checks that 2nd Attacher gets the call, since 1st rejects the resource.
+     */
+    public void testAttachFallback() throws Exception {
+        impl1 = new AttacherImpl(true, (u) -> false);
+        impl2 = new AttacherImpl(true, null);
+        
+        MockLookup.setInstances(impl1, impl2);
+        assertAsyncReturnedAtStart(u("a"), true);
+        
+        finalListenerBlock.await();
+        
+        // first attacher contacted
+        assertNotNull(res(impl1));
+        assertNull(otherRes(impl1));
+
+        // 2nd attacher reached as well
+        assertNotNull(res(impl2));
+        assertNull(otherRes(impl2));
+        
+        // listener called exactly once:
+        assertEquals(1, succeeded.get());
+        assertEquals(0, failed.get());
+    }
+    
+    /**
+     * Checks that 2nd Attacher is called when the 1st accepts, but fails.
+     */
+    public void testAttachWhenPreviousFails() throws Exception {
+        impl1 = new AttacherImpl(false, null);
+        impl2 = new AttacherImpl(true, null);
+        
+        MockLookup.setInstances(impl1, impl2);
+        assertAsyncReturnedAtStart(u("a"), false);
+        
+        attacherReached.acquire();
+        assertEquals("Failure not reported YET", 0, failed.get());
+        
+        processingBlock.release(3);
+
+        finalListenerBlock.await();
+
+        // first attacher contacted
+        assertNotNull(res(impl1));
+        assertNull(otherRes(impl1));
+
+        // 2nd attacher reached as well
+        assertNotNull(res(impl2));
+        assertNull(otherRes(impl2));
+        
+        // listener called exactly once:
+        assertEquals(1, succeeded.get());
+        assertEquals(0, failed.get());
+    }
+
+    /**
+     * Checks that context-provided Attacher is used first, before the default
+     * Lookup.
+     */
+    public void testContextAttacherPrecedence() throws Exception {
+        AttacherImpl c = new AttacherImpl(true, null);
+        impl1 = new AttacherImpl(true, null);
+        impl2 = new AttacherImpl(true, null);
+        
+        first = c;
+        
+        MockLookup.setInstances(impl1, impl2);
+        context = Lookups.fixed(c);
+        
+        assertAsyncReturnedAtStart(u("a"), false);
+        
+        finalListenerBlock.await();
+        
+        // the 'c' has accepted:
+        
+        assertNotNull(res(c));
+        assertNull(otherRes(c));
+
+        assertNull(res(impl1));
+        assertNull(otherRes(impl1));
+    }
+    
+    class AttacherImpl implements SourceJavadocAttacherImplementation {
+        final boolean succeeds;
+        final Predicate<URL> acceptor;
+        
+        volatile URL source;
+        volatile URL javadoc;
+        
+        volatile Throwable unexpectedException;
+
+        public AttacherImpl(boolean succeeds, Predicate<URL> acceptor) {
+            this.succeeds = succeeds;
+            this.acceptor = acceptor == null ? (u) -> true : acceptor;
+        }
+        
+        @Override
+        public boolean attachSources(URL root, SourceJavadocAttacher.AttachmentListener listener) throws IOException {
+            assertNull(source);
+            source = root;
+            return doComputeAttachment(root, succeeds, listener);
+        }
+        
+        @Override
+        public boolean attachJavadoc(URL root, SourceJavadocAttacher.AttachmentListener listener) throws IOException {
+            assertNull(javadoc);
+            javadoc = root;
+            return doComputeAttachment(root, succeeds, listener);
+        }
+        
+        protected boolean doComputeAttachment(URL root, boolean source, SourceJavadocAttacher.AttachmentListener listener) {
+            if (!acceptor.test(root)) {
+                return false;
+            }
+            attacherReached.release();
+            Runnable r = () -> {
+                try {
+                    processingBlock.acquire();
+                } catch (InterruptedException ex) {
+                    unexpectedException = ex;
+                    fail();
+                }
+                if (succeeds) {
+                    listener.attachmentSucceeded();
+                } else {
+                    listener.attachmentFailed();
+                }
+                listenerBlock.release();
+            };
+
+            if (async) {
+                TESTRP.post(r);
+            } else {
+                r.run();
+            }
+            return true;
+        }
+    }
+}

--- a/java/gradle.java/nbproject/project.xml
+++ b/java/gradle.java/nbproject/project.xml
@@ -67,7 +67,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.51.1</specification-version>
+                        <specification-version>1.78</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceAttacherImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceAttacherImpl.java
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.java.queries;
+
+import java.io.File;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.netbeans.api.java.queries.SourceForBinaryQuery;
+import org.netbeans.api.java.queries.SourceJavadocAttacher.AttachmentListener;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.api.GradleDependency.ModuleDependency;
+import org.netbeans.modules.gradle.api.GradleProjects;
+import org.netbeans.modules.gradle.api.execute.RunUtils;
+import org.netbeans.spi.java.queries.SourceJavadocAttacherImplementation;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
+import org.openide.util.Exceptions;
+import org.openide.util.NbBundle;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+@NbBundle.Messages({
+    "LABEL_GradleSourceDefiner=Download using Gradle",
+    "DESC_GradleSourceDefiner=Uses Gradle task of an open project to download the resources."
+})
+@ServiceProvider(service=SourceJavadocAttacherImplementation.Definer.class, position=100)
+public class GradleSourceAttacherImpl implements SourceJavadocAttacherImplementation.Definer2 {
+    /**
+     * Name of the replaceable argument for {@link #COMMAND_DL_JAVADOC}} and {@link #COMMAND_DL_SOURCES}.
+     */
+    private static final String REQUESTED_COMPONENT = "requestedComponent";    
+
+    /**
+     * Name of the 'download.sources' standard action
+     */
+    private static final String COMMAND_DL_SOURCES = "download.sources"; //NOI18N
+
+    /**
+     * Name of the 'download.javadoc' standard action
+     */
+    private static final String COMMAND_DL_JAVADOC = "download.javadoc"; //NOI18N
+
+    /**
+     * Caches last queried URL. The workflow is to filter Definers that work with the given URL
+     * first, then actually performs the download.
+     */
+    private volatile Reference<Cached>   lastChecked = new WeakReference<>(null);
+    
+    @Override
+    public boolean accepts(URL root) {
+        return cachedRootInfo(root) != null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Bundle.LABEL_GradleSourceDefiner();
+    }
+
+    @Override
+    public String getDescription() {
+        return Bundle.DESC_GradleSourceDefiner();
+    }
+    
+    @Override
+    public List<? extends URL> getSources(URL root, Callable<Boolean> cancel) {
+        return new Worker(root, true, cancel).download();
+    }
+
+    @Override
+    public List<? extends URL> getJavadoc(URL root, Callable<Boolean> cancel) {
+        return new Worker(root, false, cancel).download();
+    }
+    
+    private File findGradleCachedArtifact(URL r) {
+        if (!FileUtil.isArchiveArtifact(r)) {
+            // support JARs only
+            return null;
+        }
+        URL archive = FileUtil.getArchiveFile(r);
+        if (archive == null) {
+            return null;
+        }
+        FileObject fo = URLMapper.findFileObject(archive);
+        if (fo == null) {
+            return null;
+        }
+        File maybeArtifact = FileUtil.toFile(fo);
+        return GradleProjects.isGradleCacheArtifact(maybeArtifact) ? maybeArtifact : null;
+    }
+    
+    private static class E {
+        final Project  project;
+        final ModuleDependency dep;
+
+        public E(Project project, ModuleDependency dep) {
+            this.project = project;
+            this.dep = dep;
+        }
+    }
+    
+    private static class Cached {
+        final URL u;
+        final E[] projectsAndModules;
+
+        public Cached(URL u, E[] projectsAndModules) {
+            this.u = u;
+            this.projectsAndModules = projectsAndModules;
+        }
+    }
+    
+    private E[] findOwnerProjects(URL u, File f) {
+        Cached c = lastChecked.get();
+        if (c != null && 
+                u.toString().equals(c.u.toString())) {
+            return c.projectsAndModules;
+        }
+        List<E> fallbacks = new ArrayList<>();
+        List<E> result = new ArrayList<>();
+        for (Project candidate : OpenProjects.getDefault().getOpenProjects()) {
+            /*
+            boolean trusted = ProjectTrust.getDefault().isTrusted(candidate);
+            */
+            GradleBaseProject gbp = GradleBaseProject.get(candidate);
+            if (gbp == null) {
+                continue;
+            }
+            boolean resolved = gbp.isResolved();
+            ModuleDependency dep = checkGradleContains(candidate, f);
+            if (dep != null) {
+                (resolved ? result : fallbacks).add(new E(candidate, dep));
+            }
+        }
+        result.addAll(fallbacks);
+        c = new Cached(u, result.toArray(new E[result.size()]));
+        lastChecked = new WeakReference<>(c);
+        return c.projectsAndModules;
+    }
+    
+    private ModuleDependency checkGradleContains(Project p, File f) {
+        GradleBaseProject gbp = GradleBaseProject.get(p);
+        if (p == null) {
+            return null;
+        }
+        
+        // project that does not offer to download is useless...
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        if (ap == null) {
+            return null;
+        }
+        
+        Collection<String> s = Arrays.asList(ap.getSupportedActions());
+        if (!(s.contains(COMMAND_DL_JAVADOC) || s.contains(COMMAND_DL_SOURCES))) {
+            return null;
+        }
+
+        File absF = f.getAbsoluteFile();
+        Stream<ModuleDependency> mods = gbp.getConfigurations().values().stream().
+                    flatMap(cfg -> cfg.getModules().stream());
+        return mods.filter(m -> m.getArtifacts().contains(absF)).findFirst().orElse(null);
+    }
+
+    E[] cachedRootInfo(URL u) {
+        Cached c = lastChecked.get();
+        if (c != null && u.toString().equals(c.u.toString())) {
+            return c.projectsAndModules;
+        } else {
+            File a = findGradleCachedArtifact(u);
+            if (a == null) {
+                return null;
+            }
+            E[] result = findOwnerProjects(u, a);
+            return result != null && result.length > 0 ? result : null;
+        }
+    }
+    
+    class Worker extends  ActionProgress implements Runnable {
+        private final URL root;
+        private final E[] locations;
+        private final Callable<Boolean> cancel;
+        private final boolean sources;
+        private final Semaphore sync = new Semaphore(0);
+        private final AttachmentListener listener;
+        private volatile Boolean result;
+
+        public Worker(URL root, boolean sources, Callable<Boolean> cancel) {
+            this.root = root;
+            this.sources = sources;
+            this.cancel = cancel;
+            this.listener = null;
+            this.locations = cachedRootInfo(root);
+        }
+        
+        public Worker(URL root, boolean sources, E[] locations, AttachmentListener listener) {
+            this.root = root;
+            this.sources = sources;
+            this.cancel = () -> false; // not supported in this mode
+            this.locations = locations;
+            this.listener = listener;
+        }
+
+        @Override
+        public void run() {
+            download();
+        }
+        
+        List<? extends URL> download() {
+            boolean ok = false;
+            try {
+                List<? extends URL> ret = download0();
+                ok = ret != null && !ret.isEmpty();
+                return ret;
+            } finally {
+                if (listener != null) {
+                    if (ok) {
+                        listener.attachmentSucceeded();
+                    } else {
+                        listener.attachmentFailed();
+                    }
+                }
+            }
+        }
+            
+        List<? extends URL> download0() {
+            if (locations == null) {
+                return Collections.emptyList();
+            }
+            for (E l : locations) {
+                try {
+                    if (cancel.call()) {
+                        return Collections.emptyList();
+                    }
+                } catch (Exception ex) {
+                    Exceptions.printStackTrace(ex);
+                    return Collections.emptyList();
+                }
+                if (invokeWaitDownloadAction(l.project.getLookup().lookup(ActionProvider.class), 
+                        sources ? COMMAND_DL_SOURCES : COMMAND_DL_JAVADOC, 
+                        l.dep)
+                    ) {
+                    // now should be reachable by SFBQ:
+                    FileObject[] fobs = SourceForBinaryQuery.findSourceRoots(root).getRoots();
+                    if (fobs.length != 0) {
+                        List<URL> res = new ArrayList<>();
+                        for (FileObject ff : fobs) {
+                            URL u = URLMapper.findURL(ff, URLMapper.INTERNAL);
+                            if (u != null) {
+                                res.add(u);
+                            }
+                        }
+                        if (!res.isEmpty()) {
+                            return res;
+                        }
+                    }
+                }
+            }
+            return Collections.emptyList();
+        }
+        
+        boolean invokeWaitDownloadAction(ActionProvider ap, String command, ModuleDependency dep) {
+            if (ap == null /* || !Arrays.asList(ap.getSupportedActions()).contains(command) */) {
+                return false;
+            }
+            // assume the action is invoked asynchronously.
+            try {
+                ap.invokeAction(command, 
+                        Lookups.fixed(
+                                this,
+                                RunUtils.simpleReplaceTokenProvider(REQUESTED_COMPONENT, dep.getId())
+                        ));
+            } catch (IllegalArgumentException ex) {
+                // since we cannot test whether action exists / is enabled, catch the exception
+                // if the action is really unsupported
+                return false;
+            }
+            while (true) {
+                try {
+                    if (sync.tryAcquire(300, TimeUnit.MILLISECONDS)) {
+                        break;
+                    }
+                } catch (InterruptedException ex) {
+                }
+                try {
+                    if (cancel.call()) {
+                        // cancelled, but CANNOT cancel the project action. See NETBEANS-
+                        return false;
+                    }
+                } catch (Exception ex1) {
+                    Exceptions.printStackTrace(ex1);
+                    return false;
+                }
+            }
+            return result == Boolean.TRUE;
+        }
+
+        @Override
+        protected void started() {
+        }
+
+        @Override
+        public void finished(boolean success) {
+            result = success;
+            sync.release();
+        }
+    }
+}

--- a/java/java.j2seplatform/nbproject/project.xml
+++ b/java/java.j2seplatform/nbproject/project.xml
@@ -49,7 +49,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.60</specification-version>
+                        <specification-version>1.78</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/QueriesCache.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/QueriesCache.java
@@ -36,6 +36,7 @@ import java.util.prefs.Preferences;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.queries.JavadocForBinaryQuery;
+import org.netbeans.api.java.queries.SourceForBinaryQuery;
 import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/SourceJavadocAttacherUtil.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/SourceJavadocAttacherUtil.java
@@ -25,17 +25,19 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.stream.Collectors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.java.queries.SourceJavadocAttacher.AttachmentListener;
+import org.netbeans.api.progress.BaseProgressUtils;
 import org.netbeans.modules.java.j2seplatform.api.J2SEPlatformCreator;
-import org.netbeans.modules.java.j2seplatform.spi.J2SEPlatformDefaultJavadoc;
 import org.netbeans.spi.java.project.support.JavadocAndSourceRootDetection;
 import org.netbeans.spi.java.queries.SourceJavadocAttacherImplementation;
 import org.openide.DialogDescriptor;
@@ -43,7 +45,10 @@ import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.Cancellable;
 import org.openide.util.NbBundle;
+import org.openide.util.RequestProcessor;
+import org.openide.util.RequestProcessor.Task;
 import org.openide.util.Utilities;
 
 /**
@@ -63,7 +68,114 @@ public final class SourceJavadocAttacherUtil {
             listener.attachmentFailed();
         }
     }
+    
+    private static Collection<SourceJavadocAttacherImplementation.Definer> filterPlugins(URL root, Collection<? extends SourceJavadocAttacherImplementation.Definer> plugins) {
+        if (plugins == null || plugins.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Collection<SourceJavadocAttacherImplementation.Definer> result = new ArrayList<>();
+        List<SourceJavadocAttacherImplementation.Definer> filtered = new ArrayList<>();
+        for (SourceJavadocAttacherImplementation.Definer d : plugins) {
+            if (d instanceof SourceJavadocAttacherImplementation.Definer2) {
+                SourceJavadocAttacherImplementation.Definer2 d2 = (SourceJavadocAttacherImplementation.Definer2)d;
+                if (d2.accepts(root)) {
+                    filtered.add(d);
+                }
+            } else {
+                filtered.add(d);
+            }
+        }
+        return filtered;
+    }
+    
+    private static final RequestProcessor RP = new RequestProcessor(SelectRootsPanel.class);
 
+    /**
+     * Downloads / obtains sources using Definer. Should run in a separate thread (use {@link #runAsync}).
+     */
+    static class Downloader extends AtomicBoolean implements Callable<Boolean>, Runnable, Cancellable {
+        private final Collection<? extends SourceJavadocAttacherImplementation.Definer> plugins;
+        private final URL root;
+        private final boolean source;
+        private volatile List<? extends URI> result = Collections.emptyList();
+        
+        public Downloader(Collection<? extends SourceJavadocAttacherImplementation.Definer> plugins, URL root, boolean source) {
+            this.plugins = plugins;
+            this.root = root;
+            this.source = source;
+        }
+        
+        @Override
+        public Boolean call() {
+            return get();
+        }
+
+        @Override
+        public boolean cancel() {
+            return compareAndSet(false, true);
+        }
+        
+        String getTitle() {
+            return source ? Bundle.TITLE_ObtainingSource() : Bundle.TITLE_ObtainingJavadoc();
+        }
+
+        public List<? extends URI> getResult() {
+            return result;
+        }
+        
+        public void runAsync(Consumer<List<? extends URI>> callback) {
+            Task t = RP.post(this);
+            t.addTaskListener((x) -> {
+                callback.accept(result);
+            });
+        }
+
+        @Override
+        public void run() {
+            for (SourceJavadocAttacherImplementation.Definer d : plugins) {
+                if (get()) {
+                    // cancelled.
+                    return;
+                }
+                List<? extends URL> s = source ? d.getSources(root, this) : d.getJavadoc(root, this);
+                if (s != null || s.isEmpty()) {
+                    List<URI> r = new ArrayList<>();
+                    for (URL u : s) {
+                        try {
+                            r.add(u.toURI());
+                        } catch (URISyntaxException ex) {
+                            // ignore
+                        }
+                    }
+                    if (!r.isEmpty()) {
+                        result = r;
+                        return;
+                    }
+                }
+            }
+        }
+    }
+    
+    @NbBundle.Messages({
+        "TITLE_ObtainingSource=Obtaining source",
+        "TITLE_ObtainingJavadoc=Obtaining javadoc",
+    })
+    private static List<? extends URI> waitAttachUsingPlugins(
+            @NonNull final URL root,
+            final boolean source,
+            @NullAllowed final Collection<? extends SourceJavadocAttacherImplementation.Definer> plugins) {
+        if (plugins == null || plugins.isEmpty()) {
+            return null;
+        }
+        Downloader h = new Downloader(plugins, root, source);
+        
+        // waits for the Downloader to finish.
+        BaseProgressUtils.runOffEventDispatchThread(h, 
+                source ? Bundle.TITLE_ObtainingSource() : Bundle.TITLE_ObtainingJavadoc(), 
+                h, false);
+        return h.getResult();
+    }            
+    
     @CheckForNull
     @NbBundle.Messages({
         "TXT_SelectJavadoc=Select Javadoc",
@@ -74,25 +186,13 @@ public final class SourceJavadocAttacherUtil {
             @NonNull final List<? extends URI> attachedRoots,
             @NonNull final Callable<List<? extends String>> browseCall,
             @NonNull final Function<String,Collection<? extends URI>> convertor,
-            @NullAllowed final SourceJavadocAttacherImplementation.Definer plugin) {
+            @NullAllowed final Collection<? extends SourceJavadocAttacherImplementation.Definer> plugins) {
         assert root != null;
         assert browseCall != null;
         assert convertor != null;
         String action = NbBundle.getMessage(J2SEPlatformCreator.class, "API_Ask_attachJavadocQuestion");
         if ("yes".equalsIgnoreCase(action)) { // NOI18N
-            if (plugin == null) {
-                return null;
-            }
-            List<? extends URI> sources = plugin.getSources(root, () -> false).stream().map(url -> {
-                try {
-                    return url.toURI();
-                } catch (URISyntaxException ex) {
-                }
-                return null;
-            }).filter(uri -> uri != null).collect(Collectors.toList());
-            if (!sources.isEmpty()) {
-                return sources;
-            }
+            return waitAttachUsingPlugins(root, false, filterPlugins(root, plugins));
         } else if ("ask".equalsIgnoreCase(action)) { // NOI18N
             final SelectRootsPanel selectJavadoc = new SelectRootsPanel(
                     SelectRootsPanel.JAVADOC,
@@ -100,7 +200,7 @@ public final class SourceJavadocAttacherUtil {
                     attachedRoots,
                     browseCall,
                     convertor,
-                    plugin);
+                    filterPlugins(root, plugins));
             final DialogDescriptor dd = new DialogDescriptor(selectJavadoc, Bundle.TXT_SelectJavadoc());
             dd.setButtonListener(selectJavadoc);
             if (DialogDisplayer.getDefault().notify(dd) == DialogDescriptor.OK_OPTION) {
@@ -127,25 +227,13 @@ public final class SourceJavadocAttacherUtil {
             @NonNull final List<? extends URI> attachedRoots,
             @NonNull final Callable<List<? extends String>> browseCall,
             @NonNull final Function<String,Collection<? extends URI>> convertor,
-            @NullAllowed final SourceJavadocAttacherImplementation.Definer plugin) {
+            Collection<? extends SourceJavadocAttacherImplementation.Definer> plugins) {
         assert root != null;
         assert browseCall != null;
         assert convertor != null;
         String action = NbBundle.getMessage(J2SEPlatformCreator.class, "API_Ask_attachSourcesQuestion");
         if ("yes".equalsIgnoreCase(action)) { // NOI18N
-            if (plugin == null) {
-                return null;
-            }
-            List<? extends URI> sources = plugin.getSources(root, () -> false).stream().map(url -> {
-                try {
-                    return url.toURI();
-                } catch (URISyntaxException ex) {
-                }
-                return null;
-            }).filter(uri -> uri != null).collect(Collectors.toList());
-            if (!sources.isEmpty()) {
-                return sources;
-            }
+            return waitAttachUsingPlugins(root, true, filterPlugins(root, plugins));
         } else if ("ask".equalsIgnoreCase(action)) { // NOI18N
             final SelectRootsPanel selectSources = new SelectRootsPanel(
                     SelectRootsPanel.SOURCES,
@@ -153,7 +241,7 @@ public final class SourceJavadocAttacherUtil {
                     attachedRoots,
                     browseCall,
                     convertor,
-                    plugin);
+                    filterPlugins(root, plugins));
             final DialogDescriptor dd = new DialogDescriptor(selectSources, Bundle.TXT_SelectSources());
             dd.setButtonListener(selectSources);
             if (DialogDisplayer.getDefault().notify(dd) == DialogDescriptor.OK_OPTION) {

--- a/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceJavadocAttacherTest.java
+++ b/java/java.j2seplatform/test/unit/src/org/netbeans/modules/java/j2seplatform/queries/DefaultSourceJavadocAttacherTest.java
@@ -25,14 +25,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.fail;
 import org.netbeans.api.java.queries.SourceJavadocAttacher;
-import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.j2seplatform.AbstractJ2SEAttacherTestBase;
 import org.netbeans.spi.java.queries.SourceJavadocAttacherImplementation;
 import org.openide.filesystems.FileObject;
@@ -49,16 +46,28 @@ public class DefaultSourceJavadocAttacherTest extends AbstractJ2SEAttacherTestBa
     public DefaultSourceJavadocAttacherTest(String name) {
         super(name);
     }
-
+    
+    /**
+     * Def and def2 are complementary: def2 is more 'picky' that def, and if def2 accepts, then
+     * def should not be called at all.
+     */
+    private Definer def;
+    private Definer2 def2;
+    
+    private Definer selected;
+    
     @Override
     protected List<Object> additionalServices() {
         List<Object> l = super.additionalServices();
-        l.add(new Definer());
+        // definer2 comes first
+        l.add(def2 = new Definer2());
+        l.add(def = new Definer());
         return l;
     }
     
     URL sourceURL;
     URL javadocURL;
+    URL classes2RootURL;
 
     @Override
     protected void setUp() throws Exception {
@@ -69,15 +78,28 @@ public class DefaultSourceJavadocAttacherTest extends AbstractJ2SEAttacherTestBa
         FileObject fo = FileUtil.toFileObject(f);
         
         FileObject cl = fo.createFolder("classes");
+        FileObject cl2 = fo.createFolder("classes2");
         FileObject src = fo.createFolder("src");
         FileObject jd = fo.createFolder("javadoc");
         
         classesRootURL = URLMapper.findURL(cl, URLMapper.INTERNAL);
+        classes2RootURL = URLMapper.findURL(cl2, URLMapper.INTERNAL);
         sourceURL = URLMapper.findURL(src, URLMapper.INTERNAL);
         javadocURL = URLMapper.findURL(jd, URLMapper.INTERNAL);
+
+        selected = def;
+    }
+    
+    class Definer2 extends Definer implements SourceJavadocAttacherImplementation.Definer2 {
+        @Override
+        public boolean accepts(URL root) {
+            return classes2RootURL.equals(root);
+        }
     }
     
     class Definer implements SourceJavadocAttacherImplementation.Definer {
+        volatile URL sourceRoot;
+        volatile URL javadocRoot;
 
         @Override
         public String getDisplayName() {
@@ -91,14 +113,24 @@ public class DefaultSourceJavadocAttacherTest extends AbstractJ2SEAttacherTestBa
 
         @Override
         public List<? extends URL> getSources(URL root, Callable<Boolean> cancel) {
+            sourceRoot = root;
             return Collections.singletonList(sourceURL);
         }
 
         @Override
         public List<? extends URL> getJavadoc(URL root, Callable<Boolean> cancel) {
+            javadocRoot = root;
             return Collections.singletonList(javadocURL);
         }
         
+    }
+    
+    private void assertDefiner(boolean sources, Definer d, boolean expect) throws Exception {
+        if (expect) {
+            assertNotNull(sources ? d.sourceRoot : d.javadocRoot);
+        } else {
+            assertNull(sources ? d.sourceRoot : d.javadocRoot);
+        }
     }
     
     protected void assertAttacherResults(boolean sources) throws Exception {
@@ -133,5 +165,35 @@ public class DefaultSourceJavadocAttacherTest extends AbstractJ2SEAttacherTestBa
         cdl.await();
         assertEquals(Boolean.valueOf(expectAttach), b.get());
         assertEquals(permitUI, uiPresented.get());
+        
+        assertDefiner(sources, selected, expectAttach);
+        assertDefiner(!sources, selected, false);
+        if (def != selected) {
+            assertDefiner(sources, def, false);
+        }
+        if (def2 != selected) {
+            assertDefiner(sources, def2, false);
+        }
     }
+
+    /**
+     * Checks that Definer2 will run for javadoc for classes2, Definer won't be contacted.
+     */
+    public void testAttacherDifferentSourcesYes() throws Exception {
+        Locale.setDefault(new Locale("DA"));
+        classesRootURL = classes2RootURL;
+        selected = def2;
+        assertAttacherResults(true);
+    }
+
+    /**
+     * Checks that Definer2 will be used by UI for classes2
+     */
+    public void testAttacherDifferentJavadocWithUI() throws Exception {
+        permitUI = true;
+        classesRootURL = classes2RootURL;
+        selected = def2;
+        assertAttacherResults(false);
+    }
+    
 }

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspRunOffEdtProvider.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspRunOffEdtProvider.java
@@ -1,0 +1,32 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.netbeans.modules.nbcode.integration;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.netbeans.modules.progress.spi.RunOffEDTProvider;
+import org.openide.util.Mutex;
+import org.openide.util.RequestProcessor;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+@ServiceProvider(service = RunOffEDTProvider.class, position = 90)
+public class LspRunOffEdtProvider implements RunOffEDTProvider {
+    
+    private static final RequestProcessor TRIVIAL = new RequestProcessor(LspRunOffEdtProvider.class);
+    
+    @Override
+    public void runOffEventDispatchThread(Runnable operation, String operationDescr, AtomicBoolean cancelOperation, boolean waitForCanceled, int waitCursorAfter, int dialogAfter) {
+        if (Mutex.EVENT.isReadAccess()) {
+            // PENDING: the EDT should continue to service events.
+            TRIVIAL.post(operation).waitFinished();
+        } else {
+            operation.run();
+        }
+    }
+}


### PR DESCRIPTION
This is a follow-up to #2499 - the support developed for downloading javadoc/source is extended to:
- a project action
- a `SourceJavadocAttacherImplementation.Definer` plugin

This allows the user to click "Download" in the NetBeans IDE - and ask Gradle to download sources for the user. After (successful) download, the source re-opens instead of .class file. Since the source is downloaded to Gradle-managed area, from that point on its `SourceForBinaryQueryImplementation` should return the newly acquired source automatically.

During the course, I've made some little improvements:
- `SourceJavadocAttacher` now calls subsequent SPI implementations in the case a former fails to process the resource (the `AttachmentListener` reports a failure). This allows to bail out in case of some network error or something similar condition, giving a chance to the next Attacher
- Gradle 'reload' internal process is **sometimes** used to implement an action (prime, reload, download, ...). The loader now prints this info into the status bar to give the user better understanding of why the gradle is being executed, instead of simple "Reloading" message. This helps LSP client - its UI will display this informative string.

