### PR TITLE
Support for Micronaut's automatic restarts (mn:run) for Maven

### DIFF
--- a/enterprise/micronaut/nbproject/project.xml
+++ b/enterprise/micronaut/nbproject/project.xml
@@ -52,6 +52,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.api.maven</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.17</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/layer.xml
@@ -30,4 +30,17 @@
             </folder>
         </folder>
     </folder>
+    <folder name="Projects">
+        <folder name="org-netbeans-modules-maven">
+            <folder name="io.micronaut.build:micronaut-maven-plugin">
+                <folder name="Lookup">
+                    <file name="maven-project-actions.instance">
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
+                        <attr name="resource" stringvalue="nbres:/org/netbeans/modules/micronaut/resources/micronaut-actions.xml"/>
+                    </file>
+                </folder>
+            </folder>
+        </folder>
+    </folder>
 </filesystem>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/micronaut-actions.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/micronaut-actions.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<actions>
+    <profiles>
+        <profile>
+            <id>micronaut-auto</id>
+            <displayName>Micronaut: dev mode</displayName>
+            <actions>
+                <action>
+                    <actionName>run</actionName>
+                    <packagings>
+                        <packaging>jar</packaging>
+                    </packagings>
+                    <goals>
+                        <goal>mn:run</goal>
+                    </goals>
+                    <properties>
+                        <exec.vmArgs></exec.vmArgs>
+                        <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                        <exec.appArgs></exec.appArgs>
+                        <exec.mainClass>${packageClassName}</exec.mainClass>
+                    </properties>
+                </action>
+                <action>
+                    <actionName>run.single.main</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                    <goals>
+                        <goal>mn:run</goal>
+                    </goals>
+                    <properties>
+                        <exec.vmArgs></exec.vmArgs>
+                        <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                        <exec.mainClass>${packageClassName}</exec.mainClass>
+                        <exec.classpathScope>${classPathScope}</exec.classpathScope>
+                    </properties>
+                </action>
+            </actions>
+        </profile>
+    </profiles>
+</actions>

--- a/ide/projectapi/src/org/netbeans/spi/project/ActionProvider.java
+++ b/ide/projectapi/src/org/netbeans/spi/project/ActionProvider.java
@@ -30,6 +30,9 @@ import org.openide.util.Lookup;
  * lookup does not enable the action for a given command on the selected file then
  * the first implementation found in default lookup that is enabled will be used.
  * </p>
+ * If the project supports {@link ProjectConfiguration}s, the ActionProvider implementation 
+ * must check {@link ProjectConfiguration} presence in the action's context Lookup whether the caller
+ * requested a specific configuration, and use it to process the requested action, if found.
  * @see org.netbeans.api.project.Project#getLookup
  * @see <a href="@org-apache-tools-ant-module@/org/apache/tools/ant/module/api/support/ActionUtils.html"><code>ActionUtils</code></a>
  * @see <a href="@org-netbeans-modules-projectuiapi@/org/netbeans/spi/project/ui/support/ProjectSensitiveActions.html#projectCommandAction(java.lang.String,%20java.lang.String,%20javax.swing.Icon)"><code>ProjectSensitiveActions.projectCommandAction(...)</code></a>
@@ -189,5 +192,4 @@ public interface ActionProvider {
      * @throws IllegalArgumentException if the requested command is not supported
      */
     boolean isActionEnabled(String command, Lookup context) throws IllegalArgumentException;
-    
 }

--- a/java/api.maven/apichanges.xml
+++ b/java/api.maven/apichanges.xml
@@ -83,7 +83,22 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
-        
+        <change id="plugin.actions">
+           <api name="general"/>
+           <summary>Allow declarative action registrations</summary>
+           <version major="1" minor="17"/>
+           <date day="13" month="5" year="2021"/>
+           <author login="sdedic"/>
+           <compatibility addition="yes" semantic="compatible"/>
+           <description>
+               <p>
+                   Actions and Project Configurations can be contributed to a Maven project declaratively,
+                   using the Layer XML. See <a href="@TOP@/org/netbeans/api/maven/MavenActions.html">MavenActions</a> for spec and examples.
+               </p>
+           </description>
+           <class package="org.netbeans.api.maven" name="MavenActions"/>
+           <issue number="NETBEANS-5670"/>
+        </change>
         <change id="maven.archetype.api.init">
            <api name="general"/>
            <summary>Created the public Maven Archetype api</summary>

--- a/java/api.maven/manifest.mf
+++ b/java/api.maven/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.maven
-OpenIDE-Module-Specification-Version: 1.16
+OpenIDE-Module-Specification-Version: 1.17
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/maven/Bundle.properties
 AutoUpdate-Show-In-Client: false

--- a/java/api.maven/nbproject/project.xml
+++ b/java/api.maven/nbproject/project.xml
@@ -40,7 +40,16 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>2</release-version>
-                        <specification-version>2.106</specification-version>
+                        <specification-version>2.148</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.modules.projectapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.80</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -96,9 +105,25 @@
                         <recursive/>
                         <compile-dependency/>
                     </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.maven</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.maven</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.projectapi.nb</code-name-base>
+                        <recursive/>
+                        <compile-dependency/>
+                    </test-dependency>
                 </test-type>
             </test-dependencies>
             <public-packages>
+                <package>org.netbeans.api.maven</package>
                 <package>org.netbeans.api.maven.archetype</package>
             </public-packages>
         </data>

--- a/java/api.maven/src/org/netbeans/api/maven/MavenActions.java
+++ b/java/api.maven/src/org/netbeans/api/maven/MavenActions.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.maven;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.netbeans.api.project.Project;
+import org.netbeans.spi.project.LookupProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.URLMapper;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+import org.netbeans.modules.maven.spi.actions.AbstractMavenActionsProvider;
+
+/**
+ * APIs related to actions over the Maven project.
+ * <p>
+ * A API allows to <b>declaratively register actions</b> using project's Lookup. Action descriptions
+ * must be provided in {@code nbactions.xml} format and referenced from the Layer XML using URL (i.e. nbres: protocol).
+ * The {@code nbactions.xml} may contain descriptors of actions and even <b>profiles</b> which will be turned into
+ * {@link ProjectConfiguration}s. Actions in profiles may override the default action mappings, or supply completely new
+ * actions.
+ * <p/>
+ * <div class="nonnormative">
+ * This example shows how to declare actions in a modules' layer, and register actions when <code>org.netbeans.modules.maven:test.plugin</code>
+ * plugin is used by the maven project:
+ * {@codesnippet LayerActionsRegistration}
+ * The referenced resource may declare both default configuration actions, and actions overrides in a specific configuration:
+ * {@codesnippet ActionsExample}
+ * </div>
+ * 
+ * @author sdedic
+ * @since 1.1
+ */
+public final class MavenActions {
+    
+    static LookupProvider forProjectLayer(FileObject fromLayer) {
+        Object o = fromLayer.getAttribute("resource");
+        URL resourceURL = null;
+        
+        if (o instanceof URL) {
+            resourceURL = (URL)o;
+        } else if (o instanceof String) {
+            try {
+                resourceURL = new URL(URLMapper.findURL(fromLayer, URLMapper.INTERNAL), (String)o);
+            } catch (MalformedURLException ex) {
+                Logger.getLogger(MavenActions.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        final URL finURL = resourceURL;
+        return new LookupProvider() {
+            @Override
+            public Lookup createAdditionalLookup(Lookup baseContext) {
+                Project p = baseContext.lookup(Project.class);
+                if (p == null || finURL == null) {
+                    return Lookup.EMPTY;
+                }
+                return Lookups.fixed(AbstractMavenActionsProvider.fromNbActions(p, finURL)
+                );
+            }
+        };
+    }
+    
+}

--- a/java/api.maven/test/unit/src/META-INF/generated-layer.xml
+++ b/java/api.maven/test/unit/src/META-INF/generated-layer.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
+<filesystem>
+    <!-- BEGIN:LayerActionsRegistration -->
+    <folder name="Projects">
+        <folder name="org-netbeans-modules-maven">
+            <folder name="org.ntebeans.modules.maven:test.plugin">
+                <folder name="Lookup">
+                    <file name="maven-project-actions.instance">
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
+                        <attr name="resource" stringvalue="nbres:/org/netbeans/api/maven/test-maven-actions.xml"/>
+                    </file>
+                </folder>
+            </folder>
+        </folder>
+    </folder>
+    <!-- END:LayerActionsRegistration -->
+</filesystem>

--- a/java/api.maven/test/unit/src/org/netbeans/api/maven/MavenActionsTest.java
+++ b/java/api.maven/test/unit/src/org/netbeans/api/maven/MavenActionsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.maven;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.maven.spi.actions.MavenActionsProvider;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.LookupEvent;
+import org.openide.util.LookupListener;
+
+/**
+ *
+ * @author sdedic
+ */
+public class MavenActionsTest extends NbTestCase {
+
+    public MavenActionsTest(String name) {
+        super(name);
+    }
+    
+    /**
+     * Checks that the custom provider is included when the project contains appropriate
+     * plugin and trashed when the plugin vanishes from the model.
+     */
+    public void testCustomActionsProvider() throws Exception {
+        clearWorkDir();
+        FileObject wd = FileUtil.toFileObject(getWorkDir());
+        
+        try (OutputStream o = wd.createAndOpen("pom.xml");
+            OutputStreamWriter w = new OutputStreamWriter(o)) {
+            w.write(
+                "<project><modelVersion>4.0.0</modelVersion>"
+                + "<groupId>test</groupId><artifactId>parent</artifactId><version>1.0</version><packaging>jar</packaging>"
+                + "<build><plugins><plugin><artifactId>test.plugin</artifactId><groupId>org.ntebeans.modules.maven</groupId></plugin></plugins></build>"
+                + "</project>");
+        }
+        
+        Project p = FileOwnerQuery.getOwner(wd);
+        
+        // must open with OpenProjects, so that the project starts to listen on files:
+        OpenProjects.getDefault().open(new Project[] { p } , false);
+        OpenProjects.getDefault().openProjects().get();
+        
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        assertTrue(Arrays.asList(ap.getSupportedActions()).contains("extra"));
+        
+        CountDownLatch change = new CountDownLatch(1);
+        
+        p.getLookup().lookupResult(MavenActionsProvider.class).addLookupListener(new LookupListener() {
+            @Override
+            public void resultChanged(LookupEvent ev) {
+                change.countDown();
+            }
+        });
+        
+        FileObject pom = wd.getFileObject("pom.xml");
+
+        try (OutputStream o = pom.getOutputStream();
+            OutputStreamWriter w = new OutputStreamWriter(o)) {
+            w.write(
+                "<project><modelVersion>4.0.0</modelVersion>"
+                + "<groupId>test</groupId><artifactId>parent</artifactId><version>1.0</version><packaging>jar</packaging>"
+                + "</project>");
+        }
+        
+        // wait for the set of providers to refresh. PROP_PROJECT comes first, but Lookup takes some
+        // additional time.
+        change.await();
+   
+        assertFalse(Arrays.asList(ap.getSupportedActions()).contains("extra"));
+    }
+}

--- a/java/api.maven/test/unit/src/org/netbeans/api/maven/test-maven-actions.xml
+++ b/java/api.maven/test/unit/src/org/netbeans/api/maven/test-maven-actions.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<!-- BEGIN:ActionsExample -->
+<actions>
+    <actions>
+        <action>
+            <!-- This is a completely new action available for the default configuration -->
+            <actionName>extra</actionName>
+            <goals>
+                <goal>help:effective-pom</goal>
+            </goals>
+            <properties>
+            </properties>
+        </action>
+    </actions>
+    <profiles>
+        <profile>
+            <!-- Configuration ID; actions from same configurations will merge -->
+            <id>example-conf</id>
+            <!-- Display name for the user -->
+            <displayName>Example Configuration</displayName>
+            <actions>
+                <action>
+                    <!-- run standard action is changed in this configuration -->
+                    <actionName>run</actionName>
+                    <goals>
+                        <goal>mn:run</goal>
+                    </goals>
+                    <properties>
+                        <exec.vmArgs></exec.vmArgs>
+                        <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                        <exec.appArgs></exec.appArgs>
+                        <exec.mainClass>${packageClassName}</exec.mainClass>
+                    </properties>
+                </action>
+            </actions>
+        </profile>
+    </profiles>
+</actions>
+<!-- END:ActionsExample -->

--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-maven.jar/org/netbeans/modules/maven/configurations/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-maven.jar/org/netbeans/modules/maven/configurations/Bundle.properties
@@ -1,0 +1,1 @@
+ProjectConfigurationProvider.ExportProfiles=false

--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-maven.jar/org/netbeans/modules/maven/configurations/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-maven.jar/org/netbeans/modules/maven/configurations/Bundle.properties
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 ProjectConfigurationProvider.ExportProfiles=false

--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -58,7 +58,6 @@ disabled.modules=\
     org.eclipse.mylyn.wikitext.markdown.core,\
     org.eclipse.mylyn.wikitext.textile.core,\
     org.netbeans.api.knockout,\
-    org.netbeans.api.maven,\
     org.netbeans.api.visual,\
     org.netbeans.core.browser,\
     org.netbeans.core.browser.webview,\

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -606,7 +606,7 @@ public final class Server {
                 capabilities.setImplementationProvider(true);
                 capabilities.setDocumentHighlightProvider(true);
                 capabilities.setReferencesProvider(true);
-                List<String> commands = new ArrayList<>(Arrays.asList(JAVA_NEW_FROM_TEMPLATE, JAVA_BUILD_WORKSPACE, JAVA_LOAD_WORKSPACE_TESTS, GRAALVM_PAUSE_SCRIPT, JAVA_SUPER_IMPLEMENTATION));
+                List<String> commands = new ArrayList<>(Arrays.asList(JAVA_NEW_FROM_TEMPLATE, JAVA_BUILD_WORKSPACE, JAVA_LOAD_WORKSPACE_TESTS, GRAALVM_PAUSE_SCRIPT, JAVA_SUPER_IMPLEMENTATION, JAVA_FIND_CONFIGURATIONS));
                 for (CodeGenerator codeGenerator : Lookup.getDefault().lookupAll(CodeGenerator.class)) {
                     commands.addAll(codeGenerator.getCommands());
                 }
@@ -722,6 +722,12 @@ public final class Server {
     public static final String JAVA_LOAD_WORKSPACE_TESTS =  "java.load.workspace.tests";
     public static final String JAVA_SUPER_IMPLEMENTATION =  "java.super.implementation";
     public static final String GRAALVM_PAUSE_SCRIPT =  "graalvm.pause.script";
+    
+    /**
+     * Enumerates project configurations.
+     */
+    public static final String JAVA_FIND_CONFIGURATIONS = "java.project.configurations";
+            
     static final String INDEXING_COMPLETED = "Indexing completed.";
     static final String NO_JAVA_SUPPORT = "Cannot initialize Java support on JDK ";
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -87,6 +87,8 @@ import org.netbeans.modules.parsing.spi.ParseException;
 import org.netbeans.spi.jumpto.type.SearchType;
 import org.netbeans.spi.project.ActionProgress;
 import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ProjectConfiguration;
+import org.netbeans.spi.project.ProjectConfigurationProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.Exceptions;
@@ -170,6 +172,20 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
                 String uri = ((JsonPrimitive) params.getArguments().get(0)).getAsString();
                 Position pos = gson.fromJson(gson.toJson(params.getArguments().get(1)), Position.class);
                 return (CompletableFuture)((TextDocumentServiceImpl)server.getTextDocumentService()).superImplementations(uri, pos);
+                
+            case Server.JAVA_FIND_CONFIGURATIONS: {
+                String fileUri = ((JsonPrimitive) params.getArguments().get(0)).getAsString();
+                
+                FileObject file;
+                try {
+                    file = URLMapper.findFileObject(new URL(fileUri));
+                } catch (MalformedURLException ex) {
+                    Exceptions.printStackTrace(ex);
+                    return CompletableFuture.completedFuture(Collections.emptyList());
+                }
+
+                return findProjectConfigurations(file);
+            }
             default:
                 for (CodeGenerator codeGenerator : Lookup.getDefault().lookupAll(CodeGenerator.class)) {
                     if (codeGenerator.getCommands().contains(command)) {
@@ -178,6 +194,20 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
                 }
         }
         throw new UnsupportedOperationException("Command not supported: " + params.getCommand());
+    }
+    
+    private CompletableFuture<Object> findProjectConfigurations(FileObject ownedFile) {
+        return server.asyncOpenFileOwner(ownedFile).thenApply(p -> {
+            if (p == null) {
+                return CompletableFuture.completedFuture(Collections.emptyList());
+            }
+            ProjectConfigurationProvider<ProjectConfiguration> provider = p.getLookup().lookup(ProjectConfigurationProvider.class);
+            List<String> configDispNames = new ArrayList<>();
+            for (ProjectConfiguration c : provider.getConfigurations()) {
+                configDispNames.add(c.getDisplayName());
+            }
+            return configDispNames;
+        });
     }
 
     private CompletableFuture<Set<URL>> getTestRootURLs(Project prj) {

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -124,6 +124,13 @@
 								],
 								"description": "Arguments for the Java VM",
 								"default": null
+							},
+							"launchConfiguration" : {
+								"type": [
+									"string",
+									"null"
+								],
+								"description": "Mode and default behaviour for launch"
 							}
 						}
 					}

--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -83,6 +83,20 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="plugin-lookup">
+            <api name="general"/>
+            <summary>Plugin-dependent Lookup</summary>
+            <version major="2" minor="148"/>
+            <date day="15" month="5" year="2021"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes" semantic="compatible"/>
+            <description>
+                <p>
+                    Services can be registered not also for a specific <i>maven plugin</i>
+                    used in the project. See <a href="@TOP@/architecture-summary.html#layer-PluginLookup">PluginLookup</a>.
+                </p>
+            </description>
+        </change>
         <change id="disable-maven-repo-indexing">
             <api name="general"/>
             <summary>Default for frequency of indexing</summary>

--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -92,7 +92,7 @@ is the proper place.
             <compatibility addition="yes" semantic="compatible"/>
             <description>
                 <p>
-                    Services can be registered not also for a specific <i>maven plugin</i>
+                    Register services for a specific <i>maven plugin</i>
                     used in the project. See <a href="@TOP@/architecture-summary.html#layer-PluginLookup">PluginLookup</a>.
                 </p>
             </description>

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -123,6 +123,14 @@
         </p>
         For the details and examples, see description in <a href="@TOP@/org/netbeans/modules/maven/api/execute/PrerequisitesChecker.html">PrerequisitesChecker javadoc</a>.
     </api>
+    <api group="layer" name="PluginLookup" type="export" category="official">
+     <p>
+       Technology-related services can be registered so they activate in a project that has configured a specific Maven plugin. Such services should
+       be placed in <code>Projects/org-netbeans-modules-maven/&lt;plugin-id>/Lookup</code> folder. Maven core module will plug these providers in
+       as soon as the plugin-id appears in the POM model, and will remote them from project's Lookup when the plugin is no longer part of the project's model.
+       See <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html">NbMavenProject javadoc for details/examples</a>.
+     </p>
+    </api>
     <api group="layer" name="MavenActions" type="export" category="official">
      <p>
        "Projects/org-netbeans-modules-maven/ProjectActions", 
@@ -148,6 +156,15 @@
                <tr><td>descriptionBundleKey</td><td>optional</td><td>key in bundle file that holds localized description</td></tr>
            </tbody>
        </table>
+    </api>
+    
+    <api group="lookup" name="ActionConfiguration" type="import" category="official">
+        <p>
+            Project API clients may place <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ProjectConfiguration.html">ProjectConfiguration</a> 
+            instance in the <b>context Lookup</b> passed to <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html##isActionEnabled-java.lang.String-org.openide.util.Lookup-">ActionProvider.isActionEnabled()</a> or 
+            <a href="@org-netbeans-modules-projectapi@/org/netbeans/spi/project/ActionProvider.html##invokeAction-java.lang.String-org.openide.util.Lookup-">ActionProvider.invokeAction()</a>. If such instance is present, the action is configured according to settings in the selected configuration.
+            If not present, the active configuration is used. See example in <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html">NbMavenProject</a> documentation.
+        </p>
     </api>
 
  </answer>

--- a/java/maven/arch.xml
+++ b/java/maven/arch.xml
@@ -127,7 +127,7 @@
      <p>
        Technology-related services can be registered so they activate in a project that has configured a specific Maven plugin. Such services should
        be placed in <code>Projects/org-netbeans-modules-maven/&lt;plugin-id>/Lookup</code> folder. Maven core module will plug these providers in
-       as soon as the plugin-id appears in the POM model, and will remote them from project's Lookup when the plugin is no longer part of the project's model.
+       as soon as the plugin-id appears in the POM model, and will remove them from project's Lookup when the plugin is no longer part of the project's model.
        See <a href="@TOP@/org/netbeans/modules/maven/api/NbMavenProject.html">NbMavenProject javadoc for details/examples</a>.
      </p>
     </api>

--- a/java/maven/manifest.mf
+++ b/java/maven/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven/2
-OpenIDE-Module-Specification-Version: 2.147
+OpenIDE-Module-Specification-Version: 2.148
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/maven/layer.xml
 AutoUpdate-Show-In-Client: false

--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -33,6 +33,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,6 +44,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.swing.SwingUtilities;
 import org.apache.maven.DefaultMaven;
 import org.apache.maven.Maven;
@@ -835,6 +837,8 @@ public final class NbMavenProjectImpl implements Project {
         private final WeakReference<NbMavenProject> watcherRef;
         private String packaging;
         private final Lookup general;
+        
+        private volatile List<String> currentIds = new ArrayList<>();
 
         @SuppressWarnings("LeakingThisInConstructor")
         PackagingTypeDependentLookup(NbMavenProject watcher) {
@@ -844,27 +848,80 @@ public final class NbMavenProjectImpl implements Project {
             check();
             watcher.addPropertyChangeListener(WeakListeners.propertyChange(this, watcher));
         }
+        
+        private String pluginDirectory(Artifact pluginArtifact) {
+            String groupId = pluginArtifact.getGroupId();
+            String artId = pluginArtifact.getArtifactId();
+            
+            return groupId + ":" + artId;
+        }
+        
+        /**
+         * Defines at least some order: let the layer positions to 
+         * @param componentSet
+         * @return 
+         */
+        private List<String> partialComponentsOrder(Collection<String> componentSet) {
+            List<FileObject> fos = new ArrayList<>();
+            FileObject root = FileUtil.getConfigFile("Projects/org-netbeans-modules-maven");
+            for (String s : componentSet) {
+                FileObject f = root.getFileObject(s);
+                if (f != null) {
+                    fos.add(f);
+                }
+            }
+            List<String> orderedNames = FileUtil.getOrder(fos, false).stream().map(FileObject::getNameExt).collect(Collectors.toList());
+            List<String> origList = new ArrayList<>(componentSet);
+            origList.removeAll(orderedNames);
+            orderedNames.addAll(origList);
+            return orderedNames;
+        }
 
         private void check() {
             //this call effectively calls project.getLookup(), when called in constructor will get back to the project's baselookup only.
             // but when called from propertyChange() then will call on entire composite lookup, is it a problem?  #230469
+            List<String> newComponents = new ArrayList<>();
             NbMavenProject watcher = watcherRef.get();
             String newPackaging = packaging != null ? packaging : NbMavenProject.TYPE_JAR;
+            List<Lookup> lookups = new ArrayList<>();
+            List<String> old = currentIds;
             if (watcher != null) {
                 newPackaging = watcher.getPackagingType(); 
                 if (newPackaging == null) {
                     newPackaging = NbMavenProject.TYPE_JAR;
                 }
+                Set<Artifact> arts = watcher.getMavenProject().getPluginArtifacts();
+                List<String> compNames = new ArrayList<>();
+                if (arts != null) {
+                    for (Artifact a : arts) {
+                        compNames.add(pluginDirectory(a));
+                    }
+                }
+                compNames.add(newPackaging);
+                
+                newComponents = partialComponentsOrder(compNames);
+            } else {
+                newComponents.add(newPackaging);
             }
-            if (!newPackaging.equals(packaging)) {
-                packaging = newPackaging;
-                Lookup pack = Lookups.forPath("Projects/org-netbeans-modules-maven/" + packaging + "/Lookup");
-                // Include fallback providers for anything
-                Lookup fallback = Lookups.forPath("Projects/org-netbeans-modules-maven/_any/Lookup");
-                setLookups(general, pack, fallback);
+            
+            if (!newComponents.equals(old)) {
+                for (String s : newComponents) {
+                    lookups.add(Lookups.forPath("Projects/org-netbeans-modules-maven/" + s + "/Lookup")); // NOI18N
+                }
+                // put the general lookup last, so plugin - specific ones can override it
+                lookups.add(general);
+                lookups.add(Lookups.forPath("Projects/org-netbeans-modules-maven/_any/Lookup")); // NOI18N
+                synchronized (this) {
+                    if (currentIds != old) {
+                        // the next computation started after us, do not interfere.
+                        return;
+                    }
+                    currentIds = newComponents;
+                }
+                setLookups(lookups.toArray(new Lookup[lookups.size()]));
             }
         }
-
+        
         public @Override void propertyChange(PropertyChangeEvent evt) {
             if (NbMavenProject.PROP_PROJECT.equals(evt.getPropertyName())) {
                 check();

--- a/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/NbMavenProject.java
@@ -53,6 +53,7 @@ import org.netbeans.modules.maven.modelcache.MavenProjectCache;
 import org.netbeans.modules.maven.options.MavenSettings;
 import org.netbeans.modules.maven.options.MavenSettings.DownloadStrategy;
 import org.netbeans.modules.maven.spi.PackagingProvider;
+import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.awt.StatusDisplayer;
 import org.openide.filesystems.FileAttributeEvent;
 import org.openide.filesystems.FileChangeListener;
@@ -68,6 +69,17 @@ import org.openide.util.Utilities;
 /**
  * an instance resides in project lookup, allows to get notified on project and 
  * relative path changes.
+ * <p/>
+ * <b>From version 2.148</b> plugin-specific services can be registered using {@link ProjectServiceProvider} 
+ * annotation in subfolders of the project Lookup registration area whose names follow a Plugin group and 
+ * artifact ID. 
+ * <p/>
+ * <div class="nonnormative">
+ * {@codesnippet ProjectServiceProvider.pluginSpecific}
+ * Shows a service, that will become available from project Lookup whenever the project uses {@code org.netbeans.modules.maven:test.plugin}
+ * plugin in its model.
+ * </div>
+ * 
  * @author mkleint
  */
 public final class NbMavenProject {
@@ -77,6 +89,13 @@ public final class NbMavenProject {
      * has changed.
      */
     public static final String PROP_PROJECT = "MavenProject"; //NOI18N
+
+    /**
+     * ID of the Maven project type.
+     * @since 2.148
+     */
+    public static final String TYPE = "org-netbeans-modules-maven"; //NOI18N
+    
     /**
      * TODO comment
      * 

--- a/java/maven/src/org/netbeans/modules/maven/api/customizer/ModelHandle.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/customizer/ModelHandle.java
@@ -66,6 +66,11 @@ public final class ModelHandle {
     
     
     static class AccessorImpl extends CustomizerProviderImpl.ModelAccessor {
+
+        @Override
+        public void setConfigurationId(Configuration cfg, String id) {
+            cfg.setId(id);
+        }
         
          public @Override ModelHandle createHandle(POMModel model,
                                         MavenProject proj, 
@@ -288,5 +293,5 @@ public final class ModelHandle {
      * 
      */
     public static class Configuration extends ModelHandle2.Configuration {
-        }
-        }
+    }
+}

--- a/java/maven/src/org/netbeans/modules/maven/api/customizer/ModelHandle2.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/customizer/ModelHandle2.java
@@ -268,6 +268,13 @@ public class ModelHandle2 {
     public static Configuration createProfileConfiguration(String id) {
         return ModelHandle.createProfileConfiguration(id);
     }
+
+    public static Configuration createProvidedConfiguration(String id) {
+        ModelHandle.Configuration conf = new ModelHandle.Configuration();
+        conf.setId(id);
+        conf.setDefault(true);
+        return conf;
+    }
     
     public static Configuration createDefaultConfiguration() {
         return ModelHandle.createDefaultConfiguration();
@@ -358,6 +365,7 @@ public class ModelHandle2 {
      */
     public static class Configuration {
         private String id;
+        private String displayName;
         private boolean profileBased = false;
         private boolean defaul = false;
 
@@ -372,8 +380,31 @@ public class ModelHandle2 {
             return M2Configuration.getFileNameExt(id);
         }
 
+        /**
+         * Identifies the default configuration.
+         * @return true for just the default configuration
+         * @since 2.148
+         */
         public boolean isDefault() {
+            return defaul && M2Configuration.DEFAULT.equals(id);
+        }
+
+        /**
+         * True, if the configuration was provided but not default or profile.
+         * @return true for provided configuration
+         * @since 2.148
+         */
+        public boolean isProvided() {
             return defaul;
+        }
+        
+        /**
+         * Sets the display name of this configuration.
+         * @param dn 
+         * @since 2.148
+         */
+        public void setDisplayName(String dn) {
+            this.displayName = dn;
         }
 
         public void setDefault(boolean def) {
@@ -400,20 +431,25 @@ public class ModelHandle2 {
         @Messages({
             "DefaultConfig=<default config>",
             "# {0} - config ID", "ProfileConfig={0} (Profile)",
+            "# {0} - config ID", "ProvidedConfig={0} (provided)",
             "# {0} - config ID", "# {1} - list of profiles", "CustomConfig1={0} (Profiles: {1})",
             "# {0} - config ID", "CustomConfig2={0}"
         })
         public String getDisplayName() {
+            String n = displayName == null ? id : displayName;
             if (isDefault()) {
                 return DefaultConfig();
             }
             if (isProfileBased()) {
-                return ProfileConfig(id);
+                return ProfileConfig(n);
+            }
+            if (isProvided()) {
+                return ProvidedConfig(n);
             }
             if (getActivatedProfiles() != null && getActivatedProfiles().size() > 0) {
-                return CustomConfig1(id, Arrays.toString(getActivatedProfiles().toArray()));
+                return CustomConfig1(n, Arrays.toString(getActivatedProfiles().toArray()));
             }
-            return CustomConfig2(id);
+            return CustomConfig2(n);
         }
 
         public String getId() {

--- a/java/maven/src/org/netbeans/modules/maven/configurations/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/configurations/Bundle.properties
@@ -43,3 +43,9 @@ NewConfigurationPanel.lblProperties.text=&Set Properties
 NewConfigurationPanel.cbPrivate.AccessibleContext.accessibleDescription=Persist for others to reuse
 NewConfigurationPanel.cbPrivate.text=Keep &private to this IDE instance
 ConfigurationsPanel.btnClone.text=Clone...
+
+# Branding API: export profiles through ProjectConfigurationProvider.
+# Valid values:
+# - true (default): exports profiles as configurations
+# - anything else:  will not export profiles as configurations.
+ProjectConfigurationProvider.ExportProfiles=true

--- a/java/maven/src/org/netbeans/modules/maven/configurations/M2ConfigProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/configurations/M2ConfigProvider.java
@@ -23,11 +23,15 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -38,10 +42,19 @@ import org.netbeans.modules.maven.api.ProjectProfileHandler;
 import org.netbeans.modules.maven.api.customizer.ModelHandle2;
 import static org.netbeans.modules.maven.configurations.ConfigurationPersistenceUtils.*;
 import org.netbeans.modules.maven.customizer.CustomizerProviderImpl;
+import org.netbeans.modules.maven.execute.model.ActionToGoalMapping;
+import org.netbeans.modules.maven.execute.model.NetbeansActionMapping;
+import org.netbeans.modules.maven.execute.model.NetbeansActionProfile;
+import org.netbeans.modules.maven.spi.actions.AbstractMavenActionsProvider;
+import org.netbeans.modules.maven.spi.actions.MavenActionsProvider;
 import org.netbeans.spi.project.ActionProvider;
 import org.netbeans.spi.project.AuxiliaryConfiguration;
 import org.netbeans.spi.project.ProjectConfigurationProvider;
 import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
+import org.openide.util.LookupEvent;
+import org.openide.util.LookupListener;
+import org.openide.util.NbBundle;
 import org.openide.util.RequestProcessor;
 import org.openide.xml.XMLUtil;
 import org.w3c.dom.Element;
@@ -56,12 +69,19 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);
     private final NbMavenProjectImpl project;
     private final M2Configuration DEFAULT;
-    // next four guarded by this
+    
+    // next five guarded by this
+    private SortedSet<M2Configuration> provided = null;
     private SortedSet<M2Configuration> profiles = null;
     private SortedSet<M2Configuration> shared = null;
     private SortedSet<M2Configuration> nonshared = null;
     private M2Configuration active;
     private String initialActive;
+    
+    /**
+     * Allows a temporary configuration override for a specific execution.
+     */
+    private final ThreadLocal<M2Configuration> activeOverride = new ThreadLocal<>();
     private final AtomicBoolean initialActiveLoaded = new AtomicBoolean(false);
     private final AuxiliaryConfiguration aux;
     private final ProjectProfileHandler profileHandler;
@@ -79,23 +99,33 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
         propertyChange = new PropertyChangeListener() {
             public @Override void propertyChange(PropertyChangeEvent evt) {
                 if (NbMavenProject.PROP_PROJECT.equals(evt.getPropertyName())) {
-                    synchronized (M2ConfigProvider.this) {
-                        profiles = null;
-                        shared = null;
-                        nonshared = null;
-                        initialActive = active != null ? active.getId() : null; //#241337
-                        active = DEFAULT;
-                    }
-                    RP.post(new Runnable() {
-                        public @Override void run() {
-                            checkActiveAgainstAll(getConfigurations(), false);
-                            firePropertyChange();
-                        }
-
-                    });
+                    flush();
                 }
             }
         };
+    }
+    
+    private void flush() {
+        synchronized (M2ConfigProvider.this) {
+            provided = null;
+            profiles = null;
+            shared = null;
+            nonshared = null;
+            initialActive = active != null ? active.getId() : null; //#241337
+        }
+        RP.post(new Runnable() {
+            public @Override void run() {
+                checkActiveAgainstAll(getConfigurations(), false);
+                firePropertyChange();
+            }
+
+        });
+    }
+
+    public M2Configuration setLocalConfiguration(M2Configuration cfg) {
+        M2Configuration old = activeOverride.get();
+        activeOverride.set(cfg);
+        return old;
     }
     
     private String getInitialActive() {
@@ -104,13 +134,16 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
         }
         return initialActive;
     }
-
+    
+    private ThreadLocal<Boolean> inConfigInit = new ThreadLocal<>();
+    
     private void checkActiveAgainstAll(Collection<M2Configuration> confs, boolean async) {
-        assert !Thread.holdsLock(this);
+        Boolean b = inConfigInit.get();
+        assert b != null || !Thread.holdsLock(this);
         boolean found = false;
         String id;
         synchronized (this) {
-            id = active.getId();
+            id = internalActive().getId();
         }
         for (M2Configuration conf : confs) {
             if (conf.getId().equals(id)) {
@@ -123,7 +156,7 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
                     public @Override void run() {
                         M2Configuration _active;
                         synchronized (M2ConfigProvider.this) {
-                            _active = active;
+                            _active = internalActive();
                         }
                         try {
                             doSetActiveConfiguration(DEFAULT, _active);
@@ -144,6 +177,7 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
         if (profiles == null && !skipProfiles) {
             profiles = createProfilesList();
         }
+        skipProfiles |= !Boolean.parseBoolean(NbBundle.getMessage(M2ConfigProvider.class, "ProjectConfigurationProvider.ExportProfiles"));
         if (shared == null) {
             //read from auxconf
             shared = readConfigurations(aux, project.getProjectDirectory(), true);
@@ -152,10 +186,14 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
             //read from auxconf
             nonshared = readConfigurations(aux, project.getProjectDirectory(), false);
         }
+        if (provided == null) {
+            provided = createProvidedList();
+        }
         Collection<M2Configuration> toRet = new TreeSet<M2Configuration>();
         toRet.add(DEFAULT);
         toRet.addAll(shared);
         toRet.addAll(nonshared);
+        toRet.addAll(provided);
         if (!skipProfiles) {
             //prevent duplicates in the list
             Iterator<M2Configuration> it = profiles.iterator();
@@ -195,6 +233,11 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
         return nonshared;
     }
     
+    public synchronized Collection<M2Configuration> getProvidedConfigurations() {
+        getConfigurations();
+        return provided;
+    }
+    
     public @Override boolean hasCustomizer() {
         return true;
     }
@@ -207,23 +250,34 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
     public @Override boolean configurationsAffectAction(String action) {
         return !ActionProvider.COMMAND_DELETE.equals(action) && !ActionProvider.COMMAND_COPY.equals(action) && !ActionProvider.COMMAND_MOVE.equals(action);
     }
-
+    
+    private M2Configuration internalActive() {
+        M2Configuration c = this.activeOverride.get();
+        return c != null ? c : active;
+    }
 
     public @Override M2Configuration getActiveConfiguration() {
         M2Configuration _active;
         Collection<M2Configuration> confs;
+        Boolean b = inConfigInit.get();
         synchronized (this) {
+            _active = internalActive();
             confs = getConfigurations(false);
             String initAct = getInitialActive();
-            if (initAct != null) {
+            OUTER: if (initAct != null) {
                 for (M2Configuration conf : confs) {
                     if (initAct.equals(conf.getId())) {
-                        active = conf;
+                        if (_active != conf) {
+                            _active = conf;
+                            break OUTER;
+                        } else {
+                            _active = conf;
+                        }
                         initAct = null;
                         break;
                     }
                 }
-                if (initAct != null) {
+                if (b == null && initAct != null) {
                     RP.post(new Runnable() {
                         public @Override void run() {
                             try {
@@ -236,7 +290,9 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
                 }
                 initialActive = null; //here we reset the initial active field value to prevent this block from happening exactly once.
             }
-            _active = active;
+            if (b == null) {
+                active = _active;
+            }
         }
         checkActiveAgainstAll(confs, true);
         return _active;
@@ -301,6 +357,105 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
             config.add(c);
         }
         return config;
+    }
+    
+    private static void addProfileNames(Set<String> names, Set<M2Configuration> profile) {
+        for (M2Configuration c : profile) {
+            names.add(c.getId());
+        }
+    }
+    
+    private Lookup.Result<MavenActionsProvider> actionProviders;
+    
+    // @GuardedBy(this)
+    private SortedSet<M2Configuration> createProvidedList() {
+        SortedSet<M2Configuration> result = new TreeSet<>();
+        provided = result;
+        
+        Boolean b = inConfigInit.get();
+        inConfigInit.set(true);
+        try {
+            Collection<? extends MavenActionsProvider> providers;
+            synchronized (this) {
+                Lookup.Result<MavenActionsProvider> r = actionProviders;
+                if (r == null) {
+                    r = project.getLookup().lookupResult(MavenActionsProvider.class);
+                }
+                providers = new ArrayList<>(r.allInstances());
+                // initialize the listener after initial Lookup, otherwise the event may be fired. That could flush() 
+                // e.g. in the middle of getConfigurations() processing.
+                if (actionProviders == null) {
+                    actionProviders = r;
+                    actionProviders.addLookupListener(new LookupListener() {
+                        @Override
+                        public void resultChanged(LookupEvent ev) {
+                            flush();
+                        }
+                    });
+                }
+            }
+            for (MavenActionsProvider p : providers) {
+                if (p == this) {
+                    continue;
+                }
+                if (p instanceof AbstractMavenActionsProvider) {
+                    List<NetbeansActionProfile> profiles;
+                    M2Configuration c = setLocalConfiguration(DEFAULT);
+                    try {
+                        profiles = ((AbstractMavenActionsProvider) p).getRawMappings().getProfiles();
+                        if (profiles.isEmpty()) {
+                            continue;
+                        }
+                    } finally {
+                        setLocalConfiguration(c);
+                    }
+                    Set<String> knownIds = new HashSet<>();
+                    addProfileNames(knownIds, this.profiles);
+                    addProfileNames(knownIds, this.shared);
+                    addProfileNames(knownIds, this.nonshared);
+
+                    for (NetbeansActionProfile prof : profiles) {
+                        if (!knownIds.contains(prof.getId())) {
+                            M2Configuration cfg = new M2Configuration(prof.getId(), project.getProjectDirectory()) {
+                                @Override
+                                public ActionToGoalMapping getRawMappings() {
+                                    try (InputStream istm = getActionDefinitionStream()) {
+                                        if (istm != null) {
+                                            return super.getRawMappings();
+                                        }
+                                    } catch (IOException ex) {
+                                        // silently ignore
+                                    }
+                                    ActionToGoalMapping m = new ActionToGoalMapping();
+                                    ActionToGoalMapping allMappings = ((AbstractMavenActionsProvider) p).getRawMappings();
+                                    List<NetbeansActionProfile> profiles = ((AbstractMavenActionsProvider) p).getRawMappings().getProfiles();
+                                    for (NetbeansActionProfile p : profiles) {
+                                        if (prof.getId().equals(p.getId())) {
+                                            Set<String> overridenIds = new HashSet<>();
+                                            for (NetbeansActionMapping am : p.getActions()) {
+                                                overridenIds.add(am.getActionName());
+                                                m.addAction(am);
+                                            }
+                                            for (NetbeansActionMapping am : allMappings.getActions()) {
+                                                if (!overridenIds.contains(am.getActionName())) {
+                                                    m.addAction(am);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    return m;
+                                }
+                            };
+                            cfg.setDisplayName(prof.getDisplayName());
+                            result.add(cfg);
+                        }
+                    }
+                }
+            }
+            return result;
+        } finally {
+            inConfigInit.set(b);
+        }
     }
 
     public @Override synchronized void addPropertyChangeListener(PropertyChangeListener lst) {

--- a/java/maven/src/org/netbeans/modules/maven/configurations/M2Configuration.java
+++ b/java/maven/src/org/netbeans/modules/maven/configurations/M2Configuration.java
@@ -28,13 +28,16 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.maven.api.MavenConfiguration;
 import static org.netbeans.modules.maven.configurations.Bundle.*;
@@ -44,16 +47,23 @@ import org.netbeans.modules.maven.execute.model.NetbeansActionProfile;
 import org.netbeans.modules.maven.execute.model.NetbeansActionReader;
 import org.netbeans.modules.maven.execute.model.io.xpp3.NetbeansBuildActionXpp3Writer;
 import org.netbeans.modules.maven.spi.actions.AbstractMavenActionsProvider;
+import org.netbeans.modules.maven.spi.actions.MavenActionsProvider;
 import org.openide.filesystems.FileChangeAdapter;
 import org.openide.filesystems.FileChangeListener;
 import org.openide.filesystems.FileEvent;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileRenameEvent;
 import org.openide.filesystems.FileUtil;
-import org.openide.util.Exceptions;
 import org.openide.util.NbBundle.Messages;
 
 /**
+ * Represents a configuration, Properties defined by {@link MavenConfiguration} plus list of action descriptions
+ * for that configuration. This class is used to represent:
+ * <ul>
+ * <li>default configurations, provided by Maven project.
+ * <li>profile-based configurations
+ * <li>user-customized configurations, that loads action configs from the project directory.
+ * </ul>
  *
  * @author mkleint
  */
@@ -61,21 +71,26 @@ public class M2Configuration extends AbstractMavenActionsProvider implements Mav
     private static final Logger LOG = Logger.getLogger(M2Configuration.class.getName());
 
     public static final String DEFAULT = "%%DEFAULT%%"; //NOI18N
+    public static final String FILENAME = "nbactions.xml"; //NOI18N
+    public static final String FILENAME_PREFIX = "nbactions-"; //NOI18N
+    public static final String FILENAME_SUFFIX = ".xml"; //NOI18N
     
     public static M2Configuration createDefault(FileObject projectDirectory) {
         return new M2Configuration(DEFAULT, projectDirectory);
     }
-    
+
+    /**
+     * True, if the M2Configuration comes from a customized project storage.
+     */
+    private boolean customized;
     private @NonNull final String id;
     private List<String> profiles;
-    public static final String FILENAME = "nbactions.xml"; //NOI18N
-    public static final String FILENAME_PREFIX = "nbactions-"; //NOI18N
-    public static final String FILENAME_SUFFIX = ".xml"; //NOI18N
     private final Map<String,String> properties = new HashMap<String,String>();
     private final FileObject projectDirectory;
     
     private final AtomicBoolean resetCache = new AtomicBoolean(false);
     private FileChangeListener listener = null;
+    private String displayName;
     
     public M2Configuration(String id, FileObject projectDirectory) {
         assert id != null;
@@ -83,7 +98,6 @@ public class M2Configuration extends AbstractMavenActionsProvider implements Mav
         this.projectDirectory = projectDirectory;
         profiles = Collections.<String>emptyList();
     }
-
     
      @Override       
      @Messages("TXT_DefaultConfig=<default config>")
@@ -91,7 +105,11 @@ public class M2Configuration extends AbstractMavenActionsProvider implements Mav
         if (DEFAULT.equals(id)) {
             return TXT_DefaultConfig();
         }
-        return id;
+        return displayName != null ? displayName : id;
+    }
+     
+    void setDisplayName(String displayName) {
+        this.displayName = displayName;
     }
     
     public @NonNull String getId() {
@@ -146,10 +164,15 @@ public class M2Configuration extends AbstractMavenActionsProvider implements Mav
     public @Override InputStream getActionDefinitionStream() {
         return getActionDefinitionStream(id);
     }
-    
+
+    public boolean isCustomized() {
+        return customized;
+    }
+
     final InputStream getActionDefinitionStream(String forId) {
         checkListener();
         FileObject fo = projectDirectory.getFileObject(getFileNameExt(forId));
+        customized = fo != null;
         resetCache.set(false);
         if (fo != null) {
             try {
@@ -157,7 +180,7 @@ public class M2Configuration extends AbstractMavenActionsProvider implements Mav
             } catch (FileNotFoundException ex) {
                 LOG.log(Level.WARNING, "Cannot read " + fo, ex); // NOI18N
             }
-        }
+        } 
         return null;
     }
     
@@ -249,15 +272,25 @@ public class M2Configuration extends AbstractMavenActionsProvider implements Mav
                         rdr = new InputStreamReader(in);
                         ActionToGoalMapping def = reader.read(rdr);
                         for (NetbeansActionProfile p : def.getProfiles()) {
-                            if (id.equals(p.getId())) {
-                                ActionToGoalMapping m = new ActionToGoalMapping();
-                                m.setActions(m.getActions());
-                                m.setModelEncoding(m.getModelEncoding());
-                                originalMappings = m;
+                            if (id.equals(p.getId()) && p.getActions() != null) {
+                                Map<String, Integer> posMap = new HashMap<>();
+                                for (int i = 0; i < def.getActions().size(); i++) {
+                                    posMap.put(def.getActions().get(i).getActionName(), i);
+                                }
+                                // merge in or override global actions:
+                                for (NetbeansActionMapping am : p.getActions()) {
+                                    String n = am.getActionName();
+                                    Integer i = posMap.get(n);
+                                    if (null == i) {
+                                        def.getActions().add(am);
+                                    } else {
+                                        def.getActions().set(i, am);
+                                    }
+                                }
                                 break;
                             }
                         }
-
+                        originalMappings = def;
                     } else {
                         originalMappings = new ActionToGoalMapping();
                     }
@@ -295,19 +328,10 @@ public class M2Configuration extends AbstractMavenActionsProvider implements Mav
                 StringWriter str = new StringWriter();
                 InputStreamReader rdr = null;
                 try {
-                    InputStream in = getActionDefinitionStream();
-                    if (in == null) {
-                      in = getActionDefinitionStream(DEFAULT);
-                    }
-                    if (in == null) {
-                        return null;
-                    }                    
-                    rdr = new InputStreamReader(in);
-                    ActionToGoalMapping map = reader.read(rdr);
+                    // relay the action load to the possibly customized getRawMappings
+                    ActionToGoalMapping map = getRawMappings();
                     writer.write(str, map);
                 } catch (IOException ex) {
-                    LOG.log(Level.WARNING, "Loading raw mappings", ex);
-                } catch (XmlPullParserException ex) {
                     LOG.log(Level.WARNING, "Loading raw mappings", ex);
                 } finally {
                     if(rdr != null) {
@@ -358,5 +382,4 @@ public class M2Configuration extends AbstractMavenActionsProvider implements Mav
             }
         }.getMappingForAction(reader, LOG, actionName, null, project, null, replaceMap);
     }
-
 }

--- a/java/maven/src/org/netbeans/modules/maven/customizer/CustomizerProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/CustomizerProviderImpl.java
@@ -223,6 +223,21 @@ public class CustomizerProviderImpl implements CustomizerProvider2 {
                 active = c;
             }
         }
+
+        for (M2Configuration config : provider.getProvidedConfigurations()) {
+            mapps.put(config.getId(), reader.read(new StringReader(config.getRawMappingsAsString())));
+            c = ModelHandle.createDefaultConfiguration();
+            CustomizerProviderImpl.ACCESSOR.setConfigurationId(c, config.getId());
+            String dn = config.getDisplayName();
+            if (!config.getId().equals(dn)) {
+                c.setDisplayName(dn);
+            }
+            configs.add(c);
+            if (act.equals(config)) {
+                active = c;
+            }
+        }
+
         for (M2Configuration config : provider.getProfileConfigurations()) {
             mapps.put(config.getId(), reader.read(new StringReader(config.getRawMappingsAsString())));
             c = ModelHandle.createProfileConfiguration(config.getId());
@@ -231,6 +246,7 @@ public class CustomizerProviderImpl implements CustomizerProvider2 {
                 active = c;
             }
         }
+
         if (active == null) { //#152706
             active = configs.get(0); //default if current not found..
         }
@@ -266,6 +282,7 @@ public class CustomizerProviderImpl implements CustomizerProvider2 {
     
     
     public static abstract class ModelAccessor {
+        public abstract void setConfigurationId(ModelHandle.Configuration cfg, String id);
         
         public abstract ModelHandle createHandle(POMModel model, MavenProject proj, Map<String, ActionToGoalMapping> mapp,
                 List<ModelHandle.Configuration> configs, ModelHandle.Configuration active, MavenProjectPropsImpl auxProps);

--- a/java/maven/src/org/netbeans/modules/maven/execute/model/NetbeansActionProfile.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/model/NetbeansActionProfile.java
@@ -28,7 +28,12 @@ public class NetbeansActionProfile {
      */
     private java.util.List<NetbeansActionMapping> actions;
     private String id;
-
+    
+    /**
+     * Display name, mainly for profiles shipped with the code. No reason to
+     * have in user custom profiles named by the users. 
+     */
+    private String displayName;
 
       //-----------/
      //- Methods -/
@@ -86,5 +91,22 @@ public class NetbeansActionProfile {
     {
         this.actions = actions;
     } //-- void setActions(java.util.List) 
-    
+
+    /**
+     * Returns human-readable display name, if defined.
+     * @return display name, or {@code null}
+     * @since 2.148
+     */
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    /**
+     * Sets the display name.
+     * @param displayName new display name, can be {@code null}.
+     * @since 2.148
+     */
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
 }

--- a/java/maven/src/org/netbeans/modules/maven/execute/model/io/xpp3/NetbeansBuildActionXpp3Reader.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/model/io/xpp3/NetbeansBuildActionXpp3Reader.java
@@ -262,6 +262,8 @@ public class NetbeansBuildActionXpp3Reader {
         while ( parser.nextTag() == XmlPullParser.START_TAG ) {
             if (parser.getName().equals("id")) {
                 p.setId(parser.nextText());
+            } else if (parser.getName().equals("displayName")) { // NOI18N
+                p.setDisplayName(parser.nextText());
             } else if (parser.getName().equals("actions")) {
                 while (parser.nextTag() == XmlPullParser.START_TAG && parser.getName().equals("action")) {
                     NetbeansActionMapping r = parseNetbeansActionMapping("actions", parser, strict);

--- a/java/maven/src/org/netbeans/modules/maven/execute/model/io/xpp3/NetbeansBuildActionXpp3Writer.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/model/io/xpp3/NetbeansBuildActionXpp3Writer.java
@@ -197,6 +197,9 @@ public class NetbeansBuildActionXpp3Writer {
     throws java.io.IOException {
         serializer.startTag( NAMESPACE, tagName);
         serializer.startTag( NAMESPACE, "id" ).text( p.getId()).endTag( NAMESPACE, "id");
+        if (p.getDisplayName() != null) {
+            serializer.startTag(NAMESPACE, "displayName" ).text( p.getId()).endTag( NAMESPACE, "displayName");  // NOI18N
+        }
         serializer.startTag( NAMESPACE, "actions");
         for (NetbeansActionMapping m : p.getActions()) {
             writeNetbeansActionMapping(m, "action", serializer);

--- a/java/maven/src/org/netbeans/modules/maven/spi/actions/AbstractMavenActionsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/spi/actions/AbstractMavenActionsProvider.java
@@ -26,6 +26,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -40,11 +41,14 @@ import java.util.logging.Logger;
 import org.netbeans.modules.maven.api.NbMavenProject;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.netbeans.api.project.Project;
+import org.netbeans.modules.maven.NbMavenProjectImpl;
+import org.netbeans.modules.maven.configurations.M2ConfigProvider;
 import org.netbeans.modules.maven.configurations.M2Configuration;
 import org.netbeans.modules.maven.execute.DefaultReplaceTokenProvider;
 import org.netbeans.modules.maven.execute.ModelRunConfig;
 import org.netbeans.modules.maven.execute.model.ActionToGoalMapping;
 import org.netbeans.modules.maven.execute.model.NetbeansActionMapping;
+import org.netbeans.modules.maven.execute.model.NetbeansActionProfile;
 import org.netbeans.modules.maven.execute.model.NetbeansActionReader;
 import org.netbeans.modules.maven.execute.model.io.xpp3.NetbeansBuildActionXpp3Reader;
 import org.netbeans.modules.maven.execute.model.io.xpp3.NetbeansBuildActionXpp3Writer;
@@ -319,5 +323,123 @@ public abstract class AbstractMavenActionsProvider implements MavenActionsProvid
             }
         }
         return buf.toString();
+    }
+    
+    /**
+     * Constructs a {@link MavenActionsProvider} from declarative action descriptions. The 
+     * {@code resourceURL} parameter identifies a {@code nbactions.xml}-format resource which
+     * can add/define actions in the default configuration. It can also <b>contribute</b>
+     * configurations (profiles) using the nested {@code &lt;profile>} element.
+     * <p/>
+     * Actions in the contributed configuration profiles are merged; multiple {@link MavenActionProviders}
+     * created by {@link #fromNbActions(org.netbeans.api.project.Project, java.net.URL)} can supply their
+     * actions. The first definition of a given {@code actionName} counts, subsequent definitions from 
+     * {@link MavenActionProviders} further in the project's Lookup are ignored.
+     * <p/>
+     * Note: at the moment it is not possible to build the <b>default configuration</b> actions 
+     * from multiple {@link MavenActionProviders}. 
+     * <p/>
+     * <b>This is a part of Maven module's friend API. If possible, use se  
+     * <a href="@org-netbeans-api-maven@/org/netbeans/spi/maven/MavenActions.html">MavenActions</a> to register
+     * actions declaratively, using module layers.
+     * 
+     * @param mavenProject the maven project. 
+     * @param resourceURL action definitions.
+     * @return new {@link MavenActionProvider} instance.
+     * @since 2.148
+     */
+    public static MavenActionsProvider fromNbActions(Project mavenProject, URL resourceURL) {
+        NbMavenProjectImpl mvn = mavenProject.getLookup().lookup(NbMavenProjectImpl.class);
+        if (mvn == null) {
+            throw new IllegalArgumentException("Not a maven proejct: " + mavenProject);
+        }
+        return new ResourceConfigAwareProvider(mvn, resourceURL);
+    }
+    
+    /**
+     * This provider wraps a custom resource, and provides actions from it.
+     * It cooperates with {@link M2ConfigProvider#getActiveConfiguration()} and provides actions
+     * for just the active one. For {@link M2ConfigProvider#DEFAULT} configuration, the returned
+     * mapping contains list of contributed configurations (profiles) if defined.
+     */
+    static class ResourceConfigAwareProvider extends AbstractMavenActionsProvider {
+        /**
+         * The backing resource
+         */
+        private final URL resource;
+        
+        /**
+         * The target project.
+         */
+        private final Project project;
+        
+        /**
+         * Quick lookup for profiles.
+         */
+        private final Map<String, ActionToGoalMapping> profileMap = new HashMap<>();
+        
+        /**
+         * Project's config provider, lazy initialized to avoid Lookup calls inside
+         * constructor called from within beforeLookup.
+         */
+        private M2ConfigProvider cfg;
+        
+        ResourceConfigAwareProvider(Project prj, URL resource) {
+            this.resource = resource;
+            this.project = prj;
+        }
+        
+        private M2ConfigProvider cfg() {
+            if (this.cfg != null) {
+                return this.cfg;
+            }
+            return this.cfg = project.getLookup().lookup(M2ConfigProvider.class);
+        }
+        
+        @Override
+        public ActionToGoalMapping getRawMappings() {
+            ActionToGoalMapping  allMappings = super.getRawMappings();
+            String id = cfg().getActiveConfiguration().getId();
+            if (M2Configuration.DEFAULT.equals(id) || allMappings.getProfiles() == null || allMappings.getProfiles().isEmpty()) {
+                return allMappings;
+            }
+            synchronized (this) {
+                ActionToGoalMapping pm = profileMap.get(id);
+                if (pm != null) {
+                    return pm;
+                }
+                if (!profileMap.isEmpty()) {
+                    return allMappings;
+                }
+                
+                for (NetbeansActionProfile p : allMappings.getProfiles()) {
+                    Set<String> overridenIds = new HashSet<>();
+                    ActionToGoalMapping m = new ActionToGoalMapping();
+                    for (NetbeansActionMapping am : p.getActions()) {
+                        overridenIds.add(am.getActionName());
+                        m.addAction(am);
+                    }
+                    for (NetbeansActionMapping am : allMappings.getActions()) {
+                        if (!overridenIds.contains(am.getActionName())) {
+                            m.addAction(am);
+                        }
+                    }
+                    profileMap.put(p.getId(), m);
+                }
+                
+                pm = profileMap.get(id);
+                return pm == null ? allMappings : pm;
+            }
+        }
+
+        @Override
+        protected InputStream getActionDefinitionStream() {
+            try {
+                return resource.openStream();
+            } catch (IOException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+
     }
 }

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectImplTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectImplTest.java
@@ -29,10 +29,12 @@ import java.util.logging.Level;
 import static junit.framework.TestCase.assertEquals;
 import org.netbeans.api.annotations.common.SuppressWarnings;
 import org.netbeans.api.java.queries.SourceLevelQuery;
+import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.junit.RandomlyFails;
+import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.modules.maven.debug.MavenJPDAStart;
 import org.netbeans.modules.projectapi.nb.TimedWeakReference;
 import org.netbeans.spi.project.LookupMerger;
@@ -232,4 +234,41 @@ public class NbMavenProjectImplTest extends NbTestCase {
         TestFileUtils.touch(TestFileUtils.writeFile(wd, ".mvn/maven.config", text), null);
     }
 
+    public static interface PS {
+        public String m();
+    }
+
+    // BEGIN:ProjectServiceProvider.pluginSpecific
+    @ProjectServiceProvider(service=PS.class, 
+            projectType=NbMavenProject.TYPE + "/org.ntebeans.modules.maven:test.plugin")
+    public static class PluginService implements PS {
+        public @Override String m() {
+            return "special";
+        }
+    }
+    // END:ProjectServiceProvider.pluginSpecific
+    
+    /**
+     * Checks that a service registered against a maven plugin is not present by default.
+     */
+    public void testPluginServiceNotPresent() throws Exception {
+        TestFileUtils.writeFile(wd, "pom.xml", "<project><modelVersion>4.0.0</modelVersion>"
+                + "<groupId>test</groupId><artifactId>parent</artifactId><version>1.0</version><packaging>pom</packaging>"
+                + "</project>");
+        
+        Project p = FileOwnerQuery.getOwner(wd);
+        assertNull(p.getLookup().lookup(PS.class));
+    }
+    
+    public void testPluginServicePresentWithPlugin() throws Exception {
+        TestFileUtils.writeFile(wd, "pom.xml", "<project><modelVersion>4.0.0</modelVersion>"
+                + "<groupId>test</groupId><artifactId>parent</artifactId><version>1.0</version><packaging>pom</packaging>"
+                + "<build><plugins><plugin><artifactId>test.plugin</artifactId><groupId>org.ntebeans.modules.maven</groupId></plugin></plugins></build>"
+                + "</project>");
+        
+        Project p = FileOwnerQuery.getOwner(wd);
+        PS ps = p.getLookup().lookup(PS.class);
+        assertNotNull(ps);
+        assertEquals("special", ps.m());
+    }
 }

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectImplTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/NbMavenProjectImplTest.java
@@ -240,7 +240,7 @@ public class NbMavenProjectImplTest extends NbTestCase {
 
     // BEGIN:ProjectServiceProvider.pluginSpecific
     @ProjectServiceProvider(service=PS.class, 
-            projectType=NbMavenProject.TYPE + "/org.ntebeans.modules.maven:test.plugin")
+            projectType=NbMavenProject.TYPE + "/org.netbeans.modules.maven:test.plugin")
     public static class PluginService implements PS {
         public @Override String m() {
             return "special";
@@ -263,7 +263,7 @@ public class NbMavenProjectImplTest extends NbTestCase {
     public void testPluginServicePresentWithPlugin() throws Exception {
         TestFileUtils.writeFile(wd, "pom.xml", "<project><modelVersion>4.0.0</modelVersion>"
                 + "<groupId>test</groupId><artifactId>parent</artifactId><version>1.0</version><packaging>pom</packaging>"
-                + "<build><plugins><plugin><artifactId>test.plugin</artifactId><groupId>org.ntebeans.modules.maven</groupId></plugin></plugins></build>"
+                + "<build><plugins><plugin><artifactId>test.plugin</artifactId><groupId>org.netbeans.modules.maven</groupId></plugin></plugins></build>"
                 + "</project>");
         
         Project p = FileOwnerQuery.getOwner(wd);

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/execute/MockMavenExec.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/execute/MockMavenExec.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.execute;
+
+import java.util.concurrent.CountDownLatch;
+import org.netbeans.modules.maven.api.execute.RunConfig;
+import org.openide.execution.ExecutorTask;
+import org.openide.windows.InputOutput;
+
+/**
+ * Block the actual maven execution, but pretend that the task has been completed
+ */
+public class MockMavenExec extends MavenCommandLineExecutor.ExecuteMaven {
+
+    public volatile boolean executed;
+    public volatile RunConfig executedConfig;
+    public CountDownLatch executedLatch = new CountDownLatch(1);
+
+    @Override
+    public ExecutorTask execute(RunConfig config, InputOutput io, AbstractMavenExecutor.TabContext tc) {
+        executed = true;
+        executedConfig = config;
+        ExecutorTask t = new ExecutorTask(() -> {
+        }) {
+            @Override
+            public void stop() {
+            }
+
+            @Override
+            public int result() {
+                return 0;
+            }
+
+            @Override
+            public InputOutput getInputOutput() {
+                return null;
+            }
+        };
+        t.run();
+        executedLatch.countDown();
+        return t;
+    }
+    
+}

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/problems/PrimingActionTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/problems/PrimingActionTest.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.maven.problems;
 
+import org.netbeans.modules.maven.execute.MockMavenExec;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
@@ -171,35 +172,6 @@ public class PrimingActionTest extends NbTestCase {
         assertFalse(enabled);
     }
     
-    /**
-     * Block the actual maven execution, but pretend that the task has been completed
-     */
-    class MockMavenExec extends MavenCommandLineExecutor.ExecuteMaven {
-        volatile boolean executed;
-
-        @Override
-        public ExecutorTask execute(RunConfig config, InputOutput io, AbstractMavenExecutor.TabContext tc) {
-            executed = true;
-            ExecutorTask t = new ExecutorTask(() -> {}) {
-                @Override
-                public void stop() {
-                }
-
-                @Override
-                public int result() {
-                    return 0;
-                }
-
-                @Override
-                public InputOutput getInputOutput() {
-                    return null;
-                }
-
-            };
-            t.run();
-            return t;
-        }
-    }
     
     /**
      * Checks that the priming build does not actually run on OK project, although

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/spi/actions/ProvidedConfigurationsTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/spi/actions/ProvidedConfigurationsTest.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.spi.actions;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.Arrays;
+import org.netbeans.api.project.FileOwnerQuery;
+import org.netbeans.api.project.Project;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.modules.maven.NbMavenProjectImpl;
+import org.netbeans.modules.maven.api.MavenConfiguration;
+import org.netbeans.modules.maven.api.NbMavenProject;
+import org.netbeans.modules.maven.api.execute.RunConfig;
+import org.netbeans.modules.maven.execute.ActionToGoalUtils;
+import org.netbeans.modules.maven.execute.MockMavenExec;
+import org.netbeans.modules.maven.spi.actions.AbstractMavenActionsProvider.ResourceConfigAwareProvider;
+import org.netbeans.spi.project.ActionProvider;
+import org.netbeans.spi.project.ProjectConfiguration;
+import org.netbeans.spi.project.ProjectConfigurationProvider;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.test.MockLookup;
+import org.openide.util.test.TestFileUtils;
+
+/**
+ *
+ * @author sdedic
+ */
+public class ProvidedConfigurationsTest extends NbTestCase {
+
+    public ProvidedConfigurationsTest(String name) {
+        super(name);
+    }
+    
+    private FileObject pomFile;
+    
+    private void setupOKProject() throws Exception {
+        File f = TestFileUtils.writeFile(new File(getWorkDir(), "pom.xml"), 
+             "<project xmlns='http://maven.apache.org/POM/4.0.0'>"
+            + "<properties>"
+            + " <exec.mainClass>org.netbeans.modules.maven.test.Clazz</exec.mainClass>"
+            + "</properties>"
+            + "  <modelVersion>4.0.0</modelVersion>" 
+            + "  <artifactId>m</artifactId>" 
+            + "  <groupId>g</groupId>"
+            + "    <version>0</version>"
+            + "</project>");
+        
+        pomFile = FileUtil.toFileObject(f);
+        
+    }
+    
+    /**
+     * Checks that the contributed action is enabled on the default configuration.
+     */
+    public void testExtraActionEnabledInDefaultConfig() throws Exception {
+        setupOKProject();
+        Project p = FileOwnerQuery.getOwner(pomFile);
+        assertNotNull(p);
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        
+        assertTrue(Arrays.asList(ap.getSupportedActions()).contains("run-extra"));
+        assertTrue(ap.isActionEnabled("run-extra", Lookup.EMPTY));
+    }
+    
+    /**
+     * Checks that the contributed action is inherited into a specific
+     * configuration with no override.
+     */
+    public void testExtraActionEnabledInProvidedConfig() throws Exception {
+        setupOKProject();
+        Project p = FileOwnerQuery.getOwner(pomFile);
+        assertNotNull(p);
+        ProjectConfigurationProvider<MavenConfiguration> pcp = p.getLookup().lookup(ProjectConfigurationProvider.class);
+        MavenConfiguration c = pcp.getConfigurations().stream().filter(x -> "Micronaut: dev mode".equals(x.getDisplayName())).findAny().get();
+        pcp.setActiveConfiguration(c);
+        
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        assertTrue(ap.isActionEnabled("run-extra", Lookup.EMPTY));
+    }
+
+    /**
+     * Checks that a profile-specific action is reported from {@link ActionProvider#getSupportedActions()}
+     * but is disabled.
+     */
+    public void testProfileSpecificActionPresentAndDisabled() throws Exception {
+        setupOKProject();
+        Project p = FileOwnerQuery.getOwner(pomFile);
+        assertNotNull(p);
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        
+        assertTrue(Arrays.asList(ap.getSupportedActions()).contains("run-specific"));
+        assertFalse(ap.isActionEnabled("run-specific", Lookup.EMPTY));
+    }
+    
+    /**
+     * Checks that a profile-specific action is missing from the default configuration
+     */
+    public void testSpecificConfigurationHasExtraActions() throws Exception {
+        setupOKProject();
+        Project p = FileOwnerQuery.getOwner(pomFile);
+        assertNotNull(p);
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        
+        ProjectConfigurationProvider<MavenConfiguration> pcp = p.getLookup().lookup(ProjectConfigurationProvider.class);
+        MavenConfiguration c = pcp.getConfigurations().stream().filter(x -> "Micronaut: dev mode".equals(x.getDisplayName())).findAny().get();
+        pcp.setActiveConfiguration(c);
+
+        assertTrue(Arrays.asList(ap.getSupportedActions()).contains("run-specific"));
+        assertTrue(ap.isActionEnabled("run-specific", Lookup.EMPTY));
+    }
+    
+    /**
+     * Checks that configuration-specific overrides apply, compared to the default
+     * configuration.
+     */
+    public void testSpecificConfigurationGoalOverride() throws Exception {
+        setupOKProject();
+        Project p = FileOwnerQuery.getOwner(pomFile);
+        assertNotNull(p);
+        
+        NbMavenProjectImpl pimpl = p.getLookup().lookup(NbMavenProjectImpl.class);
+        RunConfig cfg = ActionToGoalUtils.createRunConfig("run", pimpl, Lookup.EMPTY);
+        assertEquals(Arrays.asList(
+                "process-classes",
+                "org.codehaus.mojo:exec-maven-plugin:3.0.0:exec"), cfg.getGoals());
+        
+        ProjectConfigurationProvider<MavenConfiguration> pcp = p.getLookup().lookup(ProjectConfigurationProvider.class);
+        MavenConfiguration c = pcp.getConfigurations().stream().filter(x -> "Micronaut: dev mode".equals(x.getDisplayName())).findAny().get();
+        pcp.setActiveConfiguration(c);
+
+        RunConfig cfg2 = ActionToGoalUtils.createRunConfig("run", pimpl, Lookup.EMPTY);
+        assertEquals(Arrays.asList(
+                "mn:run"), cfg2.getGoals());
+    }
+    
+    /**
+     * Checks that a nbactions.xml will override contributed action's defaults.
+     */
+    public void testContributedActionCanCustomize() throws Exception {
+        clearWorkDir();
+        setupOKProject();
+        try (OutputStream o = pomFile.getParent().createAndOpen("nbactions.xml");
+            OutputStreamWriter w = new OutputStreamWriter(o)) {
+            w.write(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "    <actions>\n" +
+                "        <action>\n" +
+                "            <actionName>run-extra</actionName>\n" +
+                "            <packagings>\n" +
+                "                <packaging>jar</packaging>\n" +
+                "            </packagings>\n" +
+                "            <goals>\n" +
+                "                <goal>boo:boo</goal>\n" +
+                "            </goals>\n" +
+                "            <properties>\n" +
+                "                <exec.vmArgs></exec.vmArgs>\n" +
+                "                <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>\n" +
+                "                <exec.appArgs></exec.appArgs>\n" +
+                "                <exec.mainClass>${packageClassName}</exec.mainClass>\n" +
+                "            </properties>\n" +
+                "        </action>\n" +
+                "    </actions>\n" +
+                ""
+            );
+        }
+        Project p = FileOwnerQuery.getOwner(pomFile);
+        NbMavenProjectImpl pimpl = p.getLookup().lookup(NbMavenProjectImpl.class);
+        RunConfig cfg = ActionToGoalUtils.createRunConfig("run-extra", pimpl, Lookup.EMPTY);
+        assertEquals(Arrays.asList("boo:boo"), cfg.getGoals());
+    }
+    
+    /**
+     * Checks that a nbactions.xml will override contributed action's defaults.
+     */
+    public void testContributedProfileActionCanCustomize() throws Exception {
+        clearWorkDir();
+        setupOKProject();
+        try (OutputStream o = pomFile.getParent().createAndOpen("nbactions-micronaut-auto.xml");
+            OutputStreamWriter w = new OutputStreamWriter(o)) {
+            w.write(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "    <actions>\n" +
+                "        <action>\n" +
+                "            <actionName>run-extra</actionName>\n" +
+                "            <packagings>\n" +
+                "                <packaging>jar</packaging>\n" +
+                "            </packagings>\n" +
+                "            <goals>\n" +
+                "                <goal>moo:moo</goal>\n" +
+                "            </goals>\n" +
+                "            <properties>\n" +
+                "                <exec.vmArgs></exec.vmArgs>\n" +
+                "                <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>\n" +
+                "                <exec.appArgs></exec.appArgs>\n" +
+                "                <exec.mainClass>${packageClassName}</exec.mainClass>\n" +
+                "            </properties>\n" +
+                "        </action>\n" +
+                "    </actions>\n" +
+                ""
+            );
+        }
+        Project p = FileOwnerQuery.getOwner(pomFile);
+        NbMavenProjectImpl pimpl = p.getLookup().lookup(NbMavenProjectImpl.class);
+        RunConfig cfg = ActionToGoalUtils.createRunConfig("run-extra", pimpl, Lookup.EMPTY);
+        assertEquals(Arrays.asList("mn:run"), cfg.getGoals());
+
+        ProjectConfigurationProvider<MavenConfiguration> pcp = p.getLookup().lookup(ProjectConfigurationProvider.class);
+        MavenConfiguration c = pcp.getConfigurations().stream().filter(x -> "Micronaut: dev mode".equals(x.getDisplayName())).findAny().get();
+        pcp.setActiveConfiguration(c);
+
+        RunConfig cfg2 = ActionToGoalUtils.createRunConfig("run-extra", pimpl, Lookup.EMPTY);
+        assertEquals(Arrays.asList(
+                "moo:moo"), cfg2.getGoals());
+    }
+    
+    /**
+     * Test that attempts to launch an action in a specific configuration, used as an example in 
+     * the Javadoc.
+     */
+    public void testExampleProviderConfigurationUsage() throws Exception {
+        MockMavenExec mme = new MockMavenExec();
+        MockLookup.setLayersAndInstances(mme);
+        
+        setupOKProject();
+        
+        FileObject theFile = pomFile;
+
+        Project p = FileOwnerQuery.getOwner(pomFile);
+        ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+        ProjectConfigurationProvider<MavenConfiguration> pcp = p.getLookup().lookup(ProjectConfigurationProvider.class);
+        ProjectConfiguration configToUse = pcp.getConfigurations().stream().
+                filter(x -> "Micronaut: dev mode".equals(x.getDisplayName())).findAny().get();
+        Lookup ctx = Lookups.fixed(theFile, configToUse);
+        if (!ap.isActionEnabled(ActionProvider.COMMAND_RUN, ctx)) {
+            // action not enabled
+            return;
+        }
+        ap.invokeAction(ActionProvider.COMMAND_RUN, ctx);
+        
+        mme.executedLatch.await();
+        assertEquals(Arrays.asList("mn:run"), mme.executedConfig.getGoals());
+    }
+    
+    @ProjectServiceProvider(service = MavenActionsProvider.class, projectType = NbMavenProject.TYPE)
+    public static class P extends ResourceConfigAwareProvider {
+        public P(Project prj) {
+            super(prj, P.class.getResource("providedActions.xml"));
+        }
+    }
+}

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/spi/actions/providedActions.xml
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/spi/actions/providedActions.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+
+<actions>
+    <actions>
+        <action>
+            <actionName>run-extra</actionName>
+            <packagings>
+                <packaging>jar</packaging>
+            </packagings>
+            <goals>
+                <goal>mn:run</goal>
+            </goals>
+            <properties>
+                <exec.vmArgs></exec.vmArgs>
+                <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                <exec.appArgs></exec.appArgs>
+                <exec.mainClass>${packageClassName}</exec.mainClass>
+            </properties>
+        </action>
+    </actions>
+    <profiles>
+        <profile>
+            <id>micronaut-auto</id>
+            <displayName>Micronaut: dev mode</displayName>
+            <actions>
+                <action>
+                    <actionName>run-specific</actionName>
+                    <packagings>
+                        <packaging>jar</packaging>
+                    </packagings>
+                    <goals>
+                        <goal>mn:run</goal>
+                    </goals>
+                    <properties>
+                        <exec.vmArgs></exec.vmArgs>
+                        <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                        <exec.appArgs></exec.appArgs>
+                        <exec.mainClass>${packageClassName}</exec.mainClass>
+                    </properties>
+                </action>
+                <action>
+                    <actionName>run</actionName>
+                    <packagings>
+                        <packaging>jar</packaging>
+                    </packagings>
+                    <goals>
+                        <goal>mn:run</goal>
+                    </goals>
+                    <properties>
+                        <exec.vmArgs></exec.vmArgs>
+                        <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                        <exec.appArgs></exec.appArgs>
+                        <exec.mainClass>${packageClassName}</exec.mainClass>
+                    </properties>
+                </action>
+                <action>
+                    <actionName>run.single.main</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                    <goals>
+                        <goal>mn:run</goal>
+                    </goals>
+                    <properties>
+                        <exec.vmArgs></exec.vmArgs>
+                        <exec.args>${exec.vmArgs} -classpath %classpath ${exec.mainClass} ${exec.appArgs}</exec.args>
+                        <exec.mainClass>${packageClassName}</exec.mainClass>
+                        <exec.classpathScope>${classPathScope}</exec.classpathScope>
+                    </properties>
+                </action>
+            </actions>
+        </profile>
+    </profiles>
+</actions>


### PR DESCRIPTION
Asking for an initial review. Outline of the changes:
- adapted @JaroslavTulach prototype of a declarative action provider for Maven. Actions can be contributed using module's layer registrations; examples provided in docs.
- synced Maven's extensibilty with Gradle: a module may inject service into project's Lookup when a certain plugin is configured for the project. This is present in Gradle and is IMHO beneficial for Maven too.
- improved interaction of default GUI and the declarative `MavenActionProviders`; supplied actions can be customized.
- Branding API for Maven to mask out POM-profile implied configurations; just real configurations (user or module-provided) will be visible in Configuration chooser
- Exported Configurations over LSP. Launch config may specify the desired configuration (unspecificed = the active one).

---

**A somewhat controversial change** is the introduction of `ActionProvider.ConfigurationAware` interface. For the purpose of this PR, the `getSupportedActions` method does not get enough context: an action may be defined for a specific configuration only (in Maven). An option would be to disallow defining new action IDs local to a configuration; or merge all IDs form all configurations.

Discussed offline with @dbalek whether it is preferrable to pass the selected `ProjectConfiguration` in the context Lookup (see docs for ProjectConfigurationProvider); the result was that given both concepts are exposed in the Project API, wormholing through Lookup seems awkward - so I introduced `ConfigurationAware` to create a configuration-bound `ActionProvider` instance.

I developed the implementation, but I need to get review on this `ConfigurationAware` concept now. If approved, I neeed to provide `ProjectUtils` methods for API clients, so they need not interact with ProjectConfigurationProvider SPI that much + provide compatibility bridge. If disapproved, I need to change Maven implementation to merge IDs from known configuration to supported IDs.