### PR TITLE
[NETBEANS-5803] Handle Maven projects with https name space.

### DIFF
--- a/apisupport/maven.apisupport/nbproject/project.xml
+++ b/apisupport/maven.apisupport/nbproject/project.xml
@@ -180,7 +180,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.34</specification-version>
+                        <specification-version>1.57</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenPackageModifierImpl.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/MavenPackageModifierImpl.java
@@ -175,7 +175,7 @@ public class MavenPackageModifierImpl implements PackageModifierImplementation {
                         }
                         if (export) {
                             for (String exp : packagesToExport) {
-                                POMExtensibilityElement pack = model.getFactory().createPOMExtensibilityElement(POMQName.createQName("publicPackage"));
+                                POMExtensibilityElement pack = model.getFactory().createPOMExtensibilityElement(POMQName.createQName("publicPackage", true, model.hasSecureNS()));
                                 publicPackages.addExtensibilityElement(pack);
                                 pack.setElementText(exp);
                             }
@@ -234,7 +234,7 @@ public class MavenPackageModifierImpl implements PackageModifierImplementation {
                                 }
                             }
                         }
-                        POMExtensibilityElement toRet = conf.getModel().getFactory().createPOMExtensibilityElement(POMQName.createQName("publicPackages"));
+                        POMExtensibilityElement toRet = conf.getModel().getFactory().createPOMExtensibilityElement(POMQName.createQName("publicPackages", true, p.getModel().hasSecureNS()));
                         conf.addExtensibilityElement(toRet);
                         return toRet;
                     }

--- a/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NBMNativeMWI.java
+++ b/apisupport/maven.apisupport/src/org/netbeans/modules/maven/apisupport/NBMNativeMWI.java
@@ -374,10 +374,10 @@ final class NBMNativeMWI {
                     }
                     Configuration c = model.getFactory().createConfiguration();
                     if (new ComparableVersion(managedPVersion).compareTo(new ComparableVersion(JAR_PLUGIN_VERSION_MANIFEST_CONFIG_CHANGE)) >= 0) {
-                        QName archiveqname = POMQName.createQName("archive", model.getPOMQNames().isNSAware());
+                        QName archiveqname = POMQName.createQName("archive", model.getPOMQNames().isNSAware(), model.hasSecureNS());
                         POMExtensibilityElement archiveelement = model.getFactory().createPOMExtensibilityElement(archiveqname);
                         
-                        QName manifestqname = POMQName.createQName("manifestFile", model.getPOMQNames().isNSAware());
+                        QName manifestqname = POMQName.createQName("manifestFile", model.getPOMQNames().isNSAware(), model.hasSecureNS());
                         POMExtensibilityElement manifestelement = model.getFactory().createPOMExtensibilityElement(manifestqname);
                         manifestelement.setElementText("${project.build.outputDirectory}/META-INF/MANIFEST.MF");
                         archiveelement.addAnyElement(manifestelement, 0);

--- a/enterprise/maven.jaxws/nbproject/project.xml
+++ b/enterprise/maven.jaxws/nbproject/project.xml
@@ -248,7 +248,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.1.1</specification-version>
+                        <specification-version>1.57</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/MavenModelUtils.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/MavenModelUtils.java
@@ -154,7 +154,7 @@ public final class MavenModelUtils {
         POMExtensibilityElement webResources = findChild(config.getConfigurationElements(), "webResources");
         if (webResources == null) {
             webResources = model.getFactory().createPOMExtensibilityElement(
-                    POMQName.createQName("webResources", model.getPOMQNames().isNSAware()));
+                    POMQName.createQName("webResources", model.getPOMQNames().isNSAware(), model.hasSecureNS()));
             config.addExtensibilityElement(webResources);
         }
         //check for resource containing jax-ws-catalog.xml
@@ -250,42 +250,41 @@ public final class MavenModelUtils {
         Configuration config = model.getFactory().createConfiguration();
         exec.setConfiguration(config);
 
-        QName qname = POMQName.createQName("wsdlFiles", model.getPOMQNames().isNSAware()); //NOI18N
+        QName qname = POMQName.createQName("wsdlFiles", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
         POMExtensibilityElement wsdlFiles = model.getFactory().createPOMExtensibilityElement(qname);
         config.addExtensibilityElement(wsdlFiles);
 
         if (packageName != null) {
-            qname = POMQName.createQName("packageName", model.getPOMQNames().isNSAware()); //NOI18N
+            qname = POMQName.createQName("packageName", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
             POMExtensibilityElement packageNameElement = model.getFactory().createPOMExtensibilityElement(qname);
             packageNameElement.setElementText(packageName);
             config.addExtensibilityElement(packageNameElement);
         }
 
-        qname = POMQName.createQName("wsdlFile", model.getPOMQNames().isNSAware()); //NOI18N
+        qname = POMQName.createQName("wsdlFile", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
         POMExtensibilityElement wsdlFile = model.getFactory().createPOMExtensibilityElement(qname);
         wsdlFile.setElementText(wsdlPath);
         wsdlFiles.addExtensibilityElement(wsdlFile);
 
         //adding <vmArgs><vmArg>-Djavax.xml.accessExternalSchema=all</vmArg></vmArgs>; see issue #244891
-        qname = POMQName.createQName("vmArgs", model.getPOMQNames().isNSAware()); //NOI18N
+        qname = POMQName.createQName("vmArgs", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
         POMExtensibilityElement vmArgs = model.getFactory().createPOMExtensibilityElement(qname);
         config.addExtensibilityElement(vmArgs);
 
-        qname = POMQName.createQName("vmArg", model.getPOMQNames().isNSAware()); //NOI18N
+        qname = POMQName.createQName("vmArg", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
         POMExtensibilityElement vmArg = model.getFactory().createPOMExtensibilityElement(qname);
         vmArg.setElementText("-Djavax.xml.accessExternalSchema=all"); //NOI18N
         vmArgs.addExtensibilityElement(vmArg);
 
         if ( originalUrl != null ){
-            qname = POMQName.createQName("wsdlLocation", model.getPOMQNames().
-                    isNSAware()); //NOI18N
+            qname = POMQName.createQName("wsdlLocation", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
             POMExtensibilityElement wsdlLocation = 
                 model.getFactory().createPOMExtensibilityElement(qname);
             wsdlLocation.setElementText(originalUrl);
             config.addExtensibilityElement(wsdlLocation);
         }
 
-        qname = POMQName.createQName("staleFile", model.getPOMQNames().isNSAware()); //NOI18N
+        qname = POMQName.createQName("staleFile", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
         POMExtensibilityElement staleFile = model.getFactory().createPOMExtensibilityElement(qname);
         staleFile.setElementText(STALE_FILE_DIRECTORY+uniqueId+STALE_FILE_EXTENSION);
         config.addExtensibilityElement(staleFile);
@@ -305,7 +304,7 @@ public final class MavenModelUtils {
                 if (execId.equals(exec.getId())) {
                     Configuration config = exec.getConfiguration();
                     if (config != null) {
-                        QName qname = POMQName.createQName("bindingDirectory", model.getPOMQNames().isNSAware()); //NOI18N
+                        QName qname = POMQName.createQName("bindingDirectory", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
                         if (config.getChildElementText(qname) == null) {
                             POMExtensibilityElement bindingDir = model.getFactory().createPOMExtensibilityElement(qname);
                             bindingDir.setElementText("${basedir}/src/jaxws-bindings");
@@ -314,7 +313,7 @@ public final class MavenModelUtils {
                         POMExtensibilityElement bindingFiles =
                                 findChild(config.getConfigurationElements(), "bindingFiles"); //NOI18N
                         if (bindingFiles == null) {
-                            qname = POMQName.createQName("bindingFiles", model.getPOMQNames().isNSAware()); //NOI18N
+                            qname = POMQName.createQName("bindingFiles", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
                             bindingFiles = model.getFactory().createPOMExtensibilityElement(qname);
                             config.addExtensibilityElement(bindingFiles);
                         }
@@ -322,7 +321,7 @@ public final class MavenModelUtils {
                         POMExtensibilityElement bindingFile =
                                 findElementForValue(bindingFiles.getExtensibilityElements(), bindingFilePath);
                         if (bindingFile == null) {
-                            qname = POMQName.createQName("bindingFile", model.getPOMQNames().isNSAware()); //NOI18N
+                            qname = POMQName.createQName("bindingFile", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
                             bindingFile = model.getFactory().createPOMExtensibilityElement(qname);
                             bindingFile.setElementText(bindingFilePath);
                             bindingFiles.addExtensibilityElement(bindingFile);
@@ -575,25 +574,25 @@ public final class MavenModelUtils {
     private static void addResource(POMModel model, POMExtensibilityElement webResources,
             String targetPath, List<String> includes) {
         POMExtensibilityElement res = model.getFactory().createPOMExtensibilityElement(
-                POMQName.createQName("resource", model.getPOMQNames().isNSAware()));
+                POMQName.createQName("resource", model.getPOMQNames().isNSAware(), model.hasSecureNS()));
         webResources.addExtensibilityElement(res);
         POMExtensibilityElement dir = model.getFactory().createPOMExtensibilityElement(
-                POMQName.createQName("directory", model.getPOMQNames().isNSAware()));
+                POMQName.createQName("directory", model.getPOMQNames().isNSAware(), model.hasSecureNS()));
         dir.setElementText("src");
         res.addExtensibilityElement(dir);
 
         POMExtensibilityElement tp = model.getFactory().createPOMExtensibilityElement(POMQName.createQName("targetPath",
-                model.getPOMQNames().isNSAware()));
+                model.getPOMQNames().isNSAware(), model.hasSecureNS()));
         tp.setElementText(targetPath);
         res.addExtensibilityElement(tp);
 
         POMExtensibilityElement in = model.getFactory().createPOMExtensibilityElement(POMQName.createQName("includes",
-                model.getPOMQNames().isNSAware()));
+                model.getPOMQNames().isNSAware(), model.hasSecureNS()));
         res.addExtensibilityElement(in);
 
         for (String includeString : includes) {
             POMExtensibilityElement include = model.getFactory().createPOMExtensibilityElement(POMQName.createQName("include",
-                    model.getPOMQNames().isNSAware()));
+                    model.getPOMQNames().isNSAware(), model.hasSecureNS()));
             include.setElementText(includeString);
             in.addExtensibilityElement(include);
         }

--- a/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/wizards/MavenSchemaCompiler.java
+++ b/enterprise/maven.jaxws/src/org/netbeans/modules/maven/jaxws/wizards/MavenSchemaCompiler.java
@@ -232,22 +232,22 @@ public class MavenSchemaCompiler implements SchemaCompiler {
         Configuration config = model.getFactory().createConfiguration();
         exec.setConfiguration(config);
 
-        QName qname = POMQName.createQName("schemaIncludes", model.getPOMQNames().isNSAware()); //NOI18N
+        QName qname = POMQName.createQName("schemaIncludes", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
         POMExtensibilityElement schemaIncludes = model.getFactory().createPOMExtensibilityElement(qname);
         config.addExtensibilityElement(schemaIncludes);
 
-        qname = POMQName.createQName("include", model.getPOMQNames().isNSAware()); //NOI18N
+        qname = POMQName.createQName("include", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
         POMExtensibilityElement include = model.getFactory().createPOMExtensibilityElement(qname);
         include.setElementText("jaxb/"+id+"/*.xsd"); //NOI18N
         schemaIncludes.addExtensibilityElement(include);
 
-        qname = POMQName.createQName("episodeFile", model.getPOMQNames().isNSAware()); //NOI18N
+        qname = POMQName.createQName("episodeFile", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
         POMExtensibilityElement episodeFile = model.getFactory().createPOMExtensibilityElement(qname);
         episodeFile.setElementText("${project.build.directory}/generated-sources/xjc/META-INF/jaxb-"+id+".episode"); //NOI18N
         config.addExtensibilityElement(episodeFile);
 
         if (packageName != null) {
-            qname = POMQName.createQName("generatePackage", model.getPOMQNames().isNSAware()); //NOI18N
+            qname = POMQName.createQName("generatePackage", model.getPOMQNames().isNSAware(), model.hasSecureNS()); //NOI18N
             POMExtensibilityElement generatePackage = model.getFactory().createPOMExtensibilityElement(qname);
             generatePackage.setElementText(packageName); //NOI18N
             config.addExtensibilityElement(generatePackage);

--- a/ide/xml.xam/apichanges.xml
+++ b/ide/xml.xam/apichanges.xml
@@ -82,7 +82,19 @@ is the proper place.
 
     <!-- ACTUAL CHANGES BEGIN HERE: -->
     <changes>
-        
+
+        <change id="getStatusMessage">
+            <api name="org.netbeans.modules.xml.xam"/>
+            <summary>Method Model.getStatusMessage() is added to provide a message when status is invalid.</summary>
+            <version major="1" minor="45"/>
+            <date day="22" month="6" year="2021"/>
+            <author login="mentlicher"/>
+            <compatibility binary="compatible" source="compatible" addition="yes"/>
+            <description>
+                Introduced default method <code>Model.getStatusMessage()</code> to provide a message when status is invalid.
+            </description>
+            <class package="org.netbeans.modules.xml.xam" name="Model"/>
+        </change>
         <change id="findEndPosition">
             <api name="org.netbeans.modules.xml.xam"/>
             <summary>Method AbstractDocumentModel.prepareChangeInfo() is replaced with a new one.</summary>

--- a/ide/xml.xam/nbproject/project.properties
+++ b/ide/xml.xam/nbproject/project.properties
@@ -18,9 +18,9 @@
 #
 
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-spec.version.base=1.44.0
+spec.version.base=1.45.0
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/xml.xam/src/org/netbeans/modules/xml/xam/Model.java
+++ b/ide/xml.xam/src/org/netbeans/modules/xml/xam/Model.java
@@ -110,6 +110,17 @@ public interface Model<C extends Component<C>> extends Referenceable {
     State getState();
     
     /**
+     * @return a status message describing the error when {@link #getState()} is
+     * not {@link State#VALID}. Can be <code>null</code> when the error is unknown.
+     * The default implementation returns <code>null</code>.
+     *
+     * @since 1.45
+     */
+    default String getStatusMessage() {
+        return null;
+    }
+    
+    /**
      * Be very careful while using this method. It returns only current state
      * and doesn't inform if the transaction has been started by current thread.
      * Only the thread, which owns the transaction can use it and do changes to

--- a/java/maven.grammar/nbproject/project.xml
+++ b/java/maven.grammar/nbproject/project.xml
@@ -183,7 +183,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.1.1</specification-version>
+                        <specification-version>1.57</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven.grammar/src/org/netbeans/modules/maven/navigator/POMModelPanel.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/navigator/POMModelPanel.java
@@ -159,7 +159,7 @@ public class POMModelPanel extends javax.swing.JPanel implements ExplorerManager
                 POMComponent pc = (POMComponent) objs[layer];
                 int pos;
                 if (elementName != null) {
-                    QName qn = POMQName.createQName(elementName, pc.getModel().getPOMQNames().isNSAware());
+                    QName qn = POMQName.createQName(elementName, pc.getModel().getPOMQNames().isNSAware(), pc.getModel().hasSecureNS());
                     NodeList nl = pc.getPeer().getElementsByTagName(qn.getLocalPart());
                     if (nl != null && nl.getLength() > 0) {
                         if (nl.getLength() == 1) {

--- a/java/maven.hints/nbproject/project.xml
+++ b/java/maven.hints/nbproject/project.xml
@@ -146,7 +146,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.26</specification-version>
+                        <specification-version>1.57</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/errors/EnablePreviewMavenProj.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/errors/EnablePreviewMavenProj.java
@@ -202,10 +202,10 @@ public class EnablePreviewMavenProj implements ErrorRule<Void> {
 
             Plugin oldPlugin = searchMavenCompilerPlugin(build);
             if (oldPlugin == null) {
-                build.addPlugin(createMavenCompilerPlugin());
+                build.addPlugin(createMavenCompilerPlugin(model.hasSecureNS()));
             } else {
 
-                Plugin newPlugin = updateMavenCompilerPlugin(oldPlugin);
+                Plugin newPlugin = updateMavenCompilerPlugin(oldPlugin, model.hasSecureNS());
 
                 build.removePlugin(oldPlugin);
                 build.addPlugin(newPlugin);
@@ -225,15 +225,15 @@ public class EnablePreviewMavenProj implements ErrorRule<Void> {
             return null;
         }
 
-        private Plugin createMavenCompilerPlugin() {
+        private Plugin createMavenCompilerPlugin(boolean secureNS) {
             Plugin plugin = factory.createPlugin();
             plugin.setGroupId(MAVEN_COMPILER_GROUP_ID);
             plugin.setArtifactId(MAVEN_COMPILER_ARTIFACT_ID);
             plugin.setVersion(MAVEN_COMPILER_VERSION);
             plugin.setConfiguration(createConfiguration());
             Configuration config = factory.createConfiguration();
-            POMExtensibilityElement compilerArgs = factory.createPOMExtensibilityElement(POMQName.createQName(COMPILER_ARG));
-            compilerArgs.setChildElementText(COMPILER_ID_PROPERTY, ENABLE_PREVIEW_FLAG, POMQName.createQName(ARG));
+            POMExtensibilityElement compilerArgs = factory.createPOMExtensibilityElement(POMQName.createQName(COMPILER_ARG, true, secureNS));
+            compilerArgs.setChildElementText(COMPILER_ID_PROPERTY, ENABLE_PREVIEW_FLAG, POMQName.createQName(ARG, true, secureNS));
             config.addExtensibilityElement(compilerArgs);
             plugin.setConfiguration(config);
             return plugin;
@@ -244,7 +244,7 @@ public class EnablePreviewMavenProj implements ErrorRule<Void> {
             return configuration;
         }
 
-        private Plugin updateMavenCompilerPlugin(final Plugin oldPlugin) {
+        private Plugin updateMavenCompilerPlugin(final Plugin oldPlugin, boolean secureNS) {
 
             Configuration currenConfig = oldPlugin.getConfiguration();
             Configuration newConfiguration = createConfiguration();
@@ -259,8 +259,8 @@ public class EnablePreviewMavenProj implements ErrorRule<Void> {
                     }
                     if (newElement.getQName().getLocalPart().equals(COMPILER_ARG)) {
                         isCompilerArgsElementPresent = true;
-                        POMExtensibilityElement compilerArgs = factory.createPOMExtensibilityElement(POMQName.createQName(COMPILER_ARG));
-                        newElement.setChildElementText(COMPILER_ID_PROPERTY, ENABLE_PREVIEW_FLAG, POMQName.createQName(ARG));
+                        POMExtensibilityElement compilerArgs = factory.createPOMExtensibilityElement(POMQName.createQName(COMPILER_ARG, true, secureNS));
+                        newElement.setChildElementText(COMPILER_ID_PROPERTY, ENABLE_PREVIEW_FLAG, POMQName.createQName(ARG, true, secureNS));
                     }
                     for (POMExtensibilityElement childElement : element.getAnyElements()) {
 
@@ -274,8 +274,8 @@ public class EnablePreviewMavenProj implements ErrorRule<Void> {
 
                 }
                 if (!isCompilerArgsElementPresent) {
-                    POMExtensibilityElement compilerArgs = factory.createPOMExtensibilityElement(POMQName.createQName(COMPILER_ARG));
-                    compilerArgs.setChildElementText(COMPILER_ID_PROPERTY, ENABLE_PREVIEW_FLAG, POMQName.createQName(ARG));
+                    POMExtensibilityElement compilerArgs = factory.createPOMExtensibilityElement(POMQName.createQName(COMPILER_ARG, true, secureNS));
+                    compilerArgs.setChildElementText(COMPILER_ID_PROPERTY, ENABLE_PREVIEW_FLAG, POMQName.createQName(ARG, true, secureNS));
                     newConfiguration.addExtensibilityElement(compilerArgs);
                 }
             }

--- a/java/maven.model/manifest.mf
+++ b/java/maven.model/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven.model/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/model/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.56
+OpenIDE-Module-Specification-Version: 1.57
 

--- a/java/maven.model/src/org/netbeans/modules/maven/model/pom/POMModel.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/pom/POMModel.java
@@ -36,6 +36,8 @@ public abstract class POMModel extends AbstractDocumentModel<POMComponent> {
 
     public abstract POMQNames getPOMQNames();
 
+    public abstract boolean hasSecureNS();
+    
     /**
      * Gets domain-specific root component.
      */

--- a/java/maven.model/src/org/netbeans/modules/maven/model/pom/POMQName.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/pom/POMQName.java
@@ -27,24 +27,41 @@ import javax.xml.namespace.QName;
 public final class POMQName {
 
     public static final String NS_URI = "http://maven.apache.org/POM/4.0.0";  // NOI18N
+    public static final String NSS_URI = "https://maven.apache.org/POM/4.0.0";  // NOI18N
     public static final String NS_PREFIX = "pom";   // NOI18N        
     
-    public static QName createQName(String localName, boolean ns) {
+    public static QName createQName(String localName, boolean ns, boolean secure) {
         if (ns) {
-            return new QName(NS_URI, localName, NS_PREFIX);
+            if (secure) {
+                return new QName(NSS_URI, localName, NS_PREFIX);
+            } else {
+                return new QName(NS_URI, localName, NS_PREFIX);
+            }
         } else {
             return new QName("", localName);
         }
     }
 
+    /**
+     * @deprecated Use {@link #createQName(String, boolean, boolean)}
+     */
+    @Deprecated
+    public static QName createQName(String localName, boolean ns) {
+        return createQName(localName, ns, false);
+    }
+
+    /**
+     * @deprecated Use {@link #createQName(String, boolean, boolean)}
+     */
+    @Deprecated
     public static QName createQName(String localName) {
         return createQName(localName, true);
     }
 
     private final QName qName;
 
-    POMQName(String localName, boolean ns) {
-        qName = createQName(localName, ns);
+    POMQName(String localName, boolean ns, boolean secure) {
+        qName = createQName(localName, ns, secure);
     }
     
     public QName getQName() {

--- a/java/maven.model/src/org/netbeans/modules/maven/model/pom/POMQNames.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/pom/POMQNames.java
@@ -183,157 +183,165 @@ public final class POMQNames {
 
     private final boolean ns;
 
+    /**
+     * @deprecated Use {@link POMQNames(boolean, boolean)}
+     */
+    @Deprecated
     public POMQNames(boolean ns) {
+        this(ns, false);
+    }
+
+    public POMQNames(boolean ns, boolean secure) {
         this.ns = ns;
-        PROJECT = new POMQName("project",ns);
-        PARENT = new POMQName("parent",ns);
-        ORGANIZATION = new POMQName("organization",ns);
-        DISTRIBUTIONMANAGEMENT = new POMQName("distributionManagement",ns);
-        SITE = new POMQName("site",ns);
-        DIST_REPOSITORY = new POMQName("repository",ns);
-        DIST_SNAPSHOTREPOSITORY = new POMQName("snapshotRepository",ns);
-        PREREQUISITES = new POMQName("prerequisites",ns);
-        CONTRIBUTOR = new POMQName("contributor",ns);
-        SCM = new POMQName("scm",ns);
-        ISSUEMANAGEMENT = new POMQName("issueManagement",ns);
-        CIMANAGEMENT = new POMQName("ciManagement",ns);
-        NOTIFIER = new POMQName("notifier",ns);
-        REPOSITORY = new POMQName("repository",ns);
-        PLUGINREPOSITORY = new POMQName("pluginRepository",ns);
-        RELEASES = new POMQName("releases",ns);
-        SNAPSHOTS = new POMQName("snapshots",ns);
-        PROFILE = new POMQName("profile",ns);
-        PLUGIN = new POMQName("plugin",ns);
-        DEPENDENCY = new POMQName("dependency",ns);
-        EXCLUSION = new POMQName("exclusion",ns);
-        EXECUTION = new POMQName("execution",ns);
-        RESOURCE = new POMQName("resource",ns);
-        TESTRESOURCE = new POMQName("testResource",ns);
-        PLUGINMANAGEMENT = new POMQName("pluginManagement",ns);
-        REPORTING = new POMQName("reporting",ns);
-        REPORTPLUGIN = new POMQName("plugin",ns);
-        REPORTSET = new POMQName("reportSet",ns);
-        ACTIVATION = new POMQName("activation",ns);
-        ACTIVATIONPROPERTY = new POMQName("property",ns);
-        ACTIVATIONOS = new POMQName("os",ns);
-        ACTIVATIONFILE = new POMQName("file",ns);
-        ACTIVATIONCUSTOM = new POMQName("custom",ns);
-        DEPENDENCYMANAGEMENT = new POMQName("dependencyManagement",ns);
-        BUILD = new POMQName("build",ns);
-        EXTENSION = new POMQName("extension",ns);
-        LICENSE = new POMQName("license",ns);
-        MAILINGLIST = new POMQName("mailingList",ns);
-        DEVELOPER = new POMQName("developer",ns);
+        PROJECT = new POMQName("project",ns,secure);
+        PARENT = new POMQName("parent",ns,secure);
+        ORGANIZATION = new POMQName("organization",ns,secure);
+        DISTRIBUTIONMANAGEMENT = new POMQName("distributionManagement",ns,secure);
+        SITE = new POMQName("site",ns,secure);
+        DIST_REPOSITORY = new POMQName("repository",ns,secure);
+        DIST_SNAPSHOTREPOSITORY = new POMQName("snapshotRepository",ns,secure);
+        PREREQUISITES = new POMQName("prerequisites",ns,secure);
+        CONTRIBUTOR = new POMQName("contributor",ns,secure);
+        SCM = new POMQName("scm",ns,secure);
+        ISSUEMANAGEMENT = new POMQName("issueManagement",ns,secure);
+        CIMANAGEMENT = new POMQName("ciManagement",ns,secure);
+        NOTIFIER = new POMQName("notifier",ns,secure);
+        REPOSITORY = new POMQName("repository",ns,secure);
+        PLUGINREPOSITORY = new POMQName("pluginRepository",ns,secure);
+        RELEASES = new POMQName("releases",ns,secure);
+        SNAPSHOTS = new POMQName("snapshots",ns,secure);
+        PROFILE = new POMQName("profile",ns,secure);
+        PLUGIN = new POMQName("plugin",ns,secure);
+        DEPENDENCY = new POMQName("dependency",ns,secure);
+        EXCLUSION = new POMQName("exclusion",ns,secure);
+        EXECUTION = new POMQName("execution",ns,secure);
+        RESOURCE = new POMQName("resource",ns,secure);
+        TESTRESOURCE = new POMQName("testResource",ns,secure);
+        PLUGINMANAGEMENT = new POMQName("pluginManagement",ns,secure);
+        REPORTING = new POMQName("reporting",ns,secure);
+        REPORTPLUGIN = new POMQName("plugin",ns,secure);
+        REPORTSET = new POMQName("reportSet",ns,secure);
+        ACTIVATION = new POMQName("activation",ns,secure);
+        ACTIVATIONPROPERTY = new POMQName("property",ns,secure);
+        ACTIVATIONOS = new POMQName("os",ns,secure);
+        ACTIVATIONFILE = new POMQName("file",ns,secure);
+        ACTIVATIONCUSTOM = new POMQName("custom",ns,secure);
+        DEPENDENCYMANAGEMENT = new POMQName("dependencyManagement",ns,secure);
+        BUILD = new POMQName("build",ns,secure);
+        EXTENSION = new POMQName("extension",ns,secure);
+        LICENSE = new POMQName("license",ns,secure);
+        MAILINGLIST = new POMQName("mailingList",ns,secure);
+        DEVELOPER = new POMQName("developer",ns,secure);
 
-        MAILINGLISTS = new POMQName("mailingLists",ns);
-        DEPENDENCIES = new POMQName("dependencies",ns);
-        DEVELOPERS = new POMQName("developers",ns);
-        CONTRIBUTORS = new POMQName("contributors",ns);
-        LICENSES = new POMQName("licenses",ns);
-        PROFILES = new POMQName("profiles",ns);
-        REPOSITORIES = new POMQName("repositories",ns);
-        PLUGINREPOSITORIES = new POMQName("pluginRepositories",ns);
-        EXCLUSIONS = new POMQName("exclusions",ns);
-        EXECUTIONS = new POMQName("executions",ns);
-        PLUGINS = new POMQName("plugins",ns);
-        EXTENSIONS = new POMQName("extensions",ns);
-        RESOURCES = new POMQName("resources",ns);
-        TESTRESOURCES = new POMQName("testResources",ns);
-        REPORTPLUGINS = new POMQName("plugins",ns);
-        REPORTSETS = new POMQName("reportSets",ns);
+        MAILINGLISTS = new POMQName("mailingLists",ns,secure);
+        DEPENDENCIES = new POMQName("dependencies",ns,secure);
+        DEVELOPERS = new POMQName("developers",ns,secure);
+        CONTRIBUTORS = new POMQName("contributors",ns,secure);
+        LICENSES = new POMQName("licenses",ns,secure);
+        PROFILES = new POMQName("profiles",ns,secure);
+        REPOSITORIES = new POMQName("repositories",ns,secure);
+        PLUGINREPOSITORIES = new POMQName("pluginRepositories",ns,secure);
+        EXCLUSIONS = new POMQName("exclusions",ns,secure);
+        EXECUTIONS = new POMQName("executions",ns,secure);
+        PLUGINS = new POMQName("plugins",ns,secure);
+        EXTENSIONS = new POMQName("extensions",ns,secure);
+        RESOURCES = new POMQName("resources",ns,secure);
+        TESTRESOURCES = new POMQName("testResources",ns,secure);
+        REPORTPLUGINS = new POMQName("plugins",ns,secure);
+        REPORTSETS = new POMQName("reportSets",ns,secure);
 
 
-        ID = new POMQName("id",ns);
-        GROUPID = new POMQName("groupId",ns);
-        ARTIFACTID = new POMQName("artifactId",ns);
-        VERSION = new POMQName("version",ns);
-        CONFIGURATION = new POMQName("configuration",ns);
-        PROPERTIES = new POMQName("properties",ns);
+        ID = new POMQName("id",ns,secure);
+        GROUPID = new POMQName("groupId",ns,secure);
+        ARTIFACTID = new POMQName("artifactId",ns,secure);
+        VERSION = new POMQName("version",ns,secure);
+        CONFIGURATION = new POMQName("configuration",ns,secure);
+        PROPERTIES = new POMQName("properties",ns,secure);
 
-        RELATIVEPATH = new POMQName("relativePath",ns);
+        RELATIVEPATH = new POMQName("relativePath",ns,secure);
 
-        MODELVERSION = new POMQName("modelVersion",ns);
-        PACKAGING = new POMQName("packaging",ns);
-        URL = new POMQName("url",ns);
-        NAME = new POMQName("name",ns);
-        DESCRIPTION = new POMQName("description",ns);
-        INCEPTIONYEAR = new POMQName("inceptionYear",ns);
+        MODELVERSION = new POMQName("modelVersion",ns,secure);
+        PACKAGING = new POMQName("packaging",ns,secure);
+        URL = new POMQName("url",ns,secure);
+        NAME = new POMQName("name",ns,secure);
+        DESCRIPTION = new POMQName("description",ns,secure);
+        INCEPTIONYEAR = new POMQName("inceptionYear",ns,secure);
 
-        TYPE = new POMQName("type",ns);
-        CLASSIFIER = new POMQName("classifier",ns);
-        SCOPE = new POMQName("scope",ns);
-        SYSTEMPATH = new POMQName("systemPath",ns);
-        OPTIONAL = new POMQName("optional",ns);
+        TYPE = new POMQName("type",ns,secure);
+        CLASSIFIER = new POMQName("classifier",ns,secure);
+        SCOPE = new POMQName("scope",ns,secure);
+        SYSTEMPATH = new POMQName("systemPath",ns,secure);
+        OPTIONAL = new POMQName("optional",ns,secure);
 
-        INHERITED = new POMQName("inherited",ns);
-        PHASE = new POMQName("phase",ns);
+        INHERITED = new POMQName("inherited",ns,secure);
+        PHASE = new POMQName("phase",ns,secure);
 
-        CIMANAG_SYSTEM = new POMQName("system",ns);
+        CIMANAG_SYSTEM = new POMQName("system",ns,secure);
 
-        DIRECTORY = new POMQName("directory",ns);
-        DEFAULTGOAL = new POMQName("defaultGoal",ns);
-        FINALNAME = new POMQName("finalName",ns);
+        DIRECTORY = new POMQName("directory",ns,secure);
+        DEFAULTGOAL = new POMQName("defaultGoal",ns,secure);
+        FINALNAME = new POMQName("finalName",ns,secure);
 
-        SOURCEDIRECTORY = new POMQName("sourceDirectory",ns);
-        SCRIPTSOURCEDIRECTORY = new POMQName("scriptSourceDirectory",ns);
-        TESTSOURCEDIRECTORY = new POMQName("testSourceDirectory",ns);
-        OUTPUTDIRECTORY = new POMQName("outputDirectory",ns);
-        TESTOUTPUTDIRECTORY = new POMQName("testOutputDirectory",ns);
+        SOURCEDIRECTORY = new POMQName("sourceDirectory",ns,secure);
+        SCRIPTSOURCEDIRECTORY = new POMQName("scriptSourceDirectory",ns,secure);
+        TESTSOURCEDIRECTORY = new POMQName("testSourceDirectory",ns,secure);
+        OUTPUTDIRECTORY = new POMQName("outputDirectory",ns,secure);
+        TESTOUTPUTDIRECTORY = new POMQName("testOutputDirectory",ns,secure);
 
-        EXCLUDEDEFAULTS = new POMQName("excludeDefaults",ns);
+        EXCLUDEDEFAULTS = new POMQName("excludeDefaults",ns,secure);
 
-        VALUE = new POMQName("value",ns);
+        VALUE = new POMQName("value",ns,secure);
 
-        LAYOUT = new POMQName("layout",ns);
+        LAYOUT = new POMQName("layout",ns,secure);
 
-        GOALS = new POMQName("goals",ns);
-        GOAL = new POMQName("goal",ns);
+        GOALS = new POMQName("goals",ns,secure);
+        GOAL = new POMQName("goal",ns,secure);
 
-        MODULES = new POMQName("modules",ns);
-        MODULE = new POMQName("module",ns);
+        MODULES = new POMQName("modules",ns,secure);
+        MODULE = new POMQName("module",ns,secure);
 
-        EXISTS = new POMQName("exists",ns);
-        MISSING = new POMQName("missing",ns);
+        EXISTS = new POMQName("exists",ns,secure);
+        MISSING = new POMQName("missing",ns,secure);
 
-        FAMILY = new POMQName("family",ns);
-        ARCH = new POMQName("arch",ns);
+        FAMILY = new POMQName("family",ns,secure);
+        ARCH = new POMQName("arch",ns,secure);
 
-        TARGETPATH = new POMQName("targetPath",ns);
-        FILTERING = new POMQName("filtering",ns);
-        INCLUDES = new POMQName("includes",ns);
-        INCLUDE = new POMQName("include",ns);
-        EXCLUDES = new POMQName("excludes",ns);
-        EXCLUDE = new POMQName("exclude",ns);
+        TARGETPATH = new POMQName("targetPath",ns,secure);
+        FILTERING = new POMQName("filtering",ns,secure);
+        INCLUDES = new POMQName("includes",ns,secure);
+        INCLUDE = new POMQName("include",ns,secure);
+        EXCLUDES = new POMQName("excludes",ns,secure);
+        EXCLUDE = new POMQName("exclude",ns,secure);
 
-        TAG = new POMQName("tag",ns);
-        CONNECTION = new POMQName("connection",ns);
-        DEVELOPERCONNECTION = new POMQName("developerConnection",ns);
+        TAG = new POMQName("tag",ns,secure);
+        CONNECTION = new POMQName("connection",ns,secure);
+        DEVELOPERCONNECTION = new POMQName("developerConnection",ns,secure);
 
-        SYSTEM = new POMQName("system",ns);
+        SYSTEM = new POMQName("system",ns,secure);
 
-        ORGANIZATIONURL = new POMQName("organizationUrl",ns);
-        EMAIL = new POMQName("email",ns);
-        TIMEZONE = new POMQName("timezone",ns);
+        ORGANIZATIONURL = new POMQName("organizationUrl",ns,secure);
+        EMAIL = new POMQName("email",ns,secure);
+        TIMEZONE = new POMQName("timezone",ns,secure);
         //when adding items here, need to add them to the set below as well.
 
-        SUBSCRIBE = new POMQName("subscribe",ns);
-        UNSUBSCRIBE = new POMQName("unsubscribe",ns);
-        POST = new POMQName("post",ns);
-        ARCHIVE = new POMQName("archive",ns);
+        SUBSCRIBE = new POMQName("subscribe",ns,secure);
+        UNSUBSCRIBE = new POMQName("unsubscribe",ns,secure);
+        POST = new POMQName("post",ns,secure);
+        ARCHIVE = new POMQName("archive",ns,secure);
 
-        DOWNLOADURL = new POMQName("downloadUrl",ns);
+        DOWNLOADURL = new POMQName("downloadUrl",ns,secure);
 
-        MAVEN = new POMQName("maven",ns);
+        MAVEN = new POMQName("maven",ns,secure);
 
-        REPORTS = new POMQName("reports",ns);
-        REPORT = new POMQName("report",ns);
+        REPORTS = new POMQName("reports",ns,secure);
+        REPORT = new POMQName("report",ns,secure);
 
-        ENABLED = new POMQName("enabled",ns);
-        UPDATEPOLICY = new POMQName("updatePolicy",ns);
-        CHECKSUMPOLICY = new POMQName("checksumPolicy",ns);
-        COMMENTS = new POMQName("comments",ns);
-        ROLES = new POMQName("roles",ns);
-        ROLE = new POMQName("role",ns);
+        ENABLED = new POMQName("enabled",ns,secure);
+        UPDATEPOLICY = new POMQName("updatePolicy",ns,secure);
+        CHECKSUMPOLICY = new POMQName("checksumPolicy",ns,secure);
+        COMMENTS = new POMQName("comments",ns,secure);
+        ROLES = new POMQName("roles",ns,secure);
+        ROLE = new POMQName("role",ns,secure);
     }
 
     public boolean isNSAware() {

--- a/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ConfigurationImpl.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ConfigurationImpl.java
@@ -69,7 +69,7 @@ public class ConfigurationImpl extends POMComponentImpl implements Configuration
             }
         }
         if (value != null) {
-            POMExtensibilityElement el = getModel().getFactory().createPOMExtensibilityElement(POMQName.createQName(parameter));
+            POMExtensibilityElement el = getModel().getFactory().createPOMExtensibilityElement(POMQName.createQName(parameter, true, ((POMModel) getModel()).hasSecureNS()));
             el.setElementText(value);
             addExtensibilityElement(el);
         }

--- a/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ElementFactoryRegistry.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/ElementFactoryRegistry.java
@@ -18,16 +18,11 @@
  */
 package org.netbeans.modules.maven.model.pom.impl;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.xml.namespace.QName;
+
 import org.netbeans.modules.maven.model.pom.spi.ElementFactory;
-import org.netbeans.modules.xml.xam.dom.AbstractDocumentModel;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
 
@@ -71,74 +66,14 @@ public class ElementFactoryRegistry {
         }
     }
     
-    public void register(ElementFactory factory) {
+    private void register(ElementFactory factory) {
         for (QName q : factory.getElementQNames()) {
             factories.put(q, factory);
         }
-        resetQNameCache();
-    }
-    
-    public void unregister(ElementFactory fac){
-        for (QName q : fac.getElementQNames()) {
-            factories.remove(q);
-        }
-        resetQNameCache();
     }
     
     public ElementFactory get(QName type) {
         return factories.get(type);
     }
     
-    private Set<Class> knownEmbeddedModelTypes = null;
-    private Set<QName> knownQNames = null;
-    private Set<String> knownNames = null;
-    
-    public void resetQNameCache() {
-        knownEmbeddedModelTypes = null;
-        knownQNames = null;
-        knownNames = null;
-    }
-    
-    public Set<QName> getKnownQNames() {
-        return Collections.unmodifiableSet(knownQNames());
-    }
-    
-    private Set<QName> knownQNames() {
-        if (knownQNames == null) {
-            knownQNames = new HashSet<QName>();
-            for (ElementFactory f : factories.values()) {
-                for (QName q : f.getElementQNames()) {
-                    if (! knownQNames.add(q)) {
-                        String msg = "Duplicate factory for: "+q;
-                        Logger.getLogger(this.getClass().getName()).log(Level.FINE, "getKnownQNames", msg); // NOI18N
-                    }
-                }
-            }
-        }
-        return knownQNames;
-    }
-
-    public Set<String> getKnownElementNames() {
-        return Collections.unmodifiableSet(knownElementNames());
-    }
-    
-    private Set<String> knownElementNames() {
-        if (knownNames == null) {
-            knownNames = new HashSet<String>();
-            for (QName q : knownQNames()) {
-                knownNames.add(q.getLocalPart());
-            }
-        }
-        return knownNames;
-    }
-    
-    public void addEmbeddedModelQNames(AbstractDocumentModel<?> embeddedModel) {
-        if (knownEmbeddedModelTypes == null) {
-            knownEmbeddedModelTypes = new HashSet<>();
-        }
-        if (! knownEmbeddedModelTypes.contains(embeddedModel.getClass())) {
-            knownQNames().addAll(embeddedModel.getQNames());
-            knownNames = null;
-        }
-    }
 }

--- a/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMElementFactoryProvider.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMElementFactoryProvider.java
@@ -36,14 +36,16 @@ import org.w3c.dom.Element;
 @ServiceProvider(service=ElementFactory.class)
 public class POMElementFactoryProvider implements ElementFactory {
 
-    private POMQNames ns = new POMQNames(true);
-    private POMQNames nonns = new POMQNames(false);
+    private POMQNames ns = new POMQNames(true, false);
+    private POMQNames nss = new POMQNames(true, true);
+    private POMQNames nonns = new POMQNames(false, false);
     private Set<QName> all;
 
 
     public POMElementFactoryProvider() {
         all = new HashSet<QName>();
         all.addAll(ns.getElementQNames());
+        all.addAll(nss.getElementQNames());
         all.addAll(nonns.getElementQNames());
     }
 

--- a/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMModelImpl.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/POMModelImpl.java
@@ -32,11 +32,14 @@ import org.w3c.dom.Element;
  */
 public class POMModelImpl extends POMModel {
     
+    private static QName PROJECT_NS = POMQName.createQName("project", true, false); // NOI18N
+    private static QName PROJECT_NSS = POMQName.createQName("project", true, true); // NOI18N
+    private static QName PROJECT = POMQName.createQName("project", false, false); // NOI18N
+
     private POMComponent rootComponent;
     private POMComponentFactory componentFactory;
     private POMQNames pomqnames;
-    private QName PROJECT_NS = POMQName.createQName("project", true); ///NOI18N
-    private QName PROJECT = POMQName.createQName("project", false); ///NOI18N
+    private boolean secureNS = false;
     
     public POMModelImpl(ModelSource source) {
         super(source);
@@ -46,6 +49,11 @@ public class POMModelImpl extends POMModel {
     @Override
     public POMComponent getRootComponent() {
         return rootComponent;
+    }
+
+    @Override
+    public boolean hasSecureNS() {
+        return secureNS;
     }
 
     @Override
@@ -63,10 +71,14 @@ public class POMModelImpl extends POMModel {
         QName q = root == null ? null : AbstractDocumentComponent.getQName(root);
         if (root != null ) {
             if (PROJECT.equals(q)) {
-                pomqnames = new POMQNames(false);
+                pomqnames = new POMQNames(false, false);
                 rootComponent = new ProjectImpl(this, root);
             } else if (PROJECT_NS.equals(q)) {
-                pomqnames = new POMQNames(true);
+                pomqnames = new POMQNames(true, false);
+                rootComponent = new ProjectImpl(this, root);
+            } else if (PROJECT_NSS.equals(q)) {
+                secureNS = true;
+                pomqnames = new POMQNames(true, true);
                 rootComponent = new ProjectImpl(this, root);
             }
         } 

--- a/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PropertiesImpl.java
+++ b/java/maven.model/src/org/netbeans/modules/maven/model/pom/impl/PropertiesImpl.java
@@ -43,17 +43,20 @@ public class PropertiesImpl extends POMComponentImpl implements Properties {
 
     // child elements
 
+    private boolean hasSecureNS() {
+        return ((POMModel) getModel()).hasSecureNS();
+    }
 
     @Override
     public void setProperty(String key, String value) {
-        QName qname = POMQName.createQName(key, getModel().getPOMQNames().isNSAware());
+        QName qname = POMQName.createQName(key, getModel().getPOMQNames().isNSAware(), hasSecureNS());
         setChildElementText(qname.getLocalPart(), value,
                 qname);
     }
 
     @Override
     public String getProperty(String key) {
-        return getChildElementText(POMQName.createQName(key, getModel().getPOMQNames().isNSAware()));
+        return getChildElementText(POMQName.createQName(key, getModel().getPOMQNames().isNSAware(), hasSecureNS()));
     }
 
     @Override
@@ -63,7 +66,7 @@ public class PropertiesImpl extends POMComponentImpl implements Properties {
         for (POMComponent pc : chlds) {
             Element el = pc.getPeer();
             String key = el.getLocalName();
-            String val = getChildElementText(POMQName.createQName(key, getModel().getPOMQNames().isNSAware()));
+            String val = getChildElementText(POMQName.createQName(key, getModel().getPOMQNames().isNSAware(), hasSecureNS()));
             toRet.put(key, val);
         }
         return toRet;

--- a/java/maven.osgi/nbproject/project.xml
+++ b/java/maven.osgi/nbproject/project.xml
@@ -119,7 +119,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.6</specification-version>
+                        <specification-version>1.57</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven.osgi/src/org/netbeans/modules/maven/osgi/templates/ActivatorIterator.java
+++ b/java/maven.osgi/src/org/netbeans/modules/maven/osgi/templates/ActivatorIterator.java
@@ -164,7 +164,7 @@ public class ActivatorIterator implements TemplateWizard.AsynchronousInstantiati
             }
         }
         if (instructions == null) {
-            instructions = mdl.getFactory().createPOMExtensibilityElement(POMQName.createQName(OSGiConstants.PARAM_INSTRUCTIONS, mdl.getPOMQNames().isNSAware()));
+            instructions = mdl.getFactory().createPOMExtensibilityElement(POMQName.createQName(OSGiConstants.PARAM_INSTRUCTIONS, mdl.getPOMQNames().isNSAware(), mdl.hasSecureNS()));
             conf.addExtensibilityElement(instructions);
         }
         elems = instructions.getExtensibilityElements();
@@ -176,7 +176,7 @@ public class ActivatorIterator implements TemplateWizard.AsynchronousInstantiati
             }
         }
         if (activator == null) {
-            activator = mdl.getFactory().createPOMExtensibilityElement(POMQName.createQName(OSGiConstants.BUNDLE_ACTIVATOR, mdl.getPOMQNames().isNSAware()));
+            activator = mdl.getFactory().createPOMExtensibilityElement(POMQName.createQName(OSGiConstants.BUNDLE_ACTIVATOR, mdl.getPOMQNames().isNSAware(), mdl.hasSecureNS()));
             instructions.addExtensibilityElement(activator);
         }
         activator.setElementText(path);

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -369,7 +369,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.4</specification-version>
+                        <specification-version>1.45</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -238,7 +238,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.45</specification-version>
+                        <specification-version>1.57</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven/src/org/netbeans/modules/maven/customizer/CustomizerProviderImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/CustomizerProviderImpl.java
@@ -119,6 +119,8 @@ public class CustomizerProviderImpl implements CustomizerProvider2 {
                "# {0} - project display name",
                "TIT_Project_Properties=Project Properties - {0}", 
                "ERR_MissingPOM=Project's pom.xml file contains invalid xml content. Please fix the file before proceeding.",
+               "# {0} - error message",
+               "ERR_MissingPOMErr=Project''s pom.xml file contains invalid xml content: {0}. Please fix the file before proceeding.",
                "TXT_Unloadable=Project is unloadable, you have to fix the problems before accessing the project properties dialog. Show Problem Resolution dialog?",
                "TIT_Unloadable=Project unlodable"
     })
@@ -136,7 +138,9 @@ public class CustomizerProviderImpl implements CustomizerProvider2 {
             POMModel mdl = init();
             //#171958 start
             if (!mdl.getState().equals(State.VALID)) {
-                NotifyDescriptor nd = new NotifyDescriptor.Message(ERR_MissingPOM(), NotifyDescriptor.ERROR_MESSAGE);
+                String statusMessage = mdl.getStatusMessage();
+                String errMessage = (statusMessage != null) ? ERR_MissingPOMErr(statusMessage) : ERR_MissingPOM();
+                NotifyDescriptor nd = new NotifyDescriptor.Message(errMessage, NotifyDescriptor.ERROR_MESSAGE);
                 DialogDisplayer.getDefault().notify(nd);
                 return;
             }


### PR DESCRIPTION
The Maven project support handles only `http` namespace. It does not count with the secure protocol.
As a result, Micronaut projects, for instance, can not be customized in NetBeans.

This PR improves the error dialog with a message describing the reason why POM wasn't parsed
and adds `https` name space.