### PR TITLE
[NETBEANS-5744] Avoid java.io deadlock of close vs. pending read.

### DIFF
--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbProcessConsoleTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbProcessConsoleTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.debugging.launch;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider;
+import org.netbeans.modules.java.lsp.server.ui.LspIOAccessor;
+import org.openide.util.Lookup;
+
+/**
+ *
+ * @author sdedic
+ */
+public class NbProcessConsoleTest {
+    NbProcessConsole console = new NbProcessConsole(new Consumer<NbProcessConsole.ConsoleMessage>() {
+        @Override
+        public void accept(NbProcessConsole.ConsoleMessage t) {
+        }
+    });
+    
+    @Test
+    public void testConsoleClose() throws Exception {
+        InputStream sin = console.getStdIn();
+        BufferedReader rdr = new BufferedReader(new InputStreamReader(sin, "UTF-8"));
+        assertReaderClosed(rdr);
+    }
+    
+    void assertReaderClosed(BufferedReader rdr) throws IOException {
+        InputStream sin = console.getStdIn();
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        AtomicBoolean read1 = new AtomicBoolean(false);
+        
+        // do not wait > 5 secs, abort
+        scheduler.schedule(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                if (!read1.get()) {
+                    System.err.println("CLOSED!");
+                    sin.close();
+                }
+                return null;
+            }
+        }, 5, TimeUnit.SECONDS);
+
+        scheduler.schedule(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                console.stdIn("Hello, world!");
+                return null;
+            }
+        }, 100, TimeUnit.MILLISECONDS);
+
+        assertEquals("Hello, world!", rdr.readLine());
+        read1.set(true);
+        
+        console.stdIn("Still there");
+        assertEquals("Still there", rdr.readLine());
+        
+        // do not wait > 5 secs, abort
+        scheduler.schedule(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                // close asynchronously
+                sin.close();
+                return null;
+            }
+        }, 300, TimeUnit.MILLISECONDS);
+
+        long millis = System.currentTimeMillis();
+        assertNull(rdr.readLine());
+        long millis2 = System.currentTimeMillis();
+        
+        assertTrue("Close should be delayed.", millis2 - millis >= 300);
+    }
+    
+    @Test
+    public void testCloseLspIOContextInput() throws Exception {
+        AbstractLspInputOutputProvider.LspIO io = LspIOAccessor.createIO("test", console, Lookup.EMPTY);
+        
+        Reader r = LspIOAccessor.reader(io);
+        BufferedReader rdr = new BufferedReader(r);
+        assertReaderClosed(rdr);
+    }
+}

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ui/LspIOAccessor.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ui/LspIOAccessor.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.ui;
+
+import java.io.Reader;
+import org.openide.util.Lookup;
+
+/**
+ *
+ * @author sdedic
+ */
+public class LspIOAccessor {
+    public static Reader reader(AbstractLspInputOutputProvider.LspIO io) {
+        return io.in;
+    }
+    
+    public static AbstractLspInputOutputProvider.LspIO createIO(String name, IOContext ioCtx, Lookup lookup) {
+        return new AbstractLspInputOutputProvider.LspIO(name, ioCtx, lookup);
+    }
+}


### PR DESCRIPTION
During testing of [NETBEANS-5744](https://issues.apache.org/jira/browse/NETBEANS-5744) I have found that there are two lockups related to stream closing, which is done during process termination:
- `StreamDecoder` synchronizes around its `read()` (reading the underlying InputStream) and so does `close`. So closing an `InputStreamReader` while read is pending will block the close() thread.
- `PipedInputStream` close() just sets a flag, but does not actually wake up potentially waiting reader and does not cause writer to return `-1` EOF indicator.

The patch attempts to fix it, as close() to streams bound to the process I/O may happen asynchronously when the client terminates the process. I've attempted to write tests that check the close can be done from other thread while read is pending / waiting for the data.
