### PR TITLE
Fixed NPEs in Truffle debugger when SourceSection is null.

### DIFF
--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/Utils.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/Utils.java
@@ -61,4 +61,13 @@ public final class Utils {
         sb.append ("</html>");
         return sb.toString ();
     }
+
+    public static String stringOrNull(String str) {
+        if ("null".equals(str)) {
+            return null;
+        } else {
+            return str;
+        }
+    }
+    
 }

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleStrataProvider.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/access/TruffleStrataProvider.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.netbeans.modules.debugger.jpda.models.CallStackFrameImpl;
 import org.netbeans.modules.debugger.jpda.spi.StrataProvider;
+import org.netbeans.modules.debugger.jpda.truffle.source.SourcePosition;
 import org.netbeans.spi.debugger.DebuggerServiceRegistration;
 
 /**
@@ -63,7 +64,12 @@ public class TruffleStrataProvider implements StrataProvider {
         if (TRUFFLE_STRATUM.equals(stratum) && isInTruffleAccessPoint(csf)) {
             CurrentPCInfo currentPCInfo = TruffleAccess.getCurrentGuestPCInfo(csf.getThread());
             if (currentPCInfo != null) {
-                return currentPCInfo.getSourcePosition().getStartLine();
+                SourcePosition sourcePosition = currentPCInfo.getSourcePosition();
+                if (sourcePosition != null) {
+                    return sourcePosition.getStartLine();
+                } else {
+                    return 0;
+                }
             }
         }
         return csf.getLineNumber(stratum);

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleActionsProvider.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleActionsProvider.java
@@ -161,6 +161,9 @@ public class DebuggingTruffleActionsProvider implements NodeActionsProviderFilte
     
     private static void goToSource(final TruffleStackFrame f) {
         final SourcePosition sourcePosition = f.getSourcePosition();
+        if (sourcePosition == null) {
+            return ;
+        }
         SwingUtilities.invokeLater (new Runnable () {
             @Override
             public void run () {
@@ -239,7 +242,7 @@ public class DebuggingTruffleActionsProvider implements NodeActionsProviderFilte
                         return false;
                     }
                     //return isGoToSourceSupported ((TruffleStackFrame) node);
-                    return true;
+                    return ((TruffleStackFrame) node).getSourcePosition() != null;
                 }
 
                 @Override

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleTreeModel.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/DebuggingTruffleTreeModel.java
@@ -35,6 +35,7 @@ import static org.netbeans.modules.debugger.jpda.truffle.access.TruffleAccess.BA
 import org.netbeans.modules.debugger.jpda.truffle.actions.StepActionProvider;
 import org.netbeans.modules.debugger.jpda.truffle.frames.TruffleStackFrame;
 import org.netbeans.modules.debugger.jpda.truffle.options.TruffleOptions;
+import org.netbeans.modules.debugger.jpda.truffle.source.SourcePosition;
 import org.netbeans.modules.debugger.jpda.ui.debugging.JPDADVFrame;
 import org.netbeans.modules.debugger.jpda.ui.debugging.JPDADVThread;
 import org.netbeans.modules.debugger.jpda.util.WeakCacheMap;
@@ -312,7 +313,11 @@ public class DebuggingTruffleTreeModel implements TreeModelFilter {
             return false;
         }
         int linej = csf.getLineNumber(null);
-        int linet = tframe.getSourcePosition().getStartLine();
+        SourcePosition sourcePosition = tframe.getSourcePosition();
+        if (sourcePosition == null) {
+            return false;
+        }
+        int linet = sourcePosition.getStartLine();
         return (linej == linet || linej == 0);
     }
     

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/TruffleDVFrame.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/TruffleDVFrame.java
@@ -24,6 +24,7 @@ import org.netbeans.modules.debugger.jpda.truffle.access.CurrentPCInfo;
 import org.netbeans.modules.debugger.jpda.truffle.access.TruffleAccess;
 import org.netbeans.modules.debugger.jpda.truffle.frames.TruffleStackFrame;
 import org.netbeans.modules.debugger.jpda.truffle.source.Source;
+import org.netbeans.modules.debugger.jpda.truffle.source.SourcePosition;
 import org.netbeans.spi.debugger.ui.DebuggingView.DVFrame;
 import org.netbeans.spi.debugger.ui.DebuggingView.DVThread;
 
@@ -65,7 +66,11 @@ public final class TruffleDVFrame implements DVFrame {
 
     @Override
     public URI getSourceURI() {
-        Source source = truffleFrame.getSourcePosition().getSource();
+        SourcePosition sourcePosition = truffleFrame.getSourcePosition();
+        if (sourcePosition == null) {
+            return null;
+        }
+        Source source = sourcePosition.getSource();
         URI uri = source.getURI();
         if (uri != null && "file".equalsIgnoreCase(uri.getScheme())) {
             return uri;
@@ -79,18 +84,33 @@ public final class TruffleDVFrame implements DVFrame {
 
     @Override
     public String getSourceMimeType() {
-        Source source = truffleFrame.getSourcePosition().getSource();
-        return source.getMimeType();
+        SourcePosition sourcePosition = truffleFrame.getSourcePosition();
+        if (sourcePosition != null) {
+            Source source = sourcePosition.getSource();
+            return source.getMimeType();
+        } else {
+            return null;
+        }
     }
 
     @Override
     public int getLine() {
-        return truffleFrame.getSourcePosition().getStartLine();
+        SourcePosition sourcePosition = truffleFrame.getSourcePosition();
+        if (sourcePosition != null) {
+            return sourcePosition.getStartLine();
+        } else {
+            return -1;
+        }
     }
 
     @Override
     public int getColumn() {
-        return truffleFrame.getSourcePosition().getStartColumn();
+        SourcePosition sourcePosition = truffleFrame.getSourcePosition();
+        if (sourcePosition != null) {
+            return sourcePosition.getStartColumn();
+        } else {
+            return -1;
+        }
     }
 
 }

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/Source.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/Source.java
@@ -86,7 +86,7 @@ public final class Source {
         this.mimeType = mimeType;
         this.hash = hash;
     }
-    
+
     public static Source getExistingSource(JPDADebugger debugger, long id) {
         synchronized (KNOWN_SOURCES) {
             Map<Long, Source> dbgSources = KNOWN_SOURCES.get(debugger);
@@ -146,6 +146,9 @@ public final class Source {
                                    URI uri,
                                    String mimeType,
                                    StringReference codeRef) {
+        if (uri == null && codeRef == null) {
+            return null;
+        }
         synchronized (KNOWN_SOURCES) {
             Map<Long, Source> dbgSources = KNOWN_SOURCES.get(debugger);
             if (dbgSources != null) {
@@ -209,6 +212,9 @@ public final class Source {
     }
 
     public String getContent() {
+        if (codeRef == null) {
+            return null;
+        }
         synchronized (this) {
             if (content == null) {
                 try {

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/FrameInfo.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/FrameInfo.java
@@ -65,7 +65,7 @@ final class FrameInfo {
                    DebuggerVisualizer.getSourceLocation(topStackFrame, isHost) + "\n" +
                    position.id + "\n" + position.name + "\n" + position.path + "\n" +
                    position.hostClassName + "\n" + position.hostMethodName + "\n" +
-                   position.uri.toString() + "\n" + position.mimeType + "\n" + position.sourceSection + "\n" +
+                   position.uri + "\n" + position.mimeType + "\n" + position.sourceSection + "\n" +
                    isInternal(topStackFrame);
         topVariables = JPDATruffleAccessor.getVariables(topStackFrame);
     }

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/JPDATruffleAccessor.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/JPDATruffleAccessor.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -309,7 +310,7 @@ public class JPDATruffleAccessor extends Object {
         str.append('\n');
         str.append(position.hostMethodName);
         str.append('\n');
-        str.append(position.uri.toString());
+        str.append(Objects.toString(position.uri));
         str.append('\n');
         str.append(position.mimeType);
         str.append('\n');

--- a/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/SourcePosition.java
+++ b/java/debugger.jpda.truffle/truffle-backend/org/netbeans/modules/debugger/jpda/backend/truffle/SourcePosition.java
@@ -47,20 +47,26 @@ final class SourcePosition {
     final String mimeType;
 
     public SourcePosition(SourceSection sourceSection, LanguageInfo languageInfo) {
-        Source source = sourceSection.getSource();
-        this.id = getId(source);
-        this.name = source.getName();
-        this.hostClassName = null;
-        this.hostMethodName = null;
-        String sourcePath = source.getPath();
-        if (sourcePath == null) {
-            sourcePath = name;
+        if (sourceSection != null) {
+            Source source = sourceSection.getSource();
+            this.id = getId(source);
+            this.name = source.getName();
+            this.hostClassName = null;
+            this.hostMethodName = null;
+            String sourcePath = source.getPath();
+            if (sourcePath == null) {
+                sourcePath = name;
+            }
+            this.path = sourcePath;
+            this.sourceSection = sourceSection.getStartLine() + "," + sourceSection.getStartColumn() + "," + sourceSection.getEndLine() + "," + sourceSection.getEndColumn();
+            this.code = source.getCharacters().toString();
+            this.uri = source.getURI();
+            this.mimeType = findMIMEType(source, languageInfo);
+        } else {
+            this.id = -1;
+            this.name = this.hostClassName = this.hostMethodName = this.path = this.sourceSection = this.code = this.mimeType = null;
+            this.uri = null;
         }
-        this.path = sourcePath;
-        this.sourceSection = sourceSection.getStartLine() + "," + sourceSection.getStartColumn() + "," + sourceSection.getEndLine() + "," + sourceSection.getEndColumn();
-        this.code = source.getCharacters().toString();
-        this.uri = source.getURI();
-        this.mimeType = findMIMEType(source, languageInfo);
     }
 
     public SourcePosition(StackTraceElement ste) {


### PR DESCRIPTION
Even though it's adviced that instrumentable Truffle Nodes provide `SourceSection`, it may happen that some Truffle language implementation does not provide it.

In the Truffle debugger implementation we need to count with `null` `SourceSection`.