### PR TITLE
Prefer .class execution over .java if the class already exists

### DIFF
--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/singlesourcefile/LaunchProcess.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/singlesourcefile/LaunchProcess.java
@@ -53,7 +53,7 @@ final class LaunchProcess implements Callable<Process> {
 
     private Process setupProcess(String port) throws InterruptedException {
         try {
-            boolean compile = SingleSourceFileUtil.findJavaVersion() < 11;
+            boolean compile = SingleSourceFileUtil.findJavaVersion() < 11 || SingleSourceFileUtil.hasClassSibling(fileObject);
 
             if (compile) {
                 Process p = SingleSourceFileUtil.compileJavaSource(fileObject);

--- a/java/java.api.common/src/org/netbeans/modules/java/api/common/singlesourcefile/SingleSourceFileUtil.java
+++ b/java/java.api.common/src/org/netbeans/modules/java/api/common/singlesourcefile/SingleSourceFileUtil.java
@@ -101,4 +101,8 @@ final class SingleSourceFileUtil {
         return null;
     }
 
+    static boolean hasClassSibling(FileObject fo) {
+        return fo.getParent().getFileObject(fo.getName(), "class") != null;
+    }
+
 }

--- a/java/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/singlesourcefile/SingleSourceFileUtilTest.java
+++ b/java/java.api.common/test/unit/src/org/netbeans/modules/java/api/common/singlesourcefile/SingleSourceFileUtilTest.java
@@ -40,5 +40,15 @@ public class SingleSourceFileUtilTest {
         assertEquals("Java FileObject found in the lookup", java, result);
     }
 
-    
+    @Test
+    public void testCanFindSiblingClass() throws IOException {
+        final FileObject folder = FileUtil.createMemoryFileSystem().getRoot().createFolder("dir");
+        FileObject java = folder.createData("Ahoj.java");
+        assertFalse("No sibling found", SingleSourceFileUtil.hasClassSibling(java));
+
+        FileObject clazz = folder.createData("Ahoj.class");
+        assertNotNull("class created", clazz);
+
+        assertTrue("Sibling found", SingleSourceFileUtil.hasClassSibling(java));
+    }
 }


### PR DESCRIPTION
Bug report: Create single `Hello.java` in an empty folder, with its `main`... method. Run and debug using JDK8. `Hello.class` file appears in the same folder. Change JDK to JDK11. Debug it. Following output prints to Debug console and it does not debug:
```
Listening on 51317 
User program running 
LineBreakpoint Hello.java : 3 successfully submitted.
error: class found on application class path: Hello
```

This PR fixes the problem by recompiling the `.class` if it already exists and continues executing using `java -cp ...` just like on JDK8 even on newer JDKs. 
