### PR TITLE
Stop PHP from invoking autocompletion for all keystrokes inside HTML

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletion.java
@@ -2166,7 +2166,7 @@ public class PHPCodeCompletion implements CodeCompletionHandler2 {
             Token t = ts.token();
             if (t != null) {
                 if (t.id() == PHPTokenId.T_INLINE_HTML) {
-                    return QueryType.ALL_COMPLETION;
+                    return QueryType.NONE;
                 } else {
                     if (AUTOPOPUP_STOP_CHARS.contains(Character.valueOf(lastChar))) {
                         return QueryType.STOP;


### PR DESCRIPTION
Stop PHP from invoking autocompletion for all keystrokes inside embedded HTML.

Changing from QueryType.ALL_COMPLETION to QueryType.NONE for embedded HTML tokens stops the PHP code completion overriding the HTML one.

This appears to fix at least some of the issues reported in https://lists.apache.org/thread.html/r6324903231edcb4ea322fc5060fe7a0620d1be6a413d33556df70468%40%3Cusers.netbeans.apache.org%3E