### PR TITLE
More consistency for virtual file objects

### DIFF
--- a/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/BaseFileObj.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/BaseFileObj.java
@@ -600,7 +600,13 @@ public abstract class BaseFileObj extends FileObject {
                     retVal = FileBasedFileSystem.getInstance().getRoot();
                 } else {
                     retVal = factory.getCachedOnly(file);
-                    retVal = (retVal == null) ? factory.getFileObject(new FileInfo(file), FileObjectFactory.Caller.GetParent, true) : retVal;
+                    if (retVal == null) {
+                        if (this.isValid()) {
+                            retVal = factory.getFileObject(new FileInfo(file), FileObjectFactory.Caller.GetParent, true);
+                        } else {
+                            retVal = factory.getFileObject(new FileInfo(file), FileObjectFactory.Caller.Refresh, false);
+                        }
+                    }
                 }
             }
             assert retVal != null : "getParent should not return null for " + this;

--- a/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FolderObjTest.java
+++ b/platform/masterfs/test/unit/src/org/netbeans/modules/masterfs/filebasedfs/fileobjects/FolderObjTest.java
@@ -1781,6 +1781,14 @@ public class FolderObjTest extends NbTestCase {
         }
     }
 
+    public void testVirtualFOs() throws IOException {
+        final FileObject wd = FileBasedFileSystem.getFileObject(getWorkDir());
+        FileObject nonExisting = wd.getFileObject("non-existing-folder/non-existing-folder/non-existing-child.xyz", false);
+        assertFalse(nonExisting.isValid());
+        assertFalse(nonExisting.getParent().isValid());
+        assertFalse(nonExisting.getParent().getParent().isValid());
+    }
+
     private class EventsEvaluator extends FileChangeAdapter {
         private int folderCreatedCount;
         private int dataCreatedCount;

--- a/platform/openide.filesystems/src/org/openide/filesystems/FileObject.java
+++ b/platform/openide.filesystems/src/org/openide/filesystems/FileObject.java
@@ -776,13 +776,27 @@ public abstract class FileObject extends Object implements Serializable, Lookup.
     public abstract OutputStream getOutputStream(FileLock lock)
     throws IOException;
 
-    /** Get output stream.
+    /** Get output stream. This method does its best even
+     * when this file object is {@linkplain #isValid() invalid} - since
+     * version 9.23 it tries to recreate the parent hierarchy
+     * and really open the stream.
+     *
      * @return output stream to overwrite the contents of this file
-     * @throws IOException if an error occurs (the file is invalid, etc.)
+     * @throws IOException if an error occurs
      * @throws FileAlreadyLockedException if the file is already locked
      * @since 6.6
      */
     public final OutputStream getOutputStream() throws FileAlreadyLockedException, IOException  {
+        if (!isValid()) {
+            final FileObject recreate = FileUtil.createData(getFileSystem().getRoot(), getPath());
+            if (recreate != null) {
+                return recreate.getOutputStreamImpl();
+            }
+        }
+        return getOutputStreamImpl();
+    }
+
+    private OutputStream getOutputStreamImpl() throws IOException {
         final FileLock lock = lock();
         final OutputStream os;
         try {

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
@@ -1204,7 +1204,53 @@ public class FileObjectTestHid extends TestBaseHid {
         
         fsAssert("getNameExt problem",fo1.getNameExt().equals(fo1.getName() + "." +fo1.getExt()));
     }
-    
+
+    public void testManualRecreateOfInvalidFileObject() throws IOException {
+        checkSetUp();
+        FileObject fold1 = getTestFolder1(root);
+
+        if (fold1.getFileSystem().isReadOnly()) {
+            return;
+        }
+
+        FileObject ch = fold1.createData("a-child");
+        ch.delete();
+        assertFalse("Not valid", ch.isValid());
+
+        FileObject newCh = ch.getParent().createData(ch.getNameExt());
+        assertEquals("Same path", ch.getPath(), newCh.getPath());
+
+        try (OutputStream os = newCh.getOutputStream()) {
+            os.write("Ahoj".getBytes("UTF-8"));
+        }
+        assertEquals("Ahoj", newCh.asText("UTF-8"));
+        assertEquals("Parents are same", ch.getParent(), newCh.getParent());
+    }
+
+    public void testRecreateOfInvalidFileObjectViaGetOutputStream() throws IOException {
+        checkSetUp();
+        FileObject fold1 = getTestFolder1(root);
+
+        if (fold1.getFileSystem().isReadOnly()) {
+            return;
+        }
+
+        FileObject ch = fold1.createData("a-child");
+        ch.delete();
+        assertFalse("Not valid", ch.isValid());
+
+        try (OutputStream os = ch.getOutputStream()) {
+            os.write("Ahoj".getBytes("UTF-8"));
+        }
+
+        if (!ch.isValid()) {
+            ch = ch.getFileSystem().findResource(ch.getPath());
+        }
+
+        assertEquals("Ahoj", ch.asText("UTF-8"));
+        assertEquals("Parents are same", ch.getParent(), ch.getParent());
+    }
+
     /** Test of existsExt method, of class org.openide.filesystems.FileObject. */
     public void  testExistsExt() {
         checkSetUp();
@@ -3503,6 +3549,21 @@ public class FileObjectTestHid extends TestBaseHid {
 
         if (!ch2Uri.toString().startsWith(foldUri.toString())) {
             fail("Expecting the child url:\n" + ch2Uri + "\nto begin with folder URL:\n" + foldUri);
+        }
+
+        if (!ch2.getFileSystem().isReadOnly()) {
+            try (Writer os = new OutputStreamWriter(ch2.getOutputStream())) {
+                os.write("Ahoj");
+            }
+            FileObject ch3;
+            if (ch2.isValid()) {
+                ch3 = ch2;
+            } else {
+                ch3 = ch2.getFileSystem().findResource(ch2.getPath());
+                assertNotNull("Found recreated file object for " + ch2, ch3);
+            }
+            assertEquals("Ahoj", ch3.asText("UTF-8"));
+            assertTrue("This file object is valid", ch3.isValid());
         }
     }
 

--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/FileObjectTestHid.java
@@ -3467,14 +3467,18 @@ public class FileObjectTestHid extends TestBaseHid {
     }
 
     public void testNonExistingFileObject() throws Exception {
-        nonExistingFileObject("non-existing-child.xyz");
+        nonExistingFileObject("non-existing-child.xyz", 0);
     }
 
     public void testNonExistingFileObjectInFolder() throws Exception {
-        nonExistingFileObject("non-existing-folder/non-existing-child.xyz");
+        nonExistingFileObject("non-existing-folder/non-existing-child.xyz", 1);
     }
 
-    private void nonExistingFileObject(String childName) throws Exception {
+    public void testNonExistingDoubleFileObjectInFolder() throws Exception {
+        nonExistingFileObject("non-existing-folder/non-existing-folder/non-existing-child.xyz", 2);
+    }
+
+    private void nonExistingFileObject(String childName, int depth) throws Exception {
         checkSetUp();
         final FileObject fold = getTestFolder1(root);
 
@@ -3485,6 +3489,14 @@ public class FileObjectTestHid extends TestBaseHid {
         assertNotNull("Non existing child created", ch2);
         assertEquals("non-existing-child.xyz", ch2.getNameExt());
         assertFalse("It is not valid to begin with", ch2.isValid());
+
+        {
+            FileObject p = ch2.getParent();
+            while (depth-- > 0) {
+                assertFalse("Parent isn't valid either", p.isValid());
+                p = p.getParent();
+            }
+        }
 
         URI foldUri = fold.toURI();
         URI ch2Uri = ch2.toURI();


### PR DESCRIPTION
Jan discovered a surprising misbehavior in masterfs related to invalid child and its parents in e450db5. This PR expands the filesystem TCK and fixes masterfs implementation. Jan also suggested that:
```java
assert !ch.isValid()) : "Let's assume file object is not valid";

try (OutputStream os = ch.getOutputStream()) {
   os.write("Ahoj".getBytes("UTF-8"));
}
```
should work. True one can use the [javax.tools.FileObject](https://docs.oracle.com/javase/8/docs/api/javax/tools/FileObject.html) this way. As the `FileObject.getOutputStream()` method is `final`, it was easy to implement such behavior across all the `FileSystem` implementations.