### PR TITLE
[NETBEANS-5914] Call notifyAll + avoid delivering changes under a lock

### DIFF
--- a/ide/projectapi/src/org/netbeans/modules/projectapi/LazyLookup.java
+++ b/ide/projectapi/src/org/netbeans/modules/projectapi/LazyLookup.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.projectapi;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Level;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.Lookups;
+import org.openide.util.lookup.ProxyLookup;
+
+final class LazyLookup extends ProxyLookup {
+    
+    private final Map<String, Object> attrs;
+    private final Lookup lkp;
+    private Collection<String> serviceNames;
+    final Thread[] LOCK = {null};
+
+    public LazyLookup(Map<String, Object> attrs, Lookup lkp) {
+        this.attrs = attrs;
+        this.lkp = lkp;
+        this.serviceNames = Arrays.asList(((String) attrs.get("service")).split(",")); // NOI18N
+    } // NOI18N
+
+    @Override
+    protected void beforeLookup(Template<?> template) {
+        LazyLookupProviders.safeToLoad(this.lkp);
+        Class<?> service = template.getType();
+        synchronized (LOCK) {
+            for (;;) {
+                if (serviceNames == null || !serviceNames.contains(service.getName())) {
+                    return;
+                }
+                if (LOCK[0] == null) {
+                    break;
+                }
+                if (LOCK[0] == Thread.currentThread()) {
+                    return;
+                }
+                try {
+                    /* deadlock - probably wait without a notify
+                    https://issues.apache.org/jira/secure/attachment/13032558/13032558_12.5-beta2-threaddump-1629986898821.tdump
+                    always make sure LOCK.notifyAll is called when changing the LOCK[0] value
+                     */
+                    LOCK.wait();
+                } catch (InterruptedException ex) {
+                    LazyLookupProviders.LOG.log(Level.INFO, null, ex);
+                }
+            }
+            LOCK[0] = Thread.currentThread();
+            LOCK.notifyAll();
+        }
+        try {
+            Object instance = LazyLookupProviders.loadPSPInstance((String) attrs.get("class"), (String) attrs.get("method"), lkp); // NOI18N
+            if (!service.isInstance(instance)) {
+                // JRE #6456938: Class.cast currently throws an exception without details.
+                throw new ClassCastException("Instance of " + instance.getClass() + " unassignable to " + service);
+            }
+            setLookups(Lookups.singleton(instance));
+            synchronized (LOCK) {
+                serviceNames = null;
+            }
+        } catch (Exception x) {
+            Exceptions.attachMessage(x, "while loading from " + attrs);
+            Exceptions.printStackTrace(x);
+        } finally {
+            synchronized (LOCK) {
+                LOCK[0] = null;
+                LOCK.notifyAll();
+            }
+        }
+    }
+
+    @Override
+    @SuppressWarnings(value = "element-type-mismatch")
+    public String toString() {
+        return "LazyLookupProviders.LookupProvider[service=" + attrs.get("service") + ", class=" + attrs.get("class") + ", orig=" + attrs.get(FileObject.class) + "]";
+    }
+    
+}

--- a/ide/projectapi/src/org/netbeans/modules/projectapi/LazyLookupProviders.java
+++ b/ide/projectapi/src/org/netbeans/modules/projectapi/LazyLookupProviders.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -37,13 +36,9 @@ import org.netbeans.api.project.Project;
 import org.netbeans.spi.project.LookupMerger;
 import org.netbeans.spi.project.LookupProvider;
 import org.netbeans.spi.project.ProjectServiceProvider;
-import org.openide.filesystems.FileObject;
 import org.openide.util.ChangeSupport;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
-import org.openide.util.Lookup.Template;
-import org.openide.util.lookup.Lookups;
-import org.openide.util.lookup.ProxyLookup;
 
 /**
  * Factory methods for lazy {@link LookupProvider} registration.
@@ -52,7 +47,7 @@ public class LazyLookupProviders {
 
     private LazyLookupProviders() {}
 
-    private static final Logger LOG = Logger.getLogger(LazyLookupProviders.class.getName());
+    static final Logger LOG = Logger.getLogger(LazyLookupProviders.class.getName());
     private static final Map<Lookup,ThreadLocal<Member>> INSIDE_LOAD = new WeakHashMap<Lookup,ThreadLocal<Member>>();
     private static final Collection<Member> WARNED = Collections.synchronizedSet(new HashSet<Member>());
 
@@ -62,102 +57,39 @@ public class LazyLookupProviders {
     public static LookupProvider forProjectServiceProvider(final Map<String,Object> attrs) throws ClassNotFoundException {
         class Prov implements LookupProvider {
             @Override
-            public Lookup createAdditionalLookup(final Lookup lkp) {
-                final Lookup result =  new ProxyLookup() {
-                    Collection<String> serviceNames = Arrays.asList(((String) attrs.get("service")).split(",")); // NOI18N
-                    final Thread[] LOCK = { null };
-                    @Override protected void beforeLookup(Template<?> template) {
-                        safeToLoad();
-                        Class<?> service = template.getType();
-                        synchronized (LOCK) {
-                            for (;;) {
-                                if (serviceNames == null || !serviceNames.contains(service.getName())) {
-                                    return;
-                                }
-                                if (LOCK[0] == null) {
-                                    break;
-                                }
-                                if (LOCK[0] == Thread.currentThread()) {
-                                    return;
-                                }
-                                try {
-                                    /* deadlock - probably wait without a notify
-                                    https://issues.apache.org/jira/secure/attachment/13032558/13032558_12.5-beta2-threaddump-1629986898821.tdump
-                                    always make sure LOCK.notifyAll is called when changing the LOCK[0] value
-                                     */
-                                    LOCK.wait();
-                                } catch (InterruptedException ex) {
-                                    LOG.log(Level.INFO, null, ex);
-                                }
-                            }
-                            LOCK[0] = Thread.currentThread();
-                            LOCK.notifyAll();
-                        }
-                        try {
-                            Object instance = loadPSPInstance((String) attrs.get("class"), (String) attrs.get("method"), lkp); // NOI18N
-                            if (!service.isInstance(instance)) {
-                                // JRE #6456938: Class.cast currently throws an exception without details.
-                                throw new ClassCastException("Instance of " + instance.getClass() + " unassignable to " + service);
-                            }
-                            setLookups(Lookups.singleton(instance));
-                            synchronized (LOCK) {
-                                serviceNames = null;
-                            }
-                        } catch (Exception x) {
-                            Exceptions.attachMessage(x, "while loading from " + attrs);
-                            Exceptions.printStackTrace(x);
-                        } finally {
-                            synchronized (LOCK) {
-                                LOCK[0] = null;
-                                LOCK.notifyAll();
-                            }
-                        }
-                    }
-                    private void safeToLoad() {
-                        ThreadLocal<Member> memberRef;
-                        synchronized (INSIDE_LOAD) {
-                            memberRef = INSIDE_LOAD.get(lkp);
-                        }
-                        if (memberRef == null) {
-                            return;
-                        }
-                        Member member = memberRef.get();
-                        if (member != null && WARNED.add(member)) {
-                            LOG.log(Level.WARNING, null, new IllegalStateException("may not call Project.getLookup().lookup(...) inside " + member.getName() + " registered under @ProjectServiceProvider"));
-                        }
-                    }
-
-                    @Override
-                    public String toString() {
-                        return Prov.this.toString();
-                    }
-                };
+            public Lookup createAdditionalLookup(Lookup lkp) {
+                LazyLookup result = new LazyLookup(attrs, lkp);
                 if (LOG.isLoggable(Level.FINE)) {
                     LOG.log(
-                        Level.FINE,
-                        "Additional lookup created: {0} service class: {1} for base lookup: {2}",   //NOI18N
-                        new Object[]{
+                            Level.FINE,
+                            "Additional lookup created: {0} service class: {1} for base lookup: {2}", //NOI18N
+                            new Object[]{
                             System.identityHashCode(result),
-                            attrs.get("class"),
-                            System.identityHashCode(lkp)
-                        });
+                                attrs.get("class"),
+                                System.identityHashCode(lkp)
+                            });
                 }
                 return result;
             }
-            
-            @Override
-            @SuppressWarnings("element-type-mismatch")
-            public String toString() {
-                return "LazyLookupProviders.LookupProvider[service=" + 
-                    attrs.get("service") + 
-                    ", class=" + attrs.get("class") + 
-                    ", orig=" + attrs.get(FileObject.class) + 
-                    "]";
-            }
-        };
+        }
         return new Prov();
     }
-    private static Object loadPSPInstance(String implName, String methodName, Lookup lkp) throws Exception {
+
+    static void safeToLoad(Lookup lkp) {
+        ThreadLocal<Member> memberRef;
+        synchronized (LazyLookupProviders.INSIDE_LOAD) {
+            memberRef = LazyLookupProviders.INSIDE_LOAD.get(lkp);
+        }
+        if (memberRef == null) {
+            return;
+        }
+        Member member = memberRef.get();
+        if (member != null && LazyLookupProviders.WARNED.add(member)) {
+            LazyLookupProviders.LOG.log(Level.WARNING, null, new IllegalStateException("may not call Project.getLookup().lookup(...) inside " + member.getName() + " registered under @ProjectServiceProvider"));
+        }
+    }
+    
+    static Object loadPSPInstance(String implName, String methodName, Lookup lkp) throws Exception {
         ClassLoader loader = Lookup.getDefault().lookup(ClassLoader.class);
         if (loader == null) {
             loader = Thread.currentThread().getContextClassLoader();

--- a/ide/projectapi/src/org/netbeans/modules/projectapi/LazyLookupProviders.java
+++ b/ide/projectapi/src/org/netbeans/modules/projectapi/LazyLookupProviders.java
@@ -81,12 +81,17 @@ public class LazyLookupProviders {
                                     return;
                                 }
                                 try {
+                                    /* deadlock - probably wait without a notify
+                                    https://issues.apache.org/jira/secure/attachment/13032558/13032558_12.5-beta2-threaddump-1629986898821.tdump
+                                    always make sure LOCK.notifyAll is called when changing the LOCK[0] value
+                                     */
                                     LOCK.wait();
                                 } catch (InterruptedException ex) {
                                     LOG.log(Level.INFO, null, ex);
                                 }
                             }
                             LOCK[0] = Thread.currentThread();
+                            LOCK.notifyAll();
                         }
                         try {
                             Object instance = loadPSPInstance((String) attrs.get("class"), (String) attrs.get("method"), lkp); // NOI18N

--- a/ide/projectapi/test/unit/src/org/netbeans/modules/projectapi/LazyLookupTest.java
+++ b/ide/projectapi/test/unit/src/org/netbeans/modules/projectapi/LazyLookupTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.projectapi;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.openide.util.Lookup;
+import org.openide.util.LookupEvent;
+import org.openide.util.LookupListener;
+
+public class LazyLookupTest {
+    
+    public LazyLookupTest() {
+    }
+    
+    @Test
+    public void testChangesAreNotifiedWithoutHoldingALock() {
+        
+        Map<String,Object> data = new HashMap<>();
+        data.put("service", String.class.getName());
+        data.put("class", LazyLookupTest.class.getName());
+        data.put("method", "testFactory");
+        LazyLookup lkp = new LazyLookup(data, Lookup.EMPTY);
+
+        class LL implements LookupListener {
+            int cnt;
+            
+            @Override
+            public void resultChanged(LookupEvent ev) {
+                cnt++;
+                assertFalse("Internal lock isn't held", lkp.isInitializing());
+            }
+        }
+        LL listener = new LL();
+
+        Lookup.Result<String> res = lkp.lookupResult(String.class);
+        res.addLookupListener(listener);
+        
+        String value = lkp.lookup(String.class);
+        assertEquals("Hello", value);
+        
+        assertEquals("One change", 1, listener.cnt);
+    }
+    
+    public static String testFactory() {
+        return "Hello";
+    }
+}

--- a/ide/projectapi/test/unit/src/org/netbeans/spi/project/support/DelegatingLookupDeadlock5914Test.java
+++ b/ide/projectapi/test/unit/src/org/netbeans/spi/project/support/DelegatingLookupDeadlock5914Test.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.netbeans.spi.project.support;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JRadioButton;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.spi.project.LookupMerger;
+import org.netbeans.spi.project.LookupProvider;
+import org.openide.util.Lookup;
+import org.openide.util.LookupEvent;
+import org.openide.util.LookupListener;
+import org.openide.util.lookup.AbstractLookup;
+import org.openide.util.lookup.InstanceContent;
+import org.openide.util.lookup.Lookups;
+
+public class DelegatingLookupDeadlock5914Test extends NbTestCase {
+
+    public DelegatingLookupDeadlock5914Test(String name) {
+        super(name);
+    }
+
+    public void testDontHoldLockWhenNotifyingChanges() {
+        LookupMergerImpl merger = new LookupMergerImpl();
+        Lookup base = Lookups.fixed(new JButton(), new JComboBox(), merger);
+        LookupProviderImpl pro1 = new LookupProviderImpl();
+        LookupProviderImpl pro2 = new LookupProviderImpl();
+        LookupProviderImpl pro3 = new LookupProviderImpl();
+
+        InstanceContent provInst = new InstanceContent();
+        Lookup providers = new AbstractLookup(provInst);
+        provInst.add(pro1);
+        provInst.add(pro2);
+
+        pro1.ic.add(new JTextField());
+        pro2.ic.add(new JTextArea());
+
+        DelegatingLookupImpl del = new DelegatingLookupImpl(base, providers, "<irrelevant>");
+        class LL implements LookupListener {
+            int cnt;
+
+            @Override
+            public void resultChanged(LookupEvent ev) {
+                assertFalse("Cannot hold lock when notifying changes!", del.holdsLock());
+                cnt++;
+            }
+        }
+        LL jbuttonListener = new LL();
+        Lookup.Result<JButton> jbuttonResult = del.lookupResult(JButton.class);
+        jbuttonResult.addLookupListener(jbuttonListener);
+        assertEquals("One button", 1, jbuttonResult.allInstances().size());
+
+        Lookup.Result<JRadioButton> jradioButtonResult = del.lookupResult(JRadioButton.class);
+        LL jradioButtonListener = new LL();
+        jradioButtonResult.addLookupListener(jradioButtonListener);
+        assertEquals("No radio button", 0, jradioButtonResult.allInstances().size());
+
+        assertNotNull(del.lookup(JTextArea.class));
+        assertNotNull(del.lookup(JComboBox.class));
+
+        // test merger..
+        JButton butt = del.lookup(JButton.class);
+        assertNotNull(butt);
+        assertEquals("CORRECT", butt.getText());
+        assertEquals(1, del.lookupAll(JButton.class).size());
+        assertEquals(1, merger.expectedCount);
+
+        pro3.ic.add(new JButton());
+        pro3.ic.add(new JRadioButton());
+        provInst.add(pro3);
+        assertNotNull(del.lookup(JRadioButton.class));
+
+        assertEquals("A change delivered", 1, jradioButtonListener.cnt);
+    }
+
+    private static class LookupMergerImpl implements LookupMerger<JButton> {
+
+        int expectedCount;
+
+        @Override public Class<JButton> getMergeableClass() {
+            return JButton.class;
+        }
+
+        @Override public JButton merge(final Lookup lookup) {
+            expectedCount = lookup.lookupAll(JButton.class).size();
+            lookup.lookupResult(JButton.class).addLookupListener(new LookupListener() {
+                public @Override void resultChanged(LookupEvent ev) {
+                    expectedCount = lookup.lookupAll(JButton.class).size();
+                }
+            });
+            return new JButton("CORRECT");
+        }
+
+    }
+
+    private static class LookupProviderImpl implements LookupProvider {
+        InstanceContent ic = new InstanceContent();
+        boolean wasAlreadyCalled = false;
+        @Override public Lookup createAdditionalLookup(Lookup baseContext) {
+            assertNotNull(baseContext.lookup(JButton.class));
+            assertNull(baseContext.lookup(JCheckBox.class));
+            assertFalse(wasAlreadyCalled);
+            wasAlreadyCalled = true;
+            return new AbstractLookup(ic);
+        }
+    }
+
+}


### PR DESCRIPTION
Visual inspection of `LazyLookupProviders` code suggests an inconsistency: `Object.wait()` waits on value of `LOCK[0]` and such value can be provided without  setting calling `Object.notifyAll()`. This should be an easy fix for [this deadlock](https://issues.apache.org/jira/secure/attachment/13032558/13032558_12.5-beta2-threaddump-1629986898821.tdump).

The rest of the [NETBEANS-5914](https://issues.apache.org/jira/browse/NETBEANS-5914) issue is going to be exorcized by 9227546