### PR TITLE
[NETBEANS-5736] Have clicking in "Projects" tree work along entire row

### DIFF
--- a/platform/openide.explorer/apichanges.xml
+++ b/platform/openide.explorer/apichanges.xml
@@ -26,6 +26,22 @@
 <apidef name="explorer">Explorer API</apidef>
 </apidefs>
 <changes>
+    <change id="setEntireRowClickable">
+        <api name="explorer"/>
+        <summary>Add the TreeView.setEntireRowClickable method.</summary>
+        <version major="6" minor="91"/>
+        <date day="13" month="3" year="2025"/>
+        <author login="ebakke"/>
+        <compatibility binary="compatible" source="compatible" deprecation="no" deletion="no" addition="yes"/>
+        <description>
+            The TreeView can now be optionally configured, via TreeView.setEntireRowClickable, so
+            that clicks in the empty space on the right-hand side of a node are interpreted as
+            clicks on said node.
+        </description>
+        <class package="org.openide.explorer.view" name="TreeView"/>
+        <issue number="NETBEANS-5736"/>
+    </change>
+
     <change id="ScrollOnExpand">
         <api name="explorer"/>
         <summary>Expose scrollOnExpand property on TreeView.</summary>

--- a/platform/openide.explorer/manifest.mf
+++ b/platform/openide.explorer/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.openide.explorer
 OpenIDE-Module-Localizing-Bundle: org/openide/explorer/Bundle.properties
 AutoUpdate-Essential-Module: true
-OpenIDE-Module-Specification-Version: 6.90
+OpenIDE-Module-Specification-Version: 6.91
 

--- a/platform/openide.explorer/src/org/openide/explorer/view/TreeViewDropSupport.java
+++ b/platform/openide.explorer/src/org/openide/explorer/view/TreeViewDropSupport.java
@@ -446,12 +446,7 @@ final class TreeViewDropSupport implements DropTargetListener, Runnable {
     /** Get a node on given point or null if there none*/
     private Node getNodeForDrop(Point p) {
         if (p != null) {
-            TreePath tp = tree.getPathForLocation(p.x, p.y);
-            if( null == tp ) {
-                //make the drop area a bit bigger at the end of the tree
-                tp = tree.getPathForLocation(p.x, p.y-tree.getRowHeight()/2);
-            }
-
+            TreePath tp = getTreePath(p.x, p.y);
             if (tp != null) {
                 return DragDropUtilities.secureFindNode(tp.getLastPathComponent());
             }
@@ -826,19 +821,38 @@ final class TreeViewDropSupport implements DropTargetListener, Runnable {
         DragDropUtilities.dropNotSuccesfull();
     }
 
+    TreePath getTreePath(int x, int y) {
+        if (view.isEntireRowClickable()) {
+            TreePath tp = tree.getClosestPathForLocation(x, y);
+            if (tp == null) {
+                return null;
+            }
+            /* Do require the y coordinate to be within the row's bounds, with some extra margin
+            intended for the last node in the tree (as in the !isEntireRowClickable case). */
+            Rectangle bounds = tree.getPathBounds(tp);
+            if (bounds == null || y < bounds.y ||
+                y > (bounds.y + bounds.height + tree.getRowHeight() / 2))
+            {
+                return null;
+            }
+            return tp;
+        } else {
+            TreePath tp = tree.getPathForLocation(x, y);
+            if( null == tp ) {
+                //make the drop area a bit bigger at the end of the tree
+                tp = tree.getPathForLocation(x, y - tree.getRowHeight() / 2);
+            }
+            return tp;
+        }
+    }
+
     /** @return The tree path to the node the cursor is above now or
     * null if no such node currently exists or if conditions were not
     * satisfied to continue with DnD operation.
     */
     TreePath getTreePath(DropTargetDragEvent dtde, int dropAction) {
-        // check location
         Point location = dtde.getLocation();
-        TreePath tp = tree.getPathForLocation(location.x, location.y);
-        if( null == tp ) {
-            //make the drop area a bit bigger at the end of the tree
-            tp = tree.getPathForLocation(location.x, location.y-tree.getRowHeight()/2);
-        }
-
+        TreePath tp = getTreePath(location.x, location.y);
         return ((tp != null) && (DragDropUtilities.secureFindNode(tp.getLastPathComponent()) != null)) ? tp : null;
     }
 


### PR DESCRIPTION
In the TreeView component, which is used for the "Projects" tab in the NetBeans IDE, the user should be able to click anywhere to the right of the node's icon to select said node. Drag-and-drop should work similarly.

This usability issue came up during user testing of a NetBeans Platform application. The user complained that files with a short filename were harder to click than files with long names. The user, a software engineer, pointed out that the equivalent tree component in IntelliJ allows the entire row to be clicked or dragged at to target a given node.

TreeView's behavior is derived from its superclass JTree. The OutlineView component does not have the same problem, as it derives from ETable and in turn JTable.

The fix required some gymnastics to trick JTree into believing the click was really within the bounds of the node's caption. The alternative (suggested by various StackOverflow posts) was to make the node actually wider, but this would be very hard to implement correctly.

Here's an illustration:
![Clickfix](https://user-images.githubusercontent.com/886243/120149972-753ce380-c1b8-11eb-8b0d-cc17514b66df.png)
