### PR TITLE
Build & Rebuild actions are disabled in mx projects!

### DIFF
--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
@@ -154,7 +154,7 @@ final class SuiteActionProvider implements ActionProvider {
         if (running != null) {
             ActionProgress progress = ActionProgress.start(context);
             running.handle((exitCode, error) -> {
-                progress.finished(exitCode == 0 && error == null);
+                progress.finished(error == null && exitCode == 0);
                 return null;
             });
         }

--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
@@ -22,6 +22,7 @@ import java.awt.Toolkit;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Future;
 import org.netbeans.api.actions.Openable;
 import org.netbeans.api.debugger.*;
@@ -44,6 +45,18 @@ import org.openide.windows.OutputEvent;
 import org.openide.windows.OutputListener;
 
 final class SuiteActionProvider implements ActionProvider {
+    private static final List<String> SUPPORTED_ACTIONS = Arrays.asList(
+        ActionProvider.COMMAND_CLEAN,
+        ActionProvider.COMMAND_BUILD,
+        ActionProvider.COMMAND_COMPILE_SINGLE,
+        ActionProvider.COMMAND_REBUILD,
+        ActionProvider.COMMAND_TEST_SINGLE,
+        ActionProvider.COMMAND_RUN_SINGLE,
+        ActionProvider.COMMAND_DEBUG_TEST_SINGLE,
+        ActionProvider.COMMAND_DEBUG_SINGLE,
+        SingleMethod.COMMAND_DEBUG_SINGLE_METHOD,
+        SingleMethod.COMMAND_RUN_SINGLE_METHOD
+    );
     private final SuiteProject prj;
 
     SuiteActionProvider(SuiteProject prj) {
@@ -52,18 +65,7 @@ final class SuiteActionProvider implements ActionProvider {
 
     @Override
     public String[] getSupportedActions() {
-        return new String[] {
-            ActionProvider.COMMAND_CLEAN,
-            ActionProvider.COMMAND_BUILD,
-            ActionProvider.COMMAND_COMPILE_SINGLE,
-            ActionProvider.COMMAND_REBUILD,
-            ActionProvider.COMMAND_TEST_SINGLE,
-            ActionProvider.COMMAND_RUN_SINGLE,
-            ActionProvider.COMMAND_DEBUG_TEST_SINGLE,
-            ActionProvider.COMMAND_DEBUG_SINGLE,
-            SingleMethod.COMMAND_DEBUG_SINGLE_METHOD,
-            SingleMethod.COMMAND_RUN_SINGLE_METHOD,
-        };
+        return SUPPORTED_ACTIONS.toArray(new String[0]);
     }
 
     @NbBundle.Messages({
@@ -251,7 +253,7 @@ final class SuiteActionProvider implements ActionProvider {
             case ActionProvider.COMMAND_DEBUG_SINGLE:
                 return fo != null;
             default:
-                return false;
+                return SUPPORTED_ACTIONS.contains(action);
         }
     }
 }

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SdkSuiteTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SdkSuiteTest.java
@@ -22,20 +22,14 @@ import java.io.File;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 import org.netbeans.api.java.queries.SourceForBinaryQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
-import org.netbeans.spi.project.ActionProgress;
-import org.netbeans.spi.project.ActionProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
-import org.openide.util.Lookup;
-import org.openide.util.lookup.Lookups;
 
 public class SdkSuiteTest extends SuiteCheck {
     public SdkSuiteTest(String n) {
@@ -48,68 +42,6 @@ public class SdkSuiteTest extends SuiteCheck {
 
     public void testParseSdkSourcesWithoutError() throws Exception {
         verifyNoErrorsInSuite("sdk");
-    }
-
-    public void testActionsEnabled() throws Exception {
-        File sdkSibling = findSuite("sdk");
-
-        FileObject fo = FileUtil.toFileObject(sdkSibling);
-        assertNotNull("project directory found", fo);
-
-        Project p = ProjectManager.getDefault().findProject(fo);
-        assertNotNull("project found", p);
-        assertEquals("It is suite project: " + p, "SuiteProject", p.getClass().getSimpleName());
-
-        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
-        assertNotNull("Action provider found", ap);
-
-        Lookup ctx = fo.getLookup();
-        assertTrue("Build is supported", ap.isActionEnabled(ActionProvider.COMMAND_BUILD, ctx));
-        assertTrue("Clean is supported", ap.isActionEnabled(ActionProvider.COMMAND_CLEAN, ctx));
-        assertTrue("Build & Clean is supported", ap.isActionEnabled(ActionProvider.COMMAND_REBUILD, ctx));
-
-        assertFalse("Move isn't supported", ap.isActionEnabled(ActionProvider.COMMAND_MOVE, ctx));
-        assertFalse("Primining isn't (yet) supported", ap.isActionEnabled(ActionProvider.COMMAND_PRIME, ctx));
-    }
-
-    public void testActionProgressIsProvided() throws Exception {
-        File sdkSibling = findSuite("sdk");
-
-        FileObject fo = FileUtil.toFileObject(sdkSibling);
-        assertNotNull("project directory found", fo);
-
-        Project p = ProjectManager.getDefault().findProject(fo);
-        assertNotNull("project found", p);
-        assertEquals("It is suite project: " + p, "SuiteProject", p.getClass().getSimpleName());
-
-        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
-        assertNotNull("Action provider found", ap);
-
-        class MockProgress extends ActionProgress {
-            volatile boolean started;
-            volatile Boolean success;
-            CountDownLatch finished = new CountDownLatch(1);
-
-            @Override
-            protected void started() {
-                this.started = true;
-            }
-
-            @Override
-            public void finished(boolean success) {
-                this.success = success;
-                this.finished.countDown();
-            }
-        }
-        MockProgress progress = new MockProgress();
-
-        Lookup ctx = Lookups.fixed(fo, p, progress);
-        assertTrue("Clean is supported", ap.isActionEnabled(ActionProvider.COMMAND_CLEAN, ctx));
-        ap.invokeAction(ActionProvider.COMMAND_CLEAN, ctx);
-
-        assertTrue("Progress started", progress.started);
-        progress.finished.await(10, TimeUnit.SECONDS);
-        assertNotNull("Progress finished", progress.success);
     }
 
     public void testRootsForAnSdkJar() throws Exception {

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SuiteActionProviderTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SuiteActionProviderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.mx.project;
+
+import java.io.File;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+
+public class SuiteActionProviderTest extends SuiteCheck {
+    public SuiteActionProviderTest(String s) {
+        super(s);
+    }
+    
+    public static junit.framework.Test suite() {
+        return suite(SuiteActionProviderTest.class);
+    }
+    
+    public void testActionsEnabledWithProgress() throws Exception {
+        File sdkSibling = findSuite("sdk");
+
+        FileObject fo = FileUtil.toFileObject(sdkSibling);
+        assertNotNull("project directory found", fo);
+
+        Project p = ProjectManager.getDefault().findProject(fo);
+        assertNotNull("project found", p);
+        assertEquals("It is suite project: " + p, "SuiteProject", p.getClass().getSimpleName());
+
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        assertNotNull("Action provider found", ap);
+
+        {
+            Lookup ctx = fo.getLookup();
+            assertTrue("Build is supported", ap.isActionEnabled(ActionProvider.COMMAND_BUILD, ctx));
+            assertTrue("Clean is supported", ap.isActionEnabled(ActionProvider.COMMAND_CLEAN, ctx));
+            assertTrue("Build & Clean is supported", ap.isActionEnabled(ActionProvider.COMMAND_REBUILD, ctx));
+
+            assertFalse("Move isn't supported", ap.isActionEnabled(ActionProvider.COMMAND_MOVE, ctx));
+            assertFalse("Primining isn't (yet) supported", ap.isActionEnabled(ActionProvider.COMMAND_PRIME, ctx));
+        }
+
+        class MockProgress extends ActionProgress {
+
+            volatile boolean started;
+            volatile Boolean success;
+            final CountDownLatch finished = new CountDownLatch(1);
+
+            @Override
+            protected void started() {
+                this.started = true;
+            }
+
+            @Override
+            public void finished(boolean success) {
+                this.success = success;
+                this.finished.countDown();
+            }
+        }
+        MockProgress progress = new MockProgress();
+
+        Lookup ctx = Lookups.fixed(fo, p, progress);
+        assertTrue("Clean is supported", ap.isActionEnabled(ActionProvider.COMMAND_CLEAN, ctx));
+        ap.invokeAction(ActionProvider.COMMAND_CLEAN, ctx);
+
+        assertTrue("Progress started", progress.started);
+        progress.finished.await(10, TimeUnit.SECONDS);
+        assertNotNull("Progress finished", progress.success);
+    }
+
+    
+}


### PR DESCRIPTION
A [mistake has been made](https://github.com/apache/netbeans/pull/2822/files#r619574208) when implementing #2822 - now build/rebuild actions are disabled for _mx projects_. This PR fixes that by returning `true` for all supported actions and `false` only otherwise.

When at it I also fixed long opened problem - to run/debug unit test one had to build first, otherwise the changes were not visible - now the build happens before running tests automatically. With 8c3b56d the VSNetBeans UI also knows when run/debug test action is over and can hide the debugging toolbar.

This is not a stopper for 12.4 (who cares about mx projects anyway?), but please consider this PR for inclusion in 12.4, if there is a chance.