### PR TITLE
[NETBEANS-2443] Fix-Can't start profiler windows

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
@@ -413,8 +413,6 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
         //#164234
         //if maven.bat file is in space containing path, we need to quote with simple quotes.
         String quote = "\"";
-        // the command line parameters with space in them need to be quoted and escaped to arrive
-        // correctly to the java runtime on windows
         for (Map.Entry<? extends String,? extends String> entry : config.getProperties().entrySet()) {
             String k = entry.getKey();
             // filter out env vars AND internal properties.

--- a/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
@@ -415,7 +415,6 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
         String quote = "\"";
         // the command line parameters with space in them need to be quoted and escaped to arrive
         // correctly to the java runtime on windows
-        String escaped = "\\" + quote;        
         for (Map.Entry<? extends String,? extends String> entry : config.getProperties().entrySet()) {
             String k = entry.getKey();
             // filter out env vars AND internal properties.
@@ -424,9 +423,8 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
             }
             //skip envs, these get filled in later.
             //#228901 since u21 we need to use cmd /c to execute on windows, quotes get escaped and when there is space in value, the value gets wrapped in quotes.
-            String value = (Utilities.isWindows() ? entry.getValue().replace(quote, escaped) : entry.getValue().replace(quote, "'"));
+            String value = (Utilities.isWindows() ? entry.getValue().replace(quote, "") : entry.getValue().replace(quote, "'"));
             if (Utilities.isWindows() && value.endsWith("\"")) {
-                //#201132 property cannot end with 2 double quotes, add a space to the end after our quote to prevent the state
                 value = value + " ";
             }
             String s = "-D" + entry.getKey() + "=" + (Utilities.isWindows() && value.contains(" ") ? quote + value + quote : value);            


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-2443

Fix start of profiler on windows the bug was caused by wrong command  generated, so i compare both commands:
![image](https://user-images.githubusercontent.com/950706/127248882-ee77521a-201e-43da-a628-1e254a9300f8.png)

After the change 
![image](https://user-images.githubusercontent.com/950706/127249014-77026362-c2dc-4198-8904-91a97a614327.png)

I try don't mess thing so much, because i don't understand why so much lines are generated, but a tested on Linux and windows.
Run, Debug e Profiler.
