### PR TITLE
Eating VSCode own Dog Food

### DIFF
--- a/java/java.lsp.server/build.xml
+++ b/java/java.lsp.server/build.xml
@@ -146,5 +146,10 @@
             <arg value="run" />
             <arg value="test" />
         </exec>
+        <exec executable="npm" failonerror="true" dir="vscode">
+            <arg value="--allow-same-version"/>
+            <arg value="run" />
+            <arg value="apisupport" />
+        </exec>
     </target>
 </project>

--- a/java/java.lsp.server/vscode/BUILD.md
+++ b/java/java.lsp.server/vscode/BUILD.md
@@ -46,7 +46,7 @@ java.lsp.server$ ant build-vscode-ext
 ```
 The resulting extension is then in the `build` directory, with the `.vsix` extension.
 #### Build Options
-- `-Dvsix.version=x.y.z`can be used to set release version. E.g. set this option to `12.3.0` to get proper NetBeans release version for extension. 
+- `-Dvsix.version=x.y.z`can be used to set release version. E.g. set this option to `12.3.0` to get proper NetBeans release version for extension.
 - `-D3rdparty.modules=` property can be set to different value than `.*nbjavac.*` to not inlcude nb-javac which allows extension to run out of the box on JDK8.
 
 The build of NetBeans VSCode extension with nb-javac included, for version 12.6.0 then looks like this:
@@ -104,6 +104,20 @@ java.lsp.server$ npm_config_https_proxy=http://your.proxy.com:port ant test-vsco
 when executing the tests for the first time. That shall overcome the proxy
 and download an instance of `code` execute the tests on.
 
+### Eating our own Dog Food
+
+Using the application yourself is the best way of testing! If you want to
+_edit/compile/debug_ Apache NetBeans sources, there is a way. After building
+the project, execute:
+
+```bash
+vscode$ npm run apisupport
+```
+
+the system connects to associated autoupdate center and downloads, installs
+and enables `org.netbeans.modules.apisupport.ant` module. With such module installed
+one can open Apache NetBeans projects and work with them directly from VSCode.
+
 ## Running and Debugging
 
 Have a sample Maven project, open it in NetBeans first and select the main file for both
@@ -126,7 +140,7 @@ and specify suitable debug arguments:
 vscode$ npm run nbcode -- --jdkhome /jdk-14/ -J-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
 ```
 
-Connect to the process with Java debugger, setup all breakpoints. Then launch 
+Connect to the process with Java debugger, setup all breakpoints. Then launch
 and connect from the VS Code extension:
 
 ```bash

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -387,8 +387,9 @@
 		"watch": "tsc -watch -p ./",
 		"test": "node ./out/test/runTest.js",
 		"nbcode": "node ./out/nbcode.js",
-		"nbjavac": "node ./out/nbcode.js -J-Dnetbeans.close=true --modules --install .*nbjavac.*"
-	},
+		"nbjavac": "node ./out/nbcode.js -J-Dnetbeans.close=true --modules --install .*nbjavac.*",
+		"apisupport": "node ./out/nbcode.js -J-Dnetbeans.close=true --modules --install '(org.netbeans.libs.xerces|org.netbeans.modules.editor.structure|org.netbeans.modules.xml|org.netbeans.modules.xml.axi|org.netbeans.modules.xml.retriever|org.netbeans.modules.xml.schema.model|org.netbeans.modules.xml.tax|org.netbeans.modules.xml.text|org.netbeans.modules.ant.browsetask|.*apisupport.*|org.netbeans.modules.debugger.jpda.ant)' && node ./out/nbcode.js -J-Dnetbeans.close=true --modules --enable .*apisupport.ant"
+        },
 	"devDependencies": {
 		"@types/glob": "^7.1.1",
 		"@types/mocha": "^7.0.2",

--- a/platform/autoupdate.cli/manifest.mf
+++ b/platform/autoupdate.cli/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.autoupdate.cli
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/autoupdate/cli/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.26
+OpenIDE-Module-Specification-Version: 1.27
 

--- a/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/CodeNameMatcher.java
+++ b/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/CodeNameMatcher.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.modules.autoupdate.cli;
+
+import java.util.Arrays;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.netbeans.spi.sendopts.Env;
+import org.openide.util.NbBundle;
+
+final class CodeNameMatcher {
+    private final Pattern[] patterns;
+    private CodeNameMatcher(Pattern[] arr) {
+        this.patterns = arr;
+    }
+
+    @NbBundle.Messages({
+        "# {0} - regexp",
+        "MSG_CantCompileRegex=Invalid regular expession ''{0}''"
+    })
+    static CodeNameMatcher create(Env env, String[] pattern) {
+        Pattern[] arr = new Pattern[pattern.length];
+        for (int i = 0; i < arr.length; i++) {
+            try {
+                arr[i] = Pattern.compile(pattern[i]);
+            } catch (PatternSyntaxException e) {
+                env.getErrorStream().println(Bundle.MSG_CantCompileRegex(pattern[i]));
+            }
+        }
+        return new CodeNameMatcher(arr);
+    }
+
+    boolean matches(String txt) {
+        for (Pattern p : patterns) {
+            if (p == null) {
+                continue;
+            }
+            if (p.matcher(txt).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    boolean isEmpty() {
+        return patterns.length == 0;
+    }
+
+    @Override
+    public String toString() {
+        return Arrays.toString(patterns);
+    }
+
+
+}

--- a/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/ModuleOptions.java
+++ b/platform/autoupdate.cli/src/org/netbeans/modules/autoupdate/cli/ModuleOptions.java
@@ -23,7 +23,6 @@ import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -31,10 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 import org.netbeans.api.autoupdate.*;
 import org.netbeans.api.autoupdate.InstallSupport.Installer;
 import org.netbeans.api.autoupdate.InstallSupport.Validator;
@@ -71,8 +69,7 @@ public class ModuleOptions extends OptionProcessor {
     private Option updateAll;
     private Option both;
     private Option extraUC;
-    
-    private Collection<UpdateUnitProvider> ownUUP = new HashSet<UpdateUnitProvider> ();
+    private final Collection<UpdateUnitProvider> ownUUP = new HashSet<> ();
     
     /** Creates a new instance of ModuleOptions */
     public ModuleOptions() {
@@ -117,11 +114,14 @@ public class ModuleOptions extends OptionProcessor {
     public Set<Option> getOptions() {
         return Collections.singleton(init());
     }
-    
+    @NbBundle.Messages({
+        "# {0} - update center name", 
+        "MSG_RefreshingUpdateCenter=Refreshing {0}"
+    })
     private void refresh(Env env) throws CommandException {
         for (UpdateUnitProvider p : UpdateUnitProviderFactory.getDefault().getUpdateUnitProviders(true)) {
             try {
-                env.getOutputStream().println("Refreshing " + p.getDisplayName());
+                env.getOutputStream().println(MSG_RefreshingUpdateCenter(p.getDisplayName()));
                 p.refresh(null, true);
             } catch (IOException ex) {
                 throw (CommandException)new CommandException(31, ex.getMessage()).initCause(ex);
@@ -175,17 +175,13 @@ public class ModuleOptions extends OptionProcessor {
                 }
 
                 if (optionValues.containsKey(disable)) {
-                    changeModuleState(optionValues.get(disable), false);
+                    changeModuleState(env, optionValues.get(disable), false);
                 }
 
                 if (optionValues.containsKey(enable)) {
-                    changeModuleState(optionValues.get(enable), true);
+                    changeModuleState(env, optionValues.get(enable), true);
                 }
-            } catch (InterruptedException ex) {
-                throw initCause(new CommandException(4), ex);
-            } catch (IOException ex) {
-                throw initCause(new CommandException(4), ex);
-            } catch (OperationException ex) {
+            } catch (InterruptedException | IOException | OperationException ex) {
                 throw initCause(new CommandException(4), ex);
             }
 
@@ -203,29 +199,41 @@ public class ModuleOptions extends OptionProcessor {
         
     }
 
-    private void changeModuleState(String[] cnbs, boolean enable) throws IOException, CommandException, InterruptedException, OperationException {
-        for (String cnb : cnbs) {
-            int slash = cnb.indexOf('/');
-            if (slash >= 0) {
-                cnb = cnb.substring(0, slash);
-            }
-        }
-        
-        Set<String> all = new HashSet<String>(Arrays.asList(cnbs));
+    @NbBundle.Messages({
+        "# {0} - name of the module",
+        "MSG_FoundButNotInstalled=Found {0}, but not installed",
+        "# {0} - requested patterns",
+        "MSG_CannotFindAnyPattern=Cannot find any module matching {0}\n"
+    })
+    private void changeModuleState(Env env, String[] cnbs, boolean enable) throws IOException, CommandException, InterruptedException, OperationException {
+        CodeNameMatcher cnm = CodeNameMatcher.create(env, cnbs);
 
         List<UpdateUnit> units = UpdateManager.getDefault().getUpdateUnits();
         OperationContainer<OperationSupport> operate = enable ? OperationContainer.createForEnable() : OperationContainer.createForDisable();
+        StringBuilder sb = new StringBuilder();
+        boolean found = false;
         for (UpdateUnit updateUnit : units) {
-            if (all.contains(updateUnit.getCodeName())) {
-                if (enable) {
-                    operate.add(updateUnit, updateUnit.getInstalled());
+            final String codeName = updateUnit.getCodeName();
+            if (cnm.matches(codeName)) {
+                final UpdateElement elem = updateUnit.getInstalled();
+                if (elem != null) {
+                    found = true;
+                    if (elem.isEnabled() != enable) {
+                        operate.add(updateUnit, elem);
+                    }
                 } else {
-                    operate.add(updateUnit, updateUnit.getInstalled());
+                    sb.append("\n").append(MSG_FoundButNotInstalled(codeName));
                 }
             }
         }
+        if (!found) {
+            sb.insert(0, MSG_CannotFindAnyPattern(cnm));
+            throw new CommandException(55, sb.toString());
+        }
         OperationSupport support = operate.getSupport();
-        support.doOperation(null);
+        if (support != null) {
+            support.doOperation(null);
+        }
     }
 
     @NbBundle.Messages({
@@ -243,7 +251,7 @@ public class ModuleOptions extends OptionProcessor {
         if (! initialized()) {
             refresh(env);
         }
-        Pattern[] pats = findMatcher(env, pattern);
+        CodeNameMatcher cnm = CodeNameMatcher.create(env, pattern);
         
         List<UpdateUnit> units = UpdateManager.getDefault().getUpdateUnits(UpdateManager.TYPE.MODULE);
         final Collection <String> firstClass = getFirstClassModules();
@@ -266,12 +274,12 @@ public class ModuleOptions extends OptionProcessor {
                     Bundle.MSG_Update(uu.getCodeName(), uu.getInstalled().getSpecificationVersion(), ue.getSpecificationVersion()
                 ));
                 if (operate.canBeAdded(uu, ue)) {
-                    LOG.fine("  ... update " + uu.getInstalled() + " -> " + ue);
+                    LOG.log(Level.FINE, "  ... update {0} -> {1}", new Object[]{uu.getInstalled(), ue});
                     firstClassHasUpdates = true;
                     OperationInfo<InstallSupport> info = operate.add(ue);
                     if (info != null) {
                         Set<UpdateElement> requiredElements = info.getRequiredElements();
-                        LOG.fine("      ... add required elements: " + requiredElements);
+                        LOG.log(Level.FINE, "      ... add required elements: {0}", requiredElements);
                         operate.add(requiredElements);
                     }
                 }
@@ -286,7 +294,7 @@ public class ModuleOptions extends OptionProcessor {
                 if (updates.isEmpty()) {
                     continue;
                 }
-                if (pattern.length > 0 && !matches(uu.getCodeName(), pats)) {
+                if (pattern.length > 0 && !cnm.matches(uu.getCodeName())) {
                     continue;
                 }
                 final UpdateElement ue = updates.get(0);
@@ -294,11 +302,11 @@ public class ModuleOptions extends OptionProcessor {
                     Bundle.MSG_Update(uu.getCodeName(), uu.getInstalled().getSpecificationVersion(), ue.getSpecificationVersion()
                 ));
                 if (operate.canBeAdded(uu, ue)) {
-                    LOG.fine("  ... update " + uu.getInstalled() + " -> " + ue);
+                    LOG.log(Level.FINE, "  ... update {0} -> {1}", new Object[]{uu.getInstalled(), ue});
                     OperationInfo<InstallSupport> info = operate.add(ue);
                     if (info != null) {
                         Set<UpdateElement> requiredElements = info.getRequiredElements();
-                        LOG.fine("      ... add required elements: " + requiredElements);
+                        LOG.log(Level.FINE, "      ... add required elements: {0}", requiredElements);
                         operate.add(requiredElements);
                     }
                 }
@@ -306,7 +314,7 @@ public class ModuleOptions extends OptionProcessor {
         }
         final InstallSupport support = operate.getSupport();
         if (support == null) {
-            env.getOutputStream().println(pats == null || pats.length == 0 ? Bundle.MSG_UpdateNotFound() : Bundle.MSG_UpdateNoMatchPattern(Arrays.asList(pats)));
+            env.getOutputStream().println(cnm.isEmpty() ? Bundle.MSG_UpdateNotFound() : Bundle.MSG_UpdateNoMatchPattern(cnm));
             env.getOutputStream().println("updates=0"); // NOI18N
             return;
         }
@@ -335,54 +343,32 @@ public class ModuleOptions extends OptionProcessor {
     }
 
     @NbBundle.Messages({
-        "# {0} - regexp",
-        "MSG_CantCompileRegex=Cannot understand regular expession ''{0}''"
-    })
-    private static Pattern[] findMatcher(Env env, String[] pattern) {
-        Pattern[] arr = new Pattern[pattern.length];
-        for (int i = 0; i < arr.length; i++) {
-            try {
-                arr[i] = Pattern.compile(pattern[i]);
-            } catch (PatternSyntaxException e) {
-                env.getErrorStream().println(Bundle.MSG_CantCompileRegex(pattern[i]));
-            }
-        }
-        return arr;
-    }
-
-    private static boolean matches(String txt, Pattern[] pats) {
-        for (Pattern p : pats) {
-            if (p == null) {
-                continue;
-            }
-            if (p.matcher(txt).matches()) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    @NbBundle.Messages({
         "# {0} - module name",
         "# {1} - module version",
         "MSG_Installing=Installing {0}@{1}",
-        "# {0} - paterns",
-        "MSG_InstallNoMatch=Cannot install. No match for {0}."
+        "# {0} - module name",
+        "MSG_AlreadyPresent=Module {0} is already installed.",
     })
     private void install(final Env env, String... pattern) throws CommandException {
         if (! initialized()) {
             refresh(env);
         }
 
-        Pattern[] pats = findMatcher(env, pattern);
+        CodeNameMatcher cnm = CodeNameMatcher.create(env, pattern);
 
         List<UpdateUnit> units = UpdateManager.getDefault().getUpdateUnits();
         OperationContainer<InstallSupport> operate = OperationContainer.createForInstall();
+        boolean found = false;
+        StringBuilder sb = new StringBuilder();
+        
+        
         for (UpdateUnit uu : units) {
-            if (uu.getInstalled() != null) {
+            if (!cnm.matches(uu.getCodeName())) {
                 continue;
             }
-            if (!matches(uu.getCodeName(), pats)) {
+            found = true;
+            if (uu.getInstalled() != null) {
+                sb.append(MSG_AlreadyPresent(uu.getCodeName())).append("\n");
                 continue;
             }
             if (uu.getAvailableUpdates().isEmpty()) {
@@ -395,7 +381,11 @@ public class ModuleOptions extends OptionProcessor {
         }
         final InstallSupport support = operate.getSupport();
         if (support == null) {
-            env.getOutputStream().println(Bundle.MSG_InstallNoMatch(Arrays.asList(pats)));
+            if (!found) {
+                sb.insert(0, MSG_CannotFindAnyPattern(cnm));
+                throw new CommandException(55, sb.toString());
+            }
+            env.getOutputStream().print(sb.toString());
             return;
         }
         try {
@@ -438,7 +428,7 @@ public class ModuleOptions extends OptionProcessor {
         "MSG_NoURL=None extra Update Center (URL) specified."
     })
     private void extraUC(Env env, String... urls) throws CommandException {
-        List<URL> url2UC = new ArrayList<URL> (urls.length);
+        List<URL> url2UC = new ArrayList<> (urls.length);
         for (String spec : urls) {
             try {
                 url2UC.add(new URL(spec));
@@ -463,7 +453,7 @@ public class ModuleOptions extends OptionProcessor {
     private Collection<String> getFirstClassModules() {
         Preferences p = NbPreferences.root().node("/org/netbeans/modules/autoupdate"); // NOI18N
         String names = p.get(PLUGIN_MANAGER_FIRST_CLASS_MODULES, "");
-        Set<String> res = new HashSet<String> ();
+        Set<String> res = new HashSet<> ();
         StringTokenizer en = new StringTokenizer (names, ","); // NOI18N
         while (en.hasMoreTokens ()) {
             res.add (en.nextToken ().trim ());

--- a/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
+++ b/platform/o.n.bootstrap/src/org/netbeans/ModuleManager.java
@@ -1275,7 +1275,11 @@ public final class ModuleManager extends Modules {
             if (! testing.containsAll(modules)) {
                 Set<Module> bogus = new HashSet<Module>(modules);
                 bogus.removeAll(testing);
-                throw new IllegalModuleException(IllegalModuleException.Reason.ENABLE_MISSING, bogus);
+                Map<Module, Set<Union2<Dependency,InvalidException>>> errors = new HashMap<>();
+                for (Module b : bogus) {
+                    errors.put(b, missingDependencies(b));
+                }
+                throw new IllegalModuleException(IllegalModuleException.Reason.ENABLE_MISSING, errors);
             }
             for (Module m : testing) {
                 if (!modules.contains(m) && !m.isAutoload() && !m.isEager()) {


### PR DESCRIPTION
Support for editing so called _API support_ projects has been intentionally left out of VSNetBeans. It is archaic and out of interest of the new generation of developers. However we, the NetBeans oldtimers, do care about editing/compiling/debugging Apache NetBeans sources.

To balance the need of these two target groups I propose a simple way to build own customized VSNetBeans extension with _API support_ modules in. Just build the extension as you are used to and then execute:

```bash
java/java.lsp.server/vscode$ npm run apisupport
```
Then you can open any Apache NetBeans project and work with it without any limitations:

```bash
java/java.lsp.server/vscode$ code --extensionDevelopmentPath=`pwd` ../../platform/autoupdate.cli/
```

Should the project still not be recognized, consider removing previous debris. I had to use 
```bash
java/java.lsp.server/vscode$ rm -rf ~/.config/Code/User/globalStorage/asf.apache-netbeans-java/ nbcode/
```
few times.