### PR TITLE
[NETBEANS-5627] [NETBEANS-5629] Gradle early Lookup and Classpath initialization.

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,22 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="reload-to-quality">
+            <api name="general"/>
+            <summary>
+                Added API to reload Gradle project information. 
+            </summary>
+            <version major="2" minor="11"/>
+            <date day="18" month="4" year="2021"/>
+            <author login="sdedic"/>
+            <compatibility semantic="compatible" addition="yes"/>
+            <description>
+                Project information can be refreshed to a desired quality using <a href="@TOP@/org/netbeans/modules/gradle/api/NbGradleProject.html#toQuality-java.lang.String-org.netbeans.modules.gradle.api.NbGradleProject.Quality-boolean-">NbGradleProject.toQuality</a>. 
+                The caller may chain after reload completes or block until the project is loaded.
+            </description>
+            <class package="org.netbeans.modules.gradle.api" name="NbGradleProject"/>
+            <issue number="NETBEANS-5627"/>
+        </change>
         <change id="local-gradle-version-discovery">
             <api name="general"/>
             <summary>GradleDistributionManager can detect local Gradle Distributions</summary>

--- a/extide/gradle/manifest.mf
+++ b/extide/gradle/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.gradle/2
 OpenIDE-Module-Layer: org/netbeans/modules/gradle/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.10
+OpenIDE-Module-Specification-Version: 2.11

--- a/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
@@ -302,7 +302,7 @@ public class ActionProviderImpl implements ActionProvider {
             if (needReload && canReload) {
                 String[] reloadArgs = RunUtils.evaluateActionArgs(project, mapping.getName(), mapping.getReloadArgs(), ctx);
                 final ActionProgress g = ActionProgress.start(context);
-                RequestProcessor.Task reloadTask = prj.reloadProject(loadReason, true, maxQualily, reloadArgs);
+                RequestProcessor.Task reloadTask = prj.forceReloadProject(loadReason, false, maxQualily, reloadArgs);
                 reloadTask.addTaskListener((t) -> {
                     g.finished(true);
                 });

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProject.java
@@ -101,8 +101,12 @@ public final class GradleProject implements Serializable, Lookup.Provider {
     }
 
     public final GradleProject invalidate(String... reasons) {
-        Set<String> p = new LinkedHashSet<>(Arrays.asList(reasons));
-        return new GradleProject(Quality.EVALUATED, p, this);
+        if (getQuality().worseThan(Quality.EVALUATED)) {
+            return this;
+        } else {
+            Set<String> p = new LinkedHashSet<>(Arrays.asList(reasons));
+            return new GradleProject(Quality.EVALUATED, p, this);
+        }
     }
 
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectFactory.java
@@ -87,7 +87,12 @@ public final class NbGradleProjectFactory implements ProjectFactory2 {
 
     @Override
     public Project loadProject(FileObject dir, ProjectState ps) throws IOException {
-        return isProject(dir) ? new NbGradleProjectImpl(dir, ps) : null;
+        if (!isProject(dir)) {
+            return null;
+        }
+        NbGradleProjectImpl prj = new NbGradleProjectImpl(dir, ps);
+        prj.getGradleProject();
+        return prj;
     }
 
     @Override

--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -236,7 +236,7 @@ public final class NbGradleProjectImpl implements Project {
         aimedQuality = FALLBACK;
     }
 
-    public final Quality getAimedQuality() {
+    public Quality getAimedQuality() {
         return aimedQuality;
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ReloadAction.java
@@ -35,7 +35,6 @@ import org.openide.util.NbBundle;
 import org.netbeans.modules.gradle.api.GradleProjects;
 
 import static org.netbeans.modules.gradle.Bundle.*;
-import org.netbeans.modules.gradle.api.GradleBaseProject;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FULL_ONLINE;
 
 /**
@@ -78,14 +77,7 @@ public class ReloadAction  extends AbstractAction implements ContextAwareAction 
         for (Project project : reload) {
             if (project instanceof NbGradleProjectImpl) {
                 NbGradleProjectImpl impl = (NbGradleProjectImpl) project;
-                NbGradleProjectImpl.RELOAD_RP.submit(() -> {
-                    // A bit low level calls, just to allow UI interaction to
-                    // Trust the project.
-                    GradleProjectLoader loader = impl.getLookup().lookup(GradleProjectLoader.class);
-                    GradleBaseProject gbp = GradleBaseProject.get(project);
-                    impl.project = loader.loadProject(FULL_ONLINE, ACT_ReloadingProject(), true, true);
-                    NbGradleProjectImpl.ACCESSOR.doFireReload(NbGradleProject.get(impl));
-                });
+                impl.forceReloadProject(ACT_ReloadingProject(), true, FULL_ONLINE);
             }
         }
     }
@@ -93,6 +85,5 @@ public class ReloadAction  extends AbstractAction implements ContextAwareAction 
     @Override public Action createContextAwareInstance(Lookup actionContext) {
         return new ReloadAction(actionContext);
     }
-
 
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/ReloadProjectDependenciesDecorator.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ReloadProjectDependenciesDecorator.java
@@ -47,7 +47,7 @@ public class ReloadProjectDependenciesDecorator implements AfterBuildActionHook 
         for (Project dep : dependencies.values()) {
             NbGradleProjectImpl impl = dep.getLookup().lookup(NbGradleProjectImpl.class);
             if ((impl != null) && impl.getAimedQuality().betterThan(impl.getGradleProject().getQuality())) {
-                impl.reloadProject(true, impl.getAimedQuality());
+                impl.forceReloadProject(null, false, impl.getAimedQuality());
             }
         }
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
@@ -206,6 +206,11 @@ public final class NbGradleProject {
     public boolean isUnloadable() {
         return getQuality().worseThan(Quality.SIMPLE);
     }
+    
+    public Quality toQuality(String reason, Quality q, boolean forceLoad) {
+        project.projectWithQuality(reason, q, false, forceLoad);
+        return getQuality();
+    }
 
     public Preferences getPreferences(boolean shared) {
         Preferences ret = shared ? sharedPrefs : privatePrefs;

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/NbGradleProject.java
@@ -28,9 +28,13 @@ import java.io.File;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.prefs.Preferences;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.annotations.common.StaticResource;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectUtils;
@@ -207,9 +211,28 @@ public final class NbGradleProject {
         return getQuality().worseThan(Quality.SIMPLE);
     }
     
-    public Quality toQuality(String reason, Quality q, boolean forceLoad) {
-        project.projectWithQuality(reason, q, false, forceLoad);
-        return getQuality();
+    /**
+     * Attempts to refresh the project to at least the desired quality. The project information
+     * may be reloaded, if the project is currently loaded with lower {@link Quality} than {@code q}.
+     * If {@code forceLoad} is true, the project reloads even if the {@code q} is worse quality than
+     * the current {@link #getQuality()} level. Reason for the reload may be specified: if the reload
+     * takes some time (i.e. executing Gradle build), the IDE may use the {@code reason} text to annotate
+     * the ongoing progress.
+     * <p/>
+     * The returned {@link CompletionStage} may complete in this thread, or asynchronously in an unspecified thread.
+     * <p/>
+     * Note that the loading may fail, so the returned Quality may be <b>less than requested</b>. For example
+     * if the project is not trusted, its Gradle build will not be executed, so the returned quality can be {@link Quality#EVALUATED}.
+     * 
+     * @param reason reason for reload, may be {@code null}.
+     * @param q the desired quality of project information
+     * @param forceLoad force load even though the current info quality is sufficient.
+     * @return {@link CompletionStage} with the reloaded project. Use {@link CompletionStage#toCompletableFuture()}.{@link CompletableFuture#get get()} 
+     * to block waiting for the result.
+     * @since 2.11
+     */
+    public @NonNull CompletionStage<NbGradleProject> toQuality(@NullAllowed String reason, @NonNull Quality q, boolean forceLoad) {
+        return project.projectWithQualityTask(reason, q, false, forceLoad).thenApply(p -> this);
     }
 
     public Preferences getPreferences(boolean shared) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.gradle.loaders;
 
 import org.netbeans.modules.gradle.GradleProject;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FALLBACK;
-import org.netbeans.modules.gradle.cache.AbstractDiskCache;
 import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache;
 import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -37,7 +37,6 @@ import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
 public class GradleProjectLoaderImpl implements GradleProjectLoader {
 
     final Project project;
-    private String actionDescription;
     private static final Logger LOGGER = Logger.getLogger(GradleProjectLoaderImpl.class.getName());
 
     public GradleProjectLoaderImpl(Project project) {

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/LegacyProjectLoader.java
@@ -46,7 +46,7 @@ import static org.netbeans.modules.gradle.loaders.GradleDaemon.INIT_SCRIPT;
 import static org.netbeans.modules.gradle.loaders.GradleDaemon.TOOLING_JAR;
 import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.NbGradleProject;
-import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FALLBACK;
+import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.EVALUATED;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FULL_ONLINE;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.SIMPLE;
 import org.netbeans.modules.gradle.api.NbProjectInfo;
@@ -94,7 +94,7 @@ public class LegacyProjectLoader extends AbstractProjectLoader {
 
     @Override
     public boolean isEnabled() {
-        return ctx.aim.betterThan(FALLBACK);
+        return ctx.aim.betterThan(EVALUATED);
     }
 
     @NbBundle.Messages({

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
@@ -26,7 +26,6 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.junit.NbTestCase;
-import org.netbeans.modules.gradle.api.NbGradleProject;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FULL_ONLINE;
 import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
 import org.netbeans.modules.project.uiapi.ProjectOpenedTrampoline;
@@ -84,18 +83,14 @@ public class AbstractGradleProjectTestCase extends NbTestCase {
         NbGradleProjectImpl.RELOAD_RP.submit(() -> {
             // A bit low level calls, just to allow UI interaction to
             // Trust the project.
-            GradleProjectLoader loader = impl.getLookup().lookup(GradleProjectLoader.class);
-            impl.project = loader.loadProject(FULL_ONLINE, null, true, true);
-            NbGradleProjectImpl.ACCESSOR.doFireReload(NbGradleProject.get(impl));
+            impl.loadOwnProject(null, true, true, FULL_ONLINE);
         }).get();
     }
     
     protected FileObject createGradleProject(String path, String buildScript, String settingsScript) throws IOException {
         FileObject ret = FileUtil.toFileObject(getWorkDir());
         if (path != null) {
-            for (String p : path.split("/")) {
-                ret = ret.getFileObject(p) != null ? ret.getFileObject(p): ret.createFolder(p);
-            }
+            ret = FileUtil.createFolder(ret, path);
         }
         if (buildScript != null) {
             TestFileUtils.writeFile(ret, "build.gradle", buildScript);

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.junit.AssertionFailedErrorException;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
+import org.openide.filesystems.FileObject;
+
+/**
+ *
+ * @author sdedic
+ */
+public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
+    
+    public NbGradleProjectImplTest(String name) {
+        super(name);
+    }
+    
+    private Project createProject() throws Exception {
+        int rnd = new Random().nextInt(1000000);
+        FileObject a = createGradleProject("projectA-" + rnd,
+                "apply plugin: 'java'\n", "");
+        return ProjectManager.getDefault().findProject(a);
+    }
+    
+    /**
+     * Checks that untrusted unopened project will present itself as a fallback.
+     * @throws Exception 
+     */
+    public void testUntrustedProjectFallback() throws Exception {
+        Project prj = createProject();
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        
+        assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+    }
+    
+    /**
+     * Checks that untrusted unopened project will present itself as a fallback.
+     * @throws Exception 
+     */
+    public void testInitialLoadDoesNotFireChange() throws Exception {
+        Project prj = createProject();
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+    }
+    
+    /**
+     * Checks that an attempt to reload project with escalated quality will fail
+     * for an untrusted project.
+     * @throws Exception 
+     */
+    public void testUntrustedProjectCannotGoUp() throws Exception {
+        Project prj = createProject();
+        
+        NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
+        assertTrue(prjImpl.getGradleProject().getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+        // attempt to load everything
+        prjImpl.setAimedQuality(NbGradleProject.Quality.FULL);
+        // ... it loaded, but did not escalate the quality bcs not trusted
+        assertTrue(prjImpl.getGradleProject().getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+    }
+    
+    /**
+     * Check that a trusted project can be loaded as 'evaluated' quality, at least.
+     * @throws Exception 
+     */
+    public void testTrustedProjectLoadsToEvaluated() throws Exception {
+        Project prj = createProject();
+        
+        NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
+        assertTrue(prjImpl.getGradleProject().getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+        ProjectTrust.getDefault().trustProject(prj);
+        
+        // attempt to load everything
+        prjImpl.setAimedQuality(NbGradleProject.Quality.FULL);
+        // ... it loaded, but did not escalate the quality bcs not trusted
+        assertTrue(prjImpl.getGradleProject().getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
+    }
+
+    class L implements PropertyChangeListener {
+        volatile PropertyChangeEvent e;
+        volatile Semaphore block = new Semaphore(20);
+        Queue<PropertyChangeEvent> all = new ArrayBlockingQueue<>(20);
+        Semaphore processing = new Semaphore(0);
+        
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            processing.release();
+            try {
+                block.acquire();
+            } catch (InterruptedException ex) {
+                throw new AssertionFailedErrorException(ex);
+            }
+            e = evt;
+            all.add(evt);
+        }
+    }
+    
+    L projL = new L();
+    
+    /**
+     * Checks that initial load with 'fallback' quality does not fire 'project reloaded'
+     * event.
+     */
+    public void testInitialLoadReloadNotFired() throws Exception {
+        Project prj = createProject();
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        
+        ngp.addPropertyChangeListener(projL);
+        
+        Quality q = ngp.getQuality();
+        assertNull(projL.e);
+    }
+    
+    /**
+     * After the project changes (increases) the quality after initial load, check
+     * that the ProjectInfo property change is fired.
+     */
+    public void testProjectQualityUpgradeFiresChange() throws Exception {
+        Project prj = createProject();
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        ProjectTrust.getDefault().trustProject(prj);
+        // initializes the project
+        assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+        
+        // force project reload
+        ngp.addPropertyChangeListener(projL);
+        NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
+        prjImpl.setAimedQuality(NbGradleProject.Quality.FULL);
+        assertTrue(prjImpl.getGradleProject().getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
+        
+        assertNotNull(projL.e);
+        assertEquals(NbGradleProject.PROP_PROJECT_INFO, projL.e.getPropertyName());
+    }
+    
+    /**
+     * Checks that ProjectInfo events are processed before completion of the load future
+     */
+    public void testEventsProcessedBeforeCompletion() throws Exception {
+        Project prj = createProject();
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        ProjectTrust.getDefault().trustProject(prj);
+        // initializes the project
+        assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+        
+        ngp.addPropertyChangeListener(projL);
+        NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
+        
+        // block the dispatch
+        projL.block.drainPermits();
+        CompletableFuture<GradleProject> f = prjImpl.loadOwnProject0("Test reload", true, true, Quality.FULL, false);
+        assertFalse(f.isDone());
+        projL.processing.acquire();
+        // still not done, since blocked inside the listener
+        assertFalse(f.isDone());
+        projL.block.release();
+        // finally wait
+        GradleProject p = f.get();
+        assertTrue(p.getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
+    }
+    
+    
+    public void testIncreaseAimedQualityChangesProject() throws Exception {
+        Project prj = createProject();
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        ProjectTrust.getDefault().trustProject(prj);
+        // initializes the project
+        assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+        
+        NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
+        GradleProject curProject = prjImpl.getGradleProject();
+        prjImpl.setAimedQuality(Quality.FULL);
+        GradleProject newProject = prjImpl.getGradleProject();
+        assertTrue(newProject.getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
+        assertNotSame(newProject, curProject);
+        
+    }
+    
+    public void testSufficientAimedQualityNoop() throws Exception {
+        checkProjectDoesNotChange(Quality.FULL);
+    }
+    
+    public void testDecreaseAimedQualityNoop() throws Exception {
+        checkProjectDoesNotChange(Quality.EVALUATED);
+    }
+    
+    private void checkProjectDoesNotChange(Quality aimed) throws Exception {
+        Project prj = createProject();
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        ProjectTrust.getDefault().trustProject(prj);
+        NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
+        prjImpl.setAimedQuality(Quality.FULL);
+        assertTrue(ngp.getQuality().atLeast(Quality.FULL));
+        
+        GradleProject curProject = prjImpl.getGradleProject();
+        
+        prjImpl.setAimedQuality(aimed);
+        GradleProject newProject = prjImpl.getGradleProject();
+        assertTrue(newProject.getQuality().atLeast(Quality.FULL));
+        assertSame(newProject, curProject);
+        assertTrue(prjImpl.getAimedQuality().notBetterThan(aimed));
+    }
+}

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
@@ -20,17 +20,22 @@ package org.netbeans.modules.gradle;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.io.IOException;
 import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
+import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.junit.AssertionFailedErrorException;
 import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.NbGradleProject.Quality;
+import org.openide.filesystems.FileLock;
 import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 
 /**
  *
@@ -42,10 +47,13 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         super(name);
     }
     
+    private FileObject projectDir;
+    
     private Project createProject() throws Exception {
         int rnd = new Random().nextInt(1000000);
         FileObject a = createGradleProject("projectA-" + rnd,
                 "apply plugin: 'java'\n", "");
+        projectDir = a;
         return ProjectManager.getDefault().findProject(a);
     }
     
@@ -174,7 +182,7 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         
         // block the dispatch
         projL.block.drainPermits();
-        CompletableFuture<GradleProject> f = prjImpl.loadOwnProject0("Test reload", true, true, Quality.FULL, false);
+        CompletableFuture<GradleProject> f = prjImpl.loadOwnProject0("Test reload", true, true, Quality.FULL, false, true);
         assertFalse(f.isDone());
         projL.processing.acquire();
         // still not done, since blocked inside the listener
@@ -185,7 +193,11 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         assertTrue(p.getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
     }
     
-    
+    /**
+     * Checks that request to increase the quality changes the project. This case checks the project
+     * going from state {@link Quality#FALLBACK} (never built, trusted) to at least {@link Quality#EVALUATED}
+     * as Gradle script execution is permitted (now).
+     */
     public void testIncreaseAimedQualityChangesProject() throws Exception {
         Project prj = createProject();
         NbGradleProject ngp = NbGradleProject.get(prj);
@@ -200,6 +212,75 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
         assertTrue(newProject.getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
         assertNotSame(newProject, curProject);
         
+    }
+    
+    /**
+     * Aiming for EVALUATED quality does not force execution of the Gradle project, if
+     * the evaluated state does not exist.
+     */
+    public void testEvaluateTrustedDoesNotExecuteScript() throws Exception {
+        Project prj = createProject();
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        ProjectTrust.getDefault().trustProject(prj);
+        // initializes the project
+        assertTrue(ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+        
+        NbGradleProjectImpl prjImpl = prj.getLookup().lookup(NbGradleProjectImpl.class);
+        GradleProject curProject = prjImpl.getGradleProject();
+        prjImpl.setAimedQuality(Quality.EVALUATED);
+        GradleProject newProject = prjImpl.getGradleProject();
+        assertTrue(newProject.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+        assertSame(newProject, curProject);
+    }
+    
+    /**
+     * Trusts and closes the project. To avoid project caches, creates a copy in another
+     * folder & swaps (FileObject will be different, name the same).
+     * Upon new open checks that the project loaded to at least evaluted quality (provided it
+     * was full before).
+     */
+    public void testAllowedProjectLoadsImmediately() throws Exception {
+        Project prj = createProject();
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        ProjectTrust.getDefault().trustProject(prj);
+
+        FileObject s = projectDir.getParent().createFolder("second");
+        
+        // open and close the project.
+        OpenProjects.getDefault().open(new Project[] { prj }, false);
+        OpenProjects.getDefault().openProjects().get();
+        OpenProjects.getDefault().close(new Project[] { prj });
+        OpenProjects.getDefault().openProjects().get();
+        
+        assertTrue(ngp.getQuality().atLeast(Quality.EVALUATED));
+
+        copy(projectDir, s);
+
+        String origName = projectDir.getName();
+        // rename the files; the cache encodes full path to the project.
+        try (FileLock fl = projectDir.lock()) {
+            projectDir.rename(fl, "old", null);
+        }
+        try (FileLock fl = s.lock()) {
+            s.rename(fl, origName, null);
+        }
+        
+        Project prj2 = FileOwnerQuery.getOwner(s);
+        NbGradleProject ngp2 = NbGradleProject.get(prj2);
+        // initializes the project, since it is trusted (reopened), should come
+        // in at least EVALUATED quality
+        assertTrue(ngp2.getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
+    }
+
+    private static void copy(FileObject orig, FileObject to) throws IOException {
+        for (FileObject x : orig.getChildren()) {
+            if (x.isFolder()) {
+                FileObject cp = FileUtil.createFolder(to, x.getNameExt());
+                copy(x, cp);
+            } else {
+                x.copy(to, x.getName(), x.getExt());
+            }
+        }
     }
     
     public void testSufficientAimedQualityNoop() throws Exception {

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/ProjectTrustTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/ProjectTrustTest.java
@@ -35,7 +35,7 @@ public class ProjectTrustTest extends AbstractGradleProjectTestCase {
     public ProjectTrustTest(String name) {
         super(name);
     }
-
+    
     public void testIsTrusted4Untrusted() throws IOException {
         int rnd = new Random().nextInt(1000000);
         FileObject a = createGradleProject("projectA-" + rnd,

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
@@ -48,6 +48,7 @@ import org.openide.util.Utilities;
 
 import static org.netbeans.api.java.classpath.ClassPath.*;
 import static org.netbeans.api.java.classpath.JavaClassPathConstants.*;
+import org.openide.util.WeakListeners;
 /**
  *
  * @author Laszlo Kishalmi
@@ -70,36 +71,58 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
     ));
 
 
-    private final Map<String, SourceSetCP> groups = new HashMap<>();
     private final Project project;
     private final PropertyChangeListener pcl;
+    private final PropertyChangeListener wPcl;
+
+    // @GuardedBy(this)
+    private volatile Map<String, SourceSetCP> groups = new HashMap<>();
 
     public ClassPathProviderImpl(Project project) {
         this.project = project;
         this.pcl = (PropertyChangeEvent evt) -> {
             if (NbGradleProject.PROP_PROJECT_INFO.equals(evt.getPropertyName())) {
-                GradleJavaProject p = GradleJavaProject.get(ClassPathProviderImpl.this.project);
-                if (p != null) {
-                    updateGroups(p.getSourceSets().keySet());
-                } else {
-                    //We are no longer a Java Project
-                    updateGroups(Collections.<String>emptySet());
-
-                }
+                updateGroups();
             }
             if (NbGradleProject.PROP_RESOURCES.endsWith(evt.getPropertyName())) {
                 URI uri = (URI) evt.getNewValue();
-                if ((uri != null) && (uri.getPath() != null) && uri.getPath().endsWith(MODULE_INFO_JAVA)) {
-                    GradleJavaProject gjp = GradleJavaProject.get(ClassPathProviderImpl.this.project);
-                    if (gjp != null) {
-                        GradleJavaSourceSet ss = gjp.containingSourceSet(Utilities.toFile(uri));
-                        if ((ss != null) && (groups.get(ss.getName()) != null)) {
-                            groups.get(ss.getName()).reset();
-                        }
-                    }
-                }
+                updateResources(uri);
             }
         };
+        this.wPcl = WeakListeners.propertyChange(pcl, null, project);
+        // by some miracle, the project might have been loaded!
+        NbGradleProject gp = NbGradleProject.get(project);
+        if (gp.isGradleProjectLoaded()) {
+            updateGroups();
+        }
+        NbGradleProject.addPropertyChangeListener(project, wPcl);
+    }
+    
+    private void updateResources(URI uri) {
+        if ((uri != null) && (uri.getPath() != null) && uri.getPath().endsWith(MODULE_INFO_JAVA)) {
+            GradleJavaProject gjp = GradleJavaProject.get(project);
+            if (gjp != null) {
+                GradleJavaSourceSet ss = gjp.containingSourceSet(Utilities.toFile(uri));
+                if (ss == null) {
+                    return;
+                }
+                SourceSetCP ssp = groups.get(ss.getName());
+                if (ssp != null) {
+                    // reset may fire events
+                    ssp.reset();
+                }
+            }
+        }
+    }
+    
+    private void updateGroups() {
+        GradleJavaProject p = GradleJavaProject.get(ClassPathProviderImpl.this.project);
+        if (p != null) {
+            updateGroups(p.getSourceSets().keySet());
+        } else {
+            //We are no longer a Java Project
+            updateGroups(Collections.<String>emptySet());
+        }
     }
 
     @Override
@@ -108,7 +131,6 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
         if (!SUPPORTED_PATHS.contains(type) || (prj == null)) {
             return null;
         }
-
         GradleJavaSourceSet sourceSet = prj.containingSourceSet(FileUtil.toFile(fo));
         return sourceSet != null ? getSourceSetPath(type, sourceSet) : null;
     }
@@ -120,7 +142,6 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
 
     @Override
     protected void projectOpened() {
-        NbGradleProject.addPropertyChangeListener(project, pcl);
         GradleJavaProject p = GradleJavaProject.get(project);
         if (p != null) {
             updateGroups(p.getSourceSets().keySet());
@@ -129,13 +150,13 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
 
     @Override
     protected void projectClosed() {
-        updateGroups(Collections.<String>emptySet());
         NbGradleProject.removePropertyChangeListener(project, pcl);
     }
 
     private void updateGroups(Set<String> newGroups) {
-        synchronized(groups) {
-            Iterator<Map.Entry<String, SourceSetCP>> it = groups.entrySet().iterator();
+        synchronized(this) {
+            Map<String, SourceSetCP> g = new HashMap<>(groups);
+            Iterator<Map.Entry<String, SourceSetCP>> it = g.entrySet().iterator();
             while(it.hasNext()) {
                 Map.Entry<String, SourceSetCP> oldGroup = it.next();
                 if (!newGroups.contains(oldGroup.getKey())) {
@@ -143,11 +164,12 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
                 }
             }
             for (String newGroup : newGroups) {
-                if (!groups.containsKey(newGroup)) {
+                if (!g.containsKey(newGroup)) {
                     SourceSetCP scp = new SourceSetCP(newGroup);
-                    groups.put(newGroup, scp);
+                    g.put(newGroup, scp);
                 }
             }
+            this.groups = g;
         }
     }
 
@@ -171,7 +193,9 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
         ClassPath moduleLegacyRuntime;
 
         final String group;
-        List<SourceSetAwareSelector> selectors = new ArrayList<>();
+        
+        // @GuardedBy(this)
+        final List<SourceSetAwareSelector> selectors = new ArrayList<>();
 
         SourceSetCP(String group) {
             this.group = group;
@@ -308,6 +332,7 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
             return moduleCompile;
         }
 
+        // @GuardedBy(this)
         private ClassPath createMultiplexClassPath(ClassPath modulePath, ClassPath classPath) {
             SourceSetAwareSelector selector = new SourceSetAwareSelector(modulePath, classPath);
             selectors.add(selector);
@@ -321,7 +346,12 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
         }
 
         public void reset() {
-            for (SourceSetAwareSelector selector : selectors) {
+            List<SourceSetAwareSelector> copy;
+            synchronized (this) {
+                copy = new ArrayList<>(selectors);
+            }
+            // fire events outside lock
+            for (SourceSetAwareSelector selector : copy) {
                 selector.reset();
             }
         }
@@ -358,11 +388,14 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
             }
 
             private void reset() {
-                ClassPath oldActive = active;
-                active = hasModuleInfo() ? modulePath : classPath;
-                if (oldActive != active) {
-                    support.firePropertyChange(PROP_ACTIVE_CLASS_PATH, null, null);
+                synchronized (this) {
+                    ClassPath oldActive = active;
+                    active = hasModuleInfo() ? modulePath : classPath;
+                    if (oldActive == active) {
+                        return;
+                    }
                 }
+                support.firePropertyChange(PROP_ACTIVE_CLASS_PATH, null, null);
             }
         }
     }

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/GradleCoreAccessor.java
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/GradleCoreAccessor.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.gradle;
+
+import org.netbeans.api.project.Project;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+
+public class GradleCoreAccessor {
+    public static void dumpProject(Project p) {
+        NbGradleProjectImpl impl = p.getLookup().lookup(NbGradleProjectImpl.class);
+        impl.setAimedQuality(NbGradleProject.Quality.FALLBACK);
+        impl.dumpProject();
+    }
+}

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImplTest.java
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImplTest.java
@@ -19,16 +19,29 @@
 package org.netbeans.modules.gradle.java.classpath;
 
 import java.io.File;
+import java.io.IOException;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import junit.framework.AssertionFailedError;
 import org.junit.Test;
 import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.modules.gradle.AbstractGradleProjectTestCase;
+import org.netbeans.modules.gradle.ProjectTrust;
+import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.java.api.GradleJavaProject;
 import org.netbeans.spi.java.classpath.ClassPathProvider;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.filesystems.FileLock;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.lookup.Lookups;
 
 /**
  *
@@ -63,5 +76,191 @@ public class ClassPathProviderImplTest extends AbstractGradleProjectTestCase {
             assertTrue(rt.contains(output));
         }
     }
+    
+    /**
+     * The created java file
+     */
+    FileObject java;
+    
+    /**
+     * The created buildscript
+     */
+    FileObject project;
+    
+    String path;
+    
+    private void createSimpleApp() throws IOException {
+        FileObject d = FileUtil.toFileObject(getDataDir());
+        FileObject main = d.getFileObject("javasimple/src/main/java/test/App.java");
+        project = createGradleProject(path, "apply plugin: 'java'", null);
+        FileObject src = FileUtil.createFolder(project, "src/main/java/test");
+        java = FileUtil.copyFile(main, src, main.getName());
+    }
+    
+    public void testUntrustedSourcePath() throws Exception {
+        createSimpleApp();
+        Project prj = FileOwnerQuery.getOwner(java);
+        assertNotNull(prj);
+        // declare the project as trusted.
+        
+        ClassPath cp = ClassPath.getClassPath(java, ClassPath.SOURCE);
+        assertNotNull("Source classpath must exist for a (standard) source folder", cp);
+        FileObject r = cp.findResource("test/App.java");
+        assertSame("Class source must be on source classpath", java, r);
+        
+        // check that the project is STILL not even EVALUATED so it did not invoke Gradle:
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        assertTrue("Untrusted new project must not leave FALLBACK", ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+    }
+    
+    public void testUntrustedSourcesNoCompile() throws Exception {
+        createSimpleApp();
+        ClassPath cp = ClassPath.getClassPath(java, ClassPath.COMPILE);
+        assertEquals("No compile roots for untrusted new project", 0, cp.getRoots().length);
+        Project prj = FileOwnerQuery.getOwner(java);
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        assertTrue("Untrusted new project must not leave FALLBACK", ngp.getQuality().worseThan(NbGradleProject.Quality.EVALUATED));
+    }
+    
+    public void testUntrustedSourceHasJDK() throws Exception {
+        createSimpleApp();
+        ClassPath bcp = ClassPath.getClassPath(java, ClassPath.BOOT);
+        assertTrue("Even untrusted project must have a JDK", bcp.getRoots().length > 0);
+    }
+    
+    private void compileProject(Project prj) throws Exception {
+        ProjectTrust.getDefault().trustProject(prj);
+        ActionProvider ap = prj.getLookup().lookup(ActionProvider.class);
+        
+        CountDownLatch latch = new CountDownLatch(1);
+        ap.invokeAction(ActionProvider.COMMAND_BUILD, Lookups.fixed(new ActionProgress() {
+            @Override
+            protected void started() {
+            }
 
+            @Override
+            public void finished(boolean success) {
+                latch.countDown();
+            }
+        }));
+        latch.await();
+    }
+    
+    /**
+     * Checks that the compile path is nonempty after successful compilaiton.
+     */
+    public void testTrustedSourcesCompilePath() throws Exception {
+        createSimpleApp();
+        Project prj = FileOwnerQuery.getOwner(java);
+        compileProject(prj);
+        ClassPath cp = ClassPath.getClassPath(java, ClassPath.COMPILE);
+        assertEquals(1, cp.getRoots().length);
+    }
+    
+    /**
+     * Checks that the project is released.
+     */
+    public void testProjectReleased() throws Exception {
+        createSimpleApp();
+        Project prj = FileOwnerQuery.getOwner(java);
+        Reference<Project> refProject = new WeakReference<>(prj);
+        prj = null;
+        
+        // because of TimedWeakReference in Project API, need to wait > 15 seconds
+        Thread.sleep(20 *1000);
+        assertGC("Project must GC", refProject);
+    }
+    
+    
+    private void openAndCloseProject(Project prj) throws Exception {
+        OpenProjects.getDefault().open(new Project[] { prj }, false);
+        OpenProjects.getDefault().openProjects().get();
+        OpenProjects.getDefault().close(new Project[] { prj });
+        OpenProjects.getDefault().openProjects().get();
+    }
+    
+    /**
+     * Checks that the project is released.
+     */
+    public void testOpenedProjectReleased() throws Exception {
+        createSimpleApp();
+        Project prj = FileOwnerQuery.getOwner(java);
+        openAndCloseProject(prj);
+        
+        Reference<Project> refProject = new WeakReference<>(prj);
+        prj = null;
+        
+        // because of TimedWeakReference in Project API, need to wait > 15 seconds
+        Thread.sleep(20 *1000);
+        assertGC("Project must GC", refProject);
+    }
+
+    /**
+     * Checks that a trusted, once compiled project will provide nonempty compile classpath
+     * just after open.
+     */
+    public void testCompileNonemptyOnceCompiled() throws Exception {
+        createSimpleApp();
+        Project prj = FileOwnerQuery.getOwner(java);
+        compileProject(prj);
+        
+        // open the project - and then close it, so the project is ditched by Gradle module.
+        openAndCloseProject(prj);
+
+        ProjectTrust.getDefault().distrustProject(prj);
+        
+        NbGradleProject ngp = NbGradleProject.get(prj);
+        assertTrue("Closed project should be at least EVALUATED", ngp.getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
+        
+        ClassPath cp = ClassPath.getClassPath(java, ClassPath.COMPILE);
+        assertFalse("Cached project must know its COMPILE path", cp.getRoots().length == 0);
+    }
+
+    /**
+     * Checks that a trusted, once compiled project will provide nonempty compile classpath
+     * just after open.
+     */
+    public void testCompilePreTrusted() throws Exception {
+        path = "first";
+        createSimpleApp();
+        Project prj = FileOwnerQuery.getOwner(java);
+        compileProject(prj);
+        
+        // open the project - and then close it, so the project is ditched by Gradle module.
+        openAndCloseProject(prj);
+
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        FileObject s = wd.createFolder("second");
+        
+        copy(project, s);
+        
+        // rename the files; the cache encodes full path to the project.
+        try (FileLock fl = project.lock()) {
+            project.rename(fl, "old", null);
+        }
+        try (FileLock fl = project.lock()) {
+            s.rename(fl, "first", null);
+        }
+        
+        Project prj2 = FileOwnerQuery.getOwner(s);
+        assertNotSame(prj, prj2);
+        FileObject j2 = s.getFileObject("src/main/java/test/App.java");
+        
+        NbGradleProject ngp = NbGradleProject.get(prj2);
+        assertTrue("Closed project should be at least EVALUATED", ngp.getQuality().atLeast(NbGradleProject.Quality.EVALUATED));
+        
+        ClassPath cp = ClassPath.getClassPath(j2, ClassPath.COMPILE);
+        assertFalse("Cached project must know its COMPILE path", cp.getRoots().length == 0);
+    }
+    
+    private void copy(FileObject orig, FileObject to) throws IOException {
+        for (FileObject x : orig.getChildren()) {
+            if (x.isFolder()) {
+                FileObject cp = FileUtil.createFolder(to, x.getNameExt());
+                copy(x, cp);
+            } else {
+                x.copy(to, x.getName(), x.getExt());
+            }
+        }
+    }
 }


### PR DESCRIPTION
This is an attempt to solve [NETBEANS-5627](https://issues.apache.org/jira/browse/NETBEANS-5627) and [NETBEANS-5629](https://issues.apache.org/jira/browse/NETBEANS-5629)

**It is still work in progress - but complete enough for feedback**

Major highlights of the change:
- a fresh new (untrusted) project still loads as `FALLBACK` state. **But** the Fallback heuristic is immediately applied, so the project (typically) knows its (java) source groups.
- creation attempts to load `EVALUATED` quality. This will eventually load cached info, if available
- with LegacyProjectLoader loading from above EVALUATED the project creation will not invoke Gradle build (the same as now).
- Lookup is initialized with plugins from the start: Fallback loader guesses something, and there's also [NETBEANS-5628](https://issues.apache.org/jira/browse/NETBEANS-5628) that could further improve the initial experience.
- Lookups are in a defined order: Plugins first, the default Lookup first, Plugins next, `_any` (any plugin, fallbacks) last. Similar to Maven. (see [NETBEANS-5629](https://issues.apache.org/jira/browse/NETBEANS-5629)). This allows to add pre-process, make specific stuff with plugin-specific services and do a post-process.
- If plugin Lookups change, their relative order is maintained
- ClassPath starts to listen at the start of its existence
- there were quite a few potential races in both NbGradleProjectImpl and ClasspathProviderImpl. Attempted to synchronize, while firing events out outside of any locks.

In effect, a code that does
```
FileObject someSource = ...;
ClassPath cp = ClassPath.getClassPath(someSource);
```
starts working even on an **unopened** Gradle project, typically. In less typical setups one has to prime / build the project, so NetBeans create its caches.

There are things to improve still:
- apichanges: the Lookups need to be documented, but see the discussion in NETBEANS-5629. Also GradleProject has one more method to (re)load the project at the defined quality
- classpath queries **might** attempt to upgrade the project to FULL when it realizes the project is lesser quality. But I didn't want to do it synchronously in the query - maybe should be done asynchronosly, but that's still lacking some reload pooling
- an attempted reload could piggyback on an asynchronous **pending or scheduled** reload. Typically a reload could reuse stuff from reload-after-build or a pending upgrade-quality reload.
- I must write more tests.
