### PR TITLE
Optionally disable groovy support in NBJLS

### DIFF
--- a/groovy/groovy.editor/manifest.mf
+++ b/groovy/groovy.editor/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.groovy.editor/3
 OpenIDE-Module-Layer: org/netbeans/modules/groovy/editor/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/groovy/editor/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.77
+OpenIDE-Module-Specification-Version: 1.78

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/utils/GroovyUtils.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/utils/GroovyUtils.java
@@ -236,4 +236,25 @@ public final class GroovyUtils {
         }
         return sb.toString();
     }
+    
+    /**
+     * True, if the indexing is enabled. Depends system property or {@link #setIndexingEnabled(boolean)}.
+     * 
+     */
+    private static volatile boolean indexingEnabled = Boolean.valueOf(System.getProperty("org.netbeans.modules.groovy.editor.api.indexingEnabled", "true"));
+    
+    /**
+     * Disables completely Groovy indexing. Temporary options only for 12.5 release, will be hopefully
+     * removed after Groovy performance improves. Currently used reflectively from java.lsp.server module only.
+     * DO NOT expose as an API.
+     * @param enabled 
+     */
+    public static void setIndexingEnabled(boolean enabled) {
+        indexingEnabled = enabled;
+    }
+    
+    public static boolean isIndexingEnabled() {
+        return indexingEnabled;
+    }
+
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientCapabilities.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientCapabilities.java
@@ -55,6 +55,11 @@ public final class NbCodeClientCapabilities {
      * </ul>
      */
     private Boolean testResultsSupport;
+    
+    /**
+     * Asks for groovy support. Temporary option, will be removed.
+     */
+    private Boolean wantsGroovySupport;
 
     public ClientCapabilities getClientCapabilities() {
         return clientCaps;
@@ -82,6 +87,18 @@ public final class NbCodeClientCapabilities {
 
     public void setTestResultsSupport(Boolean testResultsSupport) {
         this.testResultsSupport = testResultsSupport;
+    }
+
+    public Boolean getWantsGroovySupport() {
+        return wantsGroovySupport;
+    }
+
+    public void setWantGroovySupport(Boolean enableGroovy) {
+        this.wantsGroovySupport = enableGroovy;
+    }
+
+    public boolean wantsGroovySupport() {
+        return wantsGroovySupport != null && wantsGroovySupport.booleanValue();
     }
 
     private NbCodeClientCapabilities withCapabilities(ClientCapabilities caps) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.lsp.server.protocol;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -644,6 +645,7 @@ public final class Server {
         public CompletableFuture<InitializeResult> initialize(InitializeParams init) {
             NbCodeClientCapabilities capa = NbCodeClientCapabilities.get(init);
             client.setClientCaps(capa);
+            hackConfigureGroovySupport(capa);
             List<FileObject> projectCandidates = new ArrayList<>();
             List<WorkspaceFolder> folders = init.getWorkspaceFolders();
             if (folders != null) {
@@ -730,8 +732,8 @@ public final class Server {
                 }
             });
             sessionServices.add(new WorkspaceUIContext(client));
-            ((LanguageClientAware) getTextDocumentService()).connect(aClient);
-            ((LanguageClientAware) getWorkspaceService()).connect(aClient);
+            ((LanguageClientAware) getTextDocumentService()).connect(client);
+            ((LanguageClientAware) getWorkspaceService()).connect(client);
         }
     }
     
@@ -829,4 +831,22 @@ public final class Server {
             logWarning(message);
         }
     };
+    
+    
+    /**
+     * Hacky way to enable or disable Groovy support. Since it is hack, it will disable Groovy for the whole NBJLS, not just a specific client / project. Should
+     * be revisited after NetBeans 12.5, after Groovy parsing improves
+     * @param caps 
+     */
+    private static void hackConfigureGroovySupport(NbCodeClientCapabilities caps) {
+        boolean b = caps.wantsGroovySupport();
+        try {
+            Class clazz = Lookup.getDefault().lookup(ClassLoader.class).loadClass("org.netbeans.modules.groovy.editor.api.GroovyIndexer");
+            Method m = clazz.getDeclaredMethod("setIndexingEnabled", Boolean.TYPE);
+            m.setAccessible(true);
+            m.invoke(null, b);
+        } catch (ReflectiveOperationException ex) {
+            LOG.log(Level.WARNING, "Unable to configure Groovy support", ex);
+        }
+    }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -387,7 +387,8 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
             Enumeration<? extends FileObject> children = testRoot.getChildren(true);
             while(children.hasMoreElements()) {
                 FileObject fo = children.nextElement();
-                if (fo.hasExt("java") || fo.hasExt("groovy")) {
+                boolean groovy = this.client.getNbCodeCapabilities().wantsGroovySupport();
+                if (fo.hasExt("java") || (groovy && fo.hasExt("groovy"))) {
                     sources.add(((TextDocumentServiceImpl)server.getTextDocumentService()).getSource(Utils.toUri(fo)));
                 }
             }

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -84,6 +84,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Enable Run/Debug test in editor"
+				},
+				"netbeans.groovySupport.enabled": {
+					"type": "boolean",
+					"default": false,
+					"description": "Enables experimental Groovy and Spock support in Language Server"
 				}
 			}
 		},

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -29,7 +29,9 @@ import {
     Message,
     MessageType,
     LogMessageNotification,
-    RevealOutputChannelOn
+    RevealOutputChannelOn,
+    DocumentSelector,
+    DocumentFilter
 } from 'vscode-languageclient';
 
 import * as net from 'net';
@@ -520,17 +522,21 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                 }
             });
         });
-
-        // Options to control the language client
-        let clientOptions: LanguageClientOptions = {
-            // Register the server for java documents
-            documentSelector: [
+        const conf = workspace.getConfiguration();
+        let documentSelectors : DocumentSelector = [
                 { language: 'java' },
-                { language: 'groovy' },
                 { language: 'yaml', pattern: '**/{application,bootstrap}*.yml' },
                 { language: 'properties', pattern: '**/{application,bootstrap}*.properties' },
                 { language: 'jackpot-hint' }
-            ],
+        ];
+        const enableGroovy : boolean = conf.get("netbeans.groovySupport.enabled") || false;
+        if (enableGroovy) {
+            documentSelectors.push({ language: 'groovy'});
+        }
+        // Options to control the language client
+        let clientOptions: LanguageClientOptions = {
+            // Register the server for java documents
+            documentSelector: documentSelectors,
             synchronize: {
                 configurationSection: 'java',
                 fileEvents: [
@@ -543,7 +549,8 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
             initializationOptions : {
                 'nbcodeCapabilities' : {
                     'statusBarMessageSupport' : true,
-                    'testResultsSupport' : true
+                    'testResultsSupport' : true,
+                    'wantsGroovySupport' : enableGroovy
                 }
             },
             errorHandler: {


### PR DESCRIPTION
The groovy parser (or better: type resolution) is terribly slow, so it quite undermines usability of Groovy + Spock sources in the project. This PR makes it possible to disable indexing - with all the negative effects on the quality of code completion when the source is finally parsed - so that LSP client can disable it.
NetBeans IDE user can eventually disable it too using a system property; but the feature should remain undocumented and officially unsupported, since I (we) hope the parser's performace could be improved during the next release cycle.
