### PR TITLE
Debugger attach needs to be initialized.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/NbAttachRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/NbAttachRequestHandler.java
@@ -201,6 +201,8 @@ public final class NbAttachRequestHandler {
                     if (!finished.getAndSet(true)) {
                         notifyTerminated(context);
                     }
+                } else {
+                    context.getClient().initialized();
                 }
                 return ;
             }


### PR DESCRIPTION
In VSCode, when either Attach to Process or Attach to Port is used, VSCode attaches to process in both cases, shows running threads, but it does not stop on breakpoint.

When Pause is clicked in the debugger toolbar, then it stops, but `MalformedURLException: unknown protocol: debug` exception is printed to NBLS output.

The problem was in missing `initialized` notification from the server to the client.