### PR TITLE
[NETBEANS-5931] Consolidate duplicated logic to set rendering hints

### DIFF
--- a/ide/csl.api/nbproject/project.xml
+++ b/ide/csl.api/nbproject/project.xml
@@ -373,7 +373,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>6.8.0.1</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/csl.api/src/org/netbeans/modules/csl/editor/completion/MethodParamsTipPaintComponent.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/editor/completion/MethodParamsTipPaintComponent.java
@@ -21,9 +21,9 @@ package org.netbeans.modules.csl.editor.completion;
 
 import java.awt.*;
 import java.util.List;
-import java.util.Map;
 import javax.swing.*;
 import javax.swing.text.JTextComponent;
+import org.openide.awt.GraphicsUtils;
 
 /**
  *
@@ -51,20 +51,8 @@ public class MethodParamsTipPaintComponent extends JToolTip {
     }
     
     public @Override void paint(Graphics g) {
-        Object value = (Map) (Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-        Map renderingHints = (value instanceof Map) ? (java.util.Map) value : null;
-        if (renderingHints != null && g instanceof Graphics2D) {
-            Graphics2D g2d = (Graphics2D) g;
-            RenderingHints oldHints = g2d.getRenderingHints();
-            g2d.setRenderingHints(renderingHints);
-            try {
-                super.paint(g2d);
-            } finally {
-                g2d.setRenderingHints(oldHints);
-            }
-        } else {
-            super.paint(g);
-        }
+        GraphicsUtils.configureDefaultRenderingHints(g);
+        super.paint(g);
     }
 
     public @Override void paintComponent(Graphics g) {

--- a/ide/diff/nbproject/project.xml
+++ b/ide/diff/nbproject/project.xml
@@ -160,7 +160,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.50</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffSplitPaneDivider.java
+++ b/ide/diff/src/org/netbeans/modules/diff/builtin/visualizer/editable/DiffSplitPaneDivider.java
@@ -34,6 +34,7 @@ import java.awt.geom.CubicCurve2D;
 import java.awt.geom.GeneralPath;
 import java.util.*;
 import java.util.List;
+import org.openide.awt.GraphicsUtils;
 
 /**
  * Split pane divider with Diff decorations.
@@ -147,8 +148,6 @@ class DiffSplitPaneDivider extends BasicSplitPaneDivider implements MouseMotionL
         "TT_DiffPanel_JumpToCurrent=Go to Current Difference"
     })
     private class DiffSplitDivider extends JPanel {
-    
-        private Map renderingHints;
         private final DividerAction rollbackAction = new DividerAction(NbBundle.getMessage(DiffSplitDivider.class, "TT_DiffPanel_MoveAll"), null) { //NOI18N
 
             @Override
@@ -170,8 +169,6 @@ class DiffSplitPaneDivider extends BasicSplitPaneDivider implements MouseMotionL
         public DiffSplitDivider() {
             setBackground(UIManager.getColor("SplitPane.background")); // NOI18N
             setOpaque(true);
-            renderingHints = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty(
-                    "awt.font.desktophints")); // NOI18N
             
             // aqua background workaround
             if( "Aqua".equals( UIManager.getLookAndFeel().getID() ) ) {         // NOI18N
@@ -207,9 +204,7 @@ class DiffSplitPaneDivider extends BasicSplitPaneDivider implements MouseMotionL
             int rightOffset = -rightView.y + editorsOffset;
             int leftOffset = -leftView.y + editorsOffset;
 
-            if (renderingHints != null) {
-                g.addRenderingHints(renderingHints);
-            }
+            GraphicsUtils.configureDefaultRenderingHints(g);
             int currDiff = master.getCurrentDifference();
             String diffInfo = (currDiff + 1) + "/" + master.getDifferenceCount(); // NOI18N
             int width = g.getFontMetrics().stringWidth(diffInfo);

--- a/ide/editor.completion/nbproject/project.xml
+++ b/ide/editor.completion/nbproject/project.xml
@@ -109,7 +109,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>6.4</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionJList.java
+++ b/ide/editor.completion/src/org/netbeans/modules/editor/completion/CompletionJList.java
@@ -23,7 +23,6 @@ import java.awt.*;
 import java.awt.event.MouseListener;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleContext;
 import javax.swing.*;
@@ -33,6 +32,7 @@ import org.netbeans.editor.LocaleSupport;
 import org.netbeans.spi.editor.completion.CompletionItem;
 import org.netbeans.spi.editor.completion.CompositeCompletionItem;
 import org.netbeans.spi.editor.completion.LazyCompletionItem;
+import org.openide.awt.GraphicsUtils;
 import org.openide.util.ImageUtilities;
 import org.openide.util.Utilities;
 
@@ -112,20 +112,8 @@ public class CompletionJList extends JList {
     }
 
     public @Override void paint(Graphics g) {
-        Object value = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-        Map renderingHints = (value instanceof Map) ? (java.util.Map)value : null;
-        if (renderingHints != null && g instanceof Graphics2D) {
-            Graphics2D g2d = (Graphics2D) g;
-            RenderingHints oldHints = g2d.getRenderingHints();
-            g2d.addRenderingHints(renderingHints);
-            try {
-                super.paint(g2d);
-            } finally {
-                g2d.setRenderingHints(oldHints);
-            }
-        } else {
-            super.paint(g);
-        }
+        GraphicsUtils.configureDefaultRenderingHints(g);
+        super.paint(g);
     }
     
     void setData(List data, int selectedIndex) {

--- a/ide/editor.completion/src/org/netbeans/modules/editor/completion/PatchedHtmlRenderer.java
+++ b/ide/editor.completion/src/org/netbeans/modules/editor/completion/PatchedHtmlRenderer.java
@@ -23,11 +23,8 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
-import java.awt.Graphics2D;
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.Shape;
-import java.awt.Toolkit;
 import java.awt.font.LineMetrics;
 import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
@@ -40,8 +37,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
-import javax.swing.plaf.LabelUI;
-import org.openide.ErrorManager;
+import org.openide.awt.GraphicsUtils;
 import org.openide.util.Utilities;
 
 /**
@@ -81,14 +77,6 @@ public final class PatchedHtmlRenderer {
     /** System property to cause exceptions to be thrown when unparsable
      * html is encountered */
     private static final boolean STRICT_HTML = Boolean.getBoolean("netbeans.lwhtml.strict"); //NOI18N
-
-    /** System property to automatically turn on antialiasing for html strings */    
-    private static final boolean ANTIALIAS = Boolean.getBoolean("nb.cellrenderer.antialiasing") // NOI18N
-         ||Boolean.getBoolean("swing.aatext") // NOI18N
-         ||(isGTK() && gtkShouldAntialias()) // NOI18N
-         || isAqua();
-    
-    private static Boolean gtkAA;
 
     /** Cache for strings which have produced errors, so we don't post an
      * error message more than once */
@@ -369,9 +357,7 @@ public final class PatchedHtmlRenderer {
 
         g.setColor(defaultColor);
         g.setFont(f);
-        if (ANTIALIAS && g instanceof Graphics2D) {
-            ((Graphics2D) g).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        }
+        GraphicsUtils.configureDefaultRenderingHints(g);
 
         char[] chars = s.toCharArray();
         int origX = x;
@@ -1192,22 +1178,5 @@ public final class PatchedHtmlRenderer {
         } else {
             throw new IllegalArgumentException(out);
         }
-    }
-    
-    private static boolean isAqua () {
-        return "Aqua".equals(UIManager.getLookAndFeel().getID()); //NOI18N
-    }
-    
-    private static boolean isGTK () {
-        return "GTK".equals(UIManager.getLookAndFeel().getID()); //NOI18N
-    }
-    
-    private  static final boolean gtkShouldAntialias() {
-        if (gtkAA == null) {
-            Object o = Toolkit.getDefaultToolkit().getDesktopProperty("gnome.Xft/Antialias"); //NOI18N
-            gtkAA = Integer.valueOf(1).equals(o) ? Boolean.TRUE : Boolean.FALSE;
-        }
-
-        return gtkAA.booleanValue();
     }
 }

--- a/ide/editor/nbproject/project.xml
+++ b/ide/editor/nbproject/project.xml
@@ -159,7 +159,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.51</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/ListCompletionView.java
+++ b/ide/editor/src/org/netbeans/modules/editor/impl/actions/clipboardhistory/ListCompletionView.java
@@ -25,11 +25,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import java.awt.Toolkit;
 import java.awt.event.MouseListener;
-import java.util.Map;
 import javax.swing.AbstractListModel;
 import javax.swing.BorderFactory;
 import javax.swing.DefaultListCellRenderer;
@@ -39,6 +35,7 @@ import javax.swing.JList;
 import javax.swing.JViewport;
 import javax.swing.ListCellRenderer;
 import org.netbeans.lib.editor.util.StringEscapeUtils;
+import org.openide.awt.GraphicsUtils;
 import org.openide.awt.HtmlRenderer;
 import org.openide.util.ImageUtilities;
 
@@ -185,20 +182,8 @@ public class ListCompletionView extends JList {
     }
 
     public @Override void paint(Graphics g) {
-        Object value = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints"); //NOI18N
-        Map renderingHints = (value instanceof Map) ? (java.util.Map)value : null;
-        if (renderingHints != null && g instanceof Graphics2D) {
-            Graphics2D g2d = (Graphics2D) g;
-            RenderingHints oldHints = g2d.getRenderingHints();
-            g2d.setRenderingHints(renderingHints);
-            try {
-                super.paint(g2d);
-            } finally {
-                g2d.setRenderingHints(oldHints);
-            }
-        } else {
-            super.paint(g);
-        }
+        GraphicsUtils.configureDefaultRenderingHints(g);
+        super.paint(g);
     }
 
     static class Model extends AbstractListModel {

--- a/ide/gsf.codecoverage/nbproject/project.xml
+++ b/ide/gsf.codecoverage/nbproject/project.xml
@@ -110,7 +110,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.3.1</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageBar.java
+++ b/ide/gsf.codecoverage/src/org/netbeans/modules/gsf/codecoverage/CoverageBar.java
@@ -28,18 +28,16 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
-import java.awt.Toolkit;
 import java.awt.event.HierarchyEvent;
 import java.awt.event.HierarchyListener;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.awt.image.ConvolveOp;
 import java.awt.image.Kernel;
-import java.util.Map;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.ToolTipManager;
+import org.openide.awt.GraphicsUtils;
 
 /**
  * Custom component for painting code coverage. I was initially using a JProgressBar, with the
@@ -129,20 +127,8 @@ public class CoverageBar extends JComponent {
     public @Override
     void paint(Graphics g) {
         // Antialiasing if necessary
-        Object value = (Map) (Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-        Map renderingHints = (value instanceof Map) ? (java.util.Map) value : null;
-        if (renderingHints != null && g instanceof Graphics2D) {
-            Graphics2D g2d = (Graphics2D) g;
-            RenderingHints oldHints = g2d.getRenderingHints();
-            g2d.setRenderingHints(renderingHints);
-            try {
-                super.paint(g2d);
-            } finally {
-                g2d.setRenderingHints(oldHints);
-            }
-        } else {
-            super.paint(g);
-        }
+        GraphicsUtils.configureDefaultRenderingHints(g);
+        super.paint(g);
     }
 
     @Override

--- a/ide/gsf.testrunner.ui/nbproject/project.xml
+++ b/ide/gsf.testrunner.ui/nbproject/project.xml
@@ -162,7 +162,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.62</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultBar.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultBar.java
@@ -28,18 +28,15 @@ import java.awt.GradientPaint;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
-import java.awt.Rectangle;
-import java.awt.RenderingHints;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
 import java.awt.image.ConvolveOp;
 import java.awt.image.Kernel;
-import java.util.Map;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.Timer;
+import org.openide.awt.GraphicsUtils;
 
 /**
  * <strong>This is a copy of <code>CoverageBar</code> from the gsf.codecoverage</code>
@@ -166,20 +163,8 @@ public final class ResultBar extends JComponent implements ActionListener{
     @Override
     void paint(Graphics g) {
         // Antialiasing if necessary
-        Object value = (Map) (Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-        Map renderingHints = (value instanceof Map) ? (java.util.Map) value : null;
-        if (renderingHints != null && g instanceof Graphics2D) {
-            Graphics2D g2d = (Graphics2D) g;
-            RenderingHints oldHints = g2d.getRenderingHints();
-            g2d.setRenderingHints(renderingHints);
-            try {
-                super.paint(g2d);
-            } finally {
-                g2d.setRenderingHints(oldHints);
-            }
-        } else {
-            super.paint(g);
-        }
+        GraphicsUtils.configureDefaultRenderingHints(g);
+        super.paint(g);
     }
 
     @Override

--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/output/OutputView.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/output/OutputView.java
@@ -23,12 +23,7 @@ import java.awt.Color;
 import java.awt.Container;
 import java.awt.EventQueue;
 import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
 import java.awt.Shape;
-import java.awt.Toolkit;
-import java.util.Collections;
-import java.util.Map;
 import javax.swing.UIManager;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Element;
@@ -37,6 +32,7 @@ import javax.swing.text.PlainView;
 import javax.swing.text.Segment;
 import javax.swing.text.Utilities;
 import org.netbeans.modules.gsf.testrunner.ui.output.OutputDocument.DocElement;
+import org.openide.awt.GraphicsUtils;
 
 /**
  * 
@@ -51,14 +47,8 @@ final class OutputView extends PlainView {
     private int selStart, selEnd;
     private static Color selectedErr;
     private static Color unselectedErr;
-    private static Map hintsMap = null;
 
     private Color selectedFg, unselectedFg;
-
-    /* set antialiasing hints when it's requested */
-    private static final boolean antialias
-            = Boolean.getBoolean("swing.aatext")                        //NOI18N
-              || "Aqua".equals(UIManager.getLookAndFeel().getID());     //NOI18N
 
     static {
         selectedErr = UIManager.getColor("nb.output.err.foreground.selected");  //NOI18N
@@ -71,23 +61,6 @@ final class OutputView extends PlainView {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    static final Map getHints() {
-        if (hintsMap == null) {
-            //Thanks to Phil Race for making this possible
-            hintsMap = (Map) Toolkit.getDefaultToolkit().getDesktopProperty(
-                                         "awt.font.desktophints");      //NOI18N
-            if (hintsMap == null) {
-                hintsMap = antialias
-                           ? Collections.singletonMap(
-                                    RenderingHints.KEY_TEXT_ANTIALIASING,
-                                    RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
-                           : Collections.emptyMap();
-            }
-        }
-        return hintsMap;
-    }
-
     OutputView(Element element) {
         super(element);
         rootElement = (OutputDocument.RootElement) element;
@@ -95,7 +68,7 @@ final class OutputView extends PlainView {
 
     @Override
     public void paint(Graphics g, Shape a) {
-        ((Graphics2D) g).addRenderingHints(getHints());
+        GraphicsUtils.configureDefaultRenderingHints(g);
 
         Container container = getContainer();
         if (container instanceof JTextComponent) {

--- a/ide/lib.terminalemulator/nbproject/project.xml
+++ b/ide/lib.terminalemulator/nbproject/project.xml
@@ -24,7 +24,16 @@
     <configuration>
         <data xmlns="http://www.netbeans.org/ns/nb-module-project/3">
             <code-name-base>org.netbeans.lib.terminalemulator</code-name-base>
-            <module-dependencies/>
+            <module-dependencies>
+                <dependency>
+                    <code-name-base>org.openide.awt</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.82</specification-version>
+                    </run-dependency>
+                </dependency>
+            </module-dependencies>
             <test-dependencies>
                 <test-type>
                     <name>unit</name>

--- a/ide/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/ColorComboBoxRenderer.java
+++ b/ide/lib.terminalemulator/src/org/netbeans/lib/terminalemulator/support/ColorComboBoxRenderer.java
@@ -23,16 +23,14 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Graphics;
-import java.awt.Graphics2D;
 import java.awt.SystemColor;
-import java.awt.Toolkit;
 import java.awt.event.ActionListener;
-import java.util.Map;
 import javax.swing.ComboBoxEditor;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JList;
 import javax.swing.ListCellRenderer;
+import org.openide.awt.GraphicsUtils;
 
 
 /**
@@ -62,15 +60,8 @@ ListCellRenderer<ColorValue>, ComboBoxEditor {
 
     @Override
     public void paint (Graphics g) {
-        
-        //AntiAliasing check
-        @SuppressWarnings("unchecked") //NOI18N
-        Map<?, ?> aa = (Map<?, ?>) Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints"); //NOI18N
+        GraphicsUtils.configureDefaultRenderingHints(g);
 
-        if (aa != null) {
-            ((Graphics2D) g).setRenderingHints(aa);
-        }
-        
         Color oldColor = g.getColor ();
         Dimension size = getSize ();
         if (isFocusOwner ()) {

--- a/ide/spi.editor.hints/nbproject/project.xml
+++ b/ide/spi.editor.hints/nbproject/project.xml
@@ -92,7 +92,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>6.5</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/spi.editor.hints/src/org/netbeans/modules/editor/hints/borrowed/ListCompletionView.java
+++ b/ide/spi.editor.hints/src/org/netbeans/modules/editor/hints/borrowed/ListCompletionView.java
@@ -25,17 +25,13 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
-import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
-import java.awt.Toolkit;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.AbstractListModel;
@@ -60,6 +56,7 @@ import org.netbeans.modules.editor.hints.FixData;
 import org.netbeans.modules.editor.hints.HintsControllerImpl;
 import org.netbeans.modules.editor.hints.HintsUI;
 import org.netbeans.spi.editor.hints.Fix;
+import org.openide.awt.GraphicsUtils;
 import org.openide.awt.HtmlRenderer;
 import org.openide.util.ImageUtilities;
 
@@ -225,20 +222,8 @@ public class ListCompletionView extends JList {
     }
 
     public @Override void paint(Graphics g) {
-        Object value = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-        Map renderingHints = (value instanceof Map) ? (java.util.Map)value : null;
-        if (renderingHints != null && g instanceof Graphics2D) {
-            Graphics2D g2d = (Graphics2D) g;
-            RenderingHints oldHints = g2d.getRenderingHints();
-            g2d.setRenderingHints(renderingHints);
-            try {
-                super.paint(g2d);
-            } finally {
-                g2d.setRenderingHints(oldHints);
-            }
-        } else {
-            super.paint(g);
-        }
+        GraphicsUtils.configureDefaultRenderingHints(g);
+        super.paint(g);
     }
     
     static class Model extends AbstractListModel implements PropertyChangeListener {

--- a/ide/team.commons/nbproject/project.xml
+++ b/ide/team.commons/nbproject/project.xml
@@ -81,7 +81,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.2</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/LinkButton.java
+++ b/ide/team.commons/src/org/netbeans/modules/bugtracking/commons/LinkButton.java
@@ -29,9 +29,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
-import java.awt.RenderingHints;
 import java.awt.Stroke;
-import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
@@ -43,7 +41,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
-import java.util.Map;
 import java.util.logging.Level;
 import javax.swing.Action;
 import javax.swing.Icon;
@@ -51,6 +48,7 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
+import org.openide.awt.GraphicsUtils;
 
 /**
  *
@@ -182,7 +180,8 @@ public class LinkButton extends JButton implements MouseListener, FocusListener 
     
     @Override
     protected void paintComponent(Graphics g) {
-        Graphics2D g2 = prepareGraphics( g );
+        Graphics2D g2 = (Graphics2D) g;
+        GraphicsUtils.configureDefaultRenderingHints(g2);
         super.paintComponent(g2);
 
         Dimension size = getSize();
@@ -229,17 +228,6 @@ public class LinkButton extends JButton implements MouseListener, FocusListener 
     
     protected boolean isVisited() {
         return false;
-    }
-
-    private static Graphics2D prepareGraphics(Graphics g) {
-        Graphics2D g2 = (Graphics2D) g;
-        Map rhints = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-        if( rhints == null && Boolean.getBoolean("swing.aatext") ) { //NOI18N
-             g2.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON );
-        } else if( rhints != null ) {
-            g2.addRenderingHints( rhints );
-        }
-        return g2;
     }
 
     private static Font getButtonFont() {

--- a/ide/versioning.util/nbproject/project.xml
+++ b/ide/versioning.util/nbproject/project.xml
@@ -239,7 +239,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.50</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/history/LinkButton.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/history/LinkButton.java
@@ -28,18 +28,16 @@ import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
-import java.awt.RenderingHints;
 import java.awt.Stroke;
-import java.awt.Toolkit;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.Map;
 import javax.swing.Action;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.UIManager;
 import javax.swing.border.EmptyBorder;
+import org.openide.awt.GraphicsUtils;
 
 /**
  *
@@ -147,7 +145,8 @@ public class LinkButton extends JButton implements MouseListener {
 
     @Override
     protected void paintComponent(Graphics g) {
-        Graphics2D g2 = prepareGraphics( g );
+        Graphics2D g2 = (Graphics2D) g;
+        GraphicsUtils.configureDefaultRenderingHints(g2);
         super.paintComponent(g2);
 
         Dimension size = getSize();
@@ -184,17 +183,6 @@ public class LinkButton extends JButton implements MouseListener {
     
     protected boolean isVisited() {
         return false;
-    }
-
-    private static Graphics2D prepareGraphics(Graphics g) {
-        Graphics2D g2 = (Graphics2D) g;
-        Map rhints = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-        if( rhints == null && Boolean.getBoolean("swing.aatext") ) { //NOI18N
-             g2.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON );
-        } else if( rhints != null ) {
-            g2.addRenderingHints( rhints );
-        }
-        return g2;
     }
 
     private static Font getButtonFont() {

--- a/java/java.editor/nbproject/project.xml
+++ b/java/java.editor/nbproject/project.xml
@@ -361,7 +361,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>6.2</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.editor/src/org/netbeans/modules/editor/java/MethodParamsTipPaintComponent.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/MethodParamsTipPaintComponent.java
@@ -21,9 +21,9 @@ package org.netbeans.modules.editor.java;
 
 import java.awt.*;
 import java.util.List;
-import java.util.Map;
 import javax.swing.*;
 import javax.swing.text.JTextComponent;
+import org.openide.awt.GraphicsUtils;
 
 /**
  *
@@ -64,26 +64,13 @@ public class MethodParamsTipPaintComponent extends JToolTip {
     }
     
     public void paintComponent(Graphics g) {
+        GraphicsUtils.configureDefaultRenderingHints(g);
         // clear background
         g.setColor(getBackground());
         Rectangle r = g.getClipBounds();
         g.fillRect(r.x, r.y, r.width, r.height);
         g.setColor(getForeground());
-
-        Object value = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-        Map renderingHints = (value instanceof Map) ? (java.util.Map)value : null;
-        if (renderingHints != null && g instanceof Graphics2D) {
-            Graphics2D g2d = (Graphics2D) g;
-            RenderingHints oldHints = g2d.getRenderingHints();
-            g2d.addRenderingHints(renderingHints);
-            try {
-                draw(g2d);
-            } finally {
-                g2d.setRenderingHints(oldHints);
-            }
-        } else {
-            draw(g);
-        }
+        draw(g);
     }
 
     protected void draw(Graphics g) {

--- a/nb/welcome/nbproject/project.xml
+++ b/nb/welcome/nbproject/project.xml
@@ -91,7 +91,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.42</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/nb/welcome/src/org/netbeans/modules/welcome/content/LinkButton.java
+++ b/nb/welcome/src/org/netbeans/modules/welcome/content/LinkButton.java
@@ -40,6 +40,7 @@ import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
+import org.openide.awt.GraphicsUtils;
 import org.openide.util.NbBundle;
 
 /**
@@ -142,10 +143,11 @@ public abstract class LinkButton extends JButton
 
     @Override
     protected void paintComponent(Graphics g) {
-        Graphics2D g2 = Utils.prepareGraphics( g );
+        GraphicsUtils.configureDefaultRenderingHints(g);
+        Graphics2D g2 = (Graphics2D) g;
         if( showBorder && !Utils.isDefaultButtons() ) {
             Border b = underline ? mouseoverBorder : regularBorder;
-            b.paintBorder(this, g, 0, 0, getWidth(), getHeight());
+            b.paintBorder(this, g2, 0, 0, getWidth(), getHeight());
         }
         super.paintComponent(g2);
 

--- a/nb/welcome/src/org/netbeans/modules/welcome/content/Utils.java
+++ b/nb/welcome/src/org/netbeans/modules/welcome/content/Utils.java
@@ -21,15 +21,10 @@ package org.netbeans.modules.welcome.content;
 
 import java.awt.Color;
 import java.awt.Font;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import java.awt.Toolkit;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.Map;
 import java.util.ResourceBundle;
 import javax.swing.Action;
 import javax.swing.UIManager;
@@ -50,17 +45,6 @@ public class Utils {
 
     /** Creates a new instance of Utils */
     private Utils() {
-    }
-
-    public static Graphics2D prepareGraphics(Graphics g) {
-        Graphics2D g2 = (Graphics2D) g;
-        Map rhints = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-        if( rhints == null && Boolean.getBoolean("swing.aatext") ) { //NOI18N
-             g2.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON );
-        } else if( rhints != null ) {
-            g2.addRenderingHints( rhints );
-        }
-        return g2;
     }
 
     public static void showURL(String href) {

--- a/platform/api.visual/nbproject/project.xml
+++ b/platform/api.visual/nbproject/project.xml
@@ -58,6 +58,14 @@
                         <specification-version>8.0</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.openide.awt</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.82</specification-version>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
             <test-dependencies>
                 <test-type>

--- a/platform/api.visual/src/org/netbeans/api/visual/widget/SceneComponent.java
+++ b/platform/api.visual/src/org/netbeans/api/visual/widget/SceneComponent.java
@@ -28,8 +28,8 @@ import java.awt.dnd.*;
 import java.awt.event.*;
 import java.awt.geom.AffineTransform;
 import java.util.List;
-import java.util.Map;
 import org.netbeans.modules.visual.laf.DefaultLookFeel;
+import org.openide.awt.GraphicsUtils;
 import org.openide.util.NbBundle;
 
 /**
@@ -101,12 +101,7 @@ final class SceneComponent extends JComponent implements Accessible, MouseListen
 //        System.out.println ("CLIP: " + g.getClipBounds ());
 //        long s = System.currentTimeMillis ();
         Graphics2D gr = (Graphics2D) g;
-
-        Object props = Toolkit.getDefaultToolkit ().getDesktopProperty ("awt.font.desktophints"); // NOI18N
-        if (props instanceof Map)
-            gr.addRenderingHints ((Map) props);
-        gr.setRenderingHint (RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        gr.setRenderingHint (RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        GraphicsUtils.configureDefaultRenderingHints(gr);
         scene.setGraphics (gr);
 
         AffineTransform previousTransform = gr.getTransform ();

--- a/platform/core.output2/nbproject/project.xml
+++ b/platform/core.output2/nbproject/project.xml
@@ -71,7 +71,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>6.8</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/core.output2/src/org/netbeans/core/output2/ExtPlainView.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/ExtPlainView.java
@@ -19,15 +19,13 @@
 
 package org.netbeans.core.output2;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.text.*;
 import java.awt.*;
 import javax.swing.text.Position.Bias;
 import org.netbeans.core.output2.options.OutputOptions;
+import org.openide.awt.GraphicsUtils;
 
 /**
  * Extension to PlainView which can paint hyperlinked lines in different
@@ -42,27 +40,6 @@ class ExtPlainView extends PlainView {
     private static final int MAX_LINE_LENGTH = 4096;
     private static final String LINE_TOO_LONG_MSG = org.openide.util.NbBundle.getMessage(ExtPlainView.class, "MSG_LINE_TOO_LONG");
 
-    /** set antialiasing hints when it's requested. */
-    private static final boolean antialias = Boolean.getBoolean ("swing.aatext") || //NOI18N
-                                             "Aqua".equals (UIManager.getLookAndFeel().getID()); // NOI18N
-
-    private static Map<RenderingHints.Key, Object> hintsMap = null;
-
-    @SuppressWarnings("unchecked")
-    static Map<RenderingHints.Key, Object> getHints() {
-        if (hintsMap == null) {
-            //Thanks to Phil Race for making this possible
-            hintsMap = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-            if (hintsMap == null) {
-                hintsMap = new HashMap<RenderingHints.Key, Object>();
-                if (antialias) {
-                    hintsMap.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-                }
-            }
-        }
-        return hintsMap;
-    }
-
     /** Creates a new instance of ExtPlainView */
     ExtPlainView(Element elem) {
         super (elem);
@@ -70,7 +47,7 @@ class ExtPlainView extends PlainView {
 
     @Override
     public void paint(Graphics g, Shape allocation) {
-        ((Graphics2D)g).addRenderingHints(getHints());
+        GraphicsUtils.configureDefaultRenderingHints(g);
         super.paint(g, allocation);
     }
 

--- a/platform/core.output2/src/org/netbeans/core/output2/WrappedTextView.java
+++ b/platform/core.output2/src/org/netbeans/core/output2/WrappedTextView.java
@@ -30,6 +30,7 @@ import static javax.swing.SwingConstants.NORTH;
 import static javax.swing.SwingConstants.SOUTH;
 import static javax.swing.SwingConstants.WEST;
 import javax.swing.text.Position.Bias;
+import org.openide.awt.GraphicsUtils;
 import org.openide.util.Exceptions;
 
 /**
@@ -93,35 +94,14 @@ public class WrappedTextView extends View implements TabExpander {
      * We do a somewhat prettier arrow if it is.
      */
     private boolean aa = false;
-    /** set antialiasing hints when it's requested. */
-    private static final boolean antialias = Boolean.getBoolean ("swing.aatext") || //NOI18N
-                                             "Aqua".equals (UIManager.getLookAndFeel().getID()); // NOI18N
 
     static final Color arrowColor = new Color (80, 162, 80);
 
-    private static Map<RenderingHints.Key, Object> hintsMap = null;
-    
     int tabSize;
     int tabBase;
     private int tabOffsetX = 0;
     
     private final PropertyChangeListener propertyChangeListener;
-
-    @SuppressWarnings("unchecked")
-    static Map<RenderingHints.Key, Object> getHints() {
-        if (hintsMap == null) {
-            //Thanks to Phil Race for making this possible
-            hintsMap = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-            if (hintsMap == null) {
-                hintsMap = new HashMap<RenderingHints.Key, Object>();
-                if (antialias) {
-                    hintsMap.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-                    hintsMap.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-                }
-            }
-        }
-        return hintsMap;
-    }
 
     public WrappedTextView(Element elem, JTextComponent comp,
             PropertyChangeListener propertyChangeListener1) {
@@ -245,8 +225,7 @@ public class WrappedTextView extends View implements TabExpander {
     }
 
     public void paint(Graphics g, Shape allocation) {
-        
-        ((Graphics2D)g).addRenderingHints(getHints());
+        GraphicsUtils.configureDefaultRenderingHints(g);
         
         comp.getHighlighter().paint(g);
 

--- a/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarContainer.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/view/ui/toolbars/ToolbarContainer.java
@@ -35,8 +35,6 @@ import java.awt.event.ContainerEvent;
 import java.awt.event.ContainerListener;
 import java.awt.event.MouseEvent;
 import java.awt.geom.Ellipse2D;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.BorderFactory;
@@ -507,21 +505,6 @@ final class ToolbarContainer extends JPanel {
         public Dimension getMaximumSize () {
             return max;
         }
-    }
-
-    private static java.util.Map<RenderingHints.Key, Object> hintsMap = null;
-    @SuppressWarnings("unchecked")
-    static final Map getHints() {
-        //XXX We REALLY need to put this in a graphics utils lib
-        if (hintsMap == null) {
-            //Thanks to Phil Race for making this possible
-            hintsMap = (Map<RenderingHints.Key, Object>)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-            if (hintsMap == null) {
-                hintsMap = new HashMap<RenderingHints.Key, Object>();
-                hintsMap.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-            }
-        }
-        return hintsMap;
     }
 
     private final class ToolbarXP extends JPanel {

--- a/platform/o.n.core/nbproject/project.xml
+++ b/platform/o.n.core/nbproject/project.xml
@@ -80,7 +80,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.45</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/ColorEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/ColorEditor.java
@@ -27,19 +27,16 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.FontMetrics;
-import java.awt.Graphics2D;
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.SystemColor;
 import java.awt.Toolkit;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.beans.PropertyEditor;
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
 import javax.swing.border.EmptyBorder;
 import javax.swing.colorchooser.AbstractColorChooserPanel;
 import javax.swing.colorchooser.ColorSelectionModel;
@@ -54,6 +51,7 @@ import javax.swing.ListCellRenderer;
 import javax.swing.UIDefaults;
 import javax.swing.UIManager;
 import org.netbeans.core.UIExceptions;
+import org.openide.awt.GraphicsUtils;
 import org.openide.explorer.propertysheet.editors.XMLPropertyEditor;
 import org.openide.util.NbBundle;
 
@@ -130,16 +128,8 @@ public final class ColorEditor implements PropertyEditor, XMLPropertyEditor {
     private static Color swingColors[];
 
     static final boolean GTK = "GTK".equals(UIManager.getLookAndFeel().getID());//NOI18N
-    static final boolean AQUA = "Aqua".equals(UIManager.getLookAndFeel().getID());//NOI18N
-    
-    private static final boolean antialias = Boolean.getBoolean("nb.cellrenderer.antialiasing") // NOI18N
-         ||Boolean.getBoolean("swing.aatext") // NOI18N
-         ||(GTK && gtkShouldAntialias()) // NOI18N
-         ||AQUA; 
 
     private static Boolean gtkAA;
-    private static Map hintsMap;
-    
     
     // static initializer .........................................
     
@@ -405,7 +395,7 @@ public final class ColorEditor implements PropertyEditor, XMLPropertyEditor {
     public void paintValue(Graphics g, Rectangle rectangle) {
         int px;
 
-        ((Graphics2D)g).setRenderingHints (getHints ());
+        GraphicsUtils.configureDefaultRenderingHints(g);
         
         if (this.superColor != null) {
             Color color = g.getColor();
@@ -804,8 +794,8 @@ public final class ColorEditor implements PropertyEditor, XMLPropertyEditor {
             /** Paints this component. */
             @Override
             public void paint (Graphics g) {
-                ((Graphics2D)g).setRenderingHints (getHints ());
-                
+                GraphicsUtils.configureDefaultRenderingHints(g);
+
                 Dimension rectangle = this.getSize ();
                 Color color = g.getColor ();
 
@@ -947,6 +937,9 @@ public final class ColorEditor implements PropertyEditor, XMLPropertyEditor {
         return el;
     }
 
+    /**
+     * @deprecated Use {@link GraphicsUtils#configureDefaultRenderingHints(java.awt.Graphics)} instead
+     */
     public static final boolean gtkShouldAntialias() {
         if (gtkAA == null) {
             Object o = Toolkit.getDefaultToolkit().getDesktopProperty("gnome.Xft/Antialias"); //NOI18N
@@ -954,20 +947,5 @@ public final class ColorEditor implements PropertyEditor, XMLPropertyEditor {
         }
 
         return gtkAA.booleanValue();
-    }
-
-    // copied from openide/awt/HtmlLabelUI
-    @SuppressWarnings("unchecked") // need to use reflective access, no idea of type
-    private static Map getHints () {
-        if (hintsMap == null) {
-            hintsMap = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-            if (hintsMap == null) {
-                hintsMap = new HashMap();
-                if (antialias) {
-                    hintsMap.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-                }
-            }
-        }
-        return hintsMap;
     }
 }

--- a/platform/o.n.core/src/org/netbeans/beaninfo/editors/FontEditor.java
+++ b/platform/o.n.core/src/org/netbeans/beaninfo/editors/FontEditor.java
@@ -30,6 +30,7 @@ import org.netbeans.core.UIExceptions;
 import org.openide.DialogDisplayer;
 
 import org.openide.NotifyDescriptor;
+import org.openide.awt.GraphicsUtils;
 import org.openide.awt.Mnemonics;
 import org.openide.explorer.propertysheet.editors.XMLPropertyEditor;
 import org.openide.util.Exceptions;
@@ -42,11 +43,6 @@ import org.openide.util.Utilities;
 * @author Ian Formanek
 */
 public class FontEditor implements PropertyEditor, XMLPropertyEditor {
-
-    static final boolean antialias = Boolean.getBoolean("nb.cellrenderer.antialiasing") // NOI18N
-         ||Boolean.getBoolean("swing.aatext") // NOI18N
-         ||(isGTK() && gtkShouldAntialias()) // NOI18N
-         || isAqua();
 
     // static .....................................................................................
 
@@ -140,10 +136,7 @@ public class FontEditor implements PropertyEditor, XMLPropertyEditor {
     }
 
     private void paintText (Graphics g, Rectangle rectangle, String text) {
-        if( antialias && g instanceof Graphics2D ) {
-            ((Graphics2D)g).setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-            ((Graphics2D)g).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        }
+        GraphicsUtils.configureDefaultRenderingHints(g);
         Font originalFont = g.getFont ();
         
         // Fix of 21713, set default value
@@ -535,23 +528,5 @@ public class FontEditor implements PropertyEditor, XMLPropertyEditor {
         el.setAttribute (ATTR_STYLE, Integer.toString (font.getStyle ()));
         el.setAttribute (ATTR_SIZE, Integer.toString (font.getSize ()));
         return el;
-    }
-
-    private static boolean isAqua () {
-        return "Aqua".equals(UIManager.getLookAndFeel().getID());
-    }
-    
-    private static boolean isGTK () {
-        return "GTK".equals(UIManager.getLookAndFeel().getID());
-    }
-
-    private static Boolean gtkAA;
-    private static boolean gtkShouldAntialias() {
-        if (gtkAA == null) {
-            Object o = Toolkit.getDefaultToolkit().getDesktopProperty("gnome.Xft/Antialias"); //NOI18N
-            gtkAA = new Integer(1).equals(o) ? Boolean.TRUE : Boolean.FALSE;
-        }
-
-        return gtkAA.booleanValue();
     }
 }

--- a/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/UIUtils.java
+++ b/platform/o.n.swing.plaf/src/org/netbeans/swing/plaf/util/UIUtils.java
@@ -25,21 +25,12 @@ import javax.swing.*;
 import java.awt.*;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 
 /** XP color scheme installer.
  *
  * @author  Dafe Simonek
  */
 public final class UIUtils {
-    private static HashMap<RenderingHints.Key, Object> hintsMap = null;
-    private static final boolean noAntialias =
-        Boolean.getBoolean("nb.no.antialias"); //NOI18N
-
-    /** true when XP style colors are installed into UI manager, false otherwise */
-    private static boolean colorsReady = false;
-            
     /** No need to instantiate this utility class. */
     private UIUtils() {
     }
@@ -71,25 +62,6 @@ public final class UIUtils {
         Boolean isXP = (Boolean)Toolkit.getDefaultToolkit().
                         getDesktopProperty("win.xpstyle.themeActive"); //NOI18N
         return isXP == null ? false : isXP.booleanValue();
-    }
-
-     private static final Map<RenderingHints.Key, Object> getHints() {
-        //XXX should do this in update() in the UI instead
-        //Note for this method we do NOT want only text antialiasing - we 
-        //want antialiased curves.
-        if (hintsMap == null) {
-            hintsMap = new HashMap<RenderingHints.Key, Object>();
-            hintsMap.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-            hintsMap.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        }
-        return hintsMap;
-    }
-    
-    public static final void configureRenderingHints (Graphics g) {
-        if (noAntialias) return;
-        Graphics2D g2d = (Graphics2D) g;
-        
-        g2d.addRenderingHints(getHints());
     }
 
     public static Image loadImage (String s) {
@@ -168,14 +140,7 @@ public final class UIUtils {
         int blue = Math.max(0, Math.min(255, c.getBlue() + bDiff));
         return new Color(red, green, blue);
     }    
-    
-    /**
-     * Rotates a float value around 0-1
-     */
-    private static float minMax(float f) {
-        return Math.max(0, Math.min(1, f));
-    }
-    
+
     public static boolean isBrighter(Color a, Color b) {
         int[] ac = new int[]{a.getRed(), a.getGreen(), a.getBlue()};
         int[] bc = new int[]{b.getRed(), b.getGreen(), b.getBlue()};

--- a/platform/o.n.swing.tabcontrol/nbproject/project.xml
+++ b/platform/o.n.swing.tabcontrol/nbproject/project.xml
@@ -30,7 +30,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.38</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicTabDisplayerUI.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/BasicTabDisplayerUI.java
@@ -45,8 +45,8 @@ import javax.swing.event.ChangeListener;
 import javax.swing.event.ListDataEvent;
 import org.netbeans.swing.tabcontrol.TabData;
 import org.netbeans.swing.tabcontrol.TabDisplayer;
-import org.netbeans.swing.tabcontrol.WinsysInfoForTabbedContainer;
 import org.netbeans.swing.tabcontrol.event.ComplexListDataEvent;
+import org.openide.awt.GraphicsUtils;
 import org.openide.windows.TopComponent;
 
 /**
@@ -348,6 +348,9 @@ public abstract class BasicTabDisplayerUI extends AbstractTabDisplayerUI {
         return -1;
     }
 
+    /**
+     * @deprecated Use {@link GraphicsUtils#configureDefaultRenderingHints(java.awt.Graphics)} instead.
+     */
     protected boolean isAntialiased() {
         return ColorUtil.shouldAntialias();
     }
@@ -361,7 +364,7 @@ public abstract class BasicTabDisplayerUI extends AbstractTabDisplayerUI {
     public final void paint(Graphics g, JComponent c) {
         assert c == displayer;
         
-        ColorUtil.setupAntialiasing(g);
+        GraphicsUtils.configureDefaultRenderingHints(g);
         
         paintBackground(g);
         int start = getFirstVisibleTab();

--- a/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ColorUtil.java
+++ b/platform/o.n.swing.tabcontrol/src/org/netbeans/swing/tabcontrol/plaf/ColorUtil.java
@@ -26,6 +26,7 @@ import java.awt.geom.Area;
 import java.awt.image.BufferedImage;
 import java.util.HashMap;
 import java.util.Map;
+import org.openide.awt.GraphicsUtils;
 
 /**
  * Utilities for manipulating colors, caching gradient paint objects, creating a
@@ -38,8 +39,6 @@ final class ColorUtil {
     private static Map<RenderingHints.Key, Object> hintsMap = null;
     private static final boolean noGpCache = Boolean.getBoolean(
             "netbeans.winsys.nogpcache");  //NOI18N
-    private static final boolean noAntialias = 
-        Boolean.getBoolean("nb.no.antialias"); //NOI18N
     
     //Values for checking if we should flush the cache bitmap
     private static int focusedHeight = -1;
@@ -169,30 +168,8 @@ final class ColorUtil {
         return result;
     }
 
-    private static Map getHints() {
-        if (hintsMap == null) {
-            //Thanks to Phil Race for making this possible
-            hintsMap = (Map<RenderingHints.Key, Object>)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
-            if (hintsMap == null) {
-                hintsMap = new HashMap<RenderingHints.Key, Object>();
-                if (shouldAntialias()) {
-                    hintsMap.put(RenderingHints.KEY_TEXT_ANTIALIASING,
-                            RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-                }
-            }
-            if (shouldAntialias() && (hintsMap == null || !hintsMap.containsKey(RenderingHints.KEY_TEXT_ANTIALIASING))) {
-                hintsMap.put(RenderingHints.KEY_ANTIALIASING,
-                         RenderingHints.VALUE_ANTIALIAS_ON);
-            }
-        }
-        return hintsMap;
-        
-    }
-
     public static final void setupAntialiasing(Graphics g) {
-        if (noAntialias) return;
-        
-        ((Graphics2D) g).addRenderingHints(getHints());
+        GraphicsUtils.configureDefaultRenderingHints(g);
     }
     
     private static final boolean antialias = Boolean.getBoolean(
@@ -201,7 +178,10 @@ final class ColorUtil {
         gtkShouldAntialias()) || 
         Boolean.getBoolean ("swing.aatext") || //NOI18N
         "Aqua".equals(UIManager.getLookAndFeel().getID()); 
-    
+
+    /**
+     * @deprecated Use {@link GraphicsUtils#configureDefaultRenderingHints(java.awt.Graphics)} instead.
+     */
     public static final boolean shouldAntialias() {
         return antialias;
     }

--- a/platform/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/plaf/VectorIconTester.java
+++ b/platform/o.n.swing.tabcontrol/test/unit/src/org/netbeans/swing/tabcontrol/plaf/VectorIconTester.java
@@ -56,6 +56,7 @@ import javax.swing.Timer;
 import javax.swing.UIManager;
 import org.netbeans.swing.tabcontrol.TabDisplayer;
 import org.netbeans.swing.tabcontrol.TabDisplayerUI;
+import org.openide.awt.GraphicsUtils;
 import org.openide.util.ImageUtilities;
 
 /**
@@ -339,19 +340,9 @@ public class VectorIconTester extends javax.swing.JFrame {
             requestFocusInWindow();
         }
 
-        // This should really be a utility method somewhere...
-        // See VectorIcon.createGraphicsWithRenderingHintsConfigured.
         private static Graphics2D createGraphicsWithRenderingHintsConfigured(Graphics basedOn) {
             Graphics2D ret = (Graphics2D) basedOn.create();
-            Object desktopHints
-                    = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
-            Map<Object, Object> hints = new LinkedHashMap<Object, Object>();
-            if (desktopHints != null && desktopHints instanceof Map<?, ?>) {
-                hints.putAll((Map<?, ?>) desktopHints);
-            }
-            hints.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-            hints.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-            ret.addRenderingHints(hints);
+            GraphicsUtils.configureDefaultRenderingHints(basedOn);
             return ret;
         }
 

--- a/platform/openide.awt/apichanges.xml
+++ b/platform/openide.awt/apichanges.xml
@@ -26,6 +26,22 @@
 <apidef name="awt">AWT API</apidef>
 </apidefs>
 <changes>
+    <change id="configureDefaultRenderingHints">
+        <api name="awt"/>
+        <summary>Added GraphicsUtils.configureDefaultRenderingHints(Graphics).</summary>
+        <version major="7" minor="82"/>
+        <date day="28" month="9" year="2021"/>
+        <author login="ebakke"/>
+        <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
+        <description>
+        Add the GraphicsUtils.configureDefaultRenderingHints(Graphics) method (with a new
+        GraphicsUtils class), to allow configuration of standard anti-aliasing settings from custom
+        JComponent.paint(Graphics) implementations. These standard incantations were previously
+        duplicated extensively throughout the NetBeans codebase.
+        </description>
+        <class package="org.openide.awt" name="GraphicsUtils"/>
+        <issue number="NETBEANS-5931"/>
+    </change>
     <change id="getArrowIcon">
         <api name="awt"/>
         <summary>Added DropDownButtonFactory.getArrowIcon method.</summary>

--- a/platform/openide.awt/src/org/openide/awt/GraphicsUtils.java
+++ b/platform/openide.awt/src/org/openide/awt/GraphicsUtils.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide.awt;
+
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Toolkit;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.swing.UIManager;
+import javax.swing.JComponent;
+
+public final class GraphicsUtils {
+    private GraphicsUtils() {
+    }
+
+    private static final boolean antialias =
+        // System property to automatically turn on antialiasing for html strings
+        Boolean.getBoolean("nb.cellrenderer.antialiasing") // NOI18N
+         ||Boolean.getBoolean("swing.aatext") // NOI18N
+         ||(isGTK() && gtkShouldAntialias()) // NOI18N
+         || isAqua();
+    private static Boolean gtkAA;
+    private static Map<Object,Object> hintsMap;
+
+    private static boolean isAqua () {
+        return "Aqua".equals(UIManager.getLookAndFeel().getID());
+    }
+
+    private static boolean isGTK () {
+        return "GTK".equals(UIManager.getLookAndFeel().getID());
+    }
+
+    private static final boolean gtkShouldAntialias() {
+        if (gtkAA == null) {
+            Object o = Toolkit.getDefaultToolkit().getDesktopProperty("gnome.Xft/Antialias"); //NOI18N
+            gtkAA = Integer.valueOf(1).equals(o);
+        }
+
+        return gtkAA.booleanValue();
+    }
+
+    /**
+     * Configure default IDE-wide rendering hints on the supplied {@link Graphics} object. This
+     * enables anti-aliasing of manually painted text and 2D graphics, using settings that are
+     * consistent throughout the IDE. This method is typically called at the beginning of custom
+     * {@link JComponent#paint(Graphics)} implementations. By convention, callers passing the
+     * {@code Graphics} object from {@code paint} do not need to bother restoring the old rendering
+     * hints after they are done using the {@code Graphics} object.
+     */
+    public static void configureDefaultRenderingHints(Graphics graphics) {
+        if (graphics == null) {
+            throw new NullPointerException();
+        }
+        if (graphics instanceof Graphics2D) {
+            ((Graphics2D) graphics).addRenderingHints(getRenderingHints());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static final Map<?,?> getRenderingHints() {
+        Map<Object,Object> ret = hintsMap;
+        if (ret == null) {
+            //Thanks to Phil Race for making this possible
+            ret = (Map)(Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints")); //NOI18N
+            if (ret == null) {
+                ret = new HashMap<Object,Object>();
+                if (antialias) {
+                    ret.put(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+                }
+            }
+            if (antialias ||
+                !RenderingHints.VALUE_TEXT_ANTIALIAS_OFF.equals(ret.get(RenderingHints.KEY_TEXT_ANTIALIASING)))
+            {
+                // Required to get non-text antialiasing on Windows.
+                ret.put(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            }
+            hintsMap = Collections.unmodifiableMap(ret);
+        }
+        return ret;
+    }
+}

--- a/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
+++ b/platform/openide.awt/src/org/openide/awt/HtmlRenderer.java
@@ -24,18 +24,14 @@ import java.awt.EventQueue;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
-import java.awt.Graphics2D;
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.Shape;
-import java.awt.Toolkit;
 import java.awt.font.LineMetrics;
 import java.awt.geom.Area;
 import java.awt.geom.Rectangle2D;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
-import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
@@ -520,18 +516,6 @@ public final class HtmlRenderer {
         return _renderHTML( s, pos, g, x, y, w, h, f, defaultColor, style, paint, background, false );
     }
 
-    private static void configureRenderingHints(Graphics graphics) {
-        Graphics2D g = (Graphics2D) graphics;
-        Object desktopHints
-                = Toolkit.getDefaultToolkit().getDesktopProperty("awt.font.desktophints");
-        if (desktopHints instanceof Map<?, ?>) {
-            g.addRenderingHints((Map<?, ?>) desktopHints);
-        } else if (HtmlLabelUI.antialias) {
-            g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-        }
-
-    }
-
     /** Implementation of HTML rendering */
     static double _renderHTML(
         String s, int pos, Graphics g, int x, int y, int w, int h, Font f, Color defaultColor, int style, boolean paint,
@@ -558,7 +542,7 @@ public final class HtmlRenderer {
 
         g.setColor(defaultColor);
         g.setFont(f);
-        configureRenderingHints(g);
+        GraphicsUtils.configureDefaultRenderingHints(g);
 
         char[] chars = s.toCharArray();
         int origX = x;

--- a/platform/openide.explorer/nbproject/project.xml
+++ b/platform/openide.explorer/nbproject/project.xml
@@ -46,7 +46,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.43</specification-version>
+                        <specification-version>7.82</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/openide.explorer/src/org/openide/explorer/propertysheet/RendererFactory.java
+++ b/platform/openide.explorer/src/org/openide/explorer/propertysheet/RendererFactory.java
@@ -62,6 +62,7 @@ import javax.swing.border.BevelBorder;
 import javax.swing.border.Border;
 import javax.swing.event.ChangeListener;
 import javax.swing.plaf.basic.BasicGraphicsUtils;
+import org.openide.awt.GraphicsUtils;
 import org.openide.awt.HtmlRenderer;
 import org.openide.nodes.Node.Property;
 import org.openide.util.ImageUtilities;
@@ -791,6 +792,7 @@ final class RendererFactory {
                         && ! isEnabled() && ! htmlValueUsed) {
                     // the shadow effect from the label was making a problem
                     // let's paint the text "manually" in this case
+                    GraphicsUtils.configureDefaultRenderingHints(g);
                     g.setColor(lbl.getBackground());
                     g.fillRect(0, 0, lbl.getWidth(), lbl.getHeight());
                     g.setColor(lbl.getForeground());

--- a/platform/openide.util.ui/src/org/openide/util/VectorIcon.java
+++ b/platform/openide.util.ui/src/org/openide/util/VectorIcon.java
@@ -75,6 +75,9 @@ public abstract class VectorIcon implements Icon, Serializable {
         return height;
     }
 
+    /* We can't use org.openide.awt.GraphicsUtils.configureDefaultRenderingHints here, since this module
+    is not allowed to depend on it. But in any case, the rendering hints for VectorIcon are intended
+    to remain standardized, unaffected by settings elsewhere. */
     private static Graphics2D createGraphicsWithRenderingHintsConfigured(Graphics basedOn) {
         Graphics2D ret = (Graphics2D) basedOn.create();
         Object desktopHints =


### PR DESCRIPTION
There is a lot of duplicated logic around the NetBeans codebase relating to the setting of rendering hints on Graphics2D objects. This PR is an attempt to consolidate this logic into a single utility method (org.openide.awt.GraphicsUtils.configureRenderingHints(Graphics) in the org.openide.awt module).

This PR touches a lot of files throughout the codebase, and so should be tested in a development IDE for a while before reaching a release. I will start using this patch in my working IDE. Meanwhile I'm marking this PR as "work-in-progress".

The PR for this issue will also fix a minor issue where non-editable text values in the property sheet ended up not being anti-aliased. See attached screenshot. With the new utility method, this becomes a one-line fix.

![NoAntialiasing](https://user-images.githubusercontent.com/886243/129948234-4b2d2729-ee1d-4e01-8dbd-fc76fa6b64bb.png)

I put the new utility method in the org.openide.awt module, though alternatively it could be put in org.openide.util.ui . Here are the dependencies between these modules:

![dependencies](https://user-images.githubusercontent.com/886243/129949452-d704f0d2-8f86-437c-a55c-260a30acaaa7.png)
