### PR TITLE
[NETBEANS-5950] - cleanup warnings related to unreachable exception catches

### DIFF
--- a/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/share/plan/Util.java
+++ b/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/share/plan/Util.java
@@ -85,8 +85,6 @@ public class Util {
                 dp.addFileEntry(fe);
             } catch(DDException ex) {
                 giveUp(ex);
-            } catch (org.netbeans.modules.schema2beans.Schema2BeansException s2bX) {
-                giveUp(s2bX);
             } catch (java.beans.PropertyVetoException pv) {
                 giveUp(pv);
             }

--- a/enterprise/web.refactoring/src/org/netbeans/modules/web/refactoring/PositionBoundsResolver.java
+++ b/enterprise/web.refactoring/src/org/netbeans/modules/web/refactoring/PositionBoundsResolver.java
@@ -155,8 +155,6 @@ public class PositionBoundsResolver {
                 Exceptions.printStackTrace(ex);
             } catch (FileNotFoundException ex) {
                 Exceptions.printStackTrace(ex);
-            } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
             } catch (BadLocationException ex) {
                 Exceptions.printStackTrace(ex);
             }

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigDataObject.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigDataObject.java
@@ -291,11 +291,8 @@ public class StrutsConfigDataObject extends MultiDataObject
         try {
             Document doc = getDomDocument(is);
             lastGoodConfig = StrutsConfig.createGraph(doc);
-        }
-        catch(SAXParseException ex) {
+        } catch(SAXParseException ex) {
             return new SAXParseError(ex);
-        } catch(SAXException ex) {
-            throw new IOException();
         }
         return null;
     }

--- a/ide/parsing.nb/src/org/netbeans/modules/parsing/nb/EventSupport.java
+++ b/ide/parsing.nb/src/org/netbeans/modules/parsing/nb/EventSupport.java
@@ -289,9 +289,6 @@ final class EventSupport extends SourceEnvironment {
                     resetState(true, false, -1, -1, false);
                 } catch (DataObjectNotFoundException e) {
                     //Ignore - invalidated after fobj.isValid () was called
-                } catch (IOException ex) {
-                    // should not occur
-                    Exceptions.printStackTrace(ex);
                 }
             }
         }        

--- a/ide/utilities/src/org/netbeans/modules/url/URLDataObject.java
+++ b/ide/utilities/src/org/netbeans/modules/url/URLDataObject.java
@@ -130,9 +130,6 @@ public class URLDataObject extends MultiDataObject
         } catch (FileNotFoundException fne) {
             ErrorManager.getDefault().notify(ErrorManager.WARNING, fne);
             return null;
-        } catch (IOException ioe) {
-            ErrorManager.getDefault().notify(ErrorManager.WARNING, ioe);
-            return null;
         } finally {
             if (is != null) {
                 try {

--- a/java/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/util/PositionBoundsResolver.java
+++ b/java/j2ee.jpa.refactoring/src/org/netbeans/modules/j2ee/jpa/refactoring/util/PositionBoundsResolver.java
@@ -156,8 +156,6 @@ public class PositionBoundsResolver {
                 ErrorManager.getDefault().notify(ex);
             } catch (FileNotFoundException ex) {
                 ErrorManager.getDefault().notify(ex);
-            } catch (IOException ex) {
-                ErrorManager.getDefault().notify(ex);
             } catch (BadLocationException ex) {
                 ErrorManager.getDefault().notify(ex);
             }

--- a/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SEVolumeCustomizer.java
+++ b/java/java.j2seplatform/src/org/netbeans/modules/java/j2seplatform/libraries/J2SEVolumeCustomizer.java
@@ -462,8 +462,6 @@ public class J2SEVolumeCustomizer extends javax.swing.JPanel implements Customiz
                 Exceptions.printStackTrace(mue);
             } catch (URISyntaxException ue) {
                 Exceptions.printStackTrace(ue);
-            } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
             }
         }
     }//GEN-LAST:event_addResource

--- a/java/java.platform.ui/src/org/netbeans/modules/java/platform/ui/PlatformsCustomizer.java
+++ b/java/java.platform.ui/src/org/netbeans/modules/java/platform/ui/PlatformsCustomizer.java
@@ -364,9 +364,6 @@ public class PlatformsCustomizer extends javax.swing.JPanel implements PropertyC
                 } catch (DataObjectNotFoundException dfne) {
                     Exceptions.printStackTrace(dfne);
                 }
-                catch (IOException ioe) {
-                    Exceptions.printStackTrace(ioe);
-                }
             }
         });
     }//GEN-LAST:event_addNewPlatform

--- a/php/php.codeception/src/org/netbeans/modules/php/codeception/coverage/CoverageProvider.java
+++ b/php/php.codeception/src/org/netbeans/modules/php/codeception/coverage/CoverageProvider.java
@@ -45,9 +45,6 @@ public class CoverageProvider {
             LOGGER.info(String.format("File %s not found. If there are no errors in Codeception output (verify in Output window), "
                     + "please report an issue (http://www.netbeans.org/issues/).", Codecept.COVERAGE_LOG));
             return null;
-        } catch (IOException ex) {
-            LOGGER.log(Level.WARNING, null, ex);
-            return null;
         }
         return coverage;
     }


### PR DESCRIPTION
The java compiler knows explicitly what exceptions are thrown when compiling code.

This change removes all the warnings related to "warning: unreachable catch clause"

For example:

   [repeat] /home/bwalker/src/netbeans/enterprise/web.struts/src/org/netbeans/modules/web/struts/StrutsConfigDataObject.java:297: warning: unreachable catch clause
   [repeat]         } catch(SAXException ex) {
   [repeat]           ^
   [repeat]   thrown type SAXParseException has already been caught