### PR TITLE
[NETBEANS-5699] - Fixed test cases failing on JDK17

### DIFF
--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/imports/ComputeImportsTest/14/testException-filtered.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/imports/ComputeImportsTest/14/testException-filtered.pass
@@ -1,0 +1,2 @@
+Element:[javax.swing.text.Element, javax.swing.text.html.parser.Element, org.w3c.dom.Element]
+d:[]

--- a/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/imports/ComputeImportsTest/14/testException-unfiltered.pass
+++ b/java/java.editor/test/unit/data/goldenfiles/org/netbeans/modules/java/editor/imports/ComputeImportsTest/14/testException-unfiltered.pass
@@ -1,0 +1,2 @@
+Element:[javax.swing.text.Element, javax.swing.text.html.parser.Element, org.w3c.dom.Element]
+d:[]

--- a/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/view/JavaViewHierarchyRandomTest.java
+++ b/java/java.editor/test/unit/src/org/netbeans/modules/java/editor/view/JavaViewHierarchyRandomTest.java
@@ -167,6 +167,8 @@ public class JavaViewHierarchyRandomTest extends NbTestCase {
                     int endOffset = doc.getLength() + 1;
                     modelToView(startOffset);
                     modelToView(endOffset);
+                    if(System.getProperty("java.specification.version").compareTo("1.8") > 0)
+                        endOffset = doc.getLength();
                     getNextVisualPositionFrom(startOffset);
                     getNextVisualPositionFrom(endOffset);
                 } catch (BadLocationException e) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5699

1. com.sun.java.util.jar.pack.Attribute removed since JDK 14. Added new pass file for the same.
2. getNextVisualPositionFrom(int) method in javax.swing.plaf.basic.BasicTextUI class does not allow values greater than document length since JDK 9. Modified test method testModelToViewAtBoundaries for the same.