### PR TITLE
Source/javadoc attacher must report download actions as enabled.

### DIFF
--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/JavaActionProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/JavaActionProvider.java
@@ -54,6 +54,17 @@ public class JavaActionProvider extends DefaultGradleActionsProvider {
     private static final String GATLING_PLUGIN = "com.github.lkishalmi.gatling"; //NOI18N
     private static final String SIMULATION_POSTFIX = "Simulation.scala"; //NOI18N
 
+    /**
+     * Name of the 'download.sources' standard action
+     */
+    public static final String COMMAND_DL_SOURCES = "download.sources"; //NOI18N
+
+    /**
+     * Name of the 'download.javadoc' standard action
+     */
+    public static final String COMMAND_DL_JAVADOC = "download.javadoc"; //NOI18N
+
+
     private static final String[] SUPPORTED = new String[]{
         COMMAND_BUILD,
         COMMAND_CLEAN,
@@ -71,6 +82,9 @@ public class JavaActionProvider extends DefaultGradleActionsProvider {
         COMMAND_DEBUG_SINGLE,
         COMMAND_COMPILE_SINGLE,
         COMMAND_DELETE,
+        
+        COMMAND_DL_JAVADOC,
+        COMMAND_DL_SOURCES
     };
 
     public JavaActionProvider() {

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceAttacherImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceAttacherImpl.java
@@ -39,6 +39,7 @@ import org.netbeans.modules.gradle.api.GradleBaseProject;
 import org.netbeans.modules.gradle.api.GradleDependency.ModuleDependency;
 import org.netbeans.modules.gradle.api.GradleProjects;
 import org.netbeans.modules.gradle.api.execute.RunUtils;
+import org.netbeans.modules.gradle.java.JavaActionProvider;
 import org.netbeans.spi.java.queries.SourceJavadocAttacherImplementation;
 import org.netbeans.spi.project.ActionProgress;
 import org.netbeans.spi.project.ActionProvider;
@@ -46,6 +47,7 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ServiceProvider;
@@ -68,12 +70,12 @@ public class GradleSourceAttacherImpl implements SourceJavadocAttacherImplementa
     /**
      * Name of the 'download.sources' standard action
      */
-    private static final String COMMAND_DL_SOURCES = "download.sources"; //NOI18N
+    private static final String COMMAND_DL_SOURCES = JavaActionProvider.COMMAND_DL_SOURCES;
 
     /**
      * Name of the 'download.javadoc' standard action
      */
-    private static final String COMMAND_DL_JAVADOC = "download.javadoc"; //NOI18N
+    private static final String COMMAND_DL_JAVADOC = JavaActionProvider.COMMAND_DL_JAVADOC;
 
     /**
      * Caches last queried URL. The workflow is to filter Definers that work with the given URL
@@ -297,11 +299,15 @@ public class GradleSourceAttacherImpl implements SourceJavadocAttacherImplementa
             }
             // assume the action is invoked asynchronously.
             try {
-                ap.invokeAction(command, 
-                        Lookups.fixed(
+                Lookup ctx = Lookups.fixed(
                                 this,
                                 RunUtils.simpleReplaceTokenProvider(REQUESTED_COMPONENT, dep.getId())
-                        ));
+                );
+                if (ap.isActionEnabled(command, ctx)) {
+                    // disabled action will not even report action end through the Listener.
+                    return false;
+                }
+                ap.invokeAction(command, ctx);
             } catch (IllegalArgumentException ex) {
                 // since we cannot test whether action exists / is enabled, catch the exception
                 // if the action is really unsupported


### PR DESCRIPTION
As part of work on 'Continuous' gradle mode, the infrastructure started to test actions for `isEnabled()` before actually invoking them. That broke source+javadoc attacher introduced in 12.4, that downloads sources/javadocs for the user - the java code never reported the actions as 'enabled', but carried them out anyway. And to be even better, the attacher relied on ActionProgress to report `finished` which never happened, since gradle's `ActionProviderImpl` returned silently without reporting anything if the client invoked a disabled action.
As a result, the Attacher blocked, the user needs to cancel it from the UI (or will run indefinitely if run headless).