### PR TITLE
[NETBEANS-5849] Fix CC in a use declaration after a group use declaration

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/completion/CompletionContextFinder.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/completion/CompletionContextFinder.java
@@ -600,6 +600,10 @@ final class CompletionContextFinder {
 
         boolean hasCurlyOpen = false;
         do {
+            // NETBEANS-5849
+            if (tokenSequence.token().id() == PHPTokenId.PHP_USE) {
+                return false;
+            }
             if (tokenSequence.token().id() == PHPTokenId.PHP_CURLY_OPEN) {
                 hasCurlyOpen = true;
             }

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5849/NS1/Test1.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5849/NS1/Test1.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace NS1;
+
+class Test1{}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5849/NS1/Test2.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5849/NS1/Test2.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace NS1;
+
+class Test2{}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5849/NS2/Test3.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5849/NS2/Test3.php
@@ -1,0 +1,22 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+namespace NS2;
+
+class Test3{}

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5849/nb5849.php
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5849/nb5849.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use NS1\{
+    Test1,
+    Test2
+};
+use tes;

--- a/php/php.editor/test/unit/data/testfiles/completion/lib/nb5849/nb5849.php.testNb5849_01.completion
+++ b/php/php.editor/test/unit/data/testfiles/completion/lib/nb5849/nb5849.php.testNb5849_01.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+use tes|;
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+CLASS      Test1                           [PUBLIC]   NS1
+CLASS      Test2                           [PUBLIC]   NS1
+CLASS      Test3                           [PUBLIC]   NS2

--- a/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb5849Test.java
+++ b/php/php.editor/test/unit/src/org/netbeans/modules/php/editor/completion/PHPCodeCompletionNb5849Test.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.editor.completion;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import org.netbeans.api.java.classpath.ClassPath;
+import org.netbeans.modules.php.project.api.PhpSourcePath;
+import org.netbeans.spi.java.classpath.support.ClassPathSupport;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+
+public class PHPCodeCompletionNb5849Test extends PHPCodeCompletionTestBase {
+
+    public PHPCodeCompletionNb5849Test(String testName) {
+        super(testName);
+    }
+
+    public void testNb5849_01() throws Exception {
+        checkCompletion("testfiles/completion/lib/nb5849/nb5849.php", "use tes^;", false);
+    }
+
+    @Override
+    protected Map<String, ClassPath> createClassPathsForTest() {
+        return Collections.singletonMap(
+            PhpSourcePath.SOURCE_CP,
+            ClassPathSupport.createClassPath(new FileObject[] {
+                FileUtil.toFileObject(new File(getDataDir(), "/testfiles/completion/lib/nb5849"))
+            })
+        );
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-5849

Before
```php

use NS1\{
    Test1,
    Test2
};
use tes; // context: GROUP_USE_KEYWORD

```

After
```php

use NS1\{
    Test1,
    Test2
};
use tes; // context: USE_KEYWORD

```