### PR TITLE
FlatLaf: fix/improve styling of quicksearch field in menubar

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
@@ -41,6 +41,7 @@ import org.netbeans.swing.tabcontrol.plaf.TabControlButton;
 public class FlatLFCustoms extends LFCustoms {
 
     private static final ModifiableColor unifiedBackground = new ModifiableColor();
+    private static final ModifiableColor quicksearchBackground = new ModifiableColor();
 
     @Override
     public Object[] createApplicationSpecificKeysAndValues() {
@@ -56,6 +57,7 @@ public class FlatLFCustoms extends LFCustoms {
         return new Object[] {
             // unified background
             "nb.options.categories.tabPanelBackground", unifiedBackground,
+            "nb.quicksearch.background", quicksearchBackground,
 
             // options
             "TitlePane.useWindowDecorations", FlatLafPrefs.isUseWindowDecorations(),
@@ -121,10 +123,9 @@ public class FlatLFCustoms extends LFCustoms {
     }
 
     static void updateUnifiedBackground() {
-        String key = FlatLafPrefs.isUnifiedTitleBar() && FlatLafPrefs.isUseWindowDecorations()
-                ? "Panel.background"
-                : "Tree.background";
-        unifiedBackground.setRGB(UIManager.getColor(key).getRGB());
+        boolean unified = FlatLafPrefs.isUnifiedTitleBar() && FlatLafPrefs.isUseWindowDecorations();
+        unifiedBackground.setRGB(UIManager.getColor(unified ? "Panel.background" : "Tree.background").getRGB()); // NOI18N
+        quicksearchBackground.setRGB(UIManager.getColor(unified ? "Panel.background" : "MenuBar.background").getRGB()); // NOI18N
     }
 
     //---- class ModifiableColor ----------------------------------------------

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -127,8 +127,7 @@ nb.heapview.background=@background
 nb.heapview.foreground=lighten(@foreground,15%)
 
 # QuickSearch
-nb.quicksearch.background=$MenuBar.background
-nb.quicksearch.border=1,1,1,1,$MenuBar.background
+nb.quicksearch.border = 1,1,1,1
 
 # popup switcher
 nb.popupswitcher.border=1,1,1,1,$PopupMenu.borderColor

--- a/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/QuickSearchComboBar.java
+++ b/platform/spi.quicksearch/src/org/netbeans/modules/quicksearch/QuickSearchComboBar.java
@@ -143,7 +143,7 @@ public class QuickSearchComboBar extends AbstractQuickSearchComboBar {
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.weightx = 1.0;
         gridBagConstraints.weighty = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(0, 0, 0, 2);


### PR DESCRIPTION
This PR fixes/improves styling of quicksearch field in menubar and vertically centers text component when menubar is embedded into window title bar.

Before:
![image](https://user-images.githubusercontent.com/5604048/115126132-39b1d580-9fcd-11eb-9044-5e281821788f.png)

After:
![image](https://user-images.githubusercontent.com/5604048/115126134-40d8e380-9fcd-11eb-8d00-b8beac9d2ba7.png)

Before:
![image](https://user-images.githubusercontent.com/5604048/115126141-4fbf9600-9fcd-11eb-88ff-bde23e37405c.png)

After:
![image](https://user-images.githubusercontent.com/5604048/115126144-564e0d80-9fcd-11eb-86e0-0efc912294a7.png)

If menubar is **not embedded** into window title bar, it looks the same as before:
![image](https://user-images.githubusercontent.com/5604048/115126267-0cb1f280-9fce-11eb-8c20-d15052e1b13e.png)
![image](https://user-images.githubusercontent.com/5604048/115126315-674b4e80-9fce-11eb-8121-87143ad7a945.png)

Also fixes vertical centering of quicksearch text in Windows L&F (before/after):
![image](https://user-images.githubusercontent.com/5604048/115126169-78e02680-9fcd-11eb-9378-8f6d0cdd273a.png)
