### PR TITLE
Jackpot rule files migration

### DIFF
--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/resources/Bundle.properties
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/resources/Bundle.properties
@@ -17,3 +17,5 @@
 
 OpenIDE-Module-Name=Java Refactoring
 OpenIDE-Module-Display-Category=Java
+
+RefactoringRules.Options.Export.displayName=Refactoring Rules

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/resources/mf-layer.xml
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/resources/mf-layer.xml
@@ -94,4 +94,12 @@
             </folder>
         </folder>
     </folder>
+    <folder name="OptionsExport">
+        <folder name="Advanced">
+            <file name="RuleFiles">
+                <attr name="include" stringvalue="config/rules/.*"/>
+                <attr name="displayName" bundlevalue="org.netbeans.modules.refactoring.java.Bundle#RefactoringRules.Options.Export.displayName"/>
+            </file>
+        </folder>
+    </folder>
 </filesystem>


### PR DESCRIPTION
Added OptionsExport config to the java refactoring module so that NetBeans can migrate custom "inspect and transform" rules to new config folders automatically.