### PR TITLE
Prevent deadlock - Workspace shared IO supports close on input stream.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractLspInputOutputProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractLspInputOutputProvider.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.java.lsp.server.ui;
 
 import java.io.CharArrayReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.Reader;
@@ -144,11 +145,12 @@ public abstract class AbstractLspInputOutputProvider implements InputOutputProvi
             this.err = new PrintWriter(new LspWriter(false));
             Reader in;
             try {
-                in = new InputStreamReader(ioCtx.getStdIn(), "UTF-8") {
+                InputStream is = ioCtx.getStdIn();
+                in = new InputStreamReader(is, "UTF-8") {
                     @Override
                     public void close() throws IOException {
                         // the underlying StreamDecoder would just block on synchronized read(); close the underlying stream.
-                        ioCtx.getStdIn().close();
+                        is.close();
                         super.close();
                     }
                 };

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceContextTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceContextTest.java
@@ -18,25 +18,25 @@
  */
 package org.netbeans.modules.java.lsp.server.protocol;
 
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import org.eclipse.lsp4j.DidChangeConfigurationParams;
-import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
-import org.eclipse.lsp4j.ExecuteCommandParams;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
-import org.eclipse.lsp4j.SymbolInformation;
-import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.services.LanguageClient;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider;
+import org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider.LspIO;
+import org.netbeans.modules.nbcode.integration.LspInputOutputProvider;
+import org.openide.util.Lookup;
+import org.openide.util.test.MockLookup;
 
 public class WorkspaceContextTest {
 
@@ -63,6 +63,44 @@ public class WorkspaceContextTest {
 
         assertEquals("ahoj", msgs.get(0).getMessage());
         assertEquals("there!", msgs.get(1).getMessage());
+    }
+    
+    /**
+     * WorkspaceIOContext is a dead input, but must allow to be close()d, returning -1
+     * from its read().
+     */
+    @Test
+    public void testReadDoesntBlockClose() throws Exception {
+        List<MessageParams> msgs = new ArrayList<>();
+        MockLanguageClient mlc = new MockLanguageClient(msgs);
+        WorkspaceIOContext wc = new WorkspaceIOContext() {
+            @Override
+            protected LanguageClient client() {
+                return mlc;
+            }
+        };
+        
+        //LspIO io = LspIOAccessor.createIO("Test", wc, Lookup.EMPTY);
+        MockLookup.setInstances(wc);
+        AbstractLspInputOutputProvider ioProvider = new LspInputOutputProvider();
+        LspIO lspIo = ioProvider.getIO("Test", true, Lookup.EMPTY);
+
+        Reader inReader = ioProvider.getIn(lspIo); 
+        CountDownLatch closeLatch = new CountDownLatch(1);
+        final Thread readerThread = Thread.currentThread();
+        Executors.newSingleThreadScheduledExecutor().schedule(() -> {
+            inReader.close();
+            closeLatch.countDown();
+            return null;
+        }, 300, TimeUnit.MILLISECONDS);
+        
+        Executors.newSingleThreadScheduledExecutor().schedule(() -> {
+            readerThread.interrupt();
+        }, 1000, TimeUnit.MILLISECONDS);
+        int r = inReader.read();
+        
+        assert r == -1;
+        assertTrue(closeLatch.await(500, TimeUnit.MILLISECONDS));
     }
 
     private static final class MockLanguageClient implements LanguageClient {


### PR DESCRIPTION
When LSP client runs "compile workspace" operation, the (gradle) compiler's I/O is bound to the LSP `WorkspaceIOContext`. Then after Gradle finishes, the `GradleExecutor` thread remains stuck:
```
"exec_Build (3)_1" #51 prio=5 os_prio=0 tid=0x00007f04a1187800 nid=0x67d2 waiting for monitor entry [0x00007f0510afa000]
   java.lang.Thread.State: BLOCKED (on object monitor)
        at sun.nio.cs.StreamDecoder.close(StreamDecoder.java:191)
        - waiting to lock <0x0000000719a499a8> (a org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider$LspIO$1)
        at java.io.InputStreamReader.close(InputStreamReader.java:199)
        at org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider$LspIO$1.close(AbstractLspInputOutputProvider.java:152)
        at org.openide.util.io.ReaderInputStream.close(ReaderInputStream.java:130)
        at org.netbeans.modules.gradle.execute.GradleDaemonExecutor.closeInOutErr(GradleDaemonExecutor.java:348)
        - locked <0x000000071984cba0> (a org.netbeans.modules.gradle.execute.GradleDaemonExecutor)
        at org.netbeans.modules.gradle.execute.GradleDaemonExecutor.run(GradleDaemonExecutor.java:275)
        at org.netbeans.core.execution.RunClassThread.doRun(RunClassThread.java:132)
        at org.netbeans.core.execution.RunClassThread$$Lambda$311/594242913.run(Unknown Source)
        at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
        at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
        at org.netbeans.core.execution.RunClassThread.run(RunClassThread.java:81)
```
since it is waiting on the gradle's input stream to return something that could be eventually forwarded to Gradle build:
```
"DisconnectableInputStream source reader" #54 daemon prio=5 os_prio=0 tid=0x00007f045574b800 nid=0x67dd in Object.wait() [0x00007f0508386000]
   java.lang.Thread.State: WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        at java.lang.Object.wait(Object.java:502)
        at org.netbeans.modules.java.lsp.server.protocol.WorkspaceIOContext$EmptyBlockingInputStream.read(WorkspaceIOContext.java:76)
        - locked <0x00000005cc7bc980> (a org.netbeans.modules.java.lsp.server.protocol.WorkspaceIOContext$EmptyBlockingInputStream)
        at java.io.InputStream.read(InputStream.java:170)
        at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
        at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
        at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
        - locked <0x0000000719a499a8> (a org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider$LspIO$1)
        at sun.nio.cs.StreamDecoder.read0(StreamDecoder.java:127)
        - locked <0x0000000719a499a8> (a org.netbeans.modules.java.lsp.server.ui.AbstractLspInputOutputProvider$LspIO$1)
        at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:112)
        at java.io.InputStreamReader.read(InputStreamReader.java:168)
        at org.openide.util.io.ReaderInputStream.read(ReaderInputStream.java:65)
        at org.openide.util.io.ReaderInputStream.read(ReaderInputStream.java:88)
        at org.gradle.util.DisconnectableInputStream$1.run(DisconnectableInputStream.java:98)
        at java.lang.Thread.run(Thread.java:748)
```
LSP progress handle was not finished released, bcs the GradleExecutor thread did not finish its work (it was blocked). An additional `Cancel` request from LSP client blocked the entire communication:
```
"pool-1-thread-1" #41 prio=5 os_prio=0 tid=0x00007f818c0af800 nid=0x5ee3 waiting for monitor entry [0x00007f8244b25000]
   java.lang.Thread.State: BLOCKED (on object monitor)
        at org.netbeans.modules.gradle.execute.GradleDaemonExecutor.closeInOutErr(GradleDaemonExecutor.java:348)
        - waiting to lock <0x000000072e135f58> (a org.netbeans.modules.gradle.execute.GradleDaemonExecutor)
        at org.netbeans.modules.gradle.execute.GradleDaemonExecutor.cancel(GradleDaemonExecutor.java:368)
        at org.netbeans.modules.progress.spi.InternalHandle.requestCancel(InternalHandle.java:364)
        at org.netbeans.modules.java.lsp.server.protocol.Server$ConsumeWithLookup$1.lambda$consume$0(Server.java:219)
        at org.netbeans.modules.java.lsp.server.protocol.Server$ConsumeWithLookup$1$$Lambda$48/138253834.run(Unknown Source)
        at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
        at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
        at org.netbeans.modules.java.lsp.server.protocol.Server$ConsumeWithLookup$1.consume(Server.java:213)
        at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:194)
        at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:94)
        at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:113)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```
```

This change allows the waiting `InputStream.read()` to return with value -1, that will indicate EOF to the `StreamDecoder` and releases the waiting `DisconnectableInputStream` thread; that also allows `close()` to complete on that stream.
