### PR TITLE
[NETBEANS-5905] Don't check idekey for Xdebug

### DIFF
--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/DebugSession.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/DebugSession.java
@@ -160,7 +160,9 @@ public class DebugSession extends SingleThread {
         DebuggerEngine[] engines = DebuggerManager.getDebuggerManager().getDebuggerEngines();
         for (DebuggerEngine nextEngine : engines) {
             SessionId id = (SessionId) nextEngine.lookupFirst(null, SessionId.class);
-            if (id != null && id.getId().equals(message.getSessionId())) {
+            // [NETBEANS-5905] don't check about what the idekey is
+            // see also https://bugs.xdebug.org/view.php?id=2005
+            if (id != null && message.getSessionId() != null) {
                 sessionId.set(id);
                 id.initialize(message.getFileUri(), options.getPathMapping());
                 engine.set(nextEngine);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5905
See also https://bugs.xdebug.org/view.php?id=2005

Xdebug developer wrote: 
> This is not an Xdebug issue. Netbeans should not care about what the idekey is, in order to decide whether to do anything with an incoming debugging session. 