### PR TITLE
[NETBEANS-5480] Add an option(system property) to disable the feature to fold PHP tags

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/csl/FoldingScanner.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/csl/FoldingScanner.java
@@ -131,6 +131,7 @@ public final class FoldingScanner {
     );
 
     private static final String LAST_CORRECT_FOLDING_PROPERTY = "LAST_CORRECT_FOLDING_PROPERY"; //NOI18N
+    private static final boolean FOLD_PHPTAG = !Boolean.getBoolean("nb.php.editor.doNotFoldPhptag"); // NOI18N NETBEANS-5480
 
     public static FoldingScanner create() {
         return new FoldingScanner();
@@ -170,7 +171,9 @@ public final class FoldingScanner {
             Source source = phpParseResult.getSnapshot().getSource();
             assert source != null : "source was null";
             Document doc = source.getDocument(false);
-            processPHPTags(folds, doc);
+            if (FOLD_PHPTAG) {
+                processPHPTags(folds, doc);
+            }
             setFoldingProperty(doc, folds);
             return folds;
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5480

- The folding features do not have options to enable/disable each item at the moment
although there are options for each whole language (There are Enable Code Folding checkboxes)
- Users can add `-J-Dnb.php.editor.doNotFoldPhptag=true` on boot

See also: https://lists.apache.org/thread.html/r355eeab1ffcf4a96fa19847dc26256f2bd76d574573e69eb8e1f4b66%40%3Cdev.netbeans.apache.org%3E

Attached Screenshots
- https://lists.apache.org/api/email.lua?attachment=true&id=r355eeab1ffcf4a96fa19847dc26256f2bd76d574573e69eb8e1f4b66@%3Cdev.netbeans.apache.org%3E&file=9d4409e8b72c68c4e0869b4d41811cd9037fd2e2d79c7e7a8ba2e3e06de0fa7b
- https://lists.apache.org/api/email.lua?attachment=true&id=r355eeab1ffcf4a96fa19847dc26256f2bd76d574573e69eb8e1f4b66@%3Cdev.netbeans.apache.org%3E&file=7d4a0dd67aa5a1e17d97b8189c0719ed5cb9707e187c8fe6482989377d87acff
- https://lists.apache.org/api/email.lua?attachment=true&id=r355eeab1ffcf4a96fa19847dc26256f2bd76d574573e69eb8e1f4b66@%3Cdev.netbeans.apache.org%3E&file=50fa9aa5eb9fc5d28d883ad7a516d36df406cfd801a81fb18b53521a7bf7ee4d