### PR TITLE
[NETBEANS-5723] Avoid spurious error log message when dragging window system tabs

### DIFF
--- a/platform/core.nativeaccess/src/org/netbeans/core/nativeaccess/NativeWindowSystemImpl.java
+++ b/platform/core.nativeaccess/src/org/netbeans/core/nativeaccess/NativeWindowSystemImpl.java
@@ -78,18 +78,22 @@ public class NativeWindowSystemImpl extends NativeWindowSystem {
             if (gd.isWindowTranslucencySupported(GraphicsDevice.WindowTranslucency.TRANSLUCENT) ) {
                 try {
                     w.setOpacity(alpha);
+                    return;
                 } catch( Exception e ) {
                     //ignore, we'll try JNA
                 }
             }
         }
-        //try the JNA way
-        try {
-            WindowUtils.setWindowAlpha(w, alpha);
-        } catch( ThreadDeath td ) {
-            throw td;
-        } catch( Throwable e ) {
-            LOG.log(Level.INFO, null, e);
+        // Test isWindowAlphaSupported first to avoid an unnecessary log message.
+        if (WindowUtils.isWindowAlphaSupported()) {
+            //try the JNA way
+            try {
+                WindowUtils.setWindowAlpha(w, alpha);
+            } catch( ThreadDeath td ) {
+                throw td;
+            } catch( Throwable e ) {
+                LOG.log(Level.INFO, null, e);
+            }
         }
     }
     


### PR DESCRIPTION
On Windows, when dragging window system tags with the mouse, the following spurious error message may appear on the console running the NetBeans IDE or a NetBeans Platform application:

```
java.lang.UnsupportedOperationException: Set sun.java2d.noddraw=true to enable transparent windows
	at com.sun.jna.platform.WindowUtils$W32WindowUtils.setWindowAlpha(WindowUtils.java:796)
	at com.sun.jna.platform.WindowUtils.setWindowAlpha(WindowUtils.java:1940)
[catch] at org.netbeans.core.nativeaccess.NativeWindowSystemImpl.setWindowAlpha(NativeWindowSystemImpl.java:88)
	at org.netbeans.core.windows.view.dnd.DragAndDropFeedbackVisualizer.createDragWindow(DragAndDropFeedbackVisualizer.java:89)
	at org.netbeans.core.windows.view.dnd.DragAndDropFeedbackVisualizer.start(DragAndDropFeedbackVisualizer.java:110)
	at org.netbeans.core.windows.view.dnd.TopComponentDragSupport.doStartDrag(TopComponentDragSupport.java:402)
	at org.netbeans.core.windows.view.dnd.TopComponentDragSupport.eventDispatched(TopComponentDragSupport.java:327)
	at java.desktop/java.awt.Toolkit$SelectiveAWTEventListener.eventDispatched(Toolkit.java:2194)
```

This patch avoids the message. The patch was tested on both Windows and MacOS, and the tab preview overlay is still translucent as intended.