### PR TITLE
By default build release-like version of .vsix

### DIFF
--- a/java/java.lsp.server/build.xml
+++ b/java/java.lsp.server/build.xml
@@ -41,11 +41,8 @@
         <chmod file="${lsp.build.dir}/bin/nbcode" perm="u+x" />
         <chmod file="${lsp.build.dir}/platform/lib/nbexec" perm="u+x"/>
         <chmod file="${lsp.build.dir}/java/maven/bin/mvn" perm="u+x" />
-        <delete file="${lsp.build.dir}/lib/nb-javac-9-api.jar" />
-        <delete file="${lsp.build.dir}/lib/nb-javac-9-impl.jar" />
-        <delete file="${lsp.build.dir}/lib/org-netbeans-modules-java-source-nbjavac.jar" />
 
-        <property name="3rdparty.modules" value="dont-install-anything"/>
+        <property name="3rdparty.modules" value=".*nbjavac.*"/>
         <autoupdate todir="${lsp.build.dir}/extra" updatecenter="file://${nb_all}/nb/updatecenters/build/classes/org/netbeans/modules/updatecenters/resources/3rdparty-catalog.xml">
             <modules includes="${3rdparty.modules}"/>
         </autoupdate>
@@ -144,11 +141,6 @@
     </target>
 
     <target name="test-vscode-ext" depends="test-lsp-server" description="Tests the Visual Studio Code extension built by 'build-vscode-ext' target.">
-        <exec executable="npm" failonerror="true" dir="vscode">
-            <arg value="--allow-same-version"/>
-            <arg value="run" />
-            <arg value="nbjavac" />
-        </exec>
         <exec executable="npm" failonerror="true" dir="vscode">
             <arg value="--allow-same-version"/>
             <arg value="run" />

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
@@ -24,7 +24,6 @@
     <folder name="Services">
         <folder name="AutoupdateType">
             <file name="82pluginportal-update-provider.instance_hidden"/>
-            <file name="distribution-update-provider.instance_hidden"/>
             <file name="pluginportal-update-provider.instance_hidden"/>
         </folder>
     </folder>

--- a/java/java.lsp.server/nbcode/integration/test/unit/src/org/netbeans/modules/nbcode/integration/VerifyPresentUpdateCentersTest.java
+++ b/java/java.lsp.server/nbcode/integration/test/unit/src/org/netbeans/modules/nbcode/integration/VerifyPresentUpdateCentersTest.java
@@ -19,20 +19,22 @@
 package org.netbeans.modules.nbcode.integration;
 
 import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
 import org.netbeans.junit.NbModuleSuite;
 import org.netbeans.junit.NbTestCase;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
-public class VerifyJustOneUpdateCenterTest extends NbTestCase {
+public class VerifyPresentUpdateCentersTest extends NbTestCase {
 
-    public VerifyJustOneUpdateCenterTest(String name) {
+    public VerifyPresentUpdateCentersTest(String name) {
         super(name);
     }
 
     public static junit.framework.Test suite() {
-        return NbModuleSuite.createConfiguration(VerifyJustOneUpdateCenterTest.class).
-            gui(true).
+        return NbModuleSuite.createConfiguration(VerifyPresentUpdateCentersTest.class).
+            gui(false).
             suite();
     }
 
@@ -42,7 +44,14 @@ public class VerifyJustOneUpdateCenterTest extends NbTestCase {
         FileObject au = services.getFileObject("AutoupdateType");
         assertNotNull("AutoUpdate folder found", au);
         FileObject[] arr = au.getChildren();
-        assertEquals("Just one AutoUpdate center registration: " + Arrays.toString(arr), 1, arr.length);
-        assertEquals("3rdparty.instance", arr[0].getNameExt());
+        assertEquals("Two AutoUpdate center registrations: " + Arrays.toString(arr), 2, arr.length);
+
+        Set<String> names = new TreeSet<>();
+        names.add(arr[0].getNameExt());
+        names.add(arr[1].getNameExt());
+
+        String[] arrNames = names.toArray(new String[0]);
+        assertEquals("3rdparty.instance", arrNames[0]);
+        assertEquals("distribution-update-provider.instance", arrNames[1]);
     }
 }

--- a/java/java.lsp.server/vscode/BUILD.md
+++ b/java/java.lsp.server/vscode/BUILD.md
@@ -47,13 +47,13 @@ java.lsp.server$ ant build-vscode-ext
 The resulting extension is then in the `build` directory, with the `.vsix` extension.
 #### Build Options
 - `-Dvsix.version=x.y.z`can be used to set release version. E.g. set this option to `12.3.0` to get proper NetBeans release version for extension. 
-- `-D3rdparty.modules=.*nbjavac.*` can be set to include nb-javac which allows extension to run out of the box on JDK8. For **zsh** it is necessary to wrap it: `-D3rdparty.modules='.*nbjavac.*'`
+- `-D3rdparty.modules=` property can be set to different value than `.*nbjavac.*` to not inlcude nb-javac which allows extension to run out of the box on JDK8.
 
-The build of NetBeans VSCode extension with nb-javac included, for version 12.3.0 then looks like this:
+The build of NetBeans VSCode extension with nb-javac included, for version 12.6.0 then looks like this:
 ```bash
 netbeans$ ant build
 netbeans$ cd java/java.lsp.server
-java.lsp.server$ ant build-vscode-ext -D3rdparty.modules=.*nbjavac.* -Dvsix.version=12.3.0
+java.lsp.server$ ant build-vscode-ext -Dvsix.version=12.6.0
 ```
 
 
@@ -63,13 +63,12 @@ If you want to develop the extension, use these steps for building instead:
 
 ```bash
 netbeans$ cd java/java.lsp.server
-java.lsp.server$ ant build-lsp-server -D3rdparty.modules=.*nbjavac.*
+java.lsp.server$ ant build-lsp-server
 java.lsp.server$ cd vscode
 vscode$ npm install
 vscode$ npm run watch
 ```
 
-The `3rdparty.modules` property doesn't have to be set at all.
 This target is faster than building the `.vsix` file. Find the instructions
 for running and debugging below.
 


### PR DESCRIPTION
The `.vsix` file as published on [marketplace](https://marketplace.visualstudio.com/items?itemName=ASF.apache-netbeans-java) has traditionally been assembled together with `nbjavac` library for better cross-JDK editing support and ability to run the extension on JDK8 without any additional downloads. Time to make it the default. That's what  1d74cad does.

In addition to that I am opening access to default release catalog - originally removed in a panic by ac183a7904d1c53d7e89df18e36bcc8188005b19 - turned out that properly building the `.vsix` file with proper metarelease information and also fa85b5178041cba0ab65d70ec2e6a6340a04ef5e is enough to prevent the former problems.

Moreover having the update center enabled allows one to install additional modules not packaged in `.vsix` by default:
```bash
java/java.lsp.server/vscode$ npm run nbcode -- --modules --install .*debugger.*

> apache-netbeans-java@12.4.0 nbcode /home/devel/NetBeansProjects/netbeans2/java/java.lsp.server/vscode
> node ./out/nbcode.js "--modules" "--install" ".*debugger.*"

Installing org.netbeans.modules.debugger.jpda.ant@1.51

Installing org.netbeans.modules.debugger.jpda.heapwalk@1.44
Installing org.netbeans.modules.debugger.jpda.visual@1.30
Installing org.netbeans.modules.web.javascript.debugger@1.28
Installing org.netbeans.modules.ant.debugger@1.50.0.2
Installing org.netbeans.modules.debugger.jpda.jsui@1.13
Installing org.netbeans.modules.debugger.jpda.js@1.23
Installing org.netbeans.modules.debugger.jpda.kit@1.28

modules=21

Establishing a connection ...
Establishing a connection ...
```
which greatly enhances the flexibility of our VSCode support.