### PR TITLE
Improved messages when project is opened bcs of file being worked on.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -342,7 +342,7 @@ public final class Server {
         @NbBundle.Messages({
             "PROMPT_AskOpenProjectForFile=File {0} belongs to project {1}. To enable all features, the project should be opened"
                     + " and initialized by the Language Server. Do you want to proceed ?",
-            "PROMPT_AskOpenProjectForFileNoName=File {0} belongs to a project. To enable all features, the project should be opened"
+            "PROMPT_AskOpenProject=To enable all features of project {0}, it should be opened"
                     + " and initialized by the Language Server. Do you want to proceed ?",
             "PROMPT_AskOpenProjectForFile_Yes=Open and initialize",
             "PROMPT_AskOpenProjectForFile_No=No",
@@ -399,10 +399,10 @@ public final class Server {
                         yes,
                         new MessageActionItem(Bundle.PROMPT_AskOpenProjectForFile_No())
                     ));
-                    if (dispName.equals(prj.getProjectDirectory().getPath())) {
-                        smrp.setMessage(Bundle.PROMPT_AskOpenProjectForFileNoName(file.getPath()));
+                    if (prj.getProjectDirectory() == file) {
+                        smrp.setMessage(Bundle.PROMPT_AskOpenProject(dispName));
                     } else {
-                        smrp.setMessage(Bundle.PROMPT_AskOpenProjectForFile(file.getPath(), dispName));
+                        smrp.setMessage(Bundle.PROMPT_AskOpenProjectForFile(file.getNameExt(), dispName));
                     }
                     smrp.setType(MessageType.Info);
 


### PR DESCRIPTION
LSP server sometimes produces very funny messages. Because of indexing features and project contents, we need to "open" the projects and perhaps prime them (so subprojects are read etc), but that happens 'behind the scenes' for the user - the user only knows he's working with a file. So a message "file belongs A to a project B" appears. But:
- if the `FileObject` passed to the asyncOpen() is the project itself, the message was very informative: "File /foo/bar/projectX belongs to project projectX...".
- the full path to file can be VERY long
