### PR TITLE
Temporary configuration takes precedence, does not fire changes.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/configurations/M2ConfigProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/configurations/M2ConfigProvider.java
@@ -260,8 +260,13 @@ public class M2ConfigProvider implements ProjectConfigurationProvider<M2Configur
         M2Configuration _active;
         Collection<M2Configuration> confs;
         Boolean b = inConfigInit.get();
+        _active  = activeOverride.get();
+        if (_active != null) {
+            // explicit temporary override, skip all the 'is still there' & fire change logic.
+            return _active;
+        }
         synchronized (this) {
-            _active = internalActive();
+            _active = active;
             confs = getConfigurations(false);
             String initAct = getInitialActive();
             OUTER: if (initAct != null) {


### PR DESCRIPTION
I overlooked a failing test, merged the erroneous code to the master - sorry :( The failure was caused by [temporarily setting active configuration to `default`](https://github.com/apache/netbeans/blob/master/java/maven/src/org/netbeans/modules/maven/configurations/M2ConfigProvider.java#L431) which caused processing that lead to **permanent** configuration switch. This change skips all processing (comparing to available configs, loading persistent active setting, ...) if the local override is active.