### PR TITLE
javac warnings should not cause background indexing to Repair the code.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorker.java
@@ -538,6 +538,7 @@ final class VanillaCompileWorker extends CompileWorker {
             public Void visitCompilationUnit(CompilationUnitTree node, Void p) {
                 diags = dc.peekDiagnostics(cut.getSourceFile())
                           .stream()
+                          .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
                           .collect(Collectors.toMap(d -> d.getPosition(),
                                                     d -> Collections.singletonList(d),
                                                     (dl1, dl2) -> Stream.of(dl1, dl2)

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/CompileWorkerTestBase.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/CompileWorkerTestBase.java
@@ -57,6 +57,7 @@ import org.netbeans.modules.parsing.impl.indexing.lucene.LuceneIndexFactory;
 import org.netbeans.modules.parsing.spi.indexing.Context;
 import org.netbeans.modules.parsing.spi.indexing.ErrorsCache;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.netbeans.spi.java.queries.CompilerOptionsQueryImplementation;
 import org.netbeans.spi.java.queries.SourceLevelQueryImplementation2;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -179,7 +180,7 @@ public abstract class CompileWorkerTestBase extends NbTestCase {
     
     @Override
     protected void setUp() throws Exception {
-        SourceUtilsTestUtil.prepareTest(new String[0], new Object[] {new SourceLevelQueryImpl()});
+        SourceUtilsTestUtil.prepareTest(new String[0], new Object[] {new SourceLevelQueryImpl(), new CompilerOptionsQueryImpl()});
         
         clearWorkDir();
         File wdFile = getWorkDir();
@@ -199,6 +200,7 @@ public abstract class CompileWorkerTestBase extends NbTestCase {
     private FileObject src;
     private FileObject extraSrc;
     private String sourceLevel;
+    private List<String> compilerOptions = Collections.emptyList();
     
     private FileObject createSrcFile(String pathAndName, String content) throws Exception {
         FileObject testFile = FileUtil.createData(src, pathAndName);
@@ -225,6 +227,10 @@ public abstract class CompileWorkerTestBase extends NbTestCase {
         this.sourceLevel = sourceLevel;
     }
 
+    protected void setCompilerOptions(List<String> compilerOptions) {
+        this.compilerOptions = compilerOptions;
+    }
+
     private final class SourceLevelQueryImpl implements SourceLevelQueryImplementation2 {
 
         @Override
@@ -241,6 +247,28 @@ public abstract class CompileWorkerTestBase extends NbTestCase {
                 @Override
                 public void removeChangeListener(ChangeListener l) {}
             };
+        }
+
+    }
+
+    private final class CompilerOptionsQueryImpl implements CompilerOptionsQueryImplementation {
+
+        private final Result result = new Result() {
+            @Override
+            public List<? extends String> getArguments() {
+                return compilerOptions;
+            }
+
+            @Override
+            public void addChangeListener(ChangeListener listener) {}
+
+            @Override
+            public void removeChangeListener(ChangeListener listener) {}
+        };
+
+        @Override
+        public Result getOptions(FileObject file) {
+            return result;
         }
 
     }

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -1761,6 +1761,49 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
         assertEquals(expected, file2Fixed);
     }
 
+    public void testWarningsAreNotErrors() throws Exception {
+        setCompilerOptions(Arrays.asList("-Xlint:rawtypes"));
+
+        Map<String, String> file2Fixed = new HashMap<>();
+        VanillaCompileWorker.fixedListener = (file, cut) -> {
+            try {
+                FileObject source = URLMapper.findFileObject(file.toUri().toURL());
+                file2Fixed.put(FileUtil.getRelativePath(getRoot(), source), cut.toString());
+            } catch (MalformedURLException ex) {
+                throw new IllegalStateException(ex);
+            }
+        };
+        ParsingOutput result = runIndexing(Arrays.asList(compileTuple("test/Test.java",
+                                                                      "package test;\n" +
+                                                                      "public class Test<T> {\n" +
+                                                                      "    Test t;\n" +
+                                                                      "}\n")),
+                                           Arrays.asList());
+
+        assertFalse(result.lowMemory);
+        assertTrue(result.success);
+
+        Set<String> createdFiles = new HashSet<String>();
+
+        for (File created : result.createdFiles) {
+            createdFiles.add(getWorkDir().toURI().relativize(created.toURI()).getPath());
+        }
+
+        assertEquals(new HashSet<String>(Arrays.asList("cache/s1/java/15/classes/test/Test.sig")),
+                     createdFiles);
+        Map<String, String> expected = Collections.singletonMap("test/Test.java",
+                "package test;\n" +
+                "\n" +
+                "public class Test<T> {\n" +
+                "    \n" +
+                "    public Test() {\n" +
+                "        super();\n" +
+                "    }\n" +
+                "    Test t;\n" +
+                "}");
+        assertEquals(expected, file2Fixed);
+    }
+
     public void testSuperCall() throws Exception {
         Map<String, String> file2Fixed = new HashMap<>();
         VanillaCompileWorker.fixedListener = (file, cut) -> {


### PR DESCRIPTION
While doing background scan, and compiling classfiles for CoS without nb-javac, warnings should not be considered to be errors, and should not cause error repair code to be triggered.