### PR TITLE
NETBEANS-5143 Fixes Maven web app twice deployment issue

### DIFF
--- a/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/MicroActionsProvider.java
+++ b/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/MicroActionsProvider.java
@@ -104,40 +104,34 @@ public class MicroActionsProvider implements MavenActionsProvider {
     @Override
     public RunConfig createConfigForDefaultAction(String actionName, Project project, Lookup lookup) {
         MicroApplication microApplication = MicroApplication.getInstance(project);
-        if (microApplication == null) {
-            return project.getLookup()
-                    .lookup(J2eeActionsProvider.class)
-                    .createConfigForDefaultAction(actionName, project, lookup);
+        if (microApplication != null) {
+            Preferences pref = getPreferences(project, MicroApplication.class, true);
+            String microVersionText = pref.get(VERSION, "");
+            RunConfig config = actionsProvider.createConfigForDefaultAction(actionName, project, lookup);
+            if (!microVersionText.isEmpty()) {
+                config.setProperty("version.payara", microVersionText);
+            }
+            return config;
         }
-        Preferences pref = getPreferences(project, MicroApplication.class, true);
-        String microVersionText = pref.get(VERSION, "");
-        RunConfig config = actionsProvider.createConfigForDefaultAction(actionName, project, lookup);
-        if(!microVersionText.isEmpty()){
-            config.setProperty("version.payara", microVersionText);
-        }
-        return config;
+        return null;
     }
 
     @Override
     public NetbeansActionMapping getMappingForAction(String actionName, Project project) {
         MicroApplication microApplication = MicroApplication.getInstance(project);
-        if (microApplication == null) {
-            return project.getLookup()
-                .lookup(J2eeActionsProvider.class)
-                .getMappingForAction(actionName, project);
+        if (microApplication != null) {
+            return actionsProvider.getMappingForAction(actionName, project);
         }
-        return actionsProvider.getMappingForAction(actionName, project);
+        return null;
     }
 
     @Override
     public boolean isActionEnable(String action, Project project, Lookup lookup) {
         MicroApplication microApplication = MicroApplication.getInstance(project);
-        if (microApplication == null) {
-            return project.getLookup()
-                    .lookup(J2eeActionsProvider.class)
-                    .isActionEnable(action, project, lookup);
+        if (microApplication != null) {
+            return actionsProvider.isActionEnable(action, project, lookup);
         }
-        return actionsProvider.isActionEnable(action, project, lookup);
+        return false;
     }
 
     @Override

--- a/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/MicroExecutionChecker.java
+++ b/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/MicroExecutionChecker.java
@@ -51,7 +51,7 @@ import org.netbeans.spi.project.ProjectServiceProvider;
         service = {
             ExecutionResultChecker.class,
             PrerequisitesChecker.class
-        }, 
+        },
         projectType = MAVEN_WAR_PROJECT_TYPE
 )
 public class MicroExecutionChecker extends ExecutionChecker {
@@ -87,13 +87,11 @@ public class MicroExecutionChecker extends ExecutionChecker {
         if (microApplication != null) {
             if (BUILD_ACTIONS.contains(config.getActionName())) {
                 microApplication.setBuilding(true, config.getActionName());
-            }else if (RUN_ACTIONS.contains(config.getActionName())) {
+            } else if (RUN_ACTIONS.contains(config.getActionName())) {
                 microApplication.setRunning(true, config.getActionName());
             }
-            return true;
-        } else {
-           return super.checkRunConfig(config);
         }
+        return true;
     }
 
     @Override
@@ -110,8 +108,6 @@ public class MicroExecutionChecker extends ExecutionChecker {
             } else if (RUN_ACTIONS.contains(config.getActionName())) {
                 microApplication.setRunning(false);
             }
-        } else {
-            super.executionResult(config, res, resultCode);
         }
     }
     

--- a/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/MicroProjectHook.java
+++ b/enterprise/payara.micro/src/org/netbeans/modules/fish/payara/micro/project/MicroProjectHook.java
@@ -48,8 +48,6 @@ public class MicroProjectHook extends ProjectHookImpl {
         if (MicroApplication.getInstance(project) != null) {
             addDeployOnSaveManager(project);
             updateMicroIcon();
-        } else {
-            super.projectOpened();
         }
     }
 
@@ -57,8 +55,6 @@ public class MicroProjectHook extends ProjectHookImpl {
     public void projectClosed() {
         if (MicroApplication.getInstance(project) != null) {
             removeDeployOnSaveManager(project);
-        } else {
-            super.projectOpened();
         }
     }
 


### PR DESCRIPTION
Payara Micro Maven tools are built on top of Maven Web Application features and if Micro Application not detected then delegating call to default feature of Web Application. In this PR, the delegation call has been removed which causes the twice deployment for cleaned or newly created project.