### PR TITLE
[NETBEANS-5910] Fix illegible heap view text with dark LAFs

### DIFF
--- a/platform/openide.actions/src/org/openide/actions/HeapView.java
+++ b/platform/openide.actions/src/org/openide/actions/HeapView.java
@@ -54,7 +54,7 @@ import org.openide.util.NbPreferences;
  * <li> nb.heapview.background - Color of widget background
  * <li> nb.heapview.foreground - Color of text
  * <li> nb.heapview.chart - Color of area chart
- * <li> nb.heapview.background - Color of outline around the text, to provide a contrast against
+ * <li> nb.heapview.highlight - Color of outline around the text, to provide a contrast against
  *                               the chart (may have a non-opaque alpha value)
  * </ul>
  * @author sky, radim, peter
@@ -112,17 +112,20 @@ class HeapView extends JComponent {
         }
         TEXT_COLOR = c;
 
-        c = UIManager.getColor("nb.heapview.highlight"); //NOI18N
-        if (null == c) {
-            c = new Color(255, 255, 255, 192);
-        }
-        OUTLINE_COLOR = c;
-
         c = UIManager.getColor("nb.heapview.background"); //NOI18N
         if (null == c) {
             c = new Color(0xCEDBE6);
         }
         BACKGROUND_COLOR = c;
+
+        c = UIManager.getColor("nb.heapview.highlight"); //NOI18N
+        if (null == c) {
+            c = new Color(BACKGROUND_COLOR.getRed(),
+                    BACKGROUND_COLOR.getGreen(),
+                    BACKGROUND_COLOR.getBlue(),
+                    192);
+        }
+        OUTLINE_COLOR = c;
     }
 
     /**


### PR DESCRIPTION

This fixes an issue with the heap view text being ugly and illegible on dark LAFs such as FlatLaf Dark. Not a major issue, but really stands out in the UI.

Unfortunately, #2965 added a hardcoded, non-optional highlight colour to the text. I considered making the value truly optional (ie. don't render the highlight at all if no key), but deriving the colour from the background colour should work OK.

### Before

![NETBEANS-5910-before](https://user-images.githubusercontent.com/3975960/128890998-e42d24ea-adc8-4df2-9da7-60308b68e785.png)

### After

![NETBEANS-5910-after](https://user-images.githubusercontent.com/3975960/128891032-57b73802-b52d-4db8-bcce-cc676fd71580.png)
