### PR TITLE
[NETBEANS-5698] Fix tabcontrol painting on MacOS retina displays (Aqua LAF)

### DIFF
--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabCellRenderer.java
@@ -222,32 +222,32 @@ class AquaEditorTabCellRenderer extends AbstractTabCellRenderer {
             Color shadowColor = UIManager.getColor("NbTabControl.borderShadowColor");
             //top
             g.setColor(borderColor);
-            g.drawLine(x, y, width-1, y);
+            drawLine(g, x, y, width-1, y);
 
             //bottom
             if( !ren.isSelected() ) {
                 g.setColor(borderColor);
-                g.drawLine(x, y+height-1, width, y+height-1);
+                drawLine(g, x, y+height-1, width, y+height-1);
 
             } else {
                 g.setColor(UIManager.getColor("NbTabControl.selectedTabDarkerBackground"));
-                g.drawLine(x, y+height-1, width, y+height-1);
+                drawLine(g, x, y+height-1, width, y+height-1);
             }
 
             //right
             if( ren.isRightmost() || !ren.isSelected() ) {
                 g.setColor(borderColor);
-                g.drawLine(x+width-1, y, x+width-1, y+height-1);
+                drawLine(g, x+width-1, y, x+width-1, y+height-1);
                 g.setColor(shadowColor);
-                g.drawLine(x+width-2, y+1, x+width-2, y+height-(ren.isSelected() ? 1 : 2));
+                drawLine(g, x+width-2, y+1, x+width-2, y+height-(ren.isSelected() ? 1 : 2));
             } else if( ren.isSelected() ) {
                 g.setColor(borderColor);
-                g.drawLine(x+width-1, y, x+width-1, y+height-1);
+                drawLine(g, x+width-1, y, x+width-1, y+height-1);
             }
             //left
             if( !ren.isLeftmost() && !ren.isSelected() ) {
                 g.setColor(shadowColor);
-                g.drawLine(x, y+1, x, y+height-2);
+                drawLine(g, x, y+1, x, y+height-2);
             }
         }
 
@@ -268,8 +268,8 @@ class AquaEditorTabCellRenderer extends AbstractTabCellRenderer {
                 int y = 0;
                 int width = ren.getWidth();
                 g.setColor(UIManager.getColor("NbTabControl.focusedTabBackground"));
-                g.drawLine(x, y+1, x+width-2, y+1);
-                g.drawLine(x, y+2, x+width-2, y+2);
+                drawLine(g, x, y+1, x+width-2, y+1);
+                drawLine(g, x, y+2, x+width-2, y+2);
             }
 
             if (!g.hitClip(r.x, r.y, r.width, r.height)) {
@@ -323,29 +323,29 @@ class AquaEditorTabCellRenderer extends AbstractTabCellRenderer {
 
             //top
             g.setColor(borderColor);
-            g.drawLine(x, y, width-1, y);
+            drawLine(g, x, y, width-1, y);
 
             //bottom
             if( !ren.isSelected() ) {
                 g.setColor(borderColor);
-                g.drawLine(x, y+height-1, width, y+height-1);
+                drawLine(g, x, y+height-1, width, y+height-1);
 
             } else {
                 g.setColor(UIManager.getColor("NbTabControl.selectedTabDarkerBackground"));
-                g.drawLine(x, y+height-1, width, y+height-1);
+                drawLine(g, x, y+height-1, width, y+height-1);
             }
 
             //right
             if( ren.isRightmost() || !ren.isSelected() ) {
                 g.setColor(borderColor);
-                g.drawLine(x+width-1, y, x+width-1, y+height-1);
+                drawLine(g, x+width-1, y, x+width-1, y+height-1);
                 g.setColor(UIManager.getColor("NbTabControl.editorBorderShadowColor"));
-                g.drawLine(x+width-2, y+1, x+width-2, y+height-(ren.isSelected() ? 1 : 2));
+                drawLine(g, x+width-2, y+1, x+width-2, y+height-(ren.isSelected() ? 1 : 2));
             }
             if( ren.isActive() && ren.isSelected() ) {
                 g.setColor(UIManager.getColor("NbTabControl.focusedTabBackground"));
-                g.drawLine(x, y+1, x+width-1, y+1);
-                g.drawLine(x, y+2, x+width-1, y+2);
+                drawLine(g, x, y+1, x+width-1, y+1);
+                drawLine(g, x, y+2, x+width-1, y+2);
             }
         }
 
@@ -410,22 +410,22 @@ class AquaEditorTabCellRenderer extends AbstractTabCellRenderer {
 
             //top
             g.setColor(borderColor);
-            g.drawLine(x, y, width, y);
+            drawLine(g, x, y, width, y);
 
             //bottom
             if( !ren.isSelected() ) {
                 g.setColor(borderColor);
-                g.drawLine(x, y+height-1, width, y+height-1);
+                drawLine(g, x, y+height-1, width, y+height-1);
 
             } else {
                 g.setColor(UIManager.getColor("NbTabControl.selectedTabDarkerBackground"));
-                g.drawLine(x, y+height-1, width, y+height-1);
+                drawLine(g, x, y+height-1, width, y+height-1);
             }
 
             //left
             if( !ren.isLeftmost() && !ren.isSelected() ) {
                 g.setColor(UIManager.getColor("NbTabControl.editorBorderShadowColor"));
-                g.drawLine(x, y+1, x, y+height-2);
+                drawLine(g, x, y+1, x, y+height-2);
             }
         }
 
@@ -440,8 +440,8 @@ class AquaEditorTabCellRenderer extends AbstractTabCellRenderer {
                 int y = 0;
                 int width = ren.getWidth();
                 g.setColor(UIManager.getColor("NbTabControl.focusedTabBackground"));
-                g.drawLine(x, y+1, x+width, y+1);
-                g.drawLine(x, y+2, x+width, y+2);
+                drawLine(g, x, y+1, x+width, y+1);
+                drawLine(g, x, y+2, x+width, y+2);
             }
         }
 
@@ -454,5 +454,9 @@ class AquaEditorTabCellRenderer extends AbstractTabCellRenderer {
                                             Rectangle bounds) {
             rect.setBounds(-20, -20, 0, 0);
         }
+    }
+
+    private static void drawLine(Graphics g, int x1, int y1, int x2, int y2) {
+        AquaEditorTabDisplayerUI.drawLine(g, x1, y1, x2, y2);
     }
 }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaEditorTabDisplayerUI.java
@@ -135,9 +135,46 @@ public class AquaEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
             rightLineStart = 6;
         }
         g.setColor(UIManager.getColor("NbTabControl.borderColor"));
-        g.drawLine(rightLineStart, y-1, rightLineEnd, y-1);
+        drawLine(g, rightLineStart, y-1, rightLineEnd, y-1);
     }
-    
+
+    /**
+     * Draw a horizontal or vertical line, one logical pixel thick, in a manner which scales evenly
+     * from the regular 1x scaling case to the 2x retina (HiDPI) scaling case.
+     *
+     * <p>To make it easier to transition old code to this method, this method takes the same set of
+     * parameters as {@link Graphics#drawLine(int, int, int, int)}. Still, this method is only
+     * intended to be used to draw horizontal or vertical lines.
+     */
+    static void drawLine(Graphics g, int x1, int y1, int x2, int y2) {
+        /* Use fillRect rather than drawLine here, to avoid the lines being offset by one device pixel
+        (half a pixel in the Graphics2D coordinate system) when retina scaling is used. An old Java2D
+        FAQ explains how this works when painting on higher-resolution surfaces:
+
+        Q: Why are my 1-pixel wide lines repositioned when I print them? How do I correct this?
+        A: For horizontal or vertical 1-pixel wide line fills, it is generally better to use fillRect
+           rather than drawLine. The rounding of the drawLine method moves lines by half a device
+           pixel [they mean a pixel in the Graphics2D coordinate system, not a pixel on the printer],
+           which make the lines appear more consistent whether or not antialiasing is applied.
+           Therefore, if you have a 1-pixel wide line, the line is moved by half of its width. Because
+           this adjustment occurs at the device-space level, your lines can move by half of a line
+           width on printouts from high-resolution printers.
+
+           https://web.archive.org/web/20120626144901/http://java.sun.com/products/java-media/2D/reference/faqs/index.html
+        */
+        if (x1 == x2) {
+            int minY = Math.min(y1, y2);
+            int maxY = Math.max(y1, y2);
+            g.fillRect(x1, minY, 1, maxY - minY + 1);
+        } else if (y1 == y2) {
+            int minX = Math.min(x1, x2);
+            int maxX = Math.max(x1, x2);
+            g.fillRect(minX, y1, maxX - minX + 1, 1);
+        } else {
+            // Not a horizontal or vertical line. Just fall back to drawLine.
+            g.drawLine(x1, y1, x2, y2);
+        }
+    }
 
     private static void initIcons() {
         if( null == buttonIconPaths ) {

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaViewTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AquaViewTabDisplayerUI.java
@@ -164,6 +164,10 @@ public class AquaViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
                           UIManager.getColor("textText"),
                           HtmlRenderer.STYLE_TRUNCATE, true);
     }
+
+    private static void drawLine(Graphics g, int x1, int y1, int x2, int y2) {
+        AquaEditorTabDisplayerUI.drawLine(g, x1, y1, x2, y2);
+    }
     
     @Override
     protected void paintTabBorder(Graphics g, int index, int x, int y,
@@ -172,33 +176,33 @@ public class AquaViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
         Color borderShadowColor = UIManager.getColor("NbTabControl.borderShadowColor");
         g.setColor(borderColor);
         if( index > 0 ) {
-            g.drawLine(x, y, x, y+height);
+            drawLine(g, x, y, x, y+height);
             if( !isSelected(index) ) {
                 g.setColor(borderShadowColor);
-                g.drawLine(x+1, y+1, x+1, y+height-1);
+                drawLine(g, x+1, y+1, x+1, y+height-1);
             }
         }
         if( index < getDataModel().size()-1 || !isUseStretchingTabs() ) {
             g.setColor(borderColor);
-            g.drawLine(x+width, y, x+width, y+height);
+            drawLine(g, x+width, y, x+width, y+height);
             if( !isSelected(index) ) {
                 g.setColor(borderShadowColor);
-                g.drawLine(x+width-1, y+1, x+width-1, y+height-1);
+                drawLine(g, x+width-1, y+1, x+width-1, y+height-1);
             }
         }
         g.setColor(borderColor);
         if( !isSelected(index) ) {
-            g.drawLine(x, y+height-1, x+width, y+height-1);
+            drawLine(g, x, y+height-1, x+width, y+height-1);
         }
-        g.drawLine(x, y, x+width, y);
+        drawLine(g, x, y, x+width, y);
         if( getDataModel().size() == 1 ) {
             g.setColor(UIManager.getColor("NbTabControl.editorTabBackground"));
-            g.drawLine(x, y+height-1, x+width, y+height-1);
+            drawLine(g, x, y+height-1, x+width, y+height-1);
         }
         if( isSelected(index) && isFocused(index) ) {
             g.setColor(UIManager.getColor("NbTabControl.focusedTabBackground"));
-            g.drawLine(x+(index == 0 ? 0 : 1), y+1, x+width-1, y+1);
-            g.drawLine(x+(index == 0 ? 0 : 1), y+2, x+width-1, y+2);
+            drawLine(g, x+(index == 0 ? 0 : 1), y+1, x+width-1, y+1);
+            drawLine(g, x+(index == 0 ? 0 : 1), y+2, x+width-1, y+2);
         }
     }
 


### PR DESCRIPTION
This PR fixes scaling problems that occur in the window system tabs on the Aqua LAF on Retina displays (2x HiDPI scaling). All MacBooks and other Apple displays use retina scaling these days.

The fix is to use Graphics.fillRect instead of Graphics.drawLine; see the comment in the code. The patch adds a new "drawLine" utility method in the tab displayer UI classes for this purpose, and then does a plain search-and-replace of "g.drawLine(" with "drawLine(g, ", with no other changes.

Note that on MacOS, standard UI panel borders are two device pixels thick on Retina screens. So scaling everything up 2x on Retina displays is the right thing to do, and looks consistent with native MacOS apps.

The fixes are illustrated below, with retina scaling (2x) enabled. When viewing these images, be sure to view them at a zoom level that makes the individual pixels apparent (i.e. 100% scaling on non-HiDPI screens).

<img width="815" alt="Summary" src="https://user-images.githubusercontent.com/886243/119020916-cb19bc00-b96c-11eb-8dd5-118c3c366549.png">

Tested on both Java 8 and Java 11. Full IDE screenshots included below.

### Before (opening in a separate tab is recommended):
<img width="907" alt="Java 11 Tabs Old" src="https://user-images.githubusercontent.com/886243/119020111-dc15fd80-b96b-11eb-9cee-a65fec011f11.png">

### After:
<img width="907" alt="Java 11 Tabs New" src="https://user-images.githubusercontent.com/886243/119020154-e7692900-b96b-11eb-8a8b-b12b302976a8.png">

