### PR TITLE
In cpplite project, when reading configuration, an empty string should not be considered a valid configuration.

### DIFF
--- a/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/BuildConfiguration.java
+++ b/cpplite/cpplite.project/src/org/netbeans/modules/cpplite/project/BuildConfiguration.java
@@ -63,7 +63,7 @@ public class BuildConfiguration {
         Map<String, List<List<String>>> commands = new HashMap<>();
         for (String command : new String[] {ActionProvider.COMMAND_BUILD, ActionProvider.COMMAND_CLEAN, ActionProvider.COMMAND_RUN}) {
             String cmd = prefs.get(command, null);
-            if (cmd == null) {
+            if (cmd == null || cmd.isEmpty()) {
                 continue;
             }
             commands.put(command, Utils.decode(cmd));


### PR DESCRIPTION
As reported here:
http://mail-archives.apache.org/mod_mbox/netbeans-users/202104.mbox/%3C56b6c75f-daca-1d28-1805-7e301639c2c2%40slipbits.com%3E

Running a cpplite project when no Run command was specified fails with an exception. When reading configuration, empty values should be ignored (as are missing values), so that the Run action is properly disabled.