### PR TITLE
[NETBEANS-5941] Add generic execute.task action to Gradle projects

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/RootActionProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/RootActionProvider.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.modules.gradle;
 
+import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.netbeans.modules.gradle.spi.actions.DefaultGradleActionsProvider;
 import org.netbeans.modules.gradle.spi.actions.GradleActionsProvider;
 import static org.netbeans.spi.project.ActionProvider.*;
@@ -36,6 +37,8 @@ public class RootActionProvider extends DefaultGradleActionsProvider {
         COMMAND_CLEAN,
         COMMAND_REBUILD,
         COMMAND_DELETE,
+        
+        RunUtils.EXECUTE_TASK_ACTION,
     };
 
     public RootActionProvider() {

--- a/extide/gradle/src/org/netbeans/modules/gradle/action-mapping.xml
+++ b/extide/gradle/src/org/netbeans/modules/gradle/action-mapping.xml
@@ -48,7 +48,7 @@
         </reload>
     </action>
 
-    <action displayName="Download sources" name="download.sources">
+    <action displayName="Download Sources" name="download.sources">
         <reload rule="ALWAYS_ONLINE">
             <args>-PdownloadSources=${requestedComponent}</args>
         </reload>
@@ -58,6 +58,10 @@
         <reload rule="ALWAYS_ONLINE">
             <args>-PdownloadSources=${requestedComponent} -PdownloadJavadoc=${requestedComponent}</args>
         </reload>
+    </action>
+
+    <action displayName="Run Task" name="execute.task">
+        <args>${taskName}</args>
     </action>
 
     <!--

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/CustomActionRegistrationSupport.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/CustomActionRegistrationSupport.java
@@ -35,7 +35,6 @@ import org.netbeans.modules.gradle.api.execute.ActionMapping;
 import org.netbeans.modules.gradle.api.execute.GradleExecConfiguration;
 import org.netbeans.modules.gradle.customizer.CustomActionMapping;
 import org.netbeans.modules.gradle.execute.ConfigurableActionProvider;
-import org.netbeans.spi.project.ProjectConfigurationProvider;
 import org.openide.awt.NotificationDisplayer;
 import org.openide.awt.NotificationDisplayer.Priority;
 import org.openide.util.NbBundle;

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/DefaultActionMapping.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/DefaultActionMapping.java
@@ -146,6 +146,12 @@ public class DefaultActionMapping implements ActionMapping {
         return Objects.equals(this.withPlugins, other.withPlugins);
     }
 
+    @Override
+    public String toString() {
+        return name + " [" + args + ']';
+    }
+
+    
     public static DefaultActionMapping DISABLED = new DefaultActionMapping();
     
     static {

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/GradleTaskTokenProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/GradleTaskTokenProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.gradle.actions;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.netbeans.modules.gradle.api.GradleTask;
+import org.netbeans.modules.gradle.api.NbGradleProject;
+import org.netbeans.modules.gradle.spi.actions.ReplaceTokenProvider;
+import org.netbeans.spi.project.ProjectServiceProvider;
+import org.openide.util.Lookup;
+
+/**
+ *
+ * @author lkishalmi
+ */
+@ProjectServiceProvider(service = ReplaceTokenProvider.class, projectType = NbGradleProject.GRADLE_PROJECT_TYPE)
+public class GradleTaskTokenProvider implements ReplaceTokenProvider {
+
+    private static Set<String> SUPPORTED = Collections.unmodifiableSet(new HashSet(Arrays.asList(
+       "taskName",
+       "taskPath",
+       "taskNames",
+       "taskPaths"
+    )));
+    
+    @Override
+    public Set<String> getSupportedTokens() {
+        return SUPPORTED;
+    }
+
+    @Override
+    public Map<String, String> createReplacements(String action, Lookup context) {
+        
+        Collection<? extends GradleTask> tasks = context.lookupAll(GradleTask.class);
+        if (!tasks.isEmpty()) {
+            Map<String, String> ret = new HashMap<>();
+            
+            GradleTask task = context.lookup(GradleTask.class);
+            ret.put("taskName", task.getName());
+            ret.put("taskPath", task.getPath());
+            
+            StringBuilder names = new StringBuilder();
+            StringBuilder paths = new StringBuilder();
+            String sep = "";
+            for (GradleTask t : tasks) {
+                names.append(sep).append(t.getName());
+                paths.append(sep).append(t.getPath());
+                sep = " ";
+            }
+            ret.put("taskNames", names.toString());
+            ret.put("taskPaths", paths.toString());
+
+            return ret;
+        }
+        return Collections.emptyMap();
+    }
+    
+}

--- a/extide/gradle/src/org/netbeans/modules/gradle/actions/ProjectActionMappingProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/actions/ProjectActionMappingProviderImpl.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 import java.util.logging.Logger;
-import org.netbeans.modules.gradle.api.execute.GradleExecConfiguration;
 import org.netbeans.modules.gradle.spi.GradleFiles;
 
 /**

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/ActionMapping.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/ActionMapping.java
@@ -34,9 +34,9 @@ import java.util.Set;
  */
 public interface ActionMapping extends Serializable, Comparable<ActionMapping> {
 
-    /** Prefix fo custom, non-default IDE actions. */
+    /** Prefix for custom, non-default IDE actions. */
     public static final String CUSTOM_PREFIX = "custom-"; //NOI18N
-
+    
     /**
      * Rule to reload the project after the Gradle execution. The project reload
      * by default done, by setting the offline flag in Gradle in order to avoid

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/RunUtils.java
@@ -90,6 +90,9 @@ public final class RunUtils {
     public static final String PROP_INCLUDE_OPEN_PROJECTS = "include.open.projects"; //NOI18N
     public static final String PROP_DEFAULT_CLI = "gradle.cli"; //NOI18N
 
+    /** Action to execute specific Gradle Tasks from the IDE (Eg. from Navigator). */
+    public static final String EXECUTE_TASK_ACTION = "execute.task"; //NOI18N
+
     private RunUtils() {}
     private static final Map<RunConfig, GradleExecutor> GRADLE_TASKS = new WeakHashMap<>();
 


### PR DESCRIPTION
My current work is based on the delivery branch, however I do not think this one would be required for 12.5.
This one would assign a real action to the GradleTask-s on the Navigator nodes.

I'm sorry I pushed a reformat on ActionProviderImpl.java...