### PR TITLE
Micronaut: Allow for creating project on JDK 16.

### DIFF
--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/newproject/BasePropertiesVisual.form
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/newproject/BasePropertiesVisual.form
@@ -306,16 +306,7 @@
     <Component class="javax.swing.JComboBox" name="javaVersionComboBox">
       <Properties>
         <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
-          <StringArray count="8">
-            <StringItem index="0" value="8"/>
-            <StringItem index="1" value="9"/>
-            <StringItem index="2" value="10"/>
-            <StringItem index="3" value="11"/>
-            <StringItem index="4" value="12"/>
-            <StringItem index="5" value="13"/>
-            <StringItem index="6" value="14"/>
-            <StringItem index="7" value="15"/>
-          </StringArray>
+          <StringArray count="0"/>
         </Property>
       </Properties>
       <AuxValues>

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/newproject/BasePropertiesVisual.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/newproject/BasePropertiesVisual.java
@@ -60,6 +60,7 @@ public class BasePropertiesVisual extends JPanel implements DocumentListener, Ac
                 customRadioButton.setSelected(true);
                 versionTextField.setText("");
                 applicationTypeComboBox.removeAllItems();
+                javaVersionComboBox.removeAllItems();
             }
             @Override
             public void focusLost(FocusEvent e) {
@@ -152,8 +153,6 @@ public class BasePropertiesVisual extends JPanel implements DocumentListener, Ac
 
         javaVersionLabel.setLabelFor(javaVersionComboBox);
         org.openide.awt.Mnemonics.setLocalizedText(javaVersionLabel, org.openide.util.NbBundle.getMessage(BasePropertiesVisual.class, "LBL_JavaVersion")); // NOI18N
-
-        javaVersionComboBox.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "8", "9", "10", "11", "12", "13", "14", "15" }));
 
         org.openide.awt.Mnemonics.setLocalizedText(languageLabel, org.openide.util.NbBundle.getMessage(BasePropertiesVisual.class, "LBL_Language")); // NOI18N
 
@@ -402,6 +401,9 @@ public class BasePropertiesVisual extends JPanel implements DocumentListener, Ac
             for (MicronautLaunchService.ApplicationType type : service.getApplicationTypes(serviceUrl)) {
                 applicationTypeComboBox.addItem(type);
             }
+            for (String version : service.getJdkVersions(serviceUrl)) {
+                javaVersionComboBox.addItem(version);
+            }
             versionTextField.setText(micronautVersion);
             initialized = true;
         } catch (Exception ex) {
@@ -423,6 +425,7 @@ public class BasePropertiesVisual extends JPanel implements DocumentListener, Ac
     public void actionPerformed(ActionEvent e) {
         versionTextField.setText("");
         applicationTypeComboBox.removeAllItems();
+        javaVersionComboBox.removeAllItems();
         if ("CUSTOM".equals(e.getActionCommand())) {
             customTextField.requestFocus();
         } else {

--- a/enterprise/micronaut/src/org/netbeans/modules/micronaut/newproject/MicronautLaunchService.java
+++ b/enterprise/micronaut/src/org/netbeans/modules/micronaut/newproject/MicronautLaunchService.java
@@ -44,6 +44,7 @@ public class MicronautLaunchService {
 
     private static final MicronautLaunchService INSTANCE = new MicronautLaunchService();
     private static final String VERSIONS = "versions/";
+    private static final String OPTIONS = "select-options/";
     private static final String APPLICATION_TYPES = "application-types/";
     private static final String FEATURES = "features/";
     private static final String CREATE = "create/";
@@ -77,6 +78,20 @@ public class MicronautLaunchService {
             types.add(new ApplicationType(jsonObject.get("title").getAsString(), jsonObject.get("value").getAsString()));
         }
         return types;
+    }
+
+    public List<String> getJdkVersions(String serviceUrl) throws IOException {
+        if (!serviceUrl.endsWith("/")) {
+            serviceUrl = serviceUrl + '/';
+        }
+        JsonObject json = gson.fromJson(getJson(serviceUrl + OPTIONS), JsonObject.class);
+        JsonArray jsonArray = json.getAsJsonObject("jdkVersion").getAsJsonArray("options");
+        ArrayList<String> jdkVersions = new ArrayList<>(jsonArray.size());
+        for (JsonElement jsonElement : jsonArray) {
+            JsonObject jsonObject = jsonElement.getAsJsonObject();
+            jdkVersions.add(jsonObject.get("label").getAsString());
+        }
+        return jdkVersions;
     }
 
     public List<Feature> getFeatures(String serviceUrl, ApplicationType appType) throws IOException {

--- a/java/java.lsp.server/nbcode/integration/release/config/Preferences/org/netbeans/modules/java/hints/default/org.netbeans.modules.java.hints.jdk.ConvertTextBlockToString.properties
+++ b/java/java.lsp.server/nbcode/integration/release/config/Preferences/org/netbeans/modules/java/hints/default/org.netbeans.modules.java.hints.jdk.ConvertTextBlockToString.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+enabled=false


### PR DESCRIPTION
- When creating a new Micronaut projects, current version of the `https://micronaut.io/launch/` service supports JDK 8, 11, and 16 only (unlinke the previous versions that supported JDKs from 8 to 15). Changing the new Micronaut project wizard to ask service for supported JDK versions.
- ConvertTextBlockToString hint disabled by default in Language Server.