### PR TITLE
Groovy Code Completion support available through LSP protocol.

### DIFF
--- a/groovy/groovy.editor/manifest.mf
+++ b/groovy/groovy.editor/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.groovy.editor/3
 OpenIDE-Module-Layer: org/netbeans/modules/groovy/editor/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/groovy/editor/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.76
+OpenIDE-Module-Specification-Version: 1.77

--- a/groovy/groovy.editor/nbproject/project.xml
+++ b/groovy/groovy.editor/nbproject/project.xml
@@ -53,6 +53,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.api.lsp</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.2</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionHandler.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionHandler.java
@@ -19,31 +19,14 @@
 package org.netbeans.modules.groovy.editor.api.completion;
 
 import groovy.lang.MetaMethod;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
-import java.io.File;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.*;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.lang.model.element.Element;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import org.codehaus.groovy.ast.ASTNode;
-import org.codehaus.groovy.ast.ModuleNode;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
-import org.codehaus.groovy.reflection.CachedClass;
-import org.netbeans.api.java.platform.JavaPlatform;
-import org.netbeans.api.java.platform.JavaPlatformManager;
-import org.netbeans.api.java.source.CompilationInfo;
-import org.netbeans.api.java.source.ui.ElementJavadoc;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.api.lexer.TokenSequence;
 import org.netbeans.editor.BaseDocument;
@@ -54,197 +37,44 @@ import org.netbeans.modules.csl.spi.DefaultCompletionResult;
 import org.netbeans.modules.csl.spi.ParserResult;
 import org.netbeans.modules.groovy.editor.api.AstPath;
 import org.netbeans.modules.groovy.editor.api.ASTUtils;
-import org.netbeans.modules.groovy.editor.completion.ProposalsCollector;
-import org.netbeans.modules.groovy.editor.api.completion.util.ContextHelper;
-import org.netbeans.modules.groovy.editor.api.elements.ast.ASTMethod;
 import org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId;
 import org.netbeans.modules.groovy.editor.api.lexer.LexUtilities;
 import org.netbeans.modules.groovy.editor.utils.GroovyUtils;
 import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
-import org.netbeans.modules.groovy.editor.java.JavaElementHandle;
-import org.netbeans.modules.groovy.support.api.GroovySettings;
-import org.openide.util.Exceptions;
-import org.openide.util.NbBundle;
-import org.openide.util.Utilities;
-import org.openide.util.WeakListeners;
+import org.netbeans.modules.groovy.editor.completion.provider.GroovyCompletionImpl;
+import org.openide.util.Lookup;
 
 public class CompletionHandler implements CodeCompletionHandler2 {
-
     private static final Logger LOG = Logger.getLogger(CompletionHandler.class.getName());
-    private final PropertyChangeListener docListener;
-    private String jdkJavaDocBase = null;
-    private String groovyJavaDocBase = null;
-    private String groovyApiDocBase = null;
+    /**
+     * The real implementation, in an implementation package.
+     */
+    private GroovyCompletionImpl impl;
     
-
     public CompletionHandler() {
-        JavaPlatformManager platformMan = JavaPlatformManager.getDefault();
-        JavaPlatform platform = platformMan.getDefaultPlatform();
-        List<URL> docfolder = platform.getJavadocFolders();
-
-        for (URL url : docfolder) {
-            LOG.log(Level.FINEST, "JDK Doc path: {0}", url.toString()); // NOI18N
-            jdkJavaDocBase = url.toString();
-        }
-
-        GroovySettings groovySettings = GroovySettings.getInstance();
-        docListener = new PropertyChangeListener() {
-
-            @Override
-            public void propertyChange(PropertyChangeEvent evt) {
-                synchronized (CompletionHandler.this) {
-                    groovyJavaDocBase = null;
-                    groovyApiDocBase = null;
-                }
+    }
+    
+    private GroovyCompletionImpl impl() {
+        if (impl == null) {
+            impl = Lookup.getDefault().lookup(GroovyCompletionImpl.class);
+            if (impl == null) {
+                LOG.severe("Unable to find completion impl");
+                impl = new GroovyCompletionImpl();
             }
-        };
-        groovySettings.addPropertyChangeListener(WeakListeners.propertyChange(docListener, this));
+        }
+        return impl;
     }
 
     @Override
     public CodeCompletionResult complete(CodeCompletionContext completionContext) {
-        ParserResult parserResult = completionContext.getParserResult();
-        String prefix = completionContext.getPrefix();
-        
-        // Documentation says that @NonNull is return from getPrefix() but it's not true
-        // Invoking "this.^" makes the return value null
-        if (prefix == null) {
-            prefix = "";
-        }
-        
-        int lexOffset = completionContext.getCaretOffset();
-        int astOffset = ASTUtils.getAstOffset(parserResult, lexOffset);
-        int anchor = lexOffset - prefix.length();
-
-        LOG.log(Level.FINEST, "complete(...), prefix      : {0}", prefix); // NOI18N
-        LOG.log(Level.FINEST, "complete(...), lexOffset   : {0}", lexOffset); // NOI18N
-        LOG.log(Level.FINEST, "complete(...), astOffset   : {0}", astOffset); // NOI18N
-
-        final Document document = parserResult.getSnapshot().getSource().getDocument(false);
-        if (document == null) {
+        GroovyCompletionImpl.CompletionImplResult rs = impl().makeProposals(completionContext);
+        if (rs == null) {
             return CodeCompletionResult.NONE;
+        } 
+        if (rs.isEmpty()) {
+            return new DefaultCompletionResult(Collections.<CompletionProposal>emptyList(), false);
         }
-        final BaseDocument doc = (BaseDocument) document;
-
-        doc.readLock(); // Read-lock due to Token hierarchy use
-
-        try {
-            CompletionContext context = new CompletionContext(parserResult, prefix, anchor, lexOffset, astOffset, doc);
-            context.init();
-
-            // if we are above a package statement or inside a comment there's no completion at all.
-            if (context.location == CaretLocation.ABOVE_PACKAGE || context.location == CaretLocation.INSIDE_COMMENT) {
-                return new DefaultCompletionResult(Collections.<CompletionProposal>emptyList(), false);
-            }
-            
-            ProposalsCollector proposalsCollector = new ProposalsCollector(context);
-
-            if (ContextHelper.isVariableNameDefinition(context) || ContextHelper.isFieldNameDefinition(context)) {
-                proposalsCollector.completeNewVars(context);
-            } else {
-                if (!(context.location == CaretLocation.OUTSIDE_CLASSES || context.location == CaretLocation.INSIDE_STRING)) {
-                    proposalsCollector.completePackages(context);
-                    proposalsCollector.completeTypes(context);
-                }
-
-                if (!context.isBehindImportStatement()) {
-                    if (context.location != CaretLocation.INSIDE_STRING) {
-                        proposalsCollector.completeKeywords(context);
-                        proposalsCollector.completeMethods(context);
-                    }
-
-                    proposalsCollector.completeFields(context);
-                    proposalsCollector.completeLocalVars(context);
-                }
-
-                if (context.location == CaretLocation.INSIDE_CONSTRUCTOR_CALL) {
-                    if (ContextHelper.isAfterComma(context) || ContextHelper.isAfterLeftParenthesis(context)) {
-                        proposalsCollector.completeNamedParams(context);
-                    }
-                }
-            }
-            proposalsCollector.completeCamelCase(context);
-
-            return new GroovyCompletionResult(proposalsCollector.getCollectedProposals(), context);
-        } finally {
-            doc.readUnlock();
-        }
-    }
-
-    private String getGroovyJavadocBase() {
-        synchronized (this) {
-            if (groovyJavaDocBase == null) {
-                String docroot = GroovySettings.getInstance().getGroovyDoc() + "/"; // NOI18N
-                groovyJavaDocBase = directoryNameToUrl(docroot + "groovy-jdk/"); // NOI18N
-            }
-            return groovyJavaDocBase;
-        }
-    }
-
-    private String getGroovyApiDocBase() {
-        synchronized (this) {
-            if (groovyApiDocBase == null) {
-                String docroot = GroovySettings.getInstance().getGroovyDoc() + "/"; // NOI18N
-                groovyApiDocBase = directoryNameToUrl(docroot + "gapi/"); // NOI18N
-            }
-            return groovyApiDocBase;
-        }
-    }
-
-    private static String directoryNameToUrl(String dirname) {
-        if (dirname == null) {
-            return "";
-        }
-
-        // FIXME use FileObject (?)
-        File dirFile = new File(dirname);
-
-        if (dirFile != null && dirFile.exists() && dirFile.isDirectory()) {
-            String fileURL = "";
-            if (Utilities.isWindows()) {
-                dirname = dirname.replace("\\", "/");
-                fileURL = "file:/"; // NOI18N
-            } else {
-                fileURL = "file://"; // NOI18N
-            }
-            return fileURL + dirname;
-        } else {
-            return "";
-        }
-    }
-
-    private static void printASTNodeInformation(String description, ASTNode node) {
-
-        LOG.log(Level.FINEST, "--------------------------------------------------------");
-        LOG.log(Level.FINEST, "{0}", description);
-
-        if (node == null) {
-            LOG.log(Level.FINEST, "node == null");
-        } else {
-            LOG.log(Level.FINEST, "Node.getText()  : {0}", node.getText());
-            LOG.log(Level.FINEST, "Node.toString() : {0}", node.toString());
-            LOG.log(Level.FINEST, "Node.getClass() : {0}", node.getClass());
-            LOG.log(Level.FINEST, "Node.hashCode() : {0}", node.hashCode());
-
-
-            if (node instanceof ModuleNode) {
-                LOG.log(Level.FINEST, "ModuleNode.getClasses() : {0}", ((ModuleNode) node).getClasses());
-                LOG.log(Level.FINEST, "SourceUnit.getName() : {0}", ((ModuleNode) node).getContext().getName());
-            }
-        }
-
-        LOG.log(Level.FINEST, "--------------------------------------------------------");
-    }
-
-    private static void printMethod(MetaMethod mm) {
-
-        LOG.log(Level.FINEST, "--------------------------------------------------");
-        LOG.log(Level.FINEST, "getName()           : {0}", mm.getName());
-        LOG.log(Level.FINEST, "toString()          : {0}", mm.toString());
-        LOG.log(Level.FINEST, "getDescriptor()     : {0}", mm.getDescriptor());
-        LOG.log(Level.FINEST, "getSignature()      : {0}", mm.getSignature());
-        // LOG.log(Level.FINEST, "getParamTypes()     : " + mm.getParameterTypes());
-        LOG.log(Level.FINEST, "getDeclaringClass() : {0}", mm.getDeclaringClass());
+        return new GroovyCompletionResult(rs.getProposals(), rs.getGroovyContext());
     }
 
     boolean checkForPackageStatement(final CompletionContext request) {
@@ -439,116 +269,7 @@ public class CompletionHandler implements CodeCompletionHandler2 {
 
     @Override
     public String document(ParserResult info, ElementHandle element) {
-        LOG.log(Level.FINEST, "document(), ElementHandle : {0}", element);
-
-        String error = NbBundle.getMessage(CompletionHandler.class, "GroovyCompletion_NoJavaDocFound");
-        String doctext = null;
-        
-        if (element instanceof ASTMethod) {
-            ASTMethod ame = (ASTMethod) element;
-
-            String base = "";
-
-            String javadoc = getGroovyJavadocBase();
-            if (jdkJavaDocBase != null && ame.isGDK() == false) {
-                base = jdkJavaDocBase;
-            } else if (javadoc != null && ame.isGDK() == true) {
-                base = javadoc;
-            } else {
-                LOG.log(Level.FINEST, "Neither JDK nor GDK or error locating: {0}", ame.isGDK());
-                return error;
-            }
-
-            MetaMethod mm = ame.getMethod();
-
-            // enable this to troubleshoot subtle differences in JDK/GDK signatures
-            printMethod(mm);
-
-            // figure out who originally defined this method
-
-            String className;
-
-            if (ame.isGDK()) {
-                className = mm.getDeclaringClass()/*.getCachedClass()*/.getName();
-            } else {
-
-                String declName = null;
-
-                if (mm != null) {
-                    CachedClass cc = mm.getDeclaringClass();
-                    if (cc != null) {
-                        declName = cc.getName();
-                    }
-                    /*CachedClass cc = mm.getDeclaringClass();
-                    if (cc != null) {
-                        Class clz = cc.getCachedClass();
-                        if (clz != null) {
-                            declName = clz.getName();
-                        }
-                    }*/
-                }
-
-                if (declName != null) {
-                    className = declName;
-                } else {
-                    className = ame.getClz().getName();
-                }
-            }
-
-            // create path from fq java package name:
-            // java.lang.String -> java/lang/String.html
-            String classNamePath = className.replace(".", "/");
-            classNamePath = classNamePath + ".html"; // NOI18N
-
-            // if the file can be located in the GAPI folder prefer it
-            // over the JDK
-            if (!ame.isGDK()) {
-
-                URL url;
-                File testFile;
-
-                String apiDoc = getGroovyApiDocBase();
-                try {
-                    url = new URL(apiDoc + classNamePath);
-                    testFile = new File(url.toURI());
-                } catch (MalformedURLException ex) {
-                    LOG.log(Level.FINEST, "MalformedURLException: {0}", ex);
-                    return error;
-                } catch (URISyntaxException uriEx) {
-                    LOG.log(Level.FINEST, "URISyntaxException: {0}", uriEx);
-                    return error;
-                }
-
-                if (testFile != null && testFile.exists()) {
-                    base = apiDoc;
-                }
-            }
-
-            // create the signature-string of the method
-            String sig = getMethodSignature(ame.getMethod(), true, ame.isGDK());
-            String printSig = getMethodSignature(ame.getMethod(), false, ame.isGDK());
-
-            String urlName = base + classNamePath + "#" + sig;
-
-            try {
-                LOG.log(Level.FINEST, "Trying to load URL = {0}", urlName); // NOI18N
-                doctext = HTMLJavadocParser.getJavadocText(
-                    new URL(urlName),
-                    false,
-                    ame.isGDK());
-            } catch (MalformedURLException ex) {
-                LOG.log(Level.FINEST, "document(), URL trouble: {0}", ex); // NOI18N
-                return error;
-            }
-
-            // If we could not find a suitable JavaDoc for the method - say so.
-            if (doctext == null) {
-                return error;
-            }
-
-            doctext = "<h3>" + className + "." + printSig + "</h3><BR>" + doctext;
-        }
-        return doctext;
+        return impl().document(info, element);
     }
 
     @Override
@@ -643,40 +364,6 @@ public class CompletionHandler implements CodeCompletionHandler2 {
 
     @Override
     public Documentation documentElement(ParserResult info, ElementHandle handle, Callable<Boolean> cancel) {
-        if (handle instanceof JavaElementHandle) {
-            // let Java support do the hard work.
-            ElementJavadoc jdoc;
-            try {
-                jdoc = ((JavaElementHandle)handle).extract(info, new JavaElementHandle.ElementFunction<ElementJavadoc>() {
-                    @Override
-                    public ElementJavadoc apply(CompilationInfo info, Element el) {
-                        return ElementJavadoc.create(info, el);
-                    }
-                });
-            } catch (IOException ex) {
-                // TBR
-                return null;
-            }
-            
-            if (jdoc != null) {
-                Boolean b;
-                Future<String> content = jdoc.getTextAsync();
-                try {
-                    while (((b = cancel.call()) == null) || !b.booleanValue()) {
-                        try {
-                            return Documentation.create(content.get(250, TimeUnit.MILLISECONDS),
-                                    jdoc.getURL());
-                        } catch (TimeoutException te) {}
-                    }
-                } catch (Exception ex) {
-                    Exceptions.printStackTrace(ex);
-                    return null;
-                }
-                return null;
-            }
-        }
-        
-         String s = document(info, handle);
-         return s == null ? null : Documentation.create(s);
+        return impl().documentElement(info, handle, cancel);
     }
 }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionItem.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionItem.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.groovy.editor.api.completion;
 
 import groovy.lang.MetaMethod;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -30,6 +31,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.swing.ImageIcon;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.Variable;
+import org.codehaus.groovy.reflection.CachedClass;
 import org.netbeans.api.java.source.ui.ElementIcons;
 import org.netbeans.modules.csl.api.ElementHandle;
 import org.netbeans.modules.csl.api.ElementKind;
@@ -48,6 +50,7 @@ import org.netbeans.modules.groovy.editor.java.Utilities;
 import org.netbeans.modules.groovy.editor.utils.GroovyUtils;
 import org.netbeans.modules.groovy.support.api.GroovySources;
 import org.openide.util.ImageUtilities;
+import org.openide.util.Pair;
 
 
 /**
@@ -101,6 +104,34 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
                 }
                 return ti;
             }
+            
+            public Pair<String, List<MethodParameter>> getParametersAndType(CompletionItem item) {
+                if (item instanceof ConstructorItem) {
+                    ConstructorItem ci = (ConstructorItem)item;
+                    return Pair.of(ci.className, ci.parameters);
+                } else if (item instanceof JavaMethodItem) {
+                    JavaMethodItem jmi = (JavaMethodItem)item;
+                    return Pair.of(jmi.returnType, jmi.parameters);
+                } else if (item instanceof MetaMethodItem) {
+                    MetaMethodItem mmi = (MetaMethodItem)item;
+                    return Pair.of(mmi.getReturnType(), mmi.getParameters());
+                } else if (item instanceof DynamicMethodItem) {
+                    DynamicMethodItem dmi = (DynamicMethodItem)item;
+                    return Pair.of(dmi.returnType, dmi.parameters);
+                } else {
+                    return Pair.of(null, Collections.emptyList());
+                }
+            }
+
+            @Override
+            public CompletionItem createJavaMethod(String className, String simpleName, List<MethodParameter> parameters, String returnType, Set<javax.lang.model.element.Modifier> modifiers, int anchorOffset, boolean emphasise, boolean nameOnly) {
+                return new JavaMethodItem(className, simpleName, parameters, returnType, modifiers, anchorOffset, emphasise, nameOnly, true);
+            }
+
+            @Override
+            public CompletionItem createDynamicMethod(int anchorOffset, String name, List<MethodParameter> parameters, String returnType, boolean prefix) {
+                return new DynamicMethodItem(anchorOffset, name, parameters, returnType, prefix);
+            }
         });
     }
 
@@ -120,7 +151,7 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
     public ElementHandle getElement() {
         LOG.log(Level.FINEST, "getElement() element : {0}", element);
 
-        return null;
+        return element;
     }
 
     @Override
@@ -191,7 +222,7 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
 
         private final String className;
         private final String simpleName;
-        private final List<String> parameters;
+        private final List<MethodParameter> parameters;
         private final String returnType;
         private final Set<javax.lang.model.element.Modifier> modifiers;
         private final boolean emphasise;
@@ -207,6 +238,21 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
 
         public JavaMethodItem(String className, String simpleName, List<String> parameters, String returnType,
                 Set<javax.lang.model.element.Modifier> modifiers, int anchorOffset, boolean emphasise, boolean nameOnly) {
+            super(null, anchorOffset);
+            this.className = className;
+            this.simpleName = simpleName;
+            this.parameters = new ArrayList<>(parameters.size());
+            for (String s : parameters) {
+                this.parameters.add(new MethodParameter(s, s, null));
+            }
+            this.returnType = GroovyUtils.stripPackage(returnType);
+            this.modifiers = modifiers;
+            this.emphasise = emphasise;
+            this.nameOnly = nameOnly;
+        }
+        
+        JavaMethodItem(String className, String simpleName, List<MethodParameter> parameters, String returnType,
+                Set<javax.lang.model.element.Modifier> modifiers, int anchorOffset, boolean emphasise, boolean nameOnly, boolean _unused) {
             super(null, anchorOffset);
             this.className = className;
             this.simpleName = simpleName;
@@ -241,11 +287,11 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
         
         private String getParameters() {
             StringBuilder sb = new StringBuilder();
-            for (String string : parameters) {
+            for (MethodParameter par : parameters) {
                 if (sb.length() > 0) {
                     sb.append(", ");
                 }
-                sb.append(GroovyUtils.stripPackage(string));
+                sb.append(GroovyUtils.stripPackage(par.getFqnType()));
             }
             return sb.toString();
         }
@@ -353,12 +399,23 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
     private static class DynamicMethodItem extends CompletionItem {
 
         private final String name;
-        private final String[] parameters;
+        private final List<MethodParameter> parameters;
         private final String returnType;
         private final boolean prefix;
         
 
         public DynamicMethodItem(int anchorOffset, String name, String[] parameters, String returnType, boolean prefix) {
+            super(null, anchorOffset);
+            this.name = name;
+            this.parameters = new ArrayList<>(parameters.length);
+            for (String s : parameters) {
+                this.parameters.add(new MethodParameter(s, s, null));
+            }
+            this.returnType = returnType;
+            this.prefix = prefix;
+        }
+
+        DynamicMethodItem(int anchorOffset, String name, List<MethodParameter> parameters, String returnType, boolean prefix) {
             super(null, anchorOffset);
             this.name = name;
             this.parameters = parameters;
@@ -373,7 +430,7 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
 
         @Override
         public String getSortText() {
-            return (name + (prefix ? 1 : 0)) + parameters.length;
+            return (name + (prefix ? 1 : 0)) + parameters.size();
         }
 
         @Override
@@ -393,11 +450,11 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
             if (!prefix) {
                 StringBuilder buf = new StringBuilder();
                 // construct signature by removing package names.
-                for (String param : parameters) {
+                for (MethodParameter param : parameters) {
                     if (buf.length() > 0) {
                         buf.append(", ");
                     }
-                    buf.append(GroovyUtils.stripPackage(Utilities.translateClassLoaderTypeName(param)));
+                    buf.append(GroovyUtils.stripPackage(Utilities.translateClassLoaderTypeName(param.getFqnType())));
                 }
 
                 String simpleSig = buf.toString();
@@ -480,6 +537,23 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
         @Override
         public ElementKind getKind() {
             return ElementKind.METHOD;
+        }
+        
+        // accessed by CompletionAccessor
+        List<MethodParameter> getParameters() {
+            List<MethodParameter> params = new ArrayList<>(method.getParameterTypes().length);
+            for (CachedClass cc : method.getParameterTypes()) {
+                String tn = cc.getName();
+                MethodParameter mp = new MethodParameter(tn, GroovyUtils.stripPackage(tn));
+                params.add(mp);
+            }
+            return params;
+        }
+        
+        // accessed by CompletionAccessor
+        String getReturnType() {
+            Class c = method.getReturnType();
+            return c == null ? null : c.getName();
         }
 
         @Override
@@ -707,6 +781,7 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
 
         @Override
         public ElementKind getKind() {
+            // TODO: kind could be class or interface, depending on ek - NETBEANS-5788
             return ElementKind.CLASS;
         }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/CompletionAccessor.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/CompletionAccessor.java
@@ -19,12 +19,15 @@
 package org.netbeans.modules.groovy.editor.completion.provider;
 
 import java.util.List;
+import java.util.Set;
 import javax.lang.model.element.ElementKind;
 import org.netbeans.modules.groovy.editor.api.completion.CompletionItem;
 import org.netbeans.modules.groovy.editor.api.completion.CompletionItem.ConstructorItem;
 import org.netbeans.modules.groovy.editor.api.completion.CompletionItem.TypeItem;
 import org.netbeans.modules.groovy.editor.api.elements.common.MethodElement;
+import org.netbeans.modules.groovy.editor.api.elements.common.MethodElement.MethodParameter;
 import org.netbeans.modules.groovy.editor.java.JavaElementHandle;
+import org.openide.util.Pair;
 
 /**
  * Avoids publishing additional API methods; the API needs a thorough review, I am not 
@@ -61,4 +64,12 @@ public abstract class CompletionAccessor {
     public abstract ConstructorItem createConstructor(JavaElementHandle h, List<MethodElement.MethodParameter> parameters, int anchorOffset, boolean expand);
     
     public abstract TypeItem createType(JavaElementHandle h, String qn, String n,  int anchorOffset, javax.lang.model.element.ElementKind ek);
+    
+    public abstract CompletionItem createJavaMethod(String className, String simpleName, List<MethodParameter> parameters,
+            String returnType, Set<javax.lang.model.element.Modifier> modifiers, int anchorOffset,
+            boolean emphasise, boolean nameOnly);
+    
+    public abstract CompletionItem createDynamicMethod(int anchorOffset, String name, List<MethodParameter> parameters, String returnType, boolean prefix);
+    
+    public abstract Pair<String, List<MethodParameter>> getParametersAndType(CompletionItem item);
 }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyCompletionCollector.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyCompletionCollector.java
@@ -1,0 +1,591 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.completion.provider;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.prefs.PreferenceChangeEvent;
+import java.util.prefs.PreferenceChangeListener;
+import java.util.prefs.Preferences;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.api.editor.mimelookup.MimePath;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.editor.settings.SimpleValueNames;
+import org.netbeans.api.lsp.Completion;
+import org.netbeans.editor.BaseDocument;
+import org.netbeans.modules.csl.api.CodeCompletionContext;
+import org.netbeans.modules.csl.api.CodeCompletionHandler;
+import org.netbeans.modules.csl.api.CodeCompletionHandler.QueryType;
+import org.netbeans.modules.csl.api.CompletionProposal;
+import org.netbeans.modules.csl.api.Documentation;
+import org.netbeans.modules.csl.api.ElementKind;
+import static org.netbeans.modules.csl.api.ElementKind.METHOD;
+import org.netbeans.modules.csl.api.HtmlFormatter;
+import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.modules.groovy.editor.api.completion.CompletionItem;
+import org.netbeans.modules.groovy.editor.api.completion.CompletionItem.ConstructorItem;
+import org.netbeans.modules.groovy.editor.api.completion.CompletionItem.MetaMethodItem;
+import org.netbeans.modules.groovy.editor.api.completion.CompletionItem.NamedParameter;
+import org.netbeans.modules.groovy.editor.api.completion.CompletionItem.TypeItem;
+import org.netbeans.modules.groovy.editor.api.elements.common.MethodElement.MethodParameter;
+import org.netbeans.modules.groovy.editor.api.parser.GroovyLanguage;
+import org.netbeans.modules.groovy.editor.api.parser.GroovyParserResult;
+import org.netbeans.modules.groovy.editor.completion.provider.GroovyCompletionImpl.CompletionImplResult;
+import org.netbeans.modules.parsing.api.Embedding;
+import org.netbeans.modules.parsing.api.ParserManager;
+import org.netbeans.modules.parsing.api.ResultIterator;
+import org.netbeans.modules.parsing.api.Source;
+import org.netbeans.modules.parsing.api.UserTask;
+import org.netbeans.modules.parsing.spi.ParseException;
+import org.netbeans.modules.parsing.spi.Parser;
+import org.netbeans.spi.lsp.CompletionCollector;
+import org.openide.ErrorManager;
+import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
+import org.openide.util.Pair;
+import org.openide.util.WeakListeners;
+
+/**
+ *
+ * @author sdedic
+ */
+@MimeRegistration(mimeType = GroovyLanguage.GROOVY_MIME_TYPE, service = CompletionCollector.class)
+public class GroovyCompletionCollector implements CompletionCollector {
+    private final Lookup lkp;
+
+    private GroovyCompletionImpl cService;
+    
+    public GroovyCompletionCollector() {
+        this(Lookup.getDefault());
+    }
+
+    public GroovyCompletionCollector(Lookup lkp) {
+        this.lkp = lkp;
+    }
+    
+    @Override
+    public boolean collectCompletions(Document doc, int offset, Completion.Context context, Consumer<Completion> consumer) {
+        if (cService == null) {
+            cService = lkp.lookup(GroovyCompletionImpl.class);
+        }
+        try {
+            Source src = Source.create(doc);
+            if (src == null) {
+                return true;
+            }
+            CompletionTask task = new CompletionTask(offset, QueryType.ALL_COMPLETION, context, consumer);
+            
+            ParserManager.parse(Collections.singleton(src), task);
+            return task.complete;
+            
+        } catch (ParseException ex) {
+            Exceptions.printStackTrace(ex);
+            return true;
+        }
+    }
+    
+    private static final int ORDER_CONSTRUCTOR = 1550;
+    private static final int ORDER_METHOD = 1500;
+    private static final int ORDER_META_METHOD = 1650;
+
+    private static int ORDER_KEYWORD = 1670;
+    private static int ORDER_TYPE = 1800;
+    private static int ORDER_NAMED_PARAMETER = 1300;
+    private static int ORDER_FIELD = 1200;
+    private static int ORDER_FIELD_DYNAMIC = 1250;
+    private static int ORDER_LOCAL_VAR = 1100;
+    
+    private static int ORDER_PACKAGE = 1900;
+    
+    
+    class CompletionTask extends UserTask {
+        final int offset;
+        final Consumer<Completion> consumer;
+        final Completion.Context lspContext;
+        final QueryType queryType;
+        CompletionRequestContext cslContext;
+        GroovyParserResult groovyResult;
+        boolean complete = true;
+        CompletionImplResult groovyCompletion;
+
+        public CompletionTask(int offset, QueryType queryType, Completion.Context context, Consumer<Completion> consumer) {
+            this.offset = offset;
+            this.lspContext = context;
+            this.consumer = consumer;
+            this.queryType = queryType;
+        }
+
+        @Override
+        public void run(ResultIterator resultIterator) throws Exception {
+            if (GroovyLanguage.GROOVY_MIME_TYPE.equals(resultIterator.getSnapshot().getMimeType())) {
+                process(resultIterator.getParserResult());
+            }
+            for (Embedding e : resultIterator.getEmbeddings()) {
+                if (e.containsOriginalOffset(offset)) {
+                    run(resultIterator.getResultIterator(e));
+                }
+            }
+        }
+        
+        void process(Parser.Result r) {
+            if (!(r instanceof GroovyParserResult)) {
+                return;
+            }
+            groovyResult = (GroovyParserResult)r;
+            // CSL context for completion
+            cslContext = new CompletionRequestContext(offset,  queryType, groovyResult, true);
+            
+            List<CompletionProposal> proposals = cService.makeProposals(cslContext).getProposals();
+            for (CompletionProposal cp : proposals) {
+                Completion.Kind k = lspCompletionKind(cp.getKind());
+                if (k == null) {
+                    // unknown / unrepresentable completion kind, ignore.
+                    continue;
+                }
+                builder = CompletionCollector.newBuilder(cp.getName()).kind(k);
+                
+                Builder b = buildCompletion(cp);
+                if (b != null) {
+                    b.documentation(() -> getDocumentation(cp));
+                    consumer.accept(b.build());
+                }
+            }
+        }
+        
+        String getDocumentation(CompletionProposal cp) {
+            AtomicReference<String> doc = new AtomicReference<>();
+            Source s = groovyResult.getSnapshot().getSource();
+            if (s == null) {
+                return null;
+            }
+            GroovyCompletionImpl impl = Lookup.getDefault().lookup(GroovyCompletionImpl.class);
+            if (impl == null) {
+                return null;
+            }
+            try {
+                ParserManager.parse(Collections.singleton(s), new UserTask() {
+                    @Override
+                    public void run(ResultIterator resultIterator) throws Exception {
+                        Parser.Result r = resultIterator.getParserResult();
+                        if (r instanceof GroovyParserResult) {
+                            GroovyParserResult gpr = (GroovyParserResult)r;
+                            Documentation d = impl.documentElement(gpr, cp.getElement(), () -> false);
+                            if (d != null) {
+                                doc.set(d.getContent());
+                                return;
+                            }
+                        }
+                        for (Embedding e : resultIterator.getEmbeddings()) {
+                            if (e.containsOriginalOffset(cp.getAnchorOffset())) {
+                                run(resultIterator.getResultIterator(e));
+                            }
+                        }
+                    }
+                });
+            } catch (ParseException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+            return doc.get();
+        }
+        
+        /**
+         * Temporary value, recreated for each processed item.
+         */
+        CompletionCollector.Builder builder;
+        
+        /*
+        Handled:
+            JavaMethodItem
+            ConstructorItem
+            JavaFieldItem
+            DynamicFieldItem    
+            DynamicMethodItem  
+            NamedParameter      -> property
+
+            MetaMethodItem
+        Defaults / literal:
+            KeywordItem
+            PackageItem         -> folder
+            TypeItem
+            LocalVarItem
+            NewVarItem
+            NewFieldItem
+         */
+        
+        Builder  buildCompletion(CompletionProposal cp) {
+            if (!(cp instanceof CompletionItem)) {
+                return null;
+            }
+            CompletionItem ci = (CompletionItem)cp;
+            StringBuilder sb = new StringBuilder(cp.getLhsHtml(nullFormatter()));
+            String rhs = cp.getRhsHtml(nullFormatter());
+            if (rhs != null && !rhs.isEmpty()) {
+                sb.append(" : "); // NOI18N
+                sb.append(rhs);
+            }
+            builder.label(sb.toString());
+            builder.insertText(cp.getInsertPrefix());
+            
+            // override the default CSL > LSP type mapping, for specific cases
+            if (cp instanceof ConstructorItem) {
+                return nameAndParameters(ci);
+            } else if (cp instanceof NamedParameter) {
+                builder.kind(Completion.Kind.Property).
+                        insertText(cp.getCustomInsertTemplate()).
+                        sortText(String.format("%04d%s", ORDER_NAMED_PARAMETER, cp.getName()));
+            } else if (cp instanceof CompletionItem.DynamicFieldItem) {
+                builder.kind(Completion.Kind.Field);
+            } else if (cp instanceof CompletionItem.TypeItem) {
+                return buildType(ci);
+            } else if (cp instanceof CompletionItem.KeywordItem) {
+                return buildKeyword(ci);
+            } else if (cp instanceof CompletionItem.PackageItem) {
+                return buildPackage(ci);
+            } else if (cp.getKind() == ElementKind.METHOD) {
+                return nameAndParameters((CompletionItem)cp);
+            } else if (cp.getKind() == ElementKind.FIELD) {
+                return buildField(ci);
+            } else if (cp.getKind() == ElementKind.VARIABLE) {
+                return buildVariable(ci);
+            }
+            return builder;
+        }
+        
+        Builder buildField(CompletionItem item) {
+            int priority = ORDER_FIELD;
+            if (item instanceof CompletionItem.DynamicFieldItem) {
+                priority = ORDER_FIELD_DYNAMIC;
+            }
+            return builder.sortText(String.format("%04d%s", priority,  item.getName()));
+        }
+        
+        Builder buildVariable(CompletionItem item) {
+            return builder.sortText(String.format("%04d%s", ORDER_LOCAL_VAR,  item.getName()));
+        }
+        
+        Builder buildType(CompletionItem item) {
+            TypeItem ti = (TypeItem)item;
+            return builder.sortText(String.format("%04d%s#%s", ORDER_TYPE, 
+                    ti.getName(), ti.getFqn()));
+        }
+        
+        Builder buildKeyword(CompletionItem item) {
+            return builder.sortText(String.format("%04d%s", ORDER_KEYWORD, item.getName()));
+        }
+        
+        Builder buildPackage(CompletionItem item) {
+            return builder.sortText(String.format("%04d%s#%s", ORDER_PACKAGE, item.getName()));
+        }
+        
+        Builder buildExecutable(CompletionItem item, String simpleName, String sortParams, int cnt) {
+            int priority = item.getKind() == METHOD ? ORDER_METHOD : ORDER_CONSTRUCTOR;
+            if (item instanceof MetaMethodItem) {
+                builder.kind(Completion.Kind.Function);
+                priority = ORDER_META_METHOD;
+            }
+            return builder.sortText(String.format("%04d%s#%02d%s", priority, 
+                    simpleName, cnt, sortParams.toString()));
+        }
+
+        Builder nameAndParameters(CompletionItem item) {
+            Pair<String, List<MethodParameter>> paramsAndType = CompletionAccessor.instance().getParametersAndType(item);
+            // FIXME: report return type.
+            List<MethodParameter> params = paramsAndType.second();
+            String n = item.getName();
+            StringBuilder sortParams = new StringBuilder();
+            sortParams.append("(");
+            int paren = n.indexOf('(');
+            if (paren > -1) {
+                // constructor's name does not contain (), method's does.
+                n = n.substring(0, paren);
+            }
+            if (params.isEmpty()) {
+                return buildExecutable(item, n, sortParams.toString(), 0).
+                        insertText(n + "()");
+            }
+            StringBuilder sb = new StringBuilder(n);
+            sb.append("(");
+            int cnt = 0;
+            for (MethodParameter p : params) {
+                if (cnt > 0) {
+                    sb.append(", ");
+                    sortParams.append("#");
+                }
+                cnt++;
+                if (p.getName() == null) {
+                    sb.append("${").append(cnt);
+                } else {
+                    sb.append("${").append(cnt).append(':').append(p.getName());
+                }
+                sb.append("}");
+                sortParams.append(p.getType());
+            }
+            sb.append(")$0");
+            return buildExecutable(item, n, sortParams.toString(), params.size()).
+                    insertText(sb.toString()).insertTextFormat(Completion.TextFormat.Snippet);
+        }
+    }
+    
+    private static HtmlFormatter nullFormatter() {
+        return new NullHtmlFormatter();
+    }
+    
+    static class NullHtmlFormatter extends HtmlFormatter {
+        StringBuilder sb = new StringBuilder();
+        
+        @Override
+        public void reset() {
+            sb = new StringBuilder();
+        }
+
+        static String stripHtml( String htmlText ) {
+            if( null == htmlText )
+                return null;
+            String res = htmlText.replaceAll( "<[^>]*>", "" ); // NOI18N // NOI18N
+            res = res.replaceAll( "&nbsp;", " " ); // NOI18N // NOI18N
+            res = res.trim();
+            return res;
+        }
+        
+        @Override
+        public void appendHtml(String html) {
+            sb.append(stripHtml(html));
+        }
+
+        @Override
+        public void appendText(String text, int fromInclusive, int toExclusive) {
+            int l = toExclusive - fromInclusive;
+            if (sb.length() + l < maxLength) {
+                sb.append(text.subSequence(fromInclusive, toExclusive));
+            } else {
+                sb.append(text.subSequence(fromInclusive, toExclusive - (l - maxLength)));
+                sb.append("...");
+            }
+        }
+
+        @Override
+        public void emphasis(boolean start) {
+        }
+
+        @Override
+        public void name(ElementKind kind, boolean start) {
+        }
+
+        @Override
+        public void parameters(boolean start) {
+        }
+
+        @Override
+        public void active(boolean start) {
+        }
+
+        @Override
+        public void type(boolean start) {
+        }
+
+        @Override
+        public void deprecated(boolean start) {
+        }
+
+        @Override
+        public String getText() {
+            return sb.toString();
+        }
+    }
+    
+    static Completion.Kind lspCompletionKind(ElementKind cslKind) {
+        switch (cslKind) {
+            case CONSTRUCTOR:   return Completion.Kind.Constructor;
+            case MODULE:        return Completion.Kind.Module;
+            case PACKAGE:       return Completion.Kind.Folder;
+            case CLASS:         return Completion.Kind.Class;
+            case METHOD:        return Completion.Kind.Method;
+            case FIELD:         return Completion.Kind.Field;
+            case VARIABLE:      return Completion.Kind.Variable;
+            case ATTRIBUTE:     return Completion.Kind.Variable;
+            case CONSTANT:      return Completion.Kind.Constant;
+            case KEYWORD:       return Completion.Kind.Keyword;
+            case OTHER:         return Completion.Kind.Snippet;
+            case PARAMETER:     return Completion.Kind.Variable;
+            case GLOBAL:        return Completion.Kind.Variable;
+            case PROPERTY:      return Completion.Kind.Property;
+
+            case FILE:          return Completion.Kind.File;
+            case INTERFACE:     return Completion.Kind.Interface;
+
+            case TEST:
+            case DB:
+            case CALL:
+            case TAG:
+            case RULE:
+            case ERROR:         
+            default:
+                return null;
+            
+        }
+    }
+    
+    private static class CompletionRequestContext extends CodeCompletionContext {
+        final ParserResult parserResult;
+        final boolean prefixMatch;
+        final QueryType queryType;
+        
+        int offset;
+        String prefix;
+        CodeCompletionHandler completionHandler;
+
+        public CompletionRequestContext(int offset, QueryType queryType, ParserResult parserResult, boolean prefixMatch) {
+            this.offset = offset;
+            this.parserResult = parserResult;
+            this.prefixMatch = prefixMatch;
+            this.queryType = queryType;
+            init();
+        }
+        
+        CodeCompletionHandler getCompletionHandler() {
+            if (completionHandler == null) {
+                completionHandler = MimeLookup.getLookup(parserResult.getSnapshot().getMimeType()).lookup(CodeCompletionHandler.class);
+            }
+            return completionHandler;
+        }
+        
+        void init() {
+            final Source s = parserResult.getSnapshot().getSource();
+            Document doc = s.getDocument (false);
+            int length = doc != null ? doc.getLength() : (int)s.getFileObject().getSize();
+            if (offset > length) {
+                offset = length;
+            }
+            
+            CodeCompletionHandler completer = getCompletionHandler();
+            if (completer == null) {
+                return;
+            }
+            try {
+                if (doc != null) {
+                    int[] blk =
+                        org.netbeans.editor.Utilities.getIdentifierBlock((BaseDocument)doc,
+                            offset);
+
+                    if (blk != null) {
+                        int start = blk[0];
+
+                        if (start < offset ) {
+                            if (prefixMatch) {
+                                prefix = doc.getText(start, offset - start);
+                            } else {
+                                prefix = doc.getText(start, blk[1]-start);
+                            }
+                        }
+                    }
+                }
+            } catch (BadLocationException ex) {
+                ErrorManager.getDefault().notify(ex);
+            }
+        }
+        
+        @Override
+        public int getCaretOffset() {
+            return offset;
+        }
+
+        @Override
+        public ParserResult getParserResult() {
+            return parserResult;
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefix;
+        }
+
+        @Override
+        public CodeCompletionHandler.QueryType getQueryType() {
+            return queryType;
+        }
+
+        @Override
+        public boolean isPrefixMatch() {
+            return prefixMatch;
+        }
+
+        @Override
+        public boolean isCaseSensitive() {
+            return isCaseSensitive();
+        }
+    }
+
+    private static boolean caseSensitive = true;
+    private static boolean autoPopup = true;
+    private static boolean inited;
+
+    private static boolean isCaseSensitive() {
+        lazyInit();
+        return caseSensitive;
+    }
+
+    private static class SettingsListener implements PreferenceChangeListener {
+
+//        public void settingsChange(SettingsChangeEvent evt) {
+//            setCaseSensitive(SettingsUtil.getBoolean(GsfEditorKitFactory.GsfEditorKit.class,
+//                    ExtSettingsNames.COMPLETION_CASE_SENSITIVE,
+//                    ExtSettingsDefaults.defaultCompletionCaseSensitive));
+//        }
+
+        public void preferenceChange(PreferenceChangeEvent evt) {
+            if (evt.getKey() == null || SimpleValueNames.COMPLETION_CASE_SENSITIVE.equals(evt.getKey())) {
+                setCaseSensitive(Boolean.valueOf(evt.getNewValue()));
+            } else if (SimpleValueNames.COMPLETION_AUTO_POPUP.equals(evt.getKey())) {
+                setAutoPopup(Boolean.valueOf(evt.getNewValue()));
+            }
+        }
+    }
+
+    private static PreferenceChangeListener settingsListener = new SettingsListener();
+
+    private static void setCaseSensitive(boolean b) {
+        lazyInit();
+        caseSensitive = b;
+    }
+
+    private static void setAutoPopup(boolean b) {
+        lazyInit();
+        autoPopup = b;
+    }
+
+    private static void lazyInit() {
+        if (!inited) {
+            inited = true;
+            
+            // correctly we should use a proper mime type for the document where the completion runs,
+            // but at the moment this is enough, because completion settings are mainted globaly for all mime types
+            // (ie. their the same for all mime types). Also, if using a specific mime type
+            // this code should hold the prefs instance somewhere, but not in a static field!
+            Preferences prefs = MimeLookup.getLookup(MimePath.EMPTY).lookup(Preferences.class);
+            prefs.addPreferenceChangeListener(WeakListeners.create(PreferenceChangeListener.class, settingsListener, prefs));
+            
+            setCaseSensitive(prefs.getBoolean(SimpleValueNames.COMPLETION_CASE_SENSITIVE, false));
+            setAutoPopup(prefs.getBoolean(SimpleValueNames.COMPLETION_AUTO_POPUP, false));
+        }
+    }
+}

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyCompletionImpl.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyCompletionImpl.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.completion.provider;
+
+import groovy.lang.MetaMethod;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.lang.model.element.Element;
+import javax.swing.text.Document;
+import org.codehaus.groovy.reflection.CachedClass;
+import org.netbeans.api.java.platform.JavaPlatform;
+import org.netbeans.api.java.platform.JavaPlatformManager;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.ui.ElementJavadoc;
+import org.netbeans.editor.BaseDocument;
+import org.netbeans.modules.csl.api.CodeCompletionContext;
+import org.netbeans.modules.csl.api.CompletionProposal;
+import org.netbeans.modules.csl.api.Documentation;
+import org.netbeans.modules.csl.api.ElementHandle;
+import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.modules.groovy.editor.api.ASTUtils;
+import org.netbeans.modules.groovy.editor.api.completion.CaretLocation;
+import org.netbeans.modules.groovy.editor.api.completion.CompletionHandler;
+import static org.netbeans.modules.groovy.editor.api.completion.CompletionHandler.getMethodSignature;
+import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
+import org.netbeans.modules.groovy.editor.api.completion.util.ContextHelper;
+import org.netbeans.modules.groovy.editor.api.elements.ast.ASTMethod;
+import org.netbeans.modules.groovy.editor.completion.ProposalsCollector;
+import org.netbeans.modules.groovy.editor.java.JavaElementHandle;
+import org.netbeans.modules.groovy.support.api.GroovySettings;
+import org.openide.util.Exceptions;
+import org.openide.util.NbBundle;
+import org.openide.util.Utilities;
+import org.openide.util.WeakListeners;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Code migrated from {@link CompletionHandler} to a nonpublic package. Allows to extend
+ * internal module API without exposing details to dependent modules.
+ * 
+ * @author sdedic
+ */
+@ServiceProvider(service = GroovyCompletionImpl.class)
+public class GroovyCompletionImpl {
+    private static final Logger LOG = Logger.getLogger(GroovyCompletionImpl.class.getName());
+    private final PropertyChangeListener docListener;
+    
+    private String jdkJavaDocBase = null;
+    private String groovyJavaDocBase = null;
+    private String groovyApiDocBase = null;
+    
+
+    public GroovyCompletionImpl() {
+        JavaPlatformManager platformMan = JavaPlatformManager.getDefault();
+        JavaPlatform platform = platformMan.getDefaultPlatform();
+        List<URL> docfolder = platform.getJavadocFolders();
+
+        for (URL url : docfolder) {
+            LOG.log(Level.FINEST, "JDK Doc path: {0}", url.toString()); // NOI18N
+            jdkJavaDocBase = url.toString();
+        }
+
+        GroovySettings groovySettings = GroovySettings.getInstance();
+        docListener = new PropertyChangeListener() {
+
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                synchronized (GroovyCompletionImpl.this) {
+                    groovyJavaDocBase = null;
+                    groovyApiDocBase = null;
+                }
+            }
+        };
+        groovySettings.addPropertyChangeListener(WeakListeners.propertyChange(docListener, this));
+    }
+    
+    
+    public static final class CompletionImplResult {
+        List<CompletionProposal> proposals;
+        CompletionContext groovyContext;
+
+        public CompletionImplResult(List<CompletionProposal> proposals, CompletionContext groovyContext) {
+            this.proposals = proposals;
+            this.groovyContext = groovyContext;
+        }
+
+        public List<CompletionProposal> getProposals() {
+            return proposals;
+        }
+
+        public CompletionContext getGroovyContext() {
+            return groovyContext;
+        }
+        
+        public boolean isEmpty() {
+            return proposals == null || proposals.isEmpty();
+        }
+    }
+
+    public CompletionImplResult makeProposals(CodeCompletionContext completionContext) {
+        ParserResult parserResult = completionContext.getParserResult();
+        String prefix = completionContext.getPrefix();
+        
+        // Documentation says that @NonNull is return from getPrefix() but it's not true
+        // Invoking "this.^" makes the return value null
+        if (prefix == null) {
+            prefix = "";
+        }
+        
+        int lexOffset = completionContext.getCaretOffset();
+        int astOffset = ASTUtils.getAstOffset(parserResult, lexOffset);
+        int anchor = lexOffset - prefix.length();
+
+        LOG.log(Level.FINEST, "complete(...), prefix      : {0}", prefix); // NOI18N
+        LOG.log(Level.FINEST, "complete(...), lexOffset   : {0}", lexOffset); // NOI18N
+        LOG.log(Level.FINEST, "complete(...), astOffset   : {0}", astOffset); // NOI18N
+
+        final Document document = parserResult.getSnapshot().getSource().getDocument(false);
+        if (document == null) {
+            return null;
+        }
+        final BaseDocument doc = (BaseDocument) document;
+
+        doc.readLock(); // Read-lock due to Token hierarchy use
+
+        try {
+            CompletionContext context = new CompletionContext(parserResult, prefix, anchor, lexOffset, astOffset, doc);
+            context.init();
+
+            // if we are above a package statement or inside a comment there's no completion at all.
+            if (context.location == CaretLocation.ABOVE_PACKAGE || context.location == CaretLocation.INSIDE_COMMENT) {
+                return new CompletionImplResult(Collections.emptyList(), context);
+            }
+            
+            ProposalsCollector proposalsCollector = new ProposalsCollector(context);
+
+            if (ContextHelper.isVariableNameDefinition(context) || ContextHelper.isFieldNameDefinition(context)) {
+                proposalsCollector.completeNewVars(context);
+            } else {
+                if (!(context.location == CaretLocation.OUTSIDE_CLASSES || context.location == CaretLocation.INSIDE_STRING)) {
+                    proposalsCollector.completePackages(context);
+                    proposalsCollector.completeTypes(context);
+                }
+
+                if (!context.isBehindImportStatement()) {
+                    if (context.location != CaretLocation.INSIDE_STRING) {
+                        proposalsCollector.completeKeywords(context);
+                        proposalsCollector.completeMethods(context);
+                    }
+
+                    proposalsCollector.completeFields(context);
+                    proposalsCollector.completeLocalVars(context);
+                }
+
+                if (context.location == CaretLocation.INSIDE_CONSTRUCTOR_CALL) {
+                    if (ContextHelper.isAfterComma(context) || ContextHelper.isAfterLeftParenthesis(context)) {
+                        proposalsCollector.completeNamedParams(context);
+                    }
+                }
+            }
+            proposalsCollector.completeCamelCase(context);
+
+            return new CompletionImplResult(proposalsCollector.getCollectedProposals(), context);
+        } finally {
+            doc.readUnlock();
+        }
+    }
+
+    private String getGroovyJavadocBase() {
+        synchronized (this) {
+            if (groovyJavaDocBase == null) {
+                String docroot = GroovySettings.getInstance().getGroovyDoc() + "/"; // NOI18N
+                groovyJavaDocBase = directoryNameToUrl(docroot + "groovy-jdk/"); // NOI18N
+            }
+            return groovyJavaDocBase;
+        }
+    }
+
+    private String getGroovyApiDocBase() {
+        synchronized (this) {
+            if (groovyApiDocBase == null) {
+                String docroot = GroovySettings.getInstance().getGroovyDoc() + "/"; // NOI18N
+                groovyApiDocBase = directoryNameToUrl(docroot + "gapi/"); // NOI18N
+            }
+            return groovyApiDocBase;
+        }
+    }
+
+    private static String directoryNameToUrl(String dirname) {
+        if (dirname == null) {
+            return "";
+        }
+
+        // FIXME use FileObject (?)
+        File dirFile = new File(dirname);
+
+        if (dirFile != null && dirFile.exists() && dirFile.isDirectory()) {
+            String fileURL = "";
+            if (Utilities.isWindows()) {
+                dirname = dirname.replace("\\", "/");
+                fileURL = "file:/"; // NOI18N
+            } else {
+                fileURL = "file://"; // NOI18N
+            }
+            return fileURL + dirname;
+        } else {
+            return "";
+        }
+    }
+
+    private static void printMethod(MetaMethod mm) {
+
+        LOG.log(Level.FINEST, "--------------------------------------------------");
+        LOG.log(Level.FINEST, "getName()           : {0}", mm.getName());
+        LOG.log(Level.FINEST, "toString()          : {0}", mm.toString());
+        LOG.log(Level.FINEST, "getDescriptor()     : {0}", mm.getDescriptor());
+        LOG.log(Level.FINEST, "getSignature()      : {0}", mm.getSignature());
+        // LOG.log(Level.FINEST, "getParamTypes()     : " + mm.getParameterTypes());
+        LOG.log(Level.FINEST, "getDeclaringClass() : {0}", mm.getDeclaringClass());
+    }
+
+    public String document(ParserResult info, ElementHandle element) {
+        LOG.log(Level.FINEST, "document(), ElementHandle : {0}", element);
+
+        String error = NbBundle.getMessage(CompletionHandler.class, "GroovyCompletion_NoJavaDocFound");
+        String doctext = null;
+        
+        if (element instanceof ASTMethod) {
+            ASTMethod ame = (ASTMethod) element;
+
+            String base = "";
+
+            String javadoc = getGroovyJavadocBase();
+            if (jdkJavaDocBase != null && ame.isGDK() == false) {
+                base = jdkJavaDocBase;
+            } else if (javadoc != null && ame.isGDK() == true) {
+                base = javadoc;
+            } else {
+                LOG.log(Level.FINEST, "Neither JDK nor GDK or error locating: {0}", ame.isGDK());
+                return error;
+            }
+
+            MetaMethod mm = ame.getMethod();
+
+            // enable this to troubleshoot subtle differences in JDK/GDK signatures
+            printMethod(mm);
+
+            // figure out who originally defined this method
+
+            String className;
+
+            if (ame.isGDK()) {
+                className = mm.getDeclaringClass()/*.getCachedClass()*/.getName();
+            } else {
+
+                String declName = null;
+
+                if (mm != null) {
+                    CachedClass cc = mm.getDeclaringClass();
+                    if (cc != null) {
+                        declName = cc.getName();
+                    }
+                }
+
+                if (declName != null) {
+                    className = declName;
+                } else {
+                    className = ame.getClz().getName();
+                }
+            }
+
+            // create path from fq java package name:
+            // java.lang.String -> java/lang/String.html
+            String classNamePath = className.replace(".", "/");
+            classNamePath = classNamePath + ".html"; // NOI18N
+
+            // if the file can be located in the GAPI folder prefer it
+            // over the JDK
+            if (!ame.isGDK()) {
+
+                URL url;
+                File testFile;
+
+                String apiDoc = getGroovyApiDocBase();
+                try {
+                    url = new URL(apiDoc + classNamePath);
+                    testFile = new File(url.toURI());
+                } catch (MalformedURLException ex) {
+                    LOG.log(Level.FINEST, "MalformedURLException: {0}", ex);
+                    return error;
+                } catch (URISyntaxException uriEx) {
+                    LOG.log(Level.FINEST, "URISyntaxException: {0}", uriEx);
+                    return error;
+                }
+
+                if (testFile != null && testFile.exists()) {
+                    base = apiDoc;
+                }
+            }
+
+            // create the signature-string of the method
+            String sig = getMethodSignature(ame.getMethod(), true, ame.isGDK());
+            String printSig = getMethodSignature(ame.getMethod(), false, ame.isGDK());
+
+            String urlName = base + classNamePath + "#" + sig;
+
+            try {
+                LOG.log(Level.FINEST, "Trying to load URL = {0}", urlName); // NOI18N
+                doctext = HTMLJavadocParser.getJavadocText(
+                    new URL(urlName),
+                    false,
+                    ame.isGDK());
+            } catch (MalformedURLException ex) {
+                LOG.log(Level.FINEST, "document(), URL trouble: {0}", ex); // NOI18N
+                return error;
+            }
+
+            // If we could not find a suitable JavaDoc for the method - say so.
+            if (doctext == null) {
+                return error;
+            }
+
+            doctext = "<h3>" + className + "." + printSig + "</h3><BR>" + doctext;
+        }
+        return doctext;
+    }
+
+    public Documentation documentElement(ParserResult info, ElementHandle handle, Callable<Boolean> cancel) {
+        if (handle instanceof JavaElementHandle) {
+            // let Java support do the hard work.
+            ElementJavadoc jdoc;
+            try {
+                jdoc = ((JavaElementHandle)handle).extract(info, new JavaElementHandle.ElementFunction<ElementJavadoc>() {
+                    @Override
+                    public ElementJavadoc apply(CompilationInfo info, Element el) {
+                        return ElementJavadoc.create(info, el);
+                    }
+                });
+            } catch (IOException ex) {
+                // TBR
+                return null;
+            }
+            
+            if (jdoc != null) {
+                Boolean b;
+                Future<String> content = jdoc.getTextAsync();
+                try {
+                    while (((b = cancel.call()) == null) || !b.booleanValue()) {
+                        try {
+                            return Documentation.create(content.get(250, TimeUnit.MILLISECONDS),
+                                    jdoc.getURL());
+                        } catch (TimeoutException te) {}
+                    }
+                } catch (Exception ex) {
+                    Exceptions.printStackTrace(ex);
+                    return null;
+                }
+                return null;
+            }
+        }
+        
+         String s = document(info, handle);
+         return s == null ? null : Documentation.create(s);
+    }
+}

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyElementsProvider.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyElementsProvider.java
@@ -75,15 +75,15 @@ public final class GroovyElementsProvider implements CompletionProvider {
                                 indexedMethod.getModifiers());
                     }
                     
-                    CompletionItem ci = CompletionItem.forJavaMethod(
-                                context.getTypeName(),
-                                indexedMethod.getName(),
-                                indexedMethod.getParameterTypes(),
-                                indexedMethod.getReturnType(),
-                                Utilities.gsfModifiersToModel(indexedMethod.getModifiers(), Modifier.PUBLIC),
-                                context.getAnchor(),
-                                false,
-                                context.isNameOnly());
+                    CompletionItem ci = CompletionAccessor.instance().createJavaMethod(
+                            context.getTypeName(),
+                            indexedMethod.getName(),
+                            indexedMethod.getParameters(),
+                            indexedMethod.getReturnType(),
+                            Utilities.gsfModifiersToModel(indexedMethod.getModifiers(), Modifier.PUBLIC),
+                            context.getAnchor(),
+                            false,
+                            context.isNameOnly());
                     
                     result.put(getMethodSignature(indexedMethod), 
                         CompletionAccessor.instance().assignHandle(ci, jeh)

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/HTMLJavadocParser.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/HTMLJavadocParser.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.netbeans.modules.groovy.editor.api.completion;
+package org.netbeans.modules.groovy.editor.completion.provider;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/TransformationHandler.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/TransformationHandler.java
@@ -19,18 +19,22 @@
 package org.netbeans.modules.groovy.editor.completion.provider;
 
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.Parameter;
 import org.netbeans.modules.groovy.editor.api.GroovyIndex;
 import org.netbeans.modules.groovy.editor.api.completion.CompletionItem;
 import org.netbeans.modules.groovy.editor.api.completion.CompletionItem.FieldItem;
 import org.netbeans.modules.groovy.editor.api.completion.FieldSignature;
 import org.netbeans.modules.groovy.editor.api.completion.MethodSignature;
+import org.netbeans.modules.groovy.editor.api.elements.common.MethodElement.MethodParameter;
 import org.netbeans.modules.groovy.editor.java.Utilities;
 
 /**
@@ -114,10 +118,10 @@ public final class TransformationHandler {
             
             if (SINGLETON_ANNOTATION.equals(annotationName)) {
                 final MethodSignature signature = new MethodSignature(SINGLETON_METHOD_NAME, new String[0]);
-                final CompletionItem proposal = CompletionItem.forJavaMethod(
+                final CompletionItem proposal = CompletionAccessor.instance().createJavaMethod(
                         typeNode.getNameWithoutPackage(),
                         SINGLETON_METHOD_NAME,
-                        Collections.<String>emptyList(),
+                        Collections.emptyList(),
                         typeNode.getNameWithoutPackage(),
                         Utilities.reflectionModifiersToModel(Modifier.STATIC),
                         anchorOffset,
@@ -165,17 +169,18 @@ public final class TransformationHandler {
             final int anchorOffset) {
         
         final String methodName = method.getName();
-        final String[] methodParams = getMethodParams(method);
+        final List<MethodParameter> methodParams = getMethodParams(method);
         final String returnType = method.getReturnType().getName();
-
-        return CompletionItem.forDynamicMethod(anchorOffset, methodName, methodParams, returnType, prefixed);
+        
+        return CompletionAccessor.instance().createDynamicMethod(anchorOffset, methodName, methodParams, returnType, prefixed);
     }
     
-    private static String[] getMethodParams(MethodNode method) {
-        String[] parameters = new String[method.getParameters().length];
-        for (int i = 0; i < parameters.length; i++) {
-            parameters[i] = method.getParameters()[i].getName();
+    private static List<MethodParameter> getMethodParams(MethodNode method) {
+        List<MethodParameter> result = new ArrayList<>(method.getParameters().length);
+        Parameter[] mps = method.getParameters();
+        for (Parameter p : mps) {
+            result.add(new MethodParameter(p.getType().getName(), p.getType().getNameWithoutPackage(), p.getName()));
         }
-        return parameters;
+        return result;
     }
 }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/utils/GroovyUtils.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/utils/GroovyUtils.java
@@ -38,6 +38,16 @@ public final class GroovyUtils {
      * @return singe typename without package, or method without type
      */
     public static String stripPackage(String fqn) {
+        if (fqn.contains("<")) {
+            // TODO: This does not handle inner classes well - NETBEANS-5787
+            int first = fqn.indexOf('<');
+            int last = fqn.lastIndexOf('>');
+            if (last > first) {
+                return stripPackage(fqn.substring(0, first)) + "<" +
+                        stripPackage(fqn.substring(first + 1, last)) + ">";
+                        
+            }
+        }
         if (fqn.contains(".")) {
             int idx = fqn.lastIndexOf(".");
             fqn = fqn.substring(idx + 1);

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionInsideFor1/CompletionInsideFor1.groovy.testCompletionInsideFor1_2.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionInsideFor1/CompletionInsideFor1.groovy.testCompletionInsideFor1_2.completion
@@ -48,7 +48,7 @@ METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
 METHOD     findResults(Closure)                       Collection
-METHOD     forEach(BiConsumer<? super K,?  [PUBLIC]   void
+METHOD     forEach(BiConsumer<? super K,   [PUBLIC]   void
 METHOD     get(Object)                     [PUBLIC]   V
 METHOD     get(Object, Object)                        Object
 METHOD     getAt(Object)                              Object
@@ -97,7 +97,7 @@ METHOD     println(Object)                            void
 METHOD     println(PrintWriter)                       void
 METHOD     put(K, V)                       [PUBLIC]   V
 METHOD     putAll(Collection)                         Map
-METHOD     putAll(Map<? extends K,? exten  [PUBLIC]   void
+METHOD     putAll(Map<? extends K, ? exte  [PUBLIC]   void
 METHOD     putAt(Object, Object)                      Object
 METHOD     putAt(String, Object)                      void
 METHOD     putIfAbsent(K, V)               [PUBLIC]   V

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.completion
@@ -129,7 +129,7 @@ METHOD     isLong()                                   boolean
 METHOD     isNumber()                                 boolean
 METHOD     iterator()                                 Iterator
 METHOD     join(CharSequence, CharSequenc  [STATIC,   String
-METHOD     join(CharSequence, CharSequenc  [STATIC,   String
+METHOD     join(CharSequence, Iterable<Ch  [STATIC,   String
 METHOD     lastIndexOf(String)             [PUBLIC]   int
 METHOD     lastIndexOf(String, int)        [PUBLIC]   int
 METHOD     lastIndexOf(int)                [PUBLIC]   int

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.completion
@@ -129,7 +129,7 @@ METHOD     isLong()                                   boolean
 METHOD     isNumber()                                 boolean
 METHOD     iterator()                                 Iterator
 METHOD     join(CharSequence, CharSequenc  [STATIC,   String
-METHOD     join(CharSequence, CharSequenc  [STATIC,   String
+METHOD     join(CharSequence, Iterable<Ch  [STATIC,   String
 METHOD     lastIndexOf(String)             [PUBLIC]   int
 METHOD     lastIndexOf(String, int)        [PUBLIC]   int
 METHOD     lastIndexOf(int)                [PUBLIC]   int

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.completion
@@ -129,7 +129,7 @@ METHOD     isLong()                                   boolean
 METHOD     isNumber()                                 boolean
 METHOD     iterator()                                 Iterator
 METHOD     join(CharSequence, CharSequenc  [STATIC,   String
-METHOD     join(CharSequence, CharSequenc  [STATIC,   String
+METHOD     join(CharSequence, Iterable<Ch  [STATIC,   String
 METHOD     lastIndexOf(String)             [PUBLIC]   int
 METHOD     lastIndexOf(String, int)        [PUBLIC]   int
 METHOD     lastIndexOf(int)                [PUBLIC]   int

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/AccessCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/AccessCCTest.java
@@ -26,6 +26,7 @@ public class AccessCCTest extends GroovyCCTestBase {
 
     public AccessCCTest(String testName) {
         super(testName);
+        checkLspCompletion = true;
     }
 
     @Override

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/CamelCaseCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/CamelCaseCCTest.java
@@ -19,6 +19,9 @@
 
 package org.netbeans.modules.groovy.editor.api.completion;
 
+import org.netbeans.modules.csl.api.ElementKind;
+import org.netbeans.modules.csl.api.HtmlFormatter;
+
 /**
  *
  * @author Martin Janicek
@@ -27,8 +30,60 @@ public class CamelCaseCCTest extends GroovyCCTestBase {
 
     public CamelCaseCCTest(String testName) {
         super(testName);
+        checkLspCompletion = true;
     }
 
+    final boolean deprecatedHolder[] = new boolean[1];
+
+    final HtmlFormatter formatter = new HtmlFormatter() {
+        private StringBuilder sb = new StringBuilder();
+
+        @Override
+        public void reset() {
+            sb.setLength(0);
+        }
+
+        @Override
+        public void appendHtml(String html) {
+            sb.append(html);
+        }
+
+        @Override
+        public void appendText(String text, int fromInclusive, int toExclusive) {
+            sb.append(text, fromInclusive, toExclusive);
+        }
+
+        @Override
+        public void emphasis(boolean start) {
+        }
+
+        @Override
+        public void active(boolean start) {
+        }
+
+        @Override
+        public void name(ElementKind kind, boolean start) {
+        }
+
+        @Override
+        public void parameters(boolean start) {
+        }
+
+        @Override
+        public void type(boolean start) {
+        }
+
+        @Override
+        public void deprecated(boolean start) {
+            deprecatedHolder[0] = true;
+        }
+
+        @Override
+        public String getText() {
+            return sb.toString();
+        }
+    };
+    
     @Override
     protected String getTestType() {
         return "camelcase";

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/CodeCompletionTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/CodeCompletionTest.java
@@ -21,21 +21,22 @@ package org.netbeans.modules.groovy.editor.api.completion;
 
 import java.util.Collections;
 import java.util.Set;
-import org.netbeans.modules.groovy.editor.test.GroovyTestBase;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  *
  * @author schmidtm
  */
-public class CodeCompletionTest extends GroovyTestBase {
+public class CodeCompletionTest extends GroovyCCTestBase {
 
     String TEST_BASE = "testfiles/completion/";
 
     public CodeCompletionTest(String testName) {
         super(testName);
-        Logger.getLogger(CompletionHandler.class.getName()).setLevel(Level.FINEST);
+    }
+
+    @Override
+    protected String getTestType() {
+        return ".";
     }
 
     @Override

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/DuplicatesCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/DuplicatesCCTest.java
@@ -24,9 +24,6 @@ package org.netbeans.modules.groovy.editor.api.completion;
  * @author Petr Hejl
  */
 import java.util.Map;
-import org.netbeans.modules.groovy.editor.test.GroovyTestBase;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
@@ -36,13 +33,17 @@ import org.openide.filesystems.FileUtil;
  *
  * @author schmidtm
  */
-public class DuplicatesCCTest extends GroovyTestBase {
+public class DuplicatesCCTest extends GroovyCCTestBase {
 
     String TEST_BASE = "testfiles/completion/duplicates/";
 
     public DuplicatesCCTest(String testName) {
         super(testName);
-        Logger.getLogger(CompletionHandler.class.getName()).setLevel(Level.FINEST);
+    }
+
+    @Override
+    protected String getTestType() {
+        return ".";
     }
 
     protected @Override Map<String, ClassPath> createClassPathsForTest() {

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/FieldCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/FieldCCTest.java
@@ -24,9 +24,7 @@ package org.netbeans.modules.groovy.editor.api.completion;
  * @author schmidtm
  */
 import java.util.Map;
-import org.netbeans.modules.groovy.editor.test.GroovyTestBase;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
@@ -36,13 +34,17 @@ import org.openide.filesystems.FileUtil;
  *
  * @author schmidtm
  */
-public class FieldCCTest extends GroovyTestBase {
+public class FieldCCTest extends GroovyCCTestBase {
 
     String TEST_BASE = "testfiles/completion/field/";
 
     public FieldCCTest(String testName) {
         super(testName);
-        Logger.getLogger(CompletionHandler.class.getName()).setLevel(Level.FINEST);
+    }
+
+    @Override
+    protected String getTestType() {
+        return ".";
     }
 
     // uncomment this to have logging from GroovyLexer
@@ -67,5 +69,4 @@ public class FieldCCTest extends GroovyTestBase {
     public void testFields2() throws Exception {
         checkCompletion(TEST_BASE + "" + "Fields1.groovy", "println \"Hi: $ad^\"", true);
     }
-
 }

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/GroovyCCTestBase.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/GroovyCCTestBase.java
@@ -18,12 +18,28 @@
  */
 package org.netbeans.modules.groovy.editor.api.completion;
 
-import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.swing.text.Document;
+import static junit.framework.TestCase.assertNotNull;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.api.lsp.Completion;
+import org.netbeans.modules.csl.api.CodeCompletionHandler;
+import org.netbeans.modules.csl.api.CompletionProposal;
+import static org.netbeans.modules.csl.api.test.CslTestBase.getCaretOffset;
+import org.netbeans.modules.csl.spi.GsfUtilities;
+import org.netbeans.modules.groovy.editor.api.parser.GroovyLanguage;
+import org.netbeans.modules.groovy.editor.completion.provider.GroovyCompletionCollector;
 import org.netbeans.modules.groovy.editor.test.GroovyTestBase;
+import org.netbeans.spi.lsp.CompletionCollector;
 
 /**
  * Base class for all groovy CC tests, providing various helper methods.
@@ -101,5 +117,243 @@ public abstract class GroovyCCTestBase extends GroovyTestBase {
     private String removeSpuriousCompletionItemsFromDescription(String description) {
         return description.replaceAll("PACKAGE\\s+apple\\s+null\n", "")
                 .replaceAll("PACKAGE\\s+oracle\\s+null\n", "");
+    }
+    
+    protected boolean checkLspCompletion = true;
+    
+    public void checkCompletion(final String file, final String caretLine, final boolean includeModifiers) throws Exception {
+        super.checkCompletion(file, caretLine, includeModifiers);
+        if (checkLspCompletion) {
+            checkLSPCompletion(file, caretLine, includeModifiers);
+        }
+    }
+
+    protected void checkLSPCompletion(String file, final String caretLine, boolean includeModifiers) throws Exception {
+        Completion.Context ctx = new Completion.Context(Completion.TriggerKind.Invoked, null);
+        GroovyCompletionCollector cc = (GroovyCompletionCollector)MimeLookup.getLookup(GroovyLanguage.GROOVY_MIME_TYPE).lookup(CompletionCollector.class);
+        assertNotNull(cc);
+        
+        Document testDoc = GsfUtilities.getDocument(getTestFile(file), true);
+        String content = testDoc.getText(0, testDoc.getLength());
+        final int caretOffset;
+        if (caretLine != null) {
+            caretOffset = getCaretOffset(content, caretLine);
+        } else {
+            caretOffset = -1;
+        }
+        List<Completion> items = new ArrayList<>();
+
+        final boolean deprecatedHolder[] = new boolean[1];
+
+        GroovyCompletionCollector.CompletionTask ct = cc.collectCompletions2(testDoc, caretOffset, ctx, items::add);
+        String desc = describeCompletion(content, caretOffset, true, true, CodeCompletionHandler.QueryType.COMPLETION, items, 
+                ct.getOriginalProposals(), includeModifiers, deprecatedHolder);
+        assertDescriptionApproxMatches(file, desc, true, ".completion");
+    }
+
+    protected void assertDescriptionApproxMatches(String relFilePath, 
+            String description, boolean includeTestName, String ext) throws Exception {
+        super.assertDescriptionMatches(relFilePath, 
+                removeSpuriousCompletionItemsFromDescription(description), includeTestName, ext, true, true);            
+    }    
+    
+    private String getSourceLine(String s, int offset) {
+        int begin = offset;
+        if (begin > 0) {
+            begin = s.lastIndexOf('\n', offset-1);
+            if (begin == -1) {
+                begin = 0;
+            } else if (begin < s.length()) {
+                begin++;
+            }
+        }
+        if (s.length() == 0) {
+            return s;
+        }
+//        s.charAt(offset);
+        int end = s.indexOf('\n', begin);
+        if (end == -1) {
+            end = s.length();
+        }
+
+        if (offset < end) {
+            return (s.substring(begin, offset)+"|"+s.substring(offset,end)).trim();
+        } else {
+            return (s.substring(begin, end) + "|").trim();
+        }
+    }
+    
+    private String getLhs(Completion c) {
+        String text = c.getLabel();
+        int idx = text.indexOf(" : ");
+        if (idx > 0) {
+            return text.substring(0, idx);
+        } else {
+            return text;
+        }
+    }
+
+    private String getRhs(Completion c) {
+        String text = c.getLabel();
+        int idx = text.indexOf(" : ");
+        if (idx > 0) {
+            return text.substring(idx + 3);
+        } else {
+            return null;
+        }
+    }
+
+    private String describeCompletion(String text, int caretOffset, boolean prefixSearch, boolean caseSensitive, CodeCompletionHandler.QueryType type, 
+            List<Completion> proposals,
+            List<CompletionProposal> cslProposals,
+            boolean includeModifiers, boolean[] deprecatedHolder) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Code completion result for source line:\n");
+        String sourceLine = getSourceLine(text, caretOffset);
+        if (sourceLine.length() == 1) {
+            sourceLine = getSourceWindow(text, caretOffset);
+        }
+        sb.append(sourceLine);
+        sb.append("\n(QueryType=" + type + ", prefixSearch=" + prefixSearch + ", caseSensitive=" + caseSensitive + ")");
+        sb.append("\n");
+
+        // Sort to make test more stable
+        Map<Completion, CompletionProposal> m = new HashMap<>();
+        Map<Completion, Integer> indexes = new HashMap<>();
+        for (int idx = 0; idx < proposals.size(); idx++) {
+            Completion c = proposals.get(idx);
+            indexes.put(c, idx);
+            m.put(c, cslProposals.get(idx));
+        }
+        Collections.sort(proposals, new Comparator<Completion>() {
+
+            public int compare(Completion p1, Completion p2) {
+                int idx1 = indexes.get(p1);
+                int idx2 = indexes.get(p2);
+                
+                CompletionProposal cp1 = cslProposals.get(idx1);
+                CompletionProposal cp2 = cslProposals.get(idx2);
+                
+                // Smart items first
+                if (cp1.isSmart() != cp2.isSmart()) {
+                    return cp1.isSmart() ? -1 : 1;
+                }
+
+                if (cp1.getKind() != cp2.getKind()) {
+                    return cp1.getKind().compareTo(cp2.getKind());
+                }
+
+                String p1L = getLhs(p1);
+                String p2L = getLhs(p2);
+
+                if (!p1L.equals(p2L)) {
+                    return p1L.compareTo(p2L);
+                }
+
+                String p1Rhs = getRhs(p1);
+                String p2Rhs = getRhs(p2);
+                if (p1Rhs == null) {
+                    p1Rhs = "";
+                }
+                if (p2Rhs == null) {
+                    p2Rhs = "";
+                }
+                if (!p1Rhs.equals(p2Rhs)) {
+                    return p1Rhs.compareTo(p2Rhs);
+                }
+                return 0;
+            }
+        });
+        
+        boolean isSmart = true;
+        int idx = -1;
+        for (Completion proposal : proposals) {
+            idx++;
+            CompletionProposal cslProposal = m.get(proposal);
+            
+            if (isSmart && !cslProposal.isSmart()) {
+                sb.append("------------------------------------\n");
+                isSmart = false;
+            }
+
+            deprecatedHolder[0] = proposal.getTags() != null && proposal.getTags().contains(Completion.Tag.Deprecated);
+            boolean strike = includeModifiers && deprecatedHolder[0];
+
+            String n;
+            
+            switch (proposal.getKind()) {
+                case Folder: n = "PACKAGE"; break;
+                case Property: n = "PARAMETER"; break;
+                case Function: n = "METHOD"; break;
+                default:
+                   n = proposal.getKind().toString().toUpperCase(); 
+                   break;
+            }
+            int MAX_KIND = 10;
+            if (n.length() > MAX_KIND) {
+                sb.append(n.substring(0, MAX_KIND));
+            } else {
+                sb.append(n);
+                for (int i = n.length(); i < MAX_KIND; i++) {
+                    sb.append(" ");
+                }
+            }
+
+//            if (proposal.getModifiers().size() > 0) {
+//                List<String> modifiers = new ArrayList<String>();
+//                for (Modifier mod : proposal.getModifiers()) {
+//                    modifiers.add(mod.name());
+//                }
+//                Collections.sort(modifiers);
+//                sb.append(modifiers);
+//            }
+
+            sb.append(" ");
+
+            n = getLhs(proposal);
+            int MAX_LHS = 30;
+            if (strike) {
+                MAX_LHS -= 6; // Account for the --- --- strikethroughs
+                sb.append("---");
+            }
+            if (n.length() > MAX_LHS) {
+                sb.append(n.substring(0, MAX_LHS));
+            } else {
+                sb.append(n);
+                for (int i = n.length(); i < MAX_LHS; i++) {
+                    sb.append(" ");
+                }
+            }
+
+            if (strike) {
+                sb.append("---");
+            }
+
+            sb.append("  ");
+
+            if (cslProposal.getModifiers().isEmpty()) {
+                n = "";
+            } else {
+                n = cslProposal.getModifiers().toString();
+            }
+            int MAX_MOD = 9;
+            if (n.length() > MAX_MOD) {
+                sb.append(n.substring(0, MAX_MOD));
+            } else {
+                sb.append(n);
+                for (int i = n.length(); i < MAX_MOD; i++) {
+                    sb.append(" ");
+                }
+            }
+
+            sb.append("  ");
+
+            sb.append(getRhs(proposal));
+            sb.append("\n");
+
+            isSmart = cslProposal.isSmart();
+        }
+
+        return sb.toString();
     }
 }

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/InferenceCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/InferenceCCTest.java
@@ -24,9 +24,7 @@ package org.netbeans.modules.groovy.editor.api.completion;
  * @author Petr Hejl
  */
 import java.util.Map;
-import org.netbeans.modules.groovy.editor.test.GroovyTestBase;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
@@ -36,13 +34,17 @@ import org.openide.filesystems.FileUtil;
  *
  * @author Petr Hejl
  */
-public class InferenceCCTest extends GroovyTestBase {
+public class InferenceCCTest extends GroovyCCTestBase {
 
     String TEST_BASE = "testfiles/completion/inference/";
 
     public InferenceCCTest(String testName) {
         super(testName);
-        Logger.getLogger(CompletionHandler.class.getName()).setLevel(Level.FINEST);
+    }
+
+    @Override
+    protected String getTestType() {
+        return ".";
     }
 
     // uncomment this to have logging from GroovyLexer

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/NewVarsCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/NewVarsCCTest.java
@@ -21,9 +21,7 @@ package org.netbeans.modules.groovy.editor.api.completion;
 
 import java.util.Map;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 import org.netbeans.api.java.classpath.ClassPath;
-import org.netbeans.modules.groovy.editor.test.GroovyTestBase;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -32,14 +30,18 @@ import org.openide.filesystems.FileUtil;
  *
  * @author schmidtm
  */
-public class NewVarsCCTest extends GroovyTestBase {
+public class NewVarsCCTest extends GroovyCCTestBase {
 
     String TEST_BASE = "testfiles/completion/";
     String BASE = TEST_BASE + "newvars/";
 
     public NewVarsCCTest(String testName) {
         super(testName);
-        Logger.getLogger(CompletionHandler.class.getName()).setLevel(Level.FINEST);
+    }
+
+    @Override
+    protected String getTestType() {
+        return ".";
     }
 
     // uncomment this to have logging from GroovyLexer


### PR DESCRIPTION
Groovy support has very open APIs, so virtually anyone can derive from Groovy classes; that made a factory approach used in Java unsuitable - need to support potential alien implementations as well. At the same time I didn't want to expose any further APIs, although it was beneficial to add fields / getters to individual `CompletionItem` subclasses - so I have use package Accessor pattern to create/query the completion items. The accessor interface is hidden in a nonpublic package.

I moved most of the `CompletionHandler` implementation to a nonpublic package, `CompletionHandler` just delegates to it; gives a freedom to add methods for the module's internal consumption / testing.

The `CompletionCollector` implementation just translates original Groovy completion suggestions to the LSP protocol, using some extra information that items produced by `groovy.editor` module have, but alien items may have missed; such items could be eventually ignored on LSP.

The last bunch of changes is a compartor parallel to the one in CSL, which translates `Completion` instances back to textual form. As `Completion` carries less info than `CompletionProposal`, the missing parts are extracted from CompletionProposals - this way the original golden files can be used to verify the contents of LSP completion is the same as contents of editor native completion.

Update: some bugs were filed during impl. Should be fixed, but would typically change the CC for the IDE as well (= test data changes), so I wanted to separate them to separate PRs:
- [NETBEANS-5788](https://issues.apache.org/jira/browse/NETBEANS-5788)
- [NETBEANS-5787](https://issues.apache.org/jira/browse/NETBEANS-5787)
