### PR TITLE
Fix Three NPEs

### DIFF
--- a/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/WebServicePersistenceManager.java
+++ b/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/WebServicePersistenceManager.java
@@ -96,8 +96,9 @@ public class WebServicePersistenceManager implements ExceptionListener {
                         ErrorManager.getDefault().notify(exc);
                         decoder.close();
                     }
-
-                    wsDatas.add(wsData);
+                    if (wsData != null) {
+                        wsDatas.add(wsData);
+                    }
                 }
                 int wsGroupSize = ((Integer) decoder.readObject()).intValue();
                 Map<String, WebServiceGroup> groupByIds = new HashMap<String, WebServiceGroup>();

--- a/ide/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java
+++ b/ide/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java
@@ -154,6 +154,7 @@ public abstract class TokenInputUtils {
                 return t.getOffset () + t.getLength ();
             } else {
                 t = (ASTToken) next (1);
+                if (t == null) return 0;
                 return t.getOffset ();
             }
         }

--- a/java/form/src/org/netbeans/modules/form/ComponentDragger.java
+++ b/java/form/src/org/netbeans/modules/form/ComponentDragger.java
@@ -363,7 +363,9 @@ class ComponentDragger
             for (int i=0; i < n; i++) {
                 newCompsArray[i] = newComponents.get(i);
                 othersMetaCont.add(newCompsArray[i]);
-                newCompsArray[i].resetConstraintsProperties();
+                if (newCompsArray[i] != null) {
+                    newCompsArray[i].resetConstraintsProperties();
+                }
             }
         }
 


### PR DESCRIPTION
Hello,
Our static analyzer found three NPEs. We have checked the feasibility of this execution trace and provided the patches in the pr. Please check and confirm them. It is necessary to defend this vulnerability to improve the code quality.
Here are the bug traces

## NPE in WebServicePersistenceManager.java
1. null assigned to wsData reaches here (Trace staring point)
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/WebServicePersistenceManager.java#L100

2. Function add executes and wsDatas contains null
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/WebServicePersistenceManager.java#L100

3. Function next executes and returns
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/WebServicePersistenceManager.java#L131

4. The return value of function next is passed as the this pointer to function reset (the return value of function next can be null), which will leak to null pointer dereference
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/enterprise/websvc.manager/src/org/netbeans/modules/websvc/manager/WebServicePersistenceManager.java#L148

## NPE in ComponentDragger.java
1. Function add executes and returns, and newComponents contains null value
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/java/form/src/org/netbeans/modules/form/ComponentDragger.java#L261

2. Function get executes and returns
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/java/form/src/org/netbeans/modules/form/ComponentDragger.java#L364

3. Store the return value of function get to newCompsArray
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/java/form/src/org/netbeans/modules/form/ComponentDragger.java#L364

4. newCompsArray is passed as the this pointer to function resetConstraintsProperties (newCompsArray can be null), which will leak to null pointer dereference
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/java/form/src/org/netbeans/modules/form/ComponentDragger.java#L366

## NPE in TokenInputUtils.java
1. Return null to caller (Trace staring point)
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/ide/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java#L85

2. Function readToken executes and returns
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/ide/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java#L133

3. Function add executes, and tokens contains null value
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/ide/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java#L133

4. Function get executes and returns
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/ide/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java#L134

5. Return the return value of function get to caller (The return value can be null)
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/ide/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java#L134

6. Function next executes and stores the return value to t (t can be null)
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/ide/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java#L156

7. t is passed as the this pointer to function getOffset (t can be null), which will leak to null pointer dereference
https://github.com/apache/netbeans/blob/a8e9e91d90da15bce62781a0aeb8663c02589648/ide/languages/src/org/netbeans/modules/languages/parser/TokenInputUtils.java#L157


ContainerAnalyzer