### PR TITLE
[NETBEANS-5719] Unused property hint is shown when the property is used as a constructor argument

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/csl/SemanticAnalysis.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/csl/SemanticAnalysis.java
@@ -576,6 +576,9 @@ public class SemanticAnalysis extends SemanticAnalyzer {
                 return;
             }
             if (node.isAnonymous()) {
+                // NETBEANS-5719 scan ctor params before ClassInstanceCreationTypeInfo is created
+                // to avoid recognizing $this as an instance of an anonymous class
+                scan(node.ctorParams());
                 addToPath(node);
                 typeInfo = new ClassInstanceCreationTypeInfo(node);
                 scan(node.getAttributes());

--- a/php/php.editor/test/unit/data/testfiles/semantic/netbeans5719_01.php
+++ b/php/php.editor/test/unit/data/testfiles/semantic/netbeans5719_01.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NetBeans5719;
+
+class Test
+{
+    public function __construct(private bool $usedParameter, private bool $unusedParameter)
+    {
+    }
+
+    public function create(): TestInterface
+    {
+        return new class ($this->usedParameter) implements TestInterface // used here
+        {
+            public function __construct(private bool $anonParameter)
+            {
+            }
+
+            public function test(): bool
+            {
+                return $this->anonParameter;
+            }
+        };
+    }
+}
+
+
+interface TestInterface
+{
+    function test(): bool;
+}

--- a/php/php.editor/test/unit/data/testfiles/semantic/netbeans5719_01.php.semantic
+++ b/php/php.editor/test/unit/data/testfiles/semantic/netbeans5719_01.php.semantic
@@ -1,0 +1,49 @@
+<?php declare(strict_types = 1);
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NetBeans5719;
+
+class |>CLASS:Test<|
+{
+    public function |>METHOD:__construct<|(private bool $|>FIELD:usedParameter<|, private bool $|>FIELD,UNUSED:unusedParameter<|)
+    {
+    }
+
+    public function |>METHOD:create<|(): TestInterface
+    {
+        return new class ($this->|>FIELD:usedParameter<|) implements TestInterface // used here
+        {
+            public function |>METHOD:__construct<|(private bool $|>FIELD:anonParameter<|)
+            {
+            }
+
+            public function |>METHOD:test<|(): bool
+            {
+                return $this->|>FIELD:anonParameter<|;
+            }
+        };
+    }
+}
+
+
+interface |>CLASS:TestInterface<|
+{
+    function |>METHOD:test<|(): bool;
+}

--- a/php/php.editor/test/unit/data/testfiles/semantic/netbeans5719_02.php
+++ b/php/php.editor/test/unit/data/testfiles/semantic/netbeans5719_02.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NetBeans5719;
+
+class Test
+{
+    private bool $usedParameter;
+    private bool $unusedParameter;
+
+    public function __construct()
+    {
+    }
+
+    public function create(): TestInterface
+    {
+        return new class ($this->usedParameter) implements TestInterface // used here
+        {
+            public function __construct(private bool $anonParameter)
+            {
+            }
+
+            public function test(): bool
+            {
+                return $this->anonParameter;
+            }
+        };
+    }
+}
+
+
+interface TestInterface
+{
+    function test(): bool;
+}

--- a/php/php.editor/test/unit/data/testfiles/semantic/netbeans5719_02.php.semantic
+++ b/php/php.editor/test/unit/data/testfiles/semantic/netbeans5719_02.php.semantic
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace NetBeans5719;
+
+class |>CLASS:Test<|
+{
+    private bool $|>FIELD:usedParameter<|;
+    private bool $|>FIELD,UNUSED:unusedParameter<|;
+
+    public function |>METHOD:__construct<|()
+    {
+    }
+
+    public function |>METHOD:create<|(): TestInterface
+    {
+        return new class ($this->|>FIELD:usedParameter<|) implements TestInterface // used here
+        {
+            public function |>METHOD:__construct<|(private bool $|>FIELD:anonParameter<|)
+            {
+            }
+
+            public function |>METHOD:test<|(): bool
+            {
+                return $this->|>FIELD:anonParameter<|;
+            }
+        };
+    }
+}
+
+
+interface |>CLASS:TestInterface<|
+{
+    function |>METHOD:test<|(): bool;
+}

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/SemanticAnalyzerTest.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/csl/SemanticAnalyzerTest.java
@@ -201,4 +201,12 @@ public class SemanticAnalyzerTest extends SemanticAnalysisTestBase {
     public void testNamedArgumentsColoring() throws Exception {
         checkSemantic("testfiles/semantic/namedArgumentsColoring.php");
     }
+
+    public void testNETBEANS5719_01() throws Exception {
+        checkSemantic("testfiles/semantic/netbeans5719_01.php");
+    }
+
+    public void testNETBEANS5719_02() throws Exception {
+        checkSemantic("testfiles/semantic/netbeans5719_02.php");
+    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5719

- Scan constructor arguments of an anonymous class

#### Before:
![netbeans5719-before](https://user-images.githubusercontent.com/738383/126106358-030365e6-880a-4fca-8d4e-6aa4527769ca.png)

#### After:
![netbeans5719-after](https://user-images.githubusercontent.com/738383/126106365-85e324b5-5de5-4ccc-add0-d027e31ba783.png)
