### PR TITLE
Get elements resolved before working with types.

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/CompilationUnit.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/CompilationUnit.java
@@ -164,6 +164,7 @@ public final class CompilationUnit extends org.codehaus.groovy.control.Compilati
                 Task<CompilationController> task = new Task<CompilationController>() {
                     @Override
                     public void run(CompilationController controller) throws Exception {
+                        controller.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
                         Elements elements = controller.getElements();
                         TypeElement typeElement = ElementSearch.getClass(elements, name);
                         if (typeElement != null) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/MethodCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/MethodCompletion.java
@@ -158,8 +158,8 @@ public class MethodCompletion extends BaseCompletion {
             try {
                 javaSource.runUserActionTask(new Task<CompilationController>() {
                     @Override
-                    public void run(CompilationController info) {
-
+                    public void run(CompilationController info) throws IOException {
+                        info.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
                         List<Element> typelist = new ArrayList<>();
                         for (String importName : getAllImports()) {
                             typelist.addAll(getElementListFor(info.getElements(), importName));

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/TypesCompletion.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/TypesCompletion.java
@@ -345,9 +345,9 @@ public class TypesCompletion extends BaseCompletion {
             try {
                 javaSource.runUserActionTask(new Task<CompilationController>() {
                     @Override
-                    public void run(CompilationController info) {
+                    public void run(CompilationController info) throws IOException {
                         Elements elements = info.getElements();
-
+                        info.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
                         addPackageElements(elements.getPackageElement(pkg));
                         addTypeElements(elements.getTypeElement(pkg));
                     }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/JavaElementHandler.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/completion/provider/JavaElementHandler.java
@@ -215,7 +215,7 @@ public final class JavaElementHandler {
                     return false;
                 }
             };
-
+            info.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
             TypeElement te = elements.getTypeElement(className);
             if (te != null) {
                 for (ExecutableElement element : ElementFilter.methodsIn(te.getEnclosedElements())) {
@@ -383,7 +383,7 @@ public final class JavaElementHandler {
                         return false;
                     }
                 };
-
+                info.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
                 TypeElement te = elements.getTypeElement(className);
                 if (te != null) {
                     for (VariableElement element : ElementFilter.fieldsIn(te.getEnclosedElements())) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/java/JavaElementHandle.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/java/JavaElementHandle.java
@@ -213,6 +213,7 @@ public final class JavaElementHandle implements ElementHandle {
             @Override
             public void run(CompilationController parameter) throws Exception {
                 try {
+                    parameter.toPhase(JavaSource.Phase.ELEMENTS_RESOLVED);
                     result = resolver.apply(parameter, toElement(parameter));
                 } catch (Exception ex) {
                     thrown = ex;


### PR DESCRIPTION
The missing call is causing exceptions when the completion is invoked from LSP.