### PR TITLE
[NETBEANS-5726] Fix JCheckboxMenuItem state for 'Show Editor Tooolbar'

### DIFF
--- a/ide/editor.actions/src/org/netbeans/modules/editor/actions/ToggleAction.java
+++ b/ide/editor.actions/src/org/netbeans/modules/editor/actions/ToggleAction.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.editor.actions;
 
 import java.awt.event.ActionEvent;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.text.JTextComponent;
@@ -34,34 +35,46 @@ import org.netbeans.api.editor.EditorActionNames;
  *
  * @author Miloslav Metelka
  */
-@EditorActionRegistrations({
-    @EditorActionRegistration(
-        name = EditorActionNames.toggleToolbar,
-        menuPath = "View",
-        menuPosition = 800,
-        menuText = "#" + EditorActionNames.toggleToolbar + "_menu_text",
-        preferencesKey = SimpleValueNames.TOOLBAR_VISIBLE_PROP
-    ),
-    @EditorActionRegistration(
-        name = EditorActionNames.toggleLineNumbers,
-        menuPath = "View",
-        menuPosition = 850,
-        menuText = "#" + EditorActionNames.toggleLineNumbers + "_menu_text",
-        preferencesKey = SimpleValueNames.LINE_NUMBER_VISIBLE
-    ),
-    @EditorActionRegistration(
-        name = EditorActionNames.toggleNonPrintableCharacters,
-        menuPath = "View",
-        menuPosition = 870,
-        menuText = "#" + EditorActionNames.toggleNonPrintableCharacters + "_menu_text",
-        preferencesKey = SimpleValueNames.NON_PRINTABLE_CHARACTERS_VISIBLE
-    )
-})
 public final class ToggleAction extends AbstractEditorAction {
+    /* Use eager initialization for these actions. Otherwise the selection ("checked") state of menu
+    items will not properly track the respective Preferences value (NETBEANS-5726). */
+    @EditorActionRegistrations({
+        @EditorActionRegistration(
+            name = EditorActionNames.toggleToolbar,
+            menuPath = "View",
+            menuPosition = 800,
+            menuText = "#" + EditorActionNames.toggleToolbar + "_menu_text",
+            preferencesKey = SimpleValueNames.TOOLBAR_VISIBLE_PROP
+        ),
+        @EditorActionRegistration(
+            name = EditorActionNames.toggleLineNumbers,
+            menuPath = "View",
+            menuPosition = 850,
+            menuText = "#" + EditorActionNames.toggleLineNumbers + "_menu_text",
+            preferencesKey = SimpleValueNames.LINE_NUMBER_VISIBLE
+        ),
+        @EditorActionRegistration(
+            name = EditorActionNames.toggleNonPrintableCharacters,
+            menuPath = "View",
+            menuPosition = 870,
+            menuText = "#" + EditorActionNames.toggleNonPrintableCharacters + "_menu_text",
+            preferencesKey = SimpleValueNames.NON_PRINTABLE_CHARACTERS_VISIBLE
+        )
+    })
+    public static ToggleAction create(Map<String,?> attrs) {
+        return new ToggleAction(attrs);
+    }
 
     private static final Logger LOG = Logger.getLogger(ToggleAction.class.getName());
 
     private static final long serialVersionUID = 1L;
+
+    public ToggleAction() {
+    }
+
+    private ToggleAction(Map<String,?> attrs) {
+        super(attrs);
+    }
 
     @Override
     public void actionPerformed(ActionEvent evt, JTextComponent component) {


### PR DESCRIPTION
Fix incorrect checkbox state shown by 'Show Editor Toolbar' and other boolean editor preference actions.

To reproduce the original bug:
1) Open a file for editing in the NetBeans editor.
2) Click View->"Show Only Editor"
3) Click View->"Show Editor Toolbar"
4) Click View->"Show Only Editor"
5) Click View->"Show Editor Toolbar"
6) There's now a checkmark next to View->"Show Editor Toolbar", even though there is no editor toolbar showing.

The problem was that the relevant actions were wrapped in WrapperAction, which cannot track changes in selection state. The state is initialized once and never subsequently updated. The fact that the checkbox state sometimes seems to track actual changes is merely an accident--it just toggles itself whenever the action is invoked from that particular JCheckboxMenuItem (as opposed to from e.g. a keyboard shortcut or from an external preference change).