### PR TITLE
[NETBEANS-5638] Insane should ignore stub classes in traversal.

### DIFF
--- a/harness/o.n.insane/src/org/netbeans/insane/impl/InsaneEngine.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/impl/InsaneEngine.java
@@ -83,7 +83,17 @@ public final class InsaneEngine {
         
         // dispatch the recognition
         if (o instanceof Class) {
-            recognizeClass((Class)o);
+            try {
+                recognizeClass((Class)o);
+            } catch (SecurityException ex) {
+                if (ex.getMessage() == null || !ex.getMessage().contains("java.lang")) {
+                    throw ex;
+                }
+                // just report: possibly an upwards-compatible method 
+                // not linkable on current runtime.
+                System.err.println("Failed analysing class " + ((Class)o).getName() +
+                        " because of " + ex.getMessage());
+            }
         } else {
             recognizeObject(o);
         }


### PR DESCRIPTION
Maybe it would be better to modify `NbInstrumentation` in Bootstrap to create a subclass only when required, the 'live' instance with unlinkable methods is a potential source of issues - @jtulach  ?

But even when I've made a subclass (I didn't finish the work, the factory for NbInstrumentation has to be moved elsewhere) the Class object for the subclass was still in some (classloader ?) array, so it didn't help my cause.

So I've patched Insane traversal - now it ignores SecurityException that complains about `java.lang` package