### PR TITLE
Small LSP fixes

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -329,6 +329,9 @@ public final class Server {
          */
         @Override
         public CompletableFuture<Project[]> asyncOpenSelectedProjects(List<FileObject> projectCandidates) {
+            if (projectCandidates == null || projectCandidates.isEmpty()) {
+                return CompletableFuture.completedFuture(new Project[0]);
+            }
             CompletableFuture<Project[]> f = new CompletableFuture<>();
             SERVER_INIT_RP.post(() -> {
                 asyncOpenSelectedProjects0(f, projectCandidates, true);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -833,9 +833,14 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
             }
         }
 
-        try {
-            JavaSource js = JavaSource.forDocument(doc);
-            if (js != null) {
+        final CompletableFuture<List<Either<Command, CodeAction>>> resultFuture = new CompletableFuture<>();
+        JavaSource js = JavaSource.forDocument(doc);
+        if (js == null) {
+            resultFuture.complete(result);
+            return resultFuture;
+        }
+        BACKGROUND_TASKS.post(() -> {
+            try {
                 js.runUserActionTask(cc -> {
                     cc.toPhase(JavaSource.Phase.RESOLVED);
                     //code generators:
@@ -862,8 +867,8 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                                                     for (ModificationResult.Difference diff : diffs) {
                                                         String newText = diff.getNewText();
                                                         edits.add(new TextEdit(new Range(Utils.createPosition(fileObject, diff.getStartPosition().getOffset()),
-                                                                                         Utils.createPosition(fileObject, diff.getEndPosition().getOffset())),
-                                                                               newText != null ? newText : ""));
+                                                                Utils.createPosition(fileObject, diff.getEndPosition().getOffset())),
+                                                                newText != null ? newText : ""));
                                                     }
                                                     documentChanges.add(Either.forLeft(new TextDocumentEdit(new VersionedTextDocumentIdentifier(Utils.toUri(fileObject), -1), edits)));
                                                 }
@@ -884,14 +889,16 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                         }
                     }
                 }, true);
+            } catch (IOException ex) {
+                //TODO: include stack trace:
+                client.logMessage(new MessageParams(MessageType.Error, ex.getMessage()));
+            } finally {
+                resultFuture.complete(result);
             }
-        } catch (IOException ex) {
-            //TODO: include stack trace:
-            client.logMessage(new MessageParams(MessageType.Error, ex.getMessage()));
-        }
-
-        return CompletableFuture.completedFuture(result);
+        });
+        return resultFuture;
     }
+                
 
     private ConcurrentHashMap<String, Boolean> upToDateTests = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
Two fixes.
1. If the project is not known, thanks to @JaroslavTulach  null check the call proceeds through a series of async calls to finally return an empty array; this change does the same in a short path. I think that with no project, the original code does not wait on any Future from the backlog of projects being opened, so the change should have no impact on the sequence of operations.

2. The commit a2446ef introduced `HintsInvoker` invocation during execution of `codeAction` LSP request; although the request can return an unfinished `CompletableFuture`, which allows the client to issue additional requests through LSP protocol, the impl fully computed the code actions, then returned a `completedFuture`. The change only forks the heavy computation to background, and completes the future at the end of the task.