### PR TITLE
[NETBEANS-5673] Modernize tab controls in the Windows LAF

### DIFF
--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
@@ -211,9 +211,9 @@ public final class Windows8LFCustoms extends LFCustoms {
     @Override
     public Object[] createApplicationSpecificKeysAndValues () {
         UIBootstrapValue editorTabsUI = new Windows8EditorColorings (
-                "org.netbeans.swing.tabcontrol.plaf.Windows8VectorEditorTabDisplayerUI");
+                "org.netbeans.swing.tabcontrol.plaf.WinFlatEditorTabDisplayerUI");
 
-        Object viewTabsUI = editorTabsUI.createShared("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI");
+        Object viewTabsUI = editorTabsUI.createShared("org.netbeans.swing.tabcontrol.plaf.WinFlatViewTabDisplayerUI");
 
         /* This icon pair exists in both PNG and SVG versions; the SVG version will be substituted
         automatically if ImageUtilities and the SVG Loader implementation module is available. */
@@ -317,8 +317,10 @@ public final class Windows8LFCustoms extends LFCustoms {
 
         @Override
         public Object[] createKeysAndValues() {
+            final Color TAB_CONTENT_BORDER_COLOR = new Color(140, 140, 140);
+
             return new Object[] {
-            // ==== Windows8*TabDisplayerUI ========================================================
+            // ==== Windows8*TabDisplayerUI (no longer used, but keep around for now) ==============
             //selected & focused
             TAB_FOCUS_FILL_UPPER, new Color(236,244,252),
             TAB_FOCUS_FILL_LOWER, new Color(221,237,252),
@@ -346,56 +348,91 @@ public final class Windows8LFCustoms extends LFCustoms {
             //Borders for the tab control
             EDITOR_TAB_OUTER_BORDER, BorderFactory.createEmptyBorder(),
             EDITOR_TAB_CONTENT_BORDER,
-                new DPIUnscaledBorder(new MatteBorder(0, 1, 1, 1, new Color(137, 140, 149)), true),
+                new DPIUnscaledBorder(new MatteBorder(0, 1, 1, 1, TAB_CONTENT_BORDER_COLOR), true),
             EDITOR_TAB_TABS_BORDER, BorderFactory.createEmptyBorder(),
 
             VIEW_TAB_OUTER_BORDER, BorderFactory.createEmptyBorder(),
             VIEW_TAB_CONTENT_BORDER,
-                new DPIUnscaledBorder(new MatteBorder(0, 1, 1, 1, new Color(137, 140, 149)), true),
+                new DPIUnscaledBorder(new MatteBorder(0, 1, 1, 1, TAB_CONTENT_BORDER_COLOR), true),
             VIEW_TAB_TABS_BORDER, BorderFactory.createEmptyBorder(),
 
             // ==== WinFlat*TabDisplayerUI =========================================================
+            /* Configure the tab displayers to look like native Windows 10 tabs, except show shorter
+            separator lines instead of full borders between unselected tabs, and do not offset the
+            Y position of the selected tab. Also highlight the selected tab with a blue indicator
+            line. */
 
-            "EditorTab.tabInsets", new Insets(5,6,7,8),
-            "EditorTab.underlineHeight", 3,
-            //"EditorTab.underlineAtTop", null,
+            "EditorTab.showSelectedTabBorder", true,
+            "ViewTab.showSelectedTabBorder", true,
+            // On the Windows LAF, borders stay 1 device pixel wide regardless of HiDPI scaling.
+            "EditorTab.unscaledBorders", true,
+            "ViewTab.unscaledBorders", true,
+
+            // Left means left of the icon. Right means right of the caption, not of the "X" icon.
+            "EditorTab.tabInsets", new Insets(3,6,5,6),
+            "EditorTab.underlineHeight", 2,
+            "EditorTab.underlineAtTop", true,
             "EditorTab.showTabSeparators", true,
 
-            "ViewTab.tabInsets", new Insets(5,6,7,2),
-            "ViewTab.underlineHeight", 3,
-            //"ViewTab.underlineAtTop", null,
-            "ViewTab.showTabSeparators", true,
+            /* Left/top means left/top of the caption. Right means right of the caption. The X is
+            centered vertically. */
+            "ViewTab.tabInsets", new Insets(4,7,4,3),
+            "ViewTab.underlineHeight", 2,
+            "ViewTab.underlineAtTop", true,
+            "ViewTab.showTabSeparators", false,
 
-            "EditorTab.background", new Color(242, 242, 242),
-            //"EditorTab.foreground", null,
-            "EditorTab.hoverBackground", new Color(224, 224, 224),
+            "EditorTab.background", new Color(240, 240, 240), // Same as JPanel background.
+            // "EditorTab.foreground", null,
+
+            /* As on native Windows tabs, don't show a hover effect for the selected tab. So set
+            this to the same as selectedBackground. */
+            "EditorTab.hoverBackground", new Color(255, 255, 255),
+            // Use the hover color from native Windows tabs.
+            "EditorTab.unselectedHoverBackground", new Color(216, 234, 249),
             "EditorTab.attentionBackground", new Color(230, 200, 64),
-            "EditorTab.underlineColor", new Color(64, 131, 201),
-            "EditorTab.inactiveUnderlineColor", new Color(156, 167, 184),
-            "EditorTab.tabSeparatorColor", new Color(196, 196, 196),
-            "EditorTab.activeBackground", new Color(226, 230, 236),
+            "EditorTab.underlineColor", new Color(46, 144, 232),
+            /* Don't show emphasis for selected but unfocused tabs, so set alpha 0 here. (This makes
+            the sidebar tabs look less busy when focus is in the editor. We keep the editor tabs
+            behaving the same for consistency.) */
+            "EditorTab.inactiveUnderlineColor", new Color(0, 0, 0, 0),
+            "EditorTab.tabSeparatorColor", TAB_CONTENT_BORDER_COLOR,
+            /* Don't use a special highlight for the entire active tab row. The blue highlight on
+            the active tab already communicates this. */
+            // "EditorTab.activeBackground", new Color(255, 255, 255),
+            /* On Windows 10, the selected tab is typically white, while unselected tabs are on the
+            grey panel color. But for NetBeans editor tabs, the component immediately below is
+            usually the editor toolbar, which has a grey background. To make the tab "connect" with
+            the background of the component below, while still getting the contrast of the white
+            color against the grey tab color in unselected tabs, use a gradient from white to
+            grey. This style is also used in the Aqua LAF. */
             "EditorTab.selectedBackground", new Color(255, 255, 255),
-            //"EditorTab.activeForeground", null,
+            "EditorTab.selectedBackgroundBottomGradient", new Color(240, 240, 240),
+            // "EditorTab.activeForeground", null,
             "EditorTab.selectedForeground", new Color(0, 0, 0),
-            //"EditorTab.hoverForeground", null,
+            // "EditorTab.hoverForeground", null,
             "EditorTab.attentionForeground", new Color(0, 0, 0),
 
-            "ViewTab.background", new Color(242, 242, 242),
-            "ViewTab.hoverBackground", new Color(224, 224, 224),
+            // The style for ViewTab (sidebar tabs) is mostly the same as that for EditorTab.
+            "ViewTab.background", new Color(240, 240, 240),
+            "ViewTab.hoverBackground", new Color(255, 255, 255),
+            "ViewTab.unselectedHoverBackground", new Color(216, 234, 249),
             "ViewTab.attentionBackground", new Color(230, 200, 64),
-            "ViewTab.underlineColor", new Color(64, 131, 201),
-            "ViewTab.inactiveUnderlineColor", new Color(156, 167, 184),
-            "ViewTab.tabSeparatorColor", new Color(196, 196, 196),
-            "ViewTab.activeBackground", new Color(226, 230, 236),
-            //"ViewTab.selectedBackground", null,
-            //"ViewTab.foreground", null,
-            //"ViewTab.activeForeground", null,
-            //"ViewTab.selectedForeground", null,
-            //"ViewTab.hoverForeground", null,
+            "ViewTab.underlineColor", new Color(46, 144, 232),
+            "ViewTab.inactiveUnderlineColor", new Color(0, 0, 0, 0),
+            "ViewTab.tabSeparatorColor", TAB_CONTENT_BORDER_COLOR,
+            // "ViewTab.activeBackground", new Color(255, 255, 255),
+            /* For view tabs, there is no need for a color gradient from white to grey, since the
+            background of the component below is usually white (e.g. for the Projects and Navigator
+            panes). */
+            "ViewTab.selectedBackground", new Color(255, 255, 255),
+            // "ViewTab.foreground", null,
+            // "ViewTab.activeForeground", null,
+            // "ViewTab.selectedForeground", null,
+            // "ViewTab.hoverForeground", null,
             "ViewTab.attentionForeground", new Color(0, 0, 0),
 
-            "TabbedContainer.editor.contentBorderColor", new Color(196, 196, 196),
-            "TabbedContainer.view.contentBorderColor", new Color(196, 196, 196)
+            "TabbedContainer.editor.contentBorderColor", TAB_CONTENT_BORDER_COLOR,
+            "TabbedContainer.view.contentBorderColor", TAB_CONTENT_BORDER_COLOR,
             };
         }
     }

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
@@ -346,12 +346,12 @@ public final class Windows8LFCustoms extends LFCustoms {
             //Borders for the tab control
             EDITOR_TAB_OUTER_BORDER, BorderFactory.createEmptyBorder(),
             EDITOR_TAB_CONTENT_BORDER,
-                new DPIUnscaledBorder(new MatteBorder(0, 1, 1, 1, new Color(137, 140, 149))),
+                new DPIUnscaledBorder(new MatteBorder(0, 1, 1, 1, new Color(137, 140, 149)), true),
             EDITOR_TAB_TABS_BORDER, BorderFactory.createEmptyBorder(),
 
             VIEW_TAB_OUTER_BORDER, BorderFactory.createEmptyBorder(),
             VIEW_TAB_CONTENT_BORDER,
-                new DPIUnscaledBorder(new MatteBorder(0, 1, 1, 1, new Color(137, 140, 149))),
+                new DPIUnscaledBorder(new MatteBorder(0, 1, 1, 1, new Color(137, 140, 149)), true),
             VIEW_TAB_TABS_BORDER, BorderFactory.createEmptyBorder(),
 
             // ==== WinFlat*TabDisplayerUI =========================================================

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/windows8/Windows8LFCustoms.java
@@ -318,8 +318,7 @@ public final class Windows8LFCustoms extends LFCustoms {
         @Override
         public Object[] createKeysAndValues() {
             return new Object[] {
-            //Tab control - XXX REPLACE WITH RelativeColor - need to figure out base
-            //colors for each color
+            // ==== Windows8*TabDisplayerUI ========================================================
             //selected & focused
             TAB_FOCUS_FILL_UPPER, new Color(236,244,252),
             TAB_FOCUS_FILL_LOWER, new Color(221,237,252),
@@ -342,6 +341,8 @@ public final class Windows8LFCustoms extends LFCustoms {
             TAB_SEL_BORDER, new Color(60,127,177),
             TAB_BORDER_INNER, new Color(255,255,255),
 
+            // ==== TabbedContainerUI ==============================================================
+
             //Borders for the tab control
             EDITOR_TAB_OUTER_BORDER, BorderFactory.createEmptyBorder(),
             EDITOR_TAB_CONTENT_BORDER,
@@ -352,6 +353,49 @@ public final class Windows8LFCustoms extends LFCustoms {
             VIEW_TAB_CONTENT_BORDER,
                 new DPIUnscaledBorder(new MatteBorder(0, 1, 1, 1, new Color(137, 140, 149))),
             VIEW_TAB_TABS_BORDER, BorderFactory.createEmptyBorder(),
+
+            // ==== WinFlat*TabDisplayerUI =========================================================
+
+            "EditorTab.tabInsets", new Insets(5,6,7,8),
+            "EditorTab.underlineHeight", 3,
+            //"EditorTab.underlineAtTop", null,
+            "EditorTab.showTabSeparators", true,
+
+            "ViewTab.tabInsets", new Insets(5,6,7,2),
+            "ViewTab.underlineHeight", 3,
+            //"ViewTab.underlineAtTop", null,
+            "ViewTab.showTabSeparators", true,
+
+            "EditorTab.background", new Color(242, 242, 242),
+            //"EditorTab.foreground", null,
+            "EditorTab.hoverBackground", new Color(224, 224, 224),
+            "EditorTab.attentionBackground", new Color(230, 200, 64),
+            "EditorTab.underlineColor", new Color(64, 131, 201),
+            "EditorTab.inactiveUnderlineColor", new Color(156, 167, 184),
+            "EditorTab.tabSeparatorColor", new Color(196, 196, 196),
+            "EditorTab.activeBackground", new Color(226, 230, 236),
+            "EditorTab.selectedBackground", new Color(255, 255, 255),
+            //"EditorTab.activeForeground", null,
+            "EditorTab.selectedForeground", new Color(0, 0, 0),
+            //"EditorTab.hoverForeground", null,
+            "EditorTab.attentionForeground", new Color(0, 0, 0),
+
+            "ViewTab.background", new Color(242, 242, 242),
+            "ViewTab.hoverBackground", new Color(224, 224, 224),
+            "ViewTab.attentionBackground", new Color(230, 200, 64),
+            "ViewTab.underlineColor", new Color(64, 131, 201),
+            "ViewTab.inactiveUnderlineColor", new Color(156, 167, 184),
+            "ViewTab.tabSeparatorColor", new Color(196, 196, 196),
+            "ViewTab.activeBackground", new Color(226, 230, 236),
+            //"ViewTab.selectedBackground", null,
+            //"ViewTab.foreground", null,
+            //"ViewTab.activeForeground", null,
+            //"ViewTab.selectedForeground", null,
+            //"ViewTab.hoverForeground", null,
+            "ViewTab.attentionForeground", new Color(0, 0, 0),
+
+            "TabbedContainer.editor.contentBorderColor", new Color(196, 196, 196),
+            "TabbedContainer.view.contentBorderColor", new Color(196, 196, 196)
             };
         }
     }

--- a/platform/o.n.swing.tabcontrol/nbproject/project.properties
+++ b/platform/o.n.swing.tabcontrol/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
@@ -115,7 +115,9 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
         int txtH = fm.getHeight();
         Insets ins = getInsets();
         int availH = getHeight() - (ins.top + ins.bottom);
-        return (availH <= txtH) ? -fm.getDescent() : -1;
+        // Ad hoc adjustment for the Windows LAF.
+        int yAdjustment = 1;
+        return ((availH <= txtH) ? -fm.getDescent() : -1) + yAdjustment;
     }
 
     @Override
@@ -175,7 +177,9 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
             int iconWidth = icon.getIconWidth();
             int iconHeight = icon.getIconHeight();
             rect.x = bounds.x + bounds.width - iconWidth - UIScale.scale(CLOSE_ICON_RIGHT_PAD);
-            rect.y = bounds.y + Math.max(0, (bounds.height - iconHeight) / 2) - 1;
+            // Ad hoc adjustment for the Windows LAF.
+            int yAdjustment = 2;
+            rect.y = bounds.y + Math.max(0, (bounds.height - iconHeight) / 2) - 1 + yAdjustment;
             rect.width = iconWidth;
             rect.height = iconHeight;
         }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.swing.tabcontrol.plaf;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Polygon;
+import java.awt.Rectangle;
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.UIManager;
+import org.netbeans.swing.tabcontrol.TabDisplayer;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.FlatTabControlIcon;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.HiDPIUtils;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.UIScale;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.Utils;
+
+/**
+ * "Fork" of {@code org.netbeans.swing.laf.flatlaf.ui.FlatEditorTabCellRenderer}, for use with the
+ * Windows LAF.
+ */
+class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
+
+    private static final int CLOSE_ICON_RIGHT_PAD = 2;
+
+    private static final Color background = UIManager.getColor("EditorTab.background"); // NOI18N
+    private static final Color activeBackground = Utils.getUIColor("EditorTab.activeBackground", background); // NOI18N
+    private static final Color selectedBackground = Utils.getUIColor("EditorTab.selectedBackground", activeBackground); // NOI18N
+    private static final Color hoverBackground = UIManager.getColor("EditorTab.hoverBackground"); // NOI18N
+    private static final Color attentionBackground = UIManager.getColor("EditorTab.attentionBackground"); // NOI18N
+
+    private static final Color foreground = Utils.getUIColor( "EditorTab.foreground", "TabbedPane.foreground" ); // NOI18N
+    private static final Color activeForeground = Utils.getUIColor( "EditorTab.activeForeground", foreground ); // NOI18N
+    private static final Color selectedForeground = Utils.getUIColor( "EditorTab.selectedForeground", activeForeground ); // NOI18N
+    private static final Color hoverForeground = Utils.getUIColor( "EditorTab.hoverForeground", foreground ); // NOI18N
+    private static final Color attentionForeground = Utils.getUIColor( "EditorTab.attentionForeground", foreground ); // NOI18N
+
+    private static final Color underlineColor = UIManager.getColor("EditorTab.underlineColor"); // NOI18N
+    private static final Color inactiveUnderlineColor = UIManager.getColor("EditorTab.inactiveUnderlineColor"); // NOI18N
+    private static final Color tabSeparatorColor = UIManager.getColor("EditorTab.tabSeparatorColor"); // NOI18N
+    private static final Color contentBorderColor = UIManager.getColor("TabbedContainer.editor.contentBorderColor"); // NOI18N
+
+    private static final Insets tabInsets = UIScale.scale(UIManager.getInsets("EditorTab.tabInsets")); // NOI18N
+    private static final int underlineHeight = UIScale.scale(UIManager.getInt("EditorTab.underlineHeight")); // NOI18N
+    private static final boolean underlineAtTop = UIManager.getBoolean("EditorTab.underlineAtTop"); // NOI18N
+    private static boolean showTabSeparators = UIManager.getBoolean("EditorTab.showTabSeparators"); // NOI18N
+
+    private static final FlatTabPainter painter = new FlatTabPainter();
+
+    boolean nextTabSelected;
+
+    public WinFlatEditorTabCellRenderer() {
+        super(painter, new Dimension(tabInsets.left + tabInsets.right, tabInsets.top + tabInsets.bottom));
+    }
+
+    @Override
+    public Dimension getPadding() {
+        Dimension d = super.getPadding();
+        if (isShowCloseButton() && !Boolean.getBoolean("nb.tabs.suppressCloseButton")) { // NOI18N
+            d.width += findCloseIcon().getIconWidth() + UIScale.scale(CLOSE_ICON_RIGHT_PAD);
+        }
+        return d;
+    }
+
+    @Override
+    protected int getCaptionYAdjustment() {
+        // Workaround for a issue in AbstractTabCellRenderer.paintIconAndText(Graphics),
+        // which uses font height (which includes font descent) to calculate Y-coordinate
+        // when available height is equal to font height (availH <= txtH),
+        // but HtmlRenderer.renderString() expects Y-coordinate at baseline.
+        // So the text is painted vertically out of center.
+        //
+        // This seems to be no issue with other LAFs because they seem to use
+        // TabPainter insets differently and the available height is larger than
+        // the font height (availH > txtH), in which case 3 pixels are removed from
+        // the Y-coordinate to avoid that the text is painted vertically out of center.
+
+        FontMetrics fm = getFontMetrics(getFont());
+        int txtH = fm.getHeight();
+        Insets ins = getInsets();
+        int availH = getHeight() - (ins.top + ins.bottom);
+        return (availH <= txtH) ? -fm.getDescent() : -1;
+    }
+
+    @Override
+    protected int stateChanged(int oldState, int newState) {
+        int result = super.stateChanged(oldState, newState);
+
+        // set text color
+        setForeground(colorForState(foreground, activeForeground, selectedForeground,
+                hoverForeground, attentionForeground));
+
+        return result;
+    }
+
+    private Color colorForState(Color normal, Color active, Color selected, Color hover, Color attention) {
+        return isAttention() ? attention
+                : isArmed() ? hover
+                : isSelected() ? selected
+                : isActive() ? active
+                : normal;
+    }
+
+    private Icon findCloseIcon() {
+        return FlatTabControlIcon.get(TabControlButton.ID_CLOSE_BUTTON,
+                inCloseButton()
+                        ? (isPressed() ? TabControlButton.STATE_PRESSED : TabControlButton.STATE_ROLLOVER)
+                        : TabControlButton.STATE_DEFAULT);
+    }
+
+    private static class FlatTabPainter implements TabPainter {
+
+        @Override
+        public Insets getBorderInsets(Component c) {
+            return tabInsets;
+        }
+
+        @Override
+        public void getCloseButtonRectangle(JComponent jc, Rectangle rect, Rectangle bounds) {
+            WinFlatEditorTabCellRenderer ren = (WinFlatEditorTabCellRenderer) jc;
+
+            if (!ren.isShowCloseButton()) {
+                rect.x = -100;
+                rect.y = -100;
+                rect.width = 0;
+                rect.height = 0;
+                return;
+            }
+            Icon icon = ren.findCloseIcon();
+            int iconWidth = icon.getIconWidth();
+            int iconHeight = icon.getIconHeight();
+            rect.x = bounds.x + bounds.width - iconWidth - UIScale.scale(CLOSE_ICON_RIGHT_PAD);
+            rect.y = bounds.y + (Math.max(0, bounds.height / 2 - iconHeight / 2)) - 1;
+            rect.width = iconWidth;
+            rect.height = iconHeight;
+        }
+
+        @Override
+        public Polygon getInteriorPolygon(Component c) {
+            int x = 0;
+            int y = 0;
+            int width = c.getWidth();
+            int height = c.getHeight();
+
+            //just a plain rectangle
+            Polygon p = new Polygon();
+            p.addPoint(x, y);
+            p.addPoint(x + width, y);
+            p.addPoint(x + width, y + height);
+            p.addPoint(x, y + height);
+            return p;
+        }
+
+        @Override
+        public boolean isBorderOpaque() {
+            return true;
+        }
+
+        @Override
+        public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
+            // not using borders
+        }
+
+        @Override
+        public void paintInterior(Graphics g, Component c) {
+            // Paint the whole tab background at scale 1x (on HiDPI screens).
+            // Necessary so that it aligns nicely at bottom left and right edges
+            // with the content border, which is also painted at scale 1x.
+            HiDPIUtils.paintAtScale1x(g, 0, 0, c.getWidth(), c.getHeight(),
+                (gd, width, height, scale) -> {
+                    paintInteriorAtScale1x(gd, c, width, height, scale);
+                });
+
+            // paint close button
+            WinFlatEditorTabCellRenderer ren = (WinFlatEditorTabCellRenderer) c;
+            if (!ren.isClipLeft() && !ren.isClipRight())
+                paintCloseButton(g, ren);
+        }
+
+        private void paintInteriorAtScale1x(Graphics2D g, Component c, int width, int height, double scale) {
+            WinFlatEditorTabCellRenderer ren = (WinFlatEditorTabCellRenderer) c;
+            boolean selected = ren.isSelected();
+
+            // get background color
+            Color bg = ren.colorForState(
+                    background, activeBackground, selectedBackground,
+                    hoverBackground, attentionBackground);
+
+            boolean showSeparator = showTabSeparators && !selected && !ren.nextTabSelected;
+
+            // do not round tab separator width to get nice small lines at 125%, 150% and 175%
+            int tabSeparatorWidth = showSeparator ? (int) (1 * scale) : 0;
+
+            // paint background
+            g.setColor(bg);
+            g.fillRect(0, 0, width - (bg != background ? tabSeparatorWidth : 0), height);
+
+            if (selected && underlineHeight > 0) {
+                // paint underline if tab is selected
+                int underlineHeight = (int) Math.round(WinFlatEditorTabCellRenderer.underlineHeight * scale);
+                g.setColor(ren.isActive() ? underlineColor : inactiveUnderlineColor);
+                if (underlineAtTop)
+                    g.fillRect(0, 0, width - tabSeparatorWidth, underlineHeight);
+                else
+                    g.fillRect(0, height - underlineHeight, width - tabSeparatorWidth, underlineHeight);
+            } else {
+                // paint bottom border
+                int contentBorderWidth = HiDPIUtils.deviceBorderWidth(scale, 1);
+                g.setColor(contentBorderColor);
+                g.fillRect(0, height - contentBorderWidth, width, contentBorderWidth);
+            }
+
+            if (showSeparator) {
+                int offset = (int) (4 * scale);
+                g.setColor(tabSeparatorColor);
+                g.fillRect(width - tabSeparatorWidth, offset, tabSeparatorWidth, height - (offset * 2) - 1);
+            }
+        }
+
+        private void paintCloseButton(Graphics g, WinFlatEditorTabCellRenderer ren) {
+            //Get the close button bounds, more or less
+            Rectangle r = new Rectangle();
+            getCloseButtonRectangle(ren, r, new Rectangle(0, 0,
+                                                          ren.getWidth(),
+                                                          ren.getHeight()));
+
+            if (!g.hitClip(r.x, r.y, r.width, r.height)) {
+                return;
+            }
+
+            //paint close button
+            Icon icon = ren.findCloseIcon();
+            icon.paintIcon(ren, g, r.x, r.y);
+        }
+
+        @Override
+        public boolean supportsCloseButton(JComponent renderer) {
+            return renderer instanceof TabDisplayer ?
+                ((TabDisplayer) renderer).isShowCloseButton() : true;
+        }
+    }
+}

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
@@ -22,6 +22,7 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
+import java.awt.GradientPaint;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
@@ -41,13 +42,12 @@ import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.Utils;
  * Windows LAF.
  */
 class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
-
-    private static final int CLOSE_ICON_RIGHT_PAD = 2;
-
     private static final Color background = UIManager.getColor("EditorTab.background"); // NOI18N
     private static final Color activeBackground = Utils.getUIColor("EditorTab.activeBackground", background); // NOI18N
     private static final Color selectedBackground = Utils.getUIColor("EditorTab.selectedBackground", activeBackground); // NOI18N
+    private static final Color selectedBackgroundBottomGradient = Utils.getUIColor("EditorTab.selectedBackgroundBottomGradient", selectedBackground); // NOI18N
     private static final Color hoverBackground = UIManager.getColor("EditorTab.hoverBackground"); // NOI18N
+    private static final Color unselectedHoverBackground = Utils.getUIColor("EditorTab.unselectedHoverBackground", hoverBackground); // NOI18N
     private static final Color attentionBackground = UIManager.getColor("EditorTab.attentionBackground"); // NOI18N
 
     private static final Color foreground = Utils.getUIColor( "EditorTab.foreground", "TabbedPane.foreground" ); // NOI18N
@@ -66,12 +66,27 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
     private static final boolean underlineAtTop = UIManager.getBoolean("EditorTab.underlineAtTop"); // NOI18N
     private static boolean showTabSeparators = UIManager.getBoolean("EditorTab.showTabSeparators"); // NOI18N
 
-    private static final FlatTabPainter painter = new FlatTabPainter();
+    /**
+     * Margin on the right of the close button. Note that {@code tabInsets.right} denotes the space
+     * between the caption text and the "close" icon. Here, we set the right margin to the same
+     * value as the left margin (before the tab's caption).
+     */
+    private static final int CLOSE_ICON_RIGHT_PAD = tabInsets.left;
 
+    private static final boolean showSelectedTabBorder = Utils.getUIBoolean("EditorTab.showSelectedTabBorder", false); // NOI18N
+    private static final boolean unscaledBorders = Utils.getUIBoolean("EditorTab.unscaledBorders", false); // NOI18N
+
+    private static final FlatTabPainter leftClipPainter = new FlatTabPainter(true, false);
+    private static final FlatTabPainter noClipPainter = new FlatTabPainter(false, false);
+    private static final FlatTabPainter rightClipPainter = new FlatTabPainter(false, true);
+
+    boolean firstTab;
+    boolean lastTab;
     boolean nextTabSelected;
 
     public WinFlatEditorTabCellRenderer() {
-        super(painter, new Dimension(tabInsets.left + tabInsets.right, tabInsets.top + tabInsets.bottom));
+        super(leftClipPainter, noClipPainter, rightClipPainter,
+                new Dimension(tabInsets.left + tabInsets.right, tabInsets.top + tabInsets.bottom));
     }
 
     @Override
@@ -109,14 +124,16 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
 
         // set text color
         setForeground(colorForState(foreground, activeForeground, selectedForeground,
-                hoverForeground, attentionForeground));
+                hoverForeground, hoverForeground, attentionForeground));
 
         return result;
     }
 
-    private Color colorForState(Color normal, Color active, Color selected, Color hover, Color attention) {
+    private Color colorForState(Color normal, Color active, Color selected,
+            Color selectedHover, Color unselectedHover, Color attention)
+    {
         return isAttention() ? attention
-                : isArmed() ? hover
+                : isArmed() ? (isSelected() ? selectedHover : unselectedHover)
                 : isSelected() ? selected
                 : isActive() ? active
                 : normal;
@@ -130,6 +147,13 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
     }
 
     private static class FlatTabPainter implements TabPainter {
+        final boolean leftClip;
+        final boolean rightClip;
+
+        public FlatTabPainter(boolean leftClip, boolean rightClip) {
+            this.leftClip = leftClip;
+            this.rightClip = rightClip;
+        }
 
         @Override
         public Insets getBorderInsets(Component c) {
@@ -151,7 +175,7 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
             int iconWidth = icon.getIconWidth();
             int iconHeight = icon.getIconHeight();
             rect.x = bounds.x + bounds.width - iconWidth - UIScale.scale(CLOSE_ICON_RIGHT_PAD);
-            rect.y = bounds.y + (Math.max(0, bounds.height / 2 - iconHeight / 2)) - 1;
+            rect.y = bounds.y + Math.max(0, (bounds.height - iconHeight) / 2) - 1;
             rect.width = iconWidth;
             rect.height = iconHeight;
         }
@@ -198,6 +222,19 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
                 paintCloseButton(g, ren);
         }
 
+        private static void fillGradientRect(Graphics2D g, int x, int y, int width, int height,
+                Color color, Color bottomGradient, int gradientOffset)
+        {
+            if (bottomGradient.equals(color)) {
+                g.setColor(color);
+            } else {
+                g.setPaint(new GradientPaint(
+                        0, y          + gradientOffset, color,
+                        0, y + height - gradientOffset, bottomGradient, false));
+            }
+            g.fillRect(x, y, width, height);
+        }
+
         private void paintInteriorAtScale1x(Graphics2D g, Component c, int width, int height, double scale) {
             WinFlatEditorTabCellRenderer ren = (WinFlatEditorTabCellRenderer) c;
             boolean selected = ren.isSelected();
@@ -205,28 +242,43 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
             // get background color
             Color bg = ren.colorForState(
                     background, activeBackground, selectedBackground,
-                    hoverBackground, attentionBackground);
+                    hoverBackground, unselectedHoverBackground, attentionBackground);
 
-            boolean showSeparator = showTabSeparators && !selected && !ren.nextTabSelected;
+            boolean showSeparator = showTabSeparators && !ren.lastTab
+                    && !selected && !ren.nextTabSelected && !rightClip;
 
-            // do not round tab separator width to get nice small lines at 125%, 150% and 175%
-            int tabSeparatorWidth = showSeparator ? (int) (1 * scale) : 0;
+            int contentBorderWidth = unscaledBorders ? 1 : HiDPIUtils.deviceBorderWidth(scale, 1);
+            int tabSeparatorWidth = showSeparator ? contentBorderWidth : 0;
+            int underlineHeight = (int) Math.round(WinFlatEditorTabCellRenderer.underlineHeight * scale);
 
-            // paint background
-            g.setColor(bg);
-            g.fillRect(0, 0, width - (bg != background ? tabSeparatorWidth : 0), height);
+            fillGradientRect(g, 0, 0, width - (bg != background ? tabSeparatorWidth : 0), height, bg,
+                    selected && !selectedBackground.equals(selectedBackgroundBottomGradient)
+                            ? selectedBackgroundBottomGradient : bg,
+                    (underlineAtTop ? underlineHeight : 0));
 
-            if (selected && underlineHeight > 0) {
-                // paint underline if tab is selected
-                int underlineHeight = (int) Math.round(WinFlatEditorTabCellRenderer.underlineHeight * scale);
-                g.setColor(ren.isActive() ? underlineColor : inactiveUnderlineColor);
-                if (underlineAtTop)
-                    g.fillRect(0, 0, width - tabSeparatorWidth, underlineHeight);
-                else
-                    g.fillRect(0, height - underlineHeight, width - tabSeparatorWidth, underlineHeight);
+            if (selected) {
+                if (showSelectedTabBorder) {
+                    g.setColor(contentBorderColor);
+                    g.fillRect(0, 0, width - tabSeparatorWidth, contentBorderWidth); // Top
+                    if (!leftClip) {
+                        g.fillRect(0, 0, contentBorderWidth, height); // Left
+                    }
+                    if (!rightClip) {
+                        g.fillRect(width - tabSeparatorWidth - contentBorderWidth, 0, contentBorderWidth, height); // Right
+                    }
+                }
+
+                if (underlineHeight > 0) {
+                    // paint underline if tab is selected
+                    g.setColor(ren.isActive() ? underlineColor : inactiveUnderlineColor);
+                    if (underlineAtTop) {
+                        g.fillRect(0, 0, width - tabSeparatorWidth, underlineHeight);
+                    } else {
+                        g.fillRect(0, height - underlineHeight, width - tabSeparatorWidth, underlineHeight);
+                    }
+                }
             } else {
                 // paint bottom border
-                int contentBorderWidth = HiDPIUtils.deviceBorderWidth(scale, 1);
                 g.setColor(contentBorderColor);
                 g.fillRect(0, height - contentBorderWidth, width, contentBorderWidth);
             }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabDisplayerUI.java
@@ -48,6 +48,7 @@ public class WinFlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
     private final Color background = UIManager.getColor("EditorTab.background"); // NOI18N
     private final Color activeBackground = Utils.getUIColor("EditorTab.activeBackground", background); // NOI18N
     private final Color contentBorderColor = UIManager.getColor("TabbedContainer.editor.contentBorderColor"); // NOI18N
+    private final boolean unscaledBorders = Utils.getUIBoolean("EditorTab.unscaledBorders", false); // NOI18N
     private final Insets tabInsets = UIScale.scale(UIManager.getInsets("EditorTab.tabInsets")); // NOI18N
 
     public WinFlatEditorTabDisplayerUI(TabDisplayer displayer) {
@@ -80,8 +81,12 @@ public class WinFlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
     @Override
     public TabCellRenderer getTabCellRenderer(int tab) {
         TabCellRenderer ren = super.getTabCellRenderer(tab);
-        if (ren instanceof WinFlatEditorTabCellRenderer && tab + 1 < displayer.getModel().size()) {
-            ((WinFlatEditorTabCellRenderer)ren).nextTabSelected = (tabState.getState(tab + 1) & TabState.SELECTED) != 0;
+        if (ren instanceof WinFlatEditorTabCellRenderer) {
+            WinFlatEditorTabCellRenderer fren = (WinFlatEditorTabCellRenderer) ren;
+            int N = displayer.getModel().size();
+            fren.firstTab = (tab == 0);
+            fren.lastTab = (tab == N - 1);
+            fren.nextTabSelected = tab + 1 < N && (tabState.getState(tab + 1) & TabState.SELECTED) != 0;
         }
         return ren;
     }
@@ -114,7 +119,7 @@ public class WinFlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
         g.fillRect (0, 0, width, height);
 
         // paint bottom border
-        int contentBorderWidth = HiDPIUtils.deviceBorderWidth(scale, 1);
+        int contentBorderWidth = unscaledBorders ? 1 : HiDPIUtils.deviceBorderWidth(scale, 1);
         g.setColor(contentBorderColor);
         g.fillRect(0, height - contentBorderWidth, width, contentBorderWidth);
     }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabDisplayerUI.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.swing.tabcontrol.plaf;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.UIManager;
+import javax.swing.plaf.ComponentUI;
+import org.netbeans.swing.tabcontrol.TabDisplayer;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.FlatTabControlIcon;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.HiDPIUtils;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.UIScale;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.Utils;
+
+/**
+ * "Fork" of {@code org.netbeans.swing.laf.flatlaf.ui.FlatEditorTabDisplayerUI}, for use with the
+ * Windows LAF.
+ */
+public class WinFlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
+
+    private static final int ICON_X_PAD = 4;
+
+    private final Color background = UIManager.getColor("EditorTab.background"); // NOI18N
+    private final Color activeBackground = Utils.getUIColor("EditorTab.activeBackground", background); // NOI18N
+    private final Color contentBorderColor = UIManager.getColor("TabbedContainer.editor.contentBorderColor"); // NOI18N
+    private final Insets tabInsets = UIScale.scale(UIManager.getInsets("EditorTab.tabInsets")); // NOI18N
+
+    public WinFlatEditorTabDisplayerUI(TabDisplayer displayer) {
+        super(displayer);
+    }
+
+    public static ComponentUI createUI(JComponent c) {
+        return new WinFlatEditorTabDisplayerUI((TabDisplayer) c);
+    }
+
+    @Override
+    protected TabCellRenderer createDefaultRenderer() {
+        return new WinFlatEditorTabCellRenderer();
+    }
+
+    @Override
+    public Dimension getPreferredSize(JComponent c) {
+        int prefHeight;
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
+        if (g != null) {
+            FontMetrics fm = g.getFontMetrics(displayer.getFont());
+            Insets ins = getTabAreaInsets();
+            prefHeight = fm.getHeight() + ins.top + ins.bottom
+                    + tabInsets.top + tabInsets.bottom;
+        } else
+            prefHeight = UIScale.scale(28);
+        return new Dimension(displayer.getWidth(), prefHeight);
+    }
+
+    @Override
+    public TabCellRenderer getTabCellRenderer(int tab) {
+        TabCellRenderer ren = super.getTabCellRenderer(tab);
+        if (ren instanceof WinFlatEditorTabCellRenderer && tab + 1 < displayer.getModel().size()) {
+            ((WinFlatEditorTabCellRenderer)ren).nextTabSelected = (tabState.getState(tab + 1) & TabState.SELECTED) != 0;
+        }
+        return ren;
+    }
+
+    @Override
+    public Insets getTabAreaInsets() {
+        return new Insets(0, 0, 0, getControlButtons().getPreferredSize().width + ICON_X_PAD);
+    }
+
+    protected Rectangle getControlButtonsRectangle(Container parent) {
+        Component c = getControlButtons();
+        return new Rectangle(parent.getWidth() - c.getWidth() - ICON_X_PAD,
+                (parent.getHeight() - c.getHeight()) / 2, c.getWidth(), c.getHeight());
+    }
+
+    @Override
+    public void paintBackground(Graphics g) {
+        int width = displayer.getWidth();
+        int height = displayer.getHeight();
+
+        // Paint the whole tab background at scale 1x (on HiDPI screens).
+        // Necessary so that it aligns nicely at bottom left and right edges
+        // with the content border, which is also painted at scale 1x.
+        HiDPIUtils.paintAtScale1x(g, 0, 0, width, height, this::paintBackgroundAtScale1x);
+    }
+
+    private void paintBackgroundAtScale1x(Graphics2D g, int width, int height, double scale) {
+        // fill background
+        g.setColor (displayer.isActive() ? activeBackground : background);
+        g.fillRect (0, 0, width, height);
+
+        // paint bottom border
+        int contentBorderWidth = HiDPIUtils.deviceBorderWidth(scale, 1);
+        g.setColor(contentBorderColor);
+        g.fillRect(0, height - contentBorderWidth, width, contentBorderWidth);
+    }
+
+    @Override
+    public Icon getButtonIcon(int buttonId, int buttonState) {
+        Icon ret = FlatTabControlIcon.get(buttonId, buttonState);
+        return ret != null ? ret : super.getButtonIcon(buttonId, buttonState);
+    }
+}

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatUtils.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatUtils.java
@@ -49,6 +49,16 @@ class WinFlatUtils {
             Color color = UIManager.getColor(key);
             return (color != null) ? color : UIManager.getColor(defaultKey);
         }
+
+        static int getUIInt(String key, int defaultValue) {
+            Object value = UIManager.get(key);
+            return (value instanceof Integer) ? ((Integer) value) : defaultValue;
+        }
+
+        static boolean getUIBoolean(String key, boolean defaultValue) {
+            Object value = UIManager.get(key);
+            return (value instanceof Boolean) ? ((Boolean) value) : defaultValue;
+        }
     }
 
     /**
@@ -121,13 +131,20 @@ class WinFlatUtils {
             {
                   // HiDPI scaling is active.
                   double scale = tx.getScaleX();
-                  /* Round the starting (top-left) position up and the end (bottom-right) position down,
-                  to ensure we are painting the border in an area that will not be painted over by an
-                  adjacent component. */
-                  int deviceX = (int) Math.ceil(tx.getTranslateX());
+                  /* For non-integral HiDPI scalings (e.g. 150%), rounding of device pixel positions
+                  becomes significant; see see comments in
+                  org.netbeans.swing.plaf.windows8.DPIUnscaledBorder. Round the starting X position
+                  in a manner consistent with DPIUnscaledBorder for the tabContainer case, to ensure
+                  that the left tab border lines up between the tab and the container area. Round
+                  the other positions in the conservative direction, to avoid borders being
+                  overpainted by adjacent components. In the 125% scaling case there can sometimes
+                  still be a one-device-pixel gap between the tab and the container, but the
+                  approach taken here (and in DPIUnscaledBorder) was still what looked best across
+                  all the common situations. */
+                  int deviceX = (int) Math.round(tx.getTranslateX());
                   int deviceY = (int) Math.ceil(tx.getTranslateY());
-                  int deviceXend = (int) (tx.getTranslateX() + width * scale);
-                  int deviceYend = (int) (tx.getTranslateY() + height * scale);
+                  int deviceXend = (int) Math.floor(tx.getTranslateX() + width * scale);
+                  int deviceYend = (int) Math.floor(tx.getTranslateY() + height * scale);
                   int deviceWidth = deviceXend - deviceX;
                   int deviceHeight = deviceYend - deviceY;
                   /* Deactivate the HiDPI scaling transform so we can do paint operations in the device

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatUtils.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatUtils.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.swing.tabcontrol.plaf;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.geom.AffineTransform;
+import javax.swing.Icon;
+import javax.swing.UIManager;
+
+/**
+ * Utility methods copied from the {@code o.n.swing.laf.flatlaf} module, and no-op implementations
+ * of scaling methods from the external FlatLAF library. This organization allows the classes that
+ * were copied from the {@code flatlaf} module to be used with only minimal changes (allowing
+ * improvements to backported more easily etc.).
+ */
+class WinFlatUtils {
+    /**
+     * Corresponds to {@code org.netbeans.swing.laf.flatlaf.ui.Utils}.
+     */
+    static final class Utils {
+        private Utils() { }
+
+        static Color getUIColor(String key, Color defaultColor) {
+            Color color = UIManager.getColor(key);
+            return (color != null) ? color : defaultColor;
+        }
+
+        static Color getUIColor(String key, String defaultKey) {
+            Color color = UIManager.getColor(key);
+            return (color != null) ? color : UIManager.getColor(defaultKey);
+        }
+    }
+
+    /**
+     * Corresponds to {@code com.formdev.flatlaf.util.UIScale}. No-ops only, as there is no separate
+     * "user scaling" factor on the Windows LAF, only the per-monitor scaling defined by Swing/AWT.
+     */
+    static final class UIScale {
+        private UIScale() { }
+
+        public static Insets scale(Insets insets) {
+            return insets;
+        }
+
+        public static int scale(int value) {
+            return value;
+        }
+
+        public static Dimension scale(Dimension value) {
+            return value;
+        }
+
+        public static float getUserScaleFactor() {
+            return 1.0f;
+        }
+    }
+
+    /**
+     * Corresponds to {@code org.netbeans.swing.laf.flatlaf.ui.FlatTabControlIcon}. Just delegate
+     * to the HiDPI-enabled Windows icons.
+     */
+    final static class FlatTabControlIcon {
+        public static Icon get(int buttonId, int buttonState) {
+            return Windows8VectorTabControlIcon.get(buttonId, buttonState);
+        }
+    }
+
+    interface HiDPIPainter {
+        void paint(Graphics2D g, int width, int height, double scale);
+    }
+
+    /**
+     * Corresponds to {@code org.netbeans.swing.laf.flatlaf.HiDPIUtils}.
+     */
+    static class HiDPIUtils {
+        private HiDPIUtils() { }
+
+        /**
+         * Paint at scale factor 1x to avoid rounding issues at 125%, 150% and 175% scaling.
+         * <p>
+         * Scales the given Graphics2D down to 100% and invokes the
+         * given painter passing scaled deviceWidth and deviceHeight.
+         * <p>
+         * Transformation to device pixels borrowed from class
+         * {@link org.netbeans.swing.plaf.windows8.DPISafeBorder}.
+         */
+        public static void paintAtScale1x(Graphics g0, int x, int y, int width, int height, HiDPIPainter painter) {
+            Graphics2D g = (Graphics2D) g0;
+            final AffineTransform oldTransform = g.getTransform();
+            g.translate(x, y);
+            final AffineTransform tx = g.getTransform();
+            final int txType = tx.getType();
+            /* On fractional DPI scaling factors, such as 150%, a logical pixel position, e.g. (5,0),
+            may end up being translated to a non-integral device pixel position, e.g. (7.5, 0). The same
+            goes for border thicknesses, which are specified in logical pixels. In this method, we do
+            all calculations and painting in device pixels, to avoid rounding errors causing visible
+            artifacts. On screens without HiDPI scaling, logical pixel values and device pixel values
+            are identical, and always integral (whole number) values. */
+            if (txType == AffineTransform.TYPE_UNIFORM_SCALE ||
+                txType == (AffineTransform.TYPE_UNIFORM_SCALE | AffineTransform.TYPE_TRANSLATION))
+            {
+                  // HiDPI scaling is active.
+                  double scale = tx.getScaleX();
+                  /* Round the starting (top-left) position up and the end (bottom-right) position down,
+                  to ensure we are painting the border in an area that will not be painted over by an
+                  adjacent component. */
+                  int deviceX = (int) Math.ceil(tx.getTranslateX());
+                  int deviceY = (int) Math.ceil(tx.getTranslateY());
+                  int deviceXend = (int) (tx.getTranslateX() + width * scale);
+                  int deviceYend = (int) (tx.getTranslateY() + height * scale);
+                  int deviceWidth = deviceXend - deviceX;
+                  int deviceHeight = deviceYend - deviceY;
+                  /* Deactivate the HiDPI scaling transform so we can do paint operations in the device
+                  pixel coordinate system instead of in the logical coordinate system. */
+                  g.setTransform(new AffineTransform(1, 0, 0, 1, deviceX, deviceY));
+
+                  painter.paint(g, deviceWidth, deviceHeight, scale);
+            } else {
+                painter.paint(g, width, height, 1);
+            }
+
+            g.setTransform(oldTransform);
+        }
+
+        /**
+         * Calculates the width of a border in device pixels.
+         * The difference to com.formdev.flatlaf.util.UIScale.scale() is that this method
+         * always rounds down the result, which gives nice small 1px borders at 150% and 175%.
+         * UIScale.scale() rounds up and would return 2px at 150% and 175%.
+         */
+        public static int deviceBorderWidth(double scale, int logical) {
+            if (logical <= 0) {
+                return 0;
+            }
+            return Math.max(1, (int) (scale * logical));
+        }
+    }
+}

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatViewTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatViewTabDisplayerUI.java
@@ -131,7 +131,9 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
                 } else {
                     buttons.setVisible(true);
                     availTxtWidth -= (buttonsSize.width + ICON_X_PAD);
-                    buttons.setLocation(x + width - buttonsSize.width - ICON_X_PAD, y + ((height - buttonsSize.height) / 2) - 1);
+                    // Ad hoc adjustment for the Windows LAF.
+                    int yAdjustment = 2;
+                    buttons.setLocation(x + width - buttonsSize.width - ICON_X_PAD, y + ((height - buttonsSize.height) / 2) - 1 + yAdjustment);
                 }
             }
         }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatViewTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatViewTabDisplayerUI.java
@@ -61,6 +61,7 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
             activeBackground,       // background of tabs and tabs area if view group is active;  optional; defaults to foreground
             selectedBackground,     // background of tab if tab is selected in active view group; optional; defaults to activeBackground
             hoverBackground,        // background of tab if mouse is over tab
+            unselectedHoverBackground, // if defined, use this color instead of hoverBackground for unselected tabs
             attentionBackground,    // background of tab if tab is in attension mode
 
             foreground,             // text color if view group is inactive;               optional; defaults to TabbedPane.foreground
@@ -78,6 +79,9 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
     private static int underlineHeight;     // height of "underline" painted at bottom of tab to indicate selection
     private static boolean underlineAtTop;  // paint "underline" at top of tab
     private static boolean showTabSeparators; // paint tab separators
+
+    private static boolean showSelectedTabBorder; // Paint a border around the selected tab
+    private static boolean unscaledBorders; // Leave the thickness of borders unaffected by HiDPI scaling
 
     private Font font;
 
@@ -132,14 +136,15 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
             }
         }
 
-        // paint busy icon
+        final Icon busyIcon;
+        final int busyWidth;
         if (isTabBusy(index)) {
-            Icon busyIcon = BusyTabsSupport.getDefault().getBusyIcon(isSelected(index));
-            availTxtWidth -= busyIcon.getIconWidth() - UIScale.scale(3) - txtLeftPad;
-            busyIcon.paintIcon(displayer, g, x + txtLeftPad, y + (height - busyIcon.getIconHeight()) / 2);
-            int busyWidth = busyIcon.getIconWidth() + UIScale.scale(3);
-            x += busyWidth;
-            width -= busyWidth;
+            busyIcon = BusyTabsSupport.getDefault().getBusyIcon(isSelected(index));
+            busyWidth = busyIcon.getIconWidth() + UIScale.scale(3);
+            availTxtWidth -= busyWidth;
+        } else {
+            busyIcon = null;
+            busyWidth = 0;
         }
 
         // make sure that as much text as possible is shown (and avoid empty tabs)
@@ -149,7 +154,7 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
                 : fm.stringWidth(text);
         if (realTxtWidth > availTxtWidth) {
             // add left and right insets to available width
-            int left = Math.min(txtLeftPad - 1, realTxtWidth - availTxtWidth);
+            int left = Math.min(txtLeftPad - 2, realTxtWidth - availTxtWidth);
             availTxtWidth += left + txtRightPad;
             txtLeftPad -= left;
 
@@ -169,9 +174,15 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
             }
         }
 
+        if (busyIcon != null) {
+            busyIcon.paintIcon(displayer, g, x + txtLeftPad, y + (height - busyIcon.getIconHeight()) / 2);
+            x += busyWidth;
+            width -= busyWidth;
+        }
+
         // text color
         Color c = colorForState(index, foreground, activeForeground, selectedForeground,
-                hoverForeground, attentionForeground);
+                hoverForeground, hoverForeground, attentionForeground);
 
         // paint text
         int txtX = x + txtLeftPad;
@@ -191,7 +202,8 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
 
     @Override
     protected void paintTabBorder(Graphics g, int index, int x, int y, int width, int height) {
-        // not using borders
+        /* In the showSelectedTabBorder case, we draw borders as part of paintTabBackground, for
+        consistency with WinFlatEditorTabCellRenderer. */
     }
 
     @Override
@@ -206,32 +218,49 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
     }
 
     private void paintTabBackgroundAtScale1x(Graphics2D g, int index, int width, int height, double scale) {
-        // do not round tab separator width to get nice small lines at 125%, 150% and 175%
-        int tabSeparatorWidth = (showTabSeparators && index >= 0) ? (int) (1 * scale) : 0;
+        boolean selected = isSelected(index);
+
+        Color bg = colorForState(index, background, activeBackground, selectedBackground,
+                hoverBackground, unselectedHoverBackground, attentionBackground);
+
+        /* For the original o.n.swing.laf.flatlaf.ui.WinFlatViewTabDisplayerUI, the default seems to
+        be to show the separator after every tab, even around the selected one (unlike in
+        WinFlatEditorTabCellRenderer). Keep this behavior, except in the showSelectedTabBorder case. */
+        boolean showSeparator = showTabSeparators && index >= 0 && (!showSelectedTabBorder ||
+                !selected && index < getDataModel().size() - 1 && !isSelected(index + 1));
+
+        int contentBorderWidth = unscaledBorders ? 1 : HiDPIUtils.deviceBorderWidth(scale, 1);
+        int tabSeparatorWidth = showSeparator ? contentBorderWidth : 0;
 
         // paint background
-        Color bg = colorForState(index, background, activeBackground, selectedBackground,
-                hoverBackground, attentionBackground);
         g.setColor(bg);
         g.fillRect(0, 0, width - (bg != background ? tabSeparatorWidth : 0), height);
 
-        if (isSelected(index) && underlineHeight > 0) {
-            // paint underline if tab is selected
-            int underlineHeight = (int) Math.round(this.underlineHeight * scale);
-            g.setColor(isActive() ? underlineColor : inactiveUnderlineColor);
-            if (underlineAtTop) {
-                g.fillRect(0, 0, width - tabSeparatorWidth, underlineHeight);
-            } else {
-                g.fillRect(0, height - underlineHeight, width - tabSeparatorWidth, underlineHeight);
+        if (selected) {
+            if (showSelectedTabBorder) {
+                g.setColor(contentBorderColor);
+                g.fillRect(0, 0, width - tabSeparatorWidth, contentBorderWidth); // Top
+                g.fillRect(0, 0, contentBorderWidth, height); // Left
+                g.fillRect(width - tabSeparatorWidth - contentBorderWidth, 0, contentBorderWidth, height); // Right
+            }
+
+            if (underlineHeight > 0) {
+                // paint underline if tab is selected
+                int underlineHeight = (int) Math.round(this.underlineHeight * scale);
+                g.setColor(isActive() ? underlineColor : inactiveUnderlineColor);
+                if (underlineAtTop) {
+                    g.fillRect(0, 0, width - tabSeparatorWidth, underlineHeight);
+                } else {
+                    g.fillRect(0, height - underlineHeight, width - tabSeparatorWidth, underlineHeight);
+                }
             }
         } else {
             // paint bottom border
-            int contentBorderWidth = HiDPIUtils.deviceBorderWidth(scale, 1);
             g.setColor(contentBorderColor);
             g.fillRect(0, height - contentBorderWidth, width, contentBorderWidth);
         }
 
-        if (showTabSeparators && index >= 0) {
+        if (showSeparator) {
             int offset = (int) (4 * scale);
             g.setColor(tabSeparatorColor);
             g.fillRect(width - tabSeparatorWidth, offset, tabSeparatorWidth, height - (offset * 2) - 1);
@@ -247,10 +276,13 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
         super.paintDisplayerBackground(g, c);
     }
 
-    private Color colorForState(int index, Color normal, Color active, Color selected, Color hover, Color attention) {
+    private Color colorForState(int index, Color normal, Color active, Color selected,
+            Color selectedHover, Color unselectedHover, Color attention)
+    {
         return isAttention(index) ? attention
-                : isMouseOver(index) ? hover
-                : isActive() ? (isSelected(index) ? selected : active)
+                : isMouseOver(index) ? (isSelected(index) ? selectedHover : unselectedHover)
+                : isSelected(index) ? selected
+                : isActive() ? active
                 : normal;
     }
 
@@ -284,6 +316,7 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
             activeBackground = Utils.getUIColor("ViewTab.activeBackground", background); // NOI18N
             selectedBackground = Utils.getUIColor("ViewTab.selectedBackground", activeBackground); // NOI18N
             hoverBackground = UIManager.getColor("ViewTab.hoverBackground"); // NOI18N
+            unselectedHoverBackground = Utils.getUIColor("ViewTab.unselectedHoverBackground", hoverBackground); // NOI18N
             attentionBackground = UIManager.getColor("ViewTab.attentionBackground"); // NOI18N
 
             foreground = Utils.getUIColor("ViewTab.foreground", "TabbedPane.foreground"); // NOI18N
@@ -305,6 +338,9 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
             // scale on Java 8 and Linux
             tabInsets = UIScale.scale(tabInsets);
             underlineHeight = UIScale.scale(underlineHeight);
+
+            showSelectedTabBorder = Utils.getUIBoolean("ViewTab.showSelectedTabBorder", false); // NOI18N
+            unscaledBorders = Utils.getUIBoolean("ViewTab.unscaledBorders", false); // NOI18N
 
             colorsReady = true;
         }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatViewTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatViewTabDisplayerUI.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.swing.tabcontrol.plaf;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.MouseEvent;
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.UIManager;
+import javax.swing.plaf.ComponentUI;
+import org.netbeans.swing.tabcontrol.TabDisplayer;
+import org.netbeans.swing.tabcontrol.event.TabActionEvent;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.FlatTabControlIcon;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.HiDPIUtils;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.UIScale;
+import org.netbeans.swing.tabcontrol.plaf.WinFlatUtils.Utils;
+import org.openide.awt.HtmlRenderer;
+
+/**
+ * "Fork" of {@code org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI}, for use with the
+ * Windows LAF.
+ */
+public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
+
+    // Do not change or scale ICON_X_PAD because super class has a copy of this field.
+    // Scaling ICON_X_PAD would truncate tab title.
+    private static final int ICON_X_PAD = 4;
+
+    /**
+     * True when colors were already initialized, false otherwise
+     */
+    private static boolean colorsReady = false;
+
+    private static Color
+            background,             // background of tabs and tabs area if view group is inactive
+            activeBackground,       // background of tabs and tabs area if view group is active;  optional; defaults to foreground
+            selectedBackground,     // background of tab if tab is selected in active view group; optional; defaults to activeBackground
+            hoverBackground,        // background of tab if mouse is over tab
+            attentionBackground,    // background of tab if tab is in attension mode
+
+            foreground,             // text color if view group is inactive;               optional; defaults to TabbedPane.foreground
+            activeForeground,       // text color if view group is active;                 optional; defaults to foreground
+            selectedForeground,     // text color if tab is selected in active view group; optional; defaults to activeForeground
+            hoverForeground,        // text color if mouse is over tab;                    optional; defaults to foreground
+            attentionForeground,    // text color if tab is in attension mode;             optional; defaults to foreground
+
+            underlineColor,         // underline color of selected active tabs
+            inactiveUnderlineColor, // underline color of selected inactive tabs
+            tabSeparatorColor,      // tab separator color
+            contentBorderColor;     // bottom border color
+
+    private static Insets tabInsets;
+    private static int underlineHeight;     // height of "underline" painted at bottom of tab to indicate selection
+    private static boolean underlineAtTop;  // paint "underline" at top of tab
+    private static boolean showTabSeparators; // paint tab separators
+
+    private Font font;
+
+    public WinFlatViewTabDisplayerUI(TabDisplayer displayer) {
+        super(displayer);
+    }
+
+    public static ComponentUI createUI(JComponent c) {
+        return new WinFlatViewTabDisplayerUI((TabDisplayer) c);
+    }
+
+    @Override
+    public void installUI(JComponent c) {
+        super.installUI(c);
+        initColors();
+        getLayoutModel().setPadding(new Dimension(tabInsets.left + tabInsets.right, 0));
+    }
+
+    @Override
+    protected AbstractViewTabDisplayerUI.Controller createController() {
+        return new OwnController();
+    }
+
+    @Override
+    public Dimension getPreferredSize(JComponent c) {
+        FontMetrics fm = getTxtFontMetrics();
+        int height = fm.getHeight() + tabInsets.top + tabInsets.bottom;
+        return new Dimension(100, height);
+    }
+
+    @Override
+    protected void paintTabContent(Graphics g, int index, String text, int x, int y, int width, int height) {
+        int txtLeftPad = tabInsets.left;
+        int txtRightPad = tabInsets.right;
+
+        FontMetrics fm = getTxtFontMetrics();
+        // setting font already here to compute string width correctly
+        g.setFont(getTxtFont());
+        int availTxtWidth = width - (txtLeftPad + txtRightPad);
+        if (isSelected(index)) {
+            // layout buttons
+            Component buttons = getControlButtons();
+            if (null != buttons) {
+                Dimension buttonsSize = buttons.getPreferredSize();
+                if (width < buttonsSize.width + ICON_X_PAD) {
+                    buttons.setVisible(false);
+                } else {
+                    buttons.setVisible(true);
+                    availTxtWidth -= (buttonsSize.width + ICON_X_PAD);
+                    buttons.setLocation(x + width - buttonsSize.width - ICON_X_PAD, y + ((height - buttonsSize.height) / 2) - 1);
+                }
+            }
+        }
+
+        // paint busy icon
+        if (isTabBusy(index)) {
+            Icon busyIcon = BusyTabsSupport.getDefault().getBusyIcon(isSelected(index));
+            availTxtWidth -= busyIcon.getIconWidth() - UIScale.scale(3) - txtLeftPad;
+            busyIcon.paintIcon(displayer, g, x + txtLeftPad, y + (height - busyIcon.getIconHeight()) / 2);
+            int busyWidth = busyIcon.getIconWidth() + UIScale.scale(3);
+            x += busyWidth;
+            width -= busyWidth;
+        }
+
+        // make sure that as much text as possible is shown (and avoid empty tabs)
+        int realTxtWidth = (text.startsWith("<html") || text.startsWith("<HTML")) //NOI18N
+                ? (int) HtmlRenderer.renderString(text, g, 0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE,
+                            getTxtFont(), foreground, HtmlRenderer.STYLE_TRUNCATE, false)
+                : fm.stringWidth(text);
+        if (realTxtWidth > availTxtWidth) {
+            // add left and right insets to available width
+            int left = Math.min(txtLeftPad - 1, realTxtWidth - availTxtWidth);
+            availTxtWidth += left + txtRightPad;
+            txtLeftPad -= left;
+
+            // Truncate text here because HtmlRenderer.renderString() does not paint any text
+            // if it is longer that 3 characters and the available width is smaller
+            // than the width of the first 3 characters plus "…".
+            if (realTxtWidth > availTxtWidth && text.length() > 3) {
+                int minWidth = fm.stringWidth(text.substring(0, 3) + "…"); //NOI18N
+                if (minWidth > availTxtWidth) {
+                    // truncate text; in the worst case, text becomes "…" only
+                    for (int i = 2; i >= 0; i--) {
+                        text = text.substring(0, i) + "…"; //NOI18N
+                        if (fm.stringWidth(text) < availTxtWidth)
+                            break;
+                    }
+                }
+            }
+        }
+
+        // text color
+        Color c = colorForState(index, foreground, activeForeground, selectedForeground,
+                hoverForeground, attentionForeground);
+
+        // paint text
+        int txtX = x + txtLeftPad;
+        int txtY = y + tabInsets.top + fm.getAscent();
+        int availH = height - tabInsets.top - tabInsets.bottom;
+        if (availH > fm.getHeight()) {
+            txtY += (availH - fm.getHeight()) / 2;
+        }
+        int style = HtmlRenderer.STYLE_TRUNCATE;
+        if (!isSelected(index)) {
+            // center text of unselected tabs
+            txtX = Math.max(x + 1, x + ((width - realTxtWidth) / 2));
+        }
+        HtmlRenderer.renderString(text, g, txtX, txtY, availTxtWidth, height,
+                getTxtFont(), c, style, true);
+    }
+
+    @Override
+    protected void paintTabBorder(Graphics g, int index, int x, int y, int width, int height) {
+        // not using borders
+    }
+
+    @Override
+    protected void paintTabBackground(Graphics g, int index, int x, int y, int width, int height) {
+        // Paint the whole tab background at scale 1x (on HiDPI screens).
+        // Necessary so that it aligns nicely at bottom left and right edges
+        // with the content border, which is also painted at scale 1x.
+        HiDPIUtils.paintAtScale1x(g, x, y, width, height,
+                (g1x, width1x, height1x, scale) -> {
+                    paintTabBackgroundAtScale1x(g1x, index, width1x, height1x, scale);
+                });
+    }
+
+    private void paintTabBackgroundAtScale1x(Graphics2D g, int index, int width, int height, double scale) {
+        // do not round tab separator width to get nice small lines at 125%, 150% and 175%
+        int tabSeparatorWidth = (showTabSeparators && index >= 0) ? (int) (1 * scale) : 0;
+
+        // paint background
+        Color bg = colorForState(index, background, activeBackground, selectedBackground,
+                hoverBackground, attentionBackground);
+        g.setColor(bg);
+        g.fillRect(0, 0, width - (bg != background ? tabSeparatorWidth : 0), height);
+
+        if (isSelected(index) && underlineHeight > 0) {
+            // paint underline if tab is selected
+            int underlineHeight = (int) Math.round(this.underlineHeight * scale);
+            g.setColor(isActive() ? underlineColor : inactiveUnderlineColor);
+            if (underlineAtTop) {
+                g.fillRect(0, 0, width - tabSeparatorWidth, underlineHeight);
+            } else {
+                g.fillRect(0, height - underlineHeight, width - tabSeparatorWidth, underlineHeight);
+            }
+        } else {
+            // paint bottom border
+            int contentBorderWidth = HiDPIUtils.deviceBorderWidth(scale, 1);
+            g.setColor(contentBorderColor);
+            g.fillRect(0, height - contentBorderWidth, width, contentBorderWidth);
+        }
+
+        if (showTabSeparators && index >= 0) {
+            int offset = (int) (4 * scale);
+            g.setColor(tabSeparatorColor);
+            g.fillRect(width - tabSeparatorWidth, offset, tabSeparatorWidth, height - (offset * 2) - 1);
+        }
+    }
+
+    @Override
+    protected void paintDisplayerBackground(Graphics g, JComponent c) {
+        // Fill the whole displayer background to avoid occasional 1px gaps
+        // between tabs on HiDPI screens at 125%, 150% or 175%.
+        paintTabBackground(g, -1, 0, 0, c.getWidth(), c.getHeight());
+
+        super.paintDisplayerBackground(g, c);
+    }
+
+    private Color colorForState(int index, Color normal, Color active, Color selected, Color hover, Color attention) {
+        return isAttention(index) ? attention
+                : isMouseOver(index) ? hover
+                : isActive() ? (isSelected(index) ? selected : active)
+                : normal;
+    }
+
+    @Override
+    protected Font getTxtFont() {
+        if (font == null) {
+            font = UIManager.getFont("ViewTab.font"); // NOI18N
+            if (font == null) {
+                font = UIManager.getFont("Label.font"); // NOI18N
+            }
+        }
+        return font;
+    }
+
+    /**
+     * @return true if tab with given index has mouse cursor above, false otherwise.
+     */
+    boolean isMouseOver(int index) {
+        if (index < 0) {
+            return false;
+        }
+        return ((OwnController) getController()).getMouseIndex() == index;
+    }
+
+    /**
+     * Initialization of colors
+     */
+    private static void initColors() {
+        if (!colorsReady) {
+            background = UIManager.getColor("ViewTab.background"); // NOI18N
+            activeBackground = Utils.getUIColor("ViewTab.activeBackground", background); // NOI18N
+            selectedBackground = Utils.getUIColor("ViewTab.selectedBackground", activeBackground); // NOI18N
+            hoverBackground = UIManager.getColor("ViewTab.hoverBackground"); // NOI18N
+            attentionBackground = UIManager.getColor("ViewTab.attentionBackground"); // NOI18N
+
+            foreground = Utils.getUIColor("ViewTab.foreground", "TabbedPane.foreground"); // NOI18N
+            activeForeground = Utils.getUIColor("ViewTab.activeForeground", foreground); // NOI18N
+            selectedForeground = Utils.getUIColor("ViewTab.selectedForeground", activeForeground); // NOI18N
+            hoverForeground = Utils.getUIColor("ViewTab.hoverForeground", foreground); // NOI18N
+            attentionForeground = Utils.getUIColor("ViewTab.attentionForeground", foreground); // NOI18N
+
+            underlineColor = UIManager.getColor("ViewTab.underlineColor"); // NOI18N
+            inactiveUnderlineColor = UIManager.getColor("ViewTab.inactiveUnderlineColor"); // NOI18N
+            tabSeparatorColor = UIManager.getColor("ViewTab.tabSeparatorColor"); // NOI18N
+            contentBorderColor = UIManager.getColor("TabbedContainer.view.contentBorderColor"); // NOI18N
+
+            tabInsets = UIManager.getInsets("ViewTab.tabInsets"); // NOI18N
+            underlineHeight = UIManager.getInt("ViewTab.underlineHeight"); // NOI18N
+            underlineAtTop = UIManager.getBoolean("ViewTab.underlineAtTop"); // NOI18N
+            showTabSeparators = UIManager.getBoolean("ViewTab.showTabSeparators"); // NOI18N
+
+            // scale on Java 8 and Linux
+            tabInsets = UIScale.scale(tabInsets);
+            underlineHeight = UIScale.scale(underlineHeight);
+
+            colorsReady = true;
+        }
+    }
+
+    @Override
+    public Icon getButtonIcon(int buttonId, int buttonState) {
+        Icon ret = FlatTabControlIcon.get(buttonId, buttonState);
+        return ret != null ? ret : super.getButtonIcon(buttonId, buttonState);
+    }
+
+    @Override
+    public void postTabAction(TabActionEvent e) {
+        super.postTabAction(e);
+        if (TabDisplayer.COMMAND_MAXIMIZE.equals(e.getActionCommand())) {
+            ((OwnController) getController()).updateHighlight(-1);
+        }
+    }
+
+    /**
+     * Own close icon button controller
+     */
+    private class OwnController extends Controller {
+
+        /**
+         * holds index of tab in which mouse pointer was lastly located. -1
+         * means mouse pointer is out of component's area
+         */
+        // TBD - should be part of model, not controller
+        private int lastIndex = -1;
+
+        /**
+         * @return Index of tab in which mouse pointer is currently located.
+         */
+        public int getMouseIndex() {
+            return lastIndex;
+        }
+
+        /**
+         * Triggers visual tab header change when mouse enters/leaves tab in
+         * advance to superclass functionality.
+         */
+        @Override
+        public void mouseMoved(MouseEvent e) {
+            super.mouseMoved(e);
+            Point pos = e.getPoint();
+            updateHighlight(getLayoutModel().indexOfPoint(pos.x, pos.y));
+        }
+
+        /**
+         * Resets tab header in advance to superclass functionality
+         */
+        @Override
+        public void mouseExited(MouseEvent e) {
+            super.mouseExited(e);
+            if (!inControlButtonsRect(e.getPoint())) {
+                updateHighlight(-1);
+            }
+        }
+
+        /**
+         * Invokes repaint of dirty region if needed
+         */
+        private void updateHighlight(int curIndex) {
+            if (curIndex == lastIndex) {
+                return;
+            }
+            // compute region which needs repaint
+            TabLayoutModel tlm = getLayoutModel();
+            int x, y, w, h;
+            Rectangle repaintRect = null;
+            if (curIndex != -1) {
+                x = tlm.getX(curIndex) - 1;
+                y = tlm.getY(curIndex);
+                w = tlm.getW(curIndex) + 2;
+                h = tlm.getH(curIndex);
+                repaintRect = new Rectangle(x, y, w, h);
+            }
+            // due to model changes, lastIndex may become invalid, so check
+            if ((lastIndex != -1) && (lastIndex < getDataModel().size())) {
+                x = tlm.getX(lastIndex) - 1;
+                y = tlm.getY(lastIndex);
+                w = tlm.getW(lastIndex) + 2;
+                h = tlm.getH(lastIndex);
+                if (repaintRect != null) {
+                    repaintRect = repaintRect.union(new Rectangle(x, y, w, h));
+                } else {
+                    repaintRect = new Rectangle(x, y, w, h);
+                }
+            }
+            // trigger repaint if needed, update index
+            if (repaintRect != null) {
+                getDisplayer().repaint(repaintRect);
+            }
+            lastIndex = curIndex;
+        }
+    } // end of OwnController
+}

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/Windows8VectorTabControlIcon.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/Windows8VectorTabControlIcon.java
@@ -90,7 +90,7 @@ final class Windows8VectorTabControlIcon extends VectorIcon {
     }
 
     private Windows8VectorTabControlIcon(int buttonId, int buttonState) {
-        super(14, 14);
+        super(14, buttonId == TabControlButton.ID_CLOSE_BUTTON ? 15 : 14);
         this.buttonId = buttonId;
         this.buttonState = buttonState;
     }
@@ -118,10 +118,14 @@ final class Windows8VectorTabControlIcon extends VectorIcon {
                 bgColor = closeColor != null ? closeColor : new Color(57, 100, 178, 255);
                 fgColor = Color.WHITE;
             } else if (buttonState == TabControlButton.STATE_ROLLOVER) {
-                bgColor = closeColor != null ? closeColor
-                        // Grey (via transparent black to work well on any background).
-                        : new Color(0, 0, 0, 70);
-                fgColor = Color.WHITE;
+                if (closeColor != null) {
+                    bgColor = closeColor;
+                    fgColor = Color.WHITE;
+                } else {
+                    /* Light blue, via transparency to work well on any background. In the grey
+                    toolbar, it comes out similar to the hover background used for toolbar buttons. */
+                    bgColor = new Color(0, 132, 247, 49);
+                }
             }
         }
         if (bgColor.getAlpha() > 0) {
@@ -142,7 +146,7 @@ final class Windows8VectorTabControlIcon extends VectorIcon {
                 strokeWidth *= 1.5f;
             }
             double marginX = 3.5 * scaling; // Don't round this one.
-            int topMarginY = round(3 * scaling);
+            int topMarginY = round(4 * scaling);
             int botMarginY = round(4 * scaling);
             // Flatten the top and bottom.
             g.clip(new Rectangle2D.Double(0, topMarginY, width, height - topMarginY - botMarginY));

--- a/platform/openide.awt/src/org/openide/awt/Windows8VectorCloseButton.java
+++ b/platform/openide.awt/src/org/openide/awt/Windows8VectorCloseButton.java
@@ -34,7 +34,7 @@ final class Windows8VectorCloseButton extends VectorIcon {
     private final boolean pressed;
 
     private Windows8VectorCloseButton(boolean pressed) {
-        super(14, 14);
+        super(14, 15);
         this.pressed = pressed;
     }
 
@@ -55,7 +55,7 @@ final class Windows8VectorCloseButton extends VectorIcon {
         if (scaling > 1.0)
             strokeWidth *= 1.5f;
         double marginX = 3.5 * scaling;
-        int topMarginY = round(3 * scaling);
+        int topMarginY = round(4 * scaling);
         int botMarginY = round(4 * scaling);
         g.clip(new Rectangle2D.Double(0, topMarginY, width, height - topMarginY - botMarginY));
         g.setStroke(new BasicStroke((float) strokeWidth));


### PR DESCRIPTION
This PR modernizes the look of the main NetBeans tabs components on the Windows LAF, and makes them look good on all the standard HiDPI scalings supported on Windows (100%, 125%, 150%, 175%, 200%, and 225%).

A before/after comparison is shown here, first at 100% scaling (regular, non-HiDPI screens). To review these images, be sure to view them at 100% scaling on your screen. (If you have a HiDPI screen yourself, you may need to adjust your browser's zoom level so that each pixel in the screenshot corresponds to one device pixel on your screen.)

![Old vs  New Tab Style (1x scaling)](https://user-images.githubusercontent.com/886243/118887549-83d9ef80-b8c8-11eb-8ea2-b666ec7a92b9.png)

The new tabs adhere to the following design principles:
* Keep the tabs consistent with the style in native Windows 10 dialogs. This style is also used in the regular JTabbedPane, which is used in NetBeans e.g. in the "Output" pane.
* Keep the tab dimensions compact, as in the previous look. After trying various geometries, I ended up making the new tabs 2 pixels taller than the previous ones, but not more.
* Minimize visual complexity, while making it obvious where the user can click. Keep drawing the selected tab as an actual tab, with borders around it, but show a blue line highlight as seen in FlatLAF. Use the "flat" style from FlatLAF for unselected tabs. For the editor tab component, use the subtle separators that were introduced in FlatLAF between unselected tabs. This is also the style used in Chrome tabs. Make sure the "X" icon is not closer to the separator line than to the tab's caption; otherwise, the visual interaction between the X and the separator line can become confusing.

The new tabs also solve various problems that were previously seen when HiDPI scaling was active, especially for fractional scalings (e.g. 150%). Here are before/after screenshots on 150% HiDPI scaling:

![Old vs  New Tab Style (1 5x scaling)](https://user-images.githubusercontent.com/886243/118901325-fbb41400-b8e0-11eb-8a5d-2e1729522dee.png)

The new TabDisplayerUI classes are based on @DevCharly's previously added implementations for FlatLAF. These were already taking HiDPI scaling into account, and were very configurable. For now, I have added separate copies of these classes for the Windows LAF. I have split up the commits in this PR to make it clear which changes have been made to the "forked" copies. Some improvements, found in the second commit, could potentially be merged back into the FlatLAF classes if later desired. For example, one bug was fixed relating to the positioning of the "spinner" icon which is shown when the Navigator tab is being loaded:

![Spinner position fix](https://user-images.githubusercontent.com/886243/118890136-2cd61980-b8cc-11eb-8cf7-4cae4acf2b6b.png)

To review this PR, it's best to look at each commit separately, since the first one just makes copies of the files from FlatLAF (with minimal necessary refactorings). The commits should probably be left unsquashed.

Some related improvements were split out into separate PRs, at https://github.com/apache/netbeans/pull/2965 and https://github.com/apache/netbeans/pull/2966 .

Finally, here are some screenshots of the entire NetBeans IDE with the old and the new tabs, this time at 200% HiDPI scaling.

### Before:
![Full Screenshot Old Style Tabs (2x scaling)](https://user-images.githubusercontent.com/886243/118890270-6575f300-b8cc-11eb-940d-2f3e0a593dfa.png)

### After:
![Full Screenshot New Style Tabs (2x scaling)](https://user-images.githubusercontent.com/886243/118890284-6ad33d80-b8cc-11eb-86c9-66431ece1ff5.png)
