### PR TITLE
Support for disabling actions in Maven (used by Micronaut)

### DIFF
--- a/enterprise/micronaut/nbproject/project.xml
+++ b/enterprise/micronaut/nbproject/project.xml
@@ -56,7 +56,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.17</specification-version>
+                        <specification-version>1.18</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/micronaut-actions.xml
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/resources/micronaut-actions.xml
@@ -52,6 +52,45 @@
                         <exec.classpathScope>${classPathScope}</exec.classpathScope>
                     </properties>
                 </action>
+
+                <action>
+                    <actionName>debug</actionName>
+                    <packagings>
+                        <packaging>jar</packaging>
+                    </packagings>
+                </action>
+
+                <action>
+                    <actionName>debug.single.main</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                </action>
+
+
+                <action>
+                    <actionName>debug.test.single</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                </action>
+
+                <action>
+                    <actionName>debug.integration-test.single</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                </action>
+
+                <action>
+                    <actionName>debug.fix</actionName>
+                    <packagings>
+                        <packaging>*</packaging>
+                    </packagings>
+                    <goals>
+                        <goal>compile</goal>
+                    </goals>
+                </action>
             </actions>
         </profile>
     </profiles>

--- a/java/api.maven/manifest.mf
+++ b/java/api.maven/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.api.maven
-OpenIDE-Module-Specification-Version: 1.17
+OpenIDE-Module-Specification-Version: 1.18
 OpenIDE-Module-Localizing-Bundle: org/netbeans/api/maven/Bundle.properties
 AutoUpdate-Show-In-Client: false

--- a/java/api.maven/test/unit/src/META-INF/generated-layer.xml
+++ b/java/api.maven/test/unit/src/META-INF/generated-layer.xml
@@ -33,6 +33,11 @@
                         <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
                         <attr name="resource" stringvalue="nbres:/org/netbeans/api/maven/test-maven-actions.xml"/>
                     </file>
+                    <file name="maven-project-actions2.instance">
+                        <attr name="instanceOf" stringvalue="org.netbeans.spi.project.LookupProvider"/>
+                        <attr name="instanceCreate" methodvalue="org.netbeans.api.maven.MavenActions.forProjectLayer"/>
+                        <attr name="resource" stringvalue="nbres:/org/netbeans/api/maven/test-maven-actions2.xml"/>
+                    </file>
                 </folder>
             </folder>
         </folder>

--- a/java/api.maven/test/unit/src/org/netbeans/api/maven/test-maven-actions.xml
+++ b/java/api.maven/test/unit/src/org/netbeans/api/maven/test-maven-actions.xml
@@ -49,6 +49,11 @@
                         <exec.mainClass>${packageClassName}</exec.mainClass>
                     </properties>
                 </action>
+                <action>
+                    <!-- Since Maven 2.149, one can disable an action, so it is not inherited from the default
+                         configuration. Disabled actions have no goals -->
+                    <actionName>debug</actionName>
+                </action>
             </actions>
         </profile>
     </profiles>

--- a/java/api.maven/test/unit/src/org/netbeans/api/maven/test-maven-actions2.xml
+++ b/java/api.maven/test/unit/src/org/netbeans/api/maven/test-maven-actions2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<actions>
+    <profiles>
+        <profile>
+            <!-- Configuration ID; actions from same configurations will merge -->
+            <id>example2</id>
+            <displayName>Still enabled actions</displayName>
+            <actions>
+            </actions>
+        </profile>
+    </profiles>
+</actions>

--- a/java/maven/apichanges.xml
+++ b/java/maven/apichanges.xml
@@ -83,6 +83,20 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="disable-actions">
+            <api name="general"/>
+            <summary>Plugin-dependent Lookup</summary>
+            <version major="2" minor="149"/>
+            <date day="24" month="6" year="2021"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes" semantic="compatible"/>
+            <description>
+                <p>
+                    Actions can be <b>disabled</b> by the MavenActionsProvider for a configuration.
+                </p>
+            </description>
+            <class name="ActionToGoalUtils" package="org.netbeans.modules.maven.execute"/>
+        </change>
         <change id="plugin-lookup">
             <api name="general"/>
             <summary>Plugin-dependent Lookup</summary>

--- a/java/maven/manifest.mf
+++ b/java/maven/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.maven/2
-OpenIDE-Module-Specification-Version: 2.148
+OpenIDE-Module-Specification-Version: 2.149
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/maven/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/maven/layer.xml
 AutoUpdate-Show-In-Client: false

--- a/java/maven/src/org/netbeans/modules/maven/configurations/M2ConfigProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/configurations/M2ConfigProvider.java
@@ -427,7 +427,13 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
                                         // silently ignore
                                     }
                                     ActionToGoalMapping m = new ActionToGoalMapping();
-                                    ActionToGoalMapping allMappings = ((AbstractMavenActionsProvider) p).getRawMappings();
+                                    ActionToGoalMapping allMappings;
+                                    M2Configuration save = setLocalConfiguration(getDefaultConfig());
+                                    try {
+                                        allMappings = ((AbstractMavenActionsProvider) p).getRawMappings();
+                                    } finally {
+                                        setLocalConfiguration(save);
+                                    }
                                     List<NetbeansActionProfile> profiles = ((AbstractMavenActionsProvider) p).getRawMappings().getProfiles();
                                     for (NetbeansActionProfile p : profiles) {
                                         if (prof.getId().equals(p.getId())) {

--- a/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.form
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.form
@@ -32,7 +32,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-42,0,0,2,-102"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,2,26,0,0,2,-102"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
@@ -345,6 +345,19 @@
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
           <GridBagConstraints gridX="10" gridY="5" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
+        </Constraint>
+      </Constraints>
+    </Component>
+    <Component class="javax.swing.JButton" name="btnDisable">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/maven/customizer/Bundle.properties" key="ActionMappings.btnDisable.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+        <Property name="name" type="java.lang.String" value="" noResource="true"/>
+      </Properties>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="10" gridY="6" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>

--- a/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.maven.customizer;
 
+import java.awt.Color;
 import org.netbeans.modules.maven.runjar.PropertySplitter;
 import java.awt.Component;
 import java.awt.FlowLayout;
@@ -42,7 +43,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
-import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
@@ -332,6 +332,7 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         lblPackagings = new javax.swing.JLabel();
         txtPackagings = new javax.swing.JTextField();
         jButton1 = new javax.swing.JButton();
+        btnDisable = new javax.swing.JButton();
 
         setLayout(new java.awt.GridBagLayout());
 
@@ -576,6 +577,16 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(6, 6, 0, 12);
         add(jButton1, gridBagConstraints);
+
+        org.openide.awt.Mnemonics.setLocalizedText(btnDisable, org.openide.util.NbBundle.getMessage(ActionMappings.class, "ActionMappings.btnDisable.text")); // NOI18N
+        btnDisable.setName(""); // NOI18N
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 10;
+        gridBagConstraints.gridy = 6;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
+        gridBagConstraints.insets = new java.awt.Insets(6, 6, 0, 12);
+        add(btnDisable, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
     
 //GEN-FIRST:event_btnAddActionPerformed
@@ -641,16 +652,42 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         }
     }//GEN-LAST:event_btnRemoveActionPerformed
     
-    private void lstMappingsValueChanged(javax.swing.event.ListSelectionEvent evt) {//GEN-FIRST:event_lstMappingsValueChanged
-        Object obj = lstMappings.getSelectedValue();//GEN-HEADEREND:event_lstMappingsValueChanged
-        if (obj == null) {
-            clearFields();
-        } else {
-            MappingWrapper wr = (MappingWrapper)obj;
-            NetbeansActionMapping mapp = wr.getMapping();
+    private void updateEnabledControls(MappingWrapper wr) {
+        boolean notEmpty = wr != null;
+        boolean enable = notEmpty && !ActionToGoalUtils.isDisabledMapping(wr.getMapping());
+
+        if (enable) {
+            lblGoals.setEnabled(true);
+            lblHint.setEnabled(true);
+            lblPackagings.setEnabled(true);
+            lblProfiles.setEnabled(true);
+            lblProperties.setEnabled(true);
+            
             txtGoals.setEnabled(true);
             epProperties.setEnabled(true);
             txtProfiles.setEnabled(true);
+            cbRecursively.setEnabled(true);
+            cbBuildWithDeps.setEnabled(true);
+            btnAddProps.setEnabled(true);
+            btnDisable.setEnabled(true);
+            if (isGlobal()) {
+                txtPackagings.setEnabled(true);
+            }
+        } else {
+            clearFields();
+        }
+        if (notEmpty) {
+            btnRemove.setEnabled(true);
+        } else {
+            btnRemove.setEnabled(false);
+        }
+    }
+    
+    private void lstMappingsValueChanged(javax.swing.event.ListSelectionEvent evt) {//GEN-FIRST:event_lstMappingsValueChanged
+        MappingWrapper wr = (MappingWrapper)lstMappings.getSelectedValue();
+        updateEnabledControls(wr);
+        if (wr != null) {
+            NetbeansActionMapping mapp = wr.getMapping();
             
             txtGoals.getDocument().removeDocumentListener(goalsListener);
             txtProfiles.getDocument().removeDocumentListener(profilesListener);
@@ -659,7 +696,6 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
             cbBuildWithDeps.removeActionListener(depsListener);
             
             if (isGlobal()) {
-                txtPackagings.setEnabled(true);
                 txtPackagings.getDocument().removeDocumentListener(packagingsListener);
                 txtPackagings.setText(createSpaceSeparatedList(mapp != null ? mapp.getPackagings() : Collections.<String>emptyList()));
                 txtPackagings.getDocument().addDocumentListener(packagingsListener);
@@ -867,12 +903,20 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         txtPackagings.setEnabled(false);
         updateColor(null);
         cbRecursively.setEnabled(false);
+        cbBuildWithDeps.setEnabled(false);
         btnAddProps.setEnabled(false);
+        btnDisable.setEnabled(false);
         if (handle == null) { //only global settings
             jButton1.setEnabled(false);
             jButton1.setIcon(null);
             jButton1.setText(BTN_ShowToolbar());
         }
+        
+        lblGoals.setEnabled(false);
+        lblHint.setEnabled(false);
+        lblPackagings.setEnabled(false);
+        lblProfiles.setEnabled(false);
+        lblProperties.setEnabled(false);
     }
     
     private void updateColor(MappingWrapper wr) {
@@ -909,6 +953,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnAdd;
     private javax.swing.JButton btnAddProps;
+    private javax.swing.JButton btnDisable;
     private javax.swing.JButton btnRemove;
     private javax.swing.JCheckBox cbBuildWithDeps;
     private javax.swing.JCheckBox cbRecursively;
@@ -1013,7 +1058,11 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                 
                 
     }
-    
+
+    @NbBundle.Messages({
+        "# {0} - disabled action name",
+        "FMT_DisabledAction={0} - disabled"
+    })
     private static class Renderer extends DefaultListCellRenderer {
         
     
@@ -1029,6 +1078,10 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                     lbl.setFont(lbl.getFont().deriveFont(Font.BOLD));
                 } else {
                     lbl.setFont(lbl.getFont().deriveFont(Font.PLAIN));
+                }
+                if (ActionToGoalUtils.isDisabledMapping(wr.getMapping())) {
+                    lbl.setForeground(Color.lightGray);
+                    lbl.setText(Bundle.FMT_DisabledAction(lbl.getText()));
                 }
             }
             return supers;

--- a/java/maven/src/org/netbeans/modules/maven/customizer/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/Bundle.properties
@@ -148,3 +148,4 @@ ActionMappings.jButton1.text=Show in Toolbar
 RunJarPanel.txtVMOptions.AccessibleContext.accessibleDescription=VM options
 RunJarPanel.customizeOptionsButton.text=C&ustomize...
 RunJarPanel.wrapCheckBox.text=Wrap text
+ActionMappings.btnDisable.text=&Disable

--- a/java/maven/src/org/netbeans/modules/maven/spi/actions/MavenActionsProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/spi/actions/MavenActionsProvider.java
@@ -22,7 +22,9 @@ package org.netbeans.modules.maven.spi.actions;
 import java.util.Set;
 import org.netbeans.modules.maven.api.execute.RunConfig;
 import org.netbeans.api.project.Project;
+import org.netbeans.modules.maven.execute.ActionToGoalUtils;
 import org.netbeans.modules.maven.execute.model.NetbeansActionMapping;
+import org.netbeans.spi.project.ActionProvider;
 import org.netbeans.spi.project.ProjectServiceProvider;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.ServiceProvider;
@@ -32,6 +34,10 @@ import org.openide.util.lookup.ServiceProvider;
  * implementations of ActionProvider actions.
  * Implementations should be registered in default lookup using {@link ServiceProvider},
  * or since 2.50 may also be registered using {@link ProjectServiceProvider} if applicable to just some packagings.
+ * <p>
+ * <b>Since 2.149</b> the returned {@link NetbeansActionMapping} can be disabled - checked by
+ * {@link ActionToGoalUtils#isDisabledMapping}. Such mapping will override the action that may be even enabled by a farther 
+ * {@link MavenActionsProvider}. The {@link ActionProvider} exported from the project will report such action as disabled.
  * 
  * @author  Milos Kleint
  */


### PR DESCRIPTION
A follow-up to 3004, similar support to **disable project action** in a configuration is now implemented for Maven. The action customizer allows a simple way to disable an action, or to revert the 'disabled' instruction to a default configuration's action mapping.

Micronaut impl was updated to disable Debugs in 'dev mode' (`mn:run`).