### PR TITLE
[NETBEANS-5655] Fix build error caused by non-ASCII quotes in an arch.xml file

### DIFF
--- a/nbbuild/javadoctools/build.xml
+++ b/nbbuild/javadoctools/build.xml
@@ -125,7 +125,7 @@
         <echo file="${export.interfaces}/footer.gen">
             &lt;/alldata&gt;
         </echo>
-        <concat destfile="${netbeans.javadoc.dir}/alldatas.xml">
+        <concat destfile="${netbeans.javadoc.dir}/alldatas.xml" encoding="UTF-8" outputencoding="UTF-8">
             <fileset dir="${export.interfaces}" includes="header.gen"/>
             <fileset file="${netbeans.javadoc.dir}/allclasses.xml"/>
             <fileset file="${netbeans.javadoc.dir}/modules.xml"/>


### PR DESCRIPTION
I was doing a build on Windows today, and got the following error:

```
BUILD FAILED
C:\Users\ebakke\ZRoot\nbsrc\incubator-netbeans\nbbuild\build.xml:395: The following error occurred while executing this line:
C:\Users\ebakke\ZRoot\nbsrc\incubator-netbeans\nbbuild\javadoctools\build.xml:48: The following error occurred while executing this line:
C:\Users\ebakke\ZRoot\nbsrc\incubator-netbeans\nbbuild\javadoctools\build.xml:149: javax.xml.transform.TransformerException: javax.xml.transform.TransformerException: com.sun.org.apache.xml.internal.utils.WrappedRuntimeException: Invalid byte 3 of 3-byte UTF-8 sequence.
```

Examining build.xml:149, it points to the file nbbuild/build/javadoc/alldatas.xml, which indeed appears to have a malformed UTF-8 character somewhere.

Doing some further investigation...

```
ebakke@EBLEN:/z/nbsrc/incubator-netbeans/nbbuild/build/javadoc$ diff alldatas1.xml alldatas2.xml
5139c5139
<       when running in “compile-on-save? mode
---
>       when running in “compile-on-save�? mode
```

Easy to fix--just use regular ASCII quotes instead of MS Word style "smart quotes".