### PR TITLE
Improving usability of New from Template in VSNetBeans.

### DIFF
--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
@@ -46,11 +46,17 @@
                 <file name="org-netbeans-modules-maven-newproject-ExistingWizardIterator_hidden"/>
                 <file name="org-netbeans-modules-maven-newproject-MavenWizardIterator_hidden"/>
                 <file name="org-netbeans-modules-maven-newproject-idenative-PomJavaNativeMWI_hidden"/>
+                <file name="org-netbeans-modules-maven-newproject-idenative-SimpleJavaNativeMWI_hidden"/>
                 <file name="org-netbeans-modules-maven-osgi-templates-BundleWizard-create_hidden"/>
                 <file name="org-netbeans-modules-micronaut-newproject-MicronautProjectWizardIterator-MavenMicronautProject_hidden"/>
             </folder>
             <file name="Native_hidden"/>
             <file name="Samples_hidden"/>
+        </folder>
+        <folder name="UnitTests">
+            <file name="EmptyJUnitTest.java_hidden"/>
+            <file name="TestSuite.java_hidden"/>
+            <file name="org-netbeans-modules-junit-ui-wizards-SimpleTestCaseWizardIterator_hidden"/>
         </folder>
         <folder name="XML">
             <file name="XMLCatalog.xml_hidden"/>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/resources/LambdaBody.template
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/resources/LambdaBody.template
@@ -9,6 +9,6 @@ ${default_return_value}     a value returned by the method by default
 ${method_name}              name of the functional interface method
 -->
 <#if method_return_type?? && method_return_type != "void">
-return ${default_return_value};
+return ${default_return_value!"null"};
 <#else>
 </#if>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/resources/OverriddenMethodBody.template
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/resources/OverriddenMethodBody.template
@@ -12,7 +12,7 @@ ${class_name}               qualified name of the enclosing class
 ${simple_class_name}        simple name of the enclosing class
 -->
 <#if method_return_type?? && method_return_type != "void">
-return ${super_method_call};
+return ${super_method_call!"null"};
 <#else>
-${super_method_call};
+${super_method_call!""};
 </#if>

--- a/java/java.lsp.server/nbcode/integration/test/unit/src/org/netbeans/modules/nbcode/integration/VerifySimpleTemplatesTest.java
+++ b/java/java.lsp.server/nbcode/integration/test/unit/src/org/netbeans/modules/nbcode/integration/VerifySimpleTemplatesTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.nbcode.integration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import junit.framework.Test;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+import org.netbeans.api.actions.Editable;
+import org.netbeans.api.actions.Openable;
+import org.netbeans.junit.NbModuleSuite;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.loaders.DataFolder;
+import org.openide.loaders.DataObject;
+
+public class VerifySimpleTemplatesTest extends NbTestCase {
+    private static Logger LOG = Logger.getLogger(VerifySimpleTemplatesTest.class.getName());
+
+    public VerifySimpleTemplatesTest(String name) {
+        super(name);
+    }
+
+    public static Test suite() {
+        String v = System.getProperty("java.version");
+        if (v == null || !v.startsWith("1.8")) {
+            return NbModuleSuite.emptyConfiguration().suite();
+        }
+
+        return NbModuleSuite.emptyConfiguration().
+            clusters("(extide|java).*").
+            enableModules(".*", ".*").
+            honorAutoloadEager(true).
+            failOnException(Level.INFO).
+            addTest(VerifySimpleTemplatesTest.class).
+            suite();
+    }
+
+    public void testAllTemplates() throws IOException {
+        clearWorkDir();
+
+        DataFolder scratch = DataFolder.findFolder(FileUtil.toFileObject(getWorkDir()));
+
+        DataFolder templates = DataFolder.findFolder(FileUtil.getConfigFile("Templates"));
+        List<DataObject> groups = new ArrayList<>();
+        quickPickTemplates(templates, groups);
+
+        List<DataObject> errorneus = new ArrayList<>();
+        int cnt = 0;
+        for (DataObject g : groups) {
+            assertTrue("It is a folder: " + g, g instanceof DataFolder);
+            DataFolder f = (DataFolder) g;
+
+            List<DataObject> simpleTemplates = new ArrayList<>();
+            quickPickTemplates(f, simpleTemplates);
+
+            for (DataObject t : simpleTemplates) {
+                LOG.log(Level.WARNING, "Processing {0}", t.getPrimaryFile().getPath());
+                final DataObject generated = t.createFromTemplate(scratch, "Test" + ++cnt);
+                final FileObject pf = generated.getPrimaryFile();
+                final Editable edit = generated.getLookup().lookup(Editable.class);
+                if (edit != null) {
+                    LOG.log(Level.WARNING, "Editing {0}", pf.getPath());
+                    edit.edit();
+                } else {
+                    Openable open = generated.getLookup().lookup(Openable.class);
+                    if (open != null) {
+                        LOG.log(Level.WARNING, "Opening {0}", pf.getPath());
+                        open.open();
+                    } else {
+                        LOG.log(Level.WARNING, "Cannot open {0}", pf.getPath());
+                    }
+                }
+                if (!pf.isFolder()) {
+                    try {
+                        if (pf.asText().isEmpty()) {
+                            LOG.log(Level.WARNING, "The file is empty {0}", pf.getPath());
+                            errorneus.add(t);
+                        }
+                    } catch (IOException ex) {
+                        LOG.log(Level.WARNING, "Cannot read file " + pf.getPath(), ex);
+                        errorneus.add(t);
+                    }
+                }
+            }
+        }
+        if (errorneus.size() != 0) {
+            fail("Failed to instantiate " + errorneus.size() + " of "+ cnt + " templates:\n" + errorneus);
+        }
+    }
+
+    private void quickPickTemplates(DataFolder f, List<DataObject> collect) {
+        for (DataObject obj : f.getChildren()) {
+            if (obj instanceof DataFolder) {
+                Object o = obj.getPrimaryFile().getAttribute("simple"); // NOI18N
+                if (o == null || Boolean.TRUE.equals(o)) {
+                    collect.add(obj);
+                }
+                continue;
+            }
+            if (obj.isTemplate()) {
+                collect.add(obj);
+            }
+        }
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
@@ -98,10 +98,14 @@ abstract class LspTemplateUI {
         CompletionStage<DataObject> findTemplate = findTemplate(templates, client);
         CompletionStage<Pair<DataFolder, String>> findTargetFolderAndName = findTargetAndName(findTemplate, client, params);
         return findTargetFolderAndName.thenCombine(findTemplate, (targetAndName, source) -> {
+            final String name = targetAndName.second();
+            if (name == null || name.isEmpty()) {
+                throw raise(RuntimeException.class, new UserCancelException());
+            }
             try {
                 DataFolder target = targetAndName.first();
                 Map<String,String> prjParams = new HashMap<>();
-                DataObject newObject = source.createFromTemplate(target, targetAndName.second(), prjParams);
+                DataObject newObject = source.createFromTemplate(target, name, prjParams);
                 return (Object) newObject.getPrimaryFile().toURI().toString();
             } catch (IOException ex) {
                 throw raise(RuntimeException.class, ex);
@@ -299,7 +303,7 @@ abstract class LspTemplateUI {
     }
 
     private static String removeExtensionFromFileName(String nameWithExtension, String templateExtension) {
-        if (nameWithExtension.endsWith('.' + templateExtension)) {
+        if (nameWithExtension != null && nameWithExtension.endsWith('.' + templateExtension)) {
             return nameWithExtension.substring(0, nameWithExtension.length() - templateExtension.length() - 1);
         } else {
             return nameWithExtension;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspTemplateUI.java
@@ -339,12 +339,8 @@ abstract class LspTemplateUI {
             if (display) {
                 String detail = findDetail(obj);
                 final String displayName = n.getDisplayName();
-                String description = n.getShortDescription();
-                if (description != null && description.equals(displayName)) {
-                    description = null;
-                }
                 categories.add(new QuickPickItem(
-                    displayName, description, detail,
+                    displayName, null, detail,
                     false, fo.getNameExt()
                 ));
             }


### PR DESCRIPTION
One complain <!--GR-31888 --> was that it is not possible to cancel the creation of a template. Addressed by 270ec4e. 

Another complain suggested to avoid display _"Unrecognized file"_ obtained from a node short description <!-- GR-32181 --> - addressed by ignoring it in 125b650.

Then there were complains about some templates producing empty files <!-- GR-31337 and GR-31339 --> - as such I wrote a test in c7de9d7 to go through all available templates and verify they lead to non-empty result. Few didn't and those are branded out in 3b3aec0. Moreover some Dušan's templates couldn't be instantiated without providing some variables - fixed in 6bd46cd.
