### PR TITLE
Use static type checking to attribute AST

### DIFF
--- a/groovy/groovy.editor/apichanges.xml
+++ b/groovy/groovy.editor/apichanges.xml
@@ -86,7 +86,7 @@ is the proper place.
 <changes>
     <change id="ASTPath.outer">
         <api name="groovy-parsing"/>
-        <summary>Alternative construction for path more suitable for expressions</summary>
+        <summary>Alternative construction for path more suitable for expressions, API to resolve types</summary>
         <version major="1" minor="80"/>
         <date day="25" month="8" year="2021"/>
         <author login="sdedic"/>
@@ -96,8 +96,12 @@ is the proper place.
                 ASTPath can be constructed so it terminates on the outermost expression that spans
                 the given  index. By default the path was constructed to the deepest node.
             </p>
+            <p>
+                GroovyParserResult can resolve type names to ClassNodes using proper environment.
+            </p>
         </description>
         <class package="org.netbeans.modules.groovy.editor.api" name="ASTPath"/>
+        <class package="org.netbeans.modules.groovy.editor.api.parser" name="GroovyParserResult"/>
     </change>
     <change id="CompletionContext.setDeclaringClass">
         <api name="groovy-completion"/>

--- a/groovy/groovy.editor/apichanges.xml
+++ b/groovy/groovy.editor/apichanges.xml
@@ -84,6 +84,36 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="ASTPath.outer">
+        <api name="groovy-parsing"/>
+        <summary>Alternative construction for path more suitable for expressions</summary>
+        <version major="1" minor="80"/>
+        <date day="25" month="8" year="2021"/>
+        <author login="sdedic"/>
+        <compatibility addition="yes" binary="compatible" semantic="compatible" />
+        <description>
+            <p>
+                ASTPath can be constructed so it terminates on the outermost expression that spans
+                the given  index. By default the path was constructed to the deepest node.
+            </p>
+        </description>
+        <class package="org.netbeans.modules.groovy.editor.api" name="ASTPath"/>
+    </change>
+    <change id="CompletionContext.setDeclaringClass">
+        <api name="groovy-completion"/>
+        <summary>Accessor for CompletionContext.declaringClass</summary>
+        <version major="1" minor="80"/>
+        <date day="25" month="8" year="2021"/>
+        <author login="sdedic"/>
+        <compatibility addition="yes" binary="compatible" semantic="compatible" />
+        <description>
+            <p>
+                Added setter for <a href="@TOP@/org/netbeans/modules/groovy/editor/api/completion/util/CompletionContext.html#declaringClass">
+                    CompletionContext.declaringClass</a> that refreshes access restrictions.
+            </p>
+        </description>
+        <class package="org.netbeans.modules.groovy.editor.api.completion.util" name="CompletionContext"/>
+    </change>
     <change id="DisableTransformers">
       <api name="groovy-parsing"/>
       <summary>Allow to enable/disable AST transformation during parsing and indexing</summary>

--- a/groovy/groovy.editor/apichanges.xml
+++ b/groovy/groovy.editor/apichanges.xml
@@ -93,7 +93,7 @@ is the proper place.
         <compatibility addition="yes" binary="compatible" semantic="compatible" />
         <description>
             <p>
-                ASTPath can be constructed so it terminates on the outermost expression that spans
+                ASTPath can be constructed so it terminates on the outer expression that spans
                 the given  index. By default the path was constructed to the deepest node.
             </p>
             <p>
@@ -103,7 +103,7 @@ is the proper place.
         <class package="org.netbeans.modules.groovy.editor.api" name="ASTPath"/>
         <class package="org.netbeans.modules.groovy.editor.api.parser" name="GroovyParserResult"/>
     </change>
-    <change id="CompletionContext.setDeclaringClass">
+    <change id="Completion.improvements">
         <api name="groovy-completion"/>
         <summary>Accessor for CompletionContext.declaringClass</summary>
         <version major="1" minor="80"/>
@@ -113,10 +113,12 @@ is the proper place.
         <description>
             <p>
                 Added setter for <a href="@TOP@/org/netbeans/modules/groovy/editor/api/completion/util/CompletionContext.html#declaringClass">
-                    CompletionContext.declaringClass</a> that refreshes access restrictions.
+                    CompletionContext.declaringClass</a> that refreshes access restrictions. Added flag to only present static members. 
+                    Added sort priority to <a href="@TOP@/org/netbeans/modules/groovy/editor/api/completion/CompletionItem.html">CompletionItem</a>.
             </p>
         </description>
         <class package="org.netbeans.modules.groovy.editor.api.completion.util" name="CompletionContext"/>
+        <class package="org.netbeans.modules.groovy.editor.api.completion" name="CompletionItem"/>
     </change>
     <change id="DisableTransformers">
       <api name="groovy-parsing"/>

--- a/groovy/groovy.editor/manifest.mf
+++ b/groovy/groovy.editor/manifest.mf
@@ -3,4 +3,4 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.groovy.editor/3
 OpenIDE-Module-Layer: org/netbeans/modules/groovy/editor/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/groovy/editor/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.79
+OpenIDE-Module-Specification-Version: 1.80

--- a/groovy/groovy.editor/nbproject/project.xml
+++ b/groovy/groovy.editor/nbproject/project.xml
@@ -207,7 +207,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>1.7</specification-version>
+                        <specification-version>1.53</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/GroovyIndex.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/GroovyIndex.java
@@ -241,7 +241,8 @@ public final class GroovyIndex {
             String[] constructors = map.getValues(GroovyIndexer.CONSTRUCTOR);
 
             for (String constructor : constructors) {
-                String paramList = constructor.substring(constructor.indexOf(";") + 1, constructor.length()); // NOI18N
+                String[] parts = constructor.split(";");
+                String paramList = parts.length > 1 ? parts[1] : ""; // NOI18N
                 String[] params = paramList.split(",");
 
                 List<MethodParameter> methodParams = new ArrayList<>();
@@ -250,8 +251,11 @@ public final class GroovyIndex {
                         methodParams.add(new MethodParameter(param, GroovyUtils.stripPackage(param)));
                     }
                 }
-
-                result.add(new IndexedMethod(map, className, className, "void", methodParams, "", 0));
+                int flags = 0;
+                if (parts.length > 2) {
+                    flags = IndexedElement.stringToFlag(parts[2], 0);
+                }
+                result.add(new IndexedMethod(map, className, className, "void", methodParams, "", flags));
             }
         }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionItem.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/CompletionItem.java
@@ -67,6 +67,8 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
     private static volatile ImageIcon javaIcon;
     private static volatile ImageIcon newConstructorIcon;
     
+    private int sortOverride;
+    
     static {
         CompletionAccessor.setInstance(new CompletionAccessor() {
             @Override
@@ -132,6 +134,12 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
             public CompletionItem createDynamicMethod(int anchorOffset, String name, List<MethodParameter> parameters, String returnType, boolean prefix) {
                 return new DynamicMethodItem(anchorOffset, name, parameters, returnType, prefix);
             }
+
+            @Override
+            public CompletionItem sortOverride(CompletionItem item, int override) {
+                item.sortOverride = override;
+                return item;
+            }
         });
     }
 
@@ -162,6 +170,10 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
     @Override
     public Set<Modifier> getModifiers() {
         return element.getModifiers();
+    }
+
+    public int getSortPrioOverride() {
+        return sortOverride;
     }
 
     @Override
@@ -291,7 +303,7 @@ public abstract class CompletionItem extends DefaultCompletionProposal {
                 if (sb.length() > 0) {
                     sb.append(", ");
                 }
-                sb.append(GroovyUtils.stripPackage(par.getFqnType()));
+                sb.append(GroovyUtils.stripPackage(par.getType()));
             }
             return sb.toString();
         }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/CompletionContext.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/CompletionContext.java
@@ -115,13 +115,19 @@ public final class CompletionContext {
         this.declaringClass = dc == null ? null : dc.redirect();
     }
 
+    /**
+     * @return true, if just static members or meta-members should be considered.
+     * @since 1.80
+     */
     public boolean isStaticMembers() {
         return staticMembers;
     }
 
     /**
-     * If nonzero, the provider should 
-     * @return 
+     * If nonzero, the provider should adjust CompletionItems priority by this amount
+     * to sort the items lower/higher than usual.
+     * @return adjustment for sort priority.
+     * @since 1.80
      */
     public int getAddSortOverride() {
         return addSortOverride;
@@ -130,7 +136,8 @@ public final class CompletionContext {
     /**
      * Set an offset to the default sort priority for the provided items.
      * The provider should increase / decrease sort priority of the items
-     * @param addSortOverride 
+     * @param addSortOverride the delta.
+     * @since 1.80
      */
     public void setAddSortOverride(int addSortOverride) {
         this.addSortOverride = addSortOverride;

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/ContextHelper.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/completion/util/ContextHelper.java
@@ -156,6 +156,31 @@ public final class ContextHelper {
         return null;
     }
 
+    public static ASTNode getSurroundingClassMember(CompletionContext request) {
+        if (request.path == null) {
+            LOG.log(Level.FINEST, "path == null"); // NOI18N
+            return null;
+        }
+
+        LOG.log(Level.FINEST, "getSurroundingMethodOrClosure() ----------------------------------------");
+        LOG.log(Level.FINEST, "Path : {0}", request.path);
+
+        for (Iterator<ASTNode> it = request.path.iterator(); it.hasNext();) {
+            ASTNode current = it.next();
+            if (current instanceof MethodNode) {
+                MethodNode mn = (MethodNode) current;
+                LOG.log(Level.FINEST, "Found Method: {0}", mn.getName()); // NOI18N
+                return mn;
+            } else if (current instanceof FieldNode) {
+                FieldNode fn = (FieldNode) current;
+                return fn;
+            } else if (current instanceof ClassNode) {
+                return null;
+            }
+        }
+        return null;
+    }
+    
     /**
      * Finds out if the given {@link CompletionContext} is a complete-constructor call.
      * 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ElementHandleSupport.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ElementHandleSupport.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.groovy.editor.api.elements;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.codehaus.groovy.ast.ASTNode;
 import org.netbeans.modules.csl.api.ElementHandle;
@@ -260,6 +261,41 @@ public class ElementHandleSupport {
             return OffsetRange.NONE;
         }
 
+        @Override
+        public int hashCode() {
+            int hash = 7;
+            hash = 79 * hash + Objects.hashCode(this.className);
+            hash = 79 * hash + Objects.hashCode(this.elementName);
+            hash = 79 * hash + Objects.hashCode(this.kind);
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            final SimpleElementHandle other = (SimpleElementHandle) obj;
+            if (!Objects.equals(this.className, other.className)) {
+                return false;
+            }
+            if (!Objects.equals(this.elementName, other.elementName)) {
+                return false;
+            }
+            if (this.kind != other.kind) {
+                return false;
+            }
+            if (!Objects.equals(this.modifiers, other.modifiers)) {
+                return false;
+            }
+            return true;
+        }
 
     }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ast/ASTElement.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ast/ASTElement.java
@@ -54,6 +54,9 @@ public abstract class ASTElement extends GroovyElement {
         super(in, name);
         this.node = node;
         this.children = new ArrayList<>();
+        if (node != null) {
+            node.putNodeMetaData(ASTElement.class, this);
+        }
     }
 
     public ASTNode getNode() {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ast/ASTField.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/elements/ast/ASTField.java
@@ -41,6 +41,11 @@ public final class ASTField extends ASTElement {
     public String getName() {
         return name;
     }
+
+    @Override
+    public String getSignature() {
+        return name;
+    }
     
     @Override
     public ElementKind getKind() {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/FilteredStaticErrors.lst
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/FilteredStaticErrors.lst
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# Error messages from Groovy static type analysis, that are more artifacts of the static
+# typing visitor.
+# Each line is a regexp that has to fully match the message. Lines starting with # or empty
+# lines are ignored.
+
+Cannot statically compile constructor implicitly including non static elements from object initializers, properties or fields
+Multiple assignments without list expressions on the right hand side are unsupported in static type checking mode
+Dynamic keys in map-style constructors are unsupported in static type checking
+cannot resolve dynamic method name at compile time.
+Due to their dynamic nature, usage of categories is not possible with static type checking active

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
@@ -94,6 +94,12 @@ import org.openide.util.Lookup;
  */
 public class GroovyParser extends Parser {
 
+    /**
+     * If set, enables reporting of static type checking in editor. As there are a lot of false positives,
+     * this feature remains 'developer only' at the moment, so false reports can be seen & mitigated easily.
+     */
+    private static final boolean STATIC_ERRORS = Boolean.getBoolean(GroovyParser.class.getName() + ".staticCompileErrors");
+
     private static final Logger LOG = Logger.getLogger(GroovyParser.class.getName());
 
     private static final AtomicLong PARSING_TIME = new AtomicLong(0);
@@ -610,10 +616,14 @@ public class GroovyParser extends Parser {
             try {
                 compilationUnit.compile(Phases.CLASS_GENERATION);
                 NbGroovyErrorCollector coll = (NbGroovyErrorCollector)compilationUnit.getErrorCollector();
-                // enable static errors, they were separated aside, so that later compilation phases can run
-                coll.setShowAllErrors(true);
-                // and let the Collector to fail...
-                coll.failIfErrors();
+                // PENDING: there are too many spurious errors from static type analysis (now). Let's make the errors
+                // a dev-only feature fow now.
+                if (STATIC_ERRORS) {
+                    // enable static errors, they were separated aside, so that later compilation phases can run
+                    coll.setShowAllErrors(true);
+                    // and let the Collector to fail...
+                    coll.failIfErrors();
+                }
             } catch (CancellationException ex) {
                 // cancelled probably
                 if (isCancelled()) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
@@ -16,13 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.netbeans.modules.groovy.editor.api.parser;
 
 import groovy.lang.GroovyClassLoader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.security.CodeSource;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -35,15 +37,24 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.BadLocationException;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.AnnotationNode;
+import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.CompileUnit;
+import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.ModuleNode;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.ErrorCollector;
 import org.codehaus.groovy.control.Phases;
+import org.codehaus.groovy.control.SourceUnit;
 import org.codehaus.groovy.control.messages.Message;
 import org.codehaus.groovy.control.messages.SimpleMessage;
 import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
 import org.codehaus.groovy.syntax.SyntaxException;
+import org.codehaus.groovy.transform.StaticTypesTransformation;
+import org.codehaus.groovy.transform.stc.StaticTypeCheckingVisitor;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.source.ClasspathInfo;
@@ -76,7 +87,9 @@ import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 
 /**
- * Groovy Parser interface. This class should not be probably public. Do not use it outside the module.
+ * Groovy Parser interface. This class should not be probably public. Do not use
+ * it outside the module.
+ *
  * @author Martin Adamek
  */
 public class GroovyParser extends Parser {
@@ -151,6 +164,16 @@ public class GroovyParser extends Parser {
             // FIXME just temporary
             lastResult = createParseResult(snapshot, null, null);
         }
+    }
+
+    /**
+     * Post-configures the parser result with CompilationUnit, so that API clients
+     * may resolve ClassNodes.
+     */
+    GroovyParserResult createParseResult0(Snapshot snapshot, org.codehaus.groovy.control.CompilationUnit cu, ModuleNode rootNode, ErrorCollector errorCollector) {
+        GroovyParserResult gpr = createParseResult(snapshot, rootNode, errorCollector);
+        gpr.setUnit(cu);
+        return gpr;
     }
 
     protected GroovyParserResult createParseResult(Snapshot snapshot, ModuleNode rootNode, ErrorCollector errorCollector) {
@@ -451,7 +474,64 @@ public class GroovyParser extends Parser {
         }
         return configuration;
     }
-    
+
+    /**
+     * Provides special processing: injects {@link StaticTypeCheckingVisitor} in {@link Phases.INSTRUCTION_SELECTION}
+     * compilation phase. Also overrides ErrorCollector implementation with {@link NbGroovyErrorCollector}.
+     */
+    static class CU extends CompilationUnit {
+
+        /**
+         * Disable type attribution for indexing now.
+         */
+        final boolean indexing;
+
+        StaticTypesTransformation typesXform = new StaticTypesTransformation() {
+            @Override
+            protected StaticTypeCheckingVisitor newVisitor(SourceUnit unit, ClassNode node) {
+                return new NbGroovyErrorCollector.NbStaticTypeCheckingVisitor(unit, node, (NbGroovyErrorCollector)errorCollector);
+            }
+        };
+
+        public CU(boolean indexing, GroovyParser parser, CompilerConfiguration configuration, CodeSource security, GroovyClassLoader loader, GroovyClassLoader transformationLoader, ClasspathInfo cpInfo, ClassNodeCache classNodeCache) {
+            super(parser, configuration, security, loader, transformationLoader, cpInfo, classNodeCache);
+            this.indexing = indexing;
+            this.errorCollector = new NbGroovyErrorCollector(configuration);
+        }
+
+        public CU(boolean indexing, GroovyParser parser, CompilerConfiguration configuration, CodeSource security, GroovyClassLoader loader, GroovyClassLoader transformationLoader, ClasspathInfo cpInfo, ClassNodeCache classNodeCache, boolean isIndexing) {
+            super(parser, configuration, security, loader, transformationLoader, cpInfo, classNodeCache, isIndexing);
+            this.indexing = indexing;
+            this.errorCollector = new NbGroovyErrorCollector(configuration);
+        }
+
+        /**
+         * Inject static compilation transofmrations; apply them in the
+         *
+         * @param phase
+         * @throws CompilationFailedException
+         */
+        @Override
+        public void gotoPhase(int phase) throws CompilationFailedException {
+            super.gotoPhase(phase);
+            if (phase != Phases.INSTRUCTION_SELECTION) {
+                return;
+            }
+            if (indexing) {
+                return;
+            }
+            typesXform.setCompilationUnit(this);
+            ClassNode annoClass = getClassNodeResolver().resolveName("groovy.transform.TypeChecked", this).getClassNode();
+            for (SourceUnit su : sources.values()) {
+                for (ClassNode cn : su.getAST().getClasses()) {
+                    AnnotationNode fakeTypeChecked = new AnnotationNode(annoClass);
+                    cn.addAnnotation(fakeTypeChecked);
+                    typesXform.visit(new ASTNode[]{fakeTypeChecked, cn}, su);
+                }
+            }
+        }
+    }
+
     @SuppressWarnings("unchecked")
     GroovyParserResult parseBuffer(final Context context, final Sanitize sanitizing) {
         if (isCancelled()) {
@@ -506,8 +586,8 @@ public class GroovyParser extends Parser {
         
         boolean indexing = IndexingSupport.isIndexingTask(context.parserTask);
         configuration = makeConfiguration(configuration, context, indexing);
-        org.codehaus.groovy.control.CompilationUnit compilationUnit = new CompilationUnit(this, configuration,
-                null, classLoader, transformationLoader, cpInfo, classNodeCache, 
+        org.codehaus.groovy.control.CompilationUnit compilationUnit = new CU(indexing, this, configuration,
+                null, classLoader, transformationLoader, cpInfo, classNodeCache,
                 indexing);
         InputStream inputStream = new ByteArrayInputStream(source.getBytes());
         compilationUnit.addSource(fileName, inputStream);
@@ -529,6 +609,11 @@ public class GroovyParser extends Parser {
         try {
             try {
                 compilationUnit.compile(Phases.CLASS_GENERATION);
+                NbGroovyErrorCollector coll = (NbGroovyErrorCollector)compilationUnit.getErrorCollector();
+                // enable static errors, they were separated aside, so that later compilation phases can run
+                coll.setShowAllErrors(true);
+                // and let the Collector to fail...
+                coll.failIfErrors();
             } catch (CancellationException ex) {
                 // cancelled probably
                 if (isCancelled()) {
@@ -542,10 +627,11 @@ public class GroovyParser extends Parser {
             String localizedMessage = e.getLocalizedMessage();
 
             ErrorCollector errorCollector = compilationUnit.getErrorCollector();
+            List<? extends Message> filtered = errorCollector.getErrors();
             if (errorCollector.hasErrors()) {
-                Message message = errorCollector.getLastError();
+                Message message = filtered.get(filtered.size() - 1);
                 if (message instanceof SyntaxErrorMessage) {
-                    SyntaxException se = ((SyntaxErrorMessage)message).getCause();
+                    SyntaxException se = ((SyntaxErrorMessage) message).getCause();
 
                     // if you have a single line starting with: "$
                     // SyntaxException.getStartLine() returns 0 instead of 1
@@ -589,8 +675,8 @@ public class GroovyParser extends Parser {
                     localizedMessage = se.getLocalizedMessage();
                 }
             } else {
-                if (LOG.isLoggable(Level.FINE)) {
-                    if (e instanceof CancellationException) {
+                if (e instanceof CancellationException) {
+                    if (LOG.isLoggable(Level.FINE)) {
                         LOG.log(Level.FINE, null, e);
                     }
                 }
@@ -646,7 +732,7 @@ public class GroovyParser extends Parser {
         if (module != null) {
             context.sanitized = sanitizing;
             // FIXME parsing API
-            GroovyParserResult r = createParseResult(context.snapshot, module, compilationUnit.getErrorCollector());
+            GroovyParserResult r = createParseResult0(context.snapshot, compilationUnit, module, compilationUnit.getErrorCollector());
             r.setSanitized(context.sanitized, context.sanitizedRange, context.sanitizedContents);
             return r;
         } else {
@@ -759,7 +845,7 @@ public class GroovyParser extends Parser {
                             notifyError(context, null, Severity.ERROR, ex.getMessage(), null, startOffset, endOffset, sanitizing);
                         }
                     } else if (object instanceof SimpleMessage) {
-                        String message = ((SimpleMessage)object).getMessage();
+                        String message = ((SimpleMessage) object).getMessage();
                         notifyError(context, null, Severity.ERROR, message, null, -1, sanitizing);
                     } else {
                         notifyError(context, null, Severity.ERROR, "Error", null, -1, sanitizing);

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/NbGroovyErrorCollector.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/NbGroovyErrorCollector.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.api.parser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.control.ErrorCollector;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.control.messages.Message;
+import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
+import org.codehaus.groovy.transform.StaticTypesTransformation;
+import org.codehaus.groovy.transform.stc.StaticTypeCheckingVisitor;
+
+/**
+ * Since the parsing uses static typing, some of the reported errors must be filtered
+ * out.
+ * <p/>
+ * We want the parsing to fail with errors and report static type errors - but at the same time
+ * we need the later compilation phases to proceed. So this Collector filters out static
+ * typing errors, does not report them until told at the end of the compilation.
+ * <p/>
+ * Some of the errors are really artifact of static compilation and must be filtered out completely.
+ * They are collected, but not reported anywhere at this moment. The list of errors to be 
+ * filtered out si in resource {@code FilteredStaticErrors.lst}, see comments in there for details.
+ * 
+ * @author sdedic
+ */
+class NbGroovyErrorCollector extends ErrorCollector {
+
+    /**
+     * Resource that defines error messages that should be filtered out completely. Groovy rejects some
+     * constructions for static compilation, but we only use static compile to force attribution of the
+     * AST.
+     */
+    private static final String RESOURCE_FILTERED_ERRORS = "FilteredStaticErrors.lst"; // NOI18N
+    
+    private List<Message> filteredErrors = new ArrayList<>();
+    private List<Message> staticAnalysisErrors = new ArrayList<>();
+    private Map<Message, ASTNode> errorSources;
+    
+    /**
+     * If true, {@link #$getErrors} and the like return all errors, including the
+     * ones filtered out.
+     */
+    private boolean showStaticCompileErrors;
+    private boolean showFilteredErrors;
+    
+    /**
+     * Cached combined errors.s
+     */
+    private List<Message> combinedErrors;
+    
+    /**
+     * Maps an error message to the AST node. The message itself contains just line:column info
+     */
+    private Map<Message, ASTNode>   error2Node = new HashMap<>();
+    
+    /**
+     * Reverse map that holds err messages for an AST node
+     */
+    private Map<ASTNode, List<Message>>   node2Errors = new HashMap<>();
+    
+    /**
+     * Ambiguous references reported for a constructor or a method call, May be useful in
+     * code completion
+     */
+    private Map<ASTNode, AmbiguousReference> amiguousCandidates = new HashMap<>();
+    
+    /**
+     * Not used at the moment, but when ambiguous reference is reported, the reporter passes 
+     * in candidate symbols, so they are saved & attached to the error and the referencing
+     * AST node.
+     */
+    static class AmbiguousReference {
+        /**
+         * The referencing node
+         */
+        private final Expression astNode;
+        
+        /**
+         * Candidate methods
+         */
+        private final List<MethodNode> candidates;
+        
+        /**
+         * Actual parameter types
+         */
+        private final List<ClassNode> parameterTypes;
+
+        public AmbiguousReference(Expression astNode, List<MethodNode> candidates, List<ClassNode> parameterTypes) {
+            this.astNode = astNode;
+            this.candidates = candidates;
+            this.parameterTypes = parameterTypes;
+        }
+
+        public Expression getAstNode() {
+            return astNode;
+        }
+
+        public List<MethodNode> getCandidates() {
+            return candidates;
+        }
+
+        public List<ClassNode> getParameterTypes() {
+            return parameterTypes;
+        }
+    }
+
+    public NbGroovyErrorCollector(CompilerConfiguration configuration) {
+        super(configuration);
+        initErrorFilter();
+    }
+
+    public List<Message> getFilteredErrors() {
+        return filteredErrors;
+    }
+
+    public void setFilteredErrors(List<Message> filteredErrors) {
+        this.filteredErrors = filteredErrors;
+        combinedErrors = null;
+    }
+
+    public boolean isShowAllErrors() {
+        return showStaticCompileErrors;
+    }
+
+    public void setShowAllErrors(boolean showAllErrors) {
+        this.showStaticCompileErrors = showAllErrors;
+        combinedErrors = null;
+    }
+    
+     protected void failIfErrors() throws CompilationFailedException {
+        super.failIfErrors();
+    }
+
+    @Override
+    public boolean hasErrors() {
+        List<? extends Message> errs = getErrors();
+        return errs != null && !errs.isEmpty();
+    }
+
+    @Override
+    public List<? extends Message> getErrors() {
+        return showStaticCompileErrors ? getAllErrors() : super.getErrors();
+    }
+
+    @Override
+    public Message getError(int index) {
+        List<? extends Message> errs = getErrors();
+        return index >= errs.size() ? null : errs.get(index);
+    }
+
+    @Override
+    public int getErrorCount() {
+        List<? extends Message> errs = getErrors();
+        return errs.size();
+    }
+
+    private void addStaticTypingError(SyntaxErrorMessage m) {
+        String msg = m.getCause().getMessage();
+        if (!msg.startsWith(StaticTypesTransformation.STATIC_ERROR_PREFIX)) {
+            super.addErrorAndContinue(m);
+            return;
+        }
+        if (filtersError(msg)) {
+            filteredErrors.add(m);
+        } else {
+            staticAnalysisErrors.add(m);
+        }
+    }
+    
+    public List<Message> getAllErrors() {
+        if (combinedErrors == null) {
+            List<? extends Message> base = super.getErrors();
+            combinedErrors = new ArrayList<>();
+            if (base != null) {
+                combinedErrors.addAll(base);
+            }
+            combinedErrors.addAll(staticAnalysisErrors);
+            if (showFilteredErrors) {
+                combinedErrors.addAll(filteredErrors);
+            }
+        }
+        return combinedErrors;
+    }
+    
+    private ASTNode errNode = null;
+
+    @Override
+    public void addErrorAndContinue(String error, ASTNode node, SourceUnit source) {
+        ASTNode n = errNode;
+        errNode = node;
+        try {
+            super.addErrorAndContinue(error, node, source); 
+        } finally {
+            errNode = n;
+        }
+    }
+
+    @Override
+    public void addErrorAndContinue(Message message) {
+        combinedErrors = null;
+        if (errNode != null) {
+            error2Node.put(message, errNode);
+            node2Errors.computeIfAbsent(errNode, (n) -> new ArrayList<>(2)).add(message);
+        }
+        if (message instanceof SyntaxErrorMessage) {
+            SyntaxErrorMessage sm = (SyntaxErrorMessage) message;
+            addStaticTypingError(sm);
+            return;
+        }
+        super.addErrorAndContinue(message);
+    }
+    
+    private static Pattern errorFilter;
+    
+    private void initErrorFilter() {
+        if (errorFilter != null) {
+            return;
+        }
+        StringBuilder sb = new StringBuilder();
+        try (InputStream is = NbGroovyErrorCollector.class.getResourceAsStream(RESOURCE_FILTERED_ERRORS);
+             BufferedReader r = new BufferedReader(new InputStreamReader(is, "UTF-8"))) {
+            String line;
+            
+            while ((line = r.readLine()) != null) {
+                if (line.startsWith("#")) {
+                    continue;
+                }
+                line = line.trim();
+                if (line.isEmpty()) {
+                    continue;
+                }
+                if (sb.length() > 0) {
+                    sb.append("|");
+                }
+                sb.append(line.trim());
+            }
+            errorFilter = Pattern.compile(sb.toString());
+        } catch (IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+    
+    void markAmbiguous(Expression node, List<MethodNode> candidates, List<ClassNode> types) {
+        amiguousCandidates.put(errNode, new AmbiguousReference(node, candidates, types));
+    }
+
+    public boolean filtersError(String msg) {
+        if (msg.startsWith(StaticTypesTransformation.STATIC_ERROR_PREFIX)) {
+            msg = msg.substring(StaticTypesTransformation.STATIC_ERROR_PREFIX.length()).trim();
+        } else {
+            return false;
+        }
+        return errorFilter.matcher(msg).matches();
+    }
+
+    /**
+     * Visitor that reports candidates for an ambiguous call to the collector. The original
+     * method just prettyprints them.
+     */
+    static class NbStaticTypeCheckingVisitor extends StaticTypeCheckingVisitor {
+        private final NbGroovyErrorCollector errCollector;
+        
+        NbStaticTypeCheckingVisitor(SourceUnit source, ClassNode classNode, NbGroovyErrorCollector errorCollector) {
+            super(source, classNode);
+            this.errCollector = errorCollector;
+        }
+
+        @Override
+        protected void addAmbiguousErrorMessage(List<MethodNode> foundMethods, String name, ClassNode[] args, Expression expr) {
+            errCollector.markAmbiguous(expr, foundMethods, Arrays.asList(args));
+            super.addAmbiguousErrorMessage(foundMethods, name, args, expr);
+        }
+    }
+}

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/CompilationUnit.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/CompilationUnit.java
@@ -39,7 +39,6 @@ import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.GenericsType;
 import org.codehaus.groovy.ast.MixinNode;
 import org.codehaus.groovy.control.ClassNodeResolver.LookupResult;
-import org.codehaus.groovy.control.ClassNodeResolver;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.source.ClasspathInfo;
@@ -55,7 +54,7 @@ import org.openide.util.Exceptions;
  *
  * @author Martin Adamek
  */
-public final class CompilationUnit extends org.codehaus.groovy.control.CompilationUnit {
+public class CompilationUnit extends org.codehaus.groovy.control.CompilationUnit {
     static CompilerConfiguration processConfiguration(CompilerConfiguration configuration, boolean isIndexing) {
         Map<String, Boolean> opts = configuration.getOptimizationOptions();
         opts.put("classLoaderResolving", Boolean.FALSE); // NOI18N

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/BaseCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/BaseCompletion.java
@@ -20,8 +20,8 @@
 package org.netbeans.modules.groovy.editor.completion;
 
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -44,8 +44,8 @@ public abstract class BaseCompletion {
     protected static final Logger LOG = Logger.getLogger(BaseCompletion.class.getName());
 
 
-    public abstract boolean complete(List<CompletionProposal> proposals, CompletionContext request, int anchor);
-
+    public abstract boolean complete(Map<Object, CompletionProposal> proposals, CompletionContext request, int anchor);
+    
 
     protected class PackageCompletionRequest {
         String fullString = "";

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/BaseCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/BaseCompletion.java
@@ -183,4 +183,8 @@ public abstract class BaseCompletion {
 
         return result;
     }
+    
+    public interface SortOverride {
+        public void setPriorityOverride(int override);
+    }
 }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/ConstructorGenerationCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/ConstructorGenerationCompletion.java
@@ -20,13 +20,14 @@
 package org.netbeans.modules.groovy.editor.completion;
 
 import java.util.Collections;
-import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import org.codehaus.groovy.ast.ClassNode;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.modules.csl.api.CompletionProposal;
 import org.netbeans.modules.groovy.editor.api.completion.CaretLocation;
 import org.netbeans.modules.groovy.editor.api.completion.CompletionItem;
+import org.netbeans.modules.groovy.editor.api.completion.MethodSignature;
 import org.netbeans.modules.groovy.editor.completion.util.CamelCaseUtil;
 import org.netbeans.modules.groovy.editor.api.completion.util.ContextHelper;
 import org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId;
@@ -45,7 +46,7 @@ import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
 public class ConstructorGenerationCompletion extends BaseCompletion {
 
     @Override
-    public boolean complete(List<CompletionProposal> proposals, CompletionContext request, int anchor) {
+    public boolean complete(Map<Object, CompletionProposal> proposals, CompletionContext request, int anchor) {
         LOG.log(Level.FINEST, "-> constructor generation completion"); // NOI18N
 
         if (!isValidLocation(request)) {
@@ -62,7 +63,8 @@ public class ConstructorGenerationCompletion extends BaseCompletion {
         boolean camelCaseMatch = CamelCaseUtil.compareCamelCase(className, request.getPrefix());
         if (camelCaseMatch) {
             LOG.log(Level.FINEST, "Prefix matches Class's CamelCase signature. Adding."); // NOI18N
-            proposals.add(new CompletionItem.ConstructorItem(className, Collections.emptyList(), anchor, true));
+            CompletionItem.ConstructorItem ci = new CompletionItem.ConstructorItem(className, Collections.emptyList(), anchor, true);
+            proposals.putIfAbsent(new MethodSignature("<init>", new String[0]) , ci);
         }
 
         return camelCaseMatch;

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/FieldCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/FieldCompletion.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.groovy.editor.completion;
 
-import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import org.netbeans.api.java.source.ClasspathInfo;
@@ -43,7 +42,7 @@ import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
 public class FieldCompletion extends BaseCompletion {
 
     @Override
-    public boolean complete(List<CompletionProposal> proposals, CompletionContext context, int anchor) {
+    public boolean complete(Map<Object, CompletionProposal> proposals, CompletionContext context, int anchor) {
         LOG.log(Level.FINEST, "-> completeFields"); // NOI18N
 
         if (context.location == CaretLocation.INSIDE_PARAMETERS && context.isBehindDot() == false) {
@@ -95,7 +94,7 @@ public class FieldCompletion extends BaseCompletion {
         if (result.containsKey(prefixFieldSignature)) {
             result.remove(prefixFieldSignature);
         }
-        proposals.addAll(result.values());
+        proposals.putAll(result);
 
         return true;
     }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/FieldCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/FieldCompletion.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.groovy.editor.completion;
 
 import java.util.Map;
 import java.util.logging.Level;
+import org.codehaus.groovy.ast.ClassNode;
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.modules.csl.api.CompletionProposal;
 import org.netbeans.modules.groovy.editor.api.completion.CaretLocation;
@@ -78,7 +79,7 @@ public class FieldCompletion extends BaseCompletion {
                 }
             }
         } else {
-            context.declaringClass = ContextHelper.getSurroundingClassNode(context);
+            context.setDeclaringClass(ContextHelper.getSurroundingClassNode(context));
         }
 
         // If we are dealing with GStrings, the prefix is prefixed ;-)

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/FieldCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/FieldCompletion.java
@@ -27,6 +27,7 @@ import org.netbeans.modules.csl.api.CompletionProposal;
 import org.netbeans.modules.groovy.editor.api.completion.CaretLocation;
 import org.netbeans.modules.groovy.editor.api.completion.CompletionItem;
 import org.netbeans.modules.groovy.editor.api.completion.FieldSignature;
+import org.netbeans.modules.groovy.editor.api.completion.MethodSignature;
 import org.netbeans.modules.groovy.editor.api.completion.util.ContextHelper;
 import org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId;
 import org.netbeans.modules.groovy.editor.completion.provider.CompleteElementHandler;
@@ -79,7 +80,7 @@ public class FieldCompletion extends BaseCompletion {
                 }
             }
         } else {
-            context.setDeclaringClass(ContextHelper.getSurroundingClassNode(context));
+            context.setDeclaringClass(ContextHelper.getSurroundingClassNode(context), context.isStaticMembers());
         }
 
         // If we are dealing with GStrings, the prefix is prefixed ;-)
@@ -95,7 +96,9 @@ public class FieldCompletion extends BaseCompletion {
         if (result.containsKey(prefixFieldSignature)) {
             result.remove(prefixFieldSignature);
         }
-        proposals.putAll(result);
+        for (Map.Entry<FieldSignature, CompletionItem> e :result.entrySet()) {
+            proposals.putIfAbsent(e.getKey(), e.getValue());
+        }
 
         return true;
     }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/KeywordCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/KeywordCompletion.java
@@ -20,7 +20,7 @@
 package org.netbeans.modules.groovy.editor.completion;
 
 import java.util.EnumSet;
-import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import org.netbeans.api.lexer.Token;
 import org.netbeans.api.lexer.TokenSequence;
@@ -47,7 +47,7 @@ class KeywordCompletion extends BaseCompletion {
 
 
     @Override
-    public boolean complete(List<CompletionProposal> proposals, CompletionContext request, int anchor) {
+    public boolean complete(Map<Object, CompletionProposal> proposals, CompletionContext request, int anchor) {
         this.request = request;
 
         LOG.log(Level.FINEST, "-> completeKeywords"); // NOI18N
@@ -91,7 +91,8 @@ class KeywordCompletion extends BaseCompletion {
 
         for (GroovyKeyword groovyKeyword : keywords) {
             LOG.log(Level.FINEST, "Adding keyword proposal : {0}", groovyKeyword.getName()); // NOI18N
-            proposals.add(new CompletionItem.KeywordItem(groovyKeyword.getName(), null, anchor, request.getParserResult(), groovyKeyword.isGroovyKeyword()));
+            proposals.put("keyword:" + groovyKeyword.getName(), 
+                    new CompletionItem.KeywordItem(groovyKeyword.getName(), null, anchor, request.getParserResult(), groovyKeyword.isGroovyKeyword()));
         }
 
         return true;

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/LocalVarCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/LocalVarCompletion.java
@@ -19,7 +19,7 @@
 
 package org.netbeans.modules.groovy.editor.completion;
 
-import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import org.codehaus.groovy.ast.ModuleNode;
 import org.codehaus.groovy.ast.Variable;
@@ -36,7 +36,7 @@ import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
 public class LocalVarCompletion extends BaseCompletion {
 
     @Override
-    public boolean complete(List<CompletionProposal> proposals, CompletionContext request, int anchor) {
+    public boolean complete(Map<Object, CompletionProposal> proposals, CompletionContext request, int anchor) {
         LOG.log(Level.FINEST, "-> completeLocalVars"); // NOI18N
 
         if (!(request.location == CaretLocation.INSIDE_CLOSURE || request.location == CaretLocation.INSIDE_METHOD)
@@ -73,10 +73,10 @@ public class LocalVarCompletion extends BaseCompletion {
             LOG.log(Level.FINEST, "Node found: {0}", varName); // NOI18N
 
             if (varPrefix.length() < 1) {
-                proposals.add(new CompletionItem.LocalVarItem(node, anchor + anchorShift));
+                proposals.put("local:" + varName, new CompletionItem.LocalVarItem(node, anchor + anchorShift));
                 updated = true;
             } else if (!varName.equals(varPrefix) && varName.startsWith(varPrefix)) {
-                proposals.add(new CompletionItem.LocalVarItem(node, anchor + anchorShift));
+                proposals.put("local:" + varName, new CompletionItem.LocalVarItem(node, anchor + anchorShift));
                 updated = true;
             }
         }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/MethodCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/MethodCompletion.java
@@ -136,8 +136,9 @@ public class MethodCompletion extends BaseCompletion {
         }
 
         Map<MethodSignature, CompletionItem> result = new CompleteElementHandler(context).getMethods();
-        proposals.putAll(result);
-
+        for (Map.Entry<MethodSignature, CompletionItem> e :result.entrySet()) {
+            proposals.putIfAbsent(e.getKey(), e.getValue());
+        }
         return true;
     }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/NamedParamsCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/NamedParamsCompletion.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.groovy.editor.completion;
 
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Map;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
@@ -43,7 +44,7 @@ public class NamedParamsCompletion extends BaseCompletion {
     private CompletionContext context;
 
     @Override
-    public boolean complete(List<CompletionProposal> proposals, CompletionContext context, int anchor) {
+    public boolean complete(Map<Object, CompletionProposal> proposals, CompletionContext context, int anchor) {
         this.context = context;
 
         ASTNode leaf = context.path.leaf();
@@ -94,7 +95,7 @@ public class NamedParamsCompletion extends BaseCompletion {
     }
 
     private void completeNamedParams(
-            List<CompletionProposal> proposals,
+            Map<Object, CompletionProposal> proposals,
             int anchor,
             ConstructorCallExpression constructorCall,
             NamedArgumentListExpression namedArguments) {
@@ -122,7 +123,7 @@ public class NamedParamsCompletion extends BaseCompletion {
                 }
             }
 
-            proposals.add(new CompletionItem.NamedParameter(typeName, name, anchor));
+            proposals.put("local:" + name, new CompletionItem.NamedParameter(typeName, name, anchor));
         }
     }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/NewVarCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/NewVarCompletion.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.groovy.editor.completion;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.logging.Level;
 import org.netbeans.modules.csl.api.CompletionProposal;
 import org.netbeans.modules.groovy.editor.api.completion.CaretLocation;
@@ -38,7 +39,7 @@ public class NewVarCompletion extends BaseCompletion {
 
 
     @Override
-    public boolean complete(List<CompletionProposal> proposals, CompletionContext request, int anchor) {
+    public boolean complete(Map<Object, CompletionProposal> proposals, CompletionContext request, int anchor) {
         LOG.log(Level.FINEST, "-> completeNewVars"); // NOI18N
 
         List<String> newVars = getNewVarNameSuggestion(request.context);
@@ -51,7 +52,7 @@ public class NewVarCompletion extends BaseCompletion {
         for (String var : newVars) {
             LOG.log(Level.FINEST, "Variable candidate: {0}", var); // NOI18N
             if (var.startsWith(request.getPrefix()) && !var.equals(request.getPrefix())) {
-                proposals.add(new CompletionItem.NewVarItem(var, anchor));
+                proposals.put("local:" + var, new CompletionItem.NewVarItem(var, anchor));
                 stuffAdded = true;
             }
         }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/PackageCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/PackageCompletion.java
@@ -20,7 +20,7 @@
 package org.netbeans.modules.groovy.editor.completion;
 
 import java.util.EnumSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import org.netbeans.api.java.source.ClassIndex;
@@ -38,7 +38,7 @@ import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
 public class PackageCompletion extends BaseCompletion {
 
     @Override
-    public boolean complete(List<CompletionProposal> proposals, CompletionContext request, int anchor) {
+    public boolean complete(Map<Object, CompletionProposal> proposals, CompletionContext request, int anchor) {
         LOG.log(Level.FINEST, "-> completePackages"); // NOI18N
 
         // this can happen for ?. or similar constructs
@@ -77,7 +77,7 @@ public class PackageCompletion extends BaseCompletion {
                 if (request.isBehindImportStatement()) {
                     item.setSmart(true);
                 }
-                proposals.add(item);
+                proposals.put("pack:" + singlePackage, item);
             }
         }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/ProposalsCollector.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/ProposalsCollector.java
@@ -20,7 +20,9 @@
 package org.netbeans.modules.groovy.editor.completion;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.netbeans.modules.csl.api.CompletionProposal;
 import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
 
@@ -34,7 +36,7 @@ import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
  */
 public class ProposalsCollector {
 
-    private List<CompletionProposal> proposals;
+    private Map<Object, CompletionProposal> proposals;
     private CompletionContext context;
 
     private BaseCompletion typesCompletion;
@@ -51,7 +53,7 @@ public class ProposalsCollector {
     public ProposalsCollector(CompletionContext context) {
         this.context = context;
         
-        proposals = new ArrayList<CompletionProposal>();
+        proposals = new LinkedHashMap<Object, CompletionProposal>();
         typesCompletion = new TypesCompletion();
         fieldCompletion = new FieldCompletion();
         methodCompletion = new MethodCompletion();
@@ -100,7 +102,7 @@ public class ProposalsCollector {
     }
 
     public List<CompletionProposal> getCollectedProposals() {
-        return proposals;
+        return new ArrayList<>(proposals.values());
     }
 
     public void clearProposals() {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/TypesCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/TypesCompletion.java
@@ -83,14 +83,14 @@ import org.openide.filesystems.FileObject;
 public class TypesCompletion extends BaseCompletion {
 
     // There attributes should be initiated for each complete() method call
-    private List<CompletionProposal> proposals;
+    private Map<Object, CompletionProposal> proposals;
     private CompletionContext request;
     private int anchor;
     private boolean constructorCompletion;
 
     
     @Override
-    public boolean complete(List<CompletionProposal> proposals, CompletionContext request, int anchor) {
+    public boolean complete(Map<Object, CompletionProposal> proposals, CompletionContext request, int anchor) {
         LOG.log(Level.FINEST, "-> completeTypes"); // NOI18N
 
         this.proposals = proposals;
@@ -321,16 +321,14 @@ public class TypesCompletion extends BaseCompletion {
         }
         if (isPrefixed(request, typeName)) {
             alreadyPresent.add(type);
-            proposals.add(CompletionAccessor.instance().createType(jh, fqnTypeName, typeName, anchor, type.getKind()));
+            proposals.putIfAbsent(fqnTypeName, CompletionAccessor.instance().createType(jh, fqnTypeName, typeName, anchor, type.getKind()));
         }
 
         // We are dealing with CamelCase completion for some class type
         if (CamelCaseUtil.compareCamelCase(typeName, request.getPrefix())) {
             CompletionItem.TypeItem camelCaseProposal = CompletionAccessor.instance().createType(jh, fqnTypeName, typeName, anchor, ElementKind.CLASS);
             
-            if (!proposals.contains(camelCaseProposal)) {
-                proposals.add(camelCaseProposal);
-            }
+            proposals.putIfAbsent(fqnTypeName, camelCaseProposal);
         }
     }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/inference/GroovyTypeAnalyzer.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/inference/GroovyTypeAnalyzer.java
@@ -20,16 +20,15 @@
 package org.netbeans.modules.groovy.editor.completion.inference;
 
 import java.util.Collections;
-import java.util.ListIterator;
 import java.util.Set;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.ModuleNode;
-import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.groovy.editor.api.AstPath;
+import org.netbeans.modules.groovy.editor.utils.GroovyUtils;
 
 /**
  *
@@ -42,9 +41,13 @@ public class GroovyTypeAnalyzer {
     public GroovyTypeAnalyzer(BaseDocument document) {
         this.document = document;
     }
-
-    public Set<ClassNode> getTypes(AstPath path, int astOffset) {
+    
+   public Set<ClassNode> getTypes(AstPath path, int astOffset) {
         ASTNode caller = path.leaf();
+        ClassNode inferred = GroovyUtils.findInferredType(caller);
+        if (inferred != null) {
+            return Collections.singleton(inferred);
+        }
         if (caller instanceof VariableExpression) {
             ModuleNode moduleNode = (ModuleNode) path.root();
             TypeInferenceVisitor typeVisitor = new TypeInferenceVisitor(moduleNode.getContext(), path, document, astOffset);

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/inference/MethodInference.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/inference/MethodInference.java
@@ -37,11 +37,14 @@ import org.codehaus.groovy.ast.expr.MethodCallExpression;
 import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
 import org.codehaus.groovy.ast.tools.GenericsUtils;
+import org.codehaus.groovy.transform.stc.StaticTypeCheckingSupport;
+import org.codehaus.groovy.transform.stc.StaticTypesMarker;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.groovy.editor.api.ASTUtils;
 import org.netbeans.modules.groovy.editor.api.AstPath;
+import org.netbeans.modules.groovy.editor.utils.GroovyUtils;
 
 /**
  *
@@ -69,7 +72,13 @@ public final class MethodInference {
         // For example: someInteger.toString().^
         if (expression instanceof MethodCallExpression) {
             MethodCallExpression methodCall = (MethodCallExpression) expression;
-
+            Object o = expression.getNodeMetaData(StaticTypesMarker.DIRECT_METHOD_CALL_TARGET);
+            if (o instanceof MethodNode) {
+                MethodNode mn = (MethodNode)o;
+                if (mn.getReturnType() != null && mn.getReturnType().isResolved()) {
+                    return mn.getReturnType();
+                }
+            }
             ClassNode callerType = findCallerType(methodCall.getObjectExpression(), path, baseDocument, offset);
             if (callerType != null) {
                 return findReturnTypeFor(callerType.redirect(), methodCall.getMethodAsString(), methodCall.getArguments(), path, false, baseDocument, offset);
@@ -89,7 +98,14 @@ public final class MethodInference {
             return ((ConstantExpression) expression).getType();
         }
         if (expression instanceof ClassExpression) {
-            return ClassHelper.make(((ClassExpression) expression).getType().getName());
+            ClassExpression ce = (ClassExpression)expression;
+            ClassNode cn = ce.getType();
+            if (cn != null && cn.isResolved()) {
+                cn = cn.redirect();
+            }
+            return cn.isResolved() ? cn :
+                   // note: this is just a stabu
+                   ClassHelper.make(((ClassExpression) expression).getType().getName());
         }
 
         if (expression instanceof StaticMethodCallExpression) {
@@ -112,9 +128,15 @@ public final class MethodInference {
             ) {
 
         List<ClassNode> paramTypes = new ArrayList<>();
+        ArgumentListExpression argExpression = null;
         if (arguments instanceof ArgumentListExpression) {
-            ArgumentListExpression argExpression = (ArgumentListExpression) arguments;
+            argExpression = (ArgumentListExpression) arguments;
             for (Expression e : argExpression.getExpressions()) {
+                ClassNode cn = GroovyUtils.findInferredType(e);
+                if (cn != null && cn.isResolved()) {
+                    paramTypes.add(cn);
+                    continue;
+                }
                 if (e instanceof VariableExpression) {
                     ModuleNode moduleNode = (ModuleNode) path.root();
                     int newOffset = ASTUtils.getOffset(baseDocument, e.getLineNumber(), e.getColumnNumber());
@@ -144,14 +166,14 @@ public final class MethodInference {
             }
         }
         
-        MethodNode possibleMethod = tryFindPossibleMethod(callerType, methodName, paramTypes, isStatic);
+        MethodNode possibleMethod = tryFindPossibleMethod(callerType, methodName, paramTypes, isStatic, argExpression);
         if (possibleMethod != null) {
             return possibleMethod.getReturnType();
         }
         return null;
     }
 
-    private static MethodNode tryFindPossibleMethod(ClassNode callerType, String methodName, List<ClassNode> paramTypes, boolean isStatic) {
+    private static MethodNode tryFindPossibleMethod(ClassNode callerType, String methodName, List<ClassNode> paramTypes, boolean isStatic, ArgumentListExpression paramExpr) {
         int count = paramTypes.size();
 
         MethodNode res = null;
@@ -171,8 +193,15 @@ public final class MethodInference {
                     boolean match = true;
                     for (int i = 0; i != count; ++i) {
                         if (!paramTypes.get(i).isDerivedFrom(method.getParameters()[i].getType())) {
-                            match = false;
-                            break;
+                            // do a thorough test in addition to plain type-equals.
+                            if (!StaticTypeCheckingSupport.checkCompatibleAssignmentTypes(
+                                    method.getParameters()[i].getType(),
+                                    paramTypes.get(i),
+                                    paramExpr.getExpression(i))) {
+
+                                match = false;
+                                break;
+                            }
                         }
                     }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/CompleteElementHandler.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/CompleteElementHandler.java
@@ -68,7 +68,7 @@ public final class CompleteElementHandler {
 
     public Map<MethodSignature, CompletionItem> getMethods() {
         final ClassNode source = context.getSurroundingClass();
-        final ClassNode node = context.declaringClass;
+        final ClassNode node = context.rawDseclaringClass;
         
         if (node == null) {
             return Collections.emptyMap();
@@ -88,7 +88,7 @@ public final class CompleteElementHandler {
 
     public Map<FieldSignature, CompletionItem> getFields() {
         final ClassNode source = context.getSurroundingClass();
-        final ClassNode node = context.declaringClass;
+        final ClassNode node = context.rawDseclaringClass;
         
         if (node == null) {
             return Collections.emptyMap();

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/CompletionAccessor.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/CompletionAccessor.java
@@ -72,4 +72,6 @@ public abstract class CompletionAccessor {
     public abstract CompletionItem createDynamicMethod(int anchorOffset, String name, List<MethodParameter> parameters, String returnType, boolean prefix);
     
     public abstract Pair<String, List<MethodParameter>> getParametersAndType(CompletionItem item);
+    
+    public abstract CompletionItem sortOverride(CompletionItem item, int override);
 }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyCompletionImpl.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyCompletionImpl.java
@@ -36,6 +36,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.lang.model.element.Element;
 import javax.swing.text.Document;
+import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.reflection.CachedClass;
 import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.api.java.platform.JavaPlatformManager;
@@ -54,6 +55,7 @@ import static org.netbeans.modules.groovy.editor.api.completion.CompletionHandle
 import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
 import org.netbeans.modules.groovy.editor.api.completion.util.ContextHelper;
 import org.netbeans.modules.groovy.editor.api.elements.ast.ASTMethod;
+import org.netbeans.modules.groovy.editor.api.parser.GroovyParserResult;
 import org.netbeans.modules.groovy.editor.completion.ProposalsCollector;
 import org.netbeans.modules.groovy.editor.java.JavaElementHandle;
 import org.netbeans.modules.groovy.support.api.GroovySettings;
@@ -166,24 +168,22 @@ public class GroovyCompletionImpl {
             if (ContextHelper.isVariableNameDefinition(context) || ContextHelper.isFieldNameDefinition(context)) {
                 proposalsCollector.completeNewVars(context);
             } else {
-                if (!(context.location == CaretLocation.OUTSIDE_CLASSES || context.location == CaretLocation.INSIDE_STRING)) {
-                    proposalsCollector.completePackages(context);
-                    proposalsCollector.completeTypes(context);
-                }
-
-                if (!context.isBehindImportStatement()) {
-                    if (context.location != CaretLocation.INSIDE_STRING) {
-                        proposalsCollector.completeKeywords(context);
-                        proposalsCollector.completeMethods(context);
+                makeClassProposals(proposalsCollector, context);
+                // implicit conversion of GString > String:
+                if (context.declaringClass != null && context.declaringClass.getName().equals("groovy.lang.GString")) { // NOI18N
+                    // add String methods in addition to GString ones.
+                    ClassNode sn = ((GroovyParserResult)parserResult).resolveClassName("java.lang.String"); // NOI18N
+                    if (sn != null) {
+                        context.setDeclaringClass(sn);
+                        makeClassProposals(proposalsCollector, context);
                     }
-
-                    proposalsCollector.completeFields(context);
-                    proposalsCollector.completeLocalVars(context);
                 }
-
-                if (context.location == CaretLocation.INSIDE_CONSTRUCTOR_CALL) {
-                    if (ContextHelper.isAfterComma(context) || ContextHelper.isAfterLeftParenthesis(context)) {
-                        proposalsCollector.completeNamedParams(context);
+                if (context.rawDseclaringClass != null && context.rawDseclaringClass.getName().equals("java.lang.Class")) { // NOI18N
+                    if (context.rawDseclaringClass.getGenericsTypes().length == 1) {
+                        ClassNode cn = context.rawDseclaringClass.getGenericsTypes()[0].getType();
+                        context.setDeclaringClass(cn);
+                        context.init();
+                        makeClassProposals(proposalsCollector, context);
                     }
                 }
             }
@@ -192,6 +192,29 @@ public class GroovyCompletionImpl {
             return new CompletionImplResult(proposalsCollector.getCollectedProposals(), context);
         } finally {
             doc.readUnlock();
+        }
+    }
+    
+    private void makeClassProposals(ProposalsCollector proposalsCollector, CompletionContext context) {
+        if (!(context.location == CaretLocation.OUTSIDE_CLASSES || context.location == CaretLocation.INSIDE_STRING)) {
+            proposalsCollector.completePackages(context);
+            proposalsCollector.completeTypes(context);
+        }
+
+        if (!context.isBehindImportStatement()) {
+            if (context.location != CaretLocation.INSIDE_STRING) {
+                proposalsCollector.completeKeywords(context);
+                proposalsCollector.completeMethods(context);
+            }
+
+            proposalsCollector.completeFields(context);
+            proposalsCollector.completeLocalVars(context);
+        }
+
+        if (context.location == CaretLocation.INSIDE_CONSTRUCTOR_CALL) {
+            if (ContextHelper.isAfterComma(context) || ContextHelper.isAfterLeftParenthesis(context)) {
+                proposalsCollector.completeNamedParams(context);
+            }
         }
     }
 

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyElementsProvider.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyElementsProvider.java
@@ -115,6 +115,11 @@ public final class GroovyElementsProvider implements CompletionProvider {
             }
 
             for (IndexedField indexedField : fields) {
+                // properties are represented as indexed fields, with private access. Maybe should
+                // change so access checks can succeed without special cases.
+                if (!(indexedField.isProperty() || accept(context.access, indexedField))) {
+                    continue;
+                }
                 result.put(getFieldSignature(indexedField), new CompletionItem.FieldItem(
                         indexedField.getTypeName(),
                         indexedField.getName(),

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyElementsProvider.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/GroovyElementsProvider.java
@@ -39,6 +39,7 @@ import org.netbeans.modules.groovy.editor.java.Utilities;
 import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
 import org.netbeans.modules.groovy.editor.java.JavaElementHandle;
 import org.netbeans.modules.groovy.editor.spi.completion.CompletionProvider;
+import org.netbeans.modules.groovy.support.api.GroovySettings;
 import org.netbeans.modules.parsing.spi.indexing.support.QuerySupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.URLMapper;
@@ -54,6 +55,7 @@ public final class GroovyElementsProvider implements CompletionProvider {
     public Map<MethodSignature, CompletionItem> getMethods(CompletionContext context) {
         final GroovyIndex index = getIndex(context);
         final Map<MethodSignature, CompletionItem> result = new HashMap<>();
+        final boolean acc = GroovySettings.getInstance().isHonourAccessModifiers();
         
         if (index != null) {
             Set<IndexedMethod> methods;
@@ -65,7 +67,7 @@ public final class GroovyElementsProvider implements CompletionProvider {
             }
 
             for (IndexedMethod indexedMethod : methods) {
-                if (accept(context.access, indexedMethod)) {
+                if (!acc || accept(context.access, indexedMethod)) {
                     JavaElementHandle jeh = null;
                     if (indexedMethod.getFileObject().getMIMEType("text/x-java") != null) {
                         URL u = URLMapper.findURL(indexedMethod.getFileObject(), URLMapper.INTERNAL);
@@ -104,7 +106,7 @@ public final class GroovyElementsProvider implements CompletionProvider {
     public Map<FieldSignature, CompletionItem> getFields(CompletionContext context) {
         final GroovyIndex index = getIndex(context);
         final Map<FieldSignature, CompletionItem> result = new HashMap<>();
-        
+        final boolean acc = GroovySettings.getInstance().isHonourAccessModifiers();
         if (index != null) {
             Set<IndexedField> fields;
 
@@ -117,7 +119,7 @@ public final class GroovyElementsProvider implements CompletionProvider {
             for (IndexedField indexedField : fields) {
                 // properties are represented as indexed fields, with private access. Maybe should
                 // change so access checks can succeed without special cases.
-                if (!(indexedField.isProperty() || accept(context.access, indexedField))) {
+                if (acc && (!(indexedField.isProperty() || accept(context.access, indexedField)))) {
                     continue;
                 }
                 result.put(getFieldSignature(indexedField), new CompletionItem.FieldItem(

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/JavaElementHandler.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/JavaElementHandler.java
@@ -372,7 +372,7 @@ public final class JavaElementHandler {
                 ElementAcceptor acceptor = new ElementAcceptor() {
 
                     public boolean accept(Element e, TypeMirror type) {
-                        if (e.getKind() != ElementKind.FIELD) {
+                        if (!e.getKind().isField()) {
                             return false;
                         }
                         for (AccessLevel level : levels) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/JavaElementHandler.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/JavaElementHandler.java
@@ -38,6 +38,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
@@ -45,7 +46,6 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.CompilationController;
-import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.ElementUtilities.ElementAcceptor;
 import org.netbeans.api.java.source.JavaSource;
@@ -54,6 +54,7 @@ import org.netbeans.api.java.source.TypeUtilities;
 import org.netbeans.modules.csl.spi.ParserResult;
 import org.netbeans.modules.groovy.editor.api.completion.FieldSignature;
 import org.netbeans.modules.groovy.editor.api.completion.MethodSignature;
+import org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext;
 import org.netbeans.modules.groovy.editor.api.elements.common.MethodElement.MethodParameter;
 import org.netbeans.modules.groovy.editor.completion.AccessLevel;
 import org.netbeans.modules.groovy.editor.java.JavaElementHandle;
@@ -70,19 +71,20 @@ public final class JavaElementHandler {
     private static final Logger LOG = Logger.getLogger(GroovyElementsProvider.class.getName());
 
     private final ParserResult info;
+    private final CompletionContext context;
 
-    private JavaElementHandler(ParserResult info) {
+    private JavaElementHandler(ParserResult info, CompletionContext context) {
         this.info = info;
+        this.context = context;
     }
 
-    public static JavaElementHandler forCompilationInfo(ParserResult info) {
-        return new JavaElementHandler(info);
+    public static JavaElementHandler forCompilationInfo(ParserResult info, CompletionContext context) {
+        return new JavaElementHandler(info, context);
     }
 
     // FIXME ideally there should be something like nice CompletionRequest once public and stable
     // then this class could implement some common interface
-    public Map<MethodSignature, CompletionItem> getMethods(String className,
-            String prefix, int anchor, String[] typeParameters, boolean emphasise, Set<AccessLevel> levels, boolean nameOnly) {
+    public Map<MethodSignature, CompletionItem> getMethods(String className, String prefix, int anchor, String[] typeParameters, boolean emphasise, Set<AccessLevel> levels, boolean nameOnly) {
         JavaSource javaSource = createJavaSource();
         
         if (javaSource == null) {
@@ -96,7 +98,7 @@ public final class JavaElementHandler {
         Map<MethodSignature, CompletionItem> result = Collections.synchronizedMap(new HashMap<MethodSignature, CompletionItem>());
         try {
             javaSource.runUserActionTask(new MethodCompletionHelper(cnt, javaSource, f, className, typeParameters,
-                    levels, prefix, anchor, result, emphasise, nameOnly), true);
+                    levels, prefix, anchor, result, emphasise, nameOnly, context.isStaticMembers()), true);
         } catch (IOException ex) {
             LOG.log(Level.FINEST, "Problem in runUserActionTask :  {0}", ex.getMessage());
             return Collections.emptyMap();
@@ -125,7 +127,7 @@ public final class JavaElementHandler {
         FileObject f = info.getSnapshot().getSource().getFileObject();
         try {
             javaSource.runUserActionTask(new FieldCompletionHelper(cnt, javaSource, f, className,
-                    Collections.singleton(AccessLevel.PUBLIC), prefix, anchor, result, emphasise), true);
+                    Collections.singleton(AccessLevel.PUBLIC), prefix, anchor, result, emphasise, context.isStaticMembers()), true);
         } catch (IOException ex) {
             LOG.log(Level.FINEST, "Problem in runUserActionTask :  {0}", ex.getMessage());
             return Collections.emptyMap();
@@ -180,10 +182,12 @@ public final class JavaElementHandler {
         private final Map<MethodSignature, CompletionItem> proposals;
 
         private final boolean nameOnly;
+        
+        private final boolean staticMethods;
 
         public MethodCompletionHelper(CountDownLatch cnt, JavaSource javaSource, FileObject groovySource, String className, 
                 String[] typeParameters, Set<AccessLevel> levels, String prefix, int anchor,
-                Map<MethodSignature, CompletionItem> proposals, boolean emphasise, boolean nameOnly) {
+                Map<MethodSignature, CompletionItem> proposals, boolean emphasise, boolean nameOnly, boolean staticMethods) {
 
             this.cnt = cnt;
             this.javaSource = javaSource;
@@ -196,6 +200,7 @@ public final class JavaElementHandler {
             this.proposals = proposals;
             this.emphasise = emphasise;
             this.nameOnly = nameOnly;
+            this.staticMethods = staticMethods;
         }
 
         @Override
@@ -204,6 +209,9 @@ public final class JavaElementHandler {
             ElementAcceptor acceptor = new ElementAcceptor() {
 
                 public boolean accept(Element e, TypeMirror type) {
+                    if (staticMethods && !e.getModifiers().contains(javax.lang.model.element.Modifier.STATIC)) {
+                        return false;
+                    }
                     if (e.getKind() != ElementKind.METHOD) {
                         return false;
                     }
@@ -262,14 +270,19 @@ public final class JavaElementHandler {
             
             for (VariableElement variableElement : params) {
                 TypeMirror tm = variableElement.asType();
-                
                 String fullName;
                 String typeName;
                 
                 if (tm.getKind() == TypeKind.TYPEVAR) {
                     fullName = substituteActualType(tm, classElement, exe, info.getTypes());
                     typeName = GroovyUtils.stripPackage(fullName);
-                } else {
+                } else if (tm.getKind() == TypeKind.ARRAY &&
+                        variableElement == params.get(params.size() - 1) &&
+                        exe.isVarArgs()) {
+                    tm = ((ArrayType)tm).getComponentType();
+                    fullName = info.getTypeUtilities().getTypeName(tm, TypeUtilities.TypeNameOptions.PRINT_FQN).toString() + "..."; // NOI18N
+                    typeName = info.getTypeUtilities().getTypeName(tm).toString() + "..."; // NOI18N
+                } else { 
                     fullName = info.getTypeUtilities().getTypeName(tm, TypeUtilities.TypeNameOptions.PRINT_FQN).toString();
                     typeName = info.getTypeUtilities().getTypeName(tm).toString();
                 }
@@ -350,9 +363,11 @@ public final class JavaElementHandler {
         
         private final FileObject groovySource;
         
+        private final boolean staticMembers;
+        
         public FieldCompletionHelper(CountDownLatch cnt, JavaSource javaSource, FileObject groovySource, String className,
                 Set<AccessLevel> levels, String prefix, int anchor,
-                Map<FieldSignature, CompletionItem> proposals, boolean emphasise) {
+                Map<FieldSignature, CompletionItem> proposals, boolean emphasise, boolean staticMembers) {
 
             this.cnt = cnt;
             this.javaSource = javaSource;
@@ -363,6 +378,7 @@ public final class JavaElementHandler {
             this.anchor = anchor;
             this.proposals = proposals;
             this.emphasise = emphasise;
+            this.staticMembers = staticMembers;
         }
 
         public void run(CompilationController info) throws Exception {
@@ -373,6 +389,9 @@ public final class JavaElementHandler {
 
                     public boolean accept(Element e, TypeMirror type) {
                         if (!e.getKind().isField()) {
+                            return false;
+                        }
+                        if (staticMembers && !e.getModifiers().contains(javax.lang.model.element.Modifier.STATIC)) {
                             return false;
                         }
                         for (AccessLevel level : levels) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/java/JavaElementHandle.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/java/JavaElementHandle.java
@@ -109,6 +109,7 @@ public final class JavaElementHandle implements ElementHandle {
             case FIELD:         return ElementKind.FIELD;
             case CONSTRUCTOR:   return ElementKind.CONSTRUCTOR;
             case ENUM:          return ElementKind.CONSTANT;
+            case ENUM_CONSTANT: return ElementKind.CONSTANT;
             case ANNOTATION_TYPE: return ElementKind.INTERFACE;
                     
             default:

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/utils/GroovyUtils.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/utils/GroovyUtils.java
@@ -19,8 +19,12 @@
 
 package org.netbeans.modules.groovy.editor.utils;
 
-import java.util.List;
 import javax.swing.text.BadLocationException;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.GenericsType;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.transform.stc.StaticTypesMarker;
 
 /**
  *
@@ -235,6 +239,47 @@ public final class GroovyUtils {
             }
         }
         return sb.toString();
+    }
+    
+    /**
+     * Finds the type inferred for the expression tree. Types are inferred by
+     * static compilation visitor during INSTRUCTION_SELECTION phase.
+     * <p>
+     * If the inferred type is just Object, the method returns false.
+     * @param n the node
+     * @return inferred type or {@code null}
+     */
+    public static ClassNode findInferredType(ASTNode n) {
+        Object o = n.getNodeMetaData(StaticTypesMarker.INFERRED_TYPE);
+        ClassNode cn = null;
+        if (n instanceof Expression) {
+            cn = ((Expression)n).getType();
+            
+        }
+        ClassNode inferred = null;
+        if (o instanceof ClassNode) {
+            inferred = (ClassNode)o;
+        } 
+        /*
+        // hack: if the inferred type is j.l.Class & type is known, return that type
+        if (cn != null && inferred != null && inferred.getName().equals("java.lang.Class")) {
+            GenericsType[] gt = inferred.getGenericsTypes();
+            if (gt != null && gt.length == 1 && gt[0].getName().equals(cn.getName())) {
+                return cn;
+            }
+        }
+        */
+        if (inferred != null) {
+            cn = inferred;
+        }
+        if (cn == null) {
+            return null;
+        }
+        if (!cn.getName().equals("java.lang.Object")) {
+            return cn;
+        } else {
+            return null;
+        }
     }
     
     /**

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/utils/GroovyUtils.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/utils/GroovyUtils.java
@@ -43,6 +43,10 @@ public final class GroovyUtils {
      * @return singe typename without package, or method without type
      */
     public static String stripPackage(String fqn) {
+        // special case for method parameters, as they come with String FQN sometimes:
+        if (fqn.endsWith("...") && fqn.length() > 3) {
+            return stripPackage(fqn.substring(0, fqn.length() - 3)) + "..."; // NOI18N
+        }
         if (fqn.contains("<")) {
             // TODO: This does not handle inner classes well - NETBEANS-5787
             int first = fqn.indexOf('<');

--- a/groovy/groovy.editor/test/unit/data/testfiles/ASTPath1.groovy
+++ b/groovy/groovy.editor/test/unit/data/testfiles/ASTPath1.groovy
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ *
+ * @author sdedic
+ */
+class ASTPath1 {
+    File    someFile
+        
+    def setup() {
+        someFile = new File("Mr.Spock")
+        someFile.parentFile.mkdirs()
+        someFile.absoluteFile.parentFile.mkdirs()
+        (someFile.canonicalFile.parentFile).mkdirs()
+        
+        
+        ProcessBuilder b = new ProcessBuilder()
+        b.command("good").inheritIO().command()
+        Object o = ProcessBuilder.class;
+        
+        ProcessBuilder aa = new ProcessBuilder()
+        aa.command "bye".substring(1)
+        aa.command "hello $dolly !".substring(1)
+    }
+}
+

--- a/groovy/groovy.editor/test/unit/data/testfiles/Hello.groovy.indexed
+++ b/groovy/groovy.editor/test/unit/data/testfiles/Hello.groovy.indexed
@@ -5,8 +5,8 @@ Searchable Keys:
   class : FourthClass
   class-ig : fourthclass
   fqn : foo.FourthClass
-  method : getMetaClass;groovy.lang.MetaClass
-  method : setMetaClass(groovy.lang.MetaClass);void
+  method : getMetaClass;groovy.lang.MetaClass;01
+  method : setMetaClass(groovy.lang.MetaClass);void;01
 
 Not Searchable Keys:
 
@@ -16,8 +16,8 @@ Searchable Keys:
   class : Hello
   class-ig : hello
   fqn : foo.Hello
-  method : main(java.lang.String[]);void;08
-  method : run;java.lang.Object
+  method : main(java.lang.String[]);void;09
+  method : run;java.lang.Object;01
 
 Not Searchable Keys:
 
@@ -26,24 +26,24 @@ Document 2
 Searchable Keys:
   class : Hello1
   class-ig : hello1
-  ctor : Hello1;int
+  ctor : Hello1;int;01
   field : field1;int;00;true
   field : greeting;java.lang.Object;00;true
   field : name;java.lang.Object;00;true
-  field : privateField;java.lang.Object
+  field : privateField;java.lang.Object;02
   field : protectedField;java.lang.Object;04
   field : publicField;java.lang.Object;01
   fqn : foo.Hello1
-  method : dynamicmethod;void
-  method : getField1;int
-  method : getGreeting;java.lang.Object
-  method : getMetaClass;groovy.lang.MetaClass
-  method : getName;java.lang.Object
-  method : main(java.lang.String[]);void;08
-  method : setField1(int);void
-  method : setGreeting(java.lang.Object);void
-  method : setMetaClass(groovy.lang.MetaClass);void
-  method : setName(java.lang.Object);void
+  method : dynamicmethod;void;01
+  method : getField1;int;01
+  method : getGreeting;java.lang.Object;01
+  method : getMetaClass;groovy.lang.MetaClass;01
+  method : getName;java.lang.Object;01
+  method : main(java.lang.String[]);void;09
+  method : setField1(int);void;01
+  method : setGreeting(java.lang.Object);void;01
+  method : setMetaClass(groovy.lang.MetaClass);void;01
+  method : setName(java.lang.Object);void;01
 
 Not Searchable Keys:
 
@@ -52,11 +52,11 @@ Document 3
 Searchable Keys:
   class : SecondTestClass
   class-ig : secondtestclass
-  ctor : SecondTestClass;String
-  ctor : SecondTestClass;int
+  ctor : SecondTestClass;String;01
+  ctor : SecondTestClass;int;01
   fqn : foo.SecondTestClass
-  method : getMetaClass;groovy.lang.MetaClass
-  method : setMetaClass(groovy.lang.MetaClass);void
+  method : getMetaClass;groovy.lang.MetaClass;01
+  method : setMetaClass(groovy.lang.MetaClass);void;01
 
 Not Searchable Keys:
 
@@ -65,10 +65,10 @@ Document 4
 Searchable Keys:
   class : ThirdTestClass
   class-ig : thirdtestclass
-  ctor : ThirdTestClass;String
-  ctor : ThirdTestClass;int
+  ctor : ThirdTestClass;String;01
+  ctor : ThirdTestClass;int;01
   fqn : foo.ThirdTestClass
-  method : getMetaClass;groovy.lang.MetaClass
-  method : setMetaClass(groovy.lang.MetaClass);void
+  method : getMetaClass;groovy.lang.MetaClass;01
+  method : setMetaClass(groovy.lang.MetaClass);void;01
 
 Not Searchable Keys:

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.10.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.10.completion
@@ -23,6 +23,7 @@ METHOD     asUnmodifiable()                           List
 METHOD     average()                                  Object
 METHOD     average(Closure)                           Object
 METHOD     bufferedIterator()                         BufferedIterator
+METHOD     by(T)                           [PUBLIC]   NumberRange
 METHOD     chop(int[])                                List
 METHOD     clear()                         [PUBLIC]   void
 METHOD     collate(int)                               List
@@ -43,7 +44,7 @@ METHOD     collectNested(Collection, Clos             Collection
 METHOD     combinations()                             List
 METHOD     combinations(Closure)                      List
 METHOD     contains(Object)                [PUBLIC]   boolean
-METHOD     containsAll(Collection<?>)      [PUBLIC]   boolean
+METHOD     containsAll(Collection)         [PUBLIC]   boolean
 METHOD     containsAll(Object[])                      boolean
 METHOD     containsWithinBounds(Object)    [PUBLIC]   boolean
 METHOD     copyOf(Collection<? extends E>  [STATIC,   List<E>
@@ -59,6 +60,7 @@ METHOD     each(Closure)                              List
 METHOD     eachCombination(Closure)                   void
 METHOD     eachPermutation(Closure)                   Iterator
 METHOD     eachWithIndex(Closure)                     List
+METHOD     equals(IntRange)                [PUBLIC]   boolean
 METHOD     equals(List)                               boolean
 METHOD     equals(Object)                  [PUBLIC]   boolean
 METHOD     equals(Object[])                           boolean
@@ -84,7 +86,7 @@ METHOD     first()                                    Object
 METHOD     flatten()                                  List
 METHOD     flatten(Closure)                           Collection
 METHOD     forEach(Consumer<? super T>)    [PUBLIC]   void
-METHOD     get(int)                        [PUBLIC]   E
+METHOD     get(int)                        [PUBLIC]   Integer
 METHOD     getAt(Collection)                          List
 METHOD     getAt(EmptyRange)                          List
 METHOD     getAt(Number)                              Object
@@ -92,12 +94,15 @@ METHOD     getAt(Range)                               List
 METHOD     getAt(String)                              List
 METHOD     getAt(int)                                 Object
 METHOD     getClass()                      [PUBLIC]   Class<?>
-METHOD     getFrom()                       [PUBLIC]   T
+METHOD     getFrom()                       [PUBLIC]   Integer
+METHOD     getFromInt()                    [PUBLIC]   int
+METHOD     getInclusive()                  [PUBLIC]   Boolean
 METHOD     getIndices()                               IntRange
 METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
 METHOD     getProperties()                            Map
-METHOD     getTo()                         [PUBLIC]   T
+METHOD     getTo()                         [PUBLIC]   Integer
+METHOD     getToInt()                      [PUBLIC]   int
 METHOD     grep()                                     List
 METHOD     grep(Object)                               List
 METHOD     groupBy(Closure)                           Map
@@ -124,7 +129,7 @@ METHOD     is(Object)                                 boolean
 METHOD     isCase(Object)                             boolean
 METHOD     isEmpty()                       [PUBLIC]   boolean
 METHOD     isReverse()                     [PUBLIC]   boolean
-METHOD     iterator()                                 Iterator
+METHOD     iterator()                      [PUBLIC]   Iterator<Integer>
 METHOD     join(String)                               String
 METHOD     last()                                     Object
 METHOD     lastIndexOf(Object)             [PUBLIC]   int
@@ -220,10 +225,11 @@ METHOD     split(Closure)                             List
 METHOD     spliterator()                   [PUBLIC]   Spliterator<E>
 METHOD     sprintf(String, Object)                    String
 METHOD     sprintf(String, Object)                    String
-METHOD     step(int)                       [PUBLIC]   List<T>
+METHOD     step(int)                       [PUBLIC]   List<Integer>
 METHOD     step(int, Closure)              [PUBLIC]   void
 METHOD     stream()                                   Stream
-METHOD     subList(int, int)               [PUBLIC]   List<E>
+METHOD     subList(int, int)               [PUBLIC]   List<Integer>
+METHOD     subListBorders(int)             [PUBLIC]   RangeInfo
 METHOD     subsequences()                             Set
 METHOD     sum()                                      Object
 METHOD     sum(Closure)                               Object
@@ -237,6 +243,7 @@ METHOD     takeRight(int)                             List
 METHOD     takeWhile(Closure)                         List
 METHOD     tap(Closure)                               Object
 METHOD     toArray()                       [PUBLIC]   Object[]
+METHOD     toArray(IntFunction<T[]>)       [PUBLIC]   T[]
 METHOD     toArray(T[])                    [PUBLIC]   T[]
 METHOD     toList()                                   List
 METHOD     toListString()                             String
@@ -246,7 +253,7 @@ METHOD     toSorted()                                 List
 METHOD     toSorted(Closure)                          List
 METHOD     toSorted(Comparator)                       List
 METHOD     toSpreadMap()                              SpreadMap
-METHOD     toString()                                 String
+METHOD     toString()                      [PUBLIC]   String
 METHOD     toUnique()                                 List
 METHOD     toUnique(Closure)                          List
 METHOD     toUnique(Comparator)                       List
@@ -271,7 +278,11 @@ METHOD     withIndex()                                List
 METHOD     withIndex(int)                             List
 METHOD     withLazyDefault(Closure)                   ListWithDefault
 METHOD     withTraits(Class[])                        Object
+FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean
-FIELD      from                            [PUBLIC]   Comparable
+FIELD      from                            [PUBLIC]   Integer
+FIELD      fromInt                         [PUBLIC]   int
+FIELD      inclusive                       [PUBLIC]   Boolean
 FIELD      reverse                         [PUBLIC]   boolean
-FIELD      to                              [PUBLIC]   Comparable
+FIELD      to                              [PUBLIC]   Integer
+FIELD      toInt                           [PUBLIC]   int

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.10.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.10.completion
@@ -160,7 +160,7 @@ METHOD     of(E, E, E, E, E, E, E)         [STATIC,   List<E>
 METHOD     of(E, E, E, E, E, E, E, E)      [STATIC,   List<E>
 METHOD     of(E, E, E, E, E, E, E, E, E)   [STATIC,   List<E>
 METHOD     of(E, E, E, E, E, E, E, E, E,   [STATIC,   List<E>
-METHOD     of(E[])                         [STATIC,   List<E>
+METHOD     of(E...)                        [STATIC,   List<E>
 METHOD     parallelStream()                [PUBLIC]   Stream<E>
 METHOD     permutations()                             Set
 METHOD     permutations(Closure)                      List

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.11.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.11.completion
@@ -23,6 +23,7 @@ METHOD     asUnmodifiable()                           List
 METHOD     average()                                  Object
 METHOD     average(Closure)                           Object
 METHOD     bufferedIterator()                         BufferedIterator
+METHOD     by(T)                           [PUBLIC]   NumberRange
 METHOD     chop(int[])                                List
 METHOD     clear()                         [PUBLIC]   void
 METHOD     collate(int)                               List
@@ -43,7 +44,7 @@ METHOD     collectNested(Collection, Clos             Collection
 METHOD     combinations()                             List
 METHOD     combinations(Closure)                      List
 METHOD     contains(Object)                [PUBLIC]   boolean
-METHOD     containsAll(Collection<?>)      [PUBLIC]   boolean
+METHOD     containsAll(Collection)         [PUBLIC]   boolean
 METHOD     containsAll(Object[])                      boolean
 METHOD     containsWithinBounds(Object)    [PUBLIC]   boolean
 METHOD     copyOf(Collection<? extends E>  [STATIC,   List<E>
@@ -59,6 +60,7 @@ METHOD     each(Closure)                              List
 METHOD     eachCombination(Closure)                   void
 METHOD     eachPermutation(Closure)                   Iterator
 METHOD     eachWithIndex(Closure)                     List
+METHOD     equals(IntRange)                [PUBLIC]   boolean
 METHOD     equals(List)                               boolean
 METHOD     equals(Object)                  [PUBLIC]   boolean
 METHOD     equals(Object[])                           boolean
@@ -84,7 +86,7 @@ METHOD     first()                                    Object
 METHOD     flatten()                                  List
 METHOD     flatten(Closure)                           Collection
 METHOD     forEach(Consumer<? super T>)    [PUBLIC]   void
-METHOD     get(int)                        [PUBLIC]   E
+METHOD     get(int)                        [PUBLIC]   Integer
 METHOD     getAt(Collection)                          List
 METHOD     getAt(EmptyRange)                          List
 METHOD     getAt(Number)                              Object
@@ -92,12 +94,15 @@ METHOD     getAt(Range)                               List
 METHOD     getAt(String)                              List
 METHOD     getAt(int)                                 Object
 METHOD     getClass()                      [PUBLIC]   Class<?>
-METHOD     getFrom()                       [PUBLIC]   T
+METHOD     getFrom()                       [PUBLIC]   Integer
+METHOD     getFromInt()                    [PUBLIC]   int
+METHOD     getInclusive()                  [PUBLIC]   Boolean
 METHOD     getIndices()                               IntRange
 METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
 METHOD     getProperties()                            Map
-METHOD     getTo()                         [PUBLIC]   T
+METHOD     getTo()                         [PUBLIC]   Integer
+METHOD     getToInt()                      [PUBLIC]   int
 METHOD     grep()                                     List
 METHOD     grep(Object)                               List
 METHOD     groupBy(Closure)                           Map
@@ -124,7 +129,7 @@ METHOD     is(Object)                                 boolean
 METHOD     isCase(Object)                             boolean
 METHOD     isEmpty()                       [PUBLIC]   boolean
 METHOD     isReverse()                     [PUBLIC]   boolean
-METHOD     iterator()                                 Iterator
+METHOD     iterator()                      [PUBLIC]   Iterator<Integer>
 METHOD     join(String)                               String
 METHOD     last()                                     Object
 METHOD     lastIndexOf(Object)             [PUBLIC]   int
@@ -220,10 +225,11 @@ METHOD     split(Closure)                             List
 METHOD     spliterator()                   [PUBLIC]   Spliterator<E>
 METHOD     sprintf(String, Object)                    String
 METHOD     sprintf(String, Object)                    String
-METHOD     step(int)                       [PUBLIC]   List<T>
+METHOD     step(int)                       [PUBLIC]   List<Integer>
 METHOD     step(int, Closure)              [PUBLIC]   void
 METHOD     stream()                                   Stream
-METHOD     subList(int, int)               [PUBLIC]   List<E>
+METHOD     subList(int, int)               [PUBLIC]   List<Integer>
+METHOD     subListBorders(int)             [PUBLIC]   RangeInfo
 METHOD     subsequences()                             Set
 METHOD     sum()                                      Object
 METHOD     sum(Closure)                               Object
@@ -247,7 +253,7 @@ METHOD     toSorted()                                 List
 METHOD     toSorted(Closure)                          List
 METHOD     toSorted(Comparator)                       List
 METHOD     toSpreadMap()                              SpreadMap
-METHOD     toString()                                 String
+METHOD     toString()                      [PUBLIC]   String
 METHOD     toUnique()                                 List
 METHOD     toUnique(Closure)                          List
 METHOD     toUnique(Comparator)                       List
@@ -272,7 +278,11 @@ METHOD     withIndex()                                List
 METHOD     withIndex(int)                             List
 METHOD     withLazyDefault(Closure)                   ListWithDefault
 METHOD     withTraits(Class[])                        Object
+FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean
-FIELD      from                            [PUBLIC]   Comparable
+FIELD      from                            [PUBLIC]   Integer
+FIELD      fromInt                         [PUBLIC]   int
+FIELD      inclusive                       [PUBLIC]   Boolean
 FIELD      reverse                         [PUBLIC]   boolean
-FIELD      to                              [PUBLIC]   Comparable
+FIELD      to                              [PUBLIC]   Integer
+FIELD      toInt                           [PUBLIC]   int

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.11.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.11.completion
@@ -160,7 +160,7 @@ METHOD     of(E, E, E, E, E, E, E)         [STATIC,   List<E>
 METHOD     of(E, E, E, E, E, E, E, E)      [STATIC,   List<E>
 METHOD     of(E, E, E, E, E, E, E, E, E)   [STATIC,   List<E>
 METHOD     of(E, E, E, E, E, E, E, E, E,   [STATIC,   List<E>
-METHOD     of(E[])                         [STATIC,   List<E>
+METHOD     of(E...)                        [STATIC,   List<E>
 METHOD     parallelStream()                [PUBLIC]   Stream<E>
 METHOD     permutations()                             Set
 METHOD     permutations(Closure)                      List

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.9.completion
@@ -23,6 +23,7 @@ METHOD     asUnmodifiable()                           List
 METHOD     average()                                  Object
 METHOD     average(Closure)                           Object
 METHOD     bufferedIterator()                         BufferedIterator
+METHOD     by(T)                           [PUBLIC]   NumberRange
 METHOD     chop(int[])                                List
 METHOD     clear()                         [PUBLIC]   void
 METHOD     collate(int)                               List
@@ -43,7 +44,7 @@ METHOD     collectNested(Collection, Clos             Collection
 METHOD     combinations()                             List
 METHOD     combinations(Closure)                      List
 METHOD     contains(Object)                [PUBLIC]   boolean
-METHOD     containsAll(Collection<?>)      [PUBLIC]   boolean
+METHOD     containsAll(Collection)         [PUBLIC]   boolean
 METHOD     containsAll(Object[])                      boolean
 METHOD     containsWithinBounds(Object)    [PUBLIC]   boolean
 METHOD     count(Closure)                             Number
@@ -58,6 +59,7 @@ METHOD     each(Closure)                              List
 METHOD     eachCombination(Closure)                   void
 METHOD     eachPermutation(Closure)                   Iterator
 METHOD     eachWithIndex(Closure)                     List
+METHOD     equals(IntRange)                [PUBLIC]   boolean
 METHOD     equals(List)                               boolean
 METHOD     equals(Object)                  [PUBLIC]   boolean
 METHOD     equals(Object[])                           boolean
@@ -83,7 +85,7 @@ METHOD     first()                                    Object
 METHOD     flatten()                                  List
 METHOD     flatten(Closure)                           Collection
 METHOD     forEach(Consumer<? super T>)    [PUBLIC]   void
-METHOD     get(int)                        [PUBLIC]   E
+METHOD     get(int)                        [PUBLIC]   Integer
 METHOD     getAt(Collection)                          List
 METHOD     getAt(EmptyRange)                          List
 METHOD     getAt(Number)                              Object
@@ -91,12 +93,15 @@ METHOD     getAt(Range)                               List
 METHOD     getAt(String)                              List
 METHOD     getAt(int)                                 Object
 METHOD     getClass()                      [PUBLIC]   Class<?>
-METHOD     getFrom()                       [PUBLIC]   T
+METHOD     getFrom()                       [PUBLIC]   Integer
+METHOD     getFromInt()                    [PUBLIC]   int
+METHOD     getInclusive()                  [PUBLIC]   Boolean
 METHOD     getIndices()                               IntRange
 METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
 METHOD     getProperties()                            Map
-METHOD     getTo()                         [PUBLIC]   T
+METHOD     getTo()                         [PUBLIC]   Integer
+METHOD     getToInt()                      [PUBLIC]   int
 METHOD     grep()                                     List
 METHOD     grep(Object)                               List
 METHOD     groupBy(Closure)                           Map
@@ -123,7 +128,7 @@ METHOD     is(Object)                                 boolean
 METHOD     isCase(Object)                             boolean
 METHOD     isEmpty()                       [PUBLIC]   boolean
 METHOD     isReverse()                     [PUBLIC]   boolean
-METHOD     iterator()                                 Iterator
+METHOD     iterator()                      [PUBLIC]   Iterator<Integer>
 METHOD     join(String)                               String
 METHOD     last()                                     Object
 METHOD     lastIndexOf(Object)             [PUBLIC]   int
@@ -219,10 +224,11 @@ METHOD     split(Closure)                             List
 METHOD     spliterator()                   [PUBLIC]   Spliterator<E>
 METHOD     sprintf(String, Object)                    String
 METHOD     sprintf(String, Object)                    String
-METHOD     step(int)                       [PUBLIC]   List<T>
+METHOD     step(int)                       [PUBLIC]   List<Integer>
 METHOD     step(int, Closure)              [PUBLIC]   void
 METHOD     stream()                                   Stream
-METHOD     subList(int, int)               [PUBLIC]   List<E>
+METHOD     subList(int, int)               [PUBLIC]   List<Integer>
+METHOD     subListBorders(int)             [PUBLIC]   RangeInfo
 METHOD     subsequences()                             Set
 METHOD     sum()                                      Object
 METHOD     sum(Closure)                               Object
@@ -245,7 +251,7 @@ METHOD     toSorted()                                 List
 METHOD     toSorted(Closure)                          List
 METHOD     toSorted(Comparator)                       List
 METHOD     toSpreadMap()                              SpreadMap
-METHOD     toString()                                 String
+METHOD     toString()                      [PUBLIC]   String
 METHOD     toUnique()                                 List
 METHOD     toUnique(Closure)                          List
 METHOD     toUnique(Comparator)                       List
@@ -270,7 +276,11 @@ METHOD     withIndex()                                List
 METHOD     withIndex(int)                             List
 METHOD     withLazyDefault(Closure)                   ListWithDefault
 METHOD     withTraits(Class[])                        Object
+FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean
-FIELD      from                            [PUBLIC]   Comparable
+FIELD      from                            [PUBLIC]   Integer
+FIELD      fromInt                         [PUBLIC]   int
+FIELD      inclusive                       [PUBLIC]   Boolean
 FIELD      reverse                         [PUBLIC]   boolean
-FIELD      to                              [PUBLIC]   Comparable
+FIELD      to                              [PUBLIC]   Integer
+FIELD      toInt                           [PUBLIC]   int

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.9.completion
@@ -159,7 +159,7 @@ METHOD     of(E, E, E, E, E, E, E)         [STATIC,   List<E>
 METHOD     of(E, E, E, E, E, E, E, E)      [STATIC,   List<E>
 METHOD     of(E, E, E, E, E, E, E, E, E)   [STATIC,   List<E>
 METHOD     of(E, E, E, E, E, E, E, E, E,   [STATIC,   List<E>
-METHOD     of(E[])                         [STATIC,   List<E>
+METHOD     of(E...)                        [STATIC,   List<E>
 METHOD     parallelStream()                [PUBLIC]   Stream<E>
 METHOD     permutations()                             Set
 METHOD     permutations(Closure)                      List

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/collections/collections1/Collections1.groovy.testCollections1_5.completion
@@ -23,6 +23,7 @@ METHOD     asUnmodifiable()                           List
 METHOD     average()                                  Object
 METHOD     average(Closure)                           Object
 METHOD     bufferedIterator()                         BufferedIterator
+METHOD     by(T)                           [PUBLIC]   NumberRange
 METHOD     chop(int[])                                List
 METHOD     clear()                         [PUBLIC]   void
 METHOD     collate(int)                               List
@@ -43,7 +44,7 @@ METHOD     collectNested(Collection, Clos             Collection
 METHOD     combinations()                             List
 METHOD     combinations(Closure)                      List
 METHOD     contains(Object)                [PUBLIC]   boolean
-METHOD     containsAll(Collection<?>)      [PUBLIC]   boolean
+METHOD     containsAll(Collection)         [PUBLIC]   boolean
 METHOD     containsAll(Object[])                      boolean
 METHOD     containsWithinBounds(Object)    [PUBLIC]   boolean
 METHOD     count(Closure)                             Number
@@ -58,6 +59,7 @@ METHOD     each(Closure)                              List
 METHOD     eachCombination(Closure)                   void
 METHOD     eachPermutation(Closure)                   Iterator
 METHOD     eachWithIndex(Closure)                     List
+METHOD     equals(IntRange)                [PUBLIC]   boolean
 METHOD     equals(List)                               boolean
 METHOD     equals(Object)                  [PUBLIC]   boolean
 METHOD     equals(Object[])                           boolean
@@ -83,7 +85,7 @@ METHOD     first()                                    Object
 METHOD     flatten()                                  List
 METHOD     flatten(Closure)                           Collection
 METHOD     forEach(Consumer<? super T>)    [PUBLIC]   void
-METHOD     get(int)                        [PUBLIC]   E
+METHOD     get(int)                        [PUBLIC]   Integer
 METHOD     getAt(Collection)                          List
 METHOD     getAt(EmptyRange)                          List
 METHOD     getAt(Number)                              Object
@@ -91,12 +93,15 @@ METHOD     getAt(Range)                               List
 METHOD     getAt(String)                              List
 METHOD     getAt(int)                                 Object
 METHOD     getClass()                      [PUBLIC]   Class<?>
-METHOD     getFrom()                       [PUBLIC]   T
+METHOD     getFrom()                       [PUBLIC]   Integer
+METHOD     getFromInt()                    [PUBLIC]   int
+METHOD     getInclusive()                  [PUBLIC]   Boolean
 METHOD     getIndices()                               IntRange
 METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
 METHOD     getProperties()                            Map
-METHOD     getTo()                         [PUBLIC]   T
+METHOD     getTo()                         [PUBLIC]   Integer
+METHOD     getToInt()                      [PUBLIC]   int
 METHOD     grep()                                     List
 METHOD     grep(Object)                               List
 METHOD     groupBy(Closure)                           Map
@@ -123,7 +128,7 @@ METHOD     is(Object)                                 boolean
 METHOD     isCase(Object)                             boolean
 METHOD     isEmpty()                       [PUBLIC]   boolean
 METHOD     isReverse()                     [PUBLIC]   boolean
-METHOD     iterator()                                 Iterator
+METHOD     iterator()                      [PUBLIC]   Iterator<Integer>
 METHOD     join(String)                               String
 METHOD     last()                                     Object
 METHOD     lastIndexOf(Object)             [PUBLIC]   int
@@ -207,10 +212,11 @@ METHOD     split(Closure)                             List
 METHOD     spliterator()                   [PUBLIC]   Spliterator<E>
 METHOD     sprintf(String, Object)                    String
 METHOD     sprintf(String, Object)                    String
-METHOD     step(int)                       [PUBLIC]   List<T>
+METHOD     step(int)                       [PUBLIC]   List<Integer>
 METHOD     step(int, Closure)              [PUBLIC]   void
 METHOD     stream()                                   Stream
-METHOD     subList(int, int)               [PUBLIC]   List<E>
+METHOD     subList(int, int)               [PUBLIC]   List<Integer>
+METHOD     subListBorders(int)             [PUBLIC]   RangeInfo
 METHOD     subsequences()                             Set
 METHOD     sum()                                      Object
 METHOD     sum(Closure)                               Object
@@ -233,7 +239,7 @@ METHOD     toSorted()                                 List
 METHOD     toSorted(Closure)                          List
 METHOD     toSorted(Comparator)                       List
 METHOD     toSpreadMap()                              SpreadMap
-METHOD     toString()                                 String
+METHOD     toString()                      [PUBLIC]   String
 METHOD     toUnique()                                 List
 METHOD     toUnique(Closure)                          List
 METHOD     toUnique(Comparator)                       List
@@ -258,7 +264,11 @@ METHOD     withIndex()                                List
 METHOD     withIndex(int)                             List
 METHOD     withLazyDefault(Closure)                   ListWithDefault
 METHOD     withTraits(Class[])                        Object
+FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean
-FIELD      from                            [PUBLIC]   Comparable
+FIELD      from                            [PUBLIC]   Integer
+FIELD      fromInt                         [PUBLIC]   int
+FIELD      inclusive                       [PUBLIC]   Boolean
 FIELD      reverse                         [PUBLIC]   boolean
-FIELD      to                              [PUBLIC]   Comparable
+FIELD      to                              [PUBLIC]   Integer
+FIELD      toInt                           [PUBLIC]   int

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class Helper {
+    private File builderPrivate;
+    
+    ProcessBuilder builderProperty;
+    
+}
+
+class Fields2 {
+    File    someFile
+    private ProcessBuilder newBuilder() { return null; }
+        
+    def setup() {
+        someFile = new File("Mr.Spock")
+        someFile.parentFile.mkdirs()
+        someFile.absoluteFile.parentFile.mkdirs()
+        (someFile.canonicalFile.getParentFile).mkdirs()
+        
+        System.properties.get("foo")
+        
+        new Helper().builderProperty.inheritIO()
+        
+        System.err.println(Helper.class.classLoader)
+    }
+}
+

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_javaModifiers.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_javaModifiers.completion
@@ -1,0 +1,3 @@
+Code completion result for source line:
+System.err.println(Helper.class.classL|oader)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_javaPropertyReference.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_javaPropertyReference.9.completion
@@ -1,0 +1,16 @@
+Code completion result for source line:
+System.properties.ge|t("foo")
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     get(Object)                     [PUBLIC]   Object
+METHOD     get(Object, Object)                        Object
+METHOD     getAt(Object)                              Object
+METHOD     getAt(String)                              Object
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getOrDefault(Object, Object)    [PUBLIC]   Object
+METHOD     getOrDefault(Object, V)         [PUBLIC]   V
+METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   String
+METHOD     getProperty(String, String)     [PUBLIC]   String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_javaPropertyReference.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_javaPropertyReference.completion
@@ -1,0 +1,15 @@
+Code completion result for source line:
+System.properties.ge|t("foo")
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     get(Object)                     [PUBLIC]   V
+METHOD     get(Object, Object)                        Object
+METHOD     getAt(Object)                              Object
+METHOD     getAt(String)                              Object
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getOrDefault(Object, V)         [PUBLIC]   V
+METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   String
+METHOD     getProperty(String, String)     [PUBLIC]   String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_modifiers.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_modifiers.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+new Helper().builder|Property.inheritIO()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+FIELD      builderPrivate                  [PRIVATE]  File
+FIELD      builderProperty                 [PRIVATE]  ProcessBuilder

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_otherClassProperty.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_otherClassProperty.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+new Helper().builderProperty.inher|itIO()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     inheritIO()                     [PUBLIC]   ProcessBuilder

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_propertyChain1.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_propertyChain1.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+someFile.parent|File.mkdirs()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+FIELD      parentFile                      [PUBLIC]   File

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_propertyChain2.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_propertyChain2.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+someFile.absoluteFile.parent|File.mkdirs()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+FIELD      parentFile                      [PUBLIC]   File

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_propertyChain3.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/field/Fields2.groovy.testFields2_propertyChain3.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+someFile.absoluteFile.parentFile.mkd|irs()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     mkdir()                         [PUBLIC]   boolean
+METHOD     mkdirs()                        [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.11.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.11.completion
@@ -8,6 +8,7 @@ METHOD     any(Closure)                               boolean
 METHOD     asBoolean()                                boolean
 METHOD     asType(Class)                              Object
 METHOD     bitwiseNegate()                            Pattern
+METHOD     build(GroovyObject)             [PUBLIC]   void
 METHOD     capitalize()                               String
 METHOD     center(Number)                             String
 METHOD     center(Number, CharSequence)               String
@@ -22,8 +23,9 @@ METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
 METHOD     collectReplacements(Closure)               String
 METHOD     collectReplacements(List)                  String
-METHOD     compare(CharSequence, CharSequ  [STATIC,   int
+METHOD     compareTo(Object)               [PUBLIC]   int
 METHOD     compareTo(String)               [PUBLIC]   int
+METHOD     compareTo(T)                    [PUBLIC]   int
 METHOD     compareToIgnoreCase(String)     [PUBLIC]   int
 METHOD     concat(String)                  [PUBLIC]   String
 METHOD     contains(CharSequence)          [PUBLIC]   boolean
@@ -52,6 +54,7 @@ METHOD     eachWithIndex(Closure)                     Object
 METHOD     endsWith(String)                [PUBLIC]   boolean
 METHOD     endsWithAny(CharSequence[])                boolean
 METHOD     endsWithIgnoreCase(CharSequenc             boolean
+METHOD     equals(GString)                 [PUBLIC]   boolean
 METHOD     equals(Object)                  [PUBLIC]   boolean
 METHOD     equalsIgnoreCase(String)        [PUBLIC]   boolean
 METHOD     every()                                    boolean
@@ -100,6 +103,11 @@ METHOD     getClass()                      [PUBLIC]   Class<?>
 METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
 METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     getStrings()                    [PUBLIC]   String[]
+METHOD     getValue(int)                   [PUBLIC]   Object
+METHOD     getValueCount()                 [PUBLIC]   int
+METHOD     getValues()                     [PUBLIC]   Object[]
 METHOD     grep()                                     Collection
 METHOD     grep(Object)                               Collection
 METHOD     hasProperty(String)                        MetaProperty
@@ -119,7 +127,7 @@ METHOD     isAllWhitespace()                          boolean
 METHOD     isAtLeast(String)                          Boolean
 METHOD     isBigDecimal()                             boolean
 METHOD     isBigInteger()                             boolean
-METHOD     isBlank()                       [PUBLIC]   boolean
+METHOD     isBlank()                                  boolean
 METHOD     isCase(Object)                             boolean
 METHOD     isDouble()                                 boolean
 METHOD     isEmpty()                       [PUBLIC]   boolean
@@ -144,6 +152,7 @@ METHOD     metaClass(Closure)                         MetaClass
 METHOD     minus(Object)                              String
 METHOD     minus(Pattern)                             String
 METHOD     multiply(Number)                           String
+METHOD     negate()                        [PUBLIC]   Pattern
 METHOD     next()                                     String
 METHOD     normalize()                                String
 METHOD     notify()                        [PUBLIC]   void
@@ -155,7 +164,9 @@ METHOD     padLeft(Number, CharSequence)              String
 METHOD     padRight(Number)                           String
 METHOD     padRight(Number, CharSequence)             String
 METHOD     plus(CharSequence)                         String
+METHOD     plus(GString)                   [PUBLIC]   GString
 METHOD     plus(Object)                               String
+METHOD     plus(String)                    [PUBLIC]   GString
 METHOD     previous()                                 String
 METHOD     print(Object)                              void
 METHOD     print(PrintWriter)                         void
@@ -187,6 +198,7 @@ METHOD     respondsTo(String)                         List
 METHOD     respondsTo(String, Object)                 List
 METHOD     reverse()                                  String
 METHOD     setMetaClass(MetaClass)                    void
+METHOD     setProperty(String, Object)     [PUBLIC]   void
 METHOD     sha256()                                   String
 METHOD     size()                                     int
 METHOD     sleep(long)                                void
@@ -273,8 +285,14 @@ METHOD     wait(long, int)                 [PUBLIC]   void
 METHOD     with(Closure)                              Object
 METHOD     with(boolean, Closure)                     Object
 METHOD     withTraits(Class[])                        Object
+METHOD     writeTo(Writer)                 [PUBLIC]   Writer
 FIELD      CASE_INSENSITIVE_ORDER          [STATIC,   Comparator<String>
-FIELD      blank                           [PUBLIC]   boolean
+FIELD      EMPTY                           [STATIC,   GString
+FIELD      EMPTY_OBJECT_ARRAY              [STATIC,   Object[]
+FIELD      EMPTY_STRING_ARRAY              [STATIC,   String[]
 FIELD      bytes                           [PUBLIC]   byte[]
 FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean
+FIELD      strings                         [PUBLIC]   String[]
+FIELD      valueCount                      [PUBLIC]   int
+FIELD      values                          [PUBLIC]   Object[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.11.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.11.completion
@@ -28,7 +28,7 @@ METHOD     compareTo(String)               [PUBLIC]   int
 METHOD     compareTo(T)                    [PUBLIC]   int
 METHOD     compareToIgnoreCase(String)     [PUBLIC]   int
 METHOD     concat(String)                  [PUBLIC]   String
-METHOD     contains(CharSequence)          [PUBLIC]   boolean
+METHOD     contains(CharSequence)                     boolean
 METHOD     containsIgnoreCase(CharSequenc             boolean
 METHOD     contentEquals(CharSequence)     [PUBLIC]   boolean
 METHOD     contentEquals(StringBuffer)     [PUBLIC]   boolean
@@ -48,7 +48,7 @@ METHOD     each(Closure)                              Object
 METHOD     eachLine(Closure)                          Object
 METHOD     eachLine(int, Closure)                     Object
 METHOD     eachMatch(CharSequence, Closur             CharSequence
-METHOD     eachMatch(Pattern, Closure)                String
+METHOD     eachMatch(Pattern, Closure)                CharSequence
 METHOD     eachMatch(String, Closure)                 String
 METHOD     eachWithIndex(Closure)                     Object
 METHOD     endsWith(String)                [PUBLIC]   boolean
@@ -85,8 +85,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String
@@ -121,7 +121,7 @@ METHOD     inject(Closure)                            Object
 METHOD     inject(Object, Closure)                    Object
 METHOD     inspect()                                  String
 METHOD     intern()                        [PUBLIC]   String
-METHOD     invokeMethod(String, Object)               Object
+METHOD     invokeMethod(String, Object)    [PUBLIC]   Object
 METHOD     is(Object)                                 boolean
 METHOD     isAllWhitespace()                          boolean
 METHOD     isAtLeast(String)                          Boolean
@@ -142,7 +142,7 @@ METHOD     lastIndexOf(String)             [PUBLIC]   int
 METHOD     lastIndexOf(String, int)        [PUBLIC]   int
 METHOD     lastIndexOf(int)                [PUBLIC]   int
 METHOD     lastIndexOf(int, int)           [PUBLIC]   int
-METHOD     leftShift(Object)                          StringBuffer
+METHOD     leftShift(Object)                          StringBuilder
 METHOD     length()                        [PUBLIC]   int
 METHOD     lines()                         [PUBLIC]   Stream<String>
 METHOD     matches(Pattern)                           boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.11.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.11.completion
@@ -23,6 +23,7 @@ METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
 METHOD     collectReplacements(Closure)               String
 METHOD     collectReplacements(List)                  String
+METHOD     compare(CharSequence, CharSequ  [STATIC,   int
 METHOD     compareTo(Object)               [PUBLIC]   int
 METHOD     compareTo(String)               [PUBLIC]   int
 METHOD     compareTo(T)                    [PUBLIC]   int
@@ -290,6 +291,7 @@ FIELD      CASE_INSENSITIVE_ORDER          [STATIC,   Comparator<String>
 FIELD      EMPTY                           [STATIC,   GString
 FIELD      EMPTY_OBJECT_ARRAY              [STATIC,   Object[]
 FIELD      EMPTY_STRING_ARRAY              [STATIC,   String[]
+FIELD      blank                           [PUBLIC]   boolean
 FIELD      bytes                           [PUBLIC]   byte[]
 FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.12.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.12.completion
@@ -8,6 +8,7 @@ METHOD     any(Closure)                               boolean
 METHOD     asBoolean()                                boolean
 METHOD     asType(Class)                              Object
 METHOD     bitwiseNegate()                            Pattern
+METHOD     build(GroovyObject)             [PUBLIC]   void
 METHOD     capitalize()                               String
 METHOD     center(Number)                             String
 METHOD     center(Number, CharSequence)               String
@@ -22,8 +23,9 @@ METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
 METHOD     collectReplacements(Closure)               String
 METHOD     collectReplacements(List)                  String
-METHOD     compare(CharSequence, CharSequ  [STATIC,   int
+METHOD     compareTo(Object)               [PUBLIC]   int
 METHOD     compareTo(String)               [PUBLIC]   int
+METHOD     compareTo(T)                    [PUBLIC]   int
 METHOD     compareToIgnoreCase(String)     [PUBLIC]   int
 METHOD     concat(String)                  [PUBLIC]   String
 METHOD     contains(CharSequence)          [PUBLIC]   boolean
@@ -53,6 +55,7 @@ METHOD     eachWithIndex(Closure)                     Object
 METHOD     endsWith(String)                [PUBLIC]   boolean
 METHOD     endsWithAny(CharSequence[])                boolean
 METHOD     endsWithIgnoreCase(CharSequenc             boolean
+METHOD     equals(GString)                 [PUBLIC]   boolean
 METHOD     equals(Object)                  [PUBLIC]   boolean
 METHOD     equalsIgnoreCase(String)        [PUBLIC]   boolean
 METHOD     every()                                    boolean
@@ -101,6 +104,11 @@ METHOD     getClass()                      [PUBLIC]   Class<?>
 METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
 METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     getStrings()                    [PUBLIC]   String[]
+METHOD     getValue(int)                   [PUBLIC]   Object
+METHOD     getValueCount()                 [PUBLIC]   int
+METHOD     getValues()                     [PUBLIC]   Object[]
 METHOD     grep()                                     Collection
 METHOD     grep(Object)                               Collection
 METHOD     hasProperty(String)                        MetaProperty
@@ -121,7 +129,7 @@ METHOD     isAllWhitespace()                          boolean
 METHOD     isAtLeast(String)                          Boolean
 METHOD     isBigDecimal()                             boolean
 METHOD     isBigInteger()                             boolean
-METHOD     isBlank()                       [PUBLIC]   boolean
+METHOD     isBlank()                                  boolean
 METHOD     isCase(Object)                             boolean
 METHOD     isDouble()                                 boolean
 METHOD     isEmpty()                       [PUBLIC]   boolean
@@ -146,6 +154,7 @@ METHOD     metaClass(Closure)                         MetaClass
 METHOD     minus(Object)                              String
 METHOD     minus(Pattern)                             String
 METHOD     multiply(Number)                           String
+METHOD     negate()                        [PUBLIC]   Pattern
 METHOD     next()                                     String
 METHOD     normalize()                                String
 METHOD     notify()                        [PUBLIC]   void
@@ -157,7 +166,9 @@ METHOD     padLeft(Number, CharSequence)              String
 METHOD     padRight(Number)                           String
 METHOD     padRight(Number, CharSequence)             String
 METHOD     plus(CharSequence)                         String
+METHOD     plus(GString)                   [PUBLIC]   GString
 METHOD     plus(Object)                               String
+METHOD     plus(String)                    [PUBLIC]   GString
 METHOD     previous()                                 String
 METHOD     print(Object)                              void
 METHOD     print(PrintWriter)                         void
@@ -190,6 +201,7 @@ METHOD     respondsTo(String)                         List
 METHOD     respondsTo(String, Object)                 List
 METHOD     reverse()                                  String
 METHOD     setMetaClass(MetaClass)                    void
+METHOD     setProperty(String, Object)     [PUBLIC]   void
 METHOD     sha256()                                   String
 METHOD     size()                                     int
 METHOD     sleep(long)                                void
@@ -277,8 +289,14 @@ METHOD     wait(long, int)                 [PUBLIC]   void
 METHOD     with(Closure)                              Object
 METHOD     with(boolean, Closure)                     Object
 METHOD     withTraits(Class[])                        Object
+METHOD     writeTo(Writer)                 [PUBLIC]   Writer
 FIELD      CASE_INSENSITIVE_ORDER          [STATIC,   Comparator<String>
-FIELD      blank                           [PUBLIC]   boolean
+FIELD      EMPTY                           [STATIC,   GString
+FIELD      EMPTY_OBJECT_ARRAY              [STATIC,   Object[]
+FIELD      EMPTY_STRING_ARRAY              [STATIC,   String[]
 FIELD      bytes                           [PUBLIC]   byte[]
 FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean
+FIELD      strings                         [PUBLIC]   String[]
+FIELD      valueCount                      [PUBLIC]   int
+FIELD      values                          [PUBLIC]   Object[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.12.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.12.completion
@@ -28,7 +28,7 @@ METHOD     compareTo(String)               [PUBLIC]   int
 METHOD     compareTo(T)                    [PUBLIC]   int
 METHOD     compareToIgnoreCase(String)     [PUBLIC]   int
 METHOD     concat(String)                  [PUBLIC]   String
-METHOD     contains(CharSequence)          [PUBLIC]   boolean
+METHOD     contains(CharSequence)                     boolean
 METHOD     containsIgnoreCase(CharSequenc             boolean
 METHOD     contentEquals(CharSequence)     [PUBLIC]   boolean
 METHOD     contentEquals(StringBuffer)     [PUBLIC]   boolean
@@ -49,7 +49,7 @@ METHOD     each(Closure)                              Object
 METHOD     eachLine(Closure)                          Object
 METHOD     eachLine(int, Closure)                     Object
 METHOD     eachMatch(CharSequence, Closur             CharSequence
-METHOD     eachMatch(Pattern, Closure)                String
+METHOD     eachMatch(Pattern, Closure)                CharSequence
 METHOD     eachMatch(String, Closure)                 String
 METHOD     eachWithIndex(Closure)                     Object
 METHOD     endsWith(String)                [PUBLIC]   boolean
@@ -86,8 +86,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String
@@ -123,7 +123,7 @@ METHOD     inject(Closure)                            Object
 METHOD     inject(Object, Closure)                    Object
 METHOD     inspect()                                  String
 METHOD     intern()                        [PUBLIC]   String
-METHOD     invokeMethod(String, Object)               Object
+METHOD     invokeMethod(String, Object)    [PUBLIC]   Object
 METHOD     is(Object)                                 boolean
 METHOD     isAllWhitespace()                          boolean
 METHOD     isAtLeast(String)                          Boolean
@@ -144,7 +144,7 @@ METHOD     lastIndexOf(String)             [PUBLIC]   int
 METHOD     lastIndexOf(String, int)        [PUBLIC]   int
 METHOD     lastIndexOf(int)                [PUBLIC]   int
 METHOD     lastIndexOf(int, int)           [PUBLIC]   int
-METHOD     leftShift(Object)                          StringBuffer
+METHOD     leftShift(Object)                          StringBuilder
 METHOD     length()                        [PUBLIC]   int
 METHOD     lines()                         [PUBLIC]   Stream<String>
 METHOD     matches(Pattern)                           boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.13.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.13.completion
@@ -8,6 +8,7 @@ METHOD     any(Closure)                               boolean
 METHOD     asBoolean()                                boolean
 METHOD     asType(Class)                              Object
 METHOD     bitwiseNegate()                            Pattern
+METHOD     build(GroovyObject)             [PUBLIC]   void
 METHOD     capitalize()                               String
 METHOD     center(Number)                             String
 METHOD     center(Number, CharSequence)               String
@@ -22,8 +23,9 @@ METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
 METHOD     collectReplacements(Closure)               String
 METHOD     collectReplacements(List)                  String
-METHOD     compare(CharSequence, CharSequ  [STATIC,   int
+METHOD     compareTo(Object)               [PUBLIC]   int
 METHOD     compareTo(String)               [PUBLIC]   int
+METHOD     compareTo(T)                    [PUBLIC]   int
 METHOD     compareToIgnoreCase(String)     [PUBLIC]   int
 METHOD     concat(String)                  [PUBLIC]   String
 METHOD     contains(CharSequence)          [PUBLIC]   boolean
@@ -53,6 +55,7 @@ METHOD     eachWithIndex(Closure)                     Object
 METHOD     endsWith(String)                [PUBLIC]   boolean
 METHOD     endsWithAny(CharSequence[])                boolean
 METHOD     endsWithIgnoreCase(CharSequenc             boolean
+METHOD     equals(GString)                 [PUBLIC]   boolean
 METHOD     equals(Object)                  [PUBLIC]   boolean
 METHOD     equalsIgnoreCase(String)        [PUBLIC]   boolean
 METHOD     every()                                    boolean
@@ -102,6 +105,11 @@ METHOD     getClass()                      [PUBLIC]   Class<?>
 METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
 METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     getStrings()                    [PUBLIC]   String[]
+METHOD     getValue(int)                   [PUBLIC]   Object
+METHOD     getValueCount()                 [PUBLIC]   int
+METHOD     getValues()                     [PUBLIC]   Object[]
 METHOD     grep()                                     Collection
 METHOD     grep(Object)                               Collection
 METHOD     hasProperty(String)                        MetaProperty
@@ -122,7 +130,7 @@ METHOD     isAllWhitespace()                          boolean
 METHOD     isAtLeast(String)                          Boolean
 METHOD     isBigDecimal()                             boolean
 METHOD     isBigInteger()                             boolean
-METHOD     isBlank()                       [PUBLIC]   boolean
+METHOD     isBlank()                                  boolean
 METHOD     isCase(Object)                             boolean
 METHOD     isDouble()                                 boolean
 METHOD     isEmpty()                       [PUBLIC]   boolean
@@ -147,6 +155,7 @@ METHOD     metaClass(Closure)                         MetaClass
 METHOD     minus(Object)                              String
 METHOD     minus(Pattern)                             String
 METHOD     multiply(Number)                           String
+METHOD     negate()                        [PUBLIC]   Pattern
 METHOD     next()                                     String
 METHOD     normalize()                                String
 METHOD     notify()                        [PUBLIC]   void
@@ -158,7 +167,9 @@ METHOD     padLeft(Number, CharSequence)              String
 METHOD     padRight(Number)                           String
 METHOD     padRight(Number, CharSequence)             String
 METHOD     plus(CharSequence)                         String
+METHOD     plus(GString)                   [PUBLIC]   GString
 METHOD     plus(Object)                               String
+METHOD     plus(String)                    [PUBLIC]   GString
 METHOD     previous()                                 String
 METHOD     print(Object)                              void
 METHOD     print(PrintWriter)                         void
@@ -191,6 +202,7 @@ METHOD     respondsTo(String)                         List
 METHOD     respondsTo(String, Object)                 List
 METHOD     reverse()                                  String
 METHOD     setMetaClass(MetaClass)                    void
+METHOD     setProperty(String, Object)     [PUBLIC]   void
 METHOD     sha256()                                   String
 METHOD     size()                                     int
 METHOD     sleep(long)                                void
@@ -208,8 +220,7 @@ METHOD     startsWith(String, int)         [PUBLIC]   boolean
 METHOD     startsWithAny(CharSequence[])              boolean
 METHOD     startsWithIgnoreCase(CharSeque             boolean
 METHOD     stream()                                   Stream
-METHOD     strip()                         [PUBLIC]   String
-METHOD     stripIndent()                   [PUBLIC]   String
+METHOD     stripIndent()                              String
 METHOD     stripIndent(boolean)                       String
 METHOD     stripIndent(int)                           String
 METHOD     stripLeading()                  [PUBLIC]   String
@@ -279,8 +290,14 @@ METHOD     wait(long, int)                 [PUBLIC]   void
 METHOD     with(Closure)                              Object
 METHOD     with(boolean, Closure)                     Object
 METHOD     withTraits(Class[])                        Object
+METHOD     writeTo(Writer)                 [PUBLIC]   Writer
 FIELD      CASE_INSENSITIVE_ORDER          [STATIC,   Comparator<String>
-FIELD      blank                           [PUBLIC]   boolean
+FIELD      EMPTY                           [STATIC,   GString
+FIELD      EMPTY_OBJECT_ARRAY              [STATIC,   Object[]
+FIELD      EMPTY_STRING_ARRAY              [STATIC,   String[]
 FIELD      bytes                           [PUBLIC]   byte[]
 FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean
+FIELD      strings                         [PUBLIC]   String[]
+FIELD      valueCount                      [PUBLIC]   int
+FIELD      values                          [PUBLIC]   Object[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.13.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.13.completion
@@ -28,7 +28,7 @@ METHOD     compareTo(String)               [PUBLIC]   int
 METHOD     compareTo(T)                    [PUBLIC]   int
 METHOD     compareToIgnoreCase(String)     [PUBLIC]   int
 METHOD     concat(String)                  [PUBLIC]   String
-METHOD     contains(CharSequence)          [PUBLIC]   boolean
+METHOD     contains(CharSequence)                     boolean
 METHOD     containsIgnoreCase(CharSequenc             boolean
 METHOD     contentEquals(CharSequence)     [PUBLIC]   boolean
 METHOD     contentEquals(StringBuffer)     [PUBLIC]   boolean
@@ -49,7 +49,7 @@ METHOD     each(Closure)                              Object
 METHOD     eachLine(Closure)                          Object
 METHOD     eachLine(int, Closure)                     Object
 METHOD     eachMatch(CharSequence, Closur             CharSequence
-METHOD     eachMatch(Pattern, Closure)                String
+METHOD     eachMatch(Pattern, Closure)                CharSequence
 METHOD     eachMatch(String, Closure)                 String
 METHOD     eachWithIndex(Closure)                     Object
 METHOD     endsWith(String)                [PUBLIC]   boolean
@@ -86,8 +86,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     formatted(Object[])             [PUBLIC]   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
@@ -124,7 +124,7 @@ METHOD     inject(Closure)                            Object
 METHOD     inject(Object, Closure)                    Object
 METHOD     inspect()                                  String
 METHOD     intern()                        [PUBLIC]   String
-METHOD     invokeMethod(String, Object)               Object
+METHOD     invokeMethod(String, Object)    [PUBLIC]   Object
 METHOD     is(Object)                                 boolean
 METHOD     isAllWhitespace()                          boolean
 METHOD     isAtLeast(String)                          Boolean
@@ -145,7 +145,7 @@ METHOD     lastIndexOf(String)             [PUBLIC]   int
 METHOD     lastIndexOf(String, int)        [PUBLIC]   int
 METHOD     lastIndexOf(int)                [PUBLIC]   int
 METHOD     lastIndexOf(int, int)           [PUBLIC]   int
-METHOD     leftShift(Object)                          StringBuffer
+METHOD     leftShift(Object)                          StringBuilder
 METHOD     length()                        [PUBLIC]   int
 METHOD     lines()                         [PUBLIC]   Stream<String>
 METHOD     matches(Pattern)                           boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.9.completion
@@ -8,6 +8,7 @@ METHOD     any(Closure)                               boolean
 METHOD     asBoolean()                                boolean
 METHOD     asType(Class)                              Object
 METHOD     bitwiseNegate()                            Pattern
+METHOD     build(GroovyObject)             [PUBLIC]   void
 METHOD     capitalize()                               String
 METHOD     center(Number)                             String
 METHOD     center(Number, CharSequence)               String
@@ -22,7 +23,9 @@ METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
 METHOD     collectReplacements(Closure)               String
 METHOD     collectReplacements(List)                  String
+METHOD     compareTo(Object)               [PUBLIC]   int
 METHOD     compareTo(String)               [PUBLIC]   int
+METHOD     compareTo(T)                    [PUBLIC]   int
 METHOD     compareToIgnoreCase(String)     [PUBLIC]   int
 METHOD     concat(String)                  [PUBLIC]   String
 METHOD     contains(CharSequence)          [PUBLIC]   boolean
@@ -51,6 +54,7 @@ METHOD     eachWithIndex(Closure)                     Object
 METHOD     endsWith(String)                [PUBLIC]   boolean
 METHOD     endsWithAny(CharSequence[])                boolean
 METHOD     endsWithIgnoreCase(CharSequenc             boolean
+METHOD     equals(GString)                 [PUBLIC]   boolean
 METHOD     equals(Object)                  [PUBLIC]   boolean
 METHOD     equalsIgnoreCase(String)        [PUBLIC]   boolean
 METHOD     every()                                    boolean
@@ -99,6 +103,11 @@ METHOD     getClass()                      [PUBLIC]   Class<?>
 METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
 METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     getStrings()                    [PUBLIC]   String[]
+METHOD     getValue(int)                   [PUBLIC]   Object
+METHOD     getValueCount()                 [PUBLIC]   int
+METHOD     getValues()                     [PUBLIC]   Object[]
 METHOD     grep()                                     Collection
 METHOD     grep(Object)                               Collection
 METHOD     hasProperty(String)                        MetaProperty
@@ -142,6 +151,7 @@ METHOD     metaClass(Closure)                         MetaClass
 METHOD     minus(Object)                              String
 METHOD     minus(Pattern)                             String
 METHOD     multiply(Number)                           String
+METHOD     negate()                        [PUBLIC]   Pattern
 METHOD     next()                                     String
 METHOD     normalize()                                String
 METHOD     notify()                        [PUBLIC]   void
@@ -153,7 +163,9 @@ METHOD     padLeft(Number, CharSequence)              String
 METHOD     padRight(Number)                           String
 METHOD     padRight(Number, CharSequence)             String
 METHOD     plus(CharSequence)                         String
+METHOD     plus(GString)                   [PUBLIC]   GString
 METHOD     plus(Object)                               String
+METHOD     plus(String)                    [PUBLIC]   GString
 METHOD     previous()                                 String
 METHOD     print(Object)                              void
 METHOD     print(PrintWriter)                         void
@@ -184,6 +196,7 @@ METHOD     respondsTo(String)                         List
 METHOD     respondsTo(String, Object)                 List
 METHOD     reverse()                                  String
 METHOD     setMetaClass(MetaClass)                    void
+METHOD     setProperty(String, Object)     [PUBLIC]   void
 METHOD     sha256()                                   String
 METHOD     size()                                     int
 METHOD     sleep(long)                                void
@@ -267,7 +280,14 @@ METHOD     wait(long, int)                 [PUBLIC]   void
 METHOD     with(Closure)                              Object
 METHOD     with(boolean, Closure)                     Object
 METHOD     withTraits(Class[])                        Object
+METHOD     writeTo(Writer)                 [PUBLIC]   Writer
 FIELD      CASE_INSENSITIVE_ORDER          [STATIC,   Comparator<String>
+FIELD      EMPTY                           [STATIC,   GString
+FIELD      EMPTY_OBJECT_ARRAY              [STATIC,   Object[]
+FIELD      EMPTY_STRING_ARRAY              [STATIC,   String[]
 FIELD      bytes                           [PUBLIC]   byte[]
 FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean
+FIELD      strings                         [PUBLIC]   String[]
+FIELD      valueCount                      [PUBLIC]   int
+FIELD      values                          [PUBLIC]   Object[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.9.completion
@@ -28,7 +28,7 @@ METHOD     compareTo(String)               [PUBLIC]   int
 METHOD     compareTo(T)                    [PUBLIC]   int
 METHOD     compareToIgnoreCase(String)     [PUBLIC]   int
 METHOD     concat(String)                  [PUBLIC]   String
-METHOD     contains(CharSequence)          [PUBLIC]   boolean
+METHOD     contains(CharSequence)                     boolean
 METHOD     containsIgnoreCase(CharSequenc             boolean
 METHOD     contentEquals(CharSequence)     [PUBLIC]   boolean
 METHOD     contentEquals(StringBuffer)     [PUBLIC]   boolean
@@ -48,7 +48,7 @@ METHOD     each(Closure)                              Object
 METHOD     eachLine(Closure)                          Object
 METHOD     eachLine(int, Closure)                     Object
 METHOD     eachMatch(CharSequence, Closur             CharSequence
-METHOD     eachMatch(Pattern, Closure)                String
+METHOD     eachMatch(Pattern, Closure)                CharSequence
 METHOD     eachMatch(String, Closure)                 String
 METHOD     eachWithIndex(Closure)                     Object
 METHOD     endsWith(String)                [PUBLIC]   boolean
@@ -85,8 +85,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String
@@ -121,7 +121,7 @@ METHOD     inject(Closure)                            Object
 METHOD     inject(Object, Closure)                    Object
 METHOD     inspect()                                  String
 METHOD     intern()                        [PUBLIC]   String
-METHOD     invokeMethod(String, Object)               Object
+METHOD     invokeMethod(String, Object)    [PUBLIC]   Object
 METHOD     is(Object)                                 boolean
 METHOD     isAllWhitespace()                          boolean
 METHOD     isAtLeast(String)                          Boolean
@@ -142,7 +142,7 @@ METHOD     lastIndexOf(String)             [PUBLIC]   int
 METHOD     lastIndexOf(String, int)        [PUBLIC]   int
 METHOD     lastIndexOf(int)                [PUBLIC]   int
 METHOD     lastIndexOf(int, int)           [PUBLIC]   int
-METHOD     leftShift(Object)                          StringBuffer
+METHOD     leftShift(Object)                          StringBuilder
 METHOD     length()                        [PUBLIC]   int
 METHOD     matches(Pattern)                           boolean
 METHOD     matches(String)                 [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.completion
@@ -8,6 +8,7 @@ METHOD     any(Closure)                               boolean
 METHOD     asBoolean()                                boolean
 METHOD     asType(Class)                              Object
 METHOD     bitwiseNegate()                            Pattern
+METHOD     build(GroovyObject)             [PUBLIC]   void
 METHOD     capitalize()                               String
 METHOD     center(Number)                             String
 METHOD     center(Number, CharSequence)               String
@@ -22,7 +23,9 @@ METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
 METHOD     collectReplacements(Closure)               String
 METHOD     collectReplacements(List)                  String
+METHOD     compareTo(Object)               [PUBLIC]   int
 METHOD     compareTo(String)               [PUBLIC]   int
+METHOD     compareTo(T)                    [PUBLIC]   int
 METHOD     compareToIgnoreCase(String)     [PUBLIC]   int
 METHOD     concat(String)                  [PUBLIC]   String
 METHOD     contains(CharSequence)          [PUBLIC]   boolean
@@ -51,6 +54,7 @@ METHOD     eachWithIndex(Closure)                     Object
 METHOD     endsWith(String)                [PUBLIC]   boolean
 METHOD     endsWithAny(CharSequence[])                boolean
 METHOD     endsWithIgnoreCase(CharSequenc             boolean
+METHOD     equals(GString)                 [PUBLIC]   boolean
 METHOD     equals(Object)                  [PUBLIC]   boolean
 METHOD     equalsIgnoreCase(String)        [PUBLIC]   boolean
 METHOD     every()                                    boolean
@@ -99,6 +103,11 @@ METHOD     getClass()                      [PUBLIC]   Class<?>
 METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
 METHOD     getProperties()                            Map
+METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     getStrings()                    [PUBLIC]   String[]
+METHOD     getValue(int)                   [PUBLIC]   Object
+METHOD     getValueCount()                 [PUBLIC]   int
+METHOD     getValues()                     [PUBLIC]   Object[]
 METHOD     grep()                                     Collection
 METHOD     grep(Object)                               Collection
 METHOD     hasProperty(String)                        MetaProperty
@@ -142,6 +151,7 @@ METHOD     metaClass(Closure)                         MetaClass
 METHOD     minus(Object)                              String
 METHOD     minus(Pattern)                             String
 METHOD     multiply(Number)                           String
+METHOD     negate()                        [PUBLIC]   Pattern
 METHOD     next()                                     String
 METHOD     normalize()                                String
 METHOD     notify()                        [PUBLIC]   void
@@ -153,7 +163,9 @@ METHOD     padLeft(Number, CharSequence)              String
 METHOD     padRight(Number)                           String
 METHOD     padRight(Number, CharSequence)             String
 METHOD     plus(CharSequence)                         String
+METHOD     plus(GString)                   [PUBLIC]   GString
 METHOD     plus(Object)                               String
+METHOD     plus(String)                    [PUBLIC]   GString
 METHOD     previous()                                 String
 METHOD     print(Object)                              void
 METHOD     print(PrintWriter)                         void
@@ -184,6 +196,7 @@ METHOD     respondsTo(String)                         List
 METHOD     respondsTo(String, Object)                 List
 METHOD     reverse()                                  String
 METHOD     setMetaClass(MetaClass)                    void
+METHOD     setProperty(String, Object)     [PUBLIC]   void
 METHOD     sha256()                                   String
 METHOD     size()                                     int
 METHOD     sleep(long)                                void
@@ -267,7 +280,14 @@ METHOD     wait(long, int)                 [PUBLIC]   void
 METHOD     with(Closure)                              Object
 METHOD     with(boolean, Closure)                     Object
 METHOD     withTraits(Class[])                        Object
+METHOD     writeTo(Writer)                 [PUBLIC]   Writer
 FIELD      CASE_INSENSITIVE_ORDER          [STATIC,   Comparator<String>
+FIELD      EMPTY                           [STATIC,   GString
+FIELD      EMPTY_OBJECT_ARRAY              [STATIC,   Object[]
+FIELD      EMPTY_STRING_ARRAY              [STATIC,   String[]
 FIELD      bytes                           [PUBLIC]   byte[]
 FIELD      class                           [PUBLIC]   Class
 FIELD      empty                           [PUBLIC]   boolean
+FIELD      strings                         [PUBLIC]   String[]
+FIELD      valueCount                      [PUBLIC]   int
+FIELD      values                          [PUBLIC]   Object[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString1/CompletionNoPrefixString1.groovy.testCompletionNoPrefixString1.completion
@@ -28,7 +28,7 @@ METHOD     compareTo(String)               [PUBLIC]   int
 METHOD     compareTo(T)                    [PUBLIC]   int
 METHOD     compareToIgnoreCase(String)     [PUBLIC]   int
 METHOD     concat(String)                  [PUBLIC]   String
-METHOD     contains(CharSequence)          [PUBLIC]   boolean
+METHOD     contains(CharSequence)                     boolean
 METHOD     containsIgnoreCase(CharSequenc             boolean
 METHOD     contentEquals(CharSequence)     [PUBLIC]   boolean
 METHOD     contentEquals(StringBuffer)     [PUBLIC]   boolean
@@ -48,7 +48,7 @@ METHOD     each(Closure)                              Object
 METHOD     eachLine(Closure)                          Object
 METHOD     eachLine(int, Closure)                     Object
 METHOD     eachMatch(CharSequence, Closur             CharSequence
-METHOD     eachMatch(Pattern, Closure)                String
+METHOD     eachMatch(Pattern, Closure)                CharSequence
 METHOD     eachMatch(String, Closure)                 String
 METHOD     eachWithIndex(Closure)                     Object
 METHOD     endsWith(String)                [PUBLIC]   boolean
@@ -85,8 +85,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String
@@ -121,7 +121,7 @@ METHOD     inject(Closure)                            Object
 METHOD     inject(Object, Closure)                    Object
 METHOD     inspect()                                  String
 METHOD     intern()                        [PUBLIC]   String
-METHOD     invokeMethod(String, Object)               Object
+METHOD     invokeMethod(String, Object)    [PUBLIC]   Object
 METHOD     is(Object)                                 boolean
 METHOD     isAllWhitespace()                          boolean
 METHOD     isAtLeast(String)                          Boolean
@@ -142,7 +142,7 @@ METHOD     lastIndexOf(String)             [PUBLIC]   int
 METHOD     lastIndexOf(String, int)        [PUBLIC]   int
 METHOD     lastIndexOf(int)                [PUBLIC]   int
 METHOD     lastIndexOf(int, int)           [PUBLIC]   int
-METHOD     leftShift(Object)                          StringBuffer
+METHOD     leftShift(Object)                          StringBuilder
 METHOD     length()                        [PUBLIC]   int
 METHOD     matches(Pattern)                           boolean
 METHOD     matches(String)                 [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.11.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.11.completion
@@ -82,8 +82,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.12.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.12.completion
@@ -83,8 +83,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.13.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.13.completion
@@ -83,8 +83,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     formatted(Object[])             [PUBLIC]   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.9.completion
@@ -81,8 +81,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/completionNoPrefixString2/CompletionNoPrefixString2.groovy.testCompletionNoPrefixString2.completion
@@ -81,8 +81,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods1/Methods1.groovy.testMethods1_4.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods1/Methods1.groovy.testMethods1_4.completion
@@ -131,7 +131,6 @@ FIELD      authority                       [PUBLIC]   String
 FIELD      class                           [PUBLIC]   Class
 FIELD      content                         [PUBLIC]   Object
 FIELD      defaultPort                     [PUBLIC]   int
-FIELD      deserializedFields              [PRIVATE]  URLStreamHandler
 FIELD      file                            [PUBLIC]   String
 FIELD      host                            [PUBLIC]   String
 FIELD      path                            [PUBLIC]   String
@@ -139,5 +138,4 @@ FIELD      port                            [PUBLIC]   int
 FIELD      protocol                        [PUBLIC]   String
 FIELD      query                           [PUBLIC]   String
 FIELD      ref                             [PUBLIC]   String
-FIELD      serializedHashCode              [PRIVATE]  int
 FIELD      userInfo                        [PUBLIC]   String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+class Helper {
+    private File ovPrivate() { return null; }
+    
+    File overload(String a) {
+        return null;
+    }
+    
+    public String overload(List<String> b) {
+        return null;
+    }
+}
+
+class Methods5 {
+    File    someFile
+    private ProcessBuilder newBuilder() { return null; }
+        
+    def setup() {
+        someFile = new File("Mr.Spock")
+        someFile.getParentFile().mkdirs()
+        someFile.getAbsoluteFile().getParentFile().mkdirs()
+        (someFile.getCanonicalFile().getParentFile()).mkdirs()
+        
+        
+        ProcessBuilder b = new ProcessBuilder()
+        b.command("good").inheritIO().command()
+        Object o = ProcessBuilder.class;
+        
+        b.command(Arrays.asList("good", "bad")).inheritIO().command()
+        o = ProcessBuilder.class;
+        
+        ProcessBuilder aa = new ProcessBuilder()
+        aa.command "bye".substring(1)
+        
+        new Helper().privateNewFile()
+        new Helper().overload("hello").getAbsoluteFile();
+        new Helper().overload(Arrays.asList("hi")).substring(1)
+    }
+}
+

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_chain1.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_chain1.completion
@@ -1,0 +1,8 @@
+Code completion result for source line:
+someFile.getP|arentFile().mkdirs()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     getParent()                     [PUBLIC]   String
+METHOD     getParentFile()                 [PUBLIC]   File
+METHOD     getPath()                       [PUBLIC]   String
+METHOD     getProperties()                            Map

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_chain2.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_chain2.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+someFile.getParentFile().mk|dirs()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     mkdir()                         [PUBLIC]   boolean
+METHOD     mkdirs()                        [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_chain2a.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_chain2a.completion
@@ -1,0 +1,248 @@
+Code completion result for source line:
+someFile.getParentFile().|mkdirs()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     addShutdownHook(Closure)                   void
+METHOD     any()                                      boolean
+METHOD     any(Closure)                               boolean
+METHOD     append(InputStream)                        void
+METHOD     append(Object)                             void
+METHOD     append(Object,  boolean)                   void
+METHOD     append(Object, String)                     void
+METHOD     append(Object, String,  boolea             void
+METHOD     append(Reader)                             void
+METHOD     append(Reader,  boolean)                   void
+METHOD     append(Reader, String)                     void
+METHOD     append(Reader, String,  boolea             void
+METHOD     append(Writer)                             void
+METHOD     append(Writer,  boolean)                   void
+METHOD     append(Writer, String)                     void
+METHOD     append(Writer, String,  boolea             void
+METHOD     append(byte[])                             void
+METHOD     asBoolean()                                boolean
+METHOD     asType(Class)                              Object
+METHOD     asWritable()                               File
+METHOD     asWritable(String)                         File
+METHOD     canExecute()                    [PUBLIC]   boolean
+METHOD     canRead()                       [PUBLIC]   boolean
+METHOD     canWrite()                      [PUBLIC]   boolean
+METHOD     collect()                                  Collection
+METHOD     collect(Closure)                           List
+METHOD     collect(Collection, Closure)               Collection
+METHOD     compareTo(File)                 [PUBLIC]   int
+METHOD     createNewFile()                 [PUBLIC]   boolean
+METHOD     createTempDir()                            File
+METHOD     createTempDir(String)                      File
+METHOD     createTempDir(String, String)              File
+METHOD     createTempFile(String, String)  [STATIC,   File
+METHOD     createTempFile(String, String,  [STATIC,   File
+METHOD     delete()                        [PUBLIC]   boolean
+METHOD     deleteDir()                                boolean
+METHOD     deleteOnExit()                  [PUBLIC]   void
+METHOD     directorySize()                            long
+METHOD     dump()                                     String
+METHOD     each(Closure)                              Object
+METHOD     eachByte(Closure)                          void
+METHOD     eachByte(int, Closure)                     void
+METHOD     eachDir(Closure)                           void
+METHOD     eachDirMatch(Object, Closure)              void
+METHOD     eachDirRecurse(Closure)                    void
+METHOD     eachFile(Closure)                          void
+METHOD     eachFile(FileType, Closure)                void
+METHOD     eachFileMatch(FileType, Object             void
+METHOD     eachFileMatch(Object, Closure)             void
+METHOD     eachFileRecurse(Closure)                   void
+METHOD     eachFileRecurse(FileType, Clos             void
+METHOD     eachLine(Closure)                          Object
+METHOD     eachLine(String,  int, Closure             Object
+METHOD     eachLine(String, Closure)                  Object
+METHOD     eachLine(int, Closure)                     Object
+METHOD     eachObject(Closure)                        void
+METHOD     eachWithIndex(Closure)                     Object
+METHOD     equals(Object)                  [PUBLIC]   boolean
+METHOD     every()                                    boolean
+METHOD     every(Closure)                             boolean
+METHOD     exists()                        [PUBLIC]   boolean
+METHOD     filterLine(Closure)                        Writable
+METHOD     filterLine(String, Closure)                Writable
+METHOD     filterLine(Writer, Closure)                void
+METHOD     filterLine(Writer, String, Clo             void
+METHOD     find()                                     Object
+METHOD     find(Closure)                              Object
+METHOD     findAll()                                  Collection
+METHOD     findAll(Closure)                           Collection
+METHOD     findIndexOf(Closure)                       int
+METHOD     findIndexOf(int, Closure)                  int
+METHOD     findIndexValues(Closure)                   List
+METHOD     findIndexValues(Number, Closur             List
+METHOD     findLastIndexOf(Closure)                   int
+METHOD     findLastIndexOf(int, Closure)              int
+METHOD     findResult(Closure)                        Object
+METHOD     findResult(Object, Closure)                Object
+METHOD     getAbsoluteFile()               [PUBLIC]   File
+METHOD     getAbsolutePath()               [PUBLIC]   String
+METHOD     getAt(String)                              Object
+METHOD     getBytes()                                 byte[]
+METHOD     getCanonicalFile()              [PUBLIC]   File
+METHOD     getCanonicalPath()              [PUBLIC]   String
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getFreeSpace()                  [PUBLIC]   long
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getName()                       [PUBLIC]   String
+METHOD     getParent()                     [PUBLIC]   String
+METHOD     getParentFile()                 [PUBLIC]   File
+METHOD     getPath()                       [PUBLIC]   String
+METHOD     getProperties()                            Map
+METHOD     getText()                                  String
+METHOD     getText(String)                            String
+METHOD     getTotalSpace()                 [PUBLIC]   long
+METHOD     getUsableSpace()                [PUBLIC]   long
+METHOD     grep()                                     Collection
+METHOD     grep(Object)                               Collection
+METHOD     hasProperty(String)                        MetaProperty
+METHOD     hashCode()                      [PUBLIC]   int
+METHOD     identity(Closure)                          Object
+METHOD     inject(Closure)                            Object
+METHOD     inject(Object, Closure)                    Object
+METHOD     inspect()                                  String
+METHOD     invokeMethod(String, Object)               Object
+METHOD     is(Object)                                 boolean
+METHOD     isAbsolute()                    [PUBLIC]   boolean
+METHOD     isCase(Object)                             boolean
+METHOD     isDirectory()                   [PUBLIC]   boolean
+METHOD     isFile()                        [PUBLIC]   boolean
+METHOD     isHidden()                      [PUBLIC]   boolean
+METHOD     iterator()                                 Iterator
+METHOD     lastModified()                  [PUBLIC]   long
+METHOD     leftShift(InputStream)                     File
+METHOD     leftShift(Object)                          File
+METHOD     leftShift(byte[])                          File
+METHOD     length()                        [PUBLIC]   long
+METHOD     list()                          [PUBLIC]   String[]
+METHOD     list(FilenameFilter)            [PUBLIC]   String[]
+METHOD     listFiles()                     [PUBLIC]   File[]
+METHOD     listFiles(FileFilter)           [PUBLIC]   File[]
+METHOD     listFiles(FilenameFilter)       [PUBLIC]   File[]
+METHOD     listRoots()                     [STATIC,   File[]
+METHOD     metaClass(Closure)                         MetaClass
+METHOD     mkdir()                         [PUBLIC]   boolean
+METHOD     mkdirs()                        [PUBLIC]   boolean
+METHOD     newDataInputStream()                       DataInputStream
+METHOD     newDataOutputStream()                      DataOutputStream
+METHOD     newInputStream()                           BufferedInputStream
+METHOD     newObjectInputStream()                     ObjectInputStream
+METHOD     newObjectInputStream(ClassLoad             ObjectInputStream
+METHOD     newObjectOutputStream()                    ObjectOutputStream
+METHOD     newOutputStream()                          BufferedOutputStream
+METHOD     newPrintWriter()                           PrintWriter
+METHOD     newPrintWriter(String)                     PrintWriter
+METHOD     newReader()                                BufferedReader
+METHOD     newReader(String)                          BufferedReader
+METHOD     newWriter()                                BufferedWriter
+METHOD     newWriter(String)                          BufferedWriter
+METHOD     newWriter(String,  boolean)                BufferedWriter
+METHOD     newWriter(String,  boolean,  b             BufferedWriter
+METHOD     newWriter(boolean)                         BufferedWriter
+METHOD     notify()                        [PUBLIC]   void
+METHOD     notifyAll()                     [PUBLIC]   void
+METHOD     numberAwareCompareTo(Comparabl             int
+METHOD     print(Object)                              void
+METHOD     print(PrintWriter)                         void
+METHOD     printf(String, Object)                     void
+METHOD     printf(String, Object)                     void
+METHOD     println()                                  void
+METHOD     println(Object)                            void
+METHOD     println(PrintWriter)                       void
+METHOD     putAt(String, Object)                      void
+METHOD     readBytes()                                byte[]
+METHOD     readLines()                                List
+METHOD     readLines(String)                          List
+METHOD     relativePath(File)                         String
+METHOD     renameTo(File)                  [PUBLIC]   boolean
+METHOD     renameTo(String)                           boolean
+METHOD     respondsTo(String)                         List
+METHOD     respondsTo(String, Object)                 List
+METHOD     setBytes(byte[])                           void
+METHOD     setExecutable(boolean)          [PUBLIC]   boolean
+METHOD     setExecutable(boolean, boolean  [PUBLIC]   boolean
+METHOD     setLastModified(long)           [PUBLIC]   boolean
+METHOD     setMetaClass(MetaClass)                    void
+METHOD     setReadOnly()                   [PUBLIC]   boolean
+METHOD     setReadable(boolean)            [PUBLIC]   boolean
+METHOD     setReadable(boolean, boolean)   [PUBLIC]   boolean
+METHOD     setText(String)                            void
+METHOD     setText(String, String)                    void
+METHOD     setWritable(boolean)            [PUBLIC]   boolean
+METHOD     setWritable(boolean, boolean)   [PUBLIC]   boolean
+METHOD     size()                                     long
+METHOD     sleep(long)                                void
+METHOD     sleep(long, Closure)                       void
+METHOD     split(Closure)                             Collection
+METHOD     splitEachLine(Pattern, Closure             Object
+METHOD     splitEachLine(Pattern, String,             Object
+METHOD     splitEachLine(String, Closure)             Object
+METHOD     splitEachLine(String, String,              Object
+METHOD     sprintf(String, Object)                    String
+METHOD     sprintf(String, Object)                    String
+METHOD     stream()                                   Stream
+METHOD     tap(Closure)                               Object
+METHOD     toPath()                        [PUBLIC]   Path
+METHOD     toString()                      [PUBLIC]   String
+METHOD     toURI()                         [PUBLIC]   URI
+METHOD     toURL()                         [PUBLIC]   URL
+METHOD     traverse(Closure)                          void
+METHOD     traverse(Map)                              void
+METHOD     traverse(Map, Closure)                     void
+METHOD     use(Class, Closure)                        Object
+METHOD     use(List, Closure)                         Object
+METHOD     use(Object[])                              Object
+METHOD     wait()                          [PUBLIC]   void
+METHOD     wait(long)                      [PUBLIC]   void
+METHOD     wait(long, int)                 [PUBLIC]   void
+METHOD     with(Closure)                              Object
+METHOD     with(boolean, Closure)                     Object
+METHOD     withDataInputStream(Closure)               Object
+METHOD     withDataOutputStream(Closure)              Object
+METHOD     withInputStream(Closure)                   Object
+METHOD     withObjectInputStream(ClassLoa             Object
+METHOD     withObjectInputStream(Closure)             Object
+METHOD     withObjectOutputStream(Closure             Object
+METHOD     withOutputStream(Closure)                  Object
+METHOD     withPrintWriter(Closure)                   Object
+METHOD     withPrintWriter(String, Closur             Object
+METHOD     withReader(Closure)                        Object
+METHOD     withReader(String, Closure)                Object
+METHOD     withTraits(Class[])                        Object
+METHOD     withWriter(Closure)                        Object
+METHOD     withWriter(String, Closure)                Object
+METHOD     withWriterAppend(Closure)                  Object
+METHOD     withWriterAppend(String, Closu             Object
+METHOD     write(String)                              void
+METHOD     write(String,  boolean)                    void
+METHOD     write(String, String)                      void
+METHOD     write(String, String,  boolean             void
+FIELD      absolute                        [PUBLIC]   boolean
+FIELD      absoluteFile                    [PUBLIC]   File
+FIELD      absolutePath                    [PUBLIC]   String
+FIELD      canonicalFile                   [PUBLIC]   File
+FIELD      canonicalPath                   [PUBLIC]   String
+FIELD      class                           [PUBLIC]   Class
+FIELD      directory                       [PUBLIC]   boolean
+FIELD      executable                      [PUBLIC]   boolean
+FIELD      file                            [PUBLIC]   boolean
+FIELD      freeSpace                       [PUBLIC]   long
+FIELD      hidden                          [PUBLIC]   boolean
+FIELD      lastModified                    [PUBLIC]   long
+FIELD      name                            [PUBLIC]   String
+FIELD      parent                          [PUBLIC]   String
+FIELD      parentFile                      [PUBLIC]   File
+FIELD      path                            [PUBLIC]   String
+FIELD      pathSeparator                   [STATIC,   String
+FIELD      pathSeparatorChar               [STATIC,   char
+FIELD      readable                        [PUBLIC]   boolean
+FIELD      separator                       [STATIC,   String
+FIELD      separatorChar                   [STATIC,   char
+FIELD      totalSpace                      [PUBLIC]   long
+FIELD      usableSpace                     [PUBLIC]   long
+FIELD      writable                        [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_chain3.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_chain3.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+someFile.getAbsoluteFile().getParentFile().mk|dirs()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     mkdir()                         [PUBLIC]   boolean
+METHOD     mkdirs()                        [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_chain4.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_chain4.completion
@@ -1,0 +1,6 @@
+Code completion result for source line:
+(someFile.getCanonicalFile().getParentFile()).mk|dirs()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     mkdir()                         [PUBLIC]   boolean
+METHOD     mkdirs()                        [PUBLIC]   boolean

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_modifier.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_modifier.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+new Helper().ov|erload(Arrays.asList("hi")).substring(1)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     ovPrivate()                     [PRIVATE]  File
+METHOD     overload(List)                  [PUBLIC]   String
+METHOD     overload(String)                [PUBLIC]   File

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_noparens.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_noparens.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+aa.command "bye".su|bstring(1)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     subSequence(int, int)           [PUBLIC]   CharSequence
+METHOD     substring(int)                  [PUBLIC]   String
+METHOD     substring(int, int)             [PUBLIC]   String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_overload1.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_overload1.completion
@@ -1,0 +1,13 @@
+Code completion result for source line:
+b.command("good").i|nheritIO().command()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     identity(Closure)                          Object
+METHOD     inheritIO()                     [PUBLIC]   ProcessBuilder
+METHOD     inject(Closure)                            Object
+METHOD     inject(Object, Closure)                    Object
+METHOD     inspect()                                  String
+METHOD     invokeMethod(String, Object)               Object
+METHOD     is(Object)                                 boolean
+METHOD     isCase(Object)                             boolean
+METHOD     iterator()                                 Iterator

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_overload2.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_overload2.completion
@@ -1,0 +1,5 @@
+Code completion result for source line:
+b.command(Arrays.asList("good", "bad")).inh|eritIO().command()
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     inheritIO()                     [PUBLIC]   ProcessBuilder

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_overload3.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_overload3.completion
@@ -1,0 +1,23 @@
+Code completion result for source line:
+new Helper().overload("hello").get|AbsoluteFile();
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     getAbsoluteFile()               [PUBLIC]   File
+METHOD     getAbsolutePath()               [PUBLIC]   String
+METHOD     getAt(String)                              Object
+METHOD     getBytes()                                 byte[]
+METHOD     getCanonicalFile()              [PUBLIC]   File
+METHOD     getCanonicalPath()              [PUBLIC]   String
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getFreeSpace()                  [PUBLIC]   long
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getName()                       [PUBLIC]   String
+METHOD     getParent()                     [PUBLIC]   String
+METHOD     getParentFile()                 [PUBLIC]   File
+METHOD     getPath()                       [PUBLIC]   String
+METHOD     getProperties()                            Map
+METHOD     getText()                                  String
+METHOD     getText(String)                            String
+METHOD     getTotalSpace()                 [PUBLIC]   long
+METHOD     getUsableSpace()                [PUBLIC]   long

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_overload4.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/method/methods5/Methods5.groovy.testMethods5_overload4.completion
@@ -1,0 +1,7 @@
+Code completion result for source line:
+new Helper().overload(Arrays.asList("hi")).su|bstring(1)
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     subSequence(int, int)           [PUBLIC]   CharSequence
+METHOD     substring(int)                  [PUBLIC]   String
+METHOD     substring(int, int)             [PUBLIC]   String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/javaFieldOperator1/JavaFieldOperator1.groovy.testJavaFieldOperator1_all.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/javaFieldOperator1/JavaFieldOperator1.groovy.testJavaFieldOperator1_all.completion
@@ -3,4 +3,4 @@ new Foo().@|
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
 FIELD      class                           [PUBLIC]   Class
-FIELD      test                                       int
+FIELD      test                            [PRIVATE]  int

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/javaFieldOperator2/JavaFieldOperator2.groovy.testJavaFieldOperator2_withPrefix.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/javaFieldOperator2/JavaFieldOperator2.groovy.testJavaFieldOperator2_withPrefix.completion
@@ -2,4 +2,4 @@ Code completion result for source line:
 new Foo().@t|
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
-FIELD      test                                       int
+FIELD      test                            [PRIVATE]  int

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/javaFieldOperator3/JavaFieldOperator3.groovy.testJavaFieldOperator3_withSuffix.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/javaFieldOperator3/JavaFieldOperator3.groovy.testJavaFieldOperator3_withSuffix.completion
@@ -3,4 +3,4 @@ new Foo().@|tes
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
 FIELD      class                           [PUBLIC]   Class
-FIELD      test                                       int
+FIELD      test                            [PRIVATE]  int

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/javaFieldOperator4/JavaFieldOperator4.groovy.testJavaFieldOperator4_withinIdentifier.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/javaFieldOperator4/JavaFieldOperator4.groovy.testJavaFieldOperator4_withinIdentifier.completion
@@ -2,4 +2,4 @@ Code completion result for source line:
 new Foo().@te|s
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
-FIELD      test                                       int
+FIELD      test                            [PRIVATE]  int

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.11.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.11.completion
@@ -82,8 +82,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.12.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.12.completion
@@ -83,8 +83,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.13.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.13.completion
@@ -83,8 +83,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     formatted(Object[])             [PUBLIC]   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.9.completion
@@ -81,8 +81,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator1/SpreadOperator1.groovy.testSpreadOperator1_stringArray_all.completion
@@ -81,8 +81,8 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
-METHOD     format(Locale, String, Object[  [STATIC,   String
-METHOD     format(String, Object[])        [STATIC,   String
+METHOD     format(Locale, String, Object.  [STATIC,   String
+METHOD     format(String, Object...)       [STATIC,   String
 METHOD     getAt(Collection)                          String
 METHOD     getAt(EmptyRange)                          String
 METHOD     getAt(IntRange)                            String

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator3/SpreadOperator3.groovy.testSpreadOperator3_intArray_all.9.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/operators/spreadOperator3/SpreadOperator3.groovy.testSpreadOperator3_intArray_all.9.completion
@@ -45,6 +45,8 @@ METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
 METHOD     floatValue()                    [PUBLIC]   float
+METHOD     formatUnsignedInt(int, int, by  [STATIC]   void
+METHOD     formatUnsignedInt(int, int, ch  [STATIC]   void
 METHOD     getAt(String)                              Object
 METHOD     getChars(int, int, byte[])      [STATIC]   int
 METHOD     getClass()                      [PUBLIC]   Class<?>

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton1/Singleton1.groovy.testSingleton1_withInPrefix.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton1/Singleton1.groovy.testSingleton1_withInPrefix.completion
@@ -7,3 +7,5 @@ METHOD     inject(Object, Closure)                    Object
 METHOD     inspect()                                  String
 METHOD     invokeMethod(String, Object)               Object
 FIELD      instance                        [STATIC,   Singleton1
+FIELD      interface                       [PUBLIC]   boolean
+FIELD      interfaces                      [PUBLIC]   Class[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.11.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.11.completion
@@ -1,0 +1,60 @@
+Code completion result for source line:
+Singleton2.get|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     getAnnotatedInterfaces()        [PUBLIC]   AnnotatedType[]
+METHOD     getAnnotatedSuperclass()        [PUBLIC]   AnnotatedType
+METHOD     getAnnotation(Class<A>)         [PUBLIC]   A
+METHOD     getAnnotations()                [PUBLIC]   Annotation[]
+METHOD     getAnnotationsByType(Class<A>)  [PUBLIC]   A[]
+METHOD     getAt(String)                              Object
+METHOD     getCanonicalName()              [PUBLIC]   String
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getClassLoader()                [PUBLIC]   ClassLoader
+METHOD     getClasses()                    [PUBLIC]   Class<?>[]
+METHOD     getComponentType()              [PUBLIC]   Class<?>
+METHOD     getConstructor(Class<?>...)     [PUBLIC]   Constructor<T>
+METHOD     getConstructors()               [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredAnnotation(Class<A>  [PUBLIC]   A
+METHOD     getDeclaredAnnotations()        [PUBLIC]   Annotation[]
+METHOD     getDeclaredAnnotationsByType(C  [PUBLIC]   A[]
+METHOD     getDeclaredClasses()            [PUBLIC]   Class<?>[]
+METHOD     getDeclaredConstructor(Class<?  [PUBLIC]   Constructor<T>
+METHOD     getDeclaredConstructors()       [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredField(String)        [PUBLIC]   Field
+METHOD     getDeclaredFields()             [PUBLIC]   Field[]
+METHOD     getDeclaredMethod(String, Clas  [PUBLIC]   Method
+METHOD     getDeclaredMethods()            [PUBLIC]   Method[]
+METHOD     getDeclaringClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingConstructor()       [PUBLIC]   Constructor<?>
+METHOD     getEnclosingMethod()            [PUBLIC]   Method
+METHOD     getEnumConstants()              [PUBLIC]   T[]
+METHOD     getField(String)                [PUBLIC]   Field
+METHOD     getFields()                     [PUBLIC]   Field[]
+METHOD     getGenericInterfaces()          [PUBLIC]   Type[]
+METHOD     getGenericSuperclass()          [PUBLIC]   Type
+METHOD     getGroovydoc()                             Groovydoc
+METHOD     getInstance()                   [STATIC,   Singleton2
+METHOD     getInterfaces()                 [PUBLIC]   Class<?>[]
+METHOD     getLocation()                              URL
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getMethod(String, Class<?>...)  [PUBLIC]   Method
+METHOD     getMethods()                    [PUBLIC]   Method[]
+METHOD     getModifiers()                  [PUBLIC]   int
+METHOD     getModule()                     [PUBLIC]   Module
+METHOD     getName()                       [PUBLIC]   String
+METHOD     getNestHost()                   [PUBLIC]   Class<?>
+METHOD     getNestMembers()                [PUBLIC]   Class<?>[]
+METHOD     getPackage()                    [PUBLIC]   Package
+METHOD     getPackageName()                [PUBLIC]   String
+METHOD     getProperties()                            Map
+METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
+METHOD     getResource(String)             [PUBLIC]   URL
+METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
+METHOD     getSigners()                    [PUBLIC]   Object[]
+METHOD     getSimpleName()                 [PUBLIC]   String
+METHOD     getSuperclass()                 [PUBLIC]   Class<? super T>
+METHOD     getTypeName()                   [PUBLIC]   String
+METHOD     getTypeParameters()             [PUBLIC]   TypeVariable<Class<T>>[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.completion
@@ -2,10 +2,56 @@ Code completion result for source line:
 Singleton2.get|
 (QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
 ------------------------------------
+METHOD     getAnnotatedInterfaces()        [PUBLIC]   AnnotatedType[]
+METHOD     getAnnotatedSuperclass()        [PUBLIC]   AnnotatedType
+METHOD     getAnnotation(Class<A>)         [PUBLIC]   A
+METHOD     getAnnotations()                [PUBLIC]   Annotation[]
+METHOD     getAnnotationsByType(Class<A>)  [PUBLIC]   A[]
 METHOD     getAt(String)                              Object
+METHOD     getCanonicalName()              [PUBLIC]   String
 METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getClassLoader()                [PUBLIC]   ClassLoader
+METHOD     getClasses()                    [PUBLIC]   Class<?>[]
+METHOD     getComponentType()              [PUBLIC]   Class<?>
+METHOD     getConstructor(Class<?>[])      [PUBLIC]   Constructor<T>
+METHOD     getConstructors()               [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredAnnotation(Class<A>  [PUBLIC]   A
+METHOD     getDeclaredAnnotations()        [PUBLIC]   Annotation[]
+METHOD     getDeclaredAnnotationsByType(C  [PUBLIC]   A[]
+METHOD     getDeclaredClasses()            [PUBLIC]   Class<?>[]
+METHOD     getDeclaredConstructor(Class<?  [PUBLIC]   Constructor<T>
+METHOD     getDeclaredConstructors()       [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredField(String)        [PUBLIC]   Field
+METHOD     getDeclaredFields()             [PUBLIC]   Field[]
+METHOD     getDeclaredMethod(String, Clas  [PUBLIC]   Method
+METHOD     getDeclaredMethods()            [PUBLIC]   Method[]
+METHOD     getDeclaringClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingConstructor()       [PUBLIC]   Constructor<?>
+METHOD     getEnclosingMethod()            [PUBLIC]   Method
+METHOD     getEnumConstants()              [PUBLIC]   T[]
+METHOD     getField(String)                [PUBLIC]   Field
+METHOD     getFields()                     [PUBLIC]   Field[]
+METHOD     getGenericInterfaces()          [PUBLIC]   Type[]
+METHOD     getGenericSuperclass()          [PUBLIC]   Type
+METHOD     getGroovydoc()                             Groovydoc
 METHOD     getInstance()                   [STATIC,   Singleton2
+METHOD     getInterfaces()                 [PUBLIC]   Class<?>[]
+METHOD     getLocation()                              URL
 METHOD     getMetaClass()                  [PUBLIC]   MetaClass
 METHOD     getMetaPropertyValues()                    List
+METHOD     getMethod(String, Class<?>[])   [PUBLIC]   Method
+METHOD     getMethods()                    [PUBLIC]   Method[]
+METHOD     getModifiers()                  [PUBLIC]   int
+METHOD     getName()                       [PUBLIC]   String
+METHOD     getPackage()                    [PUBLIC]   Package
 METHOD     getProperties()                            Map
 METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
+METHOD     getResource(String)             [PUBLIC]   URL
+METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
+METHOD     getSigners()                    [PUBLIC]   Object[]
+METHOD     getSimpleName()                 [PUBLIC]   String
+METHOD     getSuperclass()                 [PUBLIC]   Class<? super T>
+METHOD     getTypeName()                   [PUBLIC]   String
+METHOD     getTypeParameters()             [PUBLIC]   TypeVariable<Class<T>>[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton2/Singleton2.groovy.testSingleton2_withGetPrefix.completion
@@ -13,7 +13,7 @@ METHOD     getClass()                      [PUBLIC]   Class<?>
 METHOD     getClassLoader()                [PUBLIC]   ClassLoader
 METHOD     getClasses()                    [PUBLIC]   Class<?>[]
 METHOD     getComponentType()              [PUBLIC]   Class<?>
-METHOD     getConstructor(Class<?>[])      [PUBLIC]   Constructor<T>
+METHOD     getConstructor(Class<?>...)     [PUBLIC]   Constructor<T>
 METHOD     getConstructors()               [PUBLIC]   Constructor<?>[]
 METHOD     getDeclaredAnnotation(Class<A>  [PUBLIC]   A
 METHOD     getDeclaredAnnotations()        [PUBLIC]   Annotation[]
@@ -38,15 +38,14 @@ METHOD     getGroovydoc()                             Groovydoc
 METHOD     getInstance()                   [STATIC,   Singleton2
 METHOD     getInterfaces()                 [PUBLIC]   Class<?>[]
 METHOD     getLocation()                              URL
-METHOD     getMetaClass()                  [PUBLIC]   MetaClass
+METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
-METHOD     getMethod(String, Class<?>[])   [PUBLIC]   Method
+METHOD     getMethod(String, Class<?>...)  [PUBLIC]   Method
 METHOD     getMethods()                    [PUBLIC]   Method[]
 METHOD     getModifiers()                  [PUBLIC]   int
 METHOD     getName()                       [PUBLIC]   String
 METHOD     getPackage()                    [PUBLIC]   Package
 METHOD     getProperties()                            Map
-METHOD     getProperty(String)             [PUBLIC]   Object
 METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
 METHOD     getResource(String)             [PUBLIC]   URL
 METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.11.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.11.completion
@@ -1,0 +1,201 @@
+Code completion result for source line:
+Singleton3.|
+(QueryType=COMPLETION, prefixSearch=true, caseSensitive=true)
+------------------------------------
+METHOD     addShutdownHook(Closure)                   void
+METHOD     any()                                      boolean
+METHOD     any(Closure)                               boolean
+METHOD     asBoolean()                                boolean
+METHOD     asSubclass(Class<U>)            [PUBLIC]   Class<? extends U>
+METHOD     asType(Class)                              Object
+METHOD     cast(Object)                    [PUBLIC]   T
+METHOD     collect()                                  Collection
+METHOD     collect(Closure)                           List
+METHOD     collect(Collection, Closure)               Collection
+METHOD     desiredAssertionStatus()        [PUBLIC]   boolean
+METHOD     dump()                                     String
+METHOD     each(Closure)                              Object
+METHOD     eachWithIndex(Closure)                     Object
+METHOD     equals(Object)                  [PUBLIC]   boolean
+METHOD     every()                                    boolean
+METHOD     every(Closure)                             boolean
+METHOD     find()                                     Object
+METHOD     find(Closure)                              Object
+METHOD     findAll()                                  Collection
+METHOD     findAll(Closure)                           Collection
+METHOD     findIndexOf(Closure)                       int
+METHOD     findIndexOf(int, Closure)                  int
+METHOD     findIndexValues(Closure)                   List
+METHOD     findIndexValues(Number, Closur             List
+METHOD     findLastIndexOf(Closure)                   int
+METHOD     findLastIndexOf(int, Closure)              int
+METHOD     findResult(Closure)                        Object
+METHOD     findResult(Object, Closure)                Object
+METHOD     forName(Module, String)         [STATIC,   Class<?>
+METHOD     forName(String)                 [STATIC,   Class<?>
+METHOD     forName(String, boolean, Class  [STATIC,   Class<?>
+METHOD     getAnnotatedInterfaces()        [PUBLIC]   AnnotatedType[]
+METHOD     getAnnotatedSuperclass()        [PUBLIC]   AnnotatedType
+METHOD     getAnnotation(Class<A>)         [PUBLIC]   A
+METHOD     getAnnotations()                [PUBLIC]   Annotation[]
+METHOD     getAnnotationsByType(Class<A>)  [PUBLIC]   A[]
+METHOD     getAt(String)                              Object
+METHOD     getCanonicalName()              [PUBLIC]   String
+METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getClassLoader()                [PUBLIC]   ClassLoader
+METHOD     getClasses()                    [PUBLIC]   Class<?>[]
+METHOD     getComponentType()              [PUBLIC]   Class<?>
+METHOD     getConstructor(Class<?>...)     [PUBLIC]   Constructor<T>
+METHOD     getConstructors()               [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredAnnotation(Class<A>  [PUBLIC]   A
+METHOD     getDeclaredAnnotations()        [PUBLIC]   Annotation[]
+METHOD     getDeclaredAnnotationsByType(C  [PUBLIC]   A[]
+METHOD     getDeclaredClasses()            [PUBLIC]   Class<?>[]
+METHOD     getDeclaredConstructor(Class<?  [PUBLIC]   Constructor<T>
+METHOD     getDeclaredConstructors()       [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredField(String)        [PUBLIC]   Field
+METHOD     getDeclaredFields()             [PUBLIC]   Field[]
+METHOD     getDeclaredMethod(String, Clas  [PUBLIC]   Method
+METHOD     getDeclaredMethods()            [PUBLIC]   Method[]
+METHOD     getDeclaringClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingConstructor()       [PUBLIC]   Constructor<?>
+METHOD     getEnclosingMethod()            [PUBLIC]   Method
+METHOD     getEnumConstants()              [PUBLIC]   T[]
+METHOD     getField(String)                [PUBLIC]   Field
+METHOD     getFields()                     [PUBLIC]   Field[]
+METHOD     getGenericInterfaces()          [PUBLIC]   Type[]
+METHOD     getGenericSuperclass()          [PUBLIC]   Type
+METHOD     getGroovydoc()                             Groovydoc
+METHOD     getInstance()                   [STATIC,   Singleton3
+METHOD     getInterfaces()                 [PUBLIC]   Class<?>[]
+METHOD     getLocation()                              URL
+METHOD     getMetaClass()                             MetaClass
+METHOD     getMetaPropertyValues()                    List
+METHOD     getMethod(String, Class<?>...)  [PUBLIC]   Method
+METHOD     getMethods()                    [PUBLIC]   Method[]
+METHOD     getModifiers()                  [PUBLIC]   int
+METHOD     getModule()                     [PUBLIC]   Module
+METHOD     getName()                       [PUBLIC]   String
+METHOD     getNestHost()                   [PUBLIC]   Class<?>
+METHOD     getNestMembers()                [PUBLIC]   Class<?>[]
+METHOD     getPackage()                    [PUBLIC]   Package
+METHOD     getPackageName()                [PUBLIC]   String
+METHOD     getProperties()                            Map
+METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
+METHOD     getResource(String)             [PUBLIC]   URL
+METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
+METHOD     getSigners()                    [PUBLIC]   Object[]
+METHOD     getSimpleName()                 [PUBLIC]   String
+METHOD     getSuperclass()                 [PUBLIC]   Class<? super T>
+METHOD     getTypeName()                   [PUBLIC]   String
+METHOD     getTypeParameters()             [PUBLIC]   TypeVariable<Class<T>>[]
+METHOD     grep()                                     Collection
+METHOD     grep(Object)                               Collection
+METHOD     hasProperty(String)                        MetaProperty
+METHOD     hashCode()                      [PUBLIC]   int
+METHOD     identity(Closure)                          Object
+METHOD     inject(Closure)                            Object
+METHOD     inject(Object, Closure)                    Object
+METHOD     inspect()                                  String
+METHOD     invokeMethod(String, Object)               Object
+METHOD     is(Object)                                 boolean
+METHOD     isAnnotation()                  [PUBLIC]   boolean
+METHOD     isAnnotationPresent(Class<? ex  [PUBLIC]   boolean
+METHOD     isAnonymousClass()              [PUBLIC]   boolean
+METHOD     isArray()                       [PUBLIC]   boolean
+METHOD     isAssignableFrom(Class<?>)      [PUBLIC]   boolean
+METHOD     isCase(Object)                             boolean
+METHOD     isEnum()                        [PUBLIC]   boolean
+METHOD     isInstance(Object)              [PUBLIC]   boolean
+METHOD     isInterface()                   [PUBLIC]   boolean
+METHOD     isLocalClass()                  [PUBLIC]   boolean
+METHOD     isMemberClass()                 [PUBLIC]   boolean
+METHOD     isNestmateOf(Class<?>)          [PUBLIC]   boolean
+METHOD     isPrimitive()                   [PUBLIC]   boolean
+METHOD     isSynthetic()                   [PUBLIC]   boolean
+METHOD     iterator()                                 Iterator
+METHOD     metaClass(Closure)                         MetaClass
+METHOD     mixin(Class)                               void
+METHOD     mixin(Class[])                             void
+METHOD     mixin(List)                                void
+METHOD     newInstance()                   [PUBLIC]   T
+METHOD     newInstance(Object[])                      Object
+METHOD     notify()                        [PUBLIC]   void
+METHOD     notifyAll()                     [PUBLIC]   void
+METHOD     print(Object)                              void
+METHOD     print(PrintWriter)                         void
+METHOD     printf(String, Object)                     void
+METHOD     printf(String, Object)                     void
+METHOD     println()                                  void
+METHOD     println(Object)                            void
+METHOD     println(PrintWriter)                       void
+METHOD     putAt(String, Object)                      void
+METHOD     respondsTo(String)                         List
+METHOD     respondsTo(String, Object)                 List
+METHOD     setMetaClass(MetaClass)                    void
+METHOD     sleep(long)                                void
+METHOD     sleep(long, Closure)                       void
+METHOD     split(Closure)                             Collection
+METHOD     sprintf(String, Object)                    String
+METHOD     sprintf(String, Object)                    String
+METHOD     stream()                                   Stream
+METHOD     tap(Closure)                               Object
+METHOD     toGenericString()               [PUBLIC]   String
+METHOD     toString()                      [PUBLIC]   String
+METHOD     use(Class, Closure)                        Object
+METHOD     use(List, Closure)                         Object
+METHOD     use(Object[])                              Object
+METHOD     wait()                          [PUBLIC]   void
+METHOD     wait(long)                      [PUBLIC]   void
+METHOD     wait(long, int)                 [PUBLIC]   void
+METHOD     with(Closure)                              Object
+METHOD     with(boolean, Closure)                     Object
+METHOD     withTraits(Class[])                        Object
+METHOD     y()                             [PUBLIC]   Object
+FIELD      annotatedInterfaces             [PUBLIC]   AnnotatedType[]
+FIELD      annotatedSuperclass             [PUBLIC]   AnnotatedType
+FIELD      annotation                      [PUBLIC]   boolean
+FIELD      annotations                     [PUBLIC]   Annotation[]
+FIELD      anonymousClass                  [PUBLIC]   boolean
+FIELD      array                           [PUBLIC]   boolean
+FIELD      canonicalName                   [PUBLIC]   String
+FIELD      class                           [PUBLIC]   Class
+FIELD      classLoader                     [PUBLIC]   ClassLoader
+FIELD      classes                         [PUBLIC]   Class[]
+FIELD      componentType                   [PUBLIC]   Class
+FIELD      constructors                    [PUBLIC]   Constructor[]
+FIELD      declaredAnnotations             [PUBLIC]   Annotation[]
+FIELD      declaredClasses                 [PUBLIC]   Class[]
+FIELD      declaredConstructors            [PUBLIC]   Constructor[]
+FIELD      declaredFields                  [PUBLIC]   Field[]
+FIELD      declaredMethods                 [PUBLIC]   Method[]
+FIELD      declaringClass                  [PUBLIC]   Class
+FIELD      enclosingClass                  [PUBLIC]   Class
+FIELD      enclosingConstructor            [PUBLIC]   Constructor
+FIELD      enclosingMethod                 [PUBLIC]   Method
+FIELD      enum                            [PUBLIC]   boolean
+FIELD      enumConstants                   [PUBLIC]   Object[]
+FIELD      fields                          [PUBLIC]   Field[]
+FIELD      genericInterfaces               [PUBLIC]   Type[]
+FIELD      genericSuperclass               [PUBLIC]   Type
+FIELD      instance                        [STATIC]   Singleton3
+FIELD      interface                       [PUBLIC]   boolean
+FIELD      interfaces                      [PUBLIC]   Class[]
+FIELD      localClass                      [PUBLIC]   boolean
+FIELD      memberClass                     [PUBLIC]   boolean
+FIELD      methods                         [PUBLIC]   Method[]
+FIELD      modifiers                       [PUBLIC]   int
+FIELD      module                          [PUBLIC]   Module
+FIELD      name                            [PUBLIC]   String
+FIELD      nestHost                        [PUBLIC]   Class
+FIELD      nestMembers                     [PUBLIC]   Class[]
+FIELD      package                         [PUBLIC]   Package
+FIELD      packageName                     [PUBLIC]   String
+FIELD      primitive                       [PUBLIC]   boolean
+FIELD      protectionDomain                [PUBLIC]   ProtectionDomain
+FIELD      simpleName                      [PUBLIC]   String
+FIELD      superclass                      [PUBLIC]   Class
+FIELD      synthetic                       [PUBLIC]   boolean
+FIELD      typeName                        [PUBLIC]   String
+FIELD      typeParameters                  [PUBLIC]   TypeVariable[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.completion
@@ -6,11 +6,14 @@ METHOD     addShutdownHook(Closure)                   void
 METHOD     any()                                      boolean
 METHOD     any(Closure)                               boolean
 METHOD     asBoolean()                                boolean
+METHOD     asSubclass(Class<U>)            [PUBLIC]   Class<? extends U>
 METHOD     asType(Class)                              Object
+METHOD     cast(Object)                    [PUBLIC]   T
 METHOD     clone()                         [PROTECTE  Object
 METHOD     collect()                                  Collection
 METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
+METHOD     desiredAssertionStatus()        [PUBLIC]   boolean
 METHOD     dump()                                     String
 METHOD     each(Closure)                              Object
 METHOD     eachWithIndex(Closure)                     Object
@@ -30,13 +33,61 @@ METHOD     findLastIndexOf(Closure)                   int
 METHOD     findLastIndexOf(int, Closure)              int
 METHOD     findResult(Closure)                        Object
 METHOD     findResult(Object, Closure)                Object
+METHOD     forName(String)                 [STATIC,   Class<?>
+METHOD     forName(String, boolean, Class  [STATIC,   Class<?>
+METHOD     getAnnotatedInterfaces()        [PUBLIC]   AnnotatedType[]
+METHOD     getAnnotatedSuperclass()        [PUBLIC]   AnnotatedType
+METHOD     getAnnotation(Class<A>)         [PUBLIC]   A
+METHOD     getAnnotations()                [PUBLIC]   Annotation[]
+METHOD     getAnnotationsByType(Class<A>)  [PUBLIC]   A[]
 METHOD     getAt(String)                              Object
+METHOD     getCanonicalName()              [PUBLIC]   String
 METHOD     getClass()                      [PUBLIC]   Class<?>
+METHOD     getClassLoader()                [PUBLIC]   ClassLoader
+METHOD     getClasses()                    [PUBLIC]   Class<?>[]
+METHOD     getComponentType()              [PUBLIC]   Class<?>
+METHOD     getConstructor(Class<?>[])      [PUBLIC]   Constructor<T>
+METHOD     getConstructors()               [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredAnnotation(Class<A>  [PUBLIC]   A
+METHOD     getDeclaredAnnotations()        [PUBLIC]   Annotation[]
+METHOD     getDeclaredAnnotationsByType(C  [PUBLIC]   A[]
+METHOD     getDeclaredClasses()            [PUBLIC]   Class<?>[]
+METHOD     getDeclaredConstructor(Class<?  [PUBLIC]   Constructor<T>
+METHOD     getDeclaredConstructors()       [PUBLIC]   Constructor<?>[]
+METHOD     getDeclaredField(String)        [PUBLIC]   Field
+METHOD     getDeclaredFields()             [PUBLIC]   Field[]
+METHOD     getDeclaredMethod(String, Clas  [PUBLIC]   Method
+METHOD     getDeclaredMethods()            [PUBLIC]   Method[]
+METHOD     getDeclaringClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingClass()             [PUBLIC]   Class<?>
+METHOD     getEnclosingConstructor()       [PUBLIC]   Constructor<?>
+METHOD     getEnclosingMethod()            [PUBLIC]   Method
+METHOD     getEnumConstants()              [PUBLIC]   T[]
+METHOD     getField(String)                [PUBLIC]   Field
+METHOD     getFields()                     [PUBLIC]   Field[]
+METHOD     getGenericInterfaces()          [PUBLIC]   Type[]
+METHOD     getGenericSuperclass()          [PUBLIC]   Type
+METHOD     getGroovydoc()                             Groovydoc
 METHOD     getInstance()                   [STATIC,   Singleton3
+METHOD     getInterfaces()                 [PUBLIC]   Class<?>[]
+METHOD     getLocation()                              URL
 METHOD     getMetaClass()                  [PUBLIC]   MetaClass
 METHOD     getMetaPropertyValues()                    List
+METHOD     getMethod(String, Class<?>[])   [PUBLIC]   Method
+METHOD     getMethods()                    [PUBLIC]   Method[]
+METHOD     getModifiers()                  [PUBLIC]   int
+METHOD     getName()                       [PUBLIC]   String
+METHOD     getPackage()                    [PUBLIC]   Package
 METHOD     getProperties()                            Map
 METHOD     getProperty(String)             [PUBLIC]   Object
+METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
+METHOD     getResource(String)             [PUBLIC]   URL
+METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
+METHOD     getSigners()                    [PUBLIC]   Object[]
+METHOD     getSimpleName()                 [PUBLIC]   String
+METHOD     getSuperclass()                 [PUBLIC]   Class<? super T>
+METHOD     getTypeName()                   [PUBLIC]   String
+METHOD     getTypeParameters()             [PUBLIC]   TypeVariable<Class<T>>[]
 METHOD     grep()                                     Collection
 METHOD     grep(Object)                               Collection
 METHOD     hasProperty(String)                        MetaProperty
@@ -47,9 +98,26 @@ METHOD     inject(Object, Closure)                    Object
 METHOD     inspect()                                  String
 METHOD     invokeMethod(String, Object)               Object
 METHOD     is(Object)                                 boolean
+METHOD     isAnnotation()                  [PUBLIC]   boolean
+METHOD     isAnnotationPresent(Class<? ex  [PUBLIC]   boolean
+METHOD     isAnonymousClass()              [PUBLIC]   boolean
+METHOD     isArray()                       [PUBLIC]   boolean
+METHOD     isAssignableFrom(Class<?>)      [PUBLIC]   boolean
 METHOD     isCase(Object)                             boolean
+METHOD     isEnum()                        [PUBLIC]   boolean
+METHOD     isInstance(Object)              [PUBLIC]   boolean
+METHOD     isInterface()                   [PUBLIC]   boolean
+METHOD     isLocalClass()                  [PUBLIC]   boolean
+METHOD     isMemberClass()                 [PUBLIC]   boolean
+METHOD     isPrimitive()                   [PUBLIC]   boolean
+METHOD     isSynthetic()                   [PUBLIC]   boolean
 METHOD     iterator()                                 Iterator
 METHOD     metaClass(Closure)                         MetaClass
+METHOD     mixin(Class)                               void
+METHOD     mixin(Class[])                             void
+METHOD     mixin(List)                                void
+METHOD     newInstance()                   [PUBLIC]   T
+METHOD     newInstance(Object[])                      Object
 METHOD     notify()                        [PUBLIC]   void
 METHOD     notifyAll()                     [PUBLIC]   void
 METHOD     print(Object)                              void
@@ -71,6 +139,7 @@ METHOD     sprintf(String, Object)                    String
 METHOD     sprintf(String, Object)                    String
 METHOD     stream()                                   Stream
 METHOD     tap(Closure)                               Object
+METHOD     toGenericString()               [PUBLIC]   String
 METHOD     toString()                      [PUBLIC]   String
 METHOD     use(Class, Closure)                        Object
 METHOD     use(List, Closure)                         Object
@@ -82,5 +151,46 @@ METHOD     with(Closure)                              Object
 METHOD     with(boolean, Closure)                     Object
 METHOD     withTraits(Class[])                        Object
 METHOD     y()                             [PUBLIC]   Object
+FIELD      annotatedInterfaces             [PUBLIC]   AnnotatedType[]
+FIELD      annotatedSuperclass             [PUBLIC]   AnnotatedType
+FIELD      annotation                      [PUBLIC]   boolean
+FIELD      annotations                     [PUBLIC]   Annotation[]
+FIELD      anonymousClass                  [PUBLIC]   boolean
+FIELD      array                           [PUBLIC]   boolean
+FIELD      canonicalName                   [PUBLIC]   String
 FIELD      class                           [PUBLIC]   Class
+FIELD      classLoader                     [PUBLIC]   ClassLoader
+FIELD      classes                         [PUBLIC]   Class[]
+FIELD      componentType                   [PUBLIC]   Class
+FIELD      constructors                    [PUBLIC]   Constructor[]
+FIELD      declaredAnnotations             [PUBLIC]   Annotation[]
+FIELD      declaredClasses                 [PUBLIC]   Class[]
+FIELD      declaredConstructors            [PUBLIC]   Constructor[]
+FIELD      declaredFields                  [PUBLIC]   Field[]
+FIELD      declaredMethods                 [PUBLIC]   Method[]
+FIELD      declaringClass                  [PUBLIC]   Class
+FIELD      enclosingClass                  [PUBLIC]   Class
+FIELD      enclosingConstructor            [PUBLIC]   Constructor
+FIELD      enclosingMethod                 [PUBLIC]   Method
+FIELD      enum                            [PUBLIC]   boolean
+FIELD      enumConstants                   [PUBLIC]   Object[]
+FIELD      fields                          [PUBLIC]   Field[]
+FIELD      genericInterfaces               [PUBLIC]   Type[]
+FIELD      genericSuperclass               [PUBLIC]   Type
 FIELD      instance                        [STATIC]   Singleton3
+FIELD      interface                       [PUBLIC]   boolean
+FIELD      interfaces                      [PUBLIC]   Class[]
+FIELD      localClass                      [PUBLIC]   boolean
+FIELD      memberClass                     [PUBLIC]   boolean
+FIELD      methods                         [PUBLIC]   Method[]
+FIELD      modifiers                       [PUBLIC]   int
+FIELD      name                            [PUBLIC]   String
+FIELD      package                         [PUBLIC]   Package
+FIELD      primitive                       [PUBLIC]   boolean
+FIELD      protectionDomain                [PUBLIC]   ProtectionDomain
+FIELD      signers                         [PUBLIC]   Object[]
+FIELD      simpleName                      [PUBLIC]   String
+FIELD      superclass                      [PUBLIC]   Class
+FIELD      synthetic                       [PUBLIC]   boolean
+FIELD      typeName                        [PUBLIC]   String
+FIELD      typeParameters                  [PUBLIC]   TypeVariable[]

--- a/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.completion
+++ b/groovy/groovy.editor/test/unit/data/testfiles/completion/transformations/singleton3/Singleton3.groovy.testSingleton3_withoutPrefix.completion
@@ -9,7 +9,6 @@ METHOD     asBoolean()                                boolean
 METHOD     asSubclass(Class<U>)            [PUBLIC]   Class<? extends U>
 METHOD     asType(Class)                              Object
 METHOD     cast(Object)                    [PUBLIC]   T
-METHOD     clone()                         [PROTECTE  Object
 METHOD     collect()                                  Collection
 METHOD     collect(Closure)                           List
 METHOD     collect(Collection, Closure)               Collection
@@ -20,7 +19,6 @@ METHOD     eachWithIndex(Closure)                     Object
 METHOD     equals(Object)                  [PUBLIC]   boolean
 METHOD     every()                                    boolean
 METHOD     every(Closure)                             boolean
-METHOD     finalize()                      [PROTECTE  void
 METHOD     find()                                     Object
 METHOD     find(Closure)                              Object
 METHOD     findAll()                                  Collection
@@ -46,7 +44,7 @@ METHOD     getClass()                      [PUBLIC]   Class<?>
 METHOD     getClassLoader()                [PUBLIC]   ClassLoader
 METHOD     getClasses()                    [PUBLIC]   Class<?>[]
 METHOD     getComponentType()              [PUBLIC]   Class<?>
-METHOD     getConstructor(Class<?>[])      [PUBLIC]   Constructor<T>
+METHOD     getConstructor(Class<?>...)     [PUBLIC]   Constructor<T>
 METHOD     getConstructors()               [PUBLIC]   Constructor<?>[]
 METHOD     getDeclaredAnnotation(Class<A>  [PUBLIC]   A
 METHOD     getDeclaredAnnotations()        [PUBLIC]   Annotation[]
@@ -71,15 +69,14 @@ METHOD     getGroovydoc()                             Groovydoc
 METHOD     getInstance()                   [STATIC,   Singleton3
 METHOD     getInterfaces()                 [PUBLIC]   Class<?>[]
 METHOD     getLocation()                              URL
-METHOD     getMetaClass()                  [PUBLIC]   MetaClass
+METHOD     getMetaClass()                             MetaClass
 METHOD     getMetaPropertyValues()                    List
-METHOD     getMethod(String, Class<?>[])   [PUBLIC]   Method
+METHOD     getMethod(String, Class<?>...)  [PUBLIC]   Method
 METHOD     getMethods()                    [PUBLIC]   Method[]
 METHOD     getModifiers()                  [PUBLIC]   int
 METHOD     getName()                       [PUBLIC]   String
 METHOD     getPackage()                    [PUBLIC]   Package
 METHOD     getProperties()                            Map
-METHOD     getProperty(String)             [PUBLIC]   Object
 METHOD     getProtectionDomain()           [PUBLIC]   ProtectionDomain
 METHOD     getResource(String)             [PUBLIC]   URL
 METHOD     getResourceAsStream(String)     [PUBLIC]   InputStream
@@ -130,8 +127,7 @@ METHOD     println(PrintWriter)                       void
 METHOD     putAt(String, Object)                      void
 METHOD     respondsTo(String)                         List
 METHOD     respondsTo(String, Object)                 List
-METHOD     setMetaClass(MetaClass)         [PUBLIC]   void
-METHOD     setProperty(String, Object)     [PUBLIC]   void
+METHOD     setMetaClass(MetaClass)                    void
 METHOD     sleep(long)                                void
 METHOD     sleep(long, Closure)                       void
 METHOD     split(Closure)                             Collection

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/FieldCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/FieldCCTest.java
@@ -43,6 +43,12 @@ public class FieldCCTest extends GroovyCCTestBase {
     }
 
     @Override
+    protected void setUp() throws Exception {
+        clearWorkDir();
+        super.setUp();
+    }
+
+    @Override
     protected String getTestType() {
         return ".";
     }
@@ -68,5 +74,47 @@ public class FieldCCTest extends GroovyCCTestBase {
 
     public void testFields2() throws Exception {
         checkCompletion(TEST_BASE + "" + "Fields1.groovy", "println \"Hi: $ad^\"", true);
+    }
+
+    /**
+     * Groovy fields (not properties) with private modifiers are accessible.
+     */
+    public void testFields2_modifiers() throws Exception {
+        checkCompletion(TEST_BASE + "" + "Fields2.groovy", "new Helper().builder^Property.inheritIO()", true);
+    }
+    
+    /**
+     * But java class fields respect the access modifiers. Must not contain 'classLoader0' property.
+     */
+    public void testFields2_javaModifiers() throws Exception {
+        checkCompletion(TEST_BASE + "" + "Fields2.groovy", "Helper.class.classL^oader", true);
+    }
+    
+    public void testFields2_propertyChain1() throws Exception {
+        checkCompletion(TEST_BASE + "" + "Fields2.groovy", "someFile.parent^File.mkdirs()", true);
+    }
+
+    public void testFields2_propertyChain2() throws Exception {
+        checkCompletion(TEST_BASE + "" + "Fields2.groovy", "someFile.absoluteFile.parent^File.mkdirs()", true);
+    }
+
+    public void testFields2_propertyChain3() throws Exception {
+        checkCompletion(TEST_BASE + "" + "Fields2.groovy", "someFile.absoluteFile.parentFile.mkd^irs()", true);
+    }
+
+    /**
+     * Cannot work ATM, see NETBEANS-5964
+     * @throws Exception 
+    public void testFields2_propertyChain4() throws Exception {
+        checkCompletion(TEST_BASE + "" + "Fields2.groovy", "(someFile.canonicalFile.getParentFile).mkd^irs()", true);
+    }
+     */
+    
+    public void testFields2_javaPropertyReference() throws Exception {
+        checkCompletion(TEST_BASE + "" + "Fields2.groovy", "System.properties.ge^t(", true);
+    }
+    
+    public void testFields2_otherClassProperty() throws Exception {
+        checkCompletion(TEST_BASE + "" + "Fields2.groovy", "new Helper().builderProperty.inher^itIO()", true);
     }
 }

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/FieldCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/FieldCCTest.java
@@ -110,6 +110,12 @@ public class FieldCCTest extends GroovyCCTestBase {
     }
      */
     
+    /**
+     * See NETBEANS-5991 -- bug in type parameters substitution. Note that JDK9 added j.u.Properties#get(Object) -> Object
+     * while JDK8 had no such method. Since V (unsubstituted superclass' parameter) != Object, JDK9+ reports get() -> Object
+     * (signature of superclass' get() -> V is the same, so it is ignored) and 2 getOrDefault as the superclass' signature contains 'V' 
+     * and is therefore different.
+     */
     public void testFields2_javaPropertyReference() throws Exception {
         checkCompletion(TEST_BASE + "" + "Fields2.groovy", "System.properties.ge^t(", true);
     }

--- a/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/MethodCCTest.java
+++ b/groovy/groovy.editor/test/unit/src/org/netbeans/modules/groovy/editor/api/completion/MethodCCTest.java
@@ -157,5 +157,83 @@ public class MethodCCTest extends GroovyCCTestBase {
     public void testMethods4() throws Exception {
         checkCompletion(BASE + "Methods4.groovy", "iface.meth^", false);
     }
+    
+    /**
+     * Checks method completion on direct reference to a variable
+     */
+    public void testMethods5_chain1() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", " someFile.getP^arentFile()", true);
+    }
+
+    /**
+     * Checks method completion on 2nd reference in the chain, filtering for "m"
+     */
+    public void testMethods5_chain2() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", " someFile.getParentFile().mk^dirs()", true);
+    }
+
+    /**
+     * Checks method completion on 2nd reference in the chain, without any filter (so with
+     * fields as well)
+     */
+    public void testMethods5_chain2a() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", " someFile.getParentFile().^mkdirs()", true);
+    }
+
+    /**
+     * Checks completion in even higher in the hierarchy.
+     */
+    public void testMethods5_chain3() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", " someFile.getAbsoluteFile().getParentFile().mk^dirs()", true);
+    }
+
+    /**
+     * Checks completion after a parenthesis (not represented in AST)
+     */
+    public void testMethods5_chain4() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", " (someFile.getCanonicalFile().getParentFile()).mk^dirs()", true);
+    }
+    
+    /**
+     * Checks that overload does not damage the completion
+     */
+    public void testMethods5_overload1() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", " b.command(\"good\").i^nheritIO().command()", true);
+    }
+
+    /**
+     * Checks that overload does not damage the completion
+     */
+    public void testMethods5_overload2() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", " b.command(Arrays.asList(\"good\", \"bad\")).inh^eritIO().command()", true);
+    }
+    
+    /**
+     * Checks that correct overload is selected for type context
+     */
+    public void testMethods5_overload3() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", "new Helper().overload(\"hello\").get^AbsoluteFile", true);
+    }
+    
+    /**
+     * Checks that correct overload is selected for type context
+     */
+    public void testMethods5_overload4() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", "new Helper().overload(Arrays.asList(\"hi\")).su^bstring(1)", true);
+    }
+
+    /**
+     * Checks that private mod is respected
+     */
+    public void testMethods5_modifier() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", "new Helper().ov^erload(Arrays.asList(\"hi\")).substring(1)", true);
+    }
+
+    /**
+     * Checks that private mod is respected
+     */
+    public void testMethods5_noparens() throws Exception {
+        checkCompletion(BASE + "Methods5.groovy", "aa.command \"bye\".su^bstring(1)", true);
+    }
 }
 

--- a/groovy/groovy.support/apichanges.xml
+++ b/groovy/groovy.support/apichanges.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<?xml-stylesheet type="text/xml" href="../../nbbuild/javadoctools/apichanges.xsl"?>
+<!DOCTYPE apichanges PUBLIC "-//NetBeans//DTD API changes list 1.0//EN" "../../nbbuild/javadoctools/apichanges.dtd">
+
+<!--
+
+INFO FOR PEOPLE ADDING CHANGES:
+
+Check the DTD (apichanges.dtd) for details on the syntax. You do not
+need to regenerate the HTML, as this is part of Javadoc generation; just
+change the XML. Rough syntax of a change (several parts optional):
+
+<change>
+    <api name="compiler"/>
+    <summary>Some brief description here, can use <b>XHTML</b></summary>
+    <version major="1" minor="99"/>
+    <date day="13" month="6" year="2001"/>
+    <author login="jrhacker"/>
+    <compatibility addition="yes"/>
+    <description>
+        The main description of the change here.
+        Again can use full <b>XHTML</b> as needed.
+    </description>
+    <class package="org.openide.compiler" name="DoWhatIWantCompiler"/>
+    <issue number="14309"/>
+</change>
+
+Also permitted elements: <package>, <branch>. <version> is API spec
+version, recommended for all new changes. <compatibility> should say
+if things were added/modified/deprecated/etc. and give all information
+related to upgrading old code. List affected top-level classes and
+link to issue numbers if applicable. See the DTD for more details.
+
+Changes need not be in any particular order, they are sorted in various
+ways by the stylesheet anyway.
+
+Dates are assumed to mean "on the trunk". If you *also* make the same
+change on a stabilization branch, use the <branch> tag to indicate this
+and explain why the change was made on a branch in the <description>.
+
+Please only change this file on the trunk! Rather: you can change it
+on branches if you want, but these changes will be ignored; only the
+trunk version of this file is important.
+
+Deprecations do not count as incompatible, assuming that code using the
+deprecated calls continues to see their documented behavior. But do
+specify deprecation="yes" in <compatibility>.
+
+This file is not a replacement for Javadoc: it is intended to list changes,
+not describe the complete current behavior, for which ordinary documentation
+is the proper place.
+
+-->
+
+<apichanges>
+
+    <!-- First, a list of API names you may use: -->
+<apidefs>
+   <apidef name="groovy-support">Groovy Support APIs</apidef>
+   <!-- etc. -->
+</apidefs>
+
+    <!-- ACTUAL CHANGES BEGIN HERE: -->
+
+<changes>
+    <change id="settings.modifiers">
+        <summary>Setting to respect access modifiers</summary>
+        <version major="1" minor="53"/>
+        <date day="31" month="8" year="2021"/>
+        <author login="sdedic"/>
+        <compatibility addition="yes" binary="compatible" semantic="compatible" />
+        <description>
+            Groovy does not honour (much) access modiifers for Groovy classes (see 
+            <a href="https://issues.apache.org/jira/browse/GROOVY-3010">GROOVY-3010</a>. The
+            setting affects how modifiers of Groovy classes should be evaluated by the IDE.
+        </description>
+        <class package="org.netbeans.modules.groovy.support.api;" name="GroovySettings"/>
+    </change>
+</changes>
+
+    <!-- Now the surrounding HTML text and document structure: -->
+
+    <htmlcontents>
+<!--
+
+                            NO NO NO NO NO!
+
+         ==============>    DO NOT EDIT ME!  <==============
+
+          AUTOMATICALLY GENERATED FROM APICHANGES.XML, DO NOT EDIT
+
+                SEE openide/io/api/doc/changes/changes.xml
+
+-->
+    <head>
+      <title>Change History for the Input/Output API</title>
+      <link rel="stylesheet" href="prose.css" type="text/css"/>
+    </head>
+    <body>
+
+<p class="overviewlink"><a href="overview-summary.html">Overview</a></p>
+
+<h1>Introduction</h1>
+
+<p>This document lists changes made to the <a href="@org-openide-io@/index.html">I/O API</a>.</p>
+
+<!-- The actual lists of changes, as summaries and details: -->
+      <hr/>
+      <standard-changelists module-code-name="org.openide.io"/>
+
+      <hr/><p>@FOOTER@</p>
+
+    </body>
+  </htmlcontents>
+
+</apichanges>

--- a/groovy/groovy.support/manifest.mf
+++ b/groovy/groovy.support/manifest.mf
@@ -3,5 +3,5 @@ AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.groovy.support
 OpenIDE-Module-Layer: org/netbeans/modules/groovy/support/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/groovy/support/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.52
+OpenIDE-Module-Specification-Version: 1.53
 OpenIDE-Module-Needs: javax.script.ScriptEngine.freemarker

--- a/groovy/groovy.support/nbproject/project.properties
+++ b/groovy/groovy.support/nbproject/project.properties
@@ -19,3 +19,4 @@ javac.source=1.8
 cp.extra=${tools.jar}
 nbm.homepage=http://wiki.netbeans.org/groovy
 nbm.module.author=Martin Adamek, Petr Hejl, Matthias Schmidt
+javadoc.apichanges=${basedir}/apichanges.xml

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/api/GroovySettings.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/api/GroovySettings.java
@@ -41,6 +41,13 @@ public final class GroovySettings extends AdvancedOption {
     public static final String GROOVY_DOC_PROPERTY  = "groovy.doc"; // NOI18N
     
     private static final String GROOVY_DOC  = "groovyDoc"; // NOI18N
+    private static final String ACCESS_MODIFIERS = "honourAccessModifiers";
+    
+    /**
+     * If true, IDE will pretend that access modifiers are not broken in Groovy.
+     */
+    private static final boolean DEFAULT_ACCESS_MODIFIERS = false;
+    
     private static GroovySettings instance;
     private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
     
@@ -78,6 +85,23 @@ public final class GroovySettings extends AdvancedOption {
             getPreferences().put(GROOVY_DOC, groovyDoc);
         }
         propertyChangeSupport.firePropertyChange(GROOVY_DOC_PROPERTY, oldValue, groovyDoc);
+    }
+    
+    public void setHonourAccessModifiers(boolean mods) {
+        boolean old;
+        synchronized (this) {
+            old = isHonourAccessModifiers();
+            getPreferences().putBoolean(ACCESS_MODIFIERS, mods);
+        }
+        propertyChangeSupport.firePropertyChange(ACCESS_MODIFIERS, old, mods);
+    }
+    
+    /**
+     * Should code analysis honour access modifiers ?
+     * @return true, if access modifiers should be respected.
+     */
+    public boolean isHonourAccessModifiers() {
+        return getPreferences().getBoolean(ACCESS_MODIFIERS, DEFAULT_ACCESS_MODIFIERS);
     }
 
     @Override


### PR DESCRIPTION
The basic idea is to use Groovy compiler's `StaticTypeCheckingVisitor` to attribute the AST. The visitor leaves evaluated types in node's metadata ('StaticTypesMarker.INFERRED_TYPE`), which is more precise than our own type evaluator (naturally).
Even more important is `StaticTypesMarker.DIRECT_METHOD_CALL_TARGET` that points to the method (`MethodNode`) to be called from the expression: out code completion attemoted to evaluate the types itself, but did not even count with subtyping (only with exactly same types) ! Not to mention things like boxing, unboxing, closures etc.

The static visitor however posts some error message. Some of them are meant for a real static compilation - report usage of disallowed features - I've filtered them out. Other ones are valid (i.e. method suitable for arg types not found), but would fail the compilation process. So I have collected them aside, making the compiler think that everything is OK and let the compilation fail after last phase if there are some errors. 

---
Code completion did not check access properly, offered sometimes even private stuff - should be fixed for properties, fields and methods. There are some special cases, too. `GString` is autocoerced to `String` when necessary. So for `GString` expressions,. bot String and GString methods are valid for completion. For this I had to fix up method and field signatures, so completion from two type-unrelated classes can merge without duplicities. Another such case is usage of class name literal - it acts both as a class qualifier, so static class members should be offered by the completion. At the same time, the class name is a shorthand for `ClassName.class`, so all `java.lang.Class<T>` properties / methods are valid completion items too - again merging.
