### PR TITLE
Indexing of inner classes/interfaces

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/ASTUtils.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/ASTUtils.java
@@ -300,7 +300,7 @@ public class ASTUtils {
                 // how to get only methods from source?
                 // for now, just check line number, if < 0 it is not from source
                 // Second part of condition is for generated accessors
-                if ((!method.isSynthetic() && method.getCode() != null)
+                if ((!method.isSynthetic() && (method.isAbstract() || method.getCode() != null))
                         || (method.isSynthetic() && possibleMethods.contains(method.getName()))) {
                     children.add(method);
                 }
@@ -352,6 +352,46 @@ public class ASTUtils {
         }
 
         return offset;
+    }
+    
+    /**
+     * Returns a simple name for a class. The result is not defined for local and
+     * anonymous classes and for closures.
+     * @param node the class
+     * @return class' simple name
+     */
+    public static String getSimpleName(ClassNode node) {
+        if (node == null) {
+            return null;
+        }
+        if (node.getOuterClass() == null) {
+            return node.getNameWithoutPackage();
+        } else {
+            String s = node.getName().substring(node.getOuterClass().getName().length());
+            if (s.startsWith("$")) {
+                return s.substring(1);
+            } else {
+                return s;
+            }
+        }
+    }
+
+    /**
+     * Returns class' parent's name. For toplevel classes, returns the package name.
+     * For inner classes, it returns the outer class' name. The result is undefined for
+     * local, anonymous classes or closures.
+     * @param node the class node.
+     * @return parent name.
+     */
+    public static String getClassParentName(ClassNode node) {
+        if (node == null) {
+            return null;
+        }
+        if (node.getOuterClass() == null) {
+            return node.getPackageName();
+        } else {
+            return node.getOuterClass().getName();
+        }
     }
 
     public static ASTNode getForeignNode(final IndexedElement o) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/GroovyIndexer.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/GroovyIndexer.java
@@ -275,6 +275,7 @@ public class GroovyIndexer extends EmbeddingIndexer {
 
             for (ASTElement child : children) {
                 switch (child.getKind()) {
+                    case INTERFACE:
                     case CLASS:
                         analyzeClass((ASTClass) child);
                         break;
@@ -298,6 +299,10 @@ public class GroovyIndexer extends EmbeddingIndexer {
                         break;
                     case FIELD:
                         indexField((ASTField) child, document);
+                        break;
+                    case INTERFACE:
+                    case CLASS:
+                        analyzeClass((ASTClass) child);
                         break;
                 }
             }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/StructureAnalyzer.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/StructureAnalyzer.java
@@ -73,6 +73,7 @@ public class StructureAnalyzer implements StructureScanner {
     private Map<ASTClass, Set<FieldNode>> fields;
     private Map<ASTClass, Set<PropertyNode>> properties;
     private List<ASTMethod> methods;
+    private Map<String, ASTClass> classes = new HashMap<>();
     
     private static final Logger LOG = Logger.getLogger(StructureAnalyzer.class.getName());
 
@@ -170,7 +171,10 @@ public class StructureAnalyzer implements StructureScanner {
             if (node instanceof ClassNode) {
                 ClassNode classNode = (ClassNode) node;
                 ASTClass co = new ASTClass(classNode, classNode.getName());
-
+                classes.put(co.getFqn(), co);
+                if (parent == null && classNode.getOuterClass() != null) {
+                    parent = classes.get(classNode.getOuterClass().getName());
+                }
                 if (parent != null) {
                     parent.addChild(co);
                 } else {
@@ -215,7 +219,9 @@ public class StructureAnalyzer implements StructureScanner {
 
         @SuppressWarnings("unchecked")
         List<ASTNode> list = ASTUtils.children(node);
-
+        
+        // classes are collected from the whole source, but the toplevel classes come
+        // first/earlier than inners.
         for (ASTNode child : list) {
             path.descend(child);
             scan(result, child, path, in, includes, parent);

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionItem.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionItem.java
@@ -538,6 +538,12 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
         public ElementKind getKind() {
             return ElementKind.METHOD;
         }
+
+        @Override
+        public int getSortPrioOverride() {
+            // sort meta-methods after normal ones, but before keywords
+            return 550;
+        }
         
         // accessed by CompletionAccessor
         List<MethodParameter> getParameters() {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ast/ASTClass.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ast/ASTClass.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.groovy.editor.api.elements.ast;
 
 import org.codehaus.groovy.ast.ClassNode;
 import org.netbeans.modules.csl.api.ElementKind;
+import org.netbeans.modules.groovy.editor.api.ASTUtils;
 import org.netbeans.modules.groovy.editor.api.elements.common.ClassElement;
 
 public class ASTClass extends ASTElement implements ClassElement {
@@ -29,14 +30,14 @@ public class ASTClass extends ASTElement implements ClassElement {
 
 
     public ASTClass(ClassNode node, String fqn) {
-        super(node, node.getPackageName(), node.getNameWithoutPackage());
+        super(node, ASTUtils.getClassParentName(node), ASTUtils.getSimpleName(node));
         if (fqn != null) {
             this.fqn = fqn;
         } else {
             this.fqn = getName();
         }
     }
-
+    
     @Override
     public String getFqn() {
         return fqn;

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ast/ASTField.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ast/ASTField.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.codehaus.groovy.ast.FieldNode;
 import org.netbeans.modules.csl.api.ElementKind;
 import org.netbeans.modules.csl.api.Modifier;
+import org.netbeans.modules.groovy.editor.api.ASTUtils;
 
 public final class ASTField extends ASTElement {
 
@@ -33,7 +34,7 @@ public final class ASTField extends ASTElement {
     public ASTField(FieldNode node, String in, boolean isProperty) {
         super(node, in, node.getName());
         this.isProperty = isProperty;
-        this.fieldType = node.getType().getNameWithoutPackage();
+        this.fieldType = ASTUtils.getSimpleName(node.getType());
     }
 
     @Override

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ast/ASTMethod.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ast/ASTMethod.java
@@ -22,10 +22,12 @@ import groovy.lang.MetaMethod;
 import java.util.ArrayList;
 import java.util.List;
 import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.ConstructorNode;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.Parameter;
 import org.netbeans.modules.csl.api.ElementKind;
+import org.netbeans.modules.groovy.editor.api.ASTUtils;
 import org.netbeans.modules.groovy.editor.api.elements.common.MethodElement;
 
 public class ASTMethod extends ASTElement implements MethodElement {
@@ -74,7 +76,7 @@ public class ASTMethod extends ASTElement implements MethodElement {
             for (Parameter parameter : ((MethodNode) node).getParameters()) {
                 String paramName = parameter.getName();
                 String fqnType = parameter.getType().getName();
-                String type = parameter.getType().getNameWithoutPackage();
+                String type = ASTUtils.getSimpleName(parameter.getType());
 
                 parameters.add(new MethodParameter(fqnType, type, paramName));
             }
@@ -115,7 +117,7 @@ public class ASTMethod extends ASTElement implements MethodElement {
     public String getName() {
         if (name == null) {
             if (node instanceof ConstructorNode) {
-                name = ((ConstructorNode) node).getDeclaringClass().getNameWithoutPackage();
+                name = ASTUtils.getSimpleName(((ConstructorNode) node).getDeclaringClass());
             } else if (node instanceof MethodNode) {
                 name = ((MethodNode) node).getName();
             }
@@ -130,7 +132,7 @@ public class ASTMethod extends ASTElement implements MethodElement {
     @Override
     public String getReturnType() {
         if (returnType == null) {
-            returnType = ((MethodNode) node).getReturnType().getNameWithoutPackage();
+            returnType = ASTUtils.getSimpleName(((MethodNode) node).getReturnType());
         }
         return returnType;
     }

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/flow/reassignment/Reassignment.groovy
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/flow/reassignment/Reassignment.groovy
@@ -1,0 +1,7 @@
+def reassignment() {
+    def varA = "ahoj"
+    def sub = varA.substring(0)
+
+    varA = ["a", "b"];
+    varA.lis
+}

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/flow/reassignment/Reassignment.groovy.testReassignment_1.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/flow/reassignment/Reassignment.groovy.testReassignment_1.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+def sub = varA.subs|tring(0)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     subSequence(int, int)           [PUBLIC]   CharSequence
+METHOD     substring(int)                  [PUBLIC]   String
+METHOD     substring(int, int)             [PUBLIC]   String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/flow/reassignment/Reassignment.groovy.testReassignment_2.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/flow/reassignment/Reassignment.groovy.testReassignment_2.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+varA.lis|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     listIterator()                  [PUBLIC]   ListIterator<E>
+METHOD     listIterator(int)               [PUBLIC]   ListIterator<E>

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods4/Methods4.groovy
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods4/Methods4.groovy
@@ -1,0 +1,21 @@
+class GroovyClass1 {
+    def method1() {}
+    def method2() {}
+    def method3() {}
+    
+    interface ISuper {
+        def methodSuper();
+    }
+    
+    interface I1 extends ISuper {
+        def methodA();
+    }
+}
+
+class GroovyClass2 {
+    def m2() {
+        GroovyClass1.I1 iface;
+        iface.meth
+
+    }
+}

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods4/Methods4.groovy.testMethods4.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods4/Methods4.groovy.testMethods4.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+iface.meth|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     methodA()                       [PUBLIC]   Object
+METHOD     methodSuper()                   [PUBLIC]   Object

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/FlowCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/FlowCCTest.java
@@ -86,4 +86,12 @@ public class FlowCCTest extends GroovyCCTestBase {
         checkCompletion(BASE + "CollectionLiterals2.groovy", "map.ent^", false);
     }
     
+    public void testReassignment_1() throws Exception {
+        checkCompletion(BASE + "Reassignment.groovy", "def sub = varA.subs^", false);
+    }
+
+    public void testReassignment_2() throws Exception {
+        checkCompletion(BASE + "Reassignment.groovy", "varA.lis^", false);
+    }
+    
 }

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/MethodCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/MethodCCTest.java
@@ -149,5 +149,13 @@ public class MethodCCTest extends GroovyCCTestBase {
     public void testCompletionNoPrefixString2() throws Exception {
         checkCompletion(BASE + "CompletionNoPrefixString2.groovy", "def name='Petr'.^", false);
     }
+    
+    /**
+     * Checks that the completion contains methods from inner interfaces and their
+     * superinterfaces.
+     */
+    public void testMethods4() throws Exception {
+        checkCompletion(BASE + "Methods4.groovy", "iface.meth^", false);
+    }
 }
 


### PR DESCRIPTION
* Abstract methods were not indexed at all, since [they have no code](https://github.com/apache/netbeans/compare/delivery...sdedic:groovy/completion-inner-classes3?expand=1#diff-6ee817fd5ae2474a0c13faafb5907287e443661413bb3a5adef6c6a250280e12L303). 
* Indexer did not dive [into inner types](https://github.com/apache/netbeans/compare/delivery...sdedic:groovy/completion-inner-classes3?expand=1#diff-a15c71a9d9bb85f1b65d31becc69c263b500c5c1fc6cea716b1629d4f531e08fR278), 
* Navigator works bad with inner types, displayed `OuterType$InnerType`
* Variable type was obscured by assignments later than caret position.