### PR TITLE
[NETBEANS-5697] Various LAF/HiDPI improvements on Windows

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/ActiveConfigAction.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/ActiveConfigAction.java
@@ -488,7 +488,6 @@ public class ActiveConfigAction extends CallableSystemAction implements LookupLi
         private Border defaultBorder = getBorder();
         
         ConfigCellRenderer() {
-            setOpaque(true);
         }
 
         public @Override Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
@@ -517,10 +516,15 @@ public class ActiveConfigAction extends CallableSystemAction implements LookupLi
             if ( isSelected ) {
                 setBackground(list.getSelectionBackground());
                 setForeground(list.getSelectionForeground());             
+                setOpaque(true);
             }
             else {
                 setBackground(list.getBackground());
                 setForeground(list.getForeground());
+                /* Avoid painting a background that does not match the rest of the JComboBox, in
+                particular when we are painting the item in the toolbar box rather than in the popup
+                list. */
+                setOpaque(false);
             }
             
             return this;

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarConfiguration.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarConfiguration.java
@@ -593,12 +593,6 @@ public final class ToolbarConfiguration implements ToolbarPool.Configuration {
         mid = new Color(r, g, b);
     }
 
-    private static boolean isWindows8() {
-        String osName = System.getProperty ("os.name");
-        return osName.indexOf("Windows 8") >= 0
-            || (osName.equals( "Windows NT (unknown)" ) && "6.2".equals( System.getProperty("os.version") ));
-    }
-
     private static final Border lowerBorder = BorderFactory.createCompoundBorder(
         BorderFactory.createMatteBorder(0, 0, 1, 0,
         fetchColor("controlShadow", Color.DARK_GRAY)),
@@ -620,18 +614,10 @@ public final class ToolbarConfiguration implements ToolbarPool.Configuration {
             //add border
             if ("Windows".equals(UIManager.getLookAndFeel().getID())) { //NOI18N
                 if( isXPTheme() ) {
-                    if( isWindows8() ) {
-                        toolbarPanel.setBorder( BorderFactory.createEmptyBorder() );
-                    } else {
-                        //Set up custom borders for XP
-                        toolbarPanel.setBorder(BorderFactory.createCompoundBorder(
-                            upperBorder,
-                            BorderFactory.createCompoundBorder(
-                                BorderFactory.createMatteBorder(0, 0, 1, 0,
-                                fetchColor("controlShadow", Color.DARK_GRAY)),
-                                BorderFactory.createMatteBorder(0, 0, 1, 0, mid))
-                        )); //NOI18N
-                    }
+                    /* There used to be some more elaborate borders for Windows versions pre
+                    Windows 8 here. As of May 2021, all of those OS versions are discontinued,
+                    though. So just support the modern simplified look here. */
+                    toolbarPanel.setBorder( BorderFactory.createEmptyBorder() );
                 } else {
                     toolbarPanel.setBorder( BorderFactory.createEtchedBorder() );
                 }

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarContainer.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarContainer.java
@@ -25,6 +25,7 @@ import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.Point;
 import java.awt.RenderingHints;
@@ -33,6 +34,7 @@ import java.awt.dnd.DropTarget;
 import java.awt.event.ContainerEvent;
 import java.awt.event.ContainerListener;
 import java.awt.event.MouseEvent;
+import java.awt.geom.Ellipse2D;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -536,62 +538,28 @@ final class ToolbarContainer extends JPanel {
         }
 
         @Override
-        public void paintComponent (Graphics g) {
-            super.paintComponent(g);
-            int x = 3;
-            for (int i=4; i < getHeight()-4; i+=4) {
-                //first draw the rectangular highlight below each dot
-                g.setColor(UIManager.getColor("controlLtHighlight")); //NOI18N
-                g.fillRect(x + 1, i + 1, 2, 2);
-                //Get the shadow color.  We'll paint the darkest dot first,
-                //and work our way to the lightest
-                Color col = UIManager.getColor("controlShadow"); //NOI18N
-                g.setColor(col);
-                //draw the darkest dot
-                g.drawLine(x+1, i+1, x+1, i+1);
-
-                //Get the color components and calculate the amount each component
-                //should increase per dot
-                int red = col.getRed();
-                int green = col.getGreen();
-                int blue = col.getBlue();
-
-                //Get the default component background - we start with the dark
-                //color, and for each dot, add a percentage of the difference
-                //between this and the background color
-                Color back = getBackground();
-                int rb = back.getRed();
-                int gb = back.getGreen();
-                int bb = back.getBlue();
-
-                //Get the amount to increment each component for each dot
-                int incr = (rb - red) / 5;
-                int incg = (gb - green) / 5;
-                int incb = (bb - blue) / 5;
-
-                //Increment the colors
-                red += incr;
-                green += incg;
-                blue += incb;
-                //Create a slightly lighter color and draw the dot
-                col = new Color(red, green, blue);
-                g.setColor(col);
-                g.drawLine(x+1, i, x+1, i);
-
-                //And do it for the next dot, and so on, for all four dots
-                red += incr;
-                green += incg;
-                blue += incb;
-                col = new Color(red, green, blue);
-                g.setColor(col);
-                g.drawLine(x, i+1, x, i+1);
-
-                red += incr;
-                green += incg;
-                blue += incb;
-                col = new Color(red, green, blue);
-                g.setColor(col);
-                g.drawLine(x, i, x, i);
+        public void paintComponent (Graphics g0) {
+            super.paintComponent(g0);
+            Graphics2D g = (Graphics2D) g0.create();
+            try {
+                g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+                g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                // Vertical spacing between the dots.
+                final int dotSpacingPixels = 4;
+                // Minimum vertical space before the first dot and after the last dot.
+                final int verticalMargin = 6;
+                // The resulting number of dots.
+                final int dotCount = (getHeight() - 2 * verticalMargin) / dotSpacingPixels + 1;
+                // Center the dots vertically.
+                final int startY = (getHeight() - (dotCount - 1) * dotSpacingPixels) / 2;
+                final int x = 4;
+                g.setColor(UIManager.getColor("controlShadow"));
+                for (int i = 0; i < dotCount; i++) {
+                    final int y = startY + i * dotSpacingPixels;
+                    g.fill(new Ellipse2D.Float(x, y, 1.8f, 1.8f));
+                }
+            } finally {
+              g.dispose();
             }
         }
 

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/EditorToolbarBorder.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/EditorToolbarBorder.java
@@ -30,7 +30,8 @@ import org.netbeans.swing.plaf.LFCustoms;
  * @since 1.30
  */
 class EditorToolbarBorder extends AbstractBorder {
-    private static final Insets insets = new Insets(1, 0, 1, 0);
+    // Add two pixels of left padding here, to give some space around the "Source" button.
+    private static final Insets insets = new Insets(1, 2, 1, 0);
 
     @Override
     public void paintBorder(Component c, Graphics g, int x, int y, int w, int h) {

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
@@ -72,6 +72,8 @@ public final class Windows8LFCustoms extends LFCustoms {
         "FormattedTextField.font", "TextField.font", "Spinner.font", "Button.font", "EditorPane.font",
         "Label.font", "ComboBox.font", "Tree.font", "TextArea.font" }; //NOI18N
 
+    final Color TAB_CONTENT_BORDER_COLOR = new Color(156, 156, 156);
+
     @Override
     public Object[] createLookAndFeelCustomizationKeysAndValues() {
         /* Don't try to fetch this font size from the LAF; it won't work reliably for HiDPI
@@ -110,6 +112,18 @@ public final class Windows8LFCustoms extends LFCustoms {
             /* Note that menu separators are still 3 pixels too tall on Windows compared to native
             apps. Fixing that would be a bigger job, though (replacing WindowsPopupMenuSeparatorUI
             to override getPreferredSize). */
+
+            /* Let the quick search area be flush with the rest of the menu bar. There's already a
+            thin border under the menu bar, and the quick search icon + the "Search (Ctrl+I)" string
+            to show the user that the quick search component is there. */
+            "nb.quicksearch.border", new EmptyBorder(0, 0, 0, 0),
+
+            // Let the HeapView component be flush with the toolbar background.
+            "nb.heapview.background", new Color(240, 240, 240),
+            "nb.heapview.foreground", new Color(45, 45, 45),
+            "nb.heapview.highlight", new Color(240, 240, 240, 240),
+            // Use the same color as EditorTab/ViewTab.underlineColor.
+            "nb.heapview.chart", new Color(61, 129, 245)
         };
         List<Object> result = new ArrayList<>();
         result.addAll(Arrays.asList(constants));
@@ -186,8 +200,6 @@ public final class Windows8LFCustoms extends LFCustoms {
                 }
             }
         }
-        result.add("nb.quicksearch.border");
-        result.add(new DPIUnscaledBorder(UIManager.getDefaults().getBorder("TextField.border")));
 
         /* JSpinner has an odd border, and seemingly two borders on top of each other. Setting an
         empty border for Spinner.border makes the component look better on various HiDPI
@@ -218,8 +230,8 @@ public final class Windows8LFCustoms extends LFCustoms {
 
             // Use the same neutral grey as in the Windows 10 "Settings" app sidebar.
             DESKTOP_BACKGROUND, new Color(230, 230, 230), //NOI18N
-            SCROLLPANE_BORDER_COLOR, new Color(140, 140, 140),
-            SCROLLPANE_BORDER_COLOR2, new Color(140, 140, 140),
+            SCROLLPANE_BORDER_COLOR, TAB_CONTENT_BORDER_COLOR,
+            SCROLLPANE_BORDER_COLOR2, TAB_CONTENT_BORDER_COLOR,
             DESKTOP_BORDER, new EmptyBorder(6, 5, 4, 6),
             SCROLLPANE_BORDER, new DPIUnscaledBorder((Border) UIManager.get("ScrollPane.border")),
             EXPLORER_STATUS_BORDER, new StatusLineBorder(StatusLineBorder.TOP),
@@ -236,7 +248,11 @@ public final class Windows8LFCustoms extends LFCustoms {
 
             WORKPLACE_FILL, new Color(230, 230, 230), // Same as DESKTOP_BACKGROUND
 
-            DESKTOP_SPLITPANE_BORDER, BorderFactory.createEmptyBorder(4, 0, 0, 0),
+            DESKTOP_SPLITPANE_BORDER, BorderFactory.createEmptyBorder(0, 0, 0, 0),
+
+            "MenuBar.border", new DPIUnscaledBorder(new MatteBorder(0, 0, 1, 0, TAB_CONTENT_BORDER_COLOR)),
+            "nb.quicksearch.background", Color.WHITE, // Match text box background.
+
             SLIDING_BUTTON_UI, "org.netbeans.swing.tabcontrol.plaf.WinVistaSlidingButtonUI",
 
             // progress component related

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
@@ -31,9 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import javax.swing.*;
 import javax.swing.border.Border;
-import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
-import javax.swing.border.LineBorder;
 import javax.swing.border.MatteBorder;
 import javax.swing.plaf.ColorUIResource;
 import org.netbeans.swing.plaf.LFCustoms;
@@ -63,8 +61,9 @@ public final class Windows8LFCustoms extends LFCustoms {
     private static final String TAB_BORDER = "tab_border"; //NOI18N      
     private static final String TAB_SEL_BORDER = "tab_sel_border"; //NOI18N
     private static final String TAB_BORDER_INNER = "tab_border_inner"; //NOI18N      
-    
-    static final String SCROLLPANE_BORDER_COLOR = "scrollpane_border"; //NOI18N
+
+    // There is also a SCROLLPANE_BORDER_COLOR constant in the superclass. Both seem to be in use.
+    static final String SCROLLPANE_BORDER_COLOR2 = "scrollpane_border"; //NOI18N
 
     private static final String[] DEFAULT_GUI_FONT_PROPERTIES = new String[] {
         "TitledBorder.font", "Slider.font", "PasswordField.font", "TableHeader.font", "TextPane.font",
@@ -180,7 +179,7 @@ public final class Windows8LFCustoms extends LFCustoms {
         not use the borders from UIManager. */
         for (String key : new String[] {
                 "TextField.border", "PasswordField.border", "FormattedTextField.border", //NOI18N
-                "ScrollPane.border", "PopupMenu.border", "Menu.border" }) //NOI18N
+                "ScrollPane.border", "PopupMenu.border", "Menu.border", "ToolTip.border" }) //NOI18N
         {
             Object value = UIManager.getDefaults().get(key);
             if (value instanceof Border) {
@@ -191,19 +190,14 @@ public final class Windows8LFCustoms extends LFCustoms {
                 }
             }
         }
-        // JSpinner requires some special treatment.
-        Object spinnerBorder = UIManager.getDefaults().get("Spinner.border"); //NOI18N
-        if (spinnerBorder instanceof CompoundBorder) {
-            CompoundBorder cb = (CompoundBorder) spinnerBorder;
-            Border ob = cb.getOutsideBorder();
-            Border ib = cb.getInsideBorder();
-            if (ob instanceof LineBorder && ib instanceof EmptyBorder) {
-                result.add("Spinner.border"); //NOI18N
-                result.add(new DPIUnscaledBorder(new CompoundBorder(
-                        new MatteBorder(1, 1, 1, 1, ((LineBorder) ob).getLineColor()),
-                        new MatteBorder(2, 2, 2, 2, Color.WHITE))));
-            }
-        }
+        result.add("nb.quicksearch.border");
+        result.add(new DPIUnscaledBorder(UIManager.getDefaults().getBorder("TextField.border")));
+
+        /* JSpinner has an odd border, and seemingly two borders on top of each other. Setting an
+        empty border for Spinner.border makes the component look better on various HiDPI
+        scalings. */
+        result.add("Spinner.border");
+        result.add(new EmptyBorder(3, 3, 3, 3));
 
         return result.toArray();
     }
@@ -225,9 +219,11 @@ public final class Windows8LFCustoms extends LFCustoms {
         Object[] uiDefaults = {
             EDITOR_TAB_DISPLAYER_UI, editorTabsUI,
             VIEW_TAB_DISPLAYER_UI, viewTabsUI,
-            
-            DESKTOP_BACKGROUND, new Color(226, 223, 214), //NOI18N
-            SCROLLPANE_BORDER_COLOR, new Color(127, 157, 185),
+
+            // Use the same neutral grey as in the Windows 10 "Settings" app sidebar.
+            DESKTOP_BACKGROUND, new Color(230, 230, 230), //NOI18N
+            SCROLLPANE_BORDER_COLOR, new Color(140, 140, 140),
+            SCROLLPANE_BORDER_COLOR2, new Color(140, 140, 140),
             DESKTOP_BORDER, new EmptyBorder(6, 5, 4, 6),
             SCROLLPANE_BORDER, new DPIUnscaledBorder((Border) UIManager.get("ScrollPane.border")),
             EXPLORER_STATUS_BORDER, new StatusLineBorder(StatusLineBorder.TOP),
@@ -237,12 +233,12 @@ public final class Windows8LFCustoms extends LFCustoms {
             EDITOR_STATUS_RIGHT_BORDER, new StatusLineBorder(StatusLineBorder.TOP | StatusLineBorder.LEFT),
             EDITOR_STATUS_INNER_BORDER, new StatusLineBorder(StatusLineBorder.TOP | StatusLineBorder.LEFT | StatusLineBorder.RIGHT),
             EDITOR_STATUS_ONLYONEBORDER, new StatusLineBorder(StatusLineBorder.TOP),
-            EDITOR_TOOLBAR_BORDER, new EditorToolbarBorder(),
+            EDITOR_TOOLBAR_BORDER, new DPIUnscaledBorder(new EditorToolbarBorder()),
             OUTPUT_SELECTION_BACKGROUND, new Color (164, 180, 255),
 
             PROPERTYSHEET_BOOTSTRAP, propertySheetValues,
 
-            WORKPLACE_FILL, new Color(226, 223, 214),
+            WORKPLACE_FILL, new Color(230, 230, 230), // Same as DESKTOP_BACKGROUND
 
             DESKTOP_SPLITPANE_BORDER, BorderFactory.createEmptyBorder(4, 0, 0, 0),
             SLIDING_BUTTON_UI, "org.netbeans.swing.tabcontrol.plaf.WinVistaSlidingButtonUI",
@@ -270,6 +266,9 @@ public final class Windows8LFCustoms extends LFCustoms {
             //browser picker
             "Nb.browser.picker.background.light", new Color(255,255,255),
             "Nb.browser.picker.foreground.light", new Color(130,130,130),
+
+            // On Windows 10, tooltip backgrounds are white rather than yellowish.
+            "ToolTip.background", new Color(255, 255, 255)
         }; //NOI18N
         
         //Workaround for JDK 1.5.0 bug 5080144 - Disabled JTextFields stay white

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
@@ -153,8 +153,7 @@ public final class Windows8LFCustoms extends LFCustoms {
                 Object key = entry.getKey();
                 /* Force loading of lazily loaded values, so we can see if the actual implementation
                 type is of the kind that needs to be patched. All currently known icon properties
-                are suffixed "icon" or "Icon". All but one is of the kind that needs to be
-                patched. */
+                are suffixed "icon" or "Icon", and all are of the kind that needs to be patched. */
                 Object value = key.toString().toLowerCase(Locale.ROOT).endsWith("icon") //NOI18N
                         ? UIManager.getDefaults().get(key) : null;
                 if (value == null) {
@@ -163,13 +162,10 @@ public final class Windows8LFCustoms extends LFCustoms {
                 String valueCN = value.getClass().getName();
                 if (value instanceof Icon &&
                     (valueCN.startsWith("com.sun.java.swing.plaf.windows.WindowsIconFactory$") || //NOI18N
-                    valueCN.startsWith("com.sun.java.swing.plaf.windows.WindowsTreeUI$")) && //NOI18N
-                    /* This particular one can't be used as a delegate, as it intentionally behaves
-                    differently when the application has overridden UIDefaults. */
-                    !valueCN.contains("VistaMenuItemCheckIcon")) //NOI18N
+                    valueCN.startsWith("com.sun.java.swing.plaf.windows.WindowsTreeUI$"))) //NOI18N
                 {
                     result.add(key);
-                    result.add(new WindowsDPIWorkaroundIcon((Icon) value));
+                    result.add(new WindowsDPIWorkaroundIcon(key, (Icon) value));
                 }
             }
         }

--- a/platform/openide.actions/src/org/openide/actions/HeapView.java
+++ b/platform/openide.actions/src/org/openide/actions/HeapView.java
@@ -19,6 +19,7 @@
 package org.openide.actions;
 
 import java.awt.AWTEvent;
+import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -26,10 +27,14 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
+import java.awt.Shape;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
+import java.awt.font.GlyphVector;
+import java.awt.geom.AffineTransform;
 import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.prefs.Preferences;
@@ -49,6 +54,8 @@ import org.openide.util.NbPreferences;
  * <li> nb.heapview.background - Color of widget background
  * <li> nb.heapview.foreground - Color of text
  * <li> nb.heapview.chart - Color of area chart
+ * <li> nb.heapview.background - Color of outline around the text, to provide a contrast against
+ *                               the chart (may have a non-opaque alpha value)
  * </ul>
  * @author sky, radim, peter
  */
@@ -70,6 +77,11 @@ class HeapView extends JComponent {
      * Color for text.
      */
     private static final Color TEXT_COLOR;
+
+    /**
+     * Color for an outline around the text.
+     */
+    private static final Color OUTLINE_COLOR;
 
     /**
      * Color for the background.
@@ -99,6 +111,12 @@ class HeapView extends JComponent {
             c = Color.DARK_GRAY;
         }
         TEXT_COLOR = c;
+
+        c = UIManager.getColor("nb.heapview.highlight"); //NOI18N
+        if (null == c) {
+            c = new Color(255, 255, 255, 192);
+        }
+        OUTLINE_COLOR = c;
 
         c = UIManager.getColor("nb.heapview.background"); //NOI18N
         if (null == c) {
@@ -155,21 +173,15 @@ class HeapView extends JComponent {
     }
 
     /**
-     * Overridden to return true, GCComponent paints in its entire bounds in an
-     * opaque manner.
-     */
-    @Override
-    public boolean isOpaque() {
-        return true;
-    }
-
-    /**
      * Updates the look and feel for this component.
      */
     @Override
     public void updateUI() {
         Font f = UIManager.getFont("Label.font");
         setFont(f);
+        /* Setting this true seems to cause some painting artifacts on 150% scaling, as we don't
+        always manage to fill every device pixel with the background color. So leave it off. */
+        setOpaque(false);
     }
 
     /**
@@ -275,17 +287,23 @@ class HeapView extends JComponent {
 
         if (width > 0 && height > 0) {
             startTimerIfNecessary();
-            Graphics2D g2 = (Graphics2D) g;
-            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-            // Fill background
-            g2.setPaint(BACKGROUND_COLOR);
-            g2.fillRect(0, 0, width + 1, height + 1);
-            // Draw samples
-            g2.setPaint(CHART_COLOR);
-            paintSamples(g2, width, height);
-            // Draw text if enabled
-            if (getShowText()) {
-                paintText(g2, width, height);
+            Graphics2D g2 = (Graphics2D) g.create();
+            try {
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                g2.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+                g2.clipRect(0, 0, width, height);
+                // Draw background.
+                g2.setColor(BACKGROUND_COLOR);
+                g2.fillRect(0, 0, width, height);
+                // Draw samples
+                g2.setColor(CHART_COLOR);
+                paintSamples(g2, width, height);
+                // Draw text if enabled
+                if (getShowText()) {
+                    paintText(g2, width, height);
+                }
+            } finally {
+              g2.dispose();
             }
         } else {
             stopTimerIfNecessary();
@@ -296,14 +314,22 @@ class HeapView extends JComponent {
      * Renders the text using an optional drop shadow.
      */
     private void paintText(Graphics2D g, int w, int h) {
-        g.setFont(getFont());
+        Font font = getFont();
         String text = getHeapSizeText();
-        FontMetrics fm = g.getFontMetrics();
-        int textWidth = fm.stringWidth(text);
-        int x = (w - maxTextWidth) / 2 + (maxTextWidth - textWidth);
-        int y = h / 2 + fm.getAscent() / 2 - 2;
+        GlyphVector gv = font.createGlyphVector(g.getFontRenderContext(), text);
+        FontMetrics fm = g.getFontMetrics(font);
+        Shape outline = gv.getOutline();
+        Rectangle2D bounds = outline.getBounds2D();
+        double x = Math.max(0, (w - bounds.getWidth()) / 2.0);
+        double y = h / 2.0 + fm.getAscent() / 2.0 - 2.0;
+        AffineTransform oldTransform = g.getTransform();
+        g.translate(x, y);
+        g.setColor(OUTLINE_COLOR);
+        g.setStroke(new BasicStroke(2.5f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        g.draw(outline);
         g.setColor(TEXT_COLOR);
-        g.drawString(text, x, y);
+        g.fill(outline);
+        g.setTransform(oldTransform);
     }
 
     private String getHeapSizeText() {

--- a/platform/openide.loaders/src/org/openide/awt/MenuBar.java
+++ b/platform/openide.loaders/src/org/openide/awt/MenuBar.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -43,7 +42,6 @@ import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
@@ -163,15 +161,21 @@ public class MenuBar extends JMenuBar implements Externalizable {
             return !UIManager.getBoolean("NbMainWindow.showCustomBackground"); //NOI18N
         return super.isOpaque();
     }
-    
+
     @Override
     public void updateUI() {
         if (EventQueue.isDispatchThread()) {
             super.updateUI();
-            boolean GTK = "GTK".equals(UIManager.getLookAndFeel().getID());
-            if (!GTK) { //Let GTK supply some border, or mnemonic underlines
-                //will be flush and look ugly
+            String laf = UIManager.getLookAndFeel().getID();
+            // Let GTK supply some border, or mnemonic underlines.
+            boolean gtk = laf.equals("GTK");
+            boolean windows = laf.equals("Windows");
+            if (!(gtk || windows)) {
                 setBorder(BorderFactory.createEmptyBorder());
+            }
+            if (windows) {
+                // Ensure that Windows8LFCustoms can provide a custom border here.
+                setBorderPainted(true);
             }
         }
     }

--- a/platform/openide.loaders/src/org/openide/awt/Toolbar.java
+++ b/platform/openide.loaders/src/org/openide/awt/Toolbar.java
@@ -80,6 +80,9 @@ public class Toolbar extends ToolbarWithOverflow /*implemented by patchsuperclas
 
     private static final boolean isFlatLaF =
             UIManager.getLookAndFeel().getID().startsWith("FlatLaf");
+
+    private static final boolean isWindowsLaF =
+            UIManager.getLookAndFeel().getID().equals("Windows");
     
     static final long serialVersionUID = 5011742660516204764L;
     static {
@@ -182,9 +185,9 @@ public class Toolbar extends ToolbarWithOverflow /*implemented by patchsuperclas
                 ((AbstractButton) c).setBorderPainted(false);
                 ((AbstractButton) c).setOpaque(false);
             }
-            //This is active for GTK L&F. It should be fixed in JDK
-            //but it is not fixed in JDK 6.0.
-            if (!isMetalLaF && !isFlatLaF) {
+            if (isWindowsLaF) {
+                ((AbstractButton) c).setMargin(new Insets(2,1,0,1));
+            } else if (!isMetalLaF && !isFlatLaF) {
                 ((AbstractButton) c).setMargin( emptyInsets );
             }
             if( null != label && c != label ) {


### PR DESCRIPTION
This PR includes a few smaller improvements that were made to the Windows LAF while working on modernized tab components. Several of these relate to NetBeans' appearance when HiDPI scaling is active. Summary:

- Apply previous border tweaks for HiDPI screens in a few more places, notably in tooltips and the quick search text field, and in the editor toolbar. Improve JSpinner borders.
- Make the background color of tooltips consistent with that of other Windows 10 apps.
- Add some pixels of left margin to the editor toolbar.
- More improvements added in another commit, see the second pair of screenshots further below.

The screenshots below are from _before_ the fixes were applied.

![Smaller fixes](https://user-images.githubusercontent.com/886243/118885993-673cb800-b8c6-11eb-97ef-9911a158532e.png)

- Also apply the workarounds from NETBEANS-3592 to JCheckboxMenuItem and friends. This fixes the following problem, where menu item checkmarks can become tiny or huge in certain situations (due to HiDPI-related bugs in Swing's Windows LAF, see https://bugs.openjdk.java.net/browse/JDK-8211715 ):

![210517 Menu Checkbox Bug](https://user-images.githubusercontent.com/886243/118886009-6b68d580-b8c6-11eb-92c6-da623bcca518.png)


