### PR TITLE
Keep old plain for loops in NetBeans sources

### DIFF
--- a/nbbuild/misc/hints-settings.xml
+++ b/nbbuild/misc/hints-settings.xml
@@ -100,7 +100,10 @@
             <attribute name="enabled" value="true"/>
         </node>
         <node name="org.netbeans.modules.java.hints.bugs.BroadCatchBlock.broadCatch"/>
-        <node name="org.netbeans.modules.java.hints.jdk.mapreduce.ForLoopToFunctionalHint"/>
+        <node name="org.netbeans.modules.java.hints.jdk.mapreduce.ForLoopToFunctionalHint">
+            <attribute name="enabled" value="true"/>
+            <attribute name="hintSeverity" value="HINT"/>
+        </node>
         <node name="org.netbeans.modules.java.hints.ShiftOutOfRange"/>
         <node name="org.netbeans.modules.java.hints.suggestions.Move.moveInitialization"/>
         <node name="org.netbeans.modules.java.hints.AssignResultToVariable"/>


### PR DESCRIPTION
I am all for _clean code_ and keeping our sources without warnings and not applied hints. However, the default set of hints includes "convert to functional operations" and I find that one particularly annoying. I am quite fine using _OPFL - old plain for loops_ most of the time.

As such I propose to suppress the hint a bit. Make it visible only on affected line, for example. I have used the NetBeans IDE UI that allows to disable the hint and following change appeared on my disk. I assume, if we integrate it, the "convert to functional operations" hint is going to be suppressed (a bit).

Various IDEs offer summaries of errors/warnings in the code and I'd be really thankful if only important hints were included in such summaries.