### PR TITLE
Fixed source+javadoc Gradle download

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleExecConfiguration.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleExecConfiguration.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import org.gradle.tooling.ConfigurableLauncher;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.project.Project;
@@ -225,6 +226,13 @@ public final class GradleExecConfiguration implements ProjectConfiguration {
                 conf.setProjectProperties(new LinkedHashMap<>(projectProps == null ? Collections.emptyMap() : projectProps));
                 return conf;
             }
+
+            @Override
+            public ConfigurableLauncher configureGradleHome(ConfigurableLauncher cfgL) {
+                ConfigurableLauncher r = GradleCommandLine.configureGradleHome(cfgL);
+                return r;
+            }
+
         });
         
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
@@ -88,7 +88,7 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
     private OutputStream errStream;
     private boolean cancelling;
     private GradleTask gradleTask;
-
+    
     @SuppressWarnings("LeakingThisInConstructor")
     public GradleDaemonExecutor(RunConfig config) {
         super(config);
@@ -100,7 +100,7 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
             }
         });
     }
-
+    
     @NbBundle.Messages({
         "# {0} - Project name",
         "BUILD_SUCCESS=Building {0} was success.",
@@ -241,6 +241,7 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
                     buildLauncher.addProgressListener(new ProgressLookupListener(provider.getProgressListener()), provider.getSupportedOperationTypes());
                 }
             }
+            GradleExecAccessor.instance().configureGradleHome(buildLauncher);
             buildLauncher.run();
             StatusDisplayer.getDefault().setStatusText(Bundle.BUILD_SUCCESS(getProjectName()));
             gradleTask.finish(0);

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleExecAccessor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleExecAccessor.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.gradle.execute;
 
 import java.util.Collections;
 import java.util.Map;
+import org.gradle.tooling.ConfigurableLauncher;
 import org.netbeans.modules.gradle.api.execute.GradleExecConfiguration;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
@@ -48,7 +49,14 @@ public abstract class GradleExecAccessor {
      */
     public abstract GradleExecConfiguration create(
             String id, String dispName, Map<String, String> projectProps, String cmdline);
-
+    
+    /**
+     * Configures launcher with the gradle home.
+     * @param cfgL the launcher
+     * @return gradle home setting
+     */
+    public abstract ConfigurableLauncher configureGradleHome(ConfigurableLauncher cfgL);
+        
     /**
      * Updates an existing instance. Cannot change the {@link GradleExecConfiguration#getId()}.
      * @param conf the configuration to update

--- a/java/gradle.java/nbproject/project.xml
+++ b/java/gradle.java/nbproject/project.xml
@@ -357,6 +357,10 @@
                         <compile-dependency/>
                         <test/>
                     </test-dependency>
+                    <test-dependency>
+                        <code-name-base>org.netbeans.modules.java.j2seplatform</code-name-base>
+                        <recursive/>
+                    </test-dependency>
                 </test-type>
             </test-dependencies>
             <public-packages>

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceAttacherImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/queries/GradleSourceAttacherImpl.java
@@ -303,7 +303,7 @@ public class GradleSourceAttacherImpl implements SourceJavadocAttacherImplementa
                                 this,
                                 RunUtils.simpleReplaceTokenProvider(REQUESTED_COMPONENT, dep.getId())
                 );
-                if (ap.isActionEnabled(command, ctx)) {
+                if (!ap.isActionEnabled(command, ctx)) {
                     // disabled action will not even report action end through the Listener.
                     return false;
                 }

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/api/execute/GradleExecApiTrampoline.java
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/api/execute/GradleExecApiTrampoline.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.api.execute;
+
+import java.nio.file.Path;
+import java.util.function.Supplier;
+
+/**
+ *
+ * @author sdedic
+ */
+public class GradleExecApiTrampoline {
+    public static void setGradleHomeProvider(Supplier<Path> homeProvider) {
+        GradleCommandLine.setHomeProvider(homeProvider);
+    }
+}

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/queries/GradleSourceAttacherImplTest.java
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/queries/GradleSourceAttacherImplTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.queries;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import static junit.framework.TestCase.assertNotNull;
+import org.junit.Assume;
+import org.netbeans.api.java.queries.SourceJavadocAttacher;
+import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectManager;
+import org.netbeans.api.project.ui.OpenProjects;
+import org.netbeans.modules.gradle.AbstractGradleProjectTestCase;
+import org.netbeans.modules.gradle.ProjectTrust;
+import org.netbeans.modules.gradle.api.GradleBaseProject;
+import org.netbeans.modules.gradle.api.GradleConfiguration;
+import org.netbeans.modules.gradle.api.GradleDependency.ModuleDependency;
+import org.netbeans.modules.gradle.api.execute.GradleExecApiTrampoline;
+import org.netbeans.modules.gradle.java.api.GradleJavaProject;
+import org.netbeans.modules.gradle.spi.GradleSettings;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.lookup.Lookups;
+
+/**
+ *
+ * @author sdedic
+ */
+public class GradleSourceAttacherImplTest extends AbstractGradleProjectTestCase{
+    private Locale defLocale;
+    
+    public GradleSourceAttacherImplTest(String name) {
+        super(name);
+        defLocale = Locale.getDefault();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        GradleSettings.getDefault().setGradleUserHome(null);
+        Locale.setDefault(defLocale);
+        super.tearDown();
+    }
+    
+    /**
+     * This test downloads org.netbeans.api:org-openide-util:RELEASE124 jar from the Maven Central repository.
+     * A fresh Gradle user home in the test work directory is used, so that no source .jar is present of this
+     * library. Then the test checks that Gradle is used to download the source artifact.
+     */
+    public void testSourceAttachActionInvokesGradle() throws Exception {
+        clearWorkDir();
+        Locale.setDefault(new Locale("DA"));
+        
+        Path wp = getWorkDir().toPath();
+        Path gradleHome = Files.createDirectories(wp.resolve("gradle-home"));
+
+        // change the gradle home. Need to change in GradleSettings as well,
+        // since the cache artifacts are constructored based on GradleSettings,
+        // not project connection.
+        GradleExecApiTrampoline.setGradleHomeProvider(() -> gradleHome);
+        GradleSettings.getDefault().setGradleUserHome(gradleHome.toFile());
+        
+        try (InputStream is = new URL("http://www.netbeans.org").openStream()) {
+        } catch (IOException ex) {
+            // bail out without failing the test suite, but leave a message in the test log.
+            Assume.assumeTrue("This test needs connectivity", false);
+        }
+
+
+        FileObject fo = createGradleProject(
+                "apply plugin: 'java'\n"
+                        + "repositories {\n" +
+                        "    mavenCentral()\n"
+                       + "}\n"
+                       + "\n"
+                       + "dependencies {\n"
+                       + "    implementation(\"org.netbeans.api:org-openide-util:RELEASE124\")\n"
+                       + "}"
+               );
+        FileObject src = FileUtil.createFolder(fo, "src/main/java");
+        FileObject java = src.createData("Whatever.java");
+        Project prj = ProjectManager.getDefault().findProject(fo);
+        assertNotNull(prj);
+        ProjectTrust.getDefault().trustProject(prj);
+
+        OpenProjects.getDefault().open(new Project[] { prj }, false);
+        Project[] opened = OpenProjects.getDefault().openProjects().get();
+        
+        ActionProvider ap = prj.getLookup().lookup(ActionProvider.class);
+        
+        
+        class AP extends ActionProgress {
+            final CountDownLatch l = new CountDownLatch(1);
+            volatile boolean success;
+            
+            @Override
+            protected void started() {
+            }
+
+            @Override
+            public void finished(boolean success) {
+                this.success = success;
+                l.countDown();
+            }
+        }
+        
+        
+        AP prg1 = new AP();
+        
+        ap.invokeAction(ActionProvider.COMMAND_BUILD, Lookups.singleton(prg1));
+        prg1.l.await();
+        
+        assertTrue("Build, including jar download succeeded - requires maven central access", prg1.success);
+
+        GradleJavaProject gp = GradleJavaProject.get(prj);
+        GradleBaseProject gbp = GradleBaseProject.get(prj);
+        GradleConfiguration cfg = gbp.getConfigurations().get("compileClasspath");
+        Set<ModuleDependency> dep = cfg.findModules("org.netbeans.api:org-openide-util:RELEASE124");
+        assertNotNull(dep);
+        assertEquals(1, dep.size());
+        Set<File> files = dep.iterator().next().getArtifacts();
+        assertNotNull(files);
+        assertEquals(1, files.size());
+        
+        File utilJar = files.iterator().next();
+        
+        // now check that the javadoc attacher is applied:
+        class L implements SourceJavadocAttacher.AttachmentListener {
+            CompletableFuture<Boolean> result = new CompletableFuture<>();
+            
+            @Override
+            public void attachmentSucceeded() {
+                result.complete(true);
+            }
+
+            @Override
+            public void attachmentFailed() {
+                result.complete(false);
+            }
+        }
+        
+        // need to get the classpath root inside the archive.
+        URL archiveRoot = FileUtil.getArchiveRoot(utilJar.toURI().toURL());
+        L l = new L();
+        SourceJavadocAttacher.attachSources(archiveRoot, l);
+        // wait at most 20 seconds for a download.
+        boolean r = l.result.get(20, TimeUnit.SECONDS);
+        assertTrue(r);
+    }
+}

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/java/j2seplatform/api/Bundle_da.properties
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/java/j2seplatform/api/Bundle_da.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+API_Ask_attachSourcesQuestion=yes
+API_Ask_attachJavadocQuestion=yes

--- a/java/gradle.java/test/unit/src/org/netbeans/modules/java/j2seplatform/api/Bundle_no.properties
+++ b/java/gradle.java/test/unit/src/org/netbeans/modules/java/j2seplatform/api/Bundle_no.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+API_Ask_attachSourcesQuestion=no
+API_Ask_attachJavadocQuestion=no
+

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/SourceJavadocAttacherUtil.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/queries/SourceJavadocAttacherUtil.java
@@ -173,7 +173,8 @@ public final class SourceJavadocAttacherUtil {
         BaseProgressUtils.runOffEventDispatchThread(h, 
                 source ? Bundle.TITLE_ObtainingSource() : Bundle.TITLE_ObtainingJavadoc(), 
                 h, false);
-        return h.getResult();
+        List<? extends URI> r = h.getResult();
+        return r != null && !r.isEmpty() ? r : null;
     }            
     
     @CheckForNull


### PR DESCRIPTION
There was a typo in PR #3029 -- an [inverted condition](https://github.com/apache/netbeans/pull/3029/files#diff-5c103f8068d80ea76751550a19a5c963ccf80879987162a74edba320ee218eefR306).  The actual [typo is fixed here](https://github.com/apache/netbeans/pull/3040/files#diff-5c103f8068d80ea76751550a19a5c963ccf80879987162a74edba320ee218eefR306) - one liner change. There was yet another [subtle bug (still unnoticed)](https://github.com/apache/netbeans/pull/3040/files#diff-c49a8b6e435ec670b8a00303efd7cee16fa59f7ed89ecde40a3b5766b20814acR177): if plugin did not attach anything the API still reported success through the listener.

The rest of this PR are tests and test infrastructure: for the source download to be reliably initiated, I've needed to run Gradle in tests with a different gradle user home, so the gradle cache is not polluted by previously downloaded artifacts. So the rest of changes basically allows the test to change gradle user home for executed gradle tasks and ProjectConnection commands - but is not exposed through APIs, it's only accessible to test using accessor classes.

I felt like I should provide a test to demonstrate the bug is finally gone...