### PR TITLE
[NETBEANS-5865] FlatLaf: fix missing texts in file chooser (update FlatLaf from 1.4 to 1.5)

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-1E93E3D19E4FFFAB2BB9AF96A6D47BBB7B3AB1CE com.formdev:flatlaf:1.4
+D5AD617D7C328784145B05F7C8F030DB2DE5234E com.formdev:flatlaf:1.5

--- a/platform/libs.flatlaf/external/flatlaf-1.5-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-1.5-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 1.4
-Files: flatlaf-1.4.jar
+Version: 1.5
+Files: flatlaf-1.5.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-1.4.jar=modules/ext/flatlaf-1.4.jar
+release.external/flatlaf-1.5.jar=modules/ext/flatlaf-1.5.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-1.4.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-1.4.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-1.5.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-1.5.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Update FlatLaf from 1.4 to 1.5 to:

- fix missing texts in file chooser: https://issues.apache.org/jira/browse/NETBEANS-5865
- fixes an occasional application crash on Windows 10 with native window decorations enabled

https://github.com/JFormDesigner/FlatLaf/releases/tag/1.5

BTW I've accidentally pushed this directly to NetBeans delivery branch some minutes ago.
I've undone it. Hope this does not cause problems.
Sorry.

Edit: And I should not have used `delivery` as branch name for this PR. Sorry.