### PR TITLE
[Groovy] Manage AST transformations

### DIFF
--- a/groovy/groovy.editor/apichanges.xml
+++ b/groovy/groovy.editor/apichanges.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<?xml-stylesheet type="text/xml" href="../../nbbuild/javadoctools/apichanges.xsl"?>
+<!DOCTYPE apichanges PUBLIC "-//NetBeans//DTD API changes list 1.0//EN" "../../nbbuild/javadoctools/apichanges.dtd">
+
+<!--
+
+INFO FOR PEOPLE ADDING CHANGES:
+
+Check the DTD (apichanges.dtd) for details on the syntax. You do not
+need to regenerate the HTML, as this is part of Javadoc generation; just
+change the XML. Rough syntax of a change (several parts optional):
+
+<change>
+    <api name="compiler"/>
+    <summary>Some brief description here, can use <b>XHTML</b></summary>
+    <version major="1" minor="99"/>
+    <date day="13" month="6" year="2001"/>
+    <author login="jrhacker"/>
+    <compatibility addition="yes"/>
+    <description>
+        The main description of the change here.
+        Again can use full <b>XHTML</b> as needed.
+    </description>
+    <class package="org.openide.compiler" name="DoWhatIWantCompiler"/>
+    <issue number="14309"/>
+</change>
+
+Also permitted elements: <package>, <branch>. <version> is API spec
+version, recommended for all new changes. <compatibility> should say
+if things were added/modified/deprecated/etc. and give all information
+related to upgrading old code. List affected top-level classes and
+link to issue numbers if applicable. See the DTD for more details.
+
+Changes need not be in any particular order, they are sorted in various
+ways by the stylesheet anyway.
+
+Dates are assumed to mean "on the trunk". If you *also* make the same
+change on a stabilization branch, use the <branch> tag to indicate this
+and explain why the change was made on a branch in the <description>.
+
+Please only change this file on the trunk! Rather: you can change it
+on branches if you want, but these changes will be ignored; only the
+trunk version of this file is important.
+
+Deprecations do not count as incompatible, assuming that code using the
+deprecated calls continues to see their documented behavior. But do
+specify deprecation="yes" in <compatibility>.
+
+This file is not a replacement for Javadoc: it is intended to list changes,
+not describe the complete current behavior, for which ordinary documentation
+is the proper place.
+
+-->
+
+<apichanges>
+
+    <!-- First, a list of API names you may use: -->
+<apidefs>
+   <apidef name="groovy-parsing">Groovy Parsing and AST APIs</apidef>
+   <apidef name="groovy-completion">Groovy Completion API</apidef>
+   <!-- etc. -->
+</apidefs>
+
+    <!-- ACTUAL CHANGES BEGIN HERE: -->
+
+<changes>
+    <change id="DisableTransformers">
+      <api name="groovy-parsing"/>
+      <summary>Allow to enable/disable AST transformation during parsing and indexing</summary>
+      <version major="1" minor="79"/>
+      <date day="28" month="7" year="2021"/>
+      <author login="sdedic"/>
+      <compatibility addition="yes" binary="compatible" semantic="compatible" />
+      <description>
+          <p>
+              Global (library) Groovy transformations can be disabled. Module-provided AST transformations 
+              can be added to a parser or indexer. 
+          </p>
+      </description>
+      <class package="org.netbeans.modules.groovy.editor.api.parser" name="ApplyGroovyTransformation"/>
+    </change>
+</changes>
+
+    <!-- Now the surrounding HTML text and document structure: -->
+
+    <htmlcontents>
+<!--
+
+                            NO NO NO NO NO!
+
+         ==============>    DO NOT EDIT ME!  <==============
+
+          AUTOMATICALLY GENERATED FROM APICHANGES.XML, DO NOT EDIT
+
+                SEE openide/io/api/doc/changes/changes.xml
+
+-->
+    <head>
+      <title>Change History for the Input/Output API</title>
+      <link rel="stylesheet" href="prose.css" type="text/css"/>
+    </head>
+    <body>
+
+<p class="overviewlink"><a href="overview-summary.html">Overview</a></p>
+
+<h1>Introduction</h1>
+
+<p>This document lists changes made to the <a href="@org-openide-io@/index.html">I/O API</a>.</p>
+
+<!-- The actual lists of changes, as summaries and details: -->
+      <hr/>
+      <standard-changelists module-code-name="org.openide.io"/>
+
+      <hr/><p>@FOOTER@</p>
+
+    </body>
+  </htmlcontents>
+
+</apichanges>

--- a/groovy/groovy.editor/arch.xml
+++ b/groovy/groovy.editor/arch.xml
@@ -1,0 +1,1121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE api-answers PUBLIC "-//NetBeans//DTD Arch Answers//EN" "../../nbbuild/antsrc/org/netbeans/nbbuild/Arch.dtd" [
+  <!ENTITY api-questions SYSTEM "../../nbbuild/antsrc/org/netbeans/nbbuild/Arch-api-questions.xml">
+]>
+
+<api-answers
+  question-version="1.29"
+  author="yourname@netbeans.org"
+>
+
+  &api-questions;
+
+
+<!--
+        <question id="arch-overall" when="init">
+            Describe the overall architecture. 
+            <hint>
+            What will be API for 
+            <a href="http://wiki.netbeans.org/API_Design#Separate_API_for_clients_from_support_API">
+                clients and what support API</a>? 
+            What parts will be pluggable?
+            How will plug-ins be registered? Please use <code>&lt;api type="export"/&gt;</code>
+            to describe your general APIs and specify their
+            <a href="http://wiki.netbeans.org/API_Stability#Private">
+            stability categories</a>.
+            If possible please provide simple diagrams.
+            </hint>
+        </question>
+-->
+ <answer id="arch-overall">
+  <ul>
+   <li>
+    <api group="java" name="groovy-parsing" type="export" category="friend">
+     <p>
+         Provides access to Groovy lexer symbols, Parser's results, structure and indexe.
+     </p>
+    </api>
+   </li>
+   <li>
+    <api group="java" name="groovy-completion" type="export" category="friend">
+     <p>
+         Provides access and extension points for code completion.
+     </p>
+    </api>
+   </li>
+  </ul>
+ </answer>
+
+
+
+<!--
+        <question id="arch-quality" when="init">
+            How will the <a href="http://www.netbeans.org/community/guidelines/q-evangelism.html">quality</a>
+            of your code be tested and 
+            how are future regressions going to be prevented?
+            <hint>
+            What kind of testing do
+            you want to use? How much functionality, in which areas,
+            should be covered by the tests? How you find out that your
+            project was successful?
+            </hint>
+        </question>
+-->
+ <answer id="arch-quality">
+  <p>
+   Unit tests
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="arch-time" when="init">
+            What are the time estimates of the work?
+            <hint>
+            Please express your estimates of how long the design, implementation,
+            stabilization are likely to last. How many people will be needed to
+            implement this and what is the expected milestone by which the work should be 
+            ready?
+            </hint>
+        </question>
+-->
+ <answer id="arch-time">
+  <p>
+   XXX no answer for arch-time
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="arch-usecases" when="init">
+            <hint>
+                Content of this answer will be displayed as part of page at
+                http://www.netbeans.org/download/dev/javadoc/usecases.html 
+                You can use tags &lt;usecase name="name&gt; regular html description &lt;/usecase&gt;
+                and if you want to use an URL you can prefix if with @TOP@ to begin
+                at the root of your javadoc
+            </hint>
+        
+            Describe the main <a href="http://wiki.netbeans.org/API_Design#The_Importance_of_Being_Use_Case_Oriented">
+            use cases</a> of the new API. Who will use it under
+            what circumstances? What kind of code would typically need to be written
+            to use the module?
+        </question>
+-->
+ <answer id="arch-usecases">
+  <p>
+   XXX no answer for arch-usecases
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="arch-what" when="init">
+            What is this project good for?
+            <hint>
+            Please provide here a few lines describing the project, 
+            what problem it should solve, provide links to documentation, 
+            specifications, etc.
+            </hint>
+        </question>
+-->
+ <answer id="arch-what">
+  <p>
+   XXX no answer for arch-what
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="arch-where" when="impl">
+            Where one can find sources for your module?
+            <hint>
+                Please provide link to the Hg web client at
+                http://hg.netbeans.org/
+                or just use tag defaultanswer generate='here'
+            </hint>
+        </question>
+-->
+ <answer id="arch-where">
+  <defaultanswer generate='here' />
+ </answer>
+
+
+
+<!--
+        <question id="compat-deprecation" when="init">
+            How the introduction of your project influences functionality
+            provided by previous version of the product?
+            <hint>
+            If you are planning to deprecate/remove/change any existing APIs,
+            list them here accompanied with the reason explaining why you
+            are doing so.
+            </hint>
+        </question>
+-->
+ <answer id="compat-deprecation">
+  <p>
+   XXX no answer for compat-deprecation
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="compat-i18n" when="impl">
+            Is your module correctly internationalized?
+            <hint>
+            Correct internationalization means that it obeys instructions 
+            at <a href="http://www.netbeans.org/download/dev/javadoc/org-openide-modules/org/openide/modules/doc-files/i18n-branding.html">
+            NetBeans I18N pages</a>.
+            </hint>
+        </question>
+-->
+ <answer id="compat-i18n">
+  <p>
+   Yes.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="compat-standards" when="init">
+            Does the module implement or define any standards? Is the 
+            implementation exact or does it deviate somehow?
+        </question>
+-->
+ <answer id="compat-standards">
+  <p>
+   No.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="compat-version" when="impl">
+            Can your module coexist with earlier and future
+            versions of itself? Can you correctly read all old settings? Will future
+            versions be able to read your current settings? Can you read
+            or politely ignore settings stored by a future version?
+            
+            <hint>
+            Very helpful for reading settings is to store version number
+            there, so future versions can decide whether how to read/convert
+            the settings and older versions can ignore the new ones.
+            </hint>
+        </question>
+-->
+ <answer id="compat-version">
+  <p>
+   XXX no answer for compat-version
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="dep-jre" when="final">
+            Which version of JRE do you need (1.2, 1.3, 1.4, etc.)?
+            <hint>
+            It is expected that if your module runs on 1.x that it will run 
+            on 1.x+1 if no, state that please. Also describe here cases where
+            you run different code on different versions of JRE and why.
+            </hint>
+        </question>
+-->
+ <answer id="dep-jre">
+  <p>
+   XXX no answer for dep-jre
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="dep-jrejdk" when="final">
+            Do you require the JDK or is the JRE enough?
+        </question>
+-->
+ <answer id="dep-jrejdk">
+  <p>
+   JDK
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="dep-nb" when="init">
+            What other NetBeans projects and modules does this one depend on?
+            <hint>
+            Depending on other NetBeans projects influnces the ability of
+            users of your work to customize their own branded version of
+            NetBeans by enabling and disabling some modules. Too
+            much dependencies restrict this kind of customization. If that
+            is your case, then you may want to split your functionality into
+            pieces of autoload, eager and regular modules which can be
+            enabled independently. Usually the answer to this question
+            is generated from your <code>project.xml</code> file, but
+            if it is not guessed correctly, you can suppress it by
+            specifying &lt;defaultanswer generate="none"/&gt; and
+            write here your own. Please describe such projects as imported APIs using
+            the <code>&lt;api name="identification" type="import or export" category="stable" url="where is the description" /&gt;</code>.
+            By doing this information gets listed in the summary page of your
+            javadoc.
+            </hint>
+        </question>
+-->
+ <answer id="dep-nb">
+  <defaultanswer generate='here' />
+ </answer>
+
+
+
+<!--
+        <question id="dep-non-nb" when="init">
+            What other projects outside NetBeans does this one depend on?
+            
+            <hint>
+            Depending on 3rd party libraries is always problematic,
+            especially if they are not open source, as that complicates
+            the licensing scheme of NetBeans. Please enumerate your
+            external dependencies here, so it is correctly understood since
+            the begining what are the legal implications of your project.
+            Also please note that
+            some non-NetBeans projects are packaged as NetBeans modules
+            (see <a href="http://libs.netbeans.org/">libraries</a>) and
+            it is preferred to use this approach when more modules may
+            depend and share such third-party libraries.
+            </hint>
+        </question>
+-->
+ <answer id="dep-non-nb">
+  <p>
+      <a href="http://https://docs.groovy-lang.org/latest/html/api/">Groovy lanuage</a>
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="dep-platform" when="init">
+            On which platforms does your module run? Does it run in the same
+            way on each?
+            <hint>
+            If you plan any dependency on OS or any usage of native code,
+            please describe why you are doing so and describe how you envision
+            to enforce the portability of your code.
+            Please note that there is a support for <a href="http://www.netbeans.org/download/dev/javadoc/org-openide-modules/org/openide/modules/doc-files/api.html#how-os-specific">OS conditionally
+            enabled modules</a> which together with autoload/eager modules
+            can allow you to enable to provide the best OS aware support
+            on certain OSes while providing compatibility bridge on the not
+            supported ones.
+            Also please list the supported
+            OSes/HW platforms and mentioned the lovest version of JDK required
+            for your project to run on. Also state whether JRE is enough or
+            you really need JDK.
+            </hint>
+        </question>
+-->
+ <answer id="dep-platform">
+  <p>
+   Same platforms as Groovy.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="deploy-dependencies" when="final">
+            What do other modules need to do to declare a dependency on this one,
+            in addition to or instead of the normal module dependency declaration
+            (e.g. tokens to require)?
+            <hint>
+                Provide a sample of the actual lines you would add to a module manifest
+                to declare a dependency, for example OpenIDE-Module-Requires: some.token.
+                If other modules should not depend on this module, or should just use a
+                simple regular module dependency, you can just answer "nothing". If you
+                intentionally expose a semistable API to clients using implementation
+                dependencies, you should mention that here (but there is no need to give
+                an example of usage).
+            </hint>
+        </question>
+-->
+ <answer id="deploy-dependencies">
+  <p>
+   None.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="deploy-jar" when="impl">
+            Do you deploy just module JAR file(s) or other files as well?
+            <hint>
+            Usually a module consist of one JAR file (perhaps with Class-Path
+            extensions) and also a configuration file that enables it. If you
+            have any other files, use
+            &lt;api group="java.io.File" name="yourname" type="export" category="friend"&gt;...&lt;/api&gt;
+            to define the location, name and stability of your files (of course
+            changing "yourname" and "friend" to suit your needs).
+            
+            If it uses more than one JAR, describe where they are located, how
+            they refer to each other. 
+            If it consist of module JAR(s) and other files, please describe
+            what is their purpose, why other files are necessary. Please 
+            make sure that installation/uninstallation leaves the system 
+            in state as it was before installation.
+            </hint>
+        </question>
+-->
+ <answer id="deploy-jar">
+  <p>
+   None.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="deploy-nbm" when="impl">
+            Can you deploy an NBM via the Update Center?
+            <hint>
+            If not why?
+            </hint>
+        </question>
+-->
+ <answer id="deploy-nbm">
+  <p>
+   Yes.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="deploy-packages" when="init">
+            Are packages of your module made inaccessible by not declaring them
+            public?
+            
+            <hint>
+            By default NetBeans build harness treats all packages are private.
+            If you export some of them - either as public or friend packages,
+            you should have a reason. If the reason is described elsewhere
+            in this document, you can ignore this question.
+            </hint>
+        </question>
+-->
+ <answer id="deploy-packages">
+  <p>
+   Selected packages form Friend API.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="deploy-shared" when="final">
+            Do you need to be installed in the shared location only, or in the user directory only,
+            or can your module be installed anywhere?
+            <hint>
+            Installation location shall not matter, if it does explain why.
+            Consider also whether <code>InstalledFileLocator</code> can help.
+            </hint>
+        </question>
+-->
+ <answer id="deploy-shared">
+  <p>
+   Anywhere.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-ant-tasks" when="impl">
+            Do you define or register any ant tasks that other can use?
+            
+            <hint>
+            If you provide an ant task that users can use, you need to be very
+            careful about its syntax and behaviour, as it most likely forms an
+	          API for end users and as there is a lot of end users, their reaction
+            when such API gets broken can be pretty strong.
+            </hint>
+        </question>
+-->
+ <answer id="exec-ant-tasks">
+  <p>
+   None.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-classloader" when="impl">
+            Does your code create its own class loader(s)?
+            <hint>
+            A bit unusual. Please explain why and what for.
+            </hint>
+        </question>
+-->
+ <answer id="exec-classloader">
+  <p>
+      <a href="https://docs.groovy-lang.org/latest/html/api/groovy/lang/GroovyClassLoader.html">GroovyClassloaders are created.</a> to access compile-time resources and perform transformations.
+  </p>
+    <ul>
+        <li><b>Transformation loader</b> - during parse, it is created from <b>compile and boot classpath</b>. Module code is not accessible from transformation loader.</li>
+        <li><b>Resolve loader</b> - during parse, accesses resources (source classpath of the source file) or compiled classes (compile + boot classpaths).</li>
+    </ul>
+ </answer>
+
+
+
+<!--
+        <question id="exec-component" when="impl">
+            Is execution of your code influenced by any (string) property
+            of any of your components?
+            
+            <hint>
+            Often <code>JComponent.getClientProperty</code>, <code>Action.getValue</code>
+            or <code>PropertyDescriptor.getValue</code>, etc. are used to influence
+            a behavior of some code. This of course forms an interface that should
+            be documented. Also if one depends on some interface that an object
+            implements (<code>component instanceof Runnable</code>) that forms an
+            API as well.
+            </hint>
+        </question>
+-->
+ <answer id="exec-component">
+  <p>
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-introspection" when="impl">
+            Does your module use any kind of runtime type information (<code>instanceof</code>,
+            work with <code>java.lang.Class</code>, etc.)?
+            <hint>
+            Check for cases when you have an object of type A and you also
+            expect it to (possibly) be of type B and do some special action. That
+            should be documented. The same applies on operations in meta-level
+            (Class.isInstance(...), Class.isAssignableFrom(...), etc.).
+            </hint>
+        </question>
+-->
+ <answer id="exec-introspection">
+  <p>
+   XXX no answer for exec-introspection
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-privateaccess" when="final">
+            Are you aware of any other parts of the system calling some of 
+            your methods by reflection?
+            <hint>
+            If so, describe the "contract" as an API. Likely private or friend one, but
+            still API and consider rewrite of it.
+            </hint>
+        </question>
+-->
+ <answer id="exec-privateaccess">
+  <p>
+   XXX no answer for exec-privateaccess
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-process" when="impl">
+            Do you execute an external process from your module? How do you ensure
+            that the result is the same on different platforms? Do you parse output?
+            Do you depend on result code?
+            <hint>
+            If you feed an input, parse the output please declare that as an API.
+            </hint>
+        </question>
+-->
+ <answer id="exec-process">
+  <p>
+   No.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-property" when="impl">
+            Is execution of your code influenced by any environment or
+            Java system (<code>System.getProperty</code>) property?
+            On a similar note, is there something interesting that you
+            pass to <code>java.util.logging.Logger</code>? Or do you observe
+            what others log?
+            <hint>
+            If there is a property that can change the behavior of your 
+            code, somebody will likely use it. You should describe what it does 
+            and the <a href="http://wiki.netbeans.org/API_Stability">stability category</a>
+            of this API. You may use
+            <pre>
+                &lt;api type="export" group="property" name="id" category="private" url="http://..."&gt;
+                    description of the property, where it is used, what it influence, etc.
+                &lt;/api&gt;            
+            </pre>
+            </hint>
+        </question>
+-->
+ <answer id="exec-property">
+  <p>
+        <api category="devel" group="systemproperty" name="org.netbeans.modules.groovy.editor.api.indexingEnabled" type="export">
+            Boolean-type property that can completely disable Groovy indexing. The default value is <code>true</code>. If set to false, Individual source files will be still 
+            parsed, but indexing will not process Groovy source files and will not create Groovy symbol index.
+        </api>
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-reflection" when="impl">
+            Does your code use Java Reflection to execute other code?
+            <hint>
+            This usually indicates a missing or insufficient API in the other
+            part of the system. If the other side is not aware of your dependency
+            this contract can be easily broken.
+            </hint>
+        </question>
+-->
+ <answer id="exec-reflection">
+  <p>
+   No.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="exec-threading" when="init">
+            What threading models, if any, does your module adhere to? How the
+            project behaves with respect to threading?
+            <hint>
+                Is your API threadsafe? Can it be accessed from any threads or
+                just from some dedicated ones? Any special relation to AWT and
+                its Event Dispatch thread? Also
+                if your module calls foreign APIs which have a specific threading model,
+                indicate how you comply with the requirements for multithreaded access
+                (synchronization, mutexes, etc.) applicable to those APIs.
+                If your module defines any APIs, or has complex internal structures
+                that might be used from multiple threads, declare how you protect
+                data against concurrent access, race conditions, deadlocks, etc.,
+                and whether such rules are enforced by runtime warnings, errors, assertions, etc.
+                Examples: a class might be non-thread-safe (like Java Collections); might
+                be fully thread-safe (internal locking); might require access through a mutex
+                (and may or may not automatically acquire that mutex on behalf of a client method);
+                might be able to run only in the event queue; etc.
+                Also describe when any events are fired: synchronously, asynchronously, etc.
+                Ideas: <a href="http://core.netbeans.org/proposals/threading/index.html#recommendations">Threading Recommendations</a> (in progress)
+            </hint>
+        </question>
+-->
+ <answer id="exec-threading">
+  <p>
+   XXX no answer for exec-threading
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="format-clipboard" when="impl">
+            Which data flavors (if any) does your code read from or insert to
+            the clipboard (by access to clipboard on means calling methods on <code>java.awt.datatransfer.Transferable</code>?
+            
+            <hint>
+            Often Node's deal with clipboard by usage of <code>Node.clipboardCopy, Node.clipboardCut and Node.pasteTypes</code>.
+            Check your code for overriding these methods.
+            </hint>
+        </question>
+-->
+ <answer id="format-clipboard">
+  <p>
+   XXX no answer for format-clipboard
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="format-dnd" when="impl">
+            Which protocols (if any) does your code understand during Drag &amp; Drop?
+            <hint>
+            Often Node's deal with clipboard by usage of <code>Node.drag, Node.getDropType</code>. 
+            Check your code for overriding these methods. Btw. if they are not overridden, they
+            by default delegate to <code>Node.clipboardCopy, Node.clipboardCut and Node.pasteTypes</code>.
+            </hint>
+        </question>
+-->
+ <answer id="format-dnd">
+  <p>
+   XXX no answer for format-dnd
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="format-types" when="impl">
+            Which protocols and file formats (if any) does your module read or write on disk,
+            or transmit or receive over the network? Do you generate an ant build script?
+            Can it be edited and modified? 
+            
+            <hint>
+            <p>
+            Files can be read and written by other programs, modules and users. If they influence
+            your behaviour, make sure you either document the format or claim that it is a private
+            api (using the &lt;api&gt; tag). 
+            </p>
+            
+            <p>
+            If you generate an ant build file, this is very likely going to be seen by end users and
+            they will be attempted to edit it. You should be ready for that and provide here a link
+            to documentation that you have for such purposes and also describe how you are going to
+            understand such files during next release, when you (very likely) slightly change the 
+            format.
+            </p>
+            </hint>
+        </question>
+-->
+ <answer id="format-types">
+  <p>
+   XXX no answer for format-types
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="lookup-lookup" when="init">
+            Does your module use <code>org.openide.util.Lookup</code>
+            or any similar technology to find any components to communicate with? Which ones?
+            
+            <hint>
+            NetBeans is build around a generic registry of services called
+            lookup. It is preferable to use it for registration and discovery
+            if possible. See
+            <a href="http://www.netbeans.org/download/dev/javadoc/org-openide-util/org/openide/util/lookup/doc-files/index.html">
+            The Solution to Comunication Between Components
+            </a>. If you do not plan to use lookup and insist usage
+            of other solution, then please describe why it is not working for
+            you.
+            <br/>
+            When filling the final version of your arch document, please
+            describe the interfaces you are searching for, where 
+            are defined, whether you are searching for just one or more of them,
+            if the order is important, etc. Also classify the stability of such
+            API contract. Use &lt;api group=&amp;lookup&amp; /&gt; tag, so
+            your information gets listed in the summary page of your javadoc.
+            </hint>
+        </question>
+-->
+ <answer id="lookup-lookup">
+  <p>
+   XXX no answer for lookup-lookup
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="lookup-register" when="final">
+            Do you register anything into lookup for other code to find?
+            <hint>
+            Do you register using layer file or using a declarative annotation such as <code>@ServiceProvider</code>?
+            Who is supposed to find your component?
+            </hint>
+        </question>
+-->
+ <answer id="lookup-register">
+  <p>
+   XXX no answer for lookup-register
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="lookup-remove" when="final">
+            Do you remove entries of other modules from lookup?
+            <hint>
+            Why? Of course, that is possible, but it can be dangerous. Is the module
+            your are masking resource from aware of what you are doing?
+            </hint>
+        </question>
+-->
+ <answer id="lookup-remove">
+  <p>
+   XXX no answer for lookup-remove
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-exit" when="final">
+            Does your module run any code on exit?
+        </question>
+-->
+ <answer id="perf-exit">
+  <p>
+   XXX no answer for perf-exit
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-huge_dialogs" when="final">
+            Does your module contain any dialogs or wizards with a large number of
+            GUI controls such as combo boxes, lists, trees, or text areas?
+        </question>
+-->
+ <answer id="perf-huge_dialogs">
+  <p>
+   XXX no answer for perf-huge_dialogs
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-limit" when="init">
+            Are there any hard-coded or practical limits in the number or size of
+            elements your code can handle?
+            <hint>
+                Most of algorithms have increasing memory and speed complexity
+                with respect to size of data they operate on. What is the critical
+                part of your project that can be seen as a bottleneck with
+                respect to speed or required memory? What are the practical
+                sizes of data you tested your project with? What is your estimate
+                of potential size of data that would cause visible performance
+                problems? Is there some kind of check to detect such situation
+                and prevent "hard" crashes - for example the CloneableEditorSupport
+                checks for size of a file to be opened in editor
+                and if it is larger than 1Mb it shows a dialog giving the
+                user the right to decide - e.g. to cancel or commit suicide.
+            </hint>
+        </question>
+-->
+ <answer id="perf-limit">
+  <p>
+   XXX no answer for perf-limit
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-mem" when="final">
+            How much memory does your component consume? Estimate
+            with a relation to the number of windows, etc.
+        </question>
+-->
+ <answer id="perf-mem">
+  <p>
+   XXX no answer for perf-mem
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-menus" when="final">
+            Does your module use dynamically updated context menus, or
+            context-sensitive actions with complicated and slow enablement logic?
+            <hint>
+                If you do a lot of tricks when adding actions to regular or context menus, you can significantly
+                slow down display of the menu, even when the user is not using your action. Pay attention to
+                actions you add to the main menu bar, and to context menus of foreign nodes or components. If
+                the action is conditionally enabled, or changes its display dynamically, you need to check the
+                impact on performance. In some cases it may be more appropriate to make a simple action that is
+                always enabled but does more detailed checks in a dialog if it is actually run.
+            </hint>
+        </question>
+-->
+ <answer id="perf-menus">
+  <p>
+   XXX no answer for perf-menus
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-progress" when="final">
+            Does your module execute any long-running tasks?
+            
+            <hint>Long running tasks should never block 
+            AWT thread as it badly hurts the UI
+            <a href="http://performance.netbeans.org/responsiveness/issues.html">
+            responsiveness</a>.
+            Tasks like connecting over
+            network, computing huge amount of data, compilation
+            be done asynchronously (for example
+            using <code>RequestProcessor</code>), definitively it should 
+            not block AWT thread.
+            </hint>
+        </question>
+-->
+ <answer id="perf-progress">
+  <p>
+   XXX no answer for perf-progress
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-scale" when="init">
+            Which external criteria influence the performance of your
+            program (size of file in editor, number of files in menu, 
+            in source directory, etc.) and how well your code scales?
+            <hint>
+            Please include some estimates, there are other more detailed 
+            questions to answer in later phases of implementation. 
+            </hint>
+        </question>
+-->
+ <answer id="perf-scale">
+  <p>
+   XXX no answer for perf-scale
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-spi" when="init">
+            How the performance of the plugged in code will be enforced?
+            <hint>
+            If you allow foreign code to be plugged into your own module, how
+            do you enforce that it will behave correctly and quickly and will not
+            negatively influence the performance of your own module?
+            </hint>
+        </question>
+-->
+ <answer id="perf-spi">
+  <p>
+   XXX no answer for perf-spi
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-startup" when="final">
+            Does your module run any code on startup?
+        </question>
+-->
+ <answer id="perf-startup">
+  <p>
+   XXX no answer for perf-startup
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="perf-wakeup" when="final">
+            Does any piece of your code wake up periodically and do something
+            even when the system is otherwise idle (no user interaction)?
+        </question>
+-->
+ <answer id="perf-wakeup">
+  <p>
+   XXX no answer for perf-wakeup
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="resources-file" when="final">
+            Does your module use <code>java.io.File</code> directly?
+            
+            <hint>
+            NetBeans provide a logical wrapper over plain files called 
+            <code>org.openide.filesystems.FileObject</code> that
+            provides uniform access to such resources and is the preferred
+            way that should be used. But of course there can be situations when
+            this is not suitable.
+            </hint>
+        </question>
+-->
+ <answer id="resources-file">
+  <p>
+   Groovy library may access groovy sources/resources as files.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="resources-layer" when="final">
+            Does your module provide own layer? Does it create any files or
+            folders in it? What it is trying to communicate by that and with which 
+            components?
+            
+            <hint>
+            NetBeans allows automatic and declarative installation of resources 
+            by module layers. Module register files into appropriate places
+            and other components use that information to perform their task
+            (build menu, toolbar, window layout, list of templates, set of
+            options, etc.). 
+            </hint>
+        </question>
+-->
+ <answer id="resources-layer">
+  <p>
+   Yes, layer is provided.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="resources-mask" when="final">
+            Does your module mask/hide/override any resources provided by other modules in
+            their layers?
+            
+            <hint>
+            If you mask a file provided by another module, you probably depend
+            on that and do not want the other module to (for example) change
+            the file's name. That module shall thus make that file available as an API
+            of some stability category.
+            </hint>
+        </question>
+-->
+ <answer id="resources-mask">
+  <p>
+   None.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="resources-preferences" when="final">
+            Does your module uses preferences via Preferences API? Does your module use NbPreferences or
+            or regular JDK Preferences ? Does it read, write or both ? 
+            Does it share preferences with other modules ? If so, then why ?
+            <hint>
+                You may use
+                    &lt;api type="export" group="preferences"
+                    name="preference node name" category="private"&gt;
+                    description of individual keys, where it is used, what it
+                    influences, whether the module reads/write it, etc.
+                    &lt;/api&gt;
+                Due to XML ID restrictions, rather than /org/netbeans/modules/foo give the "name" as org.netbeans.modules.foo.
+                Note that if you use NbPreferences this name will then be the same as the code name base of the module.
+            </hint>
+        </question>
+-->
+ <answer id="resources-preferences">
+  <p>
+   None.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="resources-read" when="final">
+            Does your module read any resources from layers? For what purpose?
+            
+            <hint>
+            As this is some kind of intermodule dependency, it is a kind of API.
+            Please describe it and classify according to 
+            <a href="http://wiki.netbeans.org/API_Design#What_is_an_API.3F">
+            common stability categories</a>.
+            </hint>
+        </question>
+-->
+ <answer id="resources-read">
+  <p>
+      <api group="layer" name="ParsingCompilerCustomizer" type="export" category="private">
+          <p>
+              <code>Editors/text/x-groovy/Parser</code> (replace the prefix with the source file's MIME type) folder may contain entries that are processed
+              and enable/disable transformers, or alter Groovy compiler configuration during parsing or indexing.
+          </p>
+      </api>
+      `
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="security-grant" when="final">
+            Does your code grant additional rights to some other code?
+            <hint>Avoid using a class loader that adds extra
+            permissions to loaded code unless really necessary.
+            Also note that your API implementation
+            can also expose unneeded permissions to enemy code by
+            calling AccessController.doPrivileged().</hint>
+        </question>
+-->
+ <answer id="security-grant">
+  <p>
+   No.
+  </p>
+ </answer>
+
+
+
+<!--
+        <question id="security-policy" when="final">
+            Does your functionality require modifications to the standard policy file?
+            <hint>Your code might pass control to third-party code not
+            coming from trusted domains. This could be code downloaded over the
+            network or code coming from libraries that are not bundled
+            with NetBeans. Which permissions need to be granted to which domains?</hint>
+        </question>
+-->
+ <answer id="security-policy">
+  <p>
+   No.
+  </p>
+ </answer>
+
+</api-answers>

--- a/groovy/groovy.editor/nbproject/project.properties
+++ b/groovy/groovy.editor/nbproject/project.properties
@@ -17,6 +17,8 @@
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 
+javadoc.arch=${basedir}/arch.xml
+javadoc.apichanges=${basedir}/apichanges.xml
 nbm.homepage=http://wiki.netbeans.org/groovy
 nbm.module.author=Martin Adamek, Petr Hejl, Matthias Schmidt, Martin Janicek
 nbm.needs.restart=true

--- a/groovy/groovy.editor/nbproject/project.xml
+++ b/groovy/groovy.editor/nbproject/project.xml
@@ -284,7 +284,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.0</specification-version>
+                        <specification-version>9.22</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/CompletionContext.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/CompletionContext.java
@@ -107,7 +107,8 @@ public final class CompletionContext {
         this.dotContext = getDotCompletionContext();
         this.nameOnly = dotContext != null && dotContext.isMethodsOnly();
 
-        this.declaringClass = getBeforeDotDeclaringClass();
+        ClassNode dc = getBeforeDotDeclaringClass();
+        this.declaringClass = dc == null ? null : dc.redirect();
     }
     
     // TODO: Move this to the constructor and change ContextHelper.getSurroundingClassNode()

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/ApplyGroovyTransformation.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/ApplyGroovyTransformation.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.api.parser;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+
+/**
+ * Enables or disables Groovy Transformations in parsing or indexing process. A transformation can be enabled/disabled for parsing, indexing or both. 
+ * The annotation can be used on either a {@link ASTTransformation} subclass without any {@link #value} to define how the class is going to be
+ * applied (value will default to the annotated class' name). The ASTTransformation <b>must be also annotated by {@link GroovyASTTransformation}</b> that specifies the {@link CompilePhase}
+ * the transformation is applied in. 
+ * <div class="nonnormative">
+ * An example of an additional ASTTransformation registered for parsing only (default) in PARSING phase: {@codesnippet GroovyTestTransformer}
+ * </div>
+ * <p>
+ * Any other type (or package element) can be also annotated by this annotation, but {@link #value} must identify fully qualified class name(s) of
+ * transformation(s) to be affected. 
+ * <div class="nonnormative">
+ * An example of an some "foreign" global transformations disabled for parsing tasks: {@codesnippet DisableTransformersStub}
+ * </div>
+ * <p>
+ * If {@link #enable} attribute is not specified when ASTTransformation is annotated, it will default to {@link #APPLY_PARSE}. 
+ * Global transformations can be disabled using {@link #disable} attribute. 
+ * 
+ * @since 1.79
+ * @author sdedic
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ ElementType.TYPE, ElementType.PACKAGE })
+public @interface ApplyGroovyTransformation {
+    /**
+     * Apply the setting when parsing individual sources.
+     */
+    public static final String APPLY_PARSE = "parse";
+    
+    /**
+     * Apply the setting during indexing.
+     */
+    public static final String APPLY_INDEX = "index";
+    
+    /**
+     * Apply on a specific mime type. The default is {@code text/x-groovy} which means
+     * all Groovy sources.
+     * 
+     * @return affected MIME types.
+     */
+    public String[] mimeTypes() default { "text/x-groovy" };
+    
+    /**
+     * When the transformation should apply. Can be one or more of:
+     * <ul>
+     * <li>{@Link #APPLY_PARSE} to apply when parsing a source
+     * <li>{@Link #APPLY_INDEX} during indexing
+     * </ul>
+     * By default the instruction is applied in all tasks if a {@link ASTTransformation} class is
+     * annotated or never, if {@link #value} is specified.
+     * @return when the instruction should be applied.
+     */
+    public String[] enable() default { };
+    
+    /**
+     * Disables a global transformation for the specified purposes. This value is not very useful when
+     * annotating a new custom transformation, as the {@link #enable} attribute controls when the transformation
+     * is applied to the Groovy compilation unit. But this setting disables an automatically discovered
+     * global transformation for the specified task types.
+     * 
+     * @return list of task types that disable the transformation.
+     */
+    public String[] disable() default { };
+
+    /**
+     * Specifies which transformation classes the instruction applies to. If not specified, this annotation
+     * must be attached to a {@link ASTTransformation} subclass. Must list fully qualified transformation class names,
+     * in the same syntax as passed to {@link ClassLoader#loadClass(java.lang.String)}. 
+     * @return affected transformation class names.
+     */
+    public String[] value() default {};
+}

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
@@ -22,8 +22,10 @@ package org.netbeans.modules.groovy.editor.api.parser;
 import groovy.lang.GroovyClassLoader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,20 +35,16 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.BadLocationException;
-import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.CompileUnit;
 import org.codehaus.groovy.ast.ModuleNode;
-import org.codehaus.groovy.classgen.GeneratorContext;
-import org.codehaus.groovy.control.CompilationFailedException;
-import org.codehaus.groovy.control.CompilePhase;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.ErrorCollector;
 import org.codehaus.groovy.control.Phases;
-import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.control.messages.Message;
 import org.codehaus.groovy.control.messages.SimpleMessage;
 import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
 import org.codehaus.groovy.syntax.SyntaxException;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.lexer.Token;
@@ -63,18 +61,22 @@ import org.netbeans.modules.groovy.editor.compiler.error.GroovyError;
 import org.netbeans.modules.groovy.editor.utils.GroovyUtils;
 import org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId;
 import org.netbeans.modules.groovy.editor.api.lexer.LexUtilities;
+import org.netbeans.modules.groovy.editor.compiler.ParsingCompilerCustomizer;
+import org.netbeans.modules.groovy.editor.compiler.SimpleTransformationCustomizer;
 import org.netbeans.modules.groovy.editor.compiler.error.CompilerErrorResolver;
 import org.netbeans.modules.parsing.api.Snapshot;
 import org.netbeans.modules.parsing.api.Task;
 import org.netbeans.modules.parsing.spi.ParseException;
 import org.netbeans.modules.parsing.spi.Parser;
 import org.netbeans.modules.parsing.spi.SourceModificationEvent;
+import org.netbeans.modules.parsing.spi.indexing.support.IndexingSupport;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
 
 /**
- *
+ * Groovy Parser interface. This class should not be probably public. Do not use it outside the module.
  * @author Martin Adamek
  */
 public class GroovyParser extends Parser {
@@ -126,18 +128,14 @@ public class GroovyParser extends Parser {
         cancelled.set(false);
         
         if (!GroovyUtils.isIndexingEnabled()) {
-            // HACK: Indexing cannot be registered 'conditionally'. Once an indexer is registered for text/x-groovy,
-            // RepositoryUpdater infrastructure calls the registred parser on all text/x-groovy sources even before
-            // the Indexer can reject the file as indexable.
-            // this hack attempts to detect that the parser is being called from RepositoryUpdater and returns null
-            // immediately if so.
-            if (task != null && task.getClass().getName().contains(".RepositoryUpdater$")) { // NOI18N
+            if (IndexingSupport.isIndexingTask(task)) { // NOI18N
                 lastResult = createParseResult(snapshot, null, null);
                 return;
             }
         }
 
         Context context = new Context(snapshot, event);
+        context.setIndexingTask(task);
         final Set<Error> errors = new HashSet<Error>();
         context.errorHandler = new ParseErrorHandler() {
 
@@ -443,6 +441,17 @@ public class GroovyParser extends Parser {
         }
     }
 
+    private static CompilerConfiguration makeConfiguration(
+            CompilerConfiguration configuration, Context context, boolean isIndexing) {
+        Map<String, Boolean> opts = configuration.getOptimizationOptions();
+        opts.put("classLoaderResolving", Boolean.FALSE);
+
+        for (ParsingCompilerCustomizer pcc : context.compilerCustomizers) {
+            configuration = pcc.configureParsingCompiler(context.customizerCtx, configuration);
+        }
+        return configuration;
+    }
+    
     @SuppressWarnings("unchecked")
     GroovyParserResult parseBuffer(final Context context, final Sanitize sanitizing) {
         if (isCancelled()) {
@@ -494,10 +503,18 @@ public class GroovyParser extends Parser {
                 bootPath == null ? ClassPath.EMPTY : bootPath,
                 compilePath == null ? ClassPath.EMPTY : compilePath,
                 sourcePath);        
-        CompilationUnit compilationUnit = new CompilationUnit(this, configuration,
-                null, classLoader, transformationLoader, cpInfo, classNodeCache);
+        
+        boolean indexing = IndexingSupport.isIndexingTask(context.parserTask);
+        configuration = makeConfiguration(configuration, context, indexing);
+        org.codehaus.groovy.control.CompilationUnit compilationUnit = new CompilationUnit(this, configuration,
+                null, classLoader, transformationLoader, cpInfo, classNodeCache, 
+                indexing);
         InputStream inputStream = new ByteArrayInputStream(source.getBytes());
         compilationUnit.addSource(fileName, inputStream);
+        
+        for (ParsingCompilerCustomizer pcc : context.compilerCustomizers) {
+            pcc.decorateCompilation(context.customizerCtx, compilationUnit);
+        }
 
         if (isCancelled()) {
             return null;
@@ -779,7 +796,8 @@ public class GroovyParser extends Parser {
         private final Snapshot snapshot;
         private final SourceModificationEvent event;
         private final BaseDocument document;
-
+        private Task parserTask;
+        
         private ParseErrorHandler errorHandler;
         private int errorOffset;
         private String source;
@@ -788,6 +806,8 @@ public class GroovyParser extends Parser {
         private String sanitizedContents;
         private int caretOffset;
         private Sanitize sanitized = Sanitize.NONE;
+        final List<ParsingCompilerCustomizer> compilerCustomizers;
+        final ParsingCompilerCustomizer.Context customizerCtx;
 
         public Context(Snapshot snapshot, SourceModificationEvent event) {
             this.snapshot = snapshot;
@@ -796,6 +816,20 @@ public class GroovyParser extends Parser {
             this.caretOffset = GsfUtilities.getLastKnownCaretOffset(snapshot, event);
             // FIXME parsing API
             this.document = LexUtilities.getDocument(snapshot.getSource(), true);
+
+
+            Lookup mlkp = MimeLookup.getLookup(snapshot.getMimePath());
+            List<ParsingCompilerCustomizer> cc = new ArrayList<>(mlkp.lookupAll(ParsingCompilerCustomizer.class));
+            compilerCustomizers = cc;
+            if (!cc.isEmpty()) {
+                customizerCtx = new ParsingCompilerCustomizer.Context(snapshot, parserTask);
+            } else {
+                customizerCtx = null;
+            }
+        }
+        
+        void setIndexingTask(Task t) {
+            this.parserTask = parserTask;
         }
 
         @Override
@@ -824,5 +858,10 @@ public class GroovyParser extends Parser {
 
         void error(Error error);
 
+    }
+    
+    // to be used form layers.
+    static ParsingCompilerCustomizer customizeTransformsFromLayer(Map<String, Object> attributes) {
+        return SimpleTransformationCustomizer.fromLayer(attributes);
     }
 }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ApplyGroovyTransformationProcessor.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ApplyGroovyTransformationProcessor.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.compiler;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.netbeans.modules.groovy.editor.api.parser.ApplyGroovyTransformation;
+import org.netbeans.modules.groovy.editor.api.parser.GroovyParser;
+import org.openide.filesystems.annotations.LayerBuilder.File;
+import org.openide.filesystems.annotations.LayerGeneratingProcessor;
+import org.openide.filesystems.annotations.LayerGenerationException;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+@ServiceProvider(service=Processor.class)
+public class ApplyGroovyTransformationProcessor extends LayerGeneratingProcessor {
+    private static final Set<String> APPLY_DEFAULT = new HashSet<>(Arrays.asList(new String[] { "parse" })); // NOI18N
+
+    public @Override Set<String> getSupportedAnnotationTypes() {
+        return Collections.singleton(ApplyGroovyTransformation.class.getCanonicalName());
+    }
+
+    @Override
+    protected boolean handleProcess(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws LayerGenerationException {
+        if (roundEnv.processingOver()) {
+            return false;
+        }
+        for (Element e : roundEnv.getElementsAnnotatedWith(ApplyGroovyTransformation.class)) {
+            ApplyGroovyTransformation agt = e.getAnnotation(ApplyGroovyTransformation.class);
+            String[] transformations = agt.value();
+            Set<String> enableFor = new HashSet<>(Arrays.asList(agt.enable()));
+            Set<String> disableFor = new HashSet<>(Arrays.asList(agt.disable()));
+                    
+            if (transformations.length == 0) {
+                TypeMirror astType = processingEnv.getElementUtils().getTypeElement(ASTTransformation.class.getName()).asType();
+                if (!processingEnv.getTypeUtils().isAssignable(e.asType(), astType)) {
+                    throw new LayerGenerationException("Element " + e + " is not subclass of " + astType + " and transformation class is not specified by the annotation.", e); //NOI18N
+                }
+                
+                String bn = processingEnv.getElementUtils().getBinaryName((TypeElement)e).toString();
+                transformations = new String[] { bn };
+                if (enableFor.isEmpty()) {
+                    enableFor = APPLY_DEFAULT;
+                }
+            } else {
+                if (enableFor.isEmpty() && disableFor.isEmpty()) {
+                    disableFor = APPLY_DEFAULT;
+                }
+            }
+            
+            for (String mt : agt.mimeTypes()) {
+                String fnbase = "Editors/" + mt + "/Parser"; // NOI18N
+                String en = null;
+                
+                if (e instanceof TypeElement) {
+                    en = ((TypeElement)e).getQualifiedName().toString();
+                } else if (e instanceof PackageElement) {
+                    en = ((PackageElement)e).getQualifiedName().toString();
+                } else {
+                    throw new LayerGenerationException("Unexpected annotated element:" + e, e); //NOI18N
+                }
+                
+                File f = null;
+                if (!enableFor.isEmpty()) {
+                    f = generateFile(f, e, fnbase, en, enableFor, "enable", transformations); // NOI18N
+                }
+                if (!disableFor.isEmpty()) {
+                    f = generateFile(f, e, fnbase, en, disableFor, "disable", transformations); // NOI18N
+                }
+                if (f != null) {
+                    f.write();
+                }
+            }
+        }
+        return true;
+    }
+    
+    private File generateFile(File f, Element e, String fnbase, String en, Set<String> items, String att, String[] transformations) throws LayerGenerationException {
+        boolean simple = items.size() == 1 && items.contains(ApplyGroovyTransformation.APPLY_PARSE);
+        
+        if (f == null) {
+            f = layer(e).instanceFile(fnbase, en).
+                    stringvalue("instanceOf", ParsingCompilerCustomizer.class.getName()). // NOI18N
+                    methodvalue("instanceCreate", 
+                            GroovyParser.class.getName(), "customizeTransformsFromLayer"); // NOI18N
+        }
+        if (!simple) {
+            f.stringvalue("apply", String.join(",", items)); // NOI18N
+        }
+        f.stringvalue(att, String.join(",", transformations)); // NOI18N
+        return f;
+    }
+    
+}

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/CompilationUnit.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/CompilationUnit.java
@@ -56,15 +56,30 @@ import org.openide.util.Exceptions;
  * @author Martin Adamek
  */
 public final class CompilationUnit extends org.codehaus.groovy.control.CompilationUnit {
-
+    static CompilerConfiguration processConfiguration(CompilerConfiguration configuration, boolean isIndexing) {
+        Map<String, Boolean> opts = configuration.getOptimizationOptions();
+        opts.put("classLoaderResolving", Boolean.FALSE); // NOI18N
+        return configuration;
+    }
+    
     public CompilationUnit(GroovyParser parser, CompilerConfiguration configuration,
             CodeSource security,
             @NonNull final GroovyClassLoader loader,
             @NonNull final GroovyClassLoader transformationLoader,
             @NonNull final ClasspathInfo cpInfo,
             @NonNull final ClassNodeCache classNodeCache) {
-
-        super(configuration, security, loader, transformationLoader);
+        this(parser, configuration, security, loader, transformationLoader, cpInfo, classNodeCache, true);
+    }
+    
+    public CompilationUnit(GroovyParser parser, CompilerConfiguration configuration,
+            CodeSource security,
+            @NonNull final GroovyClassLoader loader,
+            @NonNull final GroovyClassLoader transformationLoader,
+            @NonNull final ClasspathInfo cpInfo,
+            @NonNull final ClassNodeCache classNodeCache, boolean isIndexing) {
+    
+        super(processConfiguration(configuration, isIndexing), 
+                security, loader, transformationLoader);
         Map<String, Boolean> opts = this.configuration.getOptimizationOptions();
         opts.put("classLoaderResolving", Boolean.FALSE);
         this.configuration.setOptimizationOptions(opts);

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ParsingCompilerCustomizer.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/ParsingCompilerCustomizer.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.compiler;
+
+import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.netbeans.modules.parsing.api.Snapshot;
+import org.netbeans.modules.parsing.api.Task;
+import org.netbeans.spi.editor.mimelookup.MimeLocation;
+
+/**
+ * Customizes the Groovy Compiler for parsing purposes. Implementations may add some processors,
+ * transformations or disable global library transformations, or revert their effects.
+ * 
+ * Note: this is not yet an API class, but may become one when declarative registration (@link SimpleTransformationCustomizer} 
+ * is not sufficient.
+ * 
+ * @author sdedic
+ */
+@MimeLocation(subfolderName = "Parser")
+public interface ParsingCompilerCustomizer {
+    
+    /**
+     * Decorates initial {@link CompilerConfig} before the {@link CompilationUnit} is created. Some initialization
+     * may happen early in the constructor, like fetching global transformations. The method may return a different instance
+     * of CompilerConfiguration.
+     * 
+     * @param ctx parsing context
+     * @param cfg configuration to customize
+     * @return new configuration object
+     */
+    public CompilerConfiguration configureParsingCompiler(Context ctx, CompilerConfiguration cfg);
+    
+    /**
+     * Decorates a compilation after the CompilationUnit is constructed and before the parsing is done. Transformers added here
+     * follow the standard ones.
+     * @param ctx parsing context
+     * @param cu compilation unit instance
+     * @return decorated compilation unit
+     */
+    public void decorateCompilation(Context ctx, CompilationUnit cu);
+    
+    /**
+     * Context for the parsing task.
+     */
+    public final class Context {
+        private final Snapshot snapshot;
+        private final Task consumerTask;
+
+        /**
+         * Constructs the context. 
+         * @param snap Snapshot to be parsed.
+         * @param consumerTask task that is going to consume the parsing result. 
+         */
+        public Context(Snapshot snap, Task consumerTask) {
+            this.snapshot = snap;
+            this.consumerTask = consumerTask;
+        }
+
+        /**
+         * Returns the CompilationUnit that should be parsed. Use it to extract the URI
+         * to the source.
+         * 
+         * @return the originating CompilationUnit.
+         */
+        public Snapshot getSnapshot() {
+            return snapshot;
+        }
+
+        /**
+         * Returns the task that is about to consume the parser's results.
+         * @return 
+         */
+        public Task getConsumerTask() {
+            return consumerTask;
+        }
+    }
+}

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/SimpleTransformationCustomizer.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/SimpleTransformationCustomizer.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.compiler;
+
+import groovy.lang.GroovyClassLoader;
+import groovy.transform.CompilationUnitAware;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+import org.netbeans.modules.groovy.editor.api.parser.ApplyGroovyTransformation;
+import org.netbeans.modules.parsing.spi.indexing.support.IndexingSupport;
+
+/**
+ * Simple {@link ParsingCompilerCustomizer} implementation: adds or disables Groovy AST
+ * transformations, based on contents of {@link #PARSING_COMPILER_CONFIG} config folder.
+ * 
+ * Files in the folder can be named:
+ * <ul>
+ * <li>as a fully qualified name of the class that implements ASTTransformation interface.
+ * The file's extension determines what will be done (disable, enable).
+ * <li>arbitrarily, the attributes {@code enable} and {@code disable} must list
+ * fully qualified name(s) of class(es) affected
+ * </ul>
+ * In both cases {@code apply} String-valued attribute determines when the instruction is applied.
+ * Currently valid names are:
+ * <ul>
+ * <li>index - applied during indexing
+ * <li>parse - applied when parsing
+ * </ul>
+ * 
+ * @author sdedic
+ */
+public final class SimpleTransformationCustomizer implements ParsingCompilerCustomizer {
+    
+    private static final Logger LOG = Logger.getLogger(SimpleTransformationCustomizer.class.getName());
+    
+    /**
+     * Name of the folder that defines disabled transformations.
+     */
+    public static final String PARSING_COMPILER_CONFIG = "Parser/Transformations"; // NOI18N
+
+    /**
+     * Configuration for indexing
+     */
+    private final Cfg indexing = new Cfg();
+
+    /**
+     * Configuration for parsing
+     */
+    private final Cfg parsing = new Cfg();
+
+    /**
+     * Data holder: disabled transformations.
+     */
+    private static class Cfg {
+        private final Set<String> disableTransformations = new HashSet<>();
+        private final Collection<String> addTransformations = new LinkedHashSet<>();
+    }
+    
+    private SimpleTransformationCustomizer() {
+    }
+
+    @Override
+    public CompilerConfiguration configureParsingCompiler(Context ctx, CompilerConfiguration cfg) {
+        Cfg c = IndexingSupport.isIndexingTask(ctx.getConsumerTask()) ?
+                indexing : parsing;
+        if (!c.disableTransformations.isEmpty()) {
+            Set<String> disabled = cfg.getDisabledGlobalASTTransformations();
+            if (disabled == null) {
+                disabled = new HashSet<>();
+            } else {
+                disabled = new HashSet<>(disabled);
+            }
+            disabled.addAll(c.disableTransformations);
+            cfg.setDisabledGlobalASTTransformations(disabled);
+        }
+        return cfg;
+    }
+    
+    @Override
+    public void decorateCompilation(Context ctx, CompilationUnit cu) {
+        Cfg c = IndexingSupport.isIndexingTask(ctx.getConsumerTask()) ?
+                indexing : parsing;
+        GroovyClassLoader transformLoader = cu.getTransformLoader();
+        Collection<String> clist = c.addTransformations;
+        if (clist == null || clist.isEmpty()) {
+            return;
+        }
+        for (String cn : clist) {
+            try {
+                // similar to Groovy ASTTransformationVisitor.addPhaseOperationsForGlobalTransforms
+                Class<?> gTransClass = transformLoader.loadClass(cn, false, true, false);
+                GroovyASTTransformation transformAnnotation = gTransClass.getAnnotation(GroovyASTTransformation.class);
+                if (transformAnnotation == null) {
+                    LOG.log(Level.WARNING, 
+                        "Transform Class {0} is not annotated by {1}", new Object[] {
+                            gTransClass.getName(), GroovyASTTransformation.class.getName()
+                        });
+                    continue;
+                }
+                if (ASTTransformation.class.isAssignableFrom(gTransClass)) {
+                    ASTTransformation instance = (ASTTransformation) gTransClass.getDeclaredConstructor().newInstance();
+                    if (instance instanceof CompilationUnitAware) {
+                        ((CompilationUnitAware) instance).setCompilationUnit(cu);
+                    }
+                    CompilationUnit.ISourceUnitOperation suOp = source -> instance.visit(new ASTNode[]{source.getAST()}, source);
+                    cu.addNewPhaseOperation(suOp, transformAnnotation.phase().getPhaseNumber());
+                } else {
+                    LOG.log(Level.WARNING, 
+                        "Transform Class {0} is not ASTTransformation", gTransClass.getName());
+                }
+            } catch (CompilationFailedException | IllegalArgumentException | SecurityException | ReflectiveOperationException ex) {
+                LOG.log(Level.WARNING, "Failed to load transformation: {0}", cn);
+                LOG.log(Level.WARNING, "Class load failed with the following error:", ex);
+            }
+        }
+    }
+    
+    /**
+     * Modes to apply the setting. 
+     */
+    private static final String ATTR_MODE = "apply"; // NOI18N
+    
+    /**
+     * Apply the setting for indexing
+     */
+    private static final String VALUE_MODE_INDEXING = ApplyGroovyTransformation.APPLY_INDEX; // NOI18N
+
+    /**
+     * Apply the setting for parsing
+     */
+    private static final String VALUE_MODE_PARSING = ApplyGroovyTransformation.APPLY_PARSE; // NOI18N
+    
+    /**
+     * Attribute of the file, or its extension that disables a transformation.
+     */
+    private static final String ATTR_DISABLE_TRANSFORMATIONS = "disable"; // NOI18N
+    
+    /**
+     * Enables/adds additional AST transformations.
+     */
+    private static final String ATTR_ENABLE_TRANSFORMATIONS = "enable"; // NOI18N
+
+    public static SimpleTransformationCustomizer fromLayer(Map<String, Object> values) {
+        SimpleTransformationCustomizer instance = new SimpleTransformationCustomizer();
+        Object o = values.get(ATTR_MODE);
+        boolean applied = false;
+        if (o instanceof String) {
+            boolean warn = false;
+            A: for (String v : o.toString().split(",")) {
+                v = v.trim();
+                switch (v) {
+                    case VALUE_MODE_INDEXING:
+                        processMap(values, instance.indexing);
+                        applied = true;
+                        break;
+                    case VALUE_MODE_PARSING:
+                        processMap(values, instance.parsing);
+                        applied = true;
+                        break;
+                    default:
+                        applied = true;
+                        if (!warn) {
+                            warn = true;
+                            LOG.log(Level.WARNING, "Unexpected value of 'apply': {1}", v);
+                        }
+                        break;
+                }
+            }
+        } else if (o != null) {
+            LOG.log(Level.WARNING, "Unexpected contents of 'apply': {0}", o);
+            applied = true;
+        }
+        if (!applied) {
+            // by default apply for parsing.
+            processMap(values, instance.parsing);
+        }
+        return instance;
+    }
+    
+    static void processMap(Map<String, Object> map, Cfg target) {
+        Collection<String> disable = findNames(map.get(ATTR_DISABLE_TRANSFORMATIONS));
+        if (disable != null) {
+            target.disableTransformations.addAll(disable);
+            // in addition, remove layer-registered transformations.
+            target.addTransformations.removeAll(disable);
+        }
+        
+        Collection<String> enable = findNames(map.get(ATTR_ENABLE_TRANSFORMATIONS));
+        if (enable != null) {
+            target.addTransformations.addAll(enable);
+        }
+        
+        if (disable == null && enable == null) {
+            LOG.log(Level.WARNING, "Entry does not disable or enable transformation: {0}", map);
+        }
+    }
+
+    static Collection<String> findNames(Object o) {
+        Set<String> dtnames = new LinkedHashSet<>();
+        if (o instanceof Collection) {
+            dtnames.addAll((Collection)o);
+        } else if (o instanceof String) {
+            for (String s : o.toString().split(",")) { // NOI18N
+                s = s.trim();
+                if (!s.isEmpty()) {
+                    dtnames.add(s);
+                }
+            }
+        } else {
+            return null;
+        }
+        return dtnames;
+    }
+}

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/resources/layer.xml
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/resources/layer.xml
@@ -71,7 +71,14 @@
                         <attr name="originalFile" stringvalue="Actions/Groovy/org-netbeans-modules-groovy-editor-actions-FixImportsAction.instance"/>
                     </file>
                 </folder>
-
+                <folder name="Parser">
+                    <file name="org.spockframework.compiler.SpockTransform.instance">
+                        <attr name="instanceOf" stringvalue="org.netbeans.modules.groovy.editor.compiler.ParsingCompilerCustomizer"/>
+                        <attr
+                            methodvalue="org.netbeans.modules.groovy.editor.api.parser.GroovyParser.customizeTransformsFromLayer" name="instanceCreate"/>
+                        <attr name="disable" stringvalue="org.spockframework.compiler.SpockTransform"/>
+                    </file>
+                </folder>
                 <folder name="Popup">
                     <file name="fix-groovy-imports">
                         <attr name="position" intvalue="801"/>

--- a/groovy/groovy.editor/test/unit/src/META-INF/services/org.codehaus.groovy.transform.ASTTransformation
+++ b/groovy/groovy.editor/test/unit/src/META-INF/services/org.codehaus.groovy.transform.ASTTransformation
@@ -1,0 +1,1 @@
+org.netbeans.modules.groovy.editor.api.parser.GroovyParserTest$TestingTransformation

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParserTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParserTest.java
@@ -19,8 +19,13 @@
 
 package org.netbeans.modules.groovy.editor.api.parser;
 
+import groovy.transform.CompilationUnitAware;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Scanner;
+import java.util.Set;
 import org.codehaus.groovy.ast.ASTNode;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.groovy.editor.api.AstPath;
@@ -29,11 +34,21 @@ import org.netbeans.modules.groovy.editor.test.GroovyTestBase;
 import org.openide.filesystems.FileObject;
 import java.util.logging.Logger;
 import java.util.logging.Level;
+import static junit.framework.TestCase.assertNotNull;
+import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
 import org.netbeans.modules.csl.api.OffsetRange;
+import org.netbeans.modules.groovy.editor.test.GroovyTestTransformer;
 import org.netbeans.modules.parsing.api.ParserManager;
 import org.netbeans.modules.parsing.api.ResultIterator;
 import org.netbeans.modules.parsing.api.Source;
 import org.netbeans.modules.parsing.api.UserTask;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
 
 /**
  *
@@ -47,9 +62,31 @@ public class GroovyParserTest extends GroovyTestBase {
 
     @Override
     protected void setUp() throws Exception {
+        clearWorkDir();
         super.setUp();
         Logger.getLogger(org.netbeans.modules.groovy.editor.api.parser.GroovyParser.class.getName())
                 .setLevel(Level.FINEST);
+    }
+    
+    protected void tearDown() throws Exception {
+        // remove the static stuff
+        parserUnit = null;
+        parserConfig = null;
+        parserCompUnit = null;
+        enabledForUnit = null;
+        GroovyTestTransformer.parserCompUnit = null;
+        
+        clearWorkDir();
+        URL u = URLMapper.findURL(FileUtil.getConfigRoot(), URLMapper.EXTERNAL);
+        if (u != null) {
+            Path p = Paths.get(u.toURI());
+            FileObject fo = URLMapper.findFileObject(u);
+            if (fo != null) {
+                fo.delete();
+            }
+        }
+        FileUtil.getConfigRoot().refresh();
+        super.tearDown();
     }
 
     private void checkParseTree(final FileObject file, final String caretLine, final String nodeName) throws Exception {
@@ -178,25 +215,139 @@ public class GroovyParserTest extends GroovyTestBase {
             }
         });
     }
-
-//    public void testDuplicateDefinitions() throws Exception {
-//        copyStringToFileObject(testFO,
-//            "class DuplicateFieldExample {\n" +
-//            "String name\n" +
-//            "String name\n" +
-//            "def method() {\n" +
-//            "\tprintln 'Hello, world'\n" +
-//            "\t}\n" +
-//            "}\n");
-//
-//        Source source = Source.create(testFO);
-//        ParserManager.parse(Collections.singleton(source), new UserTask() {
-//            public @Override void run(ResultIterator resultIterator) throws Exception {
-//                GroovyParserResult result = AstUtilities.getParseResult(resultIterator.getParserResult());
-//                ASTNode root = AstUtilities.getRoot(result);
-//                assertNotNull("AstUtilities.getRoot(info) failed", root);
-//            }
-//        });
-//    }
     
+    /**
+     * Check the basic state, that the AST transformation is enabled.
+     * @throws Exception 
+     */
+    public void testRegisteredGlobalASTProcessorUsed() throws Exception {
+        copyStringToFileObject(testFO,
+                "class Hello {\n" +
+                "\tdef name = 'aaa'\n" +
+                "\tprintln name\n" +
+                "\tstatic void main(args) {\n" +
+                "\t\tprintln 'Hello, world'\n" +
+                "\t}\n" +
+                "}");
+        // delete the instruction from annotation processor, to check the default behaviour
+        FileUtil.getConfigFile("Editors/text/x-groovy/Parser/org.netbeans.modules.groovy.editor.test.DisableTransformersStub.instance").delete();
+        FileUtil.getConfigFile("Editors/text/x-groovy/Parser/org.netbeans.modules.groovy.editor.api.parser.GroovyParserTest.DormantTransformation.instance").delete();
+        Source source = Source.create(testFO);
+        ParserManager.parse(Collections.singleton(source), new UserTask() {
+            public @Override void run(ResultIterator resultIterator) throws Exception {
+                GroovyParserResult result = ASTUtils.getParseResult(resultIterator.getParserResult());
+                assertNotNull(result);
+                // parser has run the gkobal transformer
+                assertNotNull(parserUnit);
+                // but the explicit transofmrer has not.
+                assertNull(enabledForUnit);
+                assertNotNull(GroovyTestTransformer.parserCompUnit);
+            }
+        });
+    }
+    
+    /**
+     * Checks that simple .disable file will disable the transformation
+     * @throws Exception 
+     */
+    public void testGlobalASTProcessorDisabledByAttribute() throws Exception {
+        // add an instruction to skip the transformation
+        copyStringToFileObject(testFO,
+                "class Hello {\n" +
+                "\tdef name = 'aaa'\n" +
+                "\tprintln name\n" +
+                "\tstatic void main(args) {\n" +
+                "\t\tprintln 'Hello, world'\n" +
+                "\t}\n" +
+                "}");
+
+        Source source = Source.create(testFO);
+        ParserManager.parse(Collections.singleton(source), new UserTask() {
+            public @Override void run(ResultIterator resultIterator) throws Exception {
+                GroovyParserResult result = ASTUtils.getParseResult(resultIterator.getParserResult());
+                assertNotNull(result);
+                assertNull(parserUnit);
+                assertNotNull(GroovyTestTransformer.parserCompUnit);
+            }
+        });
+    }
+    
+    public void testExplicitlyEnableASTTransformationByAttr() throws Exception {
+        copyStringToFileObject(testFO,
+                "class Hello {\n" +
+                "\tdef name = 'aaa'\n" +
+                "\tprintln name\n" +
+                "\tstatic void main(args) {\n" +
+                "\t\tprintln 'Hello, world'\n" +
+                "\t}\n" +
+                "}");
+
+        Source source = Source.create(testFO);
+        ParserManager.parse(Collections.singleton(source), new UserTask() {
+            public @Override void run(ResultIterator resultIterator) throws Exception {
+                GroovyParserResult result = ASTUtils.getParseResult(resultIterator.getParserResult());
+                assertNotNull(result);
+                assertNotNull(enabledForUnit);
+                assertNotNull(GroovyTestTransformer.parserCompUnit);
+            }
+        });
+    }
+    
+    public void testSpockDisabledByDefault() throws Exception {
+        copyStringToFileObject(testFO,
+                "class Hello {\n" +
+                "\tdef name = 'aaa'\n" +
+                "\tprintln name\n" +
+                "\tstatic void main(args) {\n" +
+                "\t\tprintln 'Hello, world'\n" +
+                "\t}\n" +
+                "}");
+
+        Source source = Source.create(testFO);
+        ParserManager.parse(Collections.singleton(source), new UserTask() {
+            public @Override void run(ResultIterator resultIterator) throws Exception {
+                // the parser is lazy, must trigger parsing.
+                ASTUtils.getParseResult(resultIterator.getParserResult());
+            }
+        });
+        Set<String> disabledClasses = enabledForUnit.getConfiguration().getDisabledGlobalASTTransformations();
+        assertTrue(disabledClasses.contains("org.spockframework.compiler.SpockTransform"));
+    }
+    
+    static SourceUnit parserUnit;
+    static CompilationUnit parserCompUnit;
+    static CompilerConfiguration parserConfig;
+    
+    static CompilationUnit enabledForUnit;
+    
+    @GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
+    @ApplyGroovyTransformation(enable = "parse")
+    public static class DormantTransformation implements ASTTransformation, CompilationUnitAware {
+
+        @Override
+        public void setCompilationUnit(CompilationUnit unit) {
+            enabledForUnit = unit;
+        }
+
+        @Override
+        public void visit(ASTNode[] nodes, SourceUnit source) {
+        }
+    }
+
+    @GroovyASTTransformation(phase = CompilePhase.SEMANTIC_ANALYSIS)
+    public static class TestingTransformation implements ASTTransformation, CompilationUnitAware {
+
+        @Override
+        public void setCompilationUnit(CompilationUnit unit) {
+            parserCompUnit = unit;
+        }
+        
+        @Override
+        public void visit(ASTNode[] nodes, SourceUnit source) {
+            parserUnit = source;
+            parserConfig = source.getConfiguration();
+        }
+        
+    }
+
 }

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/test/DisableTransformersStub.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/test/DisableTransformersStub.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.test;
+
+import org.netbeans.modules.groovy.editor.api.parser.ApplyGroovyTransformation;
+
+// BEGIN:DisableTransformersStub
+@ApplyGroovyTransformation(disable = ApplyGroovyTransformation.APPLY_PARSE, value = {
+    "org.netbeans.modules.groovy.editor.test.DisabledGlobalAnnotation",
+    "org.netbeans.modules.groovy.editor.api.parser.GroovyParserTest$TestingTransformation",
+})
+public class DisableTransformersStub {
+    
+}
+// END:DisableTransformersStub

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/test/GroovyTestTransformer.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/test/GroovyTestTransformer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.test;
+
+import groovy.transform.CompilationUnitAware;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+import org.netbeans.modules.groovy.editor.api.parser.ApplyGroovyTransformation;
+
+// BEGIN:GroovyTestTransformer
+@GroovyASTTransformation(phase = CompilePhase.PARSING)
+@ApplyGroovyTransformation()
+public class GroovyTestTransformer implements ASTTransformation, CompilationUnitAware {
+    // ...
+// END:GroovyTestTransformer
+    public static CompilationUnit parserCompUnit;
+    
+    @Override
+    public void visit(ASTNode[] nodes, SourceUnit source) {
+    }
+
+    @Override
+    public void setCompilationUnit(CompilationUnit unit) {
+        parserCompUnit = unit;
+    }
+}

--- a/ide/parsing.indexing/apichanges.xml
+++ b/ide/parsing.indexing/apichanges.xml
@@ -87,6 +87,21 @@ is the proper place.
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
   <changes>
+      <change id="IndexingTask">
+          <api name="IndexingAPI"/>
+          <summary>Allow Parsers to adjust results for indexing</summary>
+          <version major="9" minor="22"/>
+          <date day="28" month="7" year="2021"/>
+          <author login="sdedic"/>
+          <compatibility source="compatible" binary="compatible" semantic="compatible" addition="yes"/>
+          <description>
+              <p>
+                  <a href="@org-netbeans-modules-parsing-api@/org/netbeans/modules/parsing/spi/Parser.html">Parsers</a> may need to provide reduced data for indexing, or enriched data for source parsing. The
+                  added <a href="@TOP@/org/netbeans/modules/parsing/spi/indexing/support/IndexingSupport.html#isIndexingTask-org.netbeans.modules.parsing.api.Task-">isIndexingTask()</a> method identifies tasks applied by indexing infrastructure.
+              </p>
+          </description>
+          <class package="org.netbeans.modules.parsing.spi.indexing.support" name="IndexingSupport"/>
+      </change>
       <change id="CustomCamelCase">
           <api name="IndexingAPI"/>
           <summary>Added custom camel case support into <code>QuerySupport</code></summary>

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexingTask.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/IndexingTask.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.parsing.impl.indexing;
+
+import org.netbeans.modules.parsing.api.Task;
+
+/**
+ * Marker interface that identifies a {@link Task} as an indexing one
+ * @author sdedic
+ */
+public interface IndexingTask {
+    
+}

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/impl/indexing/RepositoryUpdater.java
@@ -3140,7 +3140,8 @@ public final class RepositoryUpdater implements PathRegistryListener, PropertyCh
                     try {
                         // log parsing for the mimetype:
                         logStartIndexer(src.getMimeType());
-                        ParserManager.parse(Collections.singleton(src), new UserTask() {
+                        
+                        class T extends UserTask implements IndexingTask {
                             @Override
                             public void run(ResultIterator resultIterator) throws Exception {
                                 final String mimeType = resultIterator.getSnapshot().getMimeType();
@@ -3231,7 +3232,8 @@ public final class RepositoryUpdater implements PathRegistryListener, PropertyCh
                                     run(resultIterator.getResultIterator(embedding));
                                 }
                             }
-                        });
+                        }
+                        ParserManager.parse(Collections.singleton(src), new T());
                     } catch (final ParseException e) {
                         logFinishIndexer(src.getMimeType());
                         LOGGER.log(Level.WARNING, null, e);

--- a/ide/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/support/IndexingSupport.java
+++ b/ide/parsing.indexing/src/org/netbeans/modules/parsing/spi/indexing/support/IndexingSupport.java
@@ -22,13 +22,18 @@ package org.netbeans.modules.parsing.spi.indexing.support;
 import java.io.IOException;
 import java.util.logging.Logger;
 import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.modules.parsing.api.Task;
 import org.netbeans.modules.parsing.impl.indexing.ClusteredIndexables;
 import org.netbeans.modules.parsing.impl.indexing.FileObjectIndexable;
 import org.netbeans.modules.parsing.impl.indexing.IndexFactoryImpl;
+import org.netbeans.modules.parsing.impl.indexing.IndexingTask;
 import org.netbeans.modules.parsing.impl.indexing.SPIAccessor;
 import org.netbeans.modules.parsing.lucene.support.DocumentIndexCache;
 import org.netbeans.modules.parsing.lucene.support.Index;
+import org.netbeans.modules.parsing.spi.Parser;
 import org.netbeans.modules.parsing.spi.indexing.Context;
+import org.netbeans.modules.parsing.spi.indexing.CustomIndexer;
+import org.netbeans.modules.parsing.spi.indexing.EmbeddingIndexer;
 import org.netbeans.modules.parsing.spi.indexing.Indexable;
 import org.netbeans.modules.parsing.spi.indexing.SourceIndexerFactory;
 import org.openide.filesystems.FileObject;
@@ -184,4 +189,14 @@ public final class IndexingSupport {
         return res;
     }
 
+    /**
+     * Identifies parser Tasks that are executed by indexing infrastructure. Use to customize the granularity of a {@link Parser.Result}
+     * provided by e.g. {@link EmbeddingIndexer} or {@link CustomIndexer}.
+     * @param t task to check
+     * @return true, if the task is posted by indexing infra.
+     * @since 9.22
+     */
+    public static boolean isIndexingTask(Task t) {
+        return t instanceof IndexingTask;
+    }
 }


### PR DESCRIPTION
First commit: the hack made in [#3042](https://github.com/apache/netbeans/pull/3042/files#diff-890da1cd8d2dce9fb90de0ac649bf9a371f88aface37ee8dca28fa366b1e2554R134) is formalized as [an API in `parsing.indexing`](https://github.com/apache/netbeans/compare/master...sdedic:groovy/manage-transformations?expand=1#diff-59871e7c12a8f51236f02db6b30608e72129fb0e9a613531b27612a020447a5aR199). Just a simple `boolean` that identifies tasks created by Indexing infrastructure. 

I've added layer-based declarative instructions to enable or disable transformations for parsing, indexing or both. This declarative format is not an API itself, bcs per @JaroslavTulach  suggestion, I have created (and documented) [`ApplyGroovyTransformation`](https://github.com/apache/netbeans/compare/master...sdedic:groovy/manage-transformations?expand=1#diff-6d7687054187e88addbdc99e7f15688b50777a909cb0c2400501a2df23c05328R52) annotation that generates the layer stuff. Still this 'api' is +- development quality.

As a part of the changes, I've [disabled Spock transformations](https://github.com/apache/netbeans/compare/master...sdedic:groovy/manage-transformations?expand=1#diff-f79a53c73b724a2bd3cae4ddd9b4de40e3693d19ec0d860b2a8941777ae584aaR76) which alter AST that make our code completion fail in Spock tests. That does not fix all issues, but at least the Spock value-read and invocation wrappers are gone from the AST.

