### PR TITLE
Exported more packages to allow transformation loading, prevents Linkage errors

### DIFF
--- a/groovy/groovy.editor/nbproject/project.xml
+++ b/groovy/groovy.editor/nbproject/project.xml
@@ -258,7 +258,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>2.11</specification-version>
+                        <specification-version>2.12</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/PathFinderVisitor.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/PathFinderVisitor.java
@@ -260,13 +260,7 @@ public class PathFinderVisitor extends ClassCodeVisitorSupport {
     @Override
     public void visitMethodCallExpression(MethodCallExpression node) {
         if (isInside(node, line, column)) {
-            // FIXME http://jira.codehaus.org/browse/GROOVY-3263
-            if (node.isImplicitThis()) {
-                node.getMethod().visit(this);
-                node.getArguments().visit(this);
-            } else {
                 super.visitMethodCallExpression(node);
-            }
         }
     }
 

--- a/groovy/libs.groovy/manifest.mf
+++ b/groovy/libs.groovy/manifest.mf
@@ -3,5 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.libs.groovy
 OpenIDE-Module-Layer: org/netbeans/modules/libs/groovy/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/libs/groovy/Bundle.properties
-OpenIDE-Module-Specification-Version: 2.11
+OpenIDE-Module-Specification-Version: 2.12
 

--- a/groovy/libs.groovy/nbproject/project.xml
+++ b/groovy/libs.groovy/nbproject/project.xml
@@ -29,8 +29,7 @@
                 <friend>org.netbeans.modules.groovy.editor</friend>
                 <friend>org.netbeans.modules.groovy.refactoring</friend>
                 <friend>org.netbeans.modules.groovy.support</friend>
-                <package>groovy.lang</package>
-                <package>groovy.lang.groovydoc</package>
+                <subpackages>groovy</subpackages>
                 <package>groovyjarjarantlr</package>
                 <package>groovyjarjarasm.asm</package>
                 <package>org.codehaus.groovy</package>
@@ -41,15 +40,19 @@
                 <package>org.codehaus.groovy.ast.stmt</package>
                 <package>org.codehaus.groovy.ast.tools</package>
                 <package>org.codehaus.groovy.classgen</package>
+                <package>org.codehaus.groovy.classgen.asm</package>
                 <package>org.codehaus.groovy.control</package>
                 <package>org.codehaus.groovy.control.customizers</package>
                 <package>org.codehaus.groovy.control.customizers.builder</package>
+                <package>org.codehaus.groovy.control.io</package>
                 <package>org.codehaus.groovy.control.messages</package>
                 <package>org.codehaus.groovy.reflection</package>
                 <package>org.codehaus.groovy.runtime</package>
                 <package>org.codehaus.groovy.runtime.callsite</package>
                 <package>org.codehaus.groovy.syntax</package>
                 <package>org.codehaus.groovy.transform</package>
+                <package>org.codehaus.groovy.transform.sc</package>
+                <package>org.codehaus.groovy.transform.trait</package>
                 <package>org.codehaus.groovy.transform.stc</package>
             </friend-packages>
             <class-path-extension>


### PR DESCRIPTION
Packages of transformers were not exported from groovy lib; Groovy delegates to `TransformationClassloader` from groovy.editor to load transformers / extensions, but that one did not see neither transformers (from groovy core) or the extension ones in the module classloaders, so it delegated to URL classloader loading from user project's dependencies. But those extensions then attempted to use types from Groovy core (already loaded by module classloader), and loaded them again using the TransformationClassloader. CCE occured.
Whole Groovy API must be exported; the additions are more or less trial-and-error except the `subpackage` as the whole `groovy.`  subtree seems to be used by extensions.