### PR TITLE
[NETBEANS-5928] Proposed improvements to FlatLAF tab components+borders/margins

### DIFF
--- a/platform/o.n.swing.laf.flatlaf/nbproject/project.xml
+++ b/platform/o.n.swing.laf.flatlaf/nbproject/project.xml
@@ -71,7 +71,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.63</specification-version>
+                        <specification-version>1.69</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/DPISafeBorder.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/DPISafeBorder.java
@@ -57,7 +57,14 @@ final class DPISafeBorder implements Border {
 
     @Override
     public void paintBorder(Component c, Graphics g, int x, int y, int width, int height) {
-        HiDPIUtils.paintAtScale1x(g, x, y, width, height, this::paintBorderAtScale1x);
+        /* Detect borders which may need to visually connect with a prior adjacent component. This
+        applies in particular to view/editor tabs connecting to their tab containers underneath.
+        Round the starting position down towards the previous component to try to avoid a gap on
+        fractional HiDPI scalings (e.g. 150%). */
+        boolean roundXdown = insets.left == 0;
+        boolean roundYdown = insets.top == 0;
+        HiDPIUtils.paintAtScale1x(
+            g, x, y, width, height, roundXdown, roundYdown, this::paintBorderAtScale1x);
     }
 
     private void paintBorderAtScale1x(Graphics2D g, int deviceWidth, int deviceHeight, double scale) {

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties
@@ -31,29 +31,39 @@ Nb.EmptyEditorArea.background=darken(@background,5%)
 #---- EditorTab ----
 
 EditorTab.background=@background
-#EditorTab.foreground=#f00
-EditorTab.activeBackground=#3B4754
-#EditorTab.activeForeground=#f00
-EditorTab.selectedBackground=#5c6164
+EditorTab.foreground=darken(@foreground,10%)
+EditorTab.unselectedHoverForeground=darken(@foreground,10%)
+EditorTab.hoverForeground=lighten(@foreground,10%)
 EditorTab.selectedForeground=lighten(@foreground,10%)
-EditorTab.hoverBackground=$TabbedPane.hoverColor
-#EditorTab.hoverForeground=#f00
+EditorTab.activeBackground=@background
+#EditorTab.activeForeground=#f00
+EditorTab.selectedBackground=#595e5f
+EditorTab.selectedBackgroundBottomGradient=@background
+# Don't show a hover effect for the selected tab. So set this to the same as selectedBackground.
+EditorTab.hoverBackground=$EditorTab.selectedBackground
+EditorTab.unselectedHoverBackground=$TabbedPane.hoverColor
 EditorTab.attentionBackground=#E6C840
 EditorTab.attentionForeground=#000
 EditorTab.underlineColor=$TabbedPane.underlineColor
-EditorTab.inactiveUnderlineColor=lighten($TabbedPane.disabledUnderlineColor,5%)
+# Don't show emphasis for selected but unfocused tabs, so set alpha 0 here. (This makes
+# the sidebar tabs look less busy when focus is in the editor. We keep the editor tabs
+# behaving the same for consistency.)
+EditorTab.inactiveUnderlineColor=#00000000
 
 
 #---- ViewTab ----
 
 ViewTab.background=@background
-#ViewTab.foreground=#f00
-ViewTab.activeBackground=#3B4754
+ViewTab.foreground=darken(@foreground,10%)
+ViewTab.unselectedHoverForeground=darken(@foreground,10%)
+ViewTab.hoverForeground=lighten(@foreground,10%)
+ViewTab.selectedForeground=lighten(@foreground,10%)
+ViewTab.activeBackground=@background
 #ViewTab.activeForeground=#f00
-#ViewTab.selectedBackground=#f00
-#ViewTab.selectedForeground=#0f0
-ViewTab.hoverBackground=$TabbedPane.hoverColor
-#ViewTab.hoverForeground=#f00
+ViewTab.selectedBackground=#45494a
+# Don't show a hover effect for the selected tab. So set this to the same as selectedBackground.
+ViewTab.hoverBackground=$ViewTab.selectedBackground
+ViewTab.unselectedHoverBackground=$TabbedPane.hoverColor
 ViewTab.attentionBackground=$EditorTab.attentionBackground
 ViewTab.attentionForeground=$EditorTab.attentionForeground
 ViewTab.underlineColor=$TabbedPane.underlineColor

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLFCustoms.java
@@ -21,11 +21,13 @@ package org.netbeans.swing.laf.flatlaf;
 
 import com.formdev.flatlaf.util.UIScale;
 import java.awt.Color;
+import javax.swing.BorderFactory;
 import javax.swing.InputMap;
 import javax.swing.KeyStroke;
 import javax.swing.UIDefaults;
 import javax.swing.UIDefaults.LazyValue;
 import javax.swing.UIManager;
+import javax.swing.border.CompoundBorder;
 import org.netbeans.swing.laf.flatlaf.ui.FlatTabControlIcon;
 import org.netbeans.swing.plaf.LFCustoms;
 import org.netbeans.swing.tabcontrol.plaf.TabControlButton;
@@ -73,8 +75,10 @@ public class FlatLFCustoms extends LFCustoms {
             VIEW_TAB_DISPLAYER_UI, "org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI", // NOI18N
             SLIDING_BUTTON_UI, "org.netbeans.swing.laf.flatlaf.ui.FlatSlidingButtonUI", // NOI18N
 
-            EDITOR_TABSCOMPONENT_BORDER, DPISafeBorder.matte(1, 1, 1, 1, editorContentBorderColor),
-            EDITOR_TOOLBAR_BORDER, DPISafeBorder.matte(0, 0, 1, 0, editorContentBorderColor),
+            EDITOR_TABSCOMPONENT_BORDER, BorderFactory.createEmptyBorder(),
+            EDITOR_TOOLBAR_BORDER, new CompoundBorder(
+                DPISafeBorder.matte(0, 0, 1, 0, editorContentBorderColor),
+                BorderFactory.createEmptyBorder(1, 0, 1, 0)),
             EDITOR_TAB_CONTENT_BORDER, DPISafeBorder.matte(0, 1, 1, 1, editorContentBorderColor),
             VIEW_TAB_CONTENT_BORDER, DPISafeBorder.matte(0, 1, 1, 1, UIManager.getColor("TabbedContainer.view.contentBorderColor")), // NOI18N
 

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLaf.properties
@@ -29,6 +29,15 @@ controlShadow=$Component.borderColor
 SplitPaneDivider.style = plain
 
 
+#---- TabbedPane ----
+
+# Decrease a bit from the default of 32. For comparison, a selected tab on the standard Swing
+# Windows LAF is 22 pixels tall. EditorTab/ViewTab are a bit more compact, currently 21 pixels
+# tall on Windows.
+TabbedPane.tabHeight=26
+# Use 2 pixels here, for consistency with EditorTab/ViewTab.
+TabbedPane.tabSelectionHeight=2
+
 #---- TabbedContainer ----
 
 TabbedContainer.editor.contentBorderColor=$Component.borderColor
@@ -37,20 +46,24 @@ TabbedContainer.view.contentBorderColor=$Component.borderColor
 
 #---- EditorTab ----
 
-EditorTab.tabInsets=5,6,7,8
-EditorTab.underlineHeight=3
-#EditorTab.underlineAtTop=true
+EditorTab.tabInsets=3,6,3,6
+EditorTab.underlineHeight=2
+EditorTab.underlineAtTop=true
 EditorTab.tabSeparatorColor=$Component.borderColor
 EditorTab.showTabSeparators=true
+EditorTab.showSelectedTabBorder=true
+EditorTab.unscaledBorders=false
 
 
 #---- ViewTab ----
 
-ViewTab.tabInsets=5,6,7,2
-ViewTab.underlineHeight=3
-#ViewTab.underlineAtTop=true
+ViewTab.tabInsets=2,7,4,3
+ViewTab.underlineHeight=2
+ViewTab.underlineAtTop=true
 ViewTab.tabSeparatorColor=$Component.borderColor
-ViewTab.showTabSeparators=true
+ViewTab.showTabSeparators=false
+ViewTab.showSelectedTabBorder=true
+ViewTab.unscaledBorders=false
 
 
 #---- Multi-tabs ----

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties
@@ -26,27 +26,35 @@ Nb.EmptyEditorArea.background=darken(@background,10%)
 
 EditorTab.background=@background
 #EditorTab.foreground=#f00
-EditorTab.activeBackground=#E2E6EC
+EditorTab.activeBackground=@background
 #EditorTab.activeForeground=#f00
 EditorTab.selectedBackground=#FFF
+EditorTab.selectedBackgroundBottomGradient=@background
 EditorTab.selectedForeground=@foreground
-EditorTab.hoverBackground=$TabbedPane.hoverColor
+# Don't show a hover effect for the selected tab. So set this to the same as selectedBackground.
+EditorTab.hoverBackground=$EditorTab.selectedBackground
+EditorTab.unselectedHoverBackground=$TabbedPane.hoverColor
 #EditorTab.hoverForeground=#f00
 EditorTab.attentionBackground=#E6C840
 EditorTab.attentionForeground=#000
 EditorTab.underlineColor=$TabbedPane.underlineColor
-EditorTab.inactiveUnderlineColor=#9CA7B8
+# Don't show emphasis for selected but unfocused tabs, so set alpha 0 here. (This makes
+# the sidebar tabs look less busy when focus is in the editor. We keep the editor tabs
+# behaving the same for consistency.)
+EditorTab.inactiveUnderlineColor=#00000000
 
 
 #---- ViewTab ----
 
 ViewTab.background=@background
 #ViewTab.foreground=#f00
-ViewTab.activeBackground=#E2E6EC
+ViewTab.activeBackground=@background
 #ViewTab.activeForeground=#f00
-#ViewTab.selectedBackground=#f00
+ViewTab.selectedBackground=#FFFFFF
 #ViewTab.selectedForeground=#0f0
-ViewTab.hoverBackground=$TabbedPane.hoverColor
+# Don't show a hover effect for the selected tab. So set this to the same as selectedBackground.
+ViewTab.hoverBackground=$ViewTab.selectedBackground
+ViewTab.unselectedHoverBackground=$TabbedPane.hoverColor
 #ViewTab.hoverForeground=#f00
 ViewTab.attentionBackground=$EditorTab.attentionBackground
 ViewTab.attentionForeground=$EditorTab.attentionForeground

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/HiDPIUtils.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/HiDPIUtils.java
@@ -38,6 +38,18 @@ public class HiDPIUtils {
      * {@link org.netbeans.swing.plaf.windows8.DPISafeBorder}.
      */
     public static void paintAtScale1x(Graphics g0, int x, int y, int width, int height, HiDPIPainter painter) {
+        paintAtScale1x(g0, x, y, width, height, false, false, painter);
+    }
+
+    /**
+     * @param roundXdown if true, round the starting X position down when converting to device
+     *        pixels, otherwise round to the nearest device pixel position
+     * @param roundYdown if true, round the starting Y position down when converting to device
+     *        pixels, otherwise round to the nearest device pixel position
+     */
+    static void paintAtScale1x(Graphics g0, int x, int y, int width, int height,
+        boolean roundXdown, boolean roundYdown, HiDPIPainter painter)
+    {
         Graphics2D g = (Graphics2D) g0;
         final AffineTransform oldTransform = g.getTransform();
         g.translate(x, y);
@@ -54,13 +66,16 @@ public class HiDPIUtils {
         {
               // HiDPI scaling is active.
               double scale = tx.getScaleX();
-              /* Round the starting (top-left) position up and the end (bottom-right) position down,
-              to ensure we are painting the border in an area that will not be painted over by an
-              adjacent component. */
-              int deviceX = (int) Math.ceil(tx.getTranslateX());
-              int deviceY = (int) Math.ceil(tx.getTranslateY());
-              int deviceXend = (int) (tx.getTranslateX() + width * scale);
-              int deviceYend = (int) (tx.getTranslateY() + height * scale);
+              int deviceX = (int) (roundXdown
+                  ? Math.floor(tx.getTranslateX())
+                  : Math.round(tx.getTranslateX()));
+              int deviceY = (int) (roundYdown
+                  ? Math.floor(tx.getTranslateY())
+                  : Math.round(tx.getTranslateY()));
+              /* Round the the end (bottom-right) position down, to ensure we are painting the
+              border in an area that will not be painted over by an adjacent component. */
+              int deviceXend = (int) Math.floor(tx.getTranslateX() + width * scale);
+              int deviceYend = (int) Math.floor(tx.getTranslateY() + height * scale);
               int deviceWidth = deviceXend - deviceX;
               int deviceHeight = deviceYend - deviceY;
               /* Deactivate the HiDPI scaling transform so we can do paint operations in the device

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
@@ -54,6 +54,7 @@ public class FlatEditorTabCellRenderer extends AbstractTabCellRenderer {
     private static final Color activeForeground = Utils.getUIColor( "EditorTab.activeForeground", foreground ); // NOI18N
     private static final Color selectedForeground = Utils.getUIColor( "EditorTab.selectedForeground", activeForeground ); // NOI18N
     private static final Color hoverForeground = Utils.getUIColor( "EditorTab.hoverForeground", foreground ); // NOI18N
+    private static final Color unselectedHoverForeground = Utils.getUIColor( "EditorTab.unselectedHoverForeground", hoverForeground ); // NOI18N
     private static final Color attentionForeground = Utils.getUIColor( "EditorTab.attentionForeground", foreground ); // NOI18N
 
     private static final Color underlineColor = UIManager.getColor("EditorTab.underlineColor"); // NOI18N
@@ -124,7 +125,7 @@ public class FlatEditorTabCellRenderer extends AbstractTabCellRenderer {
 
         // set text color
         setForeground(colorForState(foreground, activeForeground, selectedForeground,
-                hoverForeground, hoverForeground, attentionForeground));
+                hoverForeground, unselectedHoverForeground, attentionForeground));
 
         return result;
     }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
@@ -22,13 +22,14 @@ import com.formdev.flatlaf.util.UIScale;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
+import java.awt.Font;
 import java.awt.GradientPaint;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.Polygon;
 import java.awt.Rectangle;
+import java.awt.font.FontRenderContext;
 import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.UIManager;
@@ -100,25 +101,23 @@ public class FlatEditorTabCellRenderer extends AbstractTabCellRenderer {
     }
 
     @Override
-    protected int getCaptionYAdjustment() {
-        // Workaround for a issue in AbstractTabCellRenderer.paintIconAndText(Graphics),
-        // which uses font height (which includes font descent) to calculate Y-coordinate
-        // when available height is equal to font height (availH <= txtH),
-        // but HtmlRenderer.renderString() expects Y-coordinate at baseline.
-        // So the text is painted vertically out of center.
-        //
-        // This seems to be no issue with other LAFs because they seem to use
-        // TabPainter insets differently and the available height is larger than
-        // the font height (availH > txtH), in which case 3 pixels are removed from
-        // the Y-coordinate to avoid that the text is painted vertically out of center.
-
-        FontMetrics fm = getFontMetrics(getFont());
-        int txtH = fm.getHeight();
+    protected int getCaptionYPosition(Graphics g) {
+        Font font = getFont();
+        FontRenderContext frc = (g instanceof Graphics2D)
+                ? ((Graphics2D) g).getFontRenderContext()
+                : g.getFontMetrics(font).getFontRenderContext();
+        /* Don't rely on FontMetrics.getAscent() to get the ascent; it can return values much bigger
+        than the actual, visual size of the letters. Use the actual height of a flat-topped
+        upper-case letter instead. */
+        double txtVisualAscent = font.createGlyphVector(frc, "H")
+                .getVisualBounds().getHeight();
         Insets ins = getInsets();
         int availH = getHeight() - (ins.top + ins.bottom);
-        // Ad hoc adjustment.
-        int yAdjustment = -1;
-        return ((availH <= txtH) ? -fm.getDescent() : -1) + yAdjustment;
+        final int effectiveIconYAdjustment = 2 + getIconYAdjustment();
+
+        // Center the visual ascent portion of the text vertically with respect to the icon.
+        return ins.top + (int) Math.round((availH + txtVisualAscent) / 2)
+                + effectiveIconYAdjustment;
     }
 
     @Override

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabCellRenderer.java
@@ -116,7 +116,9 @@ public class FlatEditorTabCellRenderer extends AbstractTabCellRenderer {
         int txtH = fm.getHeight();
         Insets ins = getInsets();
         int availH = getHeight() - (ins.top + ins.bottom);
-        return (availH <= txtH) ? -fm.getDescent() : -1;
+        // Ad hoc adjustment.
+        int yAdjustment = -1;
+        return ((availH <= txtH) ? -fm.getDescent() : -1) + yAdjustment;
     }
 
     @Override
@@ -176,7 +178,9 @@ public class FlatEditorTabCellRenderer extends AbstractTabCellRenderer {
             int iconWidth = icon.getIconWidth();
             int iconHeight = icon.getIconHeight();
             rect.x = bounds.x + bounds.width - iconWidth - UIScale.scale(CLOSE_ICON_RIGHT_PAD);
-            rect.y = bounds.y + Math.max(0, (bounds.height - iconHeight) / 2) - 1;
+            // Ad hoc adjustment.
+            int yAdjustment = 2;
+            rect.y = bounds.y + Math.max(0, (bounds.height - iconHeight) / 2) - 1 + yAdjustment;
             rect.width = iconWidth;
             rect.height = iconHeight;
         }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabDisplayerUI.java
@@ -48,6 +48,7 @@ public class FlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
     private final Color background = UIManager.getColor("EditorTab.background"); // NOI18N
     private final Color activeBackground = Utils.getUIColor("EditorTab.activeBackground", background); // NOI18N
     private final Color contentBorderColor = UIManager.getColor("TabbedContainer.editor.contentBorderColor"); // NOI18N
+    private final boolean unscaledBorders = Utils.getUIBoolean("EditorTab.unscaledBorders", false); // NOI18N
     private final Insets tabInsets = UIScale.scale(UIManager.getInsets("EditorTab.tabInsets")); // NOI18N
 
     public FlatEditorTabDisplayerUI(TabDisplayer displayer) {
@@ -80,8 +81,12 @@ public class FlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
     @Override
     public TabCellRenderer getTabCellRenderer(int tab) {
         TabCellRenderer ren = super.getTabCellRenderer(tab);
-        if (ren instanceof FlatEditorTabCellRenderer && tab + 1 < displayer.getModel().size()) {
-            ((FlatEditorTabCellRenderer)ren).nextTabSelected = (tabState.getState(tab + 1) & TabState.SELECTED) != 0;
+        if (ren instanceof FlatEditorTabCellRenderer) {
+            FlatEditorTabCellRenderer fren = (FlatEditorTabCellRenderer) ren;
+            int N = displayer.getModel().size();
+            fren.firstTab = (tab == 0);
+            fren.lastTab = (tab == N - 1);
+            fren.nextTabSelected = tab + 1 < N && (tabState.getState(tab + 1) & TabState.SELECTED) != 0;
         }
         return ren;
     }
@@ -114,7 +119,7 @@ public class FlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
         g.fillRect (0, 0, width, height);
 
         // paint bottom border
-        int contentBorderWidth = HiDPIUtils.deviceBorderWidth(scale, 1);
+        int contentBorderWidth = unscaledBorders ? 1 : HiDPIUtils.deviceBorderWidth(scale, 1);
         g.setColor(contentBorderColor);
         g.fillRect(0, height - contentBorderWidth, width, contentBorderWidth);
     }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatEditorTabDisplayerUI.java
@@ -66,15 +66,12 @@ public class FlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
 
     @Override
     public Dimension getPreferredSize(JComponent c) {
-        int prefHeight;
-        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
-        if (g != null) {
-            FontMetrics fm = g.getFontMetrics(displayer.getFont());
-            Insets ins = getTabAreaInsets();
-            prefHeight = fm.getHeight() + ins.top + ins.bottom
-                    + tabInsets.top + tabInsets.bottom;
-        } else
-            prefHeight = UIScale.scale(28);
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics(c);
+        FontMetrics fm = g.getFontMetrics(displayer.getFont());
+        Insets ins = getTabAreaInsets();
+        // Standard icons are 16 pixels tall, so always allocate space for them.
+        int prefHeight = Math.max(fm.getHeight(), 16) + ins.top + ins.bottom
+                + tabInsets.top + tabInsets.bottom;
         return new Dimension(displayer.getWidth(), prefHeight);
     }
 

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatTabControlIcon.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatTabControlIcon.java
@@ -110,7 +110,8 @@ public final class FlatTabControlIcon extends VectorIcon {
     }
 
     private FlatTabControlIcon(int buttonId, Integer buttonState) {
-        super(UIScale.scale(16), UIScale.scale(16));
+        super(UIScale.scale(16),
+            UIScale.scale(buttonId == TabControlButton.ID_CLOSE_BUTTON ? 15 : 16));
         this.buttonId = buttonId;
         this.buttonState = buttonState;
         this.userScaleFactor = UIScale.getUserScaleFactor();

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatViewTabDisplayerUI.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatViewTabDisplayerUI.java
@@ -69,6 +69,7 @@ public class FlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
             activeForeground,       // text color if view group is active;                 optional; defaults to foreground
             selectedForeground,     // text color if tab is selected in active view group; optional; defaults to activeForeground
             hoverForeground,        // text color if mouse is over tab;                    optional; defaults to foreground
+            unselectedHoverForeground,  // if defined, use this color instead of hoverForeground for unselected tabs
             attentionForeground,    // text color if tab is in attension mode;             optional; defaults to foreground
 
             underlineColor,         // underline color of selected active tabs
@@ -183,7 +184,7 @@ public class FlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
 
         // text color
         Color c = colorForState(index, foreground, activeForeground, selectedForeground,
-                hoverForeground, hoverForeground, attentionForeground);
+                hoverForeground, unselectedHoverForeground, attentionForeground);
 
         // paint text
         int txtX = x + txtLeftPad;
@@ -324,6 +325,7 @@ public class FlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
             activeForeground = Utils.getUIColor("ViewTab.activeForeground", foreground); // NOI18N
             selectedForeground = Utils.getUIColor("ViewTab.selectedForeground", activeForeground); // NOI18N
             hoverForeground = Utils.getUIColor("ViewTab.hoverForeground", foreground); // NOI18N
+            unselectedHoverForeground = Utils.getUIColor("ViewTab.unselectedHoverForeground", hoverForeground); // NOI18N
             attentionForeground = Utils.getUIColor("ViewTab.attentionForeground", foreground); // NOI18N
 
             underlineColor = UIManager.getColor("ViewTab.underlineColor"); // NOI18N

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatViewTabDisplayerUI.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatViewTabDisplayerUI.java
@@ -110,7 +110,10 @@ public class FlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
     @Override
     public Dimension getPreferredSize(JComponent c) {
         FontMetrics fm = getTxtFontMetrics();
-        int height = fm.getHeight() + tabInsets.top + tabInsets.bottom;
+        /* In FlatEditorTabDisplayerUI, we always allocate 16 pixels for the icon. Do the same here,
+        even though view tabs do not normally have icons, so that view tabs always line up with
+        editor tabs. */
+        int height = Math.max(16, fm.getHeight()) + tabInsets.top + tabInsets.bottom;
         return new Dimension(100, height);
     }
 
@@ -190,16 +193,19 @@ public class FlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
 
         // paint text
         int txtX = x + txtLeftPad;
-        int txtY = y + tabInsets.top + fm.getAscent();
         int availH = height - tabInsets.top - tabInsets.bottom;
-        if (availH > fm.getHeight()) {
-            txtY += (availH - fm.getHeight()) / 2;
-        }
         int style = HtmlRenderer.STYLE_TRUNCATE;
         if (!isSelected(index)) {
             // center text of unselected tabs
             txtX = Math.max(x + 1, x + ((width - realTxtWidth) / 2));
         }
+
+        /* Keep the txtY calculation the same as for FlatEditorTabCellRenderer, with an offset that
+        makes the text in view tabs and editor tabs always line up. */
+        double txtVisualAscent = getTxtFont().createGlyphVector(fm.getFontRenderContext(), "H")
+            .getVisualBounds().getHeight();
+        int txtY = tabInsets.top + (int) Math.round((availH + txtVisualAscent) / 2) + 2;
+
         HtmlRenderer.renderString(text, g, txtX, txtY, availTxtWidth, height,
                 getTxtFont(), c, style, true);
     }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatViewTabDisplayerUI.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/FlatViewTabDisplayerUI.java
@@ -133,7 +133,9 @@ public class FlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
                 } else {
                     buttons.setVisible(true);
                     availTxtWidth -= (buttonsSize.width + ICON_X_PAD);
-                    buttons.setLocation(x + width - buttonsSize.width - ICON_X_PAD, y + ((height - buttonsSize.height) / 2) - 1);
+                    // Ad hoc adjustment.
+                    int yAdjustment = 2;
+                    buttons.setLocation(x + width - buttonsSize.width - ICON_X_PAD, y + ((height - buttonsSize.height) / 2) - 1 + yAdjustment);
                 }
             }
         }

--- a/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/Utils.java
+++ b/platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/ui/Utils.java
@@ -37,6 +37,16 @@ class Utils {
         return (color != null) ? color : UIManager.getColor(defaultKey);
     }
 
+    static int getUIInt(String key, int defaultValue) {
+        Object value = UIManager.get(key);
+        return (value instanceof Integer) ? ((Integer) value) : defaultValue;
+    }
+
+    static boolean getUIBoolean(String key, boolean defaultValue) {
+        Object value = UIManager.get(key);
+        return (value instanceof Boolean) ? ((Boolean) value) : defaultValue;
+    }
+
     /**
      * Sets rendering hints used for painting.
      */

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractTabCellRenderer.java
@@ -487,18 +487,11 @@ public abstract class AbstractTabCellRenderer extends JLabel
 
         Icon icon = getIcon();
         //Check the icon non-null and height (see TabData.NO_ICON for why)
-        if (!isClipLeft() && icon != null && icon.getIconWidth() > 0
-                && icon.getIconHeight() > 0) {
-            int iconY;
-            if (availH > icon.getIconHeight()) {
-                //add 2 to make sure icon top pixels are not cut off by outline
-                iconY = ins.top
-                        + ((availH / 2) - (icon.getIconHeight() / 2))
+        if (!isClipLeft() && icon != null && icon.getIconWidth() > 0 && icon.getIconHeight() > 0) {
+            int iconY = ins.top
+                        + Math.max(0, (availH - icon.getIconHeight())) / 2
+                        //add 2 to make sure icon top pixels are not cut off by outline
                         + 2;
-            } else {
-                //add 2 to make sure icon top pixels are not cut off by outline
-                iconY = ins.top + 2;
-            }
             int iconX = ins.left + centeringToAdd;
 
             iconY += getIconYAdjustment();

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractTabCellRenderer.java
@@ -425,7 +425,9 @@ public abstract class AbstractTabCellRenderer extends JLabel
         paintIconAndText(g);
     }
 
-    /** Return non-zero to shift the text up or down by the specified number of pixels when painting.
+    /**
+     * Return non-zero to shift the text up or down by the specified number of pixels when painting.
+     * Used by the default implementation of {@link #getCaptionYPosition(Graphics)}.
      *
      * @return A positive or negative number of pixels
      */
@@ -442,12 +444,13 @@ public abstract class AbstractTabCellRenderer extends JLabel
     }
 
     /**
-     * Actually paints the icon and text (using the lightweight HTML renderer)
+     * Get the Y position of the caption. May be overridden. The default implementation uses an old
+     * formula which is retained for backwards compatibility (since subclasses may have tuned their
+     * value of {@link #getCaptionYAdjustment()} based on it).
      *
-     * @param g The graphics context
+     * @return The Y position of the caption's baseline
      */
-    protected void paintIconAndText(Graphics g) {
-        g.setFont(getFont());
+    protected int getCaptionYPosition(Graphics g) {
         FontMetrics fm = g.getFontMetrics(getFont());
         //Find out what height we need
         int txtH = fm.getHeight();
@@ -460,6 +463,23 @@ public abstract class AbstractTabCellRenderer extends JLabel
         } else {
             txtY = txtH + ins.top;
         }
+        txtY += getCaptionYAdjustment();
+        return txtY;
+    }
+
+    /**
+     * Actually paints the icon and text (using the lightweight HTML renderer)
+     *
+     * @param g The graphics context
+     */
+    protected void paintIconAndText(Graphics g) {
+        g.setFont(getFont());
+        FontMetrics fm = g.getFontMetrics(getFont());
+        //Find out what height we need
+        int txtH = fm.getHeight();
+        Insets ins = getInsets();
+        //find out the available height
+        int availH = getHeight() - (ins.top + ins.bottom);
         int txtX;
 
         int centeringToAdd = getPixelsToAddToSelection() != 0 ?
@@ -495,7 +515,7 @@ public abstract class AbstractTabCellRenderer extends JLabel
             txtX += 5;
         }
 
-        txtY += getCaptionYAdjustment();
+        int txtY = getCaptionYPosition(g);
 
         //Get the available horizontal pixels for text
         int txtW = getWidth() - (txtX + ins.right);

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractViewTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/AbstractViewTabDisplayerUI.java
@@ -225,7 +225,7 @@ public abstract class AbstractViewTabDisplayerUI extends TabDisplayerUI {
 
             if( null != btnClose ) {
                 Icon icon = btnClose.getIcon();
-                btnClose.setBounds( width, height/2-icon.getIconHeight()/2, icon.getIconWidth(), icon.getIconHeight() );
+                btnClose.setBounds( width, (height - icon.getIconHeight()) / 2, icon.getIconWidth(), icon.getIconHeight() );
                 width += icon.getIconWidth();
             }
 
@@ -233,7 +233,7 @@ public abstract class AbstractViewTabDisplayerUI extends TabDisplayerUI {
                 if( 0 != width )
                     width += ICON_X_PAD;
                 Icon icon = btnAutoHidePin.getIcon();
-                btnAutoHidePin.setBounds( width, height/2-icon.getIconHeight()/2, icon.getIconWidth(), icon.getIconHeight() );
+                btnAutoHidePin.setBounds( width, (height - icon.getIconHeight()) / 2, icon.getIconWidth(), icon.getIconHeight() );
                 width += icon.getIconWidth();
                 width += ICON_X_PAD;
             }

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicScrollingTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicScrollingTabDisplayerUI.java
@@ -383,7 +383,7 @@ public abstract class BasicScrollingTabDisplayerUI extends BasicTabDisplayerUI {
 
     /**
      * Provides an offscreen graphics context so that widths based on character
-     * size can be calculated correctly before the component is shown.
+     * size can be calculated correctly before the component is shown. Never returns null.
      *
      * <p>For more accurate text measurements, clients should prefer calling
      * {@link #getOffscreenGraphics(JComponent)}.
@@ -399,7 +399,7 @@ public abstract class BasicScrollingTabDisplayerUI extends BasicTabDisplayerUI {
 
     /**
      * Provides an offscreen graphics context so that widths based on character
-     * size can be calculated correctly before the component is shown
+     * size can be calculated correctly before the component is shown. Never returns null.
      *
      * @param component may be null without causing fatal errors, but should be set for accurate
      *        text measurement (especially on displays with HiDPI scaling enabled)

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabCellRenderer.java
@@ -21,13 +21,14 @@ package org.netbeans.swing.tabcontrol.plaf;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.FontMetrics;
+import java.awt.Font;
 import java.awt.GradientPaint;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.Polygon;
 import java.awt.Rectangle;
+import java.awt.font.FontRenderContext;
 import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.UIManager;
@@ -99,25 +100,23 @@ class WinFlatEditorTabCellRenderer extends AbstractTabCellRenderer {
     }
 
     @Override
-    protected int getCaptionYAdjustment() {
-        // Workaround for a issue in AbstractTabCellRenderer.paintIconAndText(Graphics),
-        // which uses font height (which includes font descent) to calculate Y-coordinate
-        // when available height is equal to font height (availH <= txtH),
-        // but HtmlRenderer.renderString() expects Y-coordinate at baseline.
-        // So the text is painted vertically out of center.
-        //
-        // This seems to be no issue with other LAFs because they seem to use
-        // TabPainter insets differently and the available height is larger than
-        // the font height (availH > txtH), in which case 3 pixels are removed from
-        // the Y-coordinate to avoid that the text is painted vertically out of center.
-
-        FontMetrics fm = getFontMetrics(getFont());
-        int txtH = fm.getHeight();
+    protected int getCaptionYPosition(Graphics g) {
+        Font font = getFont();
+        FontRenderContext frc = (g instanceof Graphics2D)
+                ? ((Graphics2D) g).getFontRenderContext()
+                : g.getFontMetrics(font).getFontRenderContext();
+        /* Don't rely on FontMetrics.getAscent() to get the ascent; it can return values much bigger
+        than the actual, visual size of the letters. Use the actual height of a flat-topped
+        upper-case letter instead. */
+        double txtVisualAscent = font.createGlyphVector(frc, "H")
+                .getVisualBounds().getHeight();
         Insets ins = getInsets();
         int availH = getHeight() - (ins.top + ins.bottom);
-        // Ad hoc adjustment for the Windows LAF.
-        int yAdjustment = -1;
-        return ((availH <= txtH) ? -fm.getDescent() : -1) + yAdjustment;
+        final int effectiveIconYAdjustment = 2 + getIconYAdjustment();
+
+        // Center the visual ascent portion of the text vertically with respect to the icon.
+        return ins.top + (int) Math.round((availH + txtVisualAscent) / 2)
+                + effectiveIconYAdjustment;
     }
 
     @Override

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatEditorTabDisplayerUI.java
@@ -66,15 +66,12 @@ public class WinFlatEditorTabDisplayerUI extends BasicScrollingTabDisplayerUI {
 
     @Override
     public Dimension getPreferredSize(JComponent c) {
-        int prefHeight;
-        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics();
-        if (g != null) {
-            FontMetrics fm = g.getFontMetrics(displayer.getFont());
-            Insets ins = getTabAreaInsets();
-            prefHeight = fm.getHeight() + ins.top + ins.bottom
-                    + tabInsets.top + tabInsets.bottom;
-        } else
-            prefHeight = UIScale.scale(28);
+        Graphics g = BasicScrollingTabDisplayerUI.getOffscreenGraphics(c);
+        FontMetrics fm = g.getFontMetrics(displayer.getFont());
+        Insets ins = getTabAreaInsets();
+        // Standard icons are 16 pixels tall, so always allocate space for them.
+        int prefHeight = Math.max(fm.getHeight(), 16) + ins.top + ins.bottom
+                + tabInsets.top + tabInsets.bottom;
         return new Dimension(displayer.getWidth(), prefHeight);
     }
 

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatViewTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/WinFlatViewTabDisplayerUI.java
@@ -188,16 +188,19 @@ public class WinFlatViewTabDisplayerUI extends AbstractViewTabDisplayerUI {
 
         // paint text
         int txtX = x + txtLeftPad;
-        int txtY = y + tabInsets.top + fm.getAscent();
         int availH = height - tabInsets.top - tabInsets.bottom;
-        if (availH > fm.getHeight()) {
-            txtY += (availH - fm.getHeight()) / 2;
-        }
         int style = HtmlRenderer.STYLE_TRUNCATE;
         if (!isSelected(index)) {
             // center text of unselected tabs
             txtX = Math.max(x + 1, x + ((width - realTxtWidth) / 2));
         }
+
+        /* Keep the txtY calculation the same as for WinFlatEditorTabCellRenderer, with an offset that
+        makes the text in view tabs and editor tabs always line up. */
+        double txtVisualAscent = getTxtFont().createGlyphVector(fm.getFontRenderContext(), "H")
+            .getVisualBounds().getHeight();
+        int txtY = tabInsets.top + (int) Math.round((availH + txtVisualAscent) / 2) + 2;
+
         HtmlRenderer.renderString(text, g, txtX, txtY, availTxtWidth, height,
                 getTxtFont(), c, style, true);
     }


### PR DESCRIPTION
In a previous PR ( https://github.com/apache/netbeans/pull/2967 ), the tab components in the NetBeans window system were redesigned and modernized for the Windows LAF. This PR ports related tabcontrol improvements back into FlatLAF, and proposes a similar tab style for FlatLAF. See the attached screenshots.

(This PR is split into a series of commits which will be easiest to review one at a time.)

The proposed style, compared to the current FlatLAF style, makes the selected tab look like an actual "tab" with an actual rectangular border around it, while keeping the much simpler "separators only" look for unselected tabs. The proposed style also tightens up vertical space significantly, like in other LAFs. See the attached screenshots. The new tab controls work well on all HiDPI scaling levels, and on all platforms (Windows, Linux, MacOS).

Advantages of the proposed tabcontrol style:
* Other applications that have tabs as part of their window system still tend to render at least the active window system tab as an actual "tabs", e.g. Chrome, Excel, Photoshop, Unity.
* Personally, I find it hard to orient my eyes around the old FlatLAF tab style; the drawn selected tab seems to fix this. (Hard to explain in a fully objective way!)
* The tab content areas (contents of editor, projects pane, navigator pane etc.) has borders around them, so it is logical that the border continues around the tab that is associated with them.
* Conserve vertical space. Modern monitors have tended to become wider but not taller. With e.g. 2x HiDPI scaling (as on all MacBooks), there may actually be _fewer_ logical pixels available in the vertical direction than on older laptop screens.

This PR also removes an extraneous border around the editor area, and introduces a little bit of extra space in the toolbar area.

I've been using FlatLAF as the default LAF on Linux for my NetBeans Platform application. It handles HiDPI scaling very well, and it's getting really solid--thanks to @DevCharly for all his work on it!

### Before/after screenshots, FlatLAF Light:
![flatlaf-light-1-before](https://user-images.githubusercontent.com/886243/129835780-db2f95a6-012d-4973-8e38-ab84c2c67e18.png)
![flatlaf-light-2-after](https://user-images.githubusercontent.com/886243/129835845-bc76a9bc-65c1-48aa-91dd-be0fbadfc2ea.png)

### Before/after screenshots, FlatLAF Dark:
![flatlaf-dark-1-before](https://user-images.githubusercontent.com/886243/129835816-3c953cab-4624-4d39-b041-dffc47c7f925.png)
![flatlaf-dark-2-after](https://user-images.githubusercontent.com/886243/129835819-0733dd6b-0ce9-47c7-87a0-a60feaf804cf.png)
