### PR TITLE
[NETBEANS-2373] Better than nothing support for Gradle Distribution dirs

### DIFF
--- a/extide/gradle.dists/build.xml
+++ b/extide/gradle.dists/build.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project basedir="." default="build" name="extide/gradle.dists">
+    <description>Builds, tests, and runs the project org.netbeans.modules.gradle.dists</description>
+    <import file="../../nbbuild/templates/projectized.xml"/>
+</project>
+

--- a/extide/gradle.dists/manifest.mf
+++ b/extide/gradle.dists/manifest.mf
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+AutoUpdate-Show-In-Client: true
+OpenIDE-Module: org.netbeans.modules.gradle.dists
+OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/dists/Bundle.properties
+OpenIDE-Module-Specification-Version: 1.0

--- a/extide/gradle.dists/nbproject/project.properties
+++ b/extide/gradle.dists/nbproject/project.properties
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+is.eager=true
+javac.source=1.8
+javac.compilerargs=-Xlint -Xlint:-serial
+
+nbm.module.author=Laszlo Kishalmi
+
+test-unit-sys-prop.test.netbeans.dest.dir=${netbeans.dest.dir}
+test-unit-sys-prop.java.awt.headless=true

--- a/extide/gradle.dists/nbproject/project.xml
+++ b/extide/gradle.dists/nbproject/project.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.apisupport.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/nb-module-project/3">
+            <code-name-base>org.netbeans.modules.gradle.dists</code-name-base>
+            <module-dependencies>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.gradle</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <specification-version>2.12</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.projectapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.80</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.projectuiapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.100</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.filesystems</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.23</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.loaders</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.81</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.nodes</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.57</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.19</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.lookup</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>8.46</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.20</specification-version>
+                    </run-dependency>
+                </dependency>
+            </module-dependencies>
+            <test-dependencies/>
+            <public-packages/>
+        </data>
+    </configuration>
+</project>

--- a/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/Bundle.properties
+++ b/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/Bundle.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+OpenIDE-Module-Display-Category=Gradle
+OpenIDE-Module-Name=Gradle Projects Distributions
+OpenIDE-Module-Short-Description=Better than nothing support of Gradle distribution plugin.
+

--- a/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/DistribitionSourceWatchList.java
+++ b/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/DistribitionSourceWatchList.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.dists;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.dists.api.GradleDistProject;
+import org.netbeans.modules.gradle.spi.WatchedResourceProvider;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class DistribitionSourceWatchList implements WatchedResourceProvider {
+
+    final Project project;
+
+    public DistribitionSourceWatchList(Project project) {
+        this.project = project;
+    }
+    
+    
+    @Override
+    public Set<File> getWatchedResources() {
+        Set<File> ret = Collections.emptySet();
+        GradleDistProject gdp = GradleDistProject.get(project);
+        if ((gdp != null) && !gdp.getDistributions().isEmpty()) {
+            ret = new HashSet<>();
+            for (String distribution : gdp.getDistributions()) {
+                ret.add(gdp.getDistributionSource(distribution));
+            }
+        }
+        return ret;
+    }
+    
+}

--- a/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/DistributionNodeFactory.java
+++ b/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/DistributionNodeFactory.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.dists;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectUtils;
+import org.netbeans.api.project.SourceGroup;
+import org.netbeans.api.project.Sources;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.spi.nodes.AbstractGradleNodeList;
+import org.netbeans.spi.project.ui.support.NodeFactory;
+import org.netbeans.spi.project.ui.support.NodeList;
+import org.openide.loaders.DataObject;
+import org.openide.loaders.DataObjectNotFoundException;
+import org.openide.nodes.FilterNode;
+import org.openide.nodes.Node;
+
+/**
+ *
+ * @author lkishalmi
+ */
+@NodeFactory.Registration(projectType = NbGradleProject.GRADLE_PROJECT_TYPE, position = 150)
+public class DistributionNodeFactory implements NodeFactory {
+
+    @Override
+    public NodeList<?> createNodes(Project project) {
+        return new NList(project);
+    }
+    
+    private static class NList extends AbstractGradleNodeList<SourceGroup> {
+        private final Project project;
+        private NList(Project prj) {
+            project = prj;
+        }
+
+        @Override
+        public List<SourceGroup> keys() {
+            Sources srcs = ProjectUtils.getSources(project);
+            List<SourceGroup> ret = new ArrayList<>(2);
+            ret.addAll(Arrays.asList(srcs.getSourceGroups(DistributionSourcesImpl.DISTRIBUTION_SOURCES)));
+            ret.sort(Comparator.comparing(SourceGroup::getName));
+            return ret;
+        }
+
+        @Override
+        public Node node(SourceGroup key) {
+            return DistributionFolderNode.createResourcesFolderNode(key);
+        }
+        
+    }
+    
+    private static class DistributionFolderNode extends FilterNode {
+
+        final SourceGroup group;
+
+        private DistributionFolderNode(SourceGroup group, Node original) {
+            super(original);
+            this.group = group;
+        }
+
+        @Override
+        public String getName() {
+            return group.getName();
+        }
+        
+        @Override
+        public String getDisplayName() {
+            return group.getDisplayName();
+        }
+
+        static Node createResourcesFolderNode(SourceGroup group) {
+            try {
+                DataObject root = DataObject.find(group.getRootFolder());
+                return new DistributionFolderNode(group, root.getNodeDelegate());
+            } catch(DataObjectNotFoundException ex) {
+                //Shall not happen...
+            }
+            return null;
+        }
+
+        @Override
+        public boolean canRename() {
+            return false;
+        }
+
+        @Override
+        public boolean canCut() {
+            return false;
+        }
+        
+    }
+    
+}

--- a/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/DistributionSourcesImpl.java
+++ b/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/DistributionSourcesImpl.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.dists;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.swing.event.ChangeListener;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.SourceGroup;
+import org.netbeans.api.project.Sources;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.dists.api.GradleDistProject;
+import org.netbeans.spi.project.support.GenericSources;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.*;
+
+/**
+ *
+ * @author lkishalmi
+ */
+@NbBundle.Messages({
+    "# {0} - source group name",
+    "MAIN_DIST=Distribution Files",
+    "# {0} - source group name",
+    "OTHER_DIST={0} Distribution Files",
+})
+public final class DistributionSourcesImpl implements Sources {
+
+    public static final String DISTRIBUTION_SOURCES = "distribution"; //NOI18N
+    private final Project proj;
+    private final ChangeSupport cs = new ChangeSupport(this);
+
+    private final PropertyChangeListener pcl;
+
+    private SourceGroup[] cache;
+    private Set<String> dists;
+    
+    public DistributionSourcesImpl(Project proj) {
+        this.proj = proj;
+        pcl = (PropertyChangeEvent evt) -> {
+            if (NbGradleProject.get(proj).isUnloadable()) {
+                return; //let's just continue with the old value, stripping classpath for broken project and re-creating it later serves no greater good.
+            }
+            if (NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())
+                    || NbGradleProject.PROP_RESOURCES.equals(evt.getPropertyName())) {
+                checkChanges(true);
+            }
+        };
+    }
+
+    
+    @Override
+    public SourceGroup[] getSourceGroups(String type) {
+        if (DISTRIBUTION_SOURCES.equals(type)) {
+            if (cache == null) {
+                List<SourceGroup> ret = new ArrayList<>(2);
+                GradleDistProject gdp = GradleDistProject.get(proj);
+                if (gdp != null) {
+                    dists = gdp.getAvailableDistributions();
+                    for (String distribution : dists) {
+                        FileObject rootFO = FileUtil.toFileObject(gdp.getDistributionSource(distribution));
+                        if (rootFO != null) {
+                            
+                            String displayName = "main".equals(distribution) ?  //NOI18N
+                                    Bundle.MAIN_DIST(distribution):
+                                    Bundle.OTHER_DIST(distribution);
+                            String sgName = "main".equals(distribution) ? "01main" : "02" + distribution; //NOI18N
+                            SourceGroup grp = GenericSources.group(proj, rootFO, sgName, displayName, null, null);
+                            ret.add(grp);
+                        }
+                    }
+                }
+                cache = ret.toArray(new SourceGroup[0]);
+            }
+            return cache;
+        }
+        return new SourceGroup[0];
+    }
+
+    
+    private void checkChanges(boolean fireChanges) {
+        boolean changed = dists == null;
+
+        if (GradleDistProject.get(proj) != null) {
+            Set<String> newDists = GradleDistProject.get(proj).getAvailableDistributions();
+            if (dists != null) {
+                Set<String> enteringGroups = new HashSet<>(newDists);
+                Set<String> leavingGroups = new HashSet<>(dists);
+                Set<String> remainingGroups = new HashSet<>(newDists);
+                remainingGroups.retainAll(dists);
+                enteringGroups.removeAll(remainingGroups);
+                leavingGroups.removeAll(remainingGroups);
+                changed = !leavingGroups.isEmpty() || !enteringGroups.isEmpty();
+            }
+            dists = newDists;
+            if (changed) {
+                cache = null;
+            }
+        }
+        if (changed && fireChanges) {
+            cs.fireChange();
+        }
+    }
+    
+    @Override
+    public void addChangeListener(ChangeListener listener) {
+        if (!cs.hasListeners()) {
+            NbGradleProject.addPropertyChangeListener(proj, pcl);
+        }
+        cs.addChangeListener(listener);
+    }
+
+    @Override
+    public void removeChangeListener(ChangeListener listener) {
+        cs.removeChangeListener(listener);
+        if (!cs.hasListeners()) {
+            NbGradleProject.removePropertyChangeListener(proj, pcl);
+        }
+    }
+
+}

--- a/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/LookupProviders.java
+++ b/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/LookupProviders.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.dists;
+
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.spi.project.LookupProvider;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public class LookupProviders {
+    @LookupProvider.Registration(projectType = NbGradleProject.GRADLE_PLUGIN_TYPE + "/distribution")
+    public static LookupProvider createDistributionProvider() {
+        return new LookupProvider() {
+            @Override
+            public Lookup createAdditionalLookup(Lookup baseContext) {
+                Project project = baseContext.lookup(Project.class);
+                return Lookups.fixed(
+                        new DistributionSourcesImpl(project),
+                        new DistribitionSourceWatchList(project)
+                );
+            }
+        };
+    }
+    
+}

--- a/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/api/GradleDistProject.java
+++ b/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/api/GradleDistProject.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.dists.api;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+
+/**
+ *
+ * @author lkishalmi
+ */
+public final class GradleDistProject {
+
+    final File projectDir;
+    final Set<String> distributions;
+
+    GradleDistProject(File projectDir, Set<String> distributions) {
+        this.projectDir = projectDir;
+        this.distributions = distributions;
+    }
+
+    public Set<String> getDistributions() {
+        return distributions != null ? distributions : Collections.emptySet();
+    }
+    
+    public Set<String> getAvailableDistributions() {
+        return getDistributions().stream().filter((String dist) -> getDistributionSource(dist).isDirectory()).collect(Collectors.toSet());
+    }
+    
+    public File getDistributionSource(String distribution) {
+        File src = new File(projectDir, "src"); //NOI18N
+        File dist = new File(src, distribution);
+        return new File(dist, "dist"); //NOI18N
+    }
+    
+    public static GradleDistProject get(Project project) {
+        NbGradleProject gp = NbGradleProject.get(project);
+        return gp != null ? gp.projectLookup(GradleDistProject.class) : null;
+    }
+}

--- a/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/api/GradleDistProjectBuilder.java
+++ b/extide/gradle.dists/src/org/netbeans/modules/gradle/dists/api/GradleDistProjectBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.dists.api;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.netbeans.modules.gradle.spi.GradleFiles;
+import org.netbeans.modules.gradle.spi.ProjectInfoExtractor;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author lkishalmi
+ */
+class GradleDistProjectBuilder  {
+
+    @ServiceProvider(service = ProjectInfoExtractor.class, position = Integer.MIN_VALUE)
+    @SuppressWarnings("rawtypes")
+    public static final class Extractor implements ProjectInfoExtractor {
+
+        @Override
+        public ProjectInfoExtractor.Result extract(Map<String, Object> props, Map<Class, Object> otherInfo) {
+            Set<String> dists = (Set<String>) props.get("distributions");
+            File projectDir = (File) props.get("project_projectDir");
+            return (projectDir != null) && (dists != null) ? new ProjectInfoExtractor.DefaultResult(new GradleDistProject(projectDir, dists)) : Result.NONE;
+        }
+
+        @Override
+        public ProjectInfoExtractor.Result fallback(GradleFiles files) {
+            File src = new File(files.getProjectDir(), "src"); //NOI18N
+            Set<String> dists = new HashSet<>();
+            if (src.isDirectory()) {
+                for (File dist : src.listFiles(f -> f.isDirectory())) {
+                    if (new File(dist, "dist").isDirectory()) {
+                        dists.add(dist.getName());
+                    }
+                }
+            }
+            return !dists.isEmpty() ? new ProjectInfoExtractor.DefaultResult(new GradleDistProject(files.getProjectDir(), dists)) : Result.NONE;
+        }
+
+    }
+
+    
+}

--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle/2
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.11
+OpenIDE-Module-Specification-Version: 2.12

--- a/extide/gradle/netbeans-gradle-tooling/src/main/groovy/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.groovy
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/groovy/org/netbeans/modules/gradle/tooling/NbProjectInfoBuilder.groovy
@@ -74,9 +74,16 @@ class NbProjectInfoBuilder {
         detectTests(model)
         detectDependencies(model)
         detectArtifacts(model)
+        detectDistributions(model)
         return model
     }
 
+    private void detectDistributions(NbProjectInfoModel model) {
+        if (project.plugins.hasPlugin('distribution')) {
+           model.info.distributions = storeSet(project.distributions.collect() { it.name })
+        }
+    }
+    
     private void detectLicense(NbProjectInfoModel model) {
         def license = project.hasProperty('netbeans.license') ? project.property('netbeans.license').toString() : null;
         if (license == null) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/cache/ProjectInfoDiskCache.java
@@ -39,7 +39,7 @@ import org.netbeans.modules.gradle.spi.GradleFiles;
 public final class ProjectInfoDiskCache extends AbstractDiskCache<GradleFiles, QualifiedProjectInfo> {
 
     // Increase this number if new info is gathered from the projects.
-    private static final int COMPATIBLE_CACHE_VERSION = 18;
+    private static final int COMPATIBLE_CACHE_VERSION = 19;
     private static final String INFO_CACHE_FILE_NAME = "project-info.ser"; //NOI18N
     private static final Map<GradleFiles, ProjectInfoDiskCache> DISK_CACHES = new WeakHashMap<>();
 

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -1490,6 +1490,7 @@ nb.cluster.extide.depends=\
         nb.cluster.platform
 nb.cluster.extide=\
         gradle,\
+        gradle.dists,\
         libs.gradle,\
         o.apache.tools.ant.module,\
         options.java


### PR DESCRIPTION
Gradle distribution plugin can be handy from time to time. This PR would add a SourceGroup in the project node for existing dist directories.
Unfortunately Gradle distributions are represented in Gradle as CopySpec-s which are enough to copy required files, but its API is developed for flexible composition, so it does not offer proper introspection. This plugin just assume that the default folder for distribution related sources is ```<project root>/src/<distribution name>/dist```

See: https://docs.gradle.org/current/userguide/distribution_plugin.html