### PR TITLE
Fixing TreeUtilities.pathFor in the presence of the synthetic 'value=' in annotations.

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -374,7 +374,12 @@ public final class TreeUtilities {
             
             public Void scan(Tree tree, Void p) {
                 if (tree != null) {
-                    if (sourcePositions.getStartPosition(getCurrentPath().getCompilationUnit(), tree) < pos && sourcePositions.getEndPosition(getCurrentPath().getCompilationUnit(), tree) >= pos) {
+                    long endPos = sourcePositions.getEndPosition(getCurrentPath().getCompilationUnit(), tree);
+                    if (endPos == (-1) && tree.getKind() == Kind.ASSIGNMENT && getCurrentPath().getLeaf().getKind() == Kind.ANNOTATION) {
+                        ExpressionTree value = ((AssignmentTree) tree).getExpression();
+                        endPos = sourcePositions.getEndPosition(getCurrentPath().getCompilationUnit(), value);
+                    }
+                    if (sourcePositions.getStartPosition(getCurrentPath().getCompilationUnit(), tree) < pos && endPos >= pos) {
                         if (tree.getKind() == Tree.Kind.ERRONEOUS) {
                             tree.accept(this, p);
                             throw new Result(getCurrentPath());

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TreeUtilitiesTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/TreeUtilitiesTest.java
@@ -390,6 +390,33 @@ public class TreeUtilitiesTest extends NbTestCase {
         assertFalse(Kind.METHOD == tp.getParentPath().getLeaf().getKind());
     }
     
+    public void testAnnotationSyntheticValue1() throws Exception {
+        prepareTest("Test", "package test; @Meta(Test.VALUE) public class Test { public static final String VALUE = \"\"; } @interface Meta { public String value(); }");
+        
+        TreePath tp = info.getTreeUtilities().pathFor(58 - 30);
+        
+        assertEquals(Kind.MEMBER_SELECT, tp.getLeaf().getKind());
+        assertEquals("Test.VALUE", tp.getLeaf().toString());
+    }
+    
+    public void testAnnotationSyntheticValue2() throws Exception {
+        prepareTest("Test", "package test; @Meta(Test.VALUE) public class Test { public static final String VALUE = \"\"; } @interface Meta { public String[] value(); }");
+        
+        TreePath tp = info.getTreeUtilities().pathFor(58 - 30);
+        
+        assertEquals(Kind.MEMBER_SELECT, tp.getLeaf().getKind());
+        assertEquals("Test.VALUE", tp.getLeaf().toString());
+    }
+    
+    public void testAnnotationSyntheticValue3() throws Exception {
+        prepareTest("Test", "package test; @Meta({Test.VALUE}) public class Test { public static final String VALUE = \"\"; } @interface Meta { public String[] value(); }");
+        
+        TreePath tp = info.getTreeUtilities().pathFor(58 - 30);
+        
+        assertEquals(Kind.MEMBER_SELECT, tp.getLeaf().getKind());
+        assertEquals("Test.VALUE", tp.getLeaf().toString());
+    }
+    
     public void testAutoMapComments1() throws Exception {
         prepareTest("Test", "package test;\n" +
                             "import java.io.File;\n" +


### PR DESCRIPTION
The synthetic assignment as ending position `-1`, which breaks `pathFor`. It is not quite clear if the `-1` is reasonable, but we can workaround for NetBeans, and think of the correct end position separately.