### PR TITLE
Nodes & logical view for projects

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectsTrampolineImpl.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/OpenProjectsTrampolineImpl.java
@@ -29,6 +29,7 @@ import org.netbeans.api.project.ui.ProjectGroup;
 import org.netbeans.api.project.ui.ProjectGroupChangeListener;
 import org.netbeans.modules.project.ui.groups.Group;
 import org.netbeans.modules.project.uiapi.OpenProjectsTrampoline;
+import org.openide.explorer.ExplorerManager;
 
 /**
  * List of projects open in the GUI.
@@ -135,5 +136,20 @@ public final class OpenProjectsTrampolineImpl implements OpenProjectsTrampoline,
         }
         return null;
     }
-    
+
+    @Override
+    public ExplorerManager createLogicalView() {
+        ExplorerManager em = new ExplorerManager();
+        ProjectsRootNode root = new ProjectsRootNode(ProjectsRootNode.LOGICAL_VIEW);
+        em.setRootContext(root);
+        return em;
+    }
+
+    @Override
+    public ExplorerManager createPhysicalView() {
+        ExplorerManager em = new ExplorerManager();
+        ProjectsRootNode root = new ProjectsRootNode(ProjectsRootNode.PHYSICAL_VIEW);
+        em.setRootContext(root);
+        return em;
+    }
 }

--- a/ide/projectuiapi.base/nbproject/project.properties
+++ b/ide/projectuiapi.base/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 javac.compilerargs=-Xlint -Xlint:-serial
 javac.source=1.7
-spec.version.base=1.98.0
+spec.version.base=1.100.0
 is.autoload=true
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/ide/projectuiapi.base/nbproject/project.xml
+++ b/ide/projectuiapi.base/nbproject/project.xml
@@ -53,6 +53,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.openide.explorer</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>6.75</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.filesystems</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/ide/projectuiapi.base/src/org/netbeans/api/project/ui/OpenProjects.java
+++ b/ide/projectuiapi.base/src/org/netbeans/api/project/ui/OpenProjects.java
@@ -23,7 +23,6 @@ import java.beans.PropertyChangeListener;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.concurrent.Future;
@@ -34,7 +33,7 @@ import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.project.uiapi.OpenProjectsTrampoline;
 import org.netbeans.modules.project.uiapi.BaseUtilities;
-import org.openide.util.Lookup;
+import org.openide.explorer.ExplorerManager;
 import org.openide.util.Parameters;
 
 /**
@@ -315,5 +314,24 @@ public final class OpenProjects {
     public void removeProjectGroupChangeListener( @NonNull ProjectGroupChangeListener listener) {
         trampoline.removeProjectGroupChangeListenerAPI(listener);
     }
-    
+
+    /** Creates new {@link ExplorerManager} to show and control
+     * logical structure of a project.
+     *
+     * @return new instance of the manager
+     * @since 1.100
+     */
+    public ExplorerManager createLogicalView() {
+        return trampoline.createLogicalView();
+    }
+
+    /** Creates new {@link ExplorerManager} to show and control
+     * physical structure of a project.
+     *
+     * @return new instance of the manager
+     * @since 1.100
+     */
+    public ExplorerManager createPhysicalView() {
+        return trampoline.createPhysicalView();
+    }
 }

--- a/ide/projectuiapi.base/src/org/netbeans/modules/project/uiapi/BaseUtilities.java
+++ b/ide/projectuiapi.base/src/org/netbeans/modules/project/uiapi/BaseUtilities.java
@@ -34,6 +34,7 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.api.project.ui.ProjectGroup;
 import org.netbeans.api.project.ui.ProjectGroupChangeListener;
+import org.openide.explorer.ExplorerManager;
 import org.openide.util.Lookup;
 import org.openide.util.RequestProcessor;
 
@@ -140,6 +141,16 @@ public final class BaseUtilities {
             }
             assert res != null;
             return res;
+        }
+
+        @Override
+        public ExplorerManager createLogicalView() {
+            return new ExplorerManager();
+        }
+
+        @Override
+        public ExplorerManager createPhysicalView() {
+            return new ExplorerManager();
         }
     }
 }

--- a/ide/projectuiapi.base/src/org/netbeans/modules/project/uiapi/OpenProjectsTrampoline.java
+++ b/ide/projectuiapi.base/src/org/netbeans/modules/project/uiapi/OpenProjectsTrampoline.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.ProjectGroup;
 import org.netbeans.api.project.ui.ProjectGroupChangeListener;
+import org.openide.explorer.ExplorerManager;
 
 /**
  * List of projects open in the GUI.
@@ -53,4 +54,6 @@ public interface OpenProjectsTrampoline {
 
     public void removeProjectGroupChangeListenerAPI(ProjectGroupChangeListener listener);
  
+    public ExplorerManager createLogicalView();
+    public ExplorerManager createPhysicalView();
 }

--- a/ide/projectuiapi.base/test/unit/src/org/netbeans/modules/project/ui/TestTrampoline.java
+++ b/ide/projectuiapi.base/test/unit/src/org/netbeans/modules/project/ui/TestTrampoline.java
@@ -36,6 +36,7 @@ import org.netbeans.insane.live.CancelException;
 import org.netbeans.modules.project.uiapi.OpenProjectsTrampoline;
 import org.netbeans.modules.project.uiapi.ProjectOpenedTrampoline;
 import org.netbeans.spi.project.ui.ProjectOpenedHook;
+import org.openide.explorer.ExplorerManager;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -144,6 +145,16 @@ public final class TestTrampoline implements OpenProjectsTrampoline {
 
     @Override
     public void removeProjectGroupChangeListenerAPI(ProjectGroupChangeListener listener) {
+    }
+
+    @Override
+    public ExplorerManager createLogicalView() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExplorerManager createPhysicalView() {
+        throw new UnsupportedOperationException();
     }
 
     private final class F implements Future<Project[]> {

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -478,6 +478,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.openide.explorer</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>6.50</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.filesystems</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.explorer;
+
+final class TreeItem {
+    enum CollapsibleState {
+        None, Collapsed, Expanded
+    }
+
+    // accessibilityInformation?: AccessibilityInformation
+    CollapsibleState collapsibleState;
+    // executed when the tree item is selected.
+    // command?: Command
+    // contribute item specific actions in the tree
+    String contextValue;
+    // ?: string | boolean
+    // rendered less prominent. When true, it is derived from resourceUri
+    String description;
+    // ?: string | Uri | {dark: string | Uri, light: string | Uri} | ThemeIcon
+    String iconPath;
+    // id for the tree item that has to be unique across tree.
+    // The id is used to preserve the selection and expansion state of the tree item.
+    String id;
+    // human-readable string describing this item
+    // ?: string | TreeItemLabel
+    String label;
+    // resourceUri?: Uri
+    String resourceUri;
+    // ?: string | MarkdownString | undefined
+    String tooltip;
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
@@ -21,6 +21,8 @@ package org.netbeans.modules.java.lsp.server.explorer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.URLMapper;
 import org.openide.nodes.Node;
 
 public final class TreeItem {
@@ -67,6 +69,11 @@ public final class TreeItem {
         final String desc = n.getShortDescription();
         this.description = Objects.equals(this.label, desc) ? null : desc;
         this.tooltip = n.getHtmlDisplayName();
+
+        FileObject fo = n.getLookup().lookup(FileObject.class);
+        if (fo != null) {
+            this.resourceUri = URLMapper.findURL(fo, URLMapper.EXTERNAL).toString();
+        }
     }
 
     private static int counter = 0;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
@@ -18,30 +18,79 @@
  */
 package org.netbeans.modules.java.lsp.server.explorer;
 
-final class TreeItem {
+import java.util.HashMap;
+import java.util.Map;
+import org.openide.nodes.Node;
+
+public final class TreeItem {
     enum CollapsibleState {
         None, Collapsed, Expanded
     }
 
     // accessibilityInformation?: AccessibilityInformation
-    CollapsibleState collapsibleState;
+    public CollapsibleState collapsibleState;
     // executed when the tree item is selected.
     // command?: Command
     // contribute item specific actions in the tree
-    String contextValue;
+    public String contextValue;
     // ?: string | boolean
     // rendered less prominent. When true, it is derived from resourceUri
-    String description;
+    public String description;
     // ?: string | Uri | {dark: string | Uri, light: string | Uri} | ThemeIcon
-    String iconPath;
+    public String iconPath;
     // id for the tree item that has to be unique across tree.
     // The id is used to preserve the selection and expansion state of the tree item.
-    String id;
+    public int id;
+    // programatic name of the node
+    public String name;
     // human-readable string describing this item
     // ?: string | TreeItemLabel
-    String label;
+    public String label;
     // resourceUri?: Uri
-    String resourceUri;
+    public String resourceUri;
     // ?: string | MarkdownString | undefined
-    String tooltip;
+    public String tooltip;
+
+    public TreeItem() {
+    }
+
+    private TreeItem(int id, Node n) {
+        if (n.isLeaf()) {
+            collapsibleState = TreeItem.CollapsibleState.None;
+        } else {
+            collapsibleState = TreeItem.CollapsibleState.Collapsed;
+        }
+        this.id = id;
+        this.name = n.getName();
+        this.label = n.getDisplayName();
+        this.description = n.getShortDescription();
+        this.tooltip = n.getHtmlDisplayName();
+    }
+
+    private static int counter = 0;
+    private static final Map<Integer, Node> MAP = new HashMap<>();
+
+    public static synchronized int findId(Node n) {
+        Object lspId = n.getValue("lspId");
+        if (!(lspId instanceof Integer)) {
+            lspId = ++counter;
+            n.setValue("lspId", lspId);
+            MAP.put((Integer) lspId, n);
+        }
+        return (int) lspId;
+    }
+
+    public static TreeItem find(Node n) {
+        return new TreeItem(findId(n), n);
+    }
+
+    public static synchronized TreeItem find(int id) {
+        Node n = findNode(id);
+        return n == null ? null : find(n);
+    }
+
+    public synchronized static Node findNode(int id) {
+        return MAP.get(id);
+    }
+
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.java.lsp.server.explorer;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.openide.nodes.Node;
 
 public final class TreeItem {
@@ -63,7 +64,8 @@ public final class TreeItem {
         this.id = id;
         this.name = n.getName();
         this.label = n.getDisplayName();
-        this.description = n.getShortDescription();
+        final String desc = n.getShortDescription();
+        this.description = Objects.equals(this.label, desc) ? null : desc;
         this.tooltip = n.getHtmlDisplayName();
     }
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.explorer;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.openide.explorer.ExplorerManager;
+import org.openide.nodes.Node;
+import org.openide.util.RequestProcessor;
+
+abstract class TreeViewProvider {
+    private static final RequestProcessor INITIALIZE = new RequestProcessor("Initialize nodes", 5);
+    private final ExplorerManager manager;
+
+    TreeViewProvider(ExplorerManager manager) {
+        this.manager = manager;
+    }
+    abstract void onDidChangeTreeData(Node n);
+    final CompletionStage<Node[]> getChildren(Node nodeOrNull) {
+        Node node;
+        if (nodeOrNull == null) {
+            node = manager.getRootContext();
+        } else {
+            node = nodeOrNull;
+        }
+        return CompletableFuture.supplyAsync(() -> {
+            return node.getChildren().getNodes(true);
+        }, INITIALIZE);
+    }
+
+    final CompletionStage<Node> getParent(Node node) {
+        return CompletableFuture.completedFuture(node.getParentNode());
+    }
+
+    final CompletionStage<TreeItem> getTreeItem(Node n) {
+        TreeItem item = new TreeItem();
+        if (n.isLeaf()) {
+            item.collapsibleState = TreeItem.CollapsibleState.None;
+        } else {
+            item.collapsibleState = TreeItem.CollapsibleState.Collapsed;
+        }
+        item.id = n.getName();
+        item.label = n.getDisplayName();
+        item.description = n.getShortDescription();
+        item.tooltip = n.getHtmlDisplayName();
+        return CompletableFuture.completedFuture(item);
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
@@ -18,18 +18,54 @@
  */
 package org.netbeans.modules.java.lsp.server.explorer;
 
+import java.beans.PropertyChangeEvent;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.openide.explorer.ExplorerManager;
 import org.openide.nodes.Node;
+import org.openide.nodes.NodeEvent;
+import org.openide.nodes.NodeListener;
+import org.openide.nodes.NodeMemberEvent;
+import org.openide.nodes.NodeReorderEvent;
 import org.openide.util.RequestProcessor;
+import org.openide.util.WeakSet;
 
 abstract class TreeViewProvider {
     private static final RequestProcessor INITIALIZE = new RequestProcessor("Initialize nodes", 5);
     private final ExplorerManager manager;
+    /** @GuardedBy(this) */
+    private final Set<Node> nodeListenerAttached = new WeakSet<>();
+    private final NodeListener nodeListener;
 
     TreeViewProvider(ExplorerManager manager) {
         this.manager = manager;
+        this.nodeListener = new NodeListener() {
+            @Override
+            public void childrenAdded(NodeMemberEvent ev) {
+                onDidChangeTreeData(ev.getNode());
+            }
+
+            @Override
+            public void childrenRemoved(NodeMemberEvent ev) {
+                onDidChangeTreeData(ev.getNode());
+            }
+
+            @Override
+            public void childrenReordered(NodeReorderEvent ev) {
+                onDidChangeTreeData(ev.getNode());
+            }
+
+            @Override
+            public void nodeDestroyed(NodeEvent ev) {
+                onDidChangeTreeData(ev.getNode());
+            }
+
+            @Override
+            public void propertyChange(PropertyChangeEvent ev) {
+                onDidChangeTreeData((Node) ev.getSource());
+            }
+        };
     }
     abstract void onDidChangeTreeData(Node n);
     final CompletionStage<Node[]> getChildren(Node nodeOrNull) {
@@ -39,9 +75,16 @@ abstract class TreeViewProvider {
         } else {
             node = nodeOrNull;
         }
+        ensureListenerAttached(node);
         return CompletableFuture.supplyAsync(() -> {
             return node.getChildren().getNodes(true);
         }, INITIALIZE);
+    }
+
+    private synchronized void ensureListenerAttached(Node node) {
+        if (nodeListenerAttached.add(node)) {
+            node.addNodeListener(nodeListener);
+        }
     }
 
     final CompletionStage<Node> getParent(Node node) {
@@ -49,6 +92,7 @@ abstract class TreeViewProvider {
     }
 
     final CompletionStage<TreeItem> getTreeItem(Node n) {
+        ensureListenerAttached(n);
         TreeItem item = new TreeItem();
         if (n.isLeaf()) {
             item.collapsibleState = TreeItem.CollapsibleState.None;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientWrapper.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientWrapper.java
@@ -37,7 +37,7 @@ import org.eclipse.lsp4j.WorkspaceFolder;
 /**
  * Convenience wrapper that binds language client's remote proxy together with
  * other useful methods. Will be sent out as THE client by the server core code.
- * 
+ *
  * @author sdedic
  */
 class NbCodeClientWrapper implements NbCodeLanguageClient {
@@ -158,5 +158,10 @@ class NbCodeClientWrapper implements NbCodeLanguageClient {
     @Override
     public void disposeTextEditorDecoration(String params) {
         remote.disposeTextEditorDecoration(params);
+    }
+
+    @Override
+    public void notifyNodeChange(int params) {
+        remote.notifyNodeChange(params);
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeLanguageClient.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeLanguageClient.java
@@ -32,13 +32,13 @@ import org.eclipse.lsp4j.services.LanguageClient;
  * @author sdedic
  */
 public interface NbCodeLanguageClient extends LanguageClient {
-    
+
     /**
      * Shows a message in the status bar. Log- and Info-type messages are shown "as is".
      * The other message types can be decorated by an icon according to {@link MessageParams#getType}.
      * The message will be hidden after specified number of milliseconds; 0 means the client
      * controls when the message is hidden.
-     * 
+     *
      * @param params message type and text.
      */
     @JsonNotification("window/showStatusBarMessage")
@@ -83,7 +83,7 @@ public interface NbCodeLanguageClient extends LanguageClient {
     /**
      * Set text editor decoration to an array of code ranges.
      *
-     * @param params 
+     * @param params
      */
     @JsonNotification("window/setTextEditorDecoration")
     public void setTextEditorDecoration(@NonNull SetTextEditorDecorationParams params);
@@ -97,11 +97,19 @@ public interface NbCodeLanguageClient extends LanguageClient {
     public void disposeTextEditorDecoration(@NonNull String params);
 
     /**
+     * Notifies client about change in a node.
+     *
+     * @param params the id of the node
+     */
+    @JsonNotification("nodes/notifyChange")
+    public void notifyNodeChange(int params);
+
+    /**
      * Returns extended code capabilities.
      * @return code capabilities.
      */
     public NbCodeClientCapabilities getNbCodeCapabilities();
-    
+
     public default boolean isRequestDispatcherThread() {
         return Boolean.TRUE.equals(Server.DISPATCHERS.get());
     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -36,6 +36,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.time.Instant;
+import java.io.IOException;
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProviderTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProviderTest.java
@@ -73,6 +73,29 @@ public class TreeViewProviderTest {
         assertSame("Nodes are cached", twoOneNode, TreeItem.findNode(two1.id));
     }
 
+    @Test
+    public void dontInheritTheSameDescription() {
+        AbstractNode an = new AbstractNode(Children.LEAF);
+        an.setName("a node");
+
+        TreeItem item = TreeItem.find(an);
+        assertEquals("name is set", "a node", item.name);
+        assertEquals("label is inherited", "a node", item.label);
+        assertNull("description isn't copied", item.description);
+    }
+
+    @Test
+    public void useDifferentDescription() {
+        AbstractNode an = new AbstractNode(Children.LEAF);
+        an.setName("a node");
+        an.setShortDescription("better node");
+
+        TreeItem item = TreeItem.find(an);
+        assertEquals("name is set", "a node", item.name);
+        assertEquals("label is inherited", "a node", item.label);
+        assertEquals("description is set", "better node", item.description);
+    }
+
 
     final static class TreeViewProviderImpl extends TreeViewProvider {
         private Set<Node> changed = new HashSet<>();

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProviderTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProviderTest.java
@@ -18,11 +18,15 @@
  */
 package org.netbeans.modules.java.lsp.server.explorer;
 
+import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.openide.explorer.ExplorerManager;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.filesystems.URLMapper;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
@@ -94,6 +98,21 @@ public class TreeViewProviderTest {
         assertEquals("name is set", "a node", item.name);
         assertEquals("label is inherited", "a node", item.label);
         assertEquals("description is set", "better node", item.description);
+    }
+
+    @Test
+    public void resourceUriSpecifiedOnFileObjects() throws Exception {
+        File tmp = File.createTempFile("sample", ".tmp");
+        FileObject fo = FileUtil.toFileObject(tmp);
+        assertNotNull("File object for temporary file found", fo);
+
+        AbstractNode an = new AbstractNode(Children.LEAF, fo.getLookup());
+        an.setName(fo.getNameExt());
+
+        TreeItem item = TreeItem.find(an);
+        assertEquals("label is inherited", fo.getNameExt(), item.label);
+        assertNotNull("resource uri specified", item.resourceUri);
+        assertEquals(item.resourceUri, URLMapper.findURL(fo, URLMapper.EXTERNAL).toString());
     }
 
 

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/progress/TestProgressHandlerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/progress/TestProgressHandlerTest.java
@@ -216,5 +216,10 @@ public class TestProgressHandlerTest extends NbTestCase {
         public void disposeTextEditorDecoration(String params) {
             fail();
         }
+
+        @Override
+        public void notifyNodeChange(int params) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
     }
 }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -1619,6 +1619,11 @@ public class ServerTest extends NbTestCase {
             public void disposeTextEditorDecoration(String params) {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
+
+            @Override
+            public void notifyNodeChange(int params) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
         }, client.getInputStream(), client.getOutputStream());
         serverLauncher.startListening();
         LanguageServer server = serverLauncher.getRemoteProxy();
@@ -2972,6 +2977,10 @@ public class ServerTest extends NbTestCase {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
 
+            @Override
+            public void notifyNodeChange(int params) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
         }, client.getInputStream(), client.getOutputStream());
         serverLauncher.startListening();
         LanguageServer server = serverLauncher.getRemoteProxy();
@@ -3186,6 +3195,10 @@ public class ServerTest extends NbTestCase {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
 
+            @Override
+            public void notifyNodeChange(int params) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
         }, client.getInputStream(), client.getOutputStream());
         serverLauncher.startListening();
         LanguageServer server = serverLauncher.getRemoteProxy();
@@ -3317,6 +3330,10 @@ public class ServerTest extends NbTestCase {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
 
+            @Override
+            public void notifyNodeChange(int params) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
         }, client.getInputStream(), client.getOutputStream());
         serverLauncher.startListening();
         LanguageServer server = serverLauncher.getRemoteProxy();
@@ -3449,6 +3466,10 @@ public class ServerTest extends NbTestCase {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
 
+            @Override
+            public void notifyNodeChange(int params) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
         }, client.getInputStream(), client.getOutputStream());
         serverLauncher.startListening();
         LanguageServer server = serverLauncher.getRemoteProxy();
@@ -3568,6 +3589,10 @@ public class ServerTest extends NbTestCase {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
 
+            @Override
+            public void notifyNodeChange(int params) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
         }, client.getInputStream(), client.getOutputStream());
         serverLauncher.startListening();
         LanguageServer server = serverLauncher.getRemoteProxy();
@@ -3692,6 +3717,10 @@ public class ServerTest extends NbTestCase {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
 
+            @Override
+            public void notifyNodeChange(int params) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
         }, client.getInputStream(), client.getOutputStream());
         serverLauncher.startListening();
         LanguageServer server = serverLauncher.getRemoteProxy();
@@ -3813,6 +3842,10 @@ public class ServerTest extends NbTestCase {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
 
+            @Override
+            public void notifyNodeChange(int params) {
+                throw new UnsupportedOperationException("Not supported yet.");
+            }
         }, client.getInputStream(), client.getOutputStream());
         serverLauncher.startListening();
         LanguageServer server = serverLauncher.getRemoteProxy();

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -59,6 +59,14 @@
 				"path": "./syntaxes/java.tmLanguage.json"
 			}
 		],
+		"views": {
+			"explorer": [
+				{
+					"id": "foundProjects",
+					"name": "Found projects"
+				}
+			]
+		},
 		"configuration": {
 			"title": "Java",
 			"properties": {
@@ -292,6 +300,10 @@
 				"command": "graalvm.pause.script",
 				"title": "Pause in Script",
 				"category": "GraalVM"
+			},
+			{
+				"command": "foundProjects.deleteEntry",
+				"title": "Delete"
 			}
 		],
 		"keybindings": [
@@ -347,6 +359,14 @@
 				{
 					"command": "graalvm.pause.script",
 					"when": "nbJavaLSReady"
+				}
+			],
+			"view/title": [
+			],
+			"view/item/context": [
+				{
+					"command": "foundProjects.deleteEntry",
+					"when": "view == foundProjects && viewItem == node"
 				}
 			]
 		}

--- a/java/java.lsp.server/vscode/src/explorer.ts
+++ b/java/java.lsp.server/vscode/src/explorer.ts
@@ -62,13 +62,15 @@ class Visualizer extends vscode.TreeItem {
   ) {
     super(data.label, data.collapsibleState);
     known.push(this);
-    this.id = data.name;
     this.label = data.label;
     this.description = data.description;
     this.collapsibleState = data.collapsibleState;
+    if (data.resourceUri) {
+        this.resourceUri = vscode.Uri.parse(data.resourceUri);
+    }
+    this.contextValue = "node";
   }
   parent: Visualizer | null = null;
-  contextValue = "node";
 }
 
 export function foundProjects(c : LanguageClient): vscode.TreeDataProvider<any> {

--- a/java/java.lsp.server/vscode/src/explorer.ts
+++ b/java/java.lsp.server/vscode/src/explorer.ts
@@ -57,13 +57,13 @@ class VisualizerProvider implements vscode.TreeDataProvider<Visualizer> {
 
 class Visualizer extends vscode.TreeItem {
   constructor(
-    private known : Visualizer[],
+    known : Visualizer[],
     public data : NodeInfoRequest.Data
   ) {
-    super(data.displayName, data.collapsibleState);
+    super(data.label, data.collapsibleState);
     known.push(this);
     this.id = data.name;
-    this.label = data.displayName;
+    this.label = data.label;
     this.description = data.description;
     this.collapsibleState = data.collapsibleState;
   }

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -103,6 +103,10 @@ export function findClusters(myPath : string): string[] {
     return clusters;
 }
 
+export async function findLanguageClient(): Promise<LanguageClient> {
+    return client;
+}
+
 function findJDK(onChange: (path : string | null) => void): void {
     function find(): string | null {
         let nbJdk = workspace.getConfiguration('netbeans').get('jdkhome');

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -31,7 +31,8 @@ import {
     LogMessageNotification,
     RevealOutputChannelOn,
     DocumentSelector,
-    DocumentFilter
+    DocumentFilter,
+    HandlerResult
 } from 'vscode-languageclient';
 
 import * as net from 'net';
@@ -45,8 +46,10 @@ import * as launcher from './nbcode';
 import {NbTestAdapter} from './testAdapter';
 import { StatusMessageRequest, ShowStatusMessageParams, QuickPickRequest, InputBoxRequest, TestProgressNotification, DebugConnector,
          TextEditorDecorationCreateRequest, TextEditorDecorationSetNotification, TextEditorDecorationDisposeNotification,
+         NodeQueryRequest
 } from './protocol';
 import * as launchConfigurations from './launchConfigurations';
+import * as explorer from './explorer';
 
 const API_VERSION : string = "1.0";
 let client: Promise<LanguageClient>;
@@ -622,6 +625,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                     decorationType.dispose();
                 }
             });
+            explorer.register(c);
             handleLog(log, 'Language Client: Ready');
             setClient[0](c);
             commands.executeCommand('setContext', 'nbJavaLSReady', true);

--- a/java/java.lsp.server/vscode/src/protocol.ts
+++ b/java/java.lsp.server/vscode/src/protocol.ts
@@ -147,6 +147,7 @@ export namespace NodeInfoRequest {
         name : string; /* Node.getName() */
         label : string; /* Node.getDisplayName() */
         description : string; /* Node.getShortDescription() */
+        resourceUri? : string; /* external URL to file: resource */
         collapsibleState : TreeItemCollapsibleState;
         canDestroy : boolean; /* Node.canDestroy() */
     }

--- a/java/java.lsp.server/vscode/src/protocol.ts
+++ b/java/java.lsp.server/vscode/src/protocol.ts
@@ -23,6 +23,8 @@ import {
     QuickPickItem,
     Range,
     TextEditorDecorationType,
+    TreeItem,
+    TreeItemCollapsibleState,
 } from 'vscode';
 import {
     NotificationType,
@@ -127,4 +129,25 @@ export namespace TextEditorDecorationSetNotification {
 
 export namespace TextEditorDecorationDisposeNotification {
     export const type = new NotificationType<string, void>('window/disposeTextEditorDecoration');
+}
+
+export namespace NodeQueryRequest {
+    export const type = new RequestType<string, string, void, void>('nodes/delete');
+};
+
+export namespace NodeInfoRequest {
+    export const explorermanager = new RequestType<string, Data, void, void>('nodes/explorermanager');
+    export const info = new RequestType<number, Data, void, void>('nodes/info');
+    export const children = new RequestType<number, number[], void, void>('nodes/children');
+    export const destroy = new RequestType<number, boolean, void, void>('nodes/delete');
+    export const notifyChange = new NotificationType<number, void>('nodes/notifyChange');
+
+    export interface Data {
+        id : number; /* numeric ID of the node */
+        name : string; /* Node.getName() */
+        displayName : string; /* Node.getDisplayName() */
+        description : string; /* Node.getShortDescription() */
+        collapsibleState : TreeItemCollapsibleState;
+        canDestroy : boolean; /* Node.canDestroy() */
+    }
 };

--- a/java/java.lsp.server/vscode/src/protocol.ts
+++ b/java/java.lsp.server/vscode/src/protocol.ts
@@ -145,7 +145,7 @@ export namespace NodeInfoRequest {
     export interface Data {
         id : number; /* numeric ID of the node */
         name : string; /* Node.getName() */
-        displayName : string; /* Node.getDisplayName() */
+        label : string; /* Node.getDisplayName() */
         description : string; /* Node.getShortDescription() */
         collapsibleState : TreeItemCollapsibleState;
         canDestroy : boolean; /* Node.canDestroy() */

--- a/java/java.lsp.server/vscode/src/test/suite/explorer.test.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/explorer.test.ts
@@ -24,8 +24,6 @@ suite('Explorer Test Suite', () => {
     test('Explorer can be created', async () => {
         const lvp = myExplorer.foundProjects(await myExtension.findLanguageClient());
         const firstLevelChildren = await (lvp.getChildren(null) as Thenable<any[]>);
-        assert.equal(firstLevelChildren.length, 1, "One child under the root");
-        const item = await (lvp.getTreeItem(firstLevelChildren[0]) as Thenable<vscode.TreeItem>);
-        assert.equal(item?.label, "Projects", "Element is named Projects");
+        assert.equal(firstLevelChildren.length, 0, "No child under the root");
     });
 });

--- a/java/java.lsp.server/vscode/src/test/suite/explorer.test.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/explorer.test.ts
@@ -26,6 +26,6 @@ suite('Explorer Test Suite', () => {
         const firstLevelChildren = await (lvp.getChildren(null) as Thenable<any[]>);
         assert.equal(firstLevelChildren.length, 1, "One child under the root");
         const item = await (lvp.getTreeItem(firstLevelChildren[0]) as Thenable<vscode.TreeItem>);
-        assert.equal(item?.description, "Projects", "Element is named Projects");
+        assert.equal(item?.label, "Projects", "Element is named Projects");
     });
 });

--- a/java/java.lsp.server/vscode/src/test/suite/explorer.test.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/explorer.test.ts
@@ -1,0 +1,31 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ps from 'ps-node';
+import { spawn, ChildProcessByStdio, spawnSync, SpawnSyncReturns } from 'child_process';
+import { Readable } from 'stream';
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode';
+import * as myExtension from '../../extension';
+import * as myExplorer from '../../explorer';
+import { TextDocument, TextEditor, Uri } from 'vscode';
+import { assertWorkspace, dumpJava } from './testutils';
+
+suite('Explorer Test Suite', () => {
+    vscode.window.showInformationMessage('Cleaning up workspace.');
+    let folder: string = assertWorkspace();
+    fs.rmdirSync(folder, { recursive: true });
+    fs.mkdirSync(folder, { recursive: true });
+    vscode.window.showInformationMessage('Start all tests.');
+    myExtension.enableConsoleLog();
+
+    test('Explorer can be created', async () => {
+        const lvp = myExplorer.foundProjects(await myExtension.findLanguageClient());
+        const firstLevelChildren = await (lvp.getChildren(null) as Thenable<any[]>);
+        assert.equal(firstLevelChildren.length, 1, "One child under the root");
+        const item = await (lvp.getTreeItem(firstLevelChildren[0]) as Thenable<vscode.TreeItem>);
+        assert.equal(item?.description, "Projects", "Element is named Projects");
+    });
+});

--- a/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
@@ -10,6 +10,7 @@ import { Readable } from 'stream';
 import * as vscode from 'vscode';
 import * as myExtension from '../../extension';
 import { TextDocument, TextEditor, Uri } from 'vscode';
+import { assertWorkspace, dumpJava } from './testutils';
 
 suite('Extension Test Suite', () => {
     vscode.window.showInformationMessage('Cleaning up workspace.');
@@ -303,33 +304,3 @@ class Main {
     test("Get project sources, classpath, and packages", async() => getProjectInfo());
 
 });
-
-function assertWorkspace(): string {
-    assert.ok(vscode.workspace, "workspace is defined");
-    const dirs = vscode.workspace.workspaceFolders;
-    assert.ok(dirs?.length, "There are some workspace folders: " + dirs);
-    assert.strictEqual(dirs.length, 1, "One folder provided");
-    let folder: string = dirs[0].uri.fsPath;
-    return folder;
-}
-
-async function dumpJava() {
-    const cmd = 'jps';
-    const args = [ '-v' ];
-    console.log(`Running: ${cmd} ${args.join(' ')}`);
-    let p : ChildProcessByStdio<null, Readable, Readable> = spawn(cmd, args, {
-        stdio : ["ignore", "pipe", "pipe"],
-    });
-    let n = await new Promise<number>((r, e) => {
-        p.stdout.on('data', function(d: any) {
-            console.log(d.toString());
-        });
-        p.stderr.on('data', function(d: any) {
-            console.log(d.toString());
-        });
-        p.on('close', function(code: number) {
-            r(code);
-        });
-    });
-    console.log(`${cmd} ${args.join(' ')} finished with code ${n}`);
-}

--- a/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/extension.test.ts
@@ -9,6 +9,7 @@ import { Readable } from 'stream';
 // as well as import your extension to test it
 import * as vscode from 'vscode';
 import * as myExtension from '../../extension';
+import * as myExplorer from '../../explorer';
 import { TextDocument, TextEditor, Uri } from 'vscode';
 import { assertWorkspace, dumpJava } from './testutils';
 
@@ -119,11 +120,18 @@ class Main {
         if (where === 8) return;
 
         assert.ok(fs.statSync(mainClass).isFile(), "Class created by compilation: " + mainClass);
+
+        const lvp = myExplorer.foundProjects(await myExtension.findLanguageClient());
+        const firstLevelChildren = await (lvp.getChildren(null) as Thenable<any[]>);
+        assert.equal(firstLevelChildren.length, 1, "One child under the root");
+        const item = await (lvp.getTreeItem(firstLevelChildren[0]) as Thenable<vscode.TreeItem>);
+        assert.equal(item?.label, "basicapp", "Element is named as the Maven project");
     }
 
     test("Compile workspace6", async() => demo(6));
     test("Compile workspace7", async() => demo(7));
     test("Compile workspace8", async() => demo(8));
+    test("Compile workspace9", async() => demo(9));
 
     /**
      * Checks that maven-managed process can be started, and forcefully terminated by vscode

--- a/java/java.lsp.server/vscode/src/test/suite/testutils.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/testutils.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import { spawn, ChildProcessByStdio } from 'child_process';
+import { Readable } from 'stream';
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode';
+
+export function assertWorkspace(): string {
+    assert.ok(vscode.workspace, "workspace is defined");
+    const dirs = vscode.workspace.workspaceFolders;
+    assert.ok(dirs?.length, "There are some workspace folders: " + dirs);
+    assert.strictEqual(dirs.length, 1, "One folder provided");
+    let folder: string = dirs[0].uri.fsPath;
+    return folder;
+}
+
+export async function dumpJava() {
+    const cmd = 'jps';
+    const args = [ '-v' ];
+    console.log(`Running: ${cmd} ${args.join(' ')}`);
+    let p : ChildProcessByStdio<null, Readable, Readable> = spawn(cmd, args, {
+        stdio : ["ignore", "pipe", "pipe"],
+    });
+    let n = await new Promise<number>((r, e) => {
+        p.stdout.on('data', function(d: any) {
+            console.log(d.toString());
+        });
+        p.stderr.on('data', function(d: any) {
+            console.log(d.toString());
+        });
+        p.on('close', function(code: number) {
+            r(code);
+        });
+    });
+    console.log(`${cmd} ${args.join(' ')} finished with code ${n}`);
+}


### PR DESCRIPTION
NetBeans offers great abstraction over UI - [nodes](https://bits.netbeans.org/12.3/javadoc/org-openide-nodes/overview-summary.html). Let's use the `Node` and [ExplorerManager](https://bits.netbeans.org/12.3/javadoc/org-openide-explorer/org/openide/explorer/ExplorerManager.html) concepts to share significant parts of the UI in VSNetBeans.

This PR demonstrates the concept by exposing _Projects tab_ as a VSCode side-panel.

The core component on Java side is `TreeViewProvider` which has similar API as VSCode [TreeViewProvider](https://code.visualstudio.com/api/extension-guides/tree-view). It connects to an existing `ExplorerManager` and exposes its `Node`s as `TreeItem` elements. There is `TreeViewProvider` subclass which uses LSP to transfer the node information to the typescript part. The typescript then implements the VSCode `TreeViewProvider` via so called `Visualizer`s.

There are unit tests to verify functionality on the Java side as well as integration tests that verify the transfer over language server protocol works to certain extend.