### PR TITLE
[NETBEANS-5683] - remove last remaining HashSet raw type warnings..

### DIFF
--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenWhiteListQueryImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenWhiteListQueryImpl.java
@@ -112,13 +112,13 @@ public class MavenWhiteListQueryImpl implements WhiteListQueryImplementation {
                         if (newTransitive == null) {
                             newTransitive = Collections.emptySet();
                         }
-                        HashSet oldNotNew1 = new HashSet(oldPrivate);
+                        Set<String> oldNotNew1 = new HashSet<>(oldPrivate);
                         oldNotNew1.removeAll(newPrivate);
-                        HashSet newNotOld1 = new HashSet(newPrivate);
+                        Set<String> newNotOld1 = new HashSet<>(newPrivate);
                         newNotOld1.removeAll(oldPrivate);
-                        HashSet oldNotNew2 = new HashSet(oldTransitive);
+                        Set<String> oldNotNew2 = new HashSet<>(oldTransitive);
                         oldNotNew2.removeAll(newTransitive);
-                        HashSet newNotOld2 = new HashSet(newTransitive);
+                        Set<String> newNotOld2 = new HashSet<>(newTransitive);
                         newNotOld2.removeAll(oldTransitive);
                         
                         boolean privateChanged = !oldNotNew1.isEmpty() || !newNotOld1.isEmpty();

--- a/enterprise/j2ee.genericserver/src/org/netbeans/modules/j2ee/genericserver/ide/GSJ2eePlatformFactory.java
+++ b/enterprise/j2ee.genericserver/src/org/netbeans/modules/j2ee/genericserver/ide/GSJ2eePlatformFactory.java
@@ -52,13 +52,13 @@ public class GSJ2eePlatformFactory extends J2eePlatformFactory {
         }
         
         public Set getSupportedSpecVersions() {
-            Set result = new HashSet();
+            Set<String> result = new HashSet<>();
             result.add(J2eeModule.J2EE_14);
             return result;
         }
         
-        public java.util.Set getSupportedModuleTypes() {
-            Set result = new HashSet();
+        public Set getSupportedModuleTypes() {
+            Set<Object> result = new HashSet<>();
 //            result.add(J2eeModule.EAR);
 //            result.add(J2eeModule.WAR);
             result.add(J2eeModule.EJB);
@@ -68,7 +68,7 @@ public class GSJ2eePlatformFactory extends J2eePlatformFactory {
         }
         
         public Set/*<String>*/ getSupportedJavaPlatformVersions() {
-            Set versions = new HashSet();
+            Set<String> versions = new HashSet<>();
             versions.add("1.4"); // NOI18N
             versions.add("1.5"); // NOI18N
             versions.add("1.6"); // NOI18N

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFFrameworkProvider.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/JSFFrameworkProvider.java
@@ -124,7 +124,7 @@ public class JSFFrameworkProvider extends WebFrameworkProvider {
     // not named extend() so as to avoid implementing WebFrameworkProvider.extend()
     // better to move this to JSFConfigurationPanel
     public Set extendImpl(WebModule webModule, TreeMap<String, JsfComponentCustomizer> jsfComponentCustomizers) {
-        Set result = new HashSet();
+        Set<FileObject> result = new HashSet<>();
         Library jsfLibrary = null;
         Library jstlLibrary = null;
 

--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceListModel.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/model/WebServiceListModel.java
@@ -53,7 +53,8 @@ public class WebServiceListModel {
     private static Random serviceRandom = new Random(System.currentTimeMillis());
     private static Random serviceGroupRandom = new Random(System.currentTimeMillis());
     public boolean isDirty = false;
-    Set<WebServiceListModelListener> listeners = new HashSet<WebServiceListModelListener>();
+    Set<WebServiceListModelListener> listeners = new HashSet<>();
+
     /**
      * Fix for Bug#: 5039378
      * Netbeans can potentially use multiple threads to maintain a Node's data model.
@@ -62,7 +63,7 @@ public class WebServiceListModel {
     private List<WebServiceData> webServices = Collections.synchronizedList(new ArrayList<WebServiceData>());
     private List<WebServiceGroup> webServiceGroups = Collections.synchronizedList(new ArrayList<WebServiceGroup>());
     // To maintain the display names for the webservice/port
-    private Set<String> uniqueDisplayNames = Collections.synchronizedSet(new HashSet());
+    private Set<String> uniqueDisplayNames = Collections.synchronizedSet(new HashSet<String>());
     private List<String> partnerServices = new ArrayList<String>();
     private static WebServiceListModel websvcNodeModel = new WebServiceListModel();
     private boolean initialized = false;

--- a/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/codegen/model/GenericResourceBean.java
+++ b/enterprise/websvc.rest/src/org/netbeans/modules/websvc/rest/codegen/model/GenericResourceBean.java
@@ -145,7 +145,7 @@ public class GenericResourceBean {
     }
 
     public void setMethodTypes(HttpMethodType[] types) {
-        methodTypes = new HashSet(Arrays.asList(types));
+        methodTypes = new HashSet<>(Arrays.asList(types));
     }
     
     private String[] uriParams = null;

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
@@ -154,7 +154,7 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
         ArrayList<SourceGroup> ret = new ArrayList<>();
         Set<SourceType> stype = soureType2SourceType(type);
         for (SourceType st : stype) {
-            Set<File> processed = new HashSet();
+            Set<File> processed = new HashSet<>();
             for (String group : gradleSources.keySet()) {
                 Set<File> dirs = gradleSources.get(group).getSourceDirs(st);
                 boolean unique = dirs.size() == 1;

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
@@ -213,7 +213,7 @@ public class Utilities {
     }
 
     private static boolean isChainTrusted(Collection<? extends Certificate> archiveCertificates, Collection<? extends Certificate> trustedCertificates) {
-        Collection<Certificate> c = new HashSet(trustedCertificates);
+        Collection<Certificate> c = new HashSet<>(trustedCertificates);
         c.retainAll(archiveCertificates);
         return ! c.isEmpty();
     }

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewActionMap.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewActionMap.java
@@ -24,6 +24,8 @@ import javax.swing.Action;
 import javax.swing.ActionMap;
 import javax.swing.JComponent;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.openide.windows.TopComponent;
 
 
@@ -119,7 +121,7 @@ final class MultiViewActionMap extends ActionMap {
 
 
     private Object[] keys(boolean all) {
-        java.util.Set keys = new java.util.HashSet();
+        Set<Object> keys = new HashSet<>();
 
         if (delegate != null) {
             Object[] delegateKeys;

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewTopComponentLookup.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewTopComponentLookup.java
@@ -99,7 +99,7 @@ class MultiViewTopComponentLookup extends Lookup {
         
         public Collection allInstances() {
             // this shall remove duplicates??
-            Set s = new HashSet(delegate.allInstances());
+            Set<Lookup.Result> s = new HashSet<>(delegate.allInstances());
             return s;
         }
         
@@ -109,9 +109,9 @@ class MultiViewTopComponentLookup extends Lookup {
         
         public Collection allItems() {
             // remove duplicates..
-            Set s = new HashSet(delegate.allItems());
-            Iterator<Lookup.Item> it = s.iterator();
-            Set instances = new HashSet();
+            Set<Lookup.Item> s = new HashSet<>(delegate.allItems());
+            Iterator it = s.iterator();
+            Set instances = new HashSet<>();
             while (it.hasNext()) {
                 Lookup.Item i = (Lookup.Item)it.next();
                 if (instances.contains(i.getInstance())) {

--- a/platform/openide.nodes/src/org/openide/nodes/CookieSet.java
+++ b/platform/openide.nodes/src/org/openide/nodes/CookieSet.java
@@ -240,7 +240,7 @@ public final class CookieSet extends Object implements Lookup.Provider {
      */
     static Object entryAllClassesMode() {
         Object prev = QUERY_MODE.get();
-        QUERY_MODE.set(new HashSet());
+        QUERY_MODE.set(new HashSet<Object>());
 
         return prev;
     }

--- a/platform/openide.options/src/org/openide/options/VetoSystemOption.java
+++ b/platform/openide.options/src/org/openide/options/VetoSystemOption.java
@@ -23,6 +23,7 @@ import java.beans.PropertyVetoException;
 import java.beans.VetoableChangeListener;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 
 /** Extends the functionality of <CODE>SystemOption</CODE>
@@ -45,11 +46,11 @@ public abstract class VetoSystemOption extends SystemOption {
     /** Lazy getter for veto hashtable.
     * @return the hashtable
     */
-    private HashSet getVeto() {
-        HashSet set = (HashSet) getProperty(PROP_VETO_SUPPORT);
+    private Set<VetoableChangeListener> getVeto() {
+        Set<VetoableChangeListener> set = (HashSet<VetoableChangeListener>)getProperty(PROP_VETO_SUPPORT);
 
         if (set == null) {
-            set = new HashSet();
+            set = new HashSet<>();
             putProperty(PROP_VETO_SUPPORT, set);
         }
 
@@ -87,7 +88,7 @@ public abstract class VetoSystemOption extends SystemOption {
         Iterator<VetoableChangeListener> en;
 
         synchronized (getLock()) {
-            en = ((HashSet<VetoableChangeListener>)getVeto().clone()).iterator();
+            en = getVeto().stream().collect(Collectors.toSet()).iterator();
         }
 
         while (en.hasNext()) {


### PR DESCRIPTION
This change will remove the last remaining warnings about raw type HashSet.

   [repeat] /home/bwalker/src/netbeans/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewActionMap.java:124: warning: [rawtypes] found raw type: HashSet
   [repeat]         Set keys = new HashSet();
   [repeat]                        ^
   [repeat]   missing type arguments for generic class HashSet<E>
   [repeat]   where E is a type-variable:
   [repeat]     E extends Object declared in class HashSet

At this point, we have removed all warnings related to this.. Hooray!!