### PR TITLE
Fix Options export after b5587b9a9f2b254218cce5fa910d93cd10988a04

### DIFF
--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/resources/mf-layer.xml
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/resources/mf-layer.xml
@@ -98,7 +98,7 @@
         <folder name="Advanced">
             <file name="RuleFiles">
                 <attr name="include" stringvalue="config/rules/.*"/>
-                <attr name="displayName" bundlevalue="org.netbeans.modules.refactoring.java.Bundle#RefactoringRules.Options.Export.displayName"/>
+                <attr name="displayName" bundlevalue="org.netbeans.modules.refactoring.java.resources.Bundle#RefactoringRules.Options.Export.displayName"/>
             </file>
         </folder>
     </folder>


### PR DESCRIPTION
The wrong bundle was referenced to specify the displayName for the
refactoring rules.