### PR TITLE
NETBEANS-5775: NoSuchMethodError: 'void com.sun.tools.javac.util.Log.…

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/parsing/JavacParser.java
@@ -988,7 +988,7 @@ public class JavacParser extends Parser {
 
         Context context = new Context();
         //need to preregister the Messages here, because the getTask below requires Log instance:
-        NBLog.preRegister(context, DEV_NULL, DEV_NULL, DEV_NULL);
+        NBLog.preRegister(context, DEV_NULL);
         JavacTaskImpl task = (JavacTaskImpl)JavacTool.create().getTask(null,
                 ClasspathInfoAccessor.getINSTANCE().createFileManager(cpInfo, validatedSourceLevel.name),
                 diagnosticListener, options, files.iterator().hasNext() ? null : Arrays.asList("java.lang.Object"), files,

--- a/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBLog.java
+++ b/java/lib.nbjavac/src/org/netbeans/lib/nbjavac/services/NBLog.java
@@ -49,10 +49,8 @@ public final class NBLog extends Log {
 
     private NBLog(
             final Context context,
-            final PrintWriter errWriter,
-            final PrintWriter warnWriter,
-            final PrintWriter noticeWriter) {
-        super(context, errWriter, warnWriter, noticeWriter);
+            final PrintWriter outWriter) {
+        super(context, outWriter);
     }
 
     public static NBLog instance(Context context) {
@@ -64,17 +62,13 @@ public final class NBLog extends Log {
     }
     
     public static void preRegister(Context context,
-                                   final PrintWriter errWriter,
-                                   final PrintWriter warnWriter,
-                                   final PrintWriter noticeWriter) {
+                                   final PrintWriter outWriter) {
         context.put(logKey, new Context.Factory<Log>() {
             @Override
             public Log make(Context c) {
                 return new NBLog(
                     c,
-                    errWriter,
-                    warnWriter,
-                    noticeWriter);
+                    outWriter);
             }
         });
     }

--- a/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBAttrTest.java
+++ b/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBAttrTest.java
@@ -130,7 +130,7 @@ public class NBAttrTest extends NbTestCase {
         std.setLocation(StandardLocation.CLASS_OUTPUT, Collections.singleton(workingDir));
 
         Context context = new Context();
-        NBLog.preRegister(context, DEV_NULL, DEV_NULL, DEV_NULL);
+        NBLog.preRegister(context, DEV_NULL);
         NBAttr.preRegister(context);
         final JavacTaskImpl ct = (JavacTaskImpl) ((JavacTool)tool).getTask(null, std, null, Arrays.asList("-source", "1.8", "-target", "1.8"), null, Arrays.asList(new MyFileObject(code)), context);
 

--- a/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBClassWriterTest.java
+++ b/java/lib.nbjavac/test/unit/src/org/netbeans/lib/nbjavac/services/NBClassWriterTest.java
@@ -89,7 +89,7 @@ public class NBClassWriterTest extends NbTestCase {
         std.setLocation(StandardLocation.CLASS_OUTPUT, Collections.singleton(workingDir));
 
         Context context = new Context();
-        NBLog.preRegister(context, DEV_NULL, DEV_NULL, DEV_NULL);
+        NBLog.preRegister(context, DEV_NULL);
         final JavacTaskImpl ct = (JavacTaskImpl) ((JavacTool)tool).getTask(null, std, null, Arrays.asList("-bootclasspath",  bootPath, "-source", "1.7", "-target", "1.7"), null, Arrays.asList(new MyFileObject(code)), context);
 
         NBClassReader.preRegister(ct.getContext());
@@ -109,7 +109,7 @@ public class NBClassWriterTest extends NbTestCase {
         std.setLocation(StandardLocation.CLASS_PATH, Collections.singleton(workingDir));
 
         Context context = new Context();
-        NBLog.preRegister(context, DEV_NULL, DEV_NULL, DEV_NULL);
+        NBLog.preRegister(context, DEV_NULL);
         JavacTaskImpl ct = (JavacTaskImpl)((JavacTool)tool).getTask(null, std, null, Arrays.asList("-bootclasspath",  bootPath, "-source", "1.8", "-target", "1.8"), null, Arrays.<JavaFileObject>asList(), context);
 
         NBClassReader.preRegister(ct.getContext());


### PR DESCRIPTION
…<init>in .dump files when running NetBeans with JDK17+26

Since the code uses the same DEV_NULL for all the PrintWriters, replace the removed Log constructor taking 3 PrintWriters with the one that takes just one PrintWriter and use it for all outputs, that constructor exists from JDK 8 til JDK17+26/JDK18+1.