### PR TITLE
Debugger attach configurations ask for user input and configurations are split between Initial and Dynamic.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/AttachConfigurations.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/AttachConfigurations.java
@@ -79,7 +79,8 @@ public final class AttachConfigurations {
         }, RP);
     }
 
-    @Messages({"LBL_ConnectorPort=port of the debuggee JVM", "LBL_ConnectorShmemName=shared memory name"})
+    @Messages({"DESC_HostName=Name of host machine to connect to", "DESC_Port=Port number to connect to",
+               "DESC_ShMem=Shared memory transport address at which the target VM is listening"})
     private static List<DebugConnector> listAttachingConnectors() {
         VirtualMachineManager vmm = Bootstrap.virtualMachineManager ();
         List<AttachingConnector> attachingConnectors = vmm.attachingConnectors();
@@ -91,40 +92,42 @@ public final class AttachConfigurations {
             DebugConnector connector;
             switch (connectorName) {
                 case CONNECTOR_PROCESS:
-                    connector = new DebugConnector(NAME_ATTACH_PROCESS, type,
+                    connector = new DebugConnector(connectorName, NAME_ATTACH_PROCESS, type,
                             Collections.singletonList(PROCESS_ARG_PID),
-                            Collections.singletonList("${command:" + Server.JAVA_FIND_DEBUG_PROCESS_TO_ATTACH + "}"));    // NOI18N
+                            Collections.singletonList("${command:" + Server.JAVA_FIND_DEBUG_PROCESS_TO_ATTACH + "}"),   // NOI18N
+                            Collections.singletonList(""));
                     break;
                 case CONNECTOR_SOCKET: {
                     String hostName = getArgumentOrDefault(defaultArguments.get("hostname"), "localhost");          // NOI18N
-                    String port = getArgumentOrDefault(defaultArguments.get("port"), "<"+Bundle.LBL_ConnectorPort()+">"); // NOI18N
-                    connector = new DebugConnector(NAME_ATTACH_SOCKET, type,
+                    String port = getArgumentOrDefault(defaultArguments.get("port"), "8000"); // NOI18N
+                    connector = new DebugConnector(connectorName, NAME_ATTACH_SOCKET, type,
                             Arrays.asList(SOCKET_ARG_HOST, SOCKET_ARG_PORT),
-                            Arrays.asList(hostName, port));
+                            Arrays.asList(hostName, port),
+                            Arrays.asList(Bundle.DESC_HostName(), Bundle.DESC_Port()));
                     break;
                 }
                 case CONNECTOR_SHMEM: {
-                    String name = getArgumentOrDefault(defaultArguments.get("name"), "<"+Bundle.LBL_ConnectorShmemName()+">");       // NOI18N
-                    connector = new DebugConnector(NAME_ATTACH_SHMEM, type,
+                    String name = getArgumentOrDefault(defaultArguments.get("name"), "");       // NOI18N
+                    connector = new DebugConnector(connectorName, NAME_ATTACH_SHMEM, type,
                             Collections.singletonList(SHMEM_ARG_NAME),
-                            Collections.singletonList(name));
+                            Collections.singletonList(name),
+                            Collections.singletonList(Bundle.DESC_ShMem()));
                     break;
                 }
                 default: {
                     List<String> names = new ArrayList<>();
                     List<String> values = new ArrayList<>();
+                    List<String> descriptions = new ArrayList<>();
                     for (Connector.Argument arg : defaultArguments.values()) {
                         if (arg.mustSpecify()) {
                             names.add(arg.name());
                             String value = arg.value();
-                            if (value.isEmpty()) {
-                                value = "<" + arg.description()+ ">";   // NOI18N
-                            }
                             values.add(value);
+                            descriptions.add(arg.description());
                         }
                     }
-                    connector = new DebugConnector(NAME_ATTACH_BY + connectorName, type,
-                            names, values);
+                    connector = new DebugConnector(connectorName, NAME_ATTACH_BY + connectorName, type,
+                            names, values, descriptions);
                 }
             }
             connectors.add(connector);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/DebugConnector.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/DebugConnector.java
@@ -32,6 +32,12 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 public final class DebugConnector {
 
     /**
+     * The identifier of the connector.
+     */
+    @NonNull
+    private String id;
+
+    /**
      * The display name identifier of the connector.
      */
     @NonNull
@@ -55,11 +61,28 @@ public final class DebugConnector {
     @NonNull
     private List<String> defaultValues;
 
-    public DebugConnector(String name, String type, List<String> arguments, List<String> defaultValues) {
+    /**
+     * Descriptions of debug connector arguments.
+     */
+    @NonNull
+    private List<String> descriptions;
+
+    public DebugConnector(String id, String name, String type, List<String> arguments, List<String> defaultValues, List<String> descriptions) {
+        this.id = id;
         this.name = name;
         this.type = type;
         this.arguments = arguments;
         this.defaultValues = defaultValues;
+        this.descriptions = descriptions;
+    }
+
+    @Pure
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
     }
 
     @Pure
@@ -99,13 +122,22 @@ public final class DebugConnector {
     }
 
     @Pure
+    public List<String> getDescriptions() {
+        return descriptions;
+    }
+
+    public void setDescriptions(List<String> descriptions) {
+        this.descriptions = descriptions;
+    }
+
+    @Pure
     @Override
     public int hashCode() {
         int hash = 7;
+        hash = 37 * hash + Objects.hashCode(this.id);
         hash = 37 * hash + Objects.hashCode(this.name);
         hash = 37 * hash + Objects.hashCode(this.type);
         hash = 37 * hash + Objects.hashCode(this.arguments);
-        hash = 37 * hash + Objects.hashCode(this.defaultValues);
         return hash;
     }
 
@@ -122,6 +154,9 @@ public final class DebugConnector {
             return false;
         }
         final DebugConnector other = (DebugConnector) obj;
+        if (!Objects.equals(this.id, other.id)) {
+            return false;
+        }
         if (!Objects.equals(this.name, other.name)) {
             return false;
         }
@@ -131,9 +166,6 @@ public final class DebugConnector {
         if (!Objects.equals(this.arguments, other.arguments)) {
             return false;
         }
-        if (!Objects.equals(this.defaultValues, other.defaultValues)) {
-            return false;
-        }
         return true;
     }
 
@@ -141,10 +173,12 @@ public final class DebugConnector {
     @Override
     public String toString() {
         ToStringBuilder b = new ToStringBuilder(this);
+        b.add("id", id);
         b.add("name", name);
         b.add("type", type);
         b.add("arguments", arguments.toString());
         b.add("defaultValues", defaultValues.toString());
+        b.add("descriptions", descriptions.toString());
         return b.toString();
     }
 

--- a/java/java.lsp.server/vscode/src/protocol.ts
+++ b/java/java.lsp.server/vscode/src/protocol.ts
@@ -98,8 +98,10 @@ export namespace TestProgressNotification {
 };
 
 export interface DebugConnector {
+    id: string;
     name: string;
     type: string;
     arguments: string[];
     defaultValues: string[];
+    descriptions: string[];
 }


### PR DESCRIPTION
Currently, only the "Attach to Process" has a command associated, which lets the user to pick a process from a list.
Other attach configurations need to be edited with the desired values before they can be used.

To improve the usability, we create commands for individual attach attributes that ask the user for a value. This makes the attach configurations readily usable without any editing of the configurations themselves.

We also split the configurations between "Initial" and "Dynamic", as marking all of them as "Dynamic" caused unexpected behavior. Only the attach configurations are "Dynamic".