### PR TITLE
Fixes NPE and potential lockup in tests.

### DIFF
--- a/platform/openide.execution/src/org/openide/execution/ExecutionEngine.java
+++ b/platform/openide.execution/src/org/openide/execution/ExecutionEngine.java
@@ -127,13 +127,14 @@ public abstract class ExecutionEngine extends Object {
             private RequestProcessor.Task task;
             private int resultValue;
             private final String name;
-            private InputOutput io;
+            private final InputOutput io;
             
             public ET(Runnable run, String name, InputOutput io) {
                 super(run);
                 this.originalLookup = Lookup.getDefault();
                 this.resultValue = resultValue;
                 this.name = name;
+                this.io = io;
                 task = RequestProcessor.getDefault().post(this);
             }
             

--- a/platform/openide.io/src/org/openide/windows/IOProvider.java
+++ b/platform/openide.io/src/org/openide/windows/IOProvider.java
@@ -191,7 +191,12 @@ public abstract class IOProvider {
     /** Fallback implementation. */
     private static final class Trivial extends IOProvider {
         
-        private static final Reader in = new BufferedReader(new InputStreamReader(System.in));
+        private static final Reader in = new BufferedReader(new InputStreamReader(System.in)) {
+            public void close() {
+                // do nothing, prevent blocking between System.in.read() and System.in.close();
+            }
+        };
+        
         private static final PrintStream out = System.out;
         private static final PrintStream err = System.err;
 


### PR DESCRIPTION
The following error started to appear in tests:
```
    [junit] java.lang.NullPointerException
    [junit] 	at org.netbeans.modules.gradle.ActionProviderImpl.lambda$null$6(ActionProviderImpl.java:340)
    [junit] 	at org.netbeans.modules.gradle.execute.ProjectConfigurationSupport.executeWithConfiguration(ProjectConfigurationSupport.java:96)
    [junit] 	at org.netbeans.modules.gradle.ActionProviderImpl.lambda$invokeProjectAction2$7(ActionProviderImpl.java:326)
    [junit] 	at org.openide.util.Task.notifyFinished(Task.java:215)
    [junit] 	at org.netbeans.modules.gradle.execute.GradleDaemonExecutor$GradleTask.finish(GradleDaemonExecutor.java:419)
    [junit] 	at org.netbeans.modules.gradle.execute.GradleDaemonExecutor.run(GradleDaemonExecutor.java:246)
    [junit] 	at org.openide.util.Task.run(Task.java:232)
```
This is caused by `Trivial` implementation of ExecutionEngine did not initialize `io` field at all in its constructor...

Then during debugging, I've hid a deadlock:
```
"DisconnectableInputStream source reader" #30 daemon prio=1 os_prio=0 tid=0x00007f59652fc800 nid=0x5702 runnable [0x00007f59fc2c5000]
   java.lang.Thread.State: RUNNABLE
	at java.io.FileInputStream.readBytes(Native Method)
	at java.io.FileInputStream.read(FileInputStream.java:255)
	at java.io.BufferedInputStream.read1(BufferedInputStream.java:284)
	at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
	- locked <0x00000000e250a700> (a java.io.BufferedInputStream)
	at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
	at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
	at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	- locked <0x00000000fec2cb48> (a java.io.InputStreamReader)
	at java.io.InputStreamReader.read(InputStreamReader.java:184)
	at java.io.BufferedReader.fill(BufferedReader.java:161)
	at java.io.BufferedReader.read(BufferedReader.java:182)
	- locked <0x00000000fec2cb48> (a java.io.InputStreamReader)                        <--- locked because of read in progress
	at org.openide.util.io.ReaderInputStream.read(ReaderInputStream.java:65)
	at org.openide.util.io.ReaderInputStream.read(ReaderInputStream.java:88)
	at org.gradle.util.DisconnectableInputStream$1.run(DisconnectableInputStream.java:98)
	at java.lang.Thread.run(Thread.java:748)

"Default RequestProcessor" #22 daemon prio=1 os_prio=0 tid=0x00007f5a18b8d800 nid=0x56f1 waiting for monitor entry [0x00007f59fc6c7000]
   java.lang.Thread.State: BLOCKED (on object monitor)
	at java.io.BufferedReader.close(BufferedReader.java:522)
	- waiting to lock <0x00000000fec2cb48> (a java.io.InputStreamReader)                    <---- deadlocks on close from other thread.
	at org.openide.util.io.ReaderInputStream.close(ReaderInputStream.java:130)
	at org.netbeans.modules.gradle.execute.GradleDaemonExecutor.closeInOutErr(GradleDaemonExecutor.java:348)
	- locked <0x00000000fec28190> (a org.netbeans.modules.gradle.execute.GradleDaemonExecutor)
	at org.netbeans.modules.gradle.execute.GradleDaemonExecutor.run(GradleDaemonExecutor.java:275)
	at org.openide.util.Task.run(Task.java:232)
	at org.openide.execution.ExecutionEngine$Trivial$ET.lambda$run$0(ExecutionEngine.java:156)
```

Again, `IOProvider.Trivial` implementation in Platform is the culprit: if someone starts `read()` first, then close on the `InputOuput.getIn()` stream will deadlock: it's buffered from `System.in` that is typically not closed and is empty (reader waits forever).
