### PR TITLE
allow more dot separated digit for version scheme

### DIFF
--- a/nb/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/Installer.java
+++ b/nb/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/Installer.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.autoupdate.pluginimporter;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -52,7 +53,20 @@ public class Installer extends ModuleInstall {
 
     private static final Logger LOG = Logger.getLogger (Installer.class.getName ());
     // XXX: copy from o.n.upgrader
-    private static final Comparator<String> APACHE_VERSION_COMPARATOR = (v1, v2) -> Float.compare(Float.parseFloat(v1), Float.parseFloat(v2));
+    // helper to remove dot from version for 3 digit versions
+    private static class PseudoFloat {
+        
+        static Float parseFloat(String string) {
+            List<String> split = new ArrayList<>(Arrays.asList(string.split("\\.")));
+            String myfloat = split.remove(0);
+            if (!split.isEmpty()) {
+                // concat remaining
+                myfloat += "." + String.join("", split);
+            }
+            return Float.parseFloat(myfloat);
+        }
+    }
+    private static final Comparator<String> APACHE_VERSION_COMPARATOR = (v1, v2) -> Float.compare(PseudoFloat.parseFloat(v1), PseudoFloat.parseFloat(v2));
     private static final List<String> APACHE_VERSION_TO_CHECK = Arrays.asList(NbBundle.getMessage(Installer.class, "apachenetbeanspreviousversion").split(",")).stream().sorted(APACHE_VERSION_COMPARATOR.reversed()).collect(Collectors.toList());
     private static final List<String> VERSION_TO_CHECK =
             Arrays.asList (".netbeans/7.1.2", ".netbeans/7.1.1", ".netbeans/7.1", ".netbeans/7.0", ".netbeans/6.9"); //NOI18N

--- a/nb/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/Installer.java
+++ b/nb/autoupdate.pluginimporter/src/org/netbeans/modules/autoupdate/pluginimporter/Installer.java
@@ -36,6 +36,7 @@ import org.netbeans.api.autoupdate.UpdateUnitProvider;
 import org.netbeans.api.autoupdate.UpdateUnitProviderFactory;
 import org.openide.filesystems.FileUtil;
 import org.openide.modules.ModuleInstall;
+import org.openide.modules.SpecificationVersion;
 import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
 import org.openide.util.RequestProcessor;
@@ -53,20 +54,8 @@ public class Installer extends ModuleInstall {
 
     private static final Logger LOG = Logger.getLogger (Installer.class.getName ());
     // XXX: copy from o.n.upgrader
-    // helper to remove dot from version for 3 digit versions
-    private static class PseudoFloat {
-        
-        static Float parseFloat(String string) {
-            List<String> split = new ArrayList<>(Arrays.asList(string.split("\\.")));
-            String myfloat = split.remove(0);
-            if (!split.isEmpty()) {
-                // concat remaining
-                myfloat += "." + String.join("", split);
-            }
-            return Float.parseFloat(myfloat);
-        }
-    }
-    private static final Comparator<String> APACHE_VERSION_COMPARATOR = (v1, v2) -> Float.compare(PseudoFloat.parseFloat(v1), PseudoFloat.parseFloat(v2));
+    
+    private static final Comparator<String> APACHE_VERSION_COMPARATOR = (v1, v2) -> new SpecificationVersion(v1).compareTo(new SpecificationVersion(v2));
     private static final List<String> APACHE_VERSION_TO_CHECK = Arrays.asList(NbBundle.getMessage(Installer.class, "apachenetbeanspreviousversion").split(",")).stream().sorted(APACHE_VERSION_COMPARATOR.reversed()).collect(Collectors.toList());
     private static final List<String> VERSION_TO_CHECK =
             Arrays.asList (".netbeans/7.1.2", ".netbeans/7.1.1", ".netbeans/7.1", ".netbeans/7.0", ".netbeans/6.9"); //NOI18N

--- a/nb/o.n.upgrader/src/org/netbeans/upgrade/AutoUpgrade.java
+++ b/nb/o.n.upgrader/src/org/netbeans/upgrade/AutoUpgrade.java
@@ -23,6 +23,7 @@ import java.awt.event.KeyEvent;
 import java.beans.PropertyVetoException;
 import java.io.*;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -91,13 +92,27 @@ public final class AutoUpgrade {
 
     // the order of VERSION_TO_CHECK here defines the precedence of imports
     // the first one will be choosen for import
-    final static private List<String> VERSION_TO_CHECK = 
-            Arrays.asList (new String[] { ".netbeans/7.1.2",  ".netbeans/7.1.1", ".netbeans/7.1", ".netbeans/7.0", ".netbeans/6.9" });//NOI18N
+    private static final List<String> VERSION_TO_CHECK = 
+            Arrays.asList ( ".netbeans/7.1.2",  ".netbeans/7.1.1", ".netbeans/7.1", ".netbeans/7.0", ".netbeans/6.9" );//NOI18N
     
     // userdir on OS specific root of userdir (see issue 196075)
     static final List<String> PRE_APACHE_NEWER_VERSION_TO_CHECK =
             Arrays.asList ("8.2", "8.1", "8.0.2", "8.0.1", "8.0", "7.4", "7.3.1", "7.3", "7.2.1", "7.2"); //NOI18N
-    private static final Comparator<String> APACHE_VERSION_COMPARATOR = (v1, v2) -> Float.compare(Float.parseFloat(v1), Float.parseFloat(v2));
+     // XXX: copy to autoupgrade.pluginimporter
+    // helper to remove dot from version for 3 digit versions
+    static class PseudoFloat {
+        
+        static Float parseFloat(String string) {
+            List<String> split = new ArrayList<>(Arrays.asList(string.split("\\.")));
+            String myfloat = split.remove(0);
+            if (!split.isEmpty()) {
+                // concat remaining
+                myfloat += "." + String.join("", split);
+            }
+            return Float.parseFloat(myfloat);
+        }
+    }
+    static final Comparator<String> APACHE_VERSION_COMPARATOR = (v1, v2) -> Float.compare(PseudoFloat.parseFloat(v1), PseudoFloat.parseFloat(v2));
     
     static final List<String> APACHE_VERSION_TO_CHECK = Arrays.asList(NbBundle.getMessage(AutoUpgrade.class, "apachenetbeanspreviousversion").split(",")).stream().sorted(APACHE_VERSION_COMPARATOR.reversed()).collect(Collectors.toList());
     
@@ -118,7 +133,7 @@ public final class AutoUpgrade {
         return null;
     }
 
-    static private File checkPrevious (final List<String> versionsToCheck) {        
+    private static File checkPrevious (final List<String> versionsToCheck) {        
         String userHome = System.getProperty ("user.home"); // NOI18N
         File sourceFolder = null;
         

--- a/nb/o.n.upgrader/src/org/netbeans/upgrade/AutoUpgrade.java
+++ b/nb/o.n.upgrader/src/org/netbeans/upgrade/AutoUpgrade.java
@@ -43,6 +43,7 @@ import org.openide.filesystems.LocalFileSystem;
 import org.openide.filesystems.MultiFileSystem;
 import org.openide.filesystems.XMLFileSystem;
 import org.openide.modules.InstalledFileLocator;
+import org.openide.modules.SpecificationVersion;
 import org.openide.util.NbBundle;
 import org.openide.util.Utilities;
 import org.xml.sax.SAXException;
@@ -99,20 +100,8 @@ public final class AutoUpgrade {
     static final List<String> PRE_APACHE_NEWER_VERSION_TO_CHECK =
             Arrays.asList ("8.2", "8.1", "8.0.2", "8.0.1", "8.0", "7.4", "7.3.1", "7.3", "7.2.1", "7.2"); //NOI18N
      // XXX: copy to autoupgrade.pluginimporter
-    // helper to remove dot from version for 3 digit versions
-    static class PseudoFloat {
-        
-        static Float parseFloat(String string) {
-            List<String> split = new ArrayList<>(Arrays.asList(string.split("\\.")));
-            String myfloat = split.remove(0);
-            if (!split.isEmpty()) {
-                // concat remaining
-                myfloat += "." + String.join("", split);
-            }
-            return Float.parseFloat(myfloat);
-        }
-    }
-    static final Comparator<String> APACHE_VERSION_COMPARATOR = (v1, v2) -> Float.compare(PseudoFloat.parseFloat(v1), PseudoFloat.parseFloat(v2));
+    
+    static final Comparator<String> APACHE_VERSION_COMPARATOR = (v1, v2) -> new SpecificationVersion(v1).compareTo(new SpecificationVersion(v2));
     
     static final List<String> APACHE_VERSION_TO_CHECK = Arrays.asList(NbBundle.getMessage(AutoUpgrade.class, "apachenetbeanspreviousversion").split(",")).stream().sorted(APACHE_VERSION_COMPARATOR.reversed()).collect(Collectors.toList());
     

--- a/nb/o.n.upgrader/test/unit/src/org/netbeans/upgrade/AutoUpgradeTest.java
+++ b/nb/o.n.upgrader/test/unit/src/org/netbeans/upgrade/AutoUpgradeTest.java
@@ -20,9 +20,10 @@
 package org.netbeans.upgrade;
 import java.io.File;
 import java.net.URL;
-
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.openide.filesystems.FileObject;
-
 import org.openide.filesystems.FileSystem;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.LocalFileSystem;
@@ -87,4 +88,15 @@ public final class AutoUpgradeTest extends org.netbeans.junit.NbTestCase {
         assertNotNull(newFooBarFO);
         assertEquals(attrValue, newFooBarFO.getAttribute(attrName));
     }
+    
+    public void testComparatorUpgrade() throws Exception {
+        // verify version ordering
+        List<String> versions = Arrays.asList("12.3,12.4,8.0,12.4.301".split(",")).stream().sorted(AutoUpgrade.APACHE_VERSION_COMPARATOR.reversed()).collect(Collectors.toList());
+        assertEquals(4,versions.size());
+        assertEquals("12.4.301",versions.get(0));
+        assertEquals("12.4",versions.get(1));
+        assertEquals("12.3",versions.get(2));
+        assertEquals("8.0",versions.get(3));
+    }
+    
  }


### PR DESCRIPTION
Quick fix for allowing version like 12.4.301 as for Apache NetBeans we were set with Float

test is on  nb/o.n.upgrader/test/unit/src/org/netbeans/upgrade/AutoUpgradeTest.java.

copied to Autopudate. 
Reorder modifier around  