### PR TITLE
Avoid NPEs when Finder returns DeclarationLocation.NONE or no FObject.

### DIFF
--- a/ide/api.lsp/src/org/netbeans/api/lsp/HyperlinkLocation.java
+++ b/ide/api.lsp/src/org/netbeans/api/lsp/HyperlinkLocation.java
@@ -152,7 +152,7 @@ public final class HyperlinkLocation {
             List<HyperlinkLocation> locations = new ArrayList<>(futures.length);
             for (CompletableFuture<HyperlinkLocation> future : futures) {
                 HyperlinkLocation location = future.getNow(null);
-                if (location != null) {
+                if (location != null && location.getFileObject() != null) {
                     locations.add(location);
                 }
             }

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/GoToSupport.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/hyperlink/GoToSupport.java
@@ -98,7 +98,8 @@ public class GoToSupport {
     public static CompletableFuture<HyperlinkLocation> getGoToLocation(final Document doc, final int offset) {
         DeclarationLocation[] location = new DeclarationLocation[1];
         perform(doc, offset, false, location, new AtomicBoolean());
-        return CompletableFuture.completedFuture(location[0] == null ? null : HyperlinkLocationProvider.createHyperlinkLocation(location[0].getFileObject(), location[0].getOffset(), location[0].getOffset()));
+        return CompletableFuture.completedFuture(location[0] == null || location[0] == DeclarationLocation.NONE ? 
+                null : HyperlinkLocationProvider.createHyperlinkLocation(location[0].getFileObject(), location[0].getOffset(), location[0].getOffset()));
     }
 
     private static String perform(final Document doc, final int offset, final boolean tooltip, final DeclarationLocation[] location, final AtomicBoolean cancel) {


### PR DESCRIPTION
2nd attempt to fix NPEs thrown to LSP client when hovering over source code. The DeclarationFinder sometimes returns DeclarationLocation.NONE (i.e. erroneous annotation in Groovy source), which gets reported through the CompletableFutures and fails later as it contains `null` FileObject.
