### PR TITLE
[NETBEANS-5656] Various smaller fixes in the database New Connection wizard

### DIFF
--- a/ide/db/src/org/netbeans/modules/db/explorer/Bundle.properties
+++ b/ide/db/src/org/netbeans/modules/db/explorer/Bundle.properties
@@ -21,7 +21,9 @@ SchemaIsNotSet=Default schema
 
 EXC_InsufficientConnInfo=insufficient information to create a connection
 # {0} is database URL, {1} is the database driver name, {2} is additional info 
-EXC_CannotEstablishConnection=Cannot establish a connection to {0} using {1} ({2})
+# The "New Connection Wizard" only has space for the first part of the message, so put the message
+# from the driver (parameter {2}), which usually explains the error, first.
+EXC_CannotEstablishConnection=Connection failed: {2} ({0} using {1})
 
 # {0} is a user provided value
 EXC_CannotOperateWith=Cannot operate with {0}

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
@@ -160,6 +160,7 @@ public final class AddDriverDialog extends javax.swing.JPanel {
         String fileName = null;
         dlm.clear();
         drvs.clear();
+        jarClassLoader = null;
         URL[] urls = drv == null ? new URL[0] : drv.getURLs();
         for (int i = 0; i < urls.length; i++) {
             URL url = urls[i];
@@ -379,6 +380,7 @@ public final class AddDriverDialog extends javax.swing.JPanel {
             if (lsm.isSelectedIndex(i)) {
                 dlm.remove(i);
                 drvs.remove(i);
+                jarClassLoader = null;
                 count--;
                 continue;
             }
@@ -431,6 +433,7 @@ public final class AddDriverDialog extends javax.swing.JPanel {
                     dlm.addElement(file.toString());
                     try {
                         drvs.add(file.toURI().toURL());
+                        jarClassLoader = null;
                     } catch (MalformedURLException exc) {
                         LOGGER.log(Level.WARNING,
                                 "Unable to add driver jar file " +
@@ -603,10 +606,11 @@ public final class AddDriverDialog extends javax.swing.JPanel {
     }
     
     private URLClassLoader getJarClassLoader() {
-        // This classloader is used to load classes
-        // from the jar files for the driver.  We can then use
-        // introspection to see if a class in one of these jar files
-        // implements java.sql.Driver
+        /* This classloader is used to load classes from the jar files for the driver.  We can then
+        introspection to see if a class in one of these jar files implements java.sql.Driver. (We
+        clear the jarClassLoader whenever drvs is modified, to avoid the AddDriverNotJavaSqlDriver
+        message popping up if a different driver is picked from the dropdown after an unrelated JAR
+        file is added.) */
         jarClassLoader =
                 new URLClassLoader(drvs.toArray(new URL[drvs.size()]),
                 this.getClass().getClassLoader());

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingConnectionNamePanel.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingConnectionNamePanel.java
@@ -30,6 +30,7 @@ import org.openide.util.HelpCtx;
 
 public class ChoosingConnectionNamePanel implements AddConnectionWizard.Panel {
 
+    private final int stepIndex;
     /**
      * The visual component that displays this panel. If you need to access the
      * component from this class, just use getComponent().
@@ -38,6 +39,10 @@ public class ChoosingConnectionNamePanel implements AddConnectionWizard.Panel {
     private AddConnectionWizard pw;
     private static HelpCtx CHOOSING_SCHEMA_PANEL_HELPCTX = new HelpCtx(ChoosingConnectionNamePanel.class);
     private boolean blockEventListener = false;
+
+    public ChoosingConnectionNamePanel(int stepIndex) {
+        this.stepIndex = stepIndex;
+    }
 
     // Get the visual component for the panel. In this template, the component
     // is kept separate. This can be more efficient: if the wizard is created
@@ -51,7 +56,7 @@ public class ChoosingConnectionNamePanel implements AddConnectionWizard.Panel {
             }
             assert pw != null : "ChoosingConnectionNamePanel must be initialized.";
             component = new ConnectionNamePanel(pw, pw.getDatabaseConnection().getDisplayName());
-            component.setName(pw.getSteps()[3]);
+            component.setName(pw.getSteps()[stepIndex]);
             component.addPropertyChangeListener(ConnectionNamePanel.PROP_CONNECTION_NAME,
                     new PropertyChangeListener() {
                 @Override

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingDriverPanel.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingDriverPanel.java
@@ -31,10 +31,12 @@ import org.openide.util.HelpCtx;
 
 public class ChoosingDriverPanel implements AddConnectionWizard.Panel {
 
+    private final int stepIndex;
     private AddConnectionWizard pw;
 
-    public ChoosingDriverPanel(JDBCDriver driver) {
+    public ChoosingDriverPanel(JDBCDriver driver, int stepIndex) {
         this.driver = driver;
+        this.stepIndex = stepIndex;
     }
 
     /**
@@ -56,7 +58,7 @@ public class ChoosingDriverPanel implements AddConnectionWizard.Panel {
             }
             component = new ChoosingDriverUI(this, driver, pw);
             JComponent jc = (JComponent) component;
-            jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, 0);
+            jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, stepIndex);
             jc.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, pw.getSteps());
             jc.putClientProperty(WizardDescriptor.PROP_AUTO_WIZARD_STYLE, Boolean.TRUE);
             jc.putClientProperty(WizardDescriptor.PROP_CONTENT_DISPLAYED, Boolean.FALSE);

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingSchemaPanel.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/ChoosingSchemaPanel.java
@@ -25,6 +25,7 @@ import org.openide.util.HelpCtx;
 
 public class ChoosingSchemaPanel implements AddConnectionWizard.Panel, WizardDescriptor.FinishablePanel<AddConnectionWizard> {
 
+    private final int stepIndex;
     /**
      * The visual component that displays this panel. If you need to access the
      * component from this class, just use getComponent().
@@ -32,6 +33,10 @@ public class ChoosingSchemaPanel implements AddConnectionWizard.Panel, WizardDes
     private SchemaPanel component;
     private AddConnectionWizard pw;
     private static HelpCtx CHOOSING_SCHEMA_PANEL_HELPCTX = new HelpCtx(ChoosingSchemaPanel.class);
+
+    public ChoosingSchemaPanel(int stepIndex) {
+        this.stepIndex = stepIndex;
+    }
 
     // Get the visual component for the panel. In this template, the component
     // is kept separate. This can be more efficient: if the wizard is created
@@ -46,12 +51,12 @@ public class ChoosingSchemaPanel implements AddConnectionWizard.Panel, WizardDes
             assert pw != null : "ChoosingSchemaPanel must be initialized.";
             component = new SchemaPanel(pw, pw.getDatabaseConnection());
             component.setSchemas(pw.getSchemas(), pw.getCurrentSchema());
-            component.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, 2);
+            component.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, stepIndex);
             component.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, pw.getSteps());
             component.putClientProperty(WizardDescriptor.PROP_AUTO_WIZARD_STYLE, Boolean.TRUE);
             component.putClientProperty(WizardDescriptor.PROP_CONTENT_DISPLAYED, Boolean.FALSE);
             component.putClientProperty(WizardDescriptor.PROP_CONTENT_NUMBERED, Boolean.FALSE);
-            component.setName(pw.getSteps()[2]);
+            component.setName(pw.getSteps()[stepIndex]);
         }
         return component;
     }

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionPanel.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionPanel.java
@@ -45,12 +45,15 @@ import org.openide.util.NbBundle;
 
 public class ConnectionPanel implements AddConnectionWizard.Panel, WizardDescriptor.AsynchronousValidatingPanel<AddConnectionWizard>, WizardDescriptor.FinishablePanel<AddConnectionWizard> {
 
+    private final int stepIndex;
     private DatabaseConnection databaseConnection;
     private JDBCDriver drv;
     private JDBCDriver oldDriver;
     private static HelpCtx CONNECTION_PANEL_HELPCTX = new HelpCtx(ConnectionPanel.class);
 
-    public ConnectionPanel() {}
+    public ConnectionPanel(int stepIndex) {
+        this.stepIndex = stepIndex;
+    }
     /**
      * The visual component that displays this panel. If you need to access the
      * component from this class, just use getComponent().
@@ -78,12 +81,12 @@ public class ConnectionPanel implements AddConnectionWizard.Panel, WizardDescrip
             component = new NewConnectionPanel(pw, this, drv.getClassName(), databaseConnection);
             oldDriver = drv;
             JComponent jc = (JComponent) component;
-            jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, 1);
+            jc.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, stepIndex);
             jc.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, pw.getSteps());
             jc.putClientProperty(WizardDescriptor.PROP_AUTO_WIZARD_STYLE, Boolean.TRUE);
             jc.putClientProperty(WizardDescriptor.PROP_CONTENT_DISPLAYED, Boolean.FALSE);
             jc.putClientProperty(WizardDescriptor.PROP_CONTENT_NUMBERED, Boolean.FALSE);
-            component.setName(pw.getSteps()[1]);
+            component.setName(pw.getSteps()[stepIndex]);
             fireChangeEvent();
             component.checkValid();
         }

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionPanel.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/ConnectionPanel.java
@@ -192,7 +192,7 @@ public class ConnectionPanel implements AddConnectionWizard.Panel, WizardDescrip
 
             databaseConnection.addExceptionListener(excListener);
             databaseConnection.connectAsync();
-            int maxLoops = 60;
+            int maxLoops = 20;
             int loop = 0;
             while (loop < maxLoops) {
                 try {

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/NewConnectionPanel.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/NewConnectionPanel.java
@@ -894,8 +894,14 @@ public class NewConnectionPanel extends ConnectionDialog.FocusablePanel {
             for (Entry<String, UrlField> entry : urlFields.entrySet()) {
                 if (url.requiresToken(entry.getKey()) && isEmpty(entry.getValue().getField().getText())) {
                     requiredFieldMissing = true;
+                    String fieldName = entry.getValue().getLabel().getText();
+                    /* Drop the colon, since this message goes at the bottom of the wizard dialog (e.g. avoid
+                    the message looking like "Please specify a value for TNS Name:"). */
+                    if (fieldName.endsWith(":")) {
+                        fieldName = fieldName.substring(0, fieldName.length() - 1);
+                    }
                     displayMessage(NbBundle.getMessage(NewConnectionPanel.class, "NewConnection.ERR_FieldRequired",
-                            entry.getValue().getLabel().getText()), false);
+                            fieldName), false);
                 }
             }
 

--- a/ide/db/src/org/netbeans/modules/db/util/Bundle.properties
+++ b/ide/db/src/org/netbeans/modules/db/util/Bundle.properties
@@ -36,7 +36,7 @@ DRIVERNAME_OracleThin=Oracle Thin
 DRIVERNAME_OracleOCI=Oracle OCI
 DRIVERNAME_JTDS=jTDS
 DRIVERNAME_DB2JCC=IBM DB2 Universal Driver
-DRIVERNAME_MSSQL2005=Microsoft SQL Server 2005
+DRIVERNAME_MSSQL=Microsoft SQL Server
 
 # Map JDBC URL token identifiers to human-readable strings
 <HOST>=Host

--- a/ide/db/src/org/netbeans/modules/db/util/DriverListUtil.java
+++ b/ide/db/src/org/netbeans/modules/db/util/DriverListUtil.java
@@ -213,9 +213,12 @@ public class DriverListUtil {
         "com.microsoft.jdbc.sqlserver.SQLServerDriver",
         "jdbc:microsoft:sqlserver://<HOST>[:<PORT>][;DatabaseName=<DB>]");
 
-        add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_MSSQL2005"),
+        /* Previously we used to say "Microsoft SQL Server 2005" here, but as of driver version 7.2.2
+        (latest per July 2019), the class name is still the same. So don't say "2005" anymore. */
+        url = add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_MSSQL"),
         "com.microsoft.sqlserver.jdbc.SQLServerDriver",
         "jdbc:sqlserver://[<HOST>[\\<INSTANCE>][:<PORT>]][;databaseName=<DB>][;<ADDITIONAL>]", true);
+        url.setSampleUrl("jdbc:sqlserver://localhost:1433");
         
         url = add(NbBundle.getMessage(DriverListUtil.class, "DRIVERNAME_MySQL"),
                 "com.mysql.cj.jdbc.Driver", 

--- a/ide/db/src/org/netbeans/modules/db/util/JdbcUrl.java
+++ b/ide/db/src/org/netbeans/modules/db/util/JdbcUrl.java
@@ -155,10 +155,19 @@ public class JdbcUrl extends HashMap<String, String> {
             nameAndType = displayName + " (" + getType() + ")";         //NOI18N
         }
         if (driver != null && driver.getDisplayName() != null
-                && !driver.getDisplayName().equals(displayName)) {
-            return NbBundle.getMessage(DriverListUtil.class,
-                    "JDBC_URL_DRIVER_NAME", //NOI18N
-                    nameAndType, driver.getDisplayName());
+                && !driver.getDisplayName().equals(displayName))
+        {
+            /* If the driver name has been customized such that
+            JDBC_URL_DRIVER_NAME format would yield, for instance,
+            "Oracle Thin / Service ID (SID) on Oracle", then we can just drop
+            the "on Oracle" part. */
+            if (nameAndType.startsWith(driver.getDisplayName())) {
+                return nameAndType;
+            } else {
+                return NbBundle.getMessage(DriverListUtil.class,
+                        "JDBC_URL_DRIVER_NAME", //NOI18N
+                        nameAndType, driver.getDisplayName());
+            }
         } else {
             return nameAndType;
         }

--- a/ide/db/test/unit/src/org/netbeans/modules/db/util/DriverListUtilTest.java
+++ b/ide/db/test/unit/src/org/netbeans/modules/db/util/DriverListUtilTest.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import static junit.framework.Assert.assertEquals;
 import junit.framework.TestCase;
 import org.netbeans.api.db.explorer.JDBCDriver;
 import org.openide.util.NbBundle;
@@ -350,7 +349,7 @@ public class DriverListUtilTest extends TestCase {
     
     public void testMSSQL2005() throws Exception {
         /*
-                add(getMessage("DRIVERNAME_MSSQL2005"),
+                add(getMessage("DRIVERNAME_MSSQL"),
         "com.microsoft.sqlserver.jdbc.SQLServerDriver",
         "jdbc:sqlserver://[<HOST>[\\<INSTANCE>][:<PORT>]][;databaseName=<DB>][;<ADDITIONAL>]", true);
         */
@@ -359,7 +358,7 @@ public class DriverListUtilTest extends TestCase {
         supportedProps.add(JdbcUrl.TOKEN_INSTANCE);
         
         ArrayList<String> requiredProps = new ArrayList<String>();
-        JdbcUrl url = checkUrl(getDriverName("DRIVERNAME_MSSQL2005"), null, 
+        JdbcUrl url = checkUrl(getDriverName("DRIVERNAME_MSSQL"), null,
                 "com.microsoft.sqlserver.jdbc.SQLServerDriver", 
                 "jdbc:sqlserver://[<HOST>[\\<INSTANCE>][:<PORT>]][;databaseName=<DB>][;<ADDITIONAL>]", 
                 supportedProps, requiredProps);
@@ -589,7 +588,7 @@ public class DriverListUtilTest extends TestCase {
         if (type == null) {
             assertEquals(name, url.getDisplayName());
         } else {
-            assertEquals(name + " (" + type + ")", url.getDisplayName());
+            assertEquals(name + " / " + type, url.getDisplayName());
         }
         
         assertEquals(className, url.getClassName());


### PR DESCRIPTION
Various small UI improvements to the Database module's "New Connection" wizard:
- Refactor the wizard to avoid depending on hardcoded wizard panel indexes.
- Improve two error messages in "New Connection" wizard.
- Avoid a spurious 'Specified class is not a driver' warning in certain situations.
- When detecting the Microsoft SQL Server JDBC driver, avoid showing an ancient version number.
- Add a default port number for Microsoft SQL Server.
- Tidy up presentation names in the JDBC URL format dropdown.
- Decrease the timeout of the connection validation step.
