### PR TITLE
NETBEANS-5444 hide Usage Statistics dialog and Option

### DIFF
--- a/platform/uihandler/src/org/netbeans/modules/uihandler/Installer.java
+++ b/platform/uihandler/src/org/netbeans/modules/uihandler/Installer.java
@@ -244,11 +244,11 @@ public class Installer extends ModuleInstall implements Runnable {
         logMetricsUploadFailed = prefs.getBoolean("metrics.upload.failed", false); // NOI18N
         corePref.addPreferenceChangeListener(new PrefChangeListener());
 
-        if (!Boolean.getBoolean("netbeans.full.hack") && !Boolean.getBoolean("netbeans.close")) {
-            usageStatisticsReminder();
-        }
-        
-        System.setProperty("nb.show.statistics.ui",USAGE_STATISTICS_ENABLED);
+//        if (!Boolean.getBoolean("netbeans.full.hack") && !Boolean.getBoolean("netbeans.close")) {
+//            usageStatisticsReminder();
+//        }
+//
+//        System.setProperty("nb.show.statistics.ui",USAGE_STATISTICS_ENABLED);
         logMetricsEnabled = corePref.getBoolean(USAGE_STATISTICS_ENABLED, false);
         if (logMetricsEnabled) {
             //Handler for metrics


### PR DESCRIPTION
As discussed in https://issues.apache.org/jira/browse/NETBEANS-5444 and https://github.com/apache/netbeans-website/pull/544 this change 
- stops showing Usage Statistics dialog (_Help us improve the NetBeans IDE by providing anonymous usage data_) to new users
- hides the option to enable this functionality in GeneralOptionsPanel (the first tab of Tools -> Options)

This doesn't remove any code that deals with enabling this functionality or the functionality itself as I'm not that familiar with the project and not confident for a bigger change like that. Is it OK to just hide it first?

![Screenshot from 2021-04-20 21-20-31](https://user-images.githubusercontent.com/1145361/115455088-ce147600-a221-11eb-839c-bd58bc7f4e9a.png)
