### PR TITLE
[NETBEANS-5587] Fix regression in gavSplit

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleModuleFileCache21.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleModuleFileCache21.java
@@ -247,17 +247,17 @@ public final class GradleModuleFileCache21 {
         // the general GAV format is - <group>:<artifact>:<version/snapshot>[:<classifier>][@extension]
         int firstColon = gav.indexOf(':'); // NOI18N
         int versionColon = gav.indexOf(':', firstColon + 1); // NOI18N
-        int versionEnd = gav.indexOf(':', versionColon + 1); // NO18N
+        int versionEnd = versionColon > firstColon ? gav.indexOf(':', versionColon + 1) : -1; // NO18N
 
+        if (firstColon == -1 || versionColon == -1 || firstColon == versionColon) {
+            throw new IllegalArgumentException("Invalid GAV format: '" + gav + "'"); //NOI18N
+        }
         int end = versionEnd == -1 ? gav.length() : versionEnd;
 
-        if (firstColon == -1 || firstColon == versionColon) {
-            throw new IllegalArgumentException("Invalid GAV format: " + gav); //NOI18N
-        }
         return new String[]{
             gav.substring(0, firstColon),
             gav.substring(firstColon + 1, versionColon),
-             gav.substring(versionColon + 1, end)
+            gav.substring(versionColon + 1, end)
         };
     }
 }

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/GradleModuleFileCache21Test.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/GradleModuleFileCache21Test.java
@@ -35,9 +35,9 @@ public class GradleModuleFileCache21Test extends NbTestCase {
      */
     public void testGavSplitFixedVersion() throws Exception {
         String[] parts = GradleModuleFileCache21.gavSplit("io.micronaut:micronaut-core:2.3.4"); // NOI18N
-        assertEquals(parts[0], "io.micronaut"); // NOI18N
-        assertEquals(parts[1], "micronaut-core"); // NOI18N
-        assertEquals(parts[2], "2.3.4"); // NOI18N
+        assertEquals("io.micronaut", parts[0]);
+        assertEquals("micronaut-core", parts[1]);
+        assertEquals("2.3.4", parts[2]);
     }
 
     /**
@@ -46,15 +46,63 @@ public class GradleModuleFileCache21Test extends NbTestCase {
      */
     public void testGavSplitFixedSnapshotWithMavenTimestamp() throws Exception {
         String[] parts = GradleModuleFileCache21.gavSplit("io.micronaut:micronaut-core:2.3.4-SNAPSHOT:20210302.164619-21"); // NOI18N
-        assertEquals(parts[0], "io.micronaut"); // NOI18N
-        assertEquals(parts[1], "micronaut-core"); // NOI18N
-        assertEquals(parts[2], "2.3.4-SNAPSHOT"); // NOI18N
+        assertEquals("io.micronaut", parts[0]); 
+        assertEquals("micronaut-core", parts[1]);
+        assertEquals("2.3.4-SNAPSHOT", parts[2]);
     }
 
     public void testGavSplitFixedSnapshotWithoutUnqiueId() throws Exception {
         String[] parts = GradleModuleFileCache21.gavSplit("io.micronaut:micronaut-core:2.3.4-SNAPSHOT"); // NOI18N
-        assertEquals(parts[0], "io.micronaut"); // NOI18N
-        assertEquals(parts[1], "micronaut-core"); // NOI18N
-        assertEquals(parts[2], "2.3.4-SNAPSHOT"); // NOI18N
+        assertEquals("io.micronaut", parts[0]); 
+        assertEquals("micronaut-core", parts[1]);
+        assertEquals("2.3.4-SNAPSHOT", parts[2]);
+    }
+
+    public void testGavSplitIncomplete() throws Exception {
+        try {
+            GradleModuleFileCache21.gavSplit("junit:junit");
+            fail("IllegalArgumentException expected");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("Invalid GAV format: 'junit:junit'", iae.getMessage());
+        }
+    }
+
+    public void testGavSplitIncomplete2() throws Exception {
+        try {
+            GradleModuleFileCache21.gavSplit("junit");
+            fail("IllegalArgumentException expected");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("Invalid GAV format: 'junit'", iae.getMessage());
+        }
+    }
+
+    public void testGavSplitIncomplete3() throws Exception {
+        try {
+            GradleModuleFileCache21.gavSplit("");
+            fail("IllegalArgumentException expected");
+        } catch (IllegalArgumentException iae) {
+            assertEquals("Invalid GAV format: ''", iae.getMessage());
+        }
+    }
+
+    public void testGavSplitEmpty() throws Exception {
+        String[] parts = GradleModuleFileCache21.gavSplit("org.junit.jupiter:junit-jupiter-api:");
+        assertEquals("org.junit.jupiter", parts[0]); 
+        assertEquals("junit-jupiter-api", parts[1]);
+        assertEquals("", parts[2]);
+    }
+
+    public void testGavSplitEmpty2() throws Exception {
+        String[] parts = GradleModuleFileCache21.gavSplit("org.junit.jupiter::");
+        assertEquals("org.junit.jupiter", parts[0]); 
+        assertEquals("", parts[1]);
+        assertEquals("", parts[2]);
+    }
+
+    public void testGavSplitEmpty3() throws Exception {
+        String[] parts = GradleModuleFileCache21.gavSplit("::");
+        assertEquals("", parts[0]); 
+        assertEquals("", parts[1]);
+        assertEquals("", parts[2]);
     }
 }


### PR DESCRIPTION
Well, this one fixes a regression detected by Scott Palmer.
I do not think this would be a major issue. Probably would happen on a few strange Gradle projects.
I put this against delivery and marked it for 12.4, so if the RM-s decide we need an rc3, then it would be nice to include this one.

@sdedic I've changed the argument order in assert equals as the first parameter is the expected value, the second one is the one that shall be tested.