### PR TITLE
Include URLs in Java code templates for easier customization

### DIFF
--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/CloneAndCloneableTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/CloneAndCloneableTest.java
@@ -201,7 +201,7 @@ public class CloneAndCloneableTest extends NbTestCase {
         "public class CloneTest4 implements Cloneable {\n" +
         "    @Override\n" +
         "    public Object clone() throws CloneNotSupportedException {\n" +
-        "        return super.clone(); //To change body of generated methods, choose Tools | Templates.\n" +
+        "        return super.clone(); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/OverriddenMethodBody\n" +
         "    }\n" +
         "}"
         );

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ImplementAllAbstractMethodsTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/errors/ImplementAllAbstractMethodsTest.java
@@ -49,7 +49,7 @@ public class ImplementAllAbstractMethodsTest extends ErrorHintsTestBase {
                        "public enum Test implements Runnable {\n" +
                        "     A;\n" +
                        "     public void run() {\n" +
-                       "         throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n" +
+                       "         throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n" +
                        "     }\n" +
                        "}\n").replaceAll("[ \t\n]+", " "));
     }
@@ -83,7 +83,7 @@ public class ImplementAllAbstractMethodsTest extends ErrorHintsTestBase {
                        ("package test;\n" +
                        "public class Test implements Runnable {\n" +
                        "     public void run() {\n" +
-                       "         throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n" +
+                       "         throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n" +
                        "     }\n" +
                        "}\n").replaceAll("[ \t\n]+", " "));
     }
@@ -123,7 +123,7 @@ public class ImplementAllAbstractMethodsTest extends ErrorHintsTestBase {
                         "public enum Test implements Runnable {\n" +
                         "     A {\n" +
                         "         public void run() {\n" +
-                        "             throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n" +
+                        "             throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n" +
                         "         }\n" +
                         "     };\n" +
                         "}\n").replaceAll("[ \t\n]+", " "));
@@ -143,7 +143,7 @@ public class ImplementAllAbstractMethodsTest extends ErrorHintsTestBase {
                         "     A { public void run() {} },\n" +
                         "     B {\n" +
                         "         public void run() {\n" +
-                        "             throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n" +
+                        "             throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n" +
                         "         }\n" +
                         "     };\n" +
                         "}\n").replaceAll("[ \t\n]+", " "));
@@ -164,7 +164,7 @@ public class ImplementAllAbstractMethodsTest extends ErrorHintsTestBase {
                         "\n" +
                         "        @Override\n" +
                         "        public int boo() {\n" +
-                        "            throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n" +
+                        "            throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n" +
                         "        }\n" +
                         "    };\n" +
                         "    public abstract int boo();\n" +

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/ImplementMethodsTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/suggestions/ImplementMethodsTest.java
@@ -44,7 +44,7 @@ public class ImplementMethodsTest {
                 .assertOutput("package test;\n" +
                               "public abstract class Test implements Runnable {\n" +
                               "    public void run() {\n" +
-                              "        throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n" +
+                              "        throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n" +
                               "    }\n" +
                               "}\n");
     }

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/GeneratorUtilitiesTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/GeneratorUtilitiesTest.java
@@ -1489,7 +1489,7 @@ public class GeneratorUtilitiesTest extends NbTestCase {
                     "package test; public class Test implements I { } interface I { public default void t() { } } \n",
                     "1.8",
                     new T2(),
-                    new ContentValidator("package test; public class Test implements I { \n\n    @Override\n    public void t() {\n        I.super.t(); //To change body of generated methods, choose Tools | Templates.\n    }\n } interface I { public default void t() { } } \n"),
+                    new ContentValidator("package test; public class Test implements I { \n\n    @Override\n    public void t() {\n        I.super.t(); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/OverriddenMethodBody\n    }\n } interface I { public default void t() { } } \n"),
                     false);
     }
     
@@ -1498,7 +1498,7 @@ public class GeneratorUtilitiesTest extends NbTestCase {
                     "package test; public interface Test extends I { } interface I { public void t(); } \n",
                     "1.8",
                     new T2(),
-                    new ContentValidator("package test; public interface Test extends I { \n\n    @Override\n    public default void t() {\n        throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n    }\n } interface I { public void t(); } \n"),
+                    new ContentValidator("package test; public interface Test extends I { \n\n    @Override\n    public default void t() {\n        throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n    }\n } interface I { public void t(); } \n"),
                     false);
     }
     
@@ -1507,7 +1507,7 @@ public class GeneratorUtilitiesTest extends NbTestCase {
                     "package test; public interface Test extends I { } interface I { public default void t() { } } \n",
                     "1.8",
                     new T2(),
-                    new ContentValidator("package test; public interface Test extends I { \n\n    @Override\n    public default void t() {\n        I.super.t(); //To change body of generated methods, choose Tools | Templates.\n    }\n } interface I { public default void t() { } } \n"),
+                    new ContentValidator("package test; public interface Test extends I { \n\n    @Override\n    public default void t() {\n        I.super.t(); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/OverriddenMethodBody\n    }\n } interface I { public default void t() { } } \n"),
                     false);
     }
     
@@ -1516,7 +1516,7 @@ public class GeneratorUtilitiesTest extends NbTestCase {
                     "package test; public class Test implements I { } interface I { public void t(); } \n",
                     "1.8",
                     new T2(),
-                    new ContentValidator("package test; public class Test implements I { \n\n    @Override\n    public void t() {\n        throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n    }\n } interface I { public void t(); } \n"),
+                    new ContentValidator("package test; public class Test implements I { \n\n    @Override\n    public void t() {\n        throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n    }\n } interface I { public void t(); } \n"),
                     false);
     }
     

--- a/java/java.source/src/org/netbeans/modules/java/source/resources/GeneratedMethodBody.template
+++ b/java/java.source/src/org/netbeans/modules/java/source/resources/GeneratedMethodBody.template
@@ -10,4 +10,4 @@ ${method_name}              name of the created method
 ${class_name}               qualified name of the enclosing class
 ${simple_class_name}        simple name of the enclosing class
 -->
-throw new java.lang.UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+throw new java.lang.UnsupportedOperationException("Not supported yet."); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody

--- a/java/java.source/src/org/netbeans/modules/java/source/resources/LambdaBody.template
+++ b/java/java.source/src/org/netbeans/modules/java/source/resources/LambdaBody.template
@@ -9,7 +9,7 @@ ${default_return_value}     a value returned by the method by default
 ${method_name}              name of the functional interface method
 -->
 <#if method_return_type?? && method_return_type != "void">
-return ${default_return_value}; //To change body of generated lambdas, choose Tools | Templates.
+return ${default_return_value}; // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/LambdaBody
 <#else>
-//To change body of generated lambdas, choose Tools | Templates.
+// Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/LambdaBody
 </#if>

--- a/java/java.source/src/org/netbeans/modules/java/source/resources/OverriddenMethodBody.template
+++ b/java/java.source/src/org/netbeans/modules/java/source/resources/OverriddenMethodBody.template
@@ -12,7 +12,7 @@ ${class_name}               qualified name of the enclosing class
 ${simple_class_name}        simple name of the enclosing class
 -->
 <#if method_return_type?? && method_return_type != "void">
-return ${super_method_call}; //To change body of generated methods, choose Tools | Templates.
+return ${super_method_call}; // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/OverriddenMethodBody
 <#else>
-${super_method_call!''}; //To change body of generated methods, choose Tools | Templates.
+${super_method_call!''}; // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/OverriddenMethodBody
 </#if>


### PR DESCRIPTION
While working on #2960 I forgot to modify Java code templates. That's annoying as these templates are exactly something that needs customization:

![image](https://user-images.githubusercontent.com/26887752/131607093-03655563-218f-43ca-b626-1d53280122f1.png)

Clicking the URL in editor opens the template.