### PR TITLE
[NETBEANS-5801] - Add javadoc for JDK 18 early access

### DIFF
--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/platformdefinition/J2SEPlatformDefaultJavadocImpl.java
@@ -66,6 +66,7 @@ public final class J2SEPlatformDefaultJavadocImpl implements J2SEPlatformDefault
         OFFICIAL_JAVADOC.put("15", "https://docs.oracle.com/en/java/javase/15/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("16", "https://docs.oracle.com/en/java/javase/16/docs/api/"); // NOI18N
         OFFICIAL_JAVADOC.put("17", "https://download.java.net/java/early_access/jdk17/docs/api/"); // NOI18N Early access
+        OFFICIAL_JAVADOC.put("18", "https://download.java.net/java/early_access/jdk18/docs/api/"); // NOI18N Early access
     }
 
     @Override


### PR DESCRIPTION
Add entry to the `OFFICIAL_JAVADOC` Map

https://download.java.net/java/early_access/jdk18/docs/api/