### PR TITLE
Sync timestamps in test. Detailed logging added.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
@@ -18,6 +18,8 @@
  */
 package org.netbeans.modules.gradle.loaders;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.netbeans.modules.gradle.GradleProject;
 import static org.netbeans.modules.gradle.api.NbGradleProject.Quality.FALLBACK;
 import org.netbeans.modules.gradle.cache.ProjectInfoDiskCache;
@@ -28,7 +30,8 @@ import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
  * @author lkishalmi
  */
 public class DiskCacheProjectLoader extends AbstractProjectLoader {
-
+    private static final Logger LOG = Logger.getLogger(DiskCacheProjectLoader.class.getName());
+    
     DiskCacheProjectLoader(ReloadContext ctx) {
         super(ctx);
     }
@@ -38,6 +41,7 @@ public class DiskCacheProjectLoader extends AbstractProjectLoader {
         ProjectInfoDiskCache cache = ProjectInfoDiskCache.get(ctx.project.getGradleFiles());
         if (cache.isCompatible()) {
             GradleProject prev = createGradleProject(cache.loadData());
+            LOG.log(Level.FINER, "Loaded from cache: {0}, valid: {1}", new Object[] { prev, cache.isValid() });
             if (cache.isValid()) {
                 updateSubDirectoryCache(prev);
                 return prev;

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.gradle.loaders;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.gradle.GradleProject;
@@ -69,14 +70,17 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
                     }
                     if (trust) {
                         ret = loader.load();
+                        LOGGER.log(Level.FINER, "Loaded with trusted loader {0} -> {1}", new Object[] { loader, ret });
                     } else {
                         ret = ctx.getPrevious();
                         if (ret != null) {
                             ret = ret.invalidate("Gradle execution is not trusted on this project.");
                         }
+                        LOGGER.log(Level.FINER, "Execution not allowed, invalidated {0}", ret);
                     }
                 } else {
                     ret = loader.load();
+                    LOGGER.log(Level.FINER, "Loaded with loader {0} -> {1}", new Object[] { loader, ret });
                 }
                 if (ret != null) {
                     break;

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectImplTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.gradle;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -278,7 +279,10 @@ public class NbGradleProjectImplTest extends AbstractGradleProjectTestCase {
                 FileObject cp = FileUtil.createFolder(to, x.getNameExt());
                 copy(x, cp);
             } else {
-                x.copy(to, x.getName(), x.getExt());
+                FileObject f = x.copy(to, x.getName(), x.getExt());
+                // see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8177809
+                Files.setLastModifiedTime(FileUtil.toFile(f).toPath(),
+                        Files.getLastModifiedTime(FileUtil.toFile(x).toPath()));
             }
         }
     }


### PR DESCRIPTION
Call me dumb: a while after I merged [PR-2924](https://github.com/apache/netbeans/pull/2924), the [NbGradleProjectImplTest](https://github.com/apache/netbeans/compare/master...sdedic:gradle/loadtest-fix?expand=1#diff-72dfc9a2d87b3278ba23d2642ce186c38cbd15e9b7795ce23d9d1b9850eadb6b) started to occasionally fail. The cause is that while the test makes a copy of the project dir, it does not maintain file timestamps - so cache may get copied a little earlier than the build.gradle file.

In addition, I've discovered [this nice issue in JDK](https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8177809)...

I have added some detailed logging during debugging, that could be worth to preserve for future diagnostics of the loading process 