### PR TITLE
Few quick bug fixes for OpenJDK download wizard

### DIFF
--- a/java/java.disco/src/org/netbeans/modules/java/disco/Client.java
+++ b/java/java.disco/src/org/netbeans/modules/java/disco/Client.java
@@ -37,7 +37,9 @@ import io.foojay.api.discoclient.pkg.Scope;
 import io.foojay.api.discoclient.pkg.SemVer;
 import io.foojay.api.discoclient.pkg.TermOfSupport;
 import io.foojay.api.discoclient.pkg.VersionNumber;
+import io.foojay.api.discoclient.util.Constants;
 import io.foojay.api.discoclient.util.PkgInfo;
+import java.util.Collections;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Future;
@@ -54,8 +56,13 @@ public class Client {
     }
 
     private synchronized DiscoClient getDisco() {
-        if (client == null)
+        if (client == null) {
             client = new DiscoClient();
+            // @TODO : this is just a workaround for NPE in Disco Client library
+            for (Distribution dist : Distribution.values()) {
+                Constants.SCOPE_LOOKUP.putIfAbsent(dist, Collections.EMPTY_LIST);
+            }
+        }
         return client;
     }
 
@@ -63,10 +70,10 @@ public class Client {
     }
 
     public synchronized final List<MajorVersion> getAllLTSVersions() {
-        Queue<MajorVersion> majorVersions = getDisco().getAllMajorVersions(true);
+        Queue<MajorVersion> majorVersions = getDisco().getAllMajorVersions(false);
         return majorVersions.stream()
-                            .filter(majorVersion -> majorVersion.isMaintained())
-                            .collect(Collectors.toList());
+                .filter(majorVersion -> majorVersion.isMaintained())
+                .collect(Collectors.toList());
     }
 
     public synchronized MajorVersion getLatestLts(boolean b) {

--- a/java/java.disco/src/org/netbeans/modules/java/disco/FoojayPlatformInstall.java
+++ b/java/java.disco/src/org/netbeans/modules/java/disco/FoojayPlatformInstall.java
@@ -21,7 +21,11 @@ package org.netbeans.modules.java.disco;
 import org.netbeans.spi.java.platform.CustomPlatformInstall;
 import org.openide.WizardDescriptor;
 import org.openide.WizardDescriptor.InstantiatingIterator;
+import org.openide.util.NbBundle;
 
+@NbBundle.Messages({
+    "DiscoPlatformInstall.displayName=Download OpenJDK (via foojay Disco API)"
+})
 public class FoojayPlatformInstall extends CustomPlatformInstall {
 
     private FoojayPlatformInstall() {}
@@ -33,7 +37,7 @@ public class FoojayPlatformInstall extends CustomPlatformInstall {
 
     @Override
     public String getDisplayName() {
-        return "Remote Universal OpenJDK Service";
+        return Bundle.DiscoPlatformInstall_displayName();
     }
     
     public static FoojayPlatformInstall create() {

--- a/java/java.disco/src/org/netbeans/modules/java/disco/QuickPanel.java
+++ b/java/java.disco/src/org/netbeans/modules/java/disco/QuickPanel.java
@@ -142,8 +142,8 @@ public class QuickPanel extends javax.swing.JPanel {
         public Hashtable<Integer, JLabel> createLabels() {
             Hashtable<Integer, JLabel> labels = new Hashtable<>();
             for (Integer v : versionJDKs) {
-                boolean isLTS = lts.containsKey(v);
-                String name = isLTS ? LTSes.text(v, lts.get(v)) : String.valueOf(v);
+                boolean isLTS = lts.get(v) == TermOfSupport.LTS;
+                String name = LTSes.text(v, lts.get(v));
                 JLabel label = new JLabel(name);
                 if (isLTS) {
                     //these decorations do nothing on macOS...

--- a/java/java.disco/src/org/netbeans/modules/java/disco/QuickPkgSelection.java
+++ b/java/java.disco/src/org/netbeans/modules/java/disco/QuickPkgSelection.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.java.disco;
 import io.foojay.api.discoclient.pkg.ArchiveType;
 import io.foojay.api.discoclient.pkg.Distribution;
 import io.foojay.api.discoclient.pkg.Latest;
+import io.foojay.api.discoclient.pkg.LibCType;
 import io.foojay.api.discoclient.pkg.PackageType;
 import io.foojay.api.discoclient.pkg.Pkg;
 import io.foojay.api.discoclient.pkg.VersionNumber;
@@ -40,7 +41,18 @@ class QuickPkgSelection implements PkgSelection {
     public QuickPkgSelection(QuickPanel.QuickSelection quick) {
         this.version = new VersionNumber(quick.version);
         this.filter = quick.zip
-                ? (p) -> p.getArchiveType() == ArchiveType.ZIP
+                ? (p) -> {
+                    switch (OS.getOperatingSystem()) {
+                        case MACOS:
+                            return ArchiveType.ZIP == p.getArchiveType() || ArchiveType.TAR_GZ == p.getArchiveType();
+                        case LINUX:
+                            return (ArchiveType.ZIP == p.getArchiveType() || ArchiveType.TAR_GZ == p.getArchiveType()) &&
+                                    (LibCType.MUSL != p.getLibCType());
+                        case WINDOWS:
+                        default:
+                            return ArchiveType.ZIP == p.getArchiveType();
+                    }
+                }
                 : (p) -> {
                     switch (OS.getOperatingSystem()) {
                         case WINDOWS:


### PR DESCRIPTION
Fix Linux, NPE and display issues for OpenJDK download (Disco) integration.

Make sure we get a quick package option on Linux.
Expand quick package filter to include tar.gz on Linux and macOS.
Exclude LibCType.MUSL on Linux - incorrectly coming up as option.

Only bold actual LTS labels.
Exclude early access versions- take up slider space on quick options, but none show up anyway.

Change wizard display name to more obviously describe the option, and make text localizable.

Workaround for NPE inside Disco Client library with unknown distributions.