### PR TITLE
[NETBEANS-5927] Switch Windows LAF to the now-standard "Segoe UI" font

### DIFF
--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
@@ -116,7 +116,7 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
         Insets ins = getInsets();
         int availH = getHeight() - (ins.top + ins.bottom);
         // Ad hoc adjustment for the Windows LAF.
-        int yAdjustment = 1;
+        int yAdjustment = -1;
         return ((availH <= txtH) ? -fm.getDescent() : -1) + yAdjustment;
     }
 


### PR DESCRIPTION
(Copied from JIRA issue description:)
For the last 14 years (since Windows Vista), the default UI font on Windows has been Segoe UI 12. But Swing's Windows LAF stayed with Tahoma 11, for reasons of backwards compatibility only (see JDK-6669448). This makes NetBeans look a little dated, and the font size smaller than in other Windows application. In the words of one blogger: "On a related note, this is one of the bigger visual deficiencies of NetBeans running on Vista – the smaller Tahoma font makes it less visually appealing that it could have been." https://www.pushing-pixels.org/page/213?m

This PR switches the NetBeans Windows LAF to the newer Segoe font, by borrowing logic from FlatLAF to get the actual Windows default font from the "win.messagebox.font" desktop property, which is initialized from the Win32 API. This also avoids one of the problems that were fixed in the earlier https://github.com/apache/netbeans/pull/1777 , with the Swing Windows LAF using incorrect font sizes on certain HiDPI configurations.

Segoe UI 12 looks similar to Tahoma 11, but with ascenders and descenders that extend one pixel farther up/down. Letters like "j" and "y" have some differences in their shapes.

Note that certain UI elements, notably the menu bar, were already using Segoe UI 12. And FlatLAF is already using Segoe UI 12 on Windows. Note also that this PR should not affect the main code editor font.

See the attached before/after screenshots.

![fontchange-1-before](https://user-images.githubusercontent.com/886243/129827423-65cdd1b3-434e-4d31-93cf-ffb957580623.png)
![fontchange-2-after](https://user-images.githubusercontent.com/886243/129827426-ebdfce41-fb14-4fb8-8465-131233433abd.png)
