### PR TITLE
[NETBEANS-5768] Recognize gradle projects with settings.gradle only file

### DIFF
--- a/ergonomics/ide.ergonomics/groovy.properties
+++ b/ergonomics/ide.ergonomics/groovy.properties
@@ -17,4 +17,3 @@
 
 mainModule=org.netbeans.modules.groovy.kit
 project.xpath.nbproject/project.xml=project/configuration/buildExtensions/extension[@id='groovy']
-project.file.build.gradle=org.netbeans.modules.gradle.NbGradleProjectFactory

--- a/ergonomics/ide.ergonomics/java.properties
+++ b/ergonomics/ide.ergonomics/java.properties
@@ -18,6 +18,8 @@
 project.file.pom.xml=org.netbeans.modules.maven.NbMavenProjectFactory
 project.file.../java.base/share/classes/java/lang/Object.java=org.netbeans.modules.java.openjdk.project.JDKProject$JDKProjectFactory
 project.file.mx.*/suite.py=org.netbeans.modules.java.mx.project.SuiteFactory
+project.file.build.gradle=org.netbeans.modules.gradle.NbGradleProjectFactory
+project.file.settings.gradle=org.netbeans.modules.gradle.NbGradleProjectFactory
 projectImporter=Eclipse
 
 mainModule=org.netbeans.modules.java.kit

--- a/ergonomics/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/DynamicVerifyTest.java
+++ b/ergonomics/ide.ergonomics/test/unit/src/org/netbeans/modules/ide/ergonomics/DynamicVerifyTest.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.ide.ergonomics;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import junit.framework.Test;
@@ -186,12 +187,13 @@ public class DynamicVerifyTest extends NbTestCase {
             if (f.getClass().getPackage().getName().equals("org.netbeans.modules.ide.ergonomics.fod")) {
                 continue;
             }
-            sb.append(f.getClass().getName());
+            final String cname = f.getClass().getName();
+            sb.append(cname);
             if (info != null) {
                 Object more = info.invoke(f);
                 sb.append(" info: ").append(more);
                 Object value = all.get(more);
-                if (f.getClass().getName().equals(value)) {
+                if (cname.equals(value)) {
                     sb.append(" OK");
                     all.remove(more);
                 } else {
@@ -199,10 +201,10 @@ public class DynamicVerifyTest extends NbTestCase {
                     all.put("FAIL", more.toString());
                 }
             } else {
-                if (all.values().remove(f.getClass().getName())) {
+                if (removeAllValues(all, cname)) {
                     sb.append(" OK");
                 } else {
-                    all.put("FAIL", f.getClass().getName());
+                    all.put("FAIL", cname);
                     sb.append(" not present");
                 }
             }
@@ -216,6 +218,19 @@ public class DynamicVerifyTest extends NbTestCase {
         for (Map.Entry<String, String> entry : all.entrySet()) {
             sb.append("\nNot processed: ").append(entry.getKey()).append(" = ").append(entry.getValue());
         }
+    }
+
+    private static boolean removeAllValues(Map<String, String> all, final String cname) {
+        boolean found = false;
+        Iterator<Map.Entry<String, String>> it = all.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, String> en = it.next();
+            if (cname.equals(en.getValue())) {
+                it.remove();
+                found = true;
+            }
+        }
+        return found;
     }
 
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/GradleFiles.java
@@ -22,7 +22,7 @@ package org.netbeans.modules.gradle.spi;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
@@ -222,11 +222,17 @@ public final class GradleFiles implements Serializable {
     }
 
     public boolean isProject() {
-        boolean ret = knownProject || (buildScript != null);
-        if (!ret && (settingsScript != null)) {
-            ret = SettingsFile.getSubProjects(settingsScript).contains(projectDir);
+        if (knownProject || buildScript != null) {
+            return true;
         }
-        return ret;
+        if (settingsScript != null) {
+            if (projectDir.equals(settingsScript.getParentFile())) {
+                return true;
+            }
+            Set<File> parsed = SettingsFile.getSubProjects(settingsScript);
+            return parsed.contains(projectDir); 
+        }
+        return false;
     }
 
     /**
@@ -354,7 +360,7 @@ public final class GradleFiles implements Serializable {
             Map<String, String> projectPaths = new HashMap<>();
             String rootDir = f.getParentFile().getAbsolutePath();
             try {
-                List<String> lines = Files.readAllLines(f.toPath(), Charset.forName("UTF-8")); //NOI18N
+                List<String> lines = Files.readAllLines(f.toPath(), StandardCharsets.UTF_8);
                 for (String line : lines) {
                     line = line.trim();
                     if (!line.startsWith("//")) { //NOI18N

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectFactoryTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/NbGradleProjectFactoryTest.java
@@ -18,6 +18,8 @@
  */
 package org.netbeans.modules.gradle;
 
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -114,6 +116,22 @@ public class NbGradleProjectFactoryTest extends AbstractGradleProjectTestCase {
 
         assertFalse("Pom wins on settings", NbGradleProjectFactory.isProjectCheck(prj, true));
         assertTrue("Gradle wins on parent build.gradle", NbGradleProjectFactory.isProjectCheck(prj, false));
+    }
+
+    public void testGradle70JavaInit() throws Exception {
+        FileObject parentPrj = root;
+        FileObject settings = FileUtil.createData(parentPrj, "settings.gradle");
+        try (OutputStream os = settings.getOutputStream()) {
+            os.write(("\n"
+                    + "rootProject.name = 'example'\n"
+                    + "include('app')\n"
+            ).getBytes(StandardCharsets.UTF_8));
+        }
+        FileObject app = FileUtil.createFolder(parentPrj, "app");
+        FileObject gradle = FileUtil.createData(app, "build.gradle");
+
+        assertTrue("Parent Gradle recognized", NbGradleProjectFactory.isProjectCheck(parentPrj, false));
+        assertTrue("Child Gradle recognized", NbGradleProjectFactory.isProjectCheck(app, false));
     }
 
 }

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/spi/GradleFilesTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/spi/GradleFilesTest.java
@@ -83,6 +83,15 @@ public class GradleFilesTest {
     }
 
     @Test
+    public void testGetBuildScript5() throws IOException {
+        File settings = root.newFile("settings.gradle");
+        GradleFiles gf = new GradleFiles(settings.getParentFile());
+        assertEquals("It is project", true, gf.isProject());
+        assertEquals("It has settings", settings, gf.getSettingsScript());
+        assertNull("No build script", gf.getBuildScript());
+    }
+
+    @Test
     public void testGetBuildScriptKotlin() throws IOException {
         File build = root.newFile("build.gradle.kts");
         GradleFiles gf = new GradleFiles(root.getRoot());

--- a/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
@@ -641,11 +641,13 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
             }
         }
        
-        //#195039
-        builder.environment().put("M2_HOME", mavenHome.getAbsolutePath());
-        if (!mavenHome.equals(EmbedderFactory.getDefaultMavenHome())) {
-            //only relevant display when using the non-default maven installation.
-            display.append(Utilities.escapeParameters(new String[] {"M2_HOME=" + mavenHome.getAbsolutePath()})).append(' '); // NOI18N
+        if (mavenHome != null) {
+            //#195039
+            builder.environment().put("M2_HOME", mavenHome.getAbsolutePath());
+            if (!mavenHome.equals(EmbedderFactory.getDefaultMavenHome())) {
+                //only relevant display when using the non-default maven installation.
+                display.append(Utilities.escapeParameters(new String[] {"M2_HOME=" + mavenHome.getAbsolutePath()})).append(' '); // NOI18N
+            }
         }
 
         // hide the bypass command and output the command as it used to be (before the bypass command was added)
@@ -743,6 +745,9 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
         //TEMP 
         String mavenPath = clonedConfig.getProperties().get(CosChecker.MAVENEXTCLASSPATH);
         File jar = InstalledFileLocator.getDefault().locate("maven-nblib/netbeans-eventspy.jar", "org.netbeans.modules.maven", false);
+        if (jar == null) {
+            return;
+        }
         if (mavenPath == null) {
             mavenPath = "";
         } else {

--- a/java/maven/src/org/netbeans/modules/maven/newproject/ArchetypeTemplateHandler.java
+++ b/java/maven/src/org/netbeans/modules/maven/newproject/ArchetypeTemplateHandler.java
@@ -58,7 +58,7 @@ public final class ArchetypeTemplateHandler extends CreateFromTemplateHandler {
         "MSG_NoGroupId=No groupId attribute specified for the Maven project",
     })
     @Override
-    protected List<FileObject> createFromTemplate(CreateDescriptor desc) throws IOException {
+    public List<FileObject> createFromTemplate(CreateDescriptor desc) throws IOException {
         Properties archetype = new Properties();
         try (InputStream is = desc.getTemplate().getInputStream()) {
             archetype.load(is);
@@ -85,7 +85,7 @@ public final class ArchetypeTemplateHandler extends CreateFromTemplateHandler {
         arch.setVersion(archetype.getProperty("archetypeVersion")); // NOI18N
         File projDir = desc.getValue(CommonProjectActions.PROJECT_PARENT_FOLDER);
         if (projDir == null) {
-            projDir = FileUtil.toFile(desc.getTarget()).getParentFile();
+            projDir = FileUtil.toFile(desc.getTarget());
         }
         if (projDir == null) {
             throw new IOException(CommonProjectActions.PROJECT_PARENT_FOLDER + " not specified");

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/newproject/ArchetypeCreateTest.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/newproject/ArchetypeCreateTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.maven.newproject;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import junit.framework.Test;
+import org.netbeans.api.templates.CreateDescriptor;
+import org.netbeans.api.templates.FileBuilder;
+import org.netbeans.junit.NbModuleSuite;
+import org.netbeans.junit.NbTestCase;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public final class ArchetypeCreateTest extends NbTestCase {
+
+    public ArchetypeCreateTest(String name) {
+        super(name);
+    }
+
+    public static Test suite() {
+        return NbModuleSuite.createConfiguration(ArchetypeCreateTest.class).gui(false).suite();
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        clearWorkDir();
+    }
+
+    public void testCreatingAnArchetype() throws Exception {
+        FileObject root = FileUtil.toFileObject(getWorkDir());
+
+        final FileObject template = root.createData("template.txt");
+        try (OutputStream os = template.getOutputStream()) {
+            os.write(("\n"
+                    + "archetypeArtifactId=maven-archetype-quickstart\n"
+                    + "archetypeGroupId=org.apache.maven.archetypes\n"
+                    + "archetypeVersion=1.4\n"
+                    + "\n").getBytes(StandardCharsets.UTF_8));
+        }
+
+        final FileObject targetFolder = root.createFolder("targetFolder");
+
+        CreateDescriptor desc = new FileBuilder(template, targetFolder).
+                param("artifactId", "myprj").
+                param("groupId", "org.netbeans.test").
+                createDescriptor(true);
+
+        ArchetypeTemplateHandler cftg = new ArchetypeTemplateHandler();
+        List<FileObject> out = cftg.createFromTemplate(desc);
+
+        assertEquals("One dir: " + out, 1, out.size());
+        assertEquals("Creates in right folder", targetFolder, out.get(0).getParent());
+    }
+}


### PR DESCRIPTION
[NETBEANS-5768](https://issues.apache.org/jira/browse/NETBEANS-5768) reports that our Gradle support isn't able to properly recognize
```bash
gradle init --type java-application --test-framework junit-jupiter --dsl groovy --package com.example --project-name example
```
This PR fixes that. It also moves the Ergonomics registration of Gradle build scripts to `java` cluster - it is my understanding that groovy support isn't required when dealing with Gradle anymore.
