### PR TITLE
Fixes wrong detection message when selecting a GF6.2 location.

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
@@ -209,7 +209,7 @@ public enum ServerDetails {
      */
     GLASSFISH_SERVER_6(NbBundle.getMessage(ServerDetails.class, "STR_6_SERVER_NAME", new Object[]{}), // NOI18N
         "deployer:gfv6ee9", // NOI18N
-        6,
+        600,
         "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.0.0/glassfish-6.0.0.zip", // NOI18N
         "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.0.0/glassfish-6.0.0.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
@@ -220,7 +220,7 @@ public enum ServerDetails {
      */
     GLASSFISH_SERVER_6_1_0(NbBundle.getMessage(ServerDetails.class, "STR_610_SERVER_NAME", new Object[]{}), // NOI18N
         "deployer:gfv610ee9", // NOI18N
-        6,
+        610,
         "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.1.0/glassfish-6.1.0.zip", // NOI18N
         "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.1.0/glassfish-6.1.0.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N


### PR DESCRIPTION
When adding a new server, after selecting "Glassfish Server" and pressing next, when selecting an install location, the GUI searches for a valid instance by comparing all possible instances (versions) with the one found in the location specified.

```
org.netbeans.modules.glassfish.common.wizardsServerWizardIterator::isValidInstall
org.netbeans.modules.glassfish.common.ServerDetails::isInstalledInDirectory
```

If the Glassfish version is 6.2, it shows it has found 6.1, but then goes on with the 6 version, as the 6.1 instance says it's 6.

`org.netbeans.modules.glassfish.common.ServerDetails::getVersion`

Now 6.1 says it's 610 and 6.0 says it's 600 as other versions do.

Fixes small bug in Jakarta EE 9 GlassFish 6 Support (#2902).