### PR TITLE
[NETBEANS-5640] Fixing potential NPE on out of project Folder creation

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/SimpleTargetChooserPanelGUI.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/SimpleTargetChooserPanelGUI.java
@@ -551,8 +551,8 @@ public class SimpleTargetChooserPanelGUI extends javax.swing.JPanel implements A
         public @Override Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
             if (value instanceof SourceGroup) {
                 SourceGroup group = (SourceGroup)value;
-                String projectDisplayName = ProjectUtils.getInformation( project ).getDisplayName();
                 String groupDisplayName = group.getDisplayName();
+                String projectDisplayName = project != null ? ProjectUtils.getInformation( project ).getDisplayName() : groupDisplayName;
                 if ( projectDisplayName.equals( groupDisplayName ) ) {
                     setText( groupDisplayName );
                 }


### PR DESCRIPTION
Well I get a nasty NPE when try to create a folder out of a project. This might be triggered by another bug in the system as it is unlikely to have a sourcegroup without a project though in the context of the ```SimpleTargetChooserPanelGUI``` class having the project field as ```null``` is indeed allowed. 
This is a trivial fix to prevent an NPE when that happen.

Unfortunately I do not know how to reliably reproduce this event. On one of my IDE instances it happens all the time, the other instance it does not.