### PR TITLE
Force bytecode parsing. Cache resource misses.

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/CompilationUnit.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/CompilationUnit.java
@@ -39,6 +39,7 @@ import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.GenericsType;
 import org.codehaus.groovy.ast.MixinNode;
 import org.codehaus.groovy.control.ClassNodeResolver.LookupResult;
+import org.codehaus.groovy.control.ClassNodeResolver;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.source.ClasspathInfo;
@@ -64,6 +65,9 @@ public final class CompilationUnit extends org.codehaus.groovy.control.Compilati
             @NonNull final ClassNodeCache classNodeCache) {
 
         super(configuration, security, loader, transformationLoader);
+        Map<String, Boolean> opts = this.configuration.getOptimizationOptions();
+        opts.put("classLoaderResolving", Boolean.FALSE);
+        this.configuration.setOptimizationOptions(opts);
         this.ast = new CompileUnit(parser, this.classLoader, 
                 (n) -> {
                     LookupResult lr = getClassNodeResolver().resolveName(n, this);
@@ -75,7 +79,7 @@ public final class CompilationUnit extends org.codehaus.groovy.control.Compilati
                 },
                 security, this.configuration, cpInfo, classNodeCache);
     }
-
+    
     private static class CompileUnit extends org.codehaus.groovy.ast.CompileUnit {
         private final Function<String, ClassNode> classResolver;
         private final ClassNodeCache cache;

--- a/groovy/libs.groovy/nbproject/project.xml
+++ b/groovy/libs.groovy/nbproject/project.xml
@@ -29,7 +29,24 @@
                 <friend>org.netbeans.modules.groovy.editor</friend>
                 <friend>org.netbeans.modules.groovy.refactoring</friend>
                 <friend>org.netbeans.modules.groovy.support</friend>
-                <subpackages>groovy</subpackages>
+                <package>groovy</package>
+                <package>groovy.beans</package>
+                <package>groovy.cli</package>
+                <package>groovy.grape</package>
+                <package>groovy.inspect</package>
+                <package>groovy.io</package>
+                <package>groovy.lang</package>
+                <package>groovy.lang.groovydoc</package>
+                <package>groovy.namespace</package>
+                <package>groovy.security</package>
+                <package>groovy.transform</package>
+                <package>groovy.transform.builder</package>
+                <package>groovy.transform.options</package>
+                <package>groovy.transform.stc</package>
+                <package>groovy.ui</package>
+                <package>groovy.util</package>
+                <package>groovy.util.logging</package>
+                <package>groovy.xml</package>
                 <package>groovyjarjarantlr</package>
                 <package>groovyjarjarasm.asm</package>
                 <package>org.codehaus.groovy</package>


### PR DESCRIPTION
Poor performance of the Groovy parser was the reason #/3042 allows to disable Groovy indexing. I've discovered some hot points in Groovy parsing; [attaching profiling data to this PR for reference](https://github.com/apache/netbeans/files/6849268/sampler-10ms.zip)

Groovy parser tries to call `getResource` on parsing ClassLoader, which in turn delegates to `URLClassLoader` that goes through all JARs included in the compilation. While URLClassLoader may be quite fast, adding a **negative** cache for misses would avoid querying 20+ JAR implementations for a resource that is already known to be missing.

Next the parser for whatever reason tries to **load a Class to JVM** which is both slow and **dangerous** as class initializers may be run. This feature can be disabled in parser's options.

In effect on my pet test project (micronaut `http-client`), indexing time for `main/test/groovy` went down from ~160 secs to ~20-30secs. No current groovy test seems to fail.

