### PR TITLE
Attach to a running Native Image.

### DIFF
--- a/cpplite/cpplite.debugger/nbproject/project.xml
+++ b/cpplite/cpplite.debugger/nbproject/project.xml
@@ -66,7 +66,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>0</release-version>
-                        <specification-version>0.2</specification-version>
+                        <specification-version>0.4</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteDebuggerConfig.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteDebuggerConfig.java
@@ -22,6 +22,8 @@ package org.netbeans.modules.cpplite.debugger;
 import java.io.File;
 import java.util.List;
 
+import org.netbeans.api.annotations.common.NullAllowed;
+
 /**
  *
  * @author lahvac
@@ -30,11 +32,14 @@ public final class CPPLiteDebuggerConfig {
 
     private final List<String> executable;
     private final File directory;
+    @NullAllowed
+    private final Long processId;
     private final String debugger;
 
-    public CPPLiteDebuggerConfig(List<String> executable, File directory, String debugger) {
+    public CPPLiteDebuggerConfig(List<String> executable, File directory, @NullAllowed Long processId, String debugger) {
         this.executable = executable;
         this.directory = directory;
+        this.processId = processId;
         this.debugger = debugger;
     }
 
@@ -42,12 +47,39 @@ public final class CPPLiteDebuggerConfig {
         return (!executable.isEmpty()) ? executable.get(0) : "<empty>";
     }
 
+    /**
+     * Get the executable with arguments.
+     */
     public List<String> getExecutable() {
         return executable;
     }
 
+    /**
+     * Get the directory in which the executable command is to be launched.
+     */
     public File getDirectory() {
         return directory;
+    }
+
+    /**
+     * Check if debugger should attach to a running process. Get the process ID
+     * from {@link #getAttachProcessId()}.
+     */
+    public boolean isAttach() {
+        return processId != null;
+    }
+
+    /**
+     * Get the process ID to attach to.
+     *
+     * @return the process ID
+     * @throws IllegalStateException when {@link #isAttach()} is false.
+     */
+    public long getAttachProcessId() {
+        if (processId == null) {
+            throw new IllegalStateException("No process to attach to.");
+        }
+        return processId;
     }
 
     public String getDebugger() {

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/api/Debugger.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/api/Debugger.java
@@ -21,10 +21,9 @@ package org.netbeans.modules.cpplite.debugger.api;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import org.netbeans.api.debugger.DebuggerEngine;
+
 import org.netbeans.modules.cpplite.debugger.CPPLiteDebugger;
 import org.netbeans.modules.cpplite.debugger.CPPLiteDebuggerConfig;
-import org.openide.util.Pair;
 
 /**
  *
@@ -38,8 +37,13 @@ public class Debugger {
     }
 
     public static Process startInDebugger(List<String> command, File directory) throws IOException {
-        Pair<DebuggerEngine, Process> engineProcess = CPPLiteDebugger.startDebugging(new CPPLiteDebuggerConfig(command, directory, "gdb"));
-        engineProcess.first().lookupFirst(null, CPPLiteDebugger.class).execRun();
-        return engineProcess.second();
+        CPPLiteDebugger[] debugger = new CPPLiteDebugger[] { null };
+        Process engineProcess = CPPLiteDebugger.startDebugging(
+                new CPPLiteDebuggerConfig(command, directory, null, "gdb"),
+                engine -> {
+                    debugger[0] = engine.lookupFirst(null, CPPLiteDebugger.class);
+                });
+        debugger[0].execRun();
+        return engineProcess;
     }
 }

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/ni/NIDebuggerProviderImpl.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/ni/NIDebuggerProviderImpl.java
@@ -19,6 +19,8 @@
 package org.netbeans.modules.cpplite.debugger.ni;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -44,7 +46,6 @@ import org.netbeans.modules.nativeimage.spi.debug.NIDebuggerProvider;
 import org.netbeans.modules.nativeimage.spi.debug.filters.FrameDisplayer;
 
 import org.openide.LifecycleManager;
-import org.openide.util.Pair;
 import org.openide.util.RequestProcessor;
 import org.netbeans.modules.nativeimage.spi.debug.filters.VariableDisplayer;
 
@@ -98,45 +99,87 @@ public class NIDebuggerProviderImpl implements NIDebuggerProvider {
         CompletableFuture<Void> completed = new CompletableFuture<>();
         Semaphore started = new Semaphore(0);
         ExecutionService.newService(() -> {
-            Pair<DebuggerEngine, Process> engineProcess;
-            CPPLiteDebugger debugger;
+            Process engineProcess;
+            CPPLiteDebugger[] debugger = new CPPLiteDebugger[] { null };
             try {
                 LifecycleManager.getDefault().saveAll();
                 engineProcess = CPPLiteDebugger.startDebugging(
-                        new CPPLiteDebuggerConfig(command, workingDirectory, miDebugger),
+                        new CPPLiteDebuggerConfig(command, workingDirectory, null, miDebugger),
+                        engine -> {
+                            debugger[0] = engine.lookupFirst(null, CPPLiteDebugger.class);
+                            this.debugger = debugger[0];
+                            if (startedEngine != null) {
+                                startedEngine.accept(engine);
+                            }
+                            debugger[0].addStateListener(new CPPLiteDebugger.StateListener() {
+                                @Override
+                                public void currentThread(CPPThread thread) {}
+
+                                @Override
+                                public void currentFrame(CPPFrame frame) {}
+
+                                @Override
+                                public void suspended(boolean suspended) {}
+
+                                @Override
+                                public void finished() {
+                                    breakpointsHandler.dispose();
+                                    completed.complete(null);
+                                }
+                            });
+                        },
                         frameDisplayer,
                         variablesDisplayer);
-                DebuggerEngine engine = engineProcess.first();
-                debugger = engine.lookupFirst(null, CPPLiteDebugger.class);
-                this.debugger = debugger;
-                if (startedEngine != null) {
-                    startedEngine.accept(engine);
-                }
-                debugger.addStateListener(new CPPLiteDebugger.StateListener() {
-                    @Override
-                    public void currentThread(CPPThread thread) {}
-
-                    @Override
-                    public void currentFrame(CPPFrame frame) {}
-
-                    @Override
-                    public void suspended(boolean suspended) {}
-
-                    @Override
-                    public void finished() {
-                        breakpointsHandler.dispose();
-                        completed.complete(null);
-                    }
-                });
             } finally {
                 started.release();
             }
-            debugger.execRun();
-            return engineProcess.second();
+            debugger[0].execRun();
+            return engineProcess;
         }, executionDescriptor, displayName).run();
         // Wait for the debugger to actually start up.
         // This is necessary to be able to safely call other methods on the NIDebuggerProvider.
         started.acquireUninterruptibly();
+        return completed;
+    }
+
+    @Override
+    public CompletableFuture<Void> attach(String executablePath, long processId, String miDebugger, Consumer<DebuggerEngine> startedEngine) {
+        if (debugger != null) {
+            throw new IllegalStateException("Debugger has started already.");
+        }
+        CompletableFuture<Void> completed = new CompletableFuture<>();
+        try {
+            CPPLiteDebugger.startDebugging(
+                    new CPPLiteDebuggerConfig(Collections.singletonList(executablePath), new File(System.getProperty("user.dir")), processId, miDebugger),
+                    engine -> {
+                        CPPLiteDebugger debugger = engine.lookupFirst(null, CPPLiteDebugger.class);
+                        this.debugger = debugger;
+                        if (startedEngine != null) {
+                            startedEngine.accept(engine);
+                        }
+                        debugger.addStateListener(new CPPLiteDebugger.StateListener() {
+                            @Override
+                            public void currentThread(CPPThread thread) {}
+
+                            @Override
+                            public void currentFrame(CPPFrame frame) {}
+
+                            @Override
+                            public void suspended(boolean suspended) {}
+
+                            @Override
+                            public void finished() {
+                                breakpointsHandler.dispose();
+                                completed.complete(null);
+                            }
+                        });
+                    },
+                    frameDisplayer,
+                    variablesDisplayer);
+        } catch (IOException ex) {
+            completed.completeExceptionally(ex);
+            return completed;
+        }
         return completed;
     }
 

--- a/cpplite/cpplite.debugger/test/unit/src/org/netbeans/modules/cpplite/debugger/AbstractDebugTest.java
+++ b/cpplite/cpplite.debugger/test/unit/src/org/netbeans/modules/cpplite/debugger/AbstractDebugTest.java
@@ -27,7 +27,6 @@ import junit.framework.Test;
 import org.netbeans.api.debugger.DebuggerEngine;
 import org.netbeans.junit.NbModuleSuite;
 import org.netbeans.junit.NbTestCase;
-import org.openide.util.Pair;
 
 public abstract class AbstractDebugTest extends NbTestCase {
 
@@ -53,9 +52,9 @@ public abstract class AbstractDebugTest extends NbTestCase {
     }
 
     protected final void startDebugging(String name, File wd) throws IOException {
-        Pair<DebuggerEngine, Process> engineProcess = CPPLiteDebugger.startDebugging(new CPPLiteDebuggerConfig(Arrays.asList(new File(wd, name).getAbsolutePath()), wd, "gdb"));
-        engine = engineProcess.first();
-        process = engineProcess.second();
+        this.process = CPPLiteDebugger.startDebugging(
+                new CPPLiteDebuggerConfig(Arrays.asList(new File(wd, name).getAbsolutePath()), wd, null, "gdb"),
+                engine -> this.engine = engine);
         debugger = engine.lookupFirst(null, CPPLiteDebugger.class);
         debugger.addStateListener(new CPPLiteDebugger.StateListener() {
             @Override

--- a/ide/nativeimage.api/manifest.mf
+++ b/ide/nativeimage.api/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.nativeimage.api/0
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/nativeimage/api/Bundle.properties
-OpenIDE-Module-Specification-Version: 0.3
+OpenIDE-Module-Specification-Version: 0.4
 

--- a/ide/nativeimage.api/src/org/netbeans/modules/nativeimage/api/debug/NIDebugger.java
+++ b/ide/nativeimage.api/src/org/netbeans/modules/nativeimage/api/debug/NIDebugger.java
@@ -114,6 +114,20 @@ public final class NIDebugger {
     }
 
     /**
+     * Attach to a process and create a debugging session. Call this typically after breakpoints are added.
+     *
+     * @param executablePath path to an executable representing the native image
+     * @param processId a process to attach to
+     * @param debugger the native debugger command
+     * @param startedEngine the corresponding DebuggerEngine is passed to this consumer
+     * @return future that completes on the execution finish
+     * @since 0.4
+     */
+    public CompletableFuture<Void> attach(String executablePath, long processId, String debugger, Consumer<DebuggerEngine> startedEngine) {
+        return provider.attach(executablePath,  processId, debugger, startedEngine);
+    }
+
+    /**
      * An asynchronous expression evaluation.
      *
      * @param expression the expression to evaluate

--- a/ide/nativeimage.api/src/org/netbeans/modules/nativeimage/spi/debug/NIDebuggerProvider.java
+++ b/ide/nativeimage.api/src/org/netbeans/modules/nativeimage/spi/debug/NIDebuggerProvider.java
@@ -95,6 +95,22 @@ public interface NIDebuggerProvider {
     CompletableFuture<Void> start(List<String> command, File workingDirectory, String debugger, String displayName, ExecutionDescriptor executionDescriptor, Consumer<DebuggerEngine> startedEngine);
 
     /**
+     * Attach to a process and create a debugging session. Called typically after breakpoints are added.
+     *
+     * @param executablePath path to an executable representing the native image
+     * @param processId a process to attach to
+     * @param debugger the native debugger command
+     * @param startedEngine the corresponding DebuggerEngine is passed to this consumer
+     * @return future that completes on the execution finish
+     * @since 0.4
+     */
+    default CompletableFuture<Void> attach(String executablePath, long processId, String debugger, Consumer<DebuggerEngine> startedEngine) {
+        CompletableFuture cf = new CompletableFuture();
+        cf.completeExceptionally(new UnsupportedOperationException());
+        return cf;
+    }
+
+    /**
      * An asynchronous expression evaluation.
      *
      * @param expression the expression to evaluate

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -266,7 +266,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>0</release-version>
-                        <specification-version>0.1</specification-version>
+                        <specification-version>0.3</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -344,7 +344,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>0</release-version>
-                        <specification-version>0.2</specification-version>
+                        <specification-version>0.4</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/AttachConfigurations.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/AttachConfigurations.java
@@ -46,7 +46,7 @@ import org.openide.util.NbBundle.Messages;
 import org.openide.util.RequestProcessor;
 
 /**
- * Debugger attach configurations provider.
+ * Java Debugger attach configurations provider.
  *
  * @author Martin Entlicher
  */

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/AttachNativeConfigurations.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/AttachNativeConfigurations.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.debugging.attach;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+
+import org.netbeans.modules.java.lsp.server.debugging.attach.Processes.ProcessInfo;
+import org.netbeans.modules.java.lsp.server.debugging.utils.ErrorUtilities;
+import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
+import org.netbeans.modules.java.lsp.server.protocol.QuickPickItem;
+import org.netbeans.modules.java.lsp.server.protocol.ShowQuickPickParams;
+
+import org.openide.util.NbBundle;
+import org.openide.util.RequestProcessor;
+
+/**
+ * Native Image Debugger attach configurations provider.
+ *
+ * @author Martin Entlicher
+ */
+public final class AttachNativeConfigurations {
+
+    static final String CONFIG_TYPE = "nativeimage";    // NOI18N
+    static final String CONFIG_REQUEST = "attach";      // NOI18N
+
+    static final RequestProcessor RP = new RequestProcessor(AttachNativeConfigurations.class);
+
+    public static CompletableFuture<Object> findProcessAttachTo(NbCodeLanguageClient client) {
+        return CompletableFuture.supplyAsync(() -> {
+            return listProcessesToAttachTo(client);
+        }, RP).thenCompose(params -> client.showQuickPick(params)).thenApply(itemsList -> {
+            if (itemsList == null || itemsList.isEmpty()) {
+                return null;
+            } else {
+                return itemsList.get(0).getUserData();
+            }
+        });
+    }
+
+    @NbBundle.Messages("LBL_PickNativeProcessAttach=Pick Native Image process to attach to:")
+    private static ShowQuickPickParams listProcessesToAttachTo(NbCodeLanguageClient client) {
+        List<QuickPickItem> items = new ArrayList<>();
+        List<ProcessInfo> processes = Processes.getAllProcesses();
+        for (ProcessInfo info : processes) {
+            items.add(createQuickPickItem(info));
+        }
+        if (items.isEmpty()) {
+            throw ErrorUtilities.createResponseErrorException("No debuggable native process found.", ResponseErrorCode.RequestCancelled);  // NOI18N
+        }
+        return new ShowQuickPickParams(Bundle.LBL_PickNativeProcessAttach(), items);
+    }
+
+    private static QuickPickItem createQuickPickItem(ProcessInfo info) {
+        String label = Long.toString(info.getPid());
+        String description = info.getCommand();
+        Object userData = info.getPid() + " " + info.getExecutable();
+        return new QuickPickItem(label, description, null, false, userData);
+    }
+
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/Processes.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/Processes.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.debugging.attach;
+
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.openide.util.Exceptions;
+import org.openide.util.Utilities;
+
+/**
+ * Retrieve a list of native processes.
+ * Duplicates org.netbeans.modules.java.nativeimage.debugger.actions.Processes
+ * Replace with the direct use of ProcessHandle, after JDK 8 is abandoned.
+ *
+ * @author martin
+ */
+final class Processes {
+
+    private static final String CMD_UNIX = "ps -x -o pid,command";  // NOI18N
+    private static final String CMD_WIN = "tasklist /FO CSV";       // NOI18N
+
+    static List<ProcessInfo> getAllProcesses() {
+        List<ProcessInfo> processInfos;
+        Function<Stream<ProcessInfo>, List<ProcessInfo>> collector =
+                infoStream -> infoStream
+                    .filter(info -> info != null)
+                    .sorted((info1, info2) -> (info1.getPid() == info2.getPid() ? 0 : info1.getPid() > info2.getPid() ? -1 : 1)) // descending
+                    .collect(Collectors.toList());
+        try {
+            Class<?> processHandleClass = Class.forName("java.lang.ProcessHandle");    // NOI18N
+            processInfos = getProcesses(processHandleClass, collector);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException ex) {
+            if (Utilities.isWindows()) {
+                processInfos = getProcessesWinCmd(collector);
+            } else {
+                processInfos = getProcessesUNIXCmd(collector);
+            }
+        }
+        return processInfos;
+    }
+
+    private static List<ProcessInfo> getProcesses(Class<?> processHandleClass,
+            Function<Stream<ProcessInfo>, List<ProcessInfo>> collector) throws NoSuchMethodException, IllegalAccessException {
+        Method allProcessesMethod = processHandleClass.getMethod("allProcesses");   // NOI18N
+        try {
+            @SuppressWarnings("unchecked")
+            Stream<Object> allProcesses = (Stream<Object>) allProcessesMethod.invoke(null);
+            return collector.apply(allProcesses
+                    .map(new ProcessHandle2Info(processHandleClass)));
+        } catch (IllegalArgumentException | InvocationTargetException ex) {
+            Exceptions.printStackTrace(ex);
+            return Collections.emptyList();
+        }
+    }
+
+    private static class ProcessHandle2Info implements Function<Object, ProcessInfo> {
+
+        private final Method pidMethod;
+        private final Method infoMethod;
+        private final Method commandMethod;
+        private final Method commandLineMethod;
+
+        ProcessHandle2Info(Class<?> processHandleClass) throws NoSuchMethodException {
+            pidMethod = processHandleClass.getMethod("pid");        // NOI18N
+            infoMethod = processHandleClass.getMethod("info");      // NOI18N
+            commandMethod = infoMethod.getReturnType().getMethod("command");    // NOI18N
+            commandLineMethod = infoMethod.getReturnType().getMethod("commandLine"); // NOI18N
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public ProcessInfo apply(Object processHandle) {
+            try {
+                long pid = (Long) pidMethod.invoke(processHandle);
+                Object info = infoMethod.invoke(processHandle);
+                Optional<String> command = (Optional<String>) commandMethod.invoke(info);
+                Optional<String> commandLine = (Optional<String>) commandLineMethod.invoke(info);
+                if (command.isPresent() && commandLine.isPresent()) {
+                    return new ProcessInfo(pid, command.get(), commandLine.get());
+                }
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+            return null;
+        }
+    }
+
+    private static List<ProcessInfo> getProcessesUNIXCmd(Function<Stream<ProcessInfo>, List<ProcessInfo>> collector) {
+        return getProcesses(CMD_UNIX, line -> {
+            int i2 = line.indexOf(' ');
+            if (i2 < 0) {
+                return null;
+            }
+            String pidStr = line.substring(0, i2);
+            long pid;
+            try {
+                pid = Long.parseLong(pidStr);
+            } catch (NumberFormatException ex) {
+                return null;
+            }
+            int i1 = i2 + 1;
+            String commandLine = line.substring(i1).trim();
+            if (CMD_UNIX.equals(commandLine)) {
+                return null;
+            }
+            return new ProcessInfo(pid, null, commandLine);
+        }, collector);
+    }
+
+    private static List<ProcessInfo> getProcessesWinCmd(Function<Stream<ProcessInfo>, List<ProcessInfo>> collector) {
+        return getProcesses(CMD_WIN, line -> {
+            if (!line.startsWith("")) {
+                return null;
+            }
+            int i1 = 1;
+            int i2 = line.indexOf('"', i1);
+            if (i2 < 0) {
+                return null;
+            }
+            String execName = line.substring(i1, i2);
+            i1 = line.indexOf('"', i2 + 1);
+            if (i1 < 0) {
+                return null;
+            }
+            i1++;
+            i2 = line.indexOf('"', i1);
+            if (i2 < 0) {
+                return null;
+            }
+            String pidStr = line.substring(i1, i2);
+            long pid;
+            try {
+                pid = Long.parseLong(pidStr);
+            } catch (NumberFormatException ex) {
+                return null;
+            }
+            return new ProcessInfo(pid, execName, execName);
+        }, collector);
+    }
+
+    private static List<ProcessInfo> getProcesses(String cmd,
+            Function<? super String, ? extends ProcessInfo> pmap,
+            Function<Stream<ProcessInfo>, List<ProcessInfo>> collector) {
+        try {
+            Process p = Runtime.getRuntime().exec(cmd);
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+                return collector.apply(reader
+                        .lines()
+                        .map(line -> line.trim())
+                        .map(pmap));
+            }
+        } catch (IOException ex) {
+            return Collections.emptyList();
+        }
+    }
+
+    final static class ProcessInfo {
+
+        private final long pid;
+        private final String executable;
+        private final String command;
+
+        ProcessInfo(long id, String executable, String command) {
+            assert command != null;
+            this.pid = id;
+            this.executable = executable;
+            this.command = command;
+        }
+
+        /**
+         * Get the ID of the process.
+         */
+        long getPid() {
+            return pid;
+        }
+
+        /**
+         * Get the executable of the process.
+         */
+        String getExecutable() {
+            if (executable != null) {
+                return executable;
+            }
+            File exeFile = new File("/proc/" + pid + "/exe");
+            if (exeFile.exists()) {
+                try {
+                    return exeFile.getCanonicalPath();
+                } catch (IOException ex) {}
+            }
+            int i = command.indexOf(' ');
+            return i > 0 ? command.substring(0, i) : command;
+        }
+
+        /**
+         * Get the command line of the process.
+         */
+        String getCommand() {
+            return command;
+        }
+
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbDebugSession.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbDebugSession.java
@@ -47,7 +47,8 @@ public final class NbDebugSession {
         return niDebugger;
     }
 
-    void setNIDebugger(NIDebugger niDebugger) {
+    public void setNIDebugger(NIDebugger niDebugger) {
+        assert this.niDebugger == null;
         this.niDebugger = niDebugger;
     }
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -633,7 +633,8 @@ public final class Server {
                         JAVA_NEW_FROM_TEMPLATE,
                         JAVA_NEW_PROJECT,
                         JAVA_PROJECT_CONFIGURATION_COMPLETION,
-                        JAVA_SUPER_IMPLEMENTATION));
+                        JAVA_SUPER_IMPLEMENTATION,
+                        NATIVE_IMAGE_FIND_DEBUG_PROCESS_TO_ATTACH));
                 for (CodeGenerator codeGenerator : Lookup.getDefault().lookupAll(CodeGenerator.class)) {
                     commands.addAll(codeGenerator.getCommands());
                 }
@@ -767,6 +768,10 @@ public final class Server {
      * Enumerates JVM processes eligible for debugger attach.
      */
     public static final String JAVA_FIND_DEBUG_PROCESS_TO_ATTACH = "java.attachDebugger.pickProcess";
+    /**
+     * Enumerates native processes eligible for debugger attach.
+     */
+    public static final String NATIVE_IMAGE_FIND_DEBUG_PROCESS_TO_ATTACH = "nativeImage.attachDebugger.pickProcess";
     /**
      * Provides code-completion of configurations.
      */

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -81,6 +81,7 @@ import org.netbeans.modules.gsf.testrunner.ui.spi.ComputeTestMethods;
 import org.netbeans.modules.java.lsp.server.LspServerState;
 import org.netbeans.modules.java.lsp.server.Utils;
 import org.netbeans.modules.java.lsp.server.debugging.attach.AttachConfigurations;
+import org.netbeans.modules.java.lsp.server.debugging.attach.AttachNativeConfigurations;
 import org.netbeans.modules.java.source.ui.JavaSymbolProvider;
 import org.netbeans.modules.java.source.ui.JavaTypeProvider;
 import org.netbeans.modules.java.source.usages.ClassIndexImpl;
@@ -243,6 +244,9 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
             }
             case Server.JAVA_FIND_DEBUG_PROCESS_TO_ATTACH: {
                 return AttachConfigurations.findProcessAttachTo(client);
+            }
+            case Server.NATIVE_IMAGE_FIND_DEBUG_PROCESS_TO_ATTACH: {
+                return AttachNativeConfigurations.findProcessAttachTo(client);
             }
             case Server.JAVA_PROJECT_CONFIGURATION_COMPLETION: {
                 // We expect one, two or three arguments.

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -243,6 +243,25 @@
 								"default": "internalConsole"
 							}
 						}
+					},
+					"attach": {
+						"properties": {
+							"nativeImagePath": {
+								"type": "string",
+								"description": "Absolute path to the application native image.",
+								"default": "${workspaceFolder}/build/native-image/application"
+							},
+							"processId": {
+								"type": "string",
+								"default": "${command:nativeImage.attachDebugger.pickProcess}",
+								"description": "Process Id of the native image"
+							},
+							"miDebugger": {
+								"type": "string",
+								"description": "MI Debugger",
+								"default": "gdb"
+							}
+						}
 					}
 				},
 				"initialConfigurations": [
@@ -255,13 +274,24 @@
 				],
 				"configurationSnippets": [
 					{
-						"label": "Launch Native Image",
+						"label": "Native Image: Launch",
 						"description": "Launch a native image with MI debugger.",
 						"body": {
 							"type": "nativeimage",
 							"request": "launch",
 							"name": "Launch Native Image",
 							"nativeImagePath": "^\"${1:\\${workspaceFolder\\}/build/native-image/application}\""
+						}
+					},
+					{
+						"label": "Native Image: Attach to Process",
+						"description": "Attach to a native image process with MI debugger.",
+						"body": {
+							"type": "nativeimage",
+							"request": "attach",
+							"name": "Attach to Native Image",
+							"processId": "^\"\\${command:nativeImage.attachDebugger.pickProcess\\}\"",
+							"nativeImagePath": ""
 						}
 					}
 				]

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -867,7 +867,7 @@ class NetBeansConfigurationNativeResolver implements vscode.DebugConfigurationPr
         if (!config.request) {
             config.request = 'launch';
         }
-        if (!config.nativeImagePath) {
+        if ('launch' == config.request && !config.nativeImagePath) {
             config.nativeImagePath = '${workspaceFolder}/build/native-image/application';
         }
         if (!config.miDebugger) {

--- a/java/java.nativeimage.debugger/manifest.mf
+++ b/java/java.nativeimage.debugger/manifest.mf
@@ -3,5 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.java.nativeimage.debugger/0
 OpenIDE-Module-Layer: org/netbeans/modules/java/nativeimage/debugger/resources/mf-layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/nativeimage/debugger/Bundle.properties
-OpenIDE-Module-Specification-Version: 0.2
+OpenIDE-Module-Specification-Version: 0.3
 

--- a/java/java.nativeimage.debugger/nbproject/project.xml
+++ b/java/java.nativeimage.debugger/nbproject/project.xml
@@ -85,7 +85,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>0</release-version>
-                        <specification-version>0.2</specification-version>
+                        <specification-version>0.4</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/actions/Bundle.properties
+++ b/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/actions/Bundle.properties
@@ -15,7 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NIAttachCustomizer.fileLabel.text=Image File:
-NIAttachCustomizer.fileTextField.text=
-NIAttachCustomizer.fileButton.text=Browse
-NIAttachCustomizer.dbgLabel.text=Debugger:
+NIAttachCustomizer.fileLabel.text=&Image File:
+NIAttachCustomizer.fileButton.text=&Browse
+NIAttachCustomizer.dbgLabel.text=Debu&gger:
+NIAttachCustomizer.attachLabel.text=&Attach to selected process: {0, choice, 0#none|0<{0,number,'#'}}
+# Process ID
+NIAttachCustomizer.processPID.text=PID
+NIAttachCustomizer.processCommand.text=Command

--- a/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/actions/NIAttachCustomizer.form
+++ b/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/actions/NIAttachCustomizer.form
@@ -37,22 +37,28 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" attributes="0">
+          <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="fileLabel" min="-2" max="-2" attributes="0"/>
+                  <Component id="jScrollPane1" max="32767" attributes="0"/>
+                  <Group type="102" attributes="0">
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="fileLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="dbgLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                      </Group>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Component id="fileTextField" max="32767" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="dbgTextField" max="32767" attributes="0"/>
+                          <Component id="fileTextField" max="32767" attributes="0"/>
+                      </Group>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="fileButton" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="dbgLabel" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="dbgComboBox" pref="196" max="32767" attributes="0"/>
+                  <Group type="102" attributes="0">
+                      <Component id="attachLabel" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                   </Group>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
-              <Component id="fileButton" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
@@ -69,9 +75,13 @@
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="dbgLabel" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="dbgComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="dbgTextField" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="attachLabel" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="jScrollPane1" pref="139" max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -79,17 +89,15 @@
   <SubComponents>
     <Component class="javax.swing.JLabel" name="fileLabel">
       <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="fileTextField"/>
+        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/java/nativeimage/debugger/actions/Bundle.properties" key="NIAttachCustomizer.fileLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="fileTextField">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/java/nativeimage/debugger/actions/Bundle.properties" key="NIAttachCustomizer.fileTextField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-      </Properties>
     </Component>
     <Component class="javax.swing.JButton" name="fileButton">
       <Properties>
@@ -103,23 +111,36 @@
     </Component>
     <Component class="javax.swing.JLabel" name="dbgLabel">
       <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="dbgTextField"/>
+        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/java/nativeimage/debugger/actions/Bundle.properties" key="NIAttachCustomizer.dbgLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>
-    <Component class="javax.swing.JComboBox" name="dbgComboBox">
+    <Component class="javax.swing.JTextField" name="dbgTextField">
       <Properties>
-        <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
-          <StringArray count="2">
-            <StringItem index="0" value="gdb"/>
-            <StringItem index="1" value="lldb-mi"/>
-          </StringArray>
+        <Property name="text" type="java.lang.String" value="gdb"/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="attachLabel">
+      <Properties>
+        <Property name="labelFor" type="java.awt.Component" editor="org.netbeans.modules.form.ComponentChooserEditor">
+          <ComponentRef name="processTable"/>
+        </Property>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/java/nativeimage/debugger/actions/Bundle.properties" key="NIAttachCustomizer.attachLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
-      <AuxValues>
-        <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
-      </AuxValues>
     </Component>
+    <Container class="javax.swing.JScrollPane" name="jScrollPane1">
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+      <SubComponents>
+        <Component class="javax.swing.JTable" name="processTable">
+        </Component>
+      </SubComponents>
+    </Container>
   </SubComponents>
 </Form>

--- a/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/actions/NIAttachCustomizer.java
+++ b/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/actions/NIAttachCustomizer.java
@@ -18,14 +18,17 @@
  */
 package org.netbeans.modules.java.nativeimage.debugger.actions;
 
+import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
+import java.util.List;
 import javax.swing.Action;
 import javax.swing.JFileChooser;
+import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -34,14 +37,17 @@ import javax.swing.filechooser.FileFilter;
 import org.netbeans.api.debugger.Properties;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
+import org.netbeans.modules.java.nativeimage.debugger.actions.Processes.ProcessInfo;
 import org.netbeans.modules.java.nativeimage.debugger.api.NIDebugRunner;
 import org.netbeans.spi.debugger.ui.Controller;
 import static org.netbeans.spi.debugger.ui.Controller.PROP_VALID;
 import org.netbeans.spi.debugger.ui.PersistentController;
 import static org.netbeans.spi.project.ActionProvider.COMMAND_DEBUG;
+
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.awt.Actions;
+import org.openide.awt.Mnemonics;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.modules.ModuleInfo;
@@ -59,7 +65,8 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
 
     private final ConnectController controller;
     private final ValidityDocumentListener validityDocumentListener = new ValidityDocumentListener();
-    private final RequestProcessor currentFileRP = new RequestProcessor(NIAttachCustomizer.class);
+    private final RequestProcessor RP = new RequestProcessor(NIAttachCustomizer.class.getName(), 2);
+    private ProcessInfo processInfo = null;
 
     /**
      * Creates new form NIAttachCustomizer
@@ -69,10 +76,11 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
         initComponents();
         fileTextField.getDocument().addDocumentListener(validityDocumentListener);
         initNIFile();
+        initProcesses();
     }
 
     private void initNIFile() {
-        currentFileRP.post(() -> {
+        RP.post(() -> {
             FileObject currentFO = Utilities.actionsGlobalContext().lookup(FileObject.class);
             if (currentFO != null) {
                 File currentFile = FileUtil.toFile(currentFO);
@@ -98,6 +106,66 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
         });
     }
 
+    private void initProcesses() {
+        processTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        final int spacing = 8;
+        processTable.setIntercellSpacing(new Dimension(spacing, 0));
+        Mnemonics.setLocalizedText(attachLabel, org.openide.util.NbBundle.getMessage(NIAttachCustomizer.class, "NIAttachCustomizer.attachLabel.text", 0l)); // NOI18N
+        RP.post(() -> {
+            List<ProcessInfo> processes = Processes.getAllProcesses();
+            int size = processes.size();
+            Object[][] processValues = new Object[size][];
+            for (int i = 0; i < size; i++) {
+                ProcessInfo info = processes.get(i);
+                processValues[i] = new Object[] {
+                    info.getPid(),
+                    info.getCommand()
+                };
+            }
+            SwingUtilities.invokeLater(() -> {
+                processTable.setModel(new javax.swing.table.DefaultTableModel(
+                    processValues,
+                    new String [] {
+                        NbBundle.getMessage(NIAttachCustomizer.class, "NIAttachCustomizer.processPID.text"), // NOI18N
+                        NbBundle.getMessage(NIAttachCustomizer.class, "NIAttachCustomizer.processCommand.text"), // NOI18N
+                    }
+                ) {
+                    Class<?>[] types = new Class<?>[] {
+                        Long.class, String.class
+                    };
+
+                    @Override
+                    public Class<?> getColumnClass(int columnIndex) {
+                        return types[columnIndex];
+                    }
+
+                    @Override
+                    public boolean isCellEditable(int rowIndex, int columnIndex) {
+                        return false;
+                    }
+                });
+                if (!processes.isEmpty()) {
+                    int width = processTable.getGraphics().getFontMetrics().stringWidth(Long.toString(processes.get(0).getPid()));
+                    width += 2*spacing;
+                    processTable.getColumnModel().getColumn(0).setPreferredWidth(width);
+                    processTable.getColumnModel().getColumn(0).setMaxWidth(width);
+                    processTable.getSelectionModel().addListSelectionListener(listSelectionEvent -> {
+                        int index = processTable.getSelectedRow();
+                        if (index < 0) {
+                            Mnemonics.setLocalizedText(attachLabel, NbBundle.getMessage(NIAttachCustomizer.class, "NIAttachCustomizer.attachLabel.text", 0l)); // NOI18N
+                            processInfo = null;
+                        } else {
+                            ProcessInfo info = processes.get(index);
+                            Mnemonics.setLocalizedText(attachLabel, NbBundle.getMessage(NIAttachCustomizer.class, "NIAttachCustomizer.attachLabel.text", info.getPid())); // NOI18N
+                            fileTextField.setText(info.getExecutable());
+                            processInfo = info;
+                        }
+                    });
+                }
+            });
+        });
+    }
+
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always
@@ -111,11 +179,13 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
         fileTextField = new javax.swing.JTextField();
         fileButton = new javax.swing.JButton();
         dbgLabel = new javax.swing.JLabel();
-        dbgComboBox = new javax.swing.JComboBox<>();
+        dbgTextField = new javax.swing.JTextField();
+        attachLabel = new javax.swing.JLabel();
+        jScrollPane1 = new javax.swing.JScrollPane();
+        processTable = new javax.swing.JTable();
 
+        fileLabel.setLabelFor(fileTextField);
         org.openide.awt.Mnemonics.setLocalizedText(fileLabel, org.openide.util.NbBundle.getMessage(NIAttachCustomizer.class, "NIAttachCustomizer.fileLabel.text")); // NOI18N
-
-        fileTextField.setText(org.openide.util.NbBundle.getMessage(NIAttachCustomizer.class, "NIAttachCustomizer.fileTextField.text")); // NOI18N
 
         org.openide.awt.Mnemonics.setLocalizedText(fileButton, org.openide.util.NbBundle.getMessage(NIAttachCustomizer.class, "NIAttachCustomizer.fileButton.text")); // NOI18N
         fileButton.addActionListener(new java.awt.event.ActionListener() {
@@ -124,9 +194,15 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
             }
         });
 
+        dbgLabel.setLabelFor(dbgTextField);
         org.openide.awt.Mnemonics.setLocalizedText(dbgLabel, org.openide.util.NbBundle.getMessage(NIAttachCustomizer.class, "NIAttachCustomizer.dbgLabel.text")); // NOI18N
 
-        dbgComboBox.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "gdb", "lldb-mi" }));
+        dbgTextField.setText("gdb");
+
+        attachLabel.setLabelFor(processTable);
+        org.openide.awt.Mnemonics.setLocalizedText(attachLabel, org.openide.util.NbBundle.getMessage(NIAttachCustomizer.class, "NIAttachCustomizer.attachLabel.text")); // NOI18N
+
+        jScrollPane1.setViewportView(processTable);
 
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
@@ -135,16 +211,20 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jScrollPane1)
                     .addGroup(layout.createSequentialGroup()
-                        .addComponent(fileLabel)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(fileLabel)
+                            .addComponent(dbgLabel))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(fileTextField))
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(dbgTextField)
+                            .addComponent(fileTextField))
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(fileButton))
                     .addGroup(layout.createSequentialGroup()
-                        .addComponent(dbgLabel)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(dbgComboBox, 0, 196, Short.MAX_VALUE)))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(fileButton)
+                        .addComponent(attachLabel)
+                        .addGap(0, 0, Short.MAX_VALUE)))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -158,8 +238,12 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(dbgLabel)
-                    .addComponent(dbgComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addComponent(dbgTextField, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(attachLabel)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 139, Short.MAX_VALUE)
+                .addContainerGap())
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -185,14 +269,17 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
 
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    private javax.swing.JComboBox<String> dbgComboBox;
+    private javax.swing.JLabel attachLabel;
     private javax.swing.JLabel dbgLabel;
+    private javax.swing.JTextField dbgTextField;
     private javax.swing.JButton fileButton;
     private javax.swing.JLabel fileLabel;
     private javax.swing.JTextField fileTextField;
+    private javax.swing.JScrollPane jScrollPane1;
+    private javax.swing.JTable processTable;
     // End of variables declaration//GEN-END:variables
 
-    RequestProcessor.Task validationTask = currentFileRP.create(new FileValidationTask());
+    RequestProcessor.Task validationTask = new RequestProcessor(NIAttachCustomizer.class).create(new FileValidationTask());
 
     @NbBundle.Messages({"MSG_NoFile=Native Imige File is missing."})
     private void checkValid() {
@@ -241,11 +328,13 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
 
     private static final String CPPLITE_DEBUGGER = "org.netbeans.modules.cpplite.debugger"; // NOI18N
 
-    @NbBundle.Messages({"MSG_EnableNativeDebugger=Enable {0} in Plugins Manager", "TTL_EnableNativeDebugger=Native Debugger Dependency"})
+    @NbBundle.Messages({"# {0} - Name of the module that needs to be enabled.",
+                        "MSG_EnableNativeDebugger=Enable {0} in Plugins Manager",
+                        "TTL_EnableNativeDebugger=Native Debugger Dependency"})
     private static boolean checkCPPLite() {
         ModuleInfo cppliteDebugger = Modules.getDefault().findCodeNameBase(CPPLITE_DEBUGGER);
         if (cppliteDebugger != null && !cppliteDebugger.isEnabled()) {
-            Action pluginsManager = Actions.forID("System", "org.netbeans.modules.autoupdate.ui.actions.PluginManagerAction");
+            Action pluginsManager = Actions.forID("System", "org.netbeans.modules.autoupdate.ui.actions.PluginManagerAction");  // NOI18N
             String moduleDisplayName = cppliteDebugger.getDisplayName();
             NotifyDescriptor messageDescriptor = new NotifyDescriptor.Confirmation(
                     Bundle.MSG_EnableNativeDebugger(moduleDisplayName),
@@ -264,16 +353,16 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
 
     public class ConnectController implements PersistentController {
 
-        private static final String NI_ATTACH_PROPERTIES = "native_image_attach_settings";
-        private static final String PROP_NI_FILE = "niFile";
-        private static final String PROP_DBG = "debugger";
+        private static final String NI_ATTACH_PROPERTIES = "native_image_attach_settings";  // NOI18N
+        private static final String PROP_NI_FILE = "niFile";                                // NOI18N
+        private static final String PROP_DBG = "debugger";                                  // NOI18N
 
         private PropertyChangeSupport pcs = new PropertyChangeSupport(this);
         private boolean valid = true;
 
         @Override
         public String getDisplayName() {
-            return dbgComboBox.getSelectedItem() + " " + new File(fileTextField.getText()).getName();
+            return dbgTextField.getText() + " " + new File(fileTextField.getText()).getName();
         }
 
         @Override
@@ -285,7 +374,7 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
                     @Override
                     public void run() {
                         fileTextField.setText(attachProps.getString(PROP_NI_FILE, ""));
-                        dbgComboBox.setSelectedItem(attachProps.getString(PROP_DBG, "DBG"));
+                        dbgTextField.setText(attachProps.getString(PROP_DBG, "DBG"));
                     }
                 });
             } catch (InterruptedException | InvocationTargetException ex) {
@@ -318,20 +407,25 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
 
         private void saveToProps(Properties attachProps) {
             attachProps.setString(PROP_NI_FILE, fileTextField.getText());
-            attachProps.setString(PROP_DBG, (String) dbgComboBox.getSelectedItem());
+            attachProps.setString(PROP_DBG, dbgTextField.getText());
         }
 
         @Override
         public boolean ok() {
             String filePath = fileTextField.getText();
-            String debuggerCommand = dbgComboBox.getSelectedItem().toString();
-            currentFileRP.post(() -> {
+            String debuggerCommand = dbgTextField.getText();
+            ProcessInfo attach2Process = processInfo;
+            RP.post(() -> {
                 if (!checkCPPLite()) {
                     return ;
                 }
                 File file = new File(filePath);
                 String displayName = COMMAND_DEBUG + " " + file.getName();
-                NIDebugRunner.start(file, Collections.emptyList(), debuggerCommand, null, displayName, null, null);
+                if (attach2Process != null) {
+                    NIDebugRunner.attach(file, attach2Process.getPid(), debuggerCommand, null, null);
+                } else {
+                    NIDebugRunner.start(file, Collections.emptyList(), debuggerCommand, null, displayName, null, null);
+                }
             });
             return true;
         }

--- a/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/actions/Processes.java
+++ b/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/actions/Processes.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.nativeimage.debugger.actions;
+
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.openide.util.Exceptions;
+import org.openide.util.Utilities;
+
+/**
+ * Retrieve a list of native processes.
+ * Duplicates org.netbeans.modules.java.lsp.server.debugging.attach.Processes
+ * Replace with the direct use of ProcessHandle, after JDK 8 is abandoned.
+ *
+ * @author martin
+ */
+final class Processes {
+
+    private static final String CMD_UNIX = "ps -x -o pid,command";  // NOI18N
+    private static final String CMD_WIN = "tasklist /FO CSV";       // NOI18N
+
+    static List<ProcessInfo> getAllProcesses() {
+        List<ProcessInfo> processInfos;
+        Function<Stream<ProcessInfo>, List<ProcessInfo>> collector =
+                infoStream -> infoStream
+                    .filter(info -> info != null)
+                    .sorted((info1, info2) -> (info1.getPid() == info2.getPid() ? 0 : info1.getPid() > info2.getPid() ? -1 : 1)) // descending
+                    .collect(Collectors.toList());
+        try {
+            Class<?> processHandleClass = Class.forName("java.lang.ProcessHandle");    // NOI18N
+            processInfos = getProcesses(processHandleClass, collector);
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException ex) {
+            if (Utilities.isWindows()) {
+                processInfos = getProcessesWinCmd(collector);
+            } else {
+                processInfos = getProcessesUNIXCmd(collector);
+            }
+        }
+        return processInfos;
+    }
+
+    private static List<ProcessInfo> getProcesses(Class<?> processHandleClass,
+            Function<Stream<ProcessInfo>, List<ProcessInfo>> collector) throws NoSuchMethodException, IllegalAccessException {
+        Method allProcessesMethod = processHandleClass.getMethod("allProcesses");   // NOI18N
+        try {
+            @SuppressWarnings("unchecked")
+            Stream<Object> allProcesses = (Stream<Object>) allProcessesMethod.invoke(null);
+            return collector.apply(allProcesses
+                    .map(new ProcessHandle2Info(processHandleClass)));
+        } catch (IllegalArgumentException | InvocationTargetException ex) {
+            Exceptions.printStackTrace(ex);
+            return Collections.emptyList();
+        }
+    }
+
+    private static class ProcessHandle2Info implements Function<Object, ProcessInfo> {
+
+        private final Method pidMethod;
+        private final Method infoMethod;
+        private final Method commandMethod;
+        private final Method commandLineMethod;
+
+        ProcessHandle2Info(Class<?> processHandleClass) throws NoSuchMethodException {
+            pidMethod = processHandleClass.getMethod("pid");        // NOI18N
+            infoMethod = processHandleClass.getMethod("info");      // NOI18N
+            commandMethod = infoMethod.getReturnType().getMethod("command");    // NOI18N
+            commandLineMethod = infoMethod.getReturnType().getMethod("commandLine"); // NOI18N
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public ProcessInfo apply(Object processHandle) {
+            try {
+                long pid = (Long) pidMethod.invoke(processHandle);
+                Object info = infoMethod.invoke(processHandle);
+                Optional<String> command = (Optional<String>) commandMethod.invoke(info);
+                Optional<String> commandLine = (Optional<String>) commandLineMethod.invoke(info);
+                if (command.isPresent() && commandLine.isPresent()) {
+                    return new ProcessInfo(pid, command.get(), commandLine.get());
+                }
+            } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+            return null;
+        }
+    }
+
+    private static List<ProcessInfo> getProcessesUNIXCmd(Function<Stream<ProcessInfo>, List<ProcessInfo>> collector) {
+        return getProcesses(CMD_UNIX, line -> {
+            int i2 = line.indexOf(' ');
+            if (i2 < 0) {
+                return null;
+            }
+            String pidStr = line.substring(0, i2);
+            long pid;
+            try {
+                pid = Long.parseLong(pidStr);
+            } catch (NumberFormatException ex) {
+                return null;
+            }
+            int i1 = i2 + 1;
+            String commandLine = line.substring(i1).trim();
+            if (CMD_UNIX.equals(commandLine)) {
+                return null;
+            }
+            return new ProcessInfo(pid, null, commandLine);
+        }, collector);
+    }
+
+    private static List<ProcessInfo> getProcessesWinCmd(Function<Stream<ProcessInfo>, List<ProcessInfo>> collector) {
+        return getProcesses(CMD_WIN, line -> {
+            if (!line.startsWith("")) {
+                return null;
+            }
+            int i1 = 1;
+            int i2 = line.indexOf('"', i1);
+            if (i2 < 0) {
+                return null;
+            }
+            String execName = line.substring(i1, i2);
+            i1 = line.indexOf('"', i2 + 1);
+            if (i1 < 0) {
+                return null;
+            }
+            i1++;
+            i2 = line.indexOf('"', i1);
+            if (i2 < 0) {
+                return null;
+            }
+            String pidStr = line.substring(i1, i2);
+            long pid;
+            try {
+                pid = Long.parseLong(pidStr);
+            } catch (NumberFormatException ex) {
+                return null;
+            }
+            return new ProcessInfo(pid, execName, execName);
+        }, collector);
+    }
+
+    private static List<ProcessInfo> getProcesses(String cmd,
+            Function<? super String, ? extends ProcessInfo> pmap,
+            Function<Stream<ProcessInfo>, List<ProcessInfo>> collector) {
+        try {
+            Process p = Runtime.getRuntime().exec(cmd);
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+                return collector.apply(reader
+                        .lines()
+                        .map(line -> line.trim())
+                        .map(pmap));
+            }
+        } catch (IOException ex) {
+            return Collections.emptyList();
+        }
+    }
+
+    final static class ProcessInfo {
+
+        private final long pid;
+        private final String executable;
+        private final String command;
+
+        ProcessInfo(long id, String executable, String command) {
+            assert command != null;
+            this.pid = id;
+            this.executable = executable;
+            this.command = command;
+        }
+
+        /**
+         * Get the ID of the process.
+         */
+        long getPid() {
+            return pid;
+        }
+
+        /**
+         * Get the executable of the process.
+         */
+        String getExecutable() {
+            if (executable != null) {
+                return executable;
+            }
+            File exeFile = new File("/proc/" + pid + "/exe");
+            if (exeFile.exists()) {
+                try {
+                    return exeFile.getCanonicalPath();
+                } catch (IOException ex) {}
+            }
+            int i = command.indexOf(' ');
+            return i > 0 ? command.substring(0, i) : command;
+        }
+
+        /**
+         * Get the command line of the process.
+         */
+        String getCommand() {
+            return command;
+        }
+
+    }
+}

--- a/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/api/NIDebugRunner.java
+++ b/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/api/NIDebugRunner.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import org.netbeans.api.debugger.DebuggerEngine;
@@ -80,13 +81,53 @@ public final class NIDebugRunner {
                 COMMAND_DEBUG + " " + niFile.getName(),
                 executionDescriptor,
                 (engine) -> {
-                    checkVersion(debugger.getVersion(), displayer);
                     if (startedEngine != null) {
                         startedEngine.accept(engine);
                     }
                 }).thenRun(() -> {
                     breakpointsHandler.dispose();
                 });
+        checkVersion(debugger.getVersion(), displayer);
+        return debugger;
+    }
+
+    /**
+     * Attach debugger to a Native Image.
+     *
+     * @param niFile Native Image file
+     * @param processId a process to attach to
+     * @param debuggerCommand the debugger command
+     * @param project a project associated with the native image, or <code>null</code>
+     * @param startedEngine consumer of the started {@link DebuggerEngine}.
+     * @return an instance of {@link NIDebugger}.
+     * @throws IllegalStateException when the native debugger is not available.
+     * @since 0.3
+     */
+    public static NIDebugger attach(File niFile, long processId, String debuggerCommand, Project project, Consumer<DebuggerEngine> startedEngine) throws IllegalStateException {
+        JavaVariablesDisplayer variablesDisplayer = new JavaVariablesDisplayer();
+        JavaFrameDisplayer frameDisplayer = new JavaFrameDisplayer(project);
+        NIDebugger debugger = NIDebugger.newBuilder()
+                .frameDisplayer(frameDisplayer)
+                .variablesDisplayer(variablesDisplayer)
+                .build();
+        variablesDisplayer.setDebugger(debugger);
+        JPDABreakpointsHandler breakpointsHandler = new JPDABreakpointsHandler(niFile, debugger);
+        DialogDisplayer displayer = DialogDisplayer.getDefault(); // The launcher might provide a special displayer in the lookup. This is why we grab it eagerly.
+        CompletableFuture<Void> future = debugger.attach(
+                niFile.getAbsolutePath(),
+                processId,
+                debuggerCommand,
+                (engine) -> {
+                    if (startedEngine != null) {
+                        startedEngine.accept(engine);
+                    }
+                }).thenRun(() -> {
+                    breakpointsHandler.dispose();
+                });
+        if (future.isDone()) {
+            throw new IllegalStateException("Failed to attach.");
+        }
+        checkVersion(debugger.getVersion(), displayer);
         return debugger;
     }
 


### PR DESCRIPTION
We have a launch of native image working. But attach to a running process of native image was missing.
This PR introduced the attach to both NetBeans and LSP/VSCode.
A list of running processes is provided, sorted from the newest to the oldest. In NetBeans it's added to the attach dialog, in VSCode we're introducing `nativeImage.attachDebugger.pickProcess` command.