### PR TITLE
[NETBEANS-5907] - Update eclipselink from 2.7.7 to 2.7.9

### DIFF
--- a/enterprise/websvc.restlib/src/org/netbeans/modules/websvc/swdp/swdp.xml
+++ b/enterprise/websvc.restlib/src/org/netbeans/modules/websvc/swdp/swdp.xml
@@ -47,12 +47,12 @@
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/ext/aopalliance-repackaged-2.6.1.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/ext/osgi.core-8.0.0.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.websvc.restlib/modules/ext/jersey2/ext/osgi-resource-locator-1.0.3.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.9.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-9.1.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.9.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.9.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.9.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.9.jar!/</resource>
     </volume>
     <properties>
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->

--- a/java/j2ee.eclipselink/external/binaries-list
+++ b/java/j2ee.eclipselink/external/binaries-list
@@ -14,11 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-165FF90EF6904E7A14F84C2C921C4109558C676D org.eclipse.persistence:org.eclipse.persistence.core:2.7.7
-EEA79261168918E4638D11DAC47C80557473F56A org.eclipse.persistence:org.eclipse.persistence.asm:2.7.7
-78712ED5187194106A5563F3DE0539BED69ED8E5 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.7
-CEEA5C43E5A92585846CC7A6F5D9F1E67FAC6B84 org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.7
-B4BCDECDC32C907D04108FE2E39F1CAB3AAAF186 org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.7
-8DED6B5CD72F934DD643A89C1CC792FC4079CAB8 org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.7
+32F25F49B47750381FFE79A3D4E49C4EEA7EAF28 org.eclipse.persistence:org.eclipse.persistence.core:2.7.9
+8D54EDE9C97875A52EBAD2674D8C86232A395128 org.eclipse.persistence:org.eclipse.persistence.asm:9.1.0
+78712ED5187194106A5563F3DE0539BED69ED8E5 org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.9
+8BFFFE6ECAAAB41D23DB5A0298D70232233B1B36 org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.9
+913893AD4D43B344A045E3A40ADD2A9418D2556C org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.9
+E3A9B63685E1441B12E83803D49266D0E0D972E4 org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.9
 7EA990B062655A52CA5010CF8716FB3FBDE46D2E org.eclipse.persistence:javax.persistence:2.2.1
 865540770A6BB480AFA34A785F765B567D14909B org.eclipse.persistence:javax.persistence:2.2.1:sources

--- a/java/j2ee.eclipselink/external/eclipselink-2.7.9-license.txt
+++ b/java/j2ee.eclipselink/external/eclipselink-2.7.9-license.txt
@@ -1,12 +1,12 @@
 Name: EclipseLink
 Origin: Eclipse
-Version: 2.7.7
+Version: 2.7.9
 Description: The Eclipse Persistence Services Project ( EclipseLink) project.
 License: EPL-v10-eclipselink
 Origin: http://www.eclipse.org/eclipselink/
-Files: javax.persistence-2.2.1-sources.jar, javax.persistence-2.2.1.jar, org.eclipse.persistence.core-2.7.7.jar, org.eclipse.persistence.asm-2.7.7.jar, org.eclipse.persistence.antlr-2.7.7.jar, org.eclipse.persistence.jpa-2.7.7.jar, org.eclipse.persistence.jpa.jpql-2.7.7.jar,org.eclipse.persistence.moxy-2.7.7.jar
+Files: javax.persistence-2.2.1-sources.jar, javax.persistence-2.2.1.jar, org.eclipse.persistence.core-2.7.9.jar, org.eclipse.persistence.asm-9.1.0.jar, org.eclipse.persistence.antlr-2.7.9.jar, org.eclipse.persistence.jpa-2.7.9.jar, org.eclipse.persistence.jpa.jpql-2.7.9.jar,org.eclipse.persistence.moxy-2.7.9.jar
 
-Use of EclipseLink version 2.7.7 is governed by the terms of the license below:
+Use of EclipseLink version 2.7.9 is governed by the terms of the license below:
 
 License
 

--- a/java/j2ee.eclipselink/nbproject/project.properties
+++ b/java/j2ee.eclipselink/nbproject/project.properties
@@ -19,21 +19,21 @@ is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 jnlp.indirect.jars=\
-    modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar,\
-    modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.7.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.core-2.7.9.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.asm-9.1.0.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.9.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.9.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.9.jar,\
+    modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.9.jar,\
     modules/ext/eclipselink/javax.persistence-2.2.1.jar,\
     modules/ext/docs/javax.persistence-2.2.1-doc.zip
 
-release.external/org.eclipse.persistence.core-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar
-release.external/org.eclipse.persistence.asm-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar
-release.external/org.eclipse.persistence.antlr-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar
-release.external/org.eclipse.persistence.jpa-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar
-release.external/org.eclipse.persistence.jpa.jpql-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar
-release.external/org.eclipse.persistence.moxy-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.7.jar
+release.external/org.eclipse.persistence.core-2.7.9.jar=modules/ext/eclipselink/org.eclipse.persistence.core-2.7.9.jar
+release.external/org.eclipse.persistence.asm-9.1.0.jar=modules/ext/eclipselink/org.eclipse.persistence.asm-9.1.0.jar
+release.external/org.eclipse.persistence.antlr-2.7.9.jar=modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.9.jar
+release.external/org.eclipse.persistence.jpa-2.7.9.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.9.jar
+release.external/org.eclipse.persistence.jpa.jpql-2.7.9.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.9.jar
+release.external/org.eclipse.persistence.moxy-2.7.9.jar=modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.9.jar
 release.external/javax.persistence-2.2.1.jar=modules/ext/eclipselink/javax.persistence-2.2.1.jar
 release.build/javax.persistence-2.2.1-doc.zip=modules/ext/docs/javax.persistence-2.2.1-doc.zip
 

--- a/java/j2ee.eclipselink/nbproject/project.xml
+++ b/java/j2ee.eclipselink/nbproject/project.xml
@@ -30,22 +30,22 @@
                 <subpackages>javax.persistence</subpackages>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.core-2.7.9.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.asm-9.1.0.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.antlr-2.7.9.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa-2.7.9.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.9.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.moxy-2.7.7.jar</runtime-relative-path>
+                <runtime-relative-path>ext/eclipselink/org.eclipse.persistence.moxy-2.7.9.jar</runtime-relative-path>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/eclipselink/javax.persistence-2.2.1.jar</runtime-relative-path>

--- a/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/eclipselink_lib.xml
+++ b/java/j2ee.eclipselink/src/org/netbeans/modules/j2ee/eclipselink/eclipselink_lib.xml
@@ -25,12 +25,12 @@
     <localizing-bundle>org.netbeans.modules.j2ee.eclipselink.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar!/</resource>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.9.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.asm-9.1.0.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.9.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.9.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.9.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/org.eclipse.persistence.moxy-2.7.9.jar!/</resource>
         <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselink/modules/ext/eclipselink/javax.persistence-2.2.1.jar!/</resource>
     </volume>
     <volume>
@@ -42,12 +42,12 @@
         <property>
             <name>maven-dependencies</name>
             <value>
-                org.eclipse.persistence:org.eclipse.persistence.core:2.7.7:jar
-                org.eclipse.persistence:org.eclipse.persistence.asm:2.7.7:jar
-                org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.7:jar
-                org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.7:jar
-                org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.7:jar
-                org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.7:jar
+                org.eclipse.persistence:org.eclipse.persistence.core:2.7.9:jar
+                org.eclipse.persistence:org.eclipse.persistence.asm:9.1.0:jar
+                org.eclipse.persistence:org.eclipse.persistence.antlr:2.7.9:jar
+                org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.9:jar
+                org.eclipse.persistence:org.eclipse.persistence.jpa.jpql:2.7.9:jar
+                org.eclipse.persistence:org.eclipse.persistence.moxy:2.7.9:jar
                 org.eclipse.persistence:javax.persistence:2.2.1:jar
             </value>
         </property>

--- a/java/j2ee.eclipselinkmodelgen/external/binaries-list
+++ b/java/j2ee.eclipselinkmodelgen/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-B04976CFF167CC9FF4EB84BCEA663CED9477959B org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.7
+EC653CF81D377E4E73F6C9243FC23581E3B2402F org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.9

--- a/java/j2ee.eclipselinkmodelgen/external/eclipselink-2.7.9-license.txt
+++ b/java/j2ee.eclipselinkmodelgen/external/eclipselink-2.7.9-license.txt
@@ -1,12 +1,12 @@
 Name: EclipseLink
 Origin: Eclipse
-Version: 2.7.7
+Version: 2.7.9
 Description: The Eclipse Persistence Services Project ( EclipseLink) project.
 License: EPL-v10-eclipselink
 Origin: http://www.eclipse.org/eclipselink/
-Files: org.eclipse.persistence.jpa.modelgen.processor-2.7.7.jar
+Files: org.eclipse.persistence.jpa.modelgen.processor-2.7.9.jar
 
-Use of EclipseLink version 2.7.7 is governed by the terms of the license below:
+Use of EclipseLink version 2.7.9 is governed by the terms of the license below:
 
 License
 

--- a/java/j2ee.eclipselinkmodelgen/nbproject/project.properties
+++ b/java/j2ee.eclipselinkmodelgen/nbproject/project.properties
@@ -15,7 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+javac.compilerargs=-Xlint -Xlint:-serial
+javac.source=1.8
 jnlp.indirect.jars=\
-    modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.7.jar
+    modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.9.jar
 
-release.external/org.eclipse.persistence.jpa.modelgen.processor-2.7.7.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.7.jar
+release.external/org.eclipse.persistence.jpa.modelgen.processor-2.7.9.jar=modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.9.jar

--- a/java/j2ee.eclipselinkmodelgen/src/org/netbeans/modules/j2ee/eclipselinkmodelgen/eclipselinkmodelgen_lib.xml
+++ b/java/j2ee.eclipselinkmodelgen/src/org/netbeans/modules/j2ee/eclipselinkmodelgen/eclipselinkmodelgen_lib.xml
@@ -25,7 +25,7 @@
     <localizing-bundle>org.netbeans.modules.j2ee.eclipselinkmodelgen.Bundle</localizing-bundle>
     <volume>
         <type>classpath</type>
-        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselinkmodelgen/modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.7.jar!/</resource>
+        <resource>jar:nbinst://org.netbeans.modules.j2ee.eclipselinkmodelgen/modules/ext/eclipselink/org.eclipse.persistence.jpa.modelgen.processor-2.7.9.jar!/</resource>
     </volume>
     <volume>
         <type>javadoc</type>
@@ -37,7 +37,7 @@
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->
         <property>
             <name>maven-dependencies</name>
-            <value>org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.7:jar</value>
+            <value>org.eclipse.persistence:org.eclipse.persistence.jpa.modelgen.processor:2.7.9:jar</value>
         </property>
     </properties> 
 </library>

--- a/java/j2ee.jpa.refactoring/nbproject/project.properties
+++ b/java/j2ee.jpa.refactoring/nbproject/project.properties
@@ -15,16 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 requires.nb.javac=true
 
 test.unit.run.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.1.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.9.jar:\
     ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.2.1.jar:\
     ${j2eeserver.dir}/modules/ext/jsr88javax.jar:\
     ${masterfs.dir}/modules/org-netbeans-modules-masterfs.jar

--- a/java/j2ee.metadata.model.support/nbproject/project.properties
+++ b/java/j2ee.metadata.model.support/nbproject/project.properties
@@ -15,15 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.compilerargs=-Xlint:unchecked
+javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 requires.nb.javac=true
 
 test.unit.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.1.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.9.jar:\
     ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.2.1.jar:\
     ${j2ee.core.dir}/modules/ext/javaee6-endorsed/javax.annotation.jar

--- a/java/j2ee.persistence/nbproject/project.properties
+++ b/java/j2ee.persistence/nbproject/project.properties
@@ -15,15 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
+javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
 spec.version.base=1.67.0
 
 test.unit.run.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.1.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.9.jar:\
     ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.2.1.jar:\
     ${j2eeserver.dir}/modules/ext/jsr88javax.jar:\
     ${masterfs.dir}/modules/org-netbeans-modules-masterfs.jar

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Mapping.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/spi/jpql/Mapping.java
@@ -112,5 +112,10 @@ public class Mapping implements IMapping {
     public boolean isTransient() {
         return (attribute.getMappingType() == IMappingType.TRANSIENT);
     }
+
+    @Override
+    public boolean isEmbeddable() {
+        return (attribute.getMappingType() == IMappingType.EMBEDDED) || (attribute.getMappingType() == IMappingType.EMBEDDED_ID);
+    }
     
 }

--- a/java/j2ee.persistenceapi/nbproject/project.properties
+++ b/java/j2ee.persistenceapi/nbproject/project.properties
@@ -15,8 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.8
-javac.compilerargs=-Xlint:unchecked
 
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
@@ -24,11 +24,11 @@ requires.nb.javac=true
 
 spec.version.base=1.49.0
 test.unit.cp.extra=\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.7.jar:\
-    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.7.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.core-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.asm-9.1.0.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.antlr-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa-2.7.9.jar:\
+    ${j2ee.persistence.dir}/modules/ext/eclipselink/org.eclipse.persistence.jpa.jpql-2.7.9.jar:\
     ${j2ee.persistence.dir}/modules/ext/eclipselink/javax.persistence-2.2.1.jar
 
 test.config.stableBTD.includes=**/*Test.class

--- a/nbbuild/licenses/EPL-v10-eclipselink
+++ b/nbbuild/licenses/EPL-v10-eclipselink
@@ -1,4 +1,4 @@
-Use of EclipseLink version 2.7.7 is governed by the terms of the license below:
+Use of EclipseLink version 2.7.9 is governed by the terms of the license below:
 
 License
 


### PR DESCRIPTION
Notes:

- Slightly decreased size of java/eclipselink directory (9.4 MB to 9.3 MB)
- Add and override new abstract method "isEmbeddable()"
- This is mainly a maintenance release and contains bug fixes
- Deprecated Functionality: None
- Known Issues (since 2.7.0)
  - When running EclipseLink 2.7 in Glassfish 4.0, you must specify a valid datasource 
    in the persistence.xml through either the jta-data-source or non-jta-data-source tags.
  - Java hotspot compiler may crash when compiling 
    org.eclipse.persistence.internal.sessions.CommitManager::commitChangedObjectsForClassWithChangeSet 
    As a workaround, execute java with 
    -XX:CompileCommand=exclude,org/eclipse/persistence/internal/sessions/CommitManager,commitChangedObjectsForClassWithChangeSet 
    command line option for JIT compiler.

NetBeans Testing:
- Full build done
- Verify successful execution of libraries and licenses Ant test
- Verify successful execution of unit tests for modules `websvc.restlib`, `j2ee.eclipselink`, `j2ee.eclipselinkmodelgen`, `j2ee.jpa.refactoring`, `j2ee.metadata.model.support`, `j2ee.persistence` and `j2ee.persistenceapi`
- Started NetBeans and ensure the log didn't have any ERROR or new WARNINGS
- Checked the files are in the Ant Library Manager
- Successfully create project as per [NetBeans Documentation](https://netbeans.apache.org/kb/docs/websvc/rest.html), with Payara and Glassfish

This is just an update to the eclipselink library, this will not provide support for JPA 2.2, I am working on a different Issue/PR for that matter.

[EclipseLink Web Page](https://www.eclipse.org/eclipselink/)
[EclipseLink Release Notes](https://github.com/eclipse-ee4j/eclipselink/releases/tag/2.7.9)