### PR TITLE
NETBEANS-5906: treat custom actions as enabled

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
@@ -121,11 +121,7 @@ public class ActionProviderImpl implements ActionProvider {
 
     @Override
     public String[] getSupportedActions() {
-        List<? extends GradleActionsProvider> providers = ActionToTaskUtils.actionProviders(project);
-        Set<String> actions = new HashSet<>();
-        for (GradleActionsProvider provider : providers) {
-            actions.addAll(provider.getSupportedActions());
-        }
+        Set<String> actions = new HashSet<>(ActionToTaskUtils.getAllSupportedActions(project));
         // add a fixed 'prime build' action
         actions.add(ActionProvider.COMMAND_PRIME);
         actions.add(COMMAND_DL_SOURCES);
@@ -184,7 +180,7 @@ public class ActionProviderImpl implements ActionProvider {
             LOG.log(Level.FINEST, "Priming build action for {0} is: {1}", new Object[] { project, enabled });
             return enabled;
         }
-        return ActionToTaskUtils.isActionEnabled(command, project, context);
+        return ActionToTaskUtils.isActionEnabled(command, null, project, context);
     }
 
     @NbBundle.Messages({
@@ -259,7 +255,7 @@ public class ActionProviderImpl implements ActionProvider {
             LOG.log(Level.FINE, "Attempt to run a config-disabled action: {0}", action);
             return false;
         }
-        if (!ActionToTaskUtils.isActionEnabled(action, project, context)) {
+        if (!ActionToTaskUtils.isActionEnabled(action, mapping, project, context)) {
             LOG.log(Level.FINE, "Attempt to run action that is not enabled: {0}", action);
             return false;
         }

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/ConfigurableActionsProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/ConfigurableActionsProviderImpl.java
@@ -157,12 +157,7 @@ public class ConfigurableActionsProviderImpl implements ProjectActionMappingProv
         this.project = project;
         this.projectDirectory = project.getProjectDirectory();
         
-        FileChangeListener wl =  WeakListeners.create(FileChangeListener.class, new FileChangeAdapter() {
-            @Override
-            public void fileDataCreated(FileEvent fe) {
-                actionFileChanged(fe.getFile(), null, false);
-            }
-        }, this.projectDirectory);
+        FileChangeListener wl =  WeakListeners.create(FileChangeListener.class, fcl, this.projectDirectory);
         projectDirectory.addFileChangeListener(wl);
         
         LOG.log(Level.FINER, "Initializing ConfigurableAP for {0}", project);


### PR DESCRIPTION
See [NETBEANS-5906](https://issues.apache.org/jira/browse/NETBEANS-5906). The main issue was that **enabled** is defined by **GradleActionProviders**, but the Navigator creates its own custom action (that do not belong to any proivider, naturally). 
Similarly user-defined custom actions are not managed by any provider. So this omission is likely to break any user-defined custom actions, too: Since they are reported as disabled, they won't be processed.

During implementation I've discovered [NETBEANS-5918](https://issues.apache.org/jira/browse/NETBEANS-5918): funny issue caused by a weak listener that is not referenced from anywhere and is GCed. So the cache does not react properly when a **gradle.properties** or a action mapping XML files are created in the project dir.

Finally [NETBEANS-5919](https://issues.apache.org/jira/browse/NETBEANS-5919) - it's an inconsistency, since Maven project support reports custom actions as supported...