### PR TITLE
Fix silent errors in Disco support when no valid response for quick selection

### DIFF
--- a/java/java.disco/src/org/netbeans/modules/java/disco/BrowseWizardPanel.java
+++ b/java/java.disco/src/org/netbeans/modules/java/disco/BrowseWizardPanel.java
@@ -30,7 +30,7 @@ public class BrowseWizardPanel extends AbstractWizardPanel<BrowsePanel> {
 
     @Override
     protected BrowsePanel createComponent() {
-        return BrowsePanel.create(state);
+        return new BrowsePanel(this, state);
     }
 
     @Override


### PR DESCRIPTION
Recent reporting of JDK 17 as GA by Disco (itself probably in error) shows that the quick selection doesn't handle the inability to find a download link very well.  This simple fix changes the quick selection text to show `Searching...` and to wait for Disco response before enabling next button in wizard. Also shows an error message and keeps next button disabled if Disco lookup fails.