### PR TITLE
Propagate createFromTemplate parameters to folder subobjects

### DIFF
--- a/platform/openide.loaders/apichanges.xml
+++ b/platform/openide.loaders/apichanges.xml
@@ -85,6 +85,23 @@ is the proper place.
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
   <changes>
+      <change id="folder.templating">
+          <api name="loaders"/>
+          <summary>DataFolder createFromTemplate improvements</summary>
+          <version major="7" minor="82"/>
+          <date day="15" month="6" year="2021"/>
+          <author login="jtulach"/>
+          <compatibility addition="yes" binary="compatible" source="compatible"
+                         semantic="incompatible" deletion="no"
+                         modification="yes"/>
+          <description>
+              <code>DataFolder.createFromTemplate</code> honors passed in
+              parameters for all its children, unless special
+              <code>CreateFromTemplateHandler</code> takes over the
+              instantiation process.
+          </description>
+          <class package="org.openide.loaders" name="DataFolder"/>
+      </change>
       <change id="ask.on.save.close.defaults">
           <api name="editor"/>
           <summary>Rebrand defaults for Save/Close Editor Dialogs</summary>

--- a/platform/openide.loaders/manifest.mf
+++ b/platform/openide.loaders/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.loaders
-OpenIDE-Module-Specification-Version: 7.81
+OpenIDE-Module-Specification-Version: 7.82
 OpenIDE-Module-Localizing-Bundle: org/openide/loaders/Bundle.properties
 OpenIDE-Module-Provides: org.netbeans.modules.templates.v1_0
 OpenIDE-Module-Layer: org/netbeans/modules/openide/loaders/layer.xml

--- a/platform/openide.loaders/src/org/openide/loaders/DataFolder.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataFolder.java
@@ -835,10 +835,11 @@ public class DataFolder extends MultiDataObject implements DataObject.Container 
         DataFolder newFolder = (DataFolder)super.handleCreateFromTemplate (f, name);
         Enumeration<DataObject> en = children ();
 
+        Map<String, Object> params = CreateAction.getCallParameters(null);
         while (en.hasMoreElements ()) {
             try {
                 DataObject obj = en.nextElement ();
-                obj.createFromTemplate (newFolder);
+                obj.createFromTemplate (newFolder, null, params);
             } catch (IOException ex) {
                 Exceptions.printStackTrace(ex);
             }

--- a/platform/openide.loaders/src/org/openide/loaders/DataFolder.java
+++ b/platform/openide.loaders/src/org/openide/loaders/DataFolder.java
@@ -832,19 +832,21 @@ public class DataFolder extends MultiDataObject implements DataObject.Container 
     protected DataObject handleCreateFromTemplate (
         DataFolder f, String name
     ) throws IOException {
-        DataFolder newFolder = (DataFolder)super.handleCreateFromTemplate (f, name);
-        Enumeration<DataObject> en = children ();
+        int[] fileBuilderUsed = { 0 };
+        DataFolder newFolder = (DataFolder)super.handleCreateFromTemplate (f, name, fileBuilderUsed);
+        if (fileBuilderUsed[0] == 0) {
+            Enumeration<DataObject> en = children ();
 
-        Map<String, Object> params = CreateAction.getCallParameters(null);
-        while (en.hasMoreElements ()) {
-            try {
-                DataObject obj = en.nextElement ();
-                obj.createFromTemplate (newFolder, null, params);
-            } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+            Map<String, Object> params = CreateAction.getCallParameters(null);
+            while (en.hasMoreElements ()) {
+                try {
+                    DataObject obj = en.nextElement ();
+                    obj.createFromTemplate (newFolder, null, params);
+                } catch (IOException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
             }
         }
-
         return newFolder;
     }
 

--- a/platform/openide.loaders/src/org/openide/loaders/MultiDataObject.java
+++ b/platform/openide.loaders/src/org/openide/loaders/MultiDataObject.java
@@ -838,6 +838,13 @@ public class MultiDataObject extends DataObject {
     protected DataObject handleCreateFromTemplate (
         DataFolder df, String name
     ) throws IOException {
+        return this.handleCreateFromTemplate(df, name, new int[1]);
+    }
+
+    final DataObject handleCreateFromTemplate (
+        DataFolder df, String name, int[] fileBuilderUsed
+    ) throws IOException {
+        assert fileBuilderUsed != null;
         if (name == null) {
             name = FileUtil.findFreeFileName(
                        df.getPrimaryFile (), getPrimaryFile ().getName (), getPrimaryFile ().getExt ()
@@ -854,6 +861,8 @@ public class MultiDataObject extends DataObject {
         if (pf == null) {
             // do the regular creation
             pf = getPrimaryEntry().createFromTemplate (df.getPrimaryFile (), name);
+        } else {
+            fileBuilderUsed[0]++;
         }
         
         
@@ -864,6 +873,8 @@ public class MultiDataObject extends DataObject {
             FileObject fo = FileBuilder.createFromTemplate(current, df.getPrimaryFile(), name, params, FileBuilder.Mode.FAIL);
             if (fo == null) {
                 entry.createFromTemplate (df.getPrimaryFile (), name);
+            } else {
+                fileBuilderUsed[0]++;
             }
         }
         

--- a/platform/templates/nbproject/project.xml
+++ b/platform/templates/nbproject/project.xml
@@ -70,7 +70,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.61</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -79,14 +79,6 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>6.2</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.openide.util.ui</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>9.3</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -103,6 +95,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>8.0</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.3</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/templates/test/unit/src/org/netbeans/modules/templates/PropertiesProviderTest.java
+++ b/platform/templates/test/unit/src/org/netbeans/modules/templates/PropertiesProviderTest.java
@@ -62,11 +62,11 @@ public class PropertiesProviderTest extends NbTestCase {
     static {
         System.setProperty("netbeans.full.hack", "true");
     }
-    
+
     public PropertiesProviderTest(String testName) {
         super(testName);
     }
-    
+
     @Override
     protected boolean runInEQ() {
         return true;
@@ -76,13 +76,13 @@ public class PropertiesProviderTest extends NbTestCase {
     protected Level logLevel() {
         return Level.FINE;
     }
-    
+
     @Override
     protected void setUp() throws Exception {
         clearWorkDir();
-        
+
         Lookup.getDefault().lookup(ModuleInfo.class);
-        
+
         MockServices.setServices(DD.class, Pool.class, FEQI.class);
     }
 
@@ -99,13 +99,13 @@ public class PropertiesProviderTest extends NbTestCase {
             fail("There should be some content: " + props.getSize());
         }
     }
-    
+
     public void testBasePropertiesAlwaysPresent() throws Exception {
         FileObject root = FileUtil.createMemoryFileSystem().getRoot();
         FileObject fo = FileUtil.createData(root, "simpleObject.txt");
         {
             OutputStream os = fo.getOutputStream();
-            String txt = 
+            String txt =
                 "print('<html><h1>');print(name);print('</h1>');" +
                 "print('<h2>');print(date);print('</h2>');" +
                 "print('<h3>');print(time);print('</h3>');" +
@@ -115,36 +115,36 @@ public class PropertiesProviderTest extends NbTestCase {
             os.close();
         }
         fo.setAttribute("javax.script.ScriptEngine", "js");
-        
-        
+
+
         FileObject props = FileUtil.createData(FileUtil.getConfigRoot(),
             "Templates/Properties/my.properties"
         );
-        
+
         {
             for (FileObject f : props.getChildren()) {
                 f.delete();
             }
-            
+
             OutputStream os = props.getOutputStream();
             String txt = "user=Yarda";
             os.write(txt.getBytes());
             os.close();
         }
-        
-        
+
+
         DataObject obj = DataObject.find(fo);
-        
+
         DataFolder folder = DataFolder.findFolder(FileUtil.createFolder(root, "target"));
-        
+
         Map<String,String> parameters = Collections.singletonMap("title", "Nazdar");
         DataObject n = obj.createFromTemplate(folder, "complex", parameters);
-        
+
         assertEquals("Created in right place", folder, n.getFolder());
         assertEquals("Created with right name", "complex.txt", n.getName());
-        
-        String res = readFile(n.getPrimaryFile());
-        
+
+        String res = n.getPrimaryFile().asText();
+
         if (res.indexOf("date") >= 0) {
             fail(res);
         }
@@ -157,17 +157,80 @@ public class PropertiesProviderTest extends NbTestCase {
         if (res.indexOf("name") >= 0) {
             fail(res);
         }
-        
+
         if (res.indexOf("Yarda") == -1) {
             fail("There should be Yarda:\n" + res);
         }
     }
-    
-    private static String readFile(FileObject fo) throws IOException {
-        byte[] arr = new byte[(int)fo.getSize()];
-        int len = fo.getInputStream().read(arr);
-        assertEquals("Fully read", arr.length, len);
-        return new String(arr);
+
+    public void testFolderTemplateWithProperties() throws Exception {
+        FileObject root = FileUtil.createMemoryFileSystem().getRoot();
+        FileObject tmplt = root.createFolder("tmplt");
+        FileObject fo = FileUtil.createData(tmplt, "simpleObject.txt");
+        {
+            OutputStream os = fo.getOutputStream();
+            String txt =
+                "print('<html><h1>');print(firstName);print('</h1>');" +
+                "print('<h2>');print(lastName);print('</h2>');" +
+                "print('<h3>');print(title);print('</h3>');" +
+                "print('</html>');";
+            os.write(txt.getBytes());
+            os.close();
+        }
+        fo.setAttribute("javax.script.ScriptEngine", "js");
+
+
+        FileObject props = FileUtil.createData(FileUtil.getConfigRoot(),
+            "Templates/Properties/my.properties"
+        );
+
+        {
+            for (FileObject f : props.getChildren()) {
+                f.delete();
+            }
+            props.delete();
+        }
+
+        DataObject obj = DataObject.find(tmplt);
+
+        DataFolder folder = DataFolder.findFolder(FileUtil.createFolder(root, "target"));
+
+        Map<String,String> parameters = new HashMap<>();
+        parameters.put("firstName", "Yarda");
+        parameters.put("lastName", "Tulach");
+        parameters.put("title", "Anarchitect");
+        DataObject n = obj.createFromTemplate(folder, "complex", parameters);
+
+        assertEquals("Created in right place", folder, n.getFolder());
+        assertTrue("Folder created", n instanceof DataFolder);
+        assertEquals("Created with right name", "complex", n.getName());
+
+        DataFolder nf = (DataFolder) n;
+        DataObject[] arr = nf.getChildren();
+        assertEquals("One object created", 1, arr.length);
+        assertEquals("simpleObject.txt", arr[0].getName());
+
+        String res = arr[0].getPrimaryFile().asText();
+
+        if (res.indexOf("firstName") >= 0) {
+            fail(res);
+        }
+        if (res.indexOf("lastName") >= 0) {
+            fail(res);
+        }
+        if (res.indexOf("title") >= 0) {
+            fail(res);
+        }
+
+        if (res.indexOf("Yarda") == -1) {
+            fail("There should be Yarda:\n" + res);
+        }
+        if (res.indexOf("Tulach") == -1) {
+            fail("There should be Tulach:\n" + res);
+        }
+        if (res.indexOf("Anarchitect") == -1) {
+            fail("There should be Anarchitect:\n" + res);
+        }
     }
 
     private static String readChars(FileObject fo, Charset set) throws IOException {
@@ -177,7 +240,7 @@ public class PropertiesProviderTest extends NbTestCase {
             // again
         }
         r.close();
-        
+
         arr.flip();
         return arr.toString();
     }
@@ -213,7 +276,7 @@ public class PropertiesProviderTest extends NbTestCase {
     public static final class FEQI extends FileEncodingQueryImplementation {
         public static FileSystem fs;
         public static Charset result;
-    
+
         public Charset getEncoding(FileObject f) {
             try {
                 if (f.getFileSystem() == fs) {
@@ -225,16 +288,16 @@ public class PropertiesProviderTest extends NbTestCase {
             }
         }
     }
-    
+
     public static final class Pool extends DataLoaderPool {
         protected Enumeration<DataLoader> loaders() {
-            return Enumerations.<DataLoader>array(new DataLoader[] { 
+            return Enumerations.<DataLoader>array(new DataLoader[] {
                 TwoPartLoader.getLoader(TwoPartLoader.class),
                 SimpleLoader.getLoader(SimpleLoader.class),
             });
         }
     }
-    
+
     public static final class SimpleLoader extends MultiFileLoader {
         public SimpleLoader() {
             super(SimpleObject.class.getName());
@@ -258,7 +321,7 @@ public class PropertiesProviderTest extends NbTestCase {
             return new FileEntry(obj, secondaryFile);
         }
     }
-    
+
     private static final class FE extends FileEntry {
         public FE(MultiDataObject mo, FileObject fo) {
             super(mo, fo);
@@ -270,15 +333,15 @@ public class PropertiesProviderTest extends NbTestCase {
             return null;
         }
 
-        
-        
+
+
     }
-    
+
     public static final class SimpleObject extends MultiDataObject {
         public SimpleObject(SimpleLoader l, FileObject fo) throws DataObjectExistsException {
             super(fo, l);
         }
-        
+
         @Override
         public String getName() {
             return getPrimaryFile().getNameExt();
@@ -288,7 +351,7 @@ public class PropertiesProviderTest extends NbTestCase {
     static final Logger LOG = Logger.getLogger("tst.TwoPartLoader");
     public static final class TwoPartLoader extends MultiFileLoader {
         static Map<FileObject,Integer> queried = new HashMap<FileObject,Integer>();
-        
+
         public TwoPartLoader() {
             super(TwoPartObject.class.getName ());
         }
@@ -299,13 +362,13 @@ public class PropertiesProviderTest extends NbTestCase {
             Integer i = queried.get(fo);
             queried.put(fo, i == null ? 1 : i + 1);
             FileObject ret;
-            
+
             if (fo.hasExt("java") || fo.hasExt("form")) {
                 ret = org.openide.filesystems.FileUtil.findBrother(fo, "java");
             } else {
                 ret = null;
             }
-            
+
             LOG.fine("findPrimaryFile for " + fo + " yeilded " + ret);
             return ret;
         }
@@ -333,8 +396,8 @@ public class PropertiesProviderTest extends NbTestCase {
             public Charset getEncoding(FileObject file) {
                 return encoding;
             }
-            
+
         };
     }
-    
+
 }


### PR DESCRIPTION
To use `DataFolder.createFromTemplate` on project templates, like [the one in gradle](https://github.com/apache/netbeans/blob/master/java/gradle.htmlui/src/org/netbeans/modules/gradle/htmlui/resources/layer.xml#L30), we need to propagate `packageBase`, `groupId`, etc. properties.