### PR TITLE
LspSession associates LSP and DAP servers, and check of gdb version.

### DIFF
--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteActionsProvider.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteActionsProvider.java
@@ -77,7 +77,7 @@ public final class CPPLiteActionsProvider extends ActionsProviderSupport {
     public void doAction (Object action) {
         LOGGER.log(Level.FINE, "CPPLiteDebugger.doAction({0}), is kill = {1}", new Object[]{action, action == ActionsManager.ACTION_KILL});
         if (action == ActionsManager.ACTION_KILL) {
-            debugger.finish();
+            debugger.finish(true);
         } else
         if (action == ActionsManager.ACTION_CONTINUE) {
             debugger.resume();

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspArgsProcessor.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspArgsProcessor.java
@@ -18,10 +18,12 @@
  */
 package org.netbeans.modules.java.lsp.server;
 
-import org.netbeans.modules.java.lsp.server.protocol.Server;
 import java.io.IOException;
+
 import org.netbeans.api.sendopts.CommandException;
 import org.netbeans.modules.java.lsp.server.debugging.Debugger;
+import org.netbeans.modules.java.lsp.server.protocol.Server;
+
 import org.netbeans.spi.sendopts.Arg;
 import org.netbeans.spi.sendopts.ArgsProcessor;
 import org.netbeans.spi.sendopts.Description;
@@ -42,6 +44,7 @@ public final class LspArgsProcessor implements ArgsProcessor {
 
     @Override
     public void process(Env env) throws CommandException {
+        LspSession session = new LspSession();
         if (lsPort != null) {
             try {
                 ConnectionSpec connectTo = ConnectionSpec.parse(lsPort);
@@ -49,6 +52,8 @@ public final class LspArgsProcessor implements ArgsProcessor {
                     "Java Language Server",
                     env.getInputStream(),
                     env.getOutputStream(),
+                    session,
+                    LspSession::setLspServer,
                     Server::launchServer
                 );
             } catch (IOException ex) {
@@ -62,6 +67,8 @@ public final class LspArgsProcessor implements ArgsProcessor {
                     "Java Debug Server Adapter",
                     env.getInputStream(),
                     env.getOutputStream(),
+                    session,
+                    LspSession::setDapServer,
                     Debugger::startDebugger
                 );
             } catch (IOException ex) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspSession.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspSession.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server;
+
+import java.util.concurrent.Future;
+
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.modules.java.lsp.server.debugging.NbProtocolServer;
+import org.netbeans.modules.java.lsp.server.protocol.NbLspServer;
+
+import org.openide.util.Lookup;
+import org.openide.util.lookup.ProxyLookup;
+
+/**
+ * A session that provides associated LSP and DAP servers.
+ *
+ * @author martin
+ */
+public final class LspSession {
+
+    private final ProxyLookup.Controller lspServices = new ProxyLookup.Controller();
+    private final ProxyLookup.Controller dapServices = new ProxyLookup.Controller();
+    private final Lookup sessionLookup;
+
+    private volatile NbLspServer lspServer;
+    private volatile NbProtocolServer dapServer;
+
+    LspSession() {
+        sessionLookup = new ProxyLookup(
+                new ProxyLookup(lspServices),
+                new ProxyLookup(dapServices),
+                Lookup.getDefault()
+        );
+    }
+
+    /**
+     * Set the launched LSP server.
+     */
+    void setLspServer(NbLspServer lspServer) {
+        if (lspServer != null && this.lspServer != null) {
+            throw new IllegalStateException("LSP server is set already");
+        }
+        setServerLookup(lspServer, lspServices);
+        this.lspServer = lspServer;
+    }
+
+    /**
+     * Set the launched DAP server.
+     */
+    void setDapServer(NbProtocolServer dapServer) {
+        if (dapServer != null && this.dapServer != null) {
+            throw new IllegalStateException("DAP server is set already");
+        }
+        setServerLookup(dapServer, dapServices);
+        this.dapServer = dapServer;
+    }
+
+    private static void setServerLookup(ScheduledServer server, ProxyLookup.Controller lookupControler) {
+        if (server == null) {
+            lookupControler.setLookups();
+        } else {
+            Lookup l = server.getServerLookup();
+            if (l != null) {
+                lookupControler.setLookups(l);
+            }
+        }
+    }
+
+    /**
+     * Get the session's LSP server, if any.
+     *
+     * @return the LSP server, or <code>null</code>
+     */
+    @CheckForNull
+    public NbLspServer getLspServer() {
+        return this.lspServer;
+    }
+
+    /**
+     * Get the session lookup.
+     */
+    public Lookup getLookup() {
+        return sessionLookup;
+    }
+
+    /**
+     * Get the session's DAP server, if any.
+     *
+     * @return the DAP server, or <code>null</code>
+     */
+    @CheckForNull
+    public NbProtocolServer getDapServer() {
+        return this.dapServer;
+    }
+
+    /**
+     * A base interface of the LSP/DAP server.
+     */
+    public interface ScheduledServer {
+
+        /**
+         * A future that represents a running server. The future finishes when
+         * the server finishes.
+         */
+        Future<Void> getRunningFuture();
+
+        default Lookup getServerLookup() {
+            return null;
+        }
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/DebugAdapterContext.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/DebugAdapterContext.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.lsp4j.debug.services.IDebugProtocolClient;
 
+import org.netbeans.modules.java.lsp.server.LspSession;
 import org.netbeans.modules.java.lsp.server.debugging.breakpoints.BreakpointsManager;
 import org.netbeans.modules.java.lsp.server.debugging.launch.NbDebugSession;
 import org.netbeans.modules.java.lsp.server.progress.LspInternalHandle;
@@ -39,6 +40,7 @@ import org.openide.util.Pair;
 
 public final class DebugAdapterContext {
 
+    private final LspSession lspSession;
     private IDebugProtocolClient client;
     private NbDebugSession debugSession;
     private boolean clientLinesStartAt1 = true;
@@ -63,7 +65,12 @@ public final class DebugAdapterContext {
     private final NbThreads threadsProvider = new NbThreads();
     private final BreakpointsManager breakpointManager = new BreakpointsManager(threadsProvider);
 
-    public DebugAdapterContext() {
+    DebugAdapterContext(LspSession lspSession) {
+        this.lspSession = lspSession;
+    }
+
+    public LspSession getLspSession() {
+        return lspSession;
     }
 
     public IDebugProtocolClient getClient() {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang3.StringUtils;
@@ -77,6 +78,7 @@ import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.debugger.jpda.ObjectVariable;
 import org.netbeans.api.debugger.jpda.Variable;
 import org.netbeans.modules.debugger.jpda.truffle.vars.TruffleVariable;
+import org.netbeans.modules.java.lsp.server.LspSession;
 import org.netbeans.modules.java.lsp.server.debugging.launch.NbDebugSession;
 import org.netbeans.modules.java.lsp.server.debugging.launch.NbDisconnectRequestHandler;
 import org.netbeans.modules.java.lsp.server.debugging.launch.NbLaunchRequestHandler;
@@ -93,7 +95,7 @@ import org.netbeans.spi.debugger.ui.DebuggingView.DVThread;
  *
  * @author Dusan Balek
  */
-public final class NbProtocolServer implements IDebugProtocolServer {
+public final class NbProtocolServer implements IDebugProtocolServer, LspSession.ScheduledServer {
 
     private final DebugAdapterContext context;
     private final NbLaunchRequestHandler launchRequestHandler = new NbLaunchRequestHandler();
@@ -101,6 +103,7 @@ public final class NbProtocolServer implements IDebugProtocolServer {
     private final NbBreakpointsRequestHandler breakpointsRequestHandler = new NbBreakpointsRequestHandler();
     private final NbVariablesRequestHandler variablesRequestHandler = new NbVariablesRequestHandler();
     private boolean initialized = false;
+    private Future<Void> runningServer;
 
     public NbProtocolServer(DebugAdapterContext context) {
         this.context = context;
@@ -149,6 +152,7 @@ public final class NbProtocolServer implements IDebugProtocolServer {
         return CompletableFuture.completedFuture(caps);
     }
 
+    @Override
     public CompletableFuture<Void> configurationDone(ConfigurationDoneArguments args) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         NbDebugSession debugSession = context.getDebugSession();
@@ -513,5 +517,14 @@ public final class NbProtocolServer implements IDebugProtocolServer {
             future.complete(response);
         }
         return future;
+    }
+
+    void setRunningFuture(Future<Void> runningServer) {
+        this.runningServer = runningServer;
+    }
+
+    @Override
+    public Future<Void> getRunningFuture() {
+        return runningServer;
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbLspServer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbLspServer.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.protocol;
+
+import java.util.concurrent.Future;
+
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.eclipse.lsp4j.services.WorkspaceService;
+import org.netbeans.modules.java.lsp.server.LspSession;
+import org.openide.util.Lookup;
+
+/**
+ * Representation of LSP server, which is available through {@link LspSession}.
+ *
+ * @author martin
+ */
+public final class NbLspServer implements LspSession.ScheduledServer {
+
+    private final Server.LanguageServerImpl impl;
+    private final Future<Void> runningFuture;
+
+    NbLspServer(Server.LanguageServerImpl impl, Future<Void> runningFuture) {
+        this.impl = impl;
+        this.runningFuture = runningFuture;
+    }
+
+    @Override
+    public Lookup getServerLookup() {
+        return impl.getSessionLookup();
+    }
+
+    public TextDocumentService getTextDocumentService() {
+        return impl.getTextDocumentService();
+    }
+
+    public WorkspaceService getWorkspaceService() {
+        return impl.getWorkspaceService();
+    }
+
+    @Override
+    public Future<Void> getRunningFuture() {
+        return runningFuture;
+    }
+}

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ConnectionSpecTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ConnectionSpecTest.java
@@ -23,25 +23,57 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.After;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+import org.openide.util.Pair;
+
 public class ConnectionSpecTest {
+
+    private static ThreadLocal<List<Boolean>> copySessionServer = new ThreadLocal<>();
+
     public ConnectionSpecTest() {
     }
 
-    private static void copy(InputStream is, OutputStream os) {
-        try {
-            for (;;) {
-                int ch = is.read();
-                if (ch == -1) {
-                    break;
-                }
-                os.write(ch);
+    @After
+    public void afterTest() {
+        copySessionServer.remove();
+    }
+
+    private static LspSession.ScheduledServer copy(Pair<InputStream, OutputStream> io, LspSession lspSession) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        new Thread(() -> {
+            if (lspSession == null) {
+                future.completeExceptionally(new AssertionError(new NullPointerException("null session")));
+                return ;
             }
-        } catch (IOException ex) {
-            throw new AssertionError("copying error", ex);
+            try {
+                for (;;) {
+                    int ch = io.first().read();
+                    if (ch == -1) {
+                        break;
+                    }
+                    io.second().write(ch);
+                }
+                future.complete(null);
+            } catch (IOException ex) {
+                future.completeExceptionally(new AssertionError("copying error", ex));
+            }
+        }).start();
+        return () -> future;
+    }
+
+    private static void setCopy(LspSession session, LspSession.ScheduledServer copyServer) {
+        List<Boolean> list = copySessionServer.get();
+        if (list == null) {
+            list = new ArrayList<>(4);
+            copySessionServer.set(list);
         }
+        list.add(copyServer != null);
     }
 
     @Test
@@ -51,7 +83,16 @@ public class ConnectionSpecTest {
         ByteArrayInputStream in = new ByteArrayInputStream(bytes);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-        conn.prepare("testParseNull", in, os, ConnectionSpecTest::copy);
+        conn.prepare("testParseNull", in, os, new LspSession(), ConnectionSpecTest::setCopy, ConnectionSpecTest::copy);
+        assertEquals("[true, false]", copySessionServer.get().toString());
+
+        try {
+            conn.prepare("testParseNull", in, os, null, ConnectionSpecTest::setCopy, ConnectionSpecTest::copy);
+            fail();
+        } catch (AssertionError err) {
+            assertTrue(err.getCause() instanceof NullPointerException);
+        }
+        assertEquals("[true, false, true, false]", copySessionServer.get().toString());
 
         assertArrayEquals("Copied properly", bytes, os.toByteArray());
     }
@@ -63,7 +104,8 @@ public class ConnectionSpecTest {
             ByteArrayInputStream in = new ByteArrayInputStream(bytes);
             ByteArrayOutputStream os = new ByteArrayOutputStream();
 
-            conn.prepare("testParseNull", in, os, ConnectionSpecTest::copy);
+            conn.prepare("testParseNull", in, os, new LspSession(), ConnectionSpecTest::setCopy, ConnectionSpecTest::copy);
+            assertEquals("[true, false]", copySessionServer.get().toString());
 
             assertArrayEquals("Copied properly", bytes, os.toByteArray());
         }
@@ -75,14 +117,14 @@ public class ConnectionSpecTest {
             final byte[] bytes = "Hello".getBytes();
             ByteArrayInputStream in = new ByteArrayInputStream(bytes);
             ByteArrayOutputStream os = new ByteArrayOutputStream();
-            conn.prepare("Pipe server", in, os, ConnectionSpecTest::copy);
+            conn.prepare("Pipe server", in, os, new LspSession(), ConnectionSpecTest::setCopy, ConnectionSpecTest::copy);
             String reply = os.toString("UTF-8");
             String exp = "Pipe server listening at port ";
             assertTrue(reply, reply.startsWith(exp));
             int port = Integer.parseInt(reply.substring(exp.length()));
             assertTrue("port is specified: " + port, port >= 1024);
             try (ConnectionSpec second = ConnectionSpec.parse("connect:" + port)) {
-                second.prepare("Pipe client", in, os, ConnectionSpecTest::copy);
+                second.prepare("Pipe client", in, os, new LspSession(), ConnectionSpecTest::setCopy, ConnectionSpecTest::copy);
             }
         }
     }


### PR DESCRIPTION
It's unfortunate, that GDB bug https://sourceware.org/bugzilla/show_bug.cgi?id=26139 is affecting the newly introduced native image debugging. We need to warn users about that, since native image debugging is practically unusable with the buggy version. A change needs to be done in LSP as well, to be able to show the warning in VSCode.

I'm providing two commits.

1) Introducing `LspSession`, which provides LSP and DAP servers. The getters provide the servers while they are running, they are cleared when they finish. This is handled by `ConnectionSpec`, the launch of the servers was changed to return after the server is launched and the `ConnectionSpec` is waiting for the server finish explicitly, to be able to manage the servers in the `LspSession` instance.

2) We check the version of `gdb` and provide a warning when it's the buggy version. For that we need to start debugger in `lspServer.getSessionLookup()` and obtain the `DialogDisplayer` eagerly. That assures that we get the LSP version of `DialogDisplayer` when LSP is active and the default `DialogDisplayer` in NetBeans.