### PR TITLE
Use fixed version of VSCode for running integration tests

### DIFF
--- a/java/java.lsp.server/vscode/src/test/runTest.ts
+++ b/java/java.lsp.server/vscode/src/test/runTest.ts
@@ -11,7 +11,7 @@ async function main() {
         // Passed to `--extensionDevelopmentPath`
         const extensionDevelopmentPath = path.resolve(__dirname, '../../');
 
-        const vscodeExecutablePath: string = await downloadAndUnzipVSCode('stable');
+        const vscodeExecutablePath: string = await downloadAndUnzipVSCode('1.54.3');
         const cliPath: string = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
 
         cp.spawnSync(cliPath, ['--install-extension', 'hbenl.vscode-test-explorer'], {


### PR DESCRIPTION
VSCode integration tests are [failing](https://app.travis-ci.com/github/apache/netbeans/jobs/524067665). Wouldn't fixing VSCode version to some older one help?