### PR TITLE
[NETBEANS-5475] fix potential NPE after GradleJavaSourceSet.relativePath() calls

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/GradleJavaTokenProvider.java
@@ -134,11 +134,13 @@ public class GradleJavaTokenProvider implements ReplaceTokenProvider {
             GradleJavaSourceSet sourceSet = gjp.containingSourceSet(f);
             if (sourceSet != null) {
                 String relPath = sourceSet.relativePath(f);
-                ret = (relPath.lastIndexOf('.') > 0 ?
-                        relPath.substring(0, relPath.lastIndexOf('.')) :
-                        relPath).replace('/', '.');
-                if (fo.isFolder()) {
-                    ret = ret + '*';
+                if (relPath != null) {
+                    ret = (relPath.lastIndexOf('.') > 0 ?
+                            relPath.substring(0, relPath.lastIndexOf('.')) :
+                            relPath).replace('/', '.');
+                    if (fo.isFolder()) {
+                        ret = ret + '*';
+                    }
                 }
             }
         }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/FileBuiltQueryImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/FileBuiltQueryImpl.java
@@ -113,15 +113,17 @@ public class FileBuiltQueryImpl extends ProjectOpenedHook implements FileBuiltQu
             GradleJavaSourceSet sourceSet = gjp.containingSourceSet(f);
             if (sourceSet != null) {
                 String relFile = sourceSet.relativePath(f);
-                String relClass = relFile.substring(0, relFile.lastIndexOf('.')) + ".class"; //NOI18N
-                String moduleRoot = null;
-                File moduleInfo = sourceSet.findResource("module-info.java", false, JAVA); //NOI18N
-                if (moduleInfo != null && sourceSet.getCompilerArgs(JAVA).contains("--module-source-path")) {
-                    moduleRoot = SourceUtils.parseModuleName(FileUtil.toFileObject(moduleInfo));
+                if (relFile != null) {
+                    String relClass = relFile.substring(0, relFile.lastIndexOf('.')) + ".class"; //NOI18N
+                    String moduleRoot = null;
+                    File moduleInfo = sourceSet.findResource("module-info.java", false, JAVA); //NOI18N
+                    if (moduleInfo != null && sourceSet.getCompilerArgs(JAVA).contains("--module-source-path")) {
+                        moduleRoot = SourceUtils.parseModuleName(FileUtil.toFileObject(moduleInfo));
+                    }
+                    try {
+                        ret = new StatusImpl(file, sourceSet.getOutputClassDirs(), relClass, moduleRoot);
+                    } catch (DataObjectNotFoundException ex) {}
                 }
-                try {
-                    ret = new StatusImpl(file, sourceSet.getOutputClassDirs(), relClass, moduleRoot);
-                } catch (DataObjectNotFoundException ex) {}
             }
 
         }


### PR DESCRIPTION
A trivial fix for potential NPE-s.

(NETBEANS-5475)[https://issues.apache.org/jira/browse/NETBEANS-5475] is originally marked as blocker.

It would be nice to have it in the next RC, if I had not missed the train