### PR TITLE
Cleanup raw type warning

### DIFF
--- a/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerDisplay.java
+++ b/apisupport/apisupport.ant/src/org/netbeans/modules/apisupport/project/ui/customizer/CustomizerDisplay.java
@@ -126,7 +126,7 @@ final class CustomizerDisplay extends NbPropertyPanel.Single {
                 final SortedSet<String> moduleCategories = getProperties().getModuleCategories();
                 EventQueue.invokeLater(new Runnable() {
                     public void run() {
-                        DefaultComboBoxModel model = new DefaultComboBoxModel();
+                        DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
                         categoryValue.removeAllItems();
                         for (String cat : moduleCategories) {
                             model.addElement(cat);

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/ActionTypePanel.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/ActionTypePanel.java
@@ -102,7 +102,7 @@ final class ActionTypePanel extends BasicWizardIterator.Panel {
     }
     
     private static ComboBoxModel createCookieClassModel() {
-        DefaultComboBoxModel cookieClassModel = new DefaultComboBoxModel();
+        DefaultComboBoxModel<String> cookieClassModel = new DefaultComboBoxModel<>();
         for (String fqcn : DataModel.PREDEFINED_COOKIE_CLASSES) {
             String name = DataModel.parseClassName(fqcn);
             cookieClassModel.addElement(name);

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/GUIRegistrationPanel.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/GUIRegistrationPanel.java
@@ -842,7 +842,7 @@ final class GUIRegistrationPanel extends BasicWizardIterator.Panel {
         KeyStroke[] keyStrokes = ShortcutEnterPanel.showDialog();
         if (keyStrokes != null && keyStrokes.length > 0) {
             String newShortcut = WizardUtils.keyStrokesToString(keyStrokes);
-            DefaultListModel lm = (DefaultListModel)shortcutsList.getModel();
+            DefaultListModel<String> lm = (DefaultListModel)shortcutsList.getModel();
             if (!lm.contains(newShortcut)) {
                 lm.addElement(newShortcut);
                 data.setKeyStroke(WizardUtils.keyStrokesToLogicalString(keyStrokes));

--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/WizardUtils.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/common/WizardUtils.java
@@ -333,7 +333,7 @@ public class WizardUtils {
      */
     public static ComboBoxModel createLayerPresenterComboModel(
             final Project project, final String sfsRoot, final Map<String,Object> excludeAttrs) {
-        DefaultComboBoxModel model = new DefaultComboBoxModel();
+        DefaultComboBoxModel<LayerItemPresenter> model = new DefaultComboBoxModel<>();
         try {
             FileSystem sfs = project.getLookup().lookup(NbModuleProvider.class).getEffectiveSystemFilesystem();
             FileObject root = sfs.getRoot().getFileObject(sfsRoot);

--- a/apisupport/timers/src/org/netbeans/modules/timers/TimeComponentPanel.java
+++ b/apisupport/timers/src/org/netbeans/modules/timers/TimeComponentPanel.java
@@ -214,7 +214,7 @@ public class TimeComponentPanel extends javax.swing.JPanel implements PropertyCh
     }
     
     private void fillIn() {
-        DefaultListModel model = (DefaultListModel) jList1.getModel();
+        DefaultListModel<WeakReference<Object>> model = (DefaultListModel<WeakReference<Object>>)jList1.getModel();
 
         model.removeAllElements();
 

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/AddDomainLocationVisualPanel.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/wizards/AddDomainLocationVisualPanel.java
@@ -106,7 +106,7 @@ public class AddDomainLocationVisualPanel extends javax.swing.JPanel {
         KeyListener kl = new MyKeyListener();
         if (isLocal) {
             // Put the choices into the combo box...
-            DefaultComboBoxModel model = new DefaultComboBoxModel();
+            DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
             File domainsDir = new File(
                     gfRoot, GlassfishInstance.DEFAULT_DOMAINS_FOLDER);
             File candidates[] = domainsDir.listFiles(new FileFilter() {

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/ProcessIOParser.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/ProcessIOParser.java
@@ -162,7 +162,7 @@ public class ProcessIOParser {
             String prompt = content.getCurrentPrompt();
             promptLen = prompt != null ? prompt.length() : 0;
             promptBuff = new CyclicStringBuffer(promptLen);
-            output = new LinkedList();
+            output = new LinkedList<>();
         }
 
         /**

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/response/RestXMLResponseParser.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/response/RestXMLResponseParser.java
@@ -118,7 +118,7 @@ public class RestXMLResponseParser extends RestResponseParser {
 
     private HashMap<String, String> getMapEntry(StartElement entry) {
         HashMap<String, String> entryMap = new HashMap<>();
-        Iterator iter = entry.getAttributes();
+        Iterator<Attribute> iter = entry.getAttributes();
         while (iter.hasNext()) {
             Attribute att = (Attribute) iter.next();
             entryMap.put(att.getName().getLocalPart(), att.getValue());

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishContainer.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishContainer.java
@@ -81,7 +81,7 @@ public enum GlassFishContainer implements Comparator<GlassFishContainer> {
      * conversion.
      */
     private static final Map<String, GlassFishContainer> stringValuesMap
-            = new HashMap(2 * values().length);
+            = new HashMap<>(2 * values().length);
 
     // Initialize backward String conversion Map.
     static {

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/utils/StringPrefixTree.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/utils/StringPrefixTree.java
@@ -188,7 +188,7 @@ public class StringPrefixTree<Type> {
             sb.append("Value=");
             sb.append(value != null ? value.toString() : "null");
             sb.append(" Transitions=[");
-            for (Iterator i = next.keySet().iterator(); i.hasNext(); ) {
+            for (Iterator<Character> i = next.keySet().iterator(); i.hasNext(); ) {
                 sb.append(i.next());
                 if (i.hasNext()) {
                     sb.append(',');

--- a/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/api/webservices/DDProvider.java
+++ b/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/api/webservices/DDProvider.java
@@ -28,18 +28,19 @@ import org.netbeans.modules.j2ee.dd.impl.webservices.WebServicesProxy;
 import org.netbeans.modules.schema2beans.Common;
 import org.openide.filesystems.*;
 import org.xml.sax.*;
+import java.util.HashMap;
 import java.util.Map;
 import org.w3c.dom.Document;
 
 public final class DDProvider {
     
     private static final DDProvider ddProvider = new DDProvider();
-    private Map ddMap;
+    private Map<FileObject, WebServicesProxy> ddMap;
     
     /** Creates a new instance of WebSvcModule */
     private DDProvider() {
         //ddMap=new java.util.WeakHashMap(5);
-        ddMap = new java.util.HashMap(5);
+        ddMap = new HashMap<>(5);
     }
     
     /**

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/ui/BasePanel.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/ui/BasePanel.java
@@ -146,7 +146,7 @@ public abstract class BasePanel extends JPanel {
         public void run() {
             // build the allowed values
             String allowedRegEx = jcb.getActionCommand();
-            DefaultComboBoxModel dcbm = new DefaultComboBoxModel();
+            DefaultComboBoxModel<String> dcbm = new DefaultComboBoxModel<>();
             Pattern p = Pattern.compile(allowedRegEx);
             Set<String> keys = data.keySet();
             //String pushPrefix = null;

--- a/enterprise/projectimport.eclipse.web/nbproject/project.properties
+++ b/enterprise/projectimport.eclipse.web/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 spec.version.base=1.37.0

--- a/enterprise/projectimport.eclipse.web/src/org/netbeans/modules/projectimport/eclipse/web/ServerSelection.java
+++ b/enterprise/projectimport.eclipse.web/src/org/netbeans/modules/projectimport/eclipse/web/ServerSelection.java
@@ -33,7 +33,7 @@ import org.openide.util.Exceptions;
  */
 public class ServerSelection extends javax.swing.JPanel {
 
-    private final DefaultComboBoxModel serversModel = new DefaultComboBoxModel();
+    private final DefaultComboBoxModel<ServerInstanceWrapper> serversModel = new DefaultComboBoxModel<>();
     private ServerSelectionWizardPanel wp;
     
     /** Creates new form ServerSelection */

--- a/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/InjectablesPopup.java
+++ b/enterprise/web.beans/src/org/netbeans/modules/web/beans/navigation/InjectablesPopup.java
@@ -143,7 +143,7 @@ public class InjectablesPopup extends JPanel implements FocusListener {
     }
     
     private ListModel createListModel() {
-        DefaultListModel dlm = new DefaultListModel();
+        DefaultListModel<ElementHandle<? extends Element>> dlm = new DefaultListModel<>();
         
         for (ElementHandle<? extends Element> el: myHandles) {
             dlm.addElement(el);

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/dialogs/AddManagedBeanDialog.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/dialogs/AddManagedBeanDialog.java
@@ -45,7 +45,7 @@ public class AddManagedBeanDialog extends javax.swing.JPanel implements Validati
     private JSFConfigDataObject config;
     private Hashtable existingBeans = null;
     
-    private final DefaultComboBoxModel scopeModel = new DefaultComboBoxModel();
+    private final DefaultComboBoxModel<ManagedBean.Scope> scopeModel = new DefaultComboBoxModel<>();
     /** Creates new form AddManagedBeanDialog */
     public AddManagedBeanDialog(JSFConfigDataObject config) {
         initComponents();

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/dialogs/AddNavigationCaseDialog.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/dialogs/AddNavigationCaseDialog.java
@@ -44,8 +44,8 @@ public class AddNavigationCaseDialog extends javax.swing.JPanel implements Valid
         this.config = config;
         FacesConfig facesConfig = ConfigurationUtils.getConfigModel(config.getPrimaryFile(), true).getRootComponent();
         
-        DefaultComboBoxModel modelF = (DefaultComboBoxModel)jComboBoxFromView.getModel();
-        DefaultComboBoxModel modelT = (DefaultComboBoxModel)jComboBoxToView.getModel();
+        DefaultComboBoxModel<String> modelF = (DefaultComboBoxModel<String>)jComboBoxFromView.getModel();
+        DefaultComboBoxModel<String> modelT = (DefaultComboBoxModel<String>)jComboBoxToView.getModel();
         modelF.addElement("");
         modelT.addElement("");
         Iterator<NavigationRule> iter = facesConfig.getNavigationRules().iterator();

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/JSFConfigurationPanelVisual.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/wizards/JSFConfigurationPanelVisual.java
@@ -1544,10 +1544,10 @@ private void serverLibrariesActionPerformed(java.awt.event.ActionEvent evt) {//G
     public final class JSFComponentsTableModel extends AbstractTableModel {
 
         private final Class<?>[] COLUMN_TYPES = new Class<?>[] {Boolean.class, JsfComponentImplementation.class, JButton.class};
-        private DefaultListModel model;
+        private DefaultListModel<JSFComponentModelItem> model;
 
         public JSFComponentsTableModel() {
-            model = new DefaultListModel();
+            model = new DefaultListModel<>();
         }
 
         public int getColumnCount() {

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/CustomizerCompile.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/CustomizerCompile.java
@@ -265,7 +265,7 @@ public class CustomizerCompile extends javax.swing.JPanel implements HelpCtx.Pro
         Dialog dlg = DialogDisplayer.getDefault().createDialog(desc);
         dlg.setVisible(true);
         if (desc.getValue() == DialogDescriptor.OK_OPTION) {
-            ((DefaultListModel)annotationProcessorsList.getModel()).addElement(panel.getProcessorFQN());
+            ((DefaultListModel<String>)annotationProcessorsList.getModel()).addElement(panel.getProcessorFQN());
         }
         dlg.dispose();
 }//GEN-LAST:event_addProcessorButtonActionPerformed

--- a/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/CustomizerFrameworks.java
+++ b/enterprise/web.project/src/org/netbeans/modules/web/project/ui/customizer/CustomizerFrameworks.java
@@ -69,8 +69,8 @@ public class CustomizerFrameworks extends javax.swing.JPanel implements HelpCtx.
         initComponents();
         
         project = uiProperties.getProject();
-        jListFrameworks.setModel(new DefaultListModel());
-        ((DefaultListModel) jListFrameworks.getModel()).addElement(NbBundle.getMessage(CustomizerFrameworks.class, "LBL_CustomizerFrameworks_Loading"));
+        jListFrameworks.setModel(new DefaultListModel<String>());
+        ((DefaultListModel<String>) jListFrameworks.getModel()).addElement(NbBundle.getMessage(CustomizerFrameworks.class, "LBL_CustomizerFrameworks_Loading"));
         // do not load frameworks again but use list from uiProperties; list is being loaded in background thread:
         uiProperties.getLoadingFrameworksTask().addTaskListener(new TaskListener() {
             public void taskFinished(Task task) {
@@ -107,7 +107,7 @@ public class CustomizerFrameworks extends javax.swing.JPanel implements HelpCtx.
         if (uiProperties.getCurrentFrameworks() != null) {
             for (WebFrameworkProvider framework : uiProperties.getCurrentFrameworks()) {
                 usedFrameworks.add(framework);
-                ((DefaultListModel) jListFrameworks.getModel()).addElement(framework.getName());
+                ((DefaultListModel<String>) jListFrameworks.getModel()).addElement(framework.getName());
                 WebModuleExtender extender = framework.createWebModuleExtender(webModule, controller);
                 extenders.put(framework, extender);
                 usedExtenders.add(extender);
@@ -221,7 +221,7 @@ public class CustomizerFrameworks extends javax.swing.JPanel implements HelpCtx.
             for(int i = 0; i < newFrameworks.size(); i++) {
                 WebFrameworkProvider framework = (WebFrameworkProvider) newFrameworks.get(i);
                 if (!((DefaultListModel) jListFrameworks.getModel()).contains(framework.getName()))
-                    ((DefaultListModel) jListFrameworks.getModel()).addElement(framework.getName());
+                    ((DefaultListModel<String>) jListFrameworks.getModel()).addElement(framework.getName());
 
                 boolean added = false;
                 if (usedFrameworks.size() == 0) {

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/dialogs/AddExceptionDialogPanel.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/dialogs/AddExceptionDialogPanel.java
@@ -48,8 +48,8 @@ public class AddExceptionDialogPanel extends javax.swing.JPanel implements Valid
         this.config=config;
         initComponents();
         List actions = StrutsConfigUtilities.getAllActionsInModule(config);
-        DefaultComboBoxModel model = (DefaultComboBoxModel)jComboBoxCallAction.getModel();
-        DefaultComboBoxModel model1 = (DefaultComboBoxModel)jComboBoxActionExc.getModel();
+        DefaultComboBoxModel<String> model = (DefaultComboBoxModel<String>)jComboBoxCallAction.getModel();
+        DefaultComboBoxModel<String> model1 = (DefaultComboBoxModel<String>)jComboBoxActionExc.getModel();
         Iterator iter = actions.iterator();
         while (iter.hasNext()) {
             String actionPath=((Action)iter.next()).getAttributeValue("path"); //NOI18N

--- a/enterprise/web.struts/src/org/netbeans/modules/web/struts/dialogs/AddFormPropertyPanel.java
+++ b/enterprise/web.struts/src/org/netbeans/modules/web/struts/dialogs/AddFormPropertyPanel.java
@@ -47,7 +47,7 @@ public class AddFormPropertyPanel extends javax.swing.JPanel implements Validati
         this.config=config;
         initComponents();
         List beans = StrutsConfigUtilities.getAllFormBeansInModule(config);
-        DefaultComboBoxModel model = (DefaultComboBoxModel)jComboBoxFormName.getModel();
+        DefaultComboBoxModel<String> model = (DefaultComboBoxModel<String>)jComboBoxFormName.getModel();
         Iterator iter = beans.iterator();
         while (iter.hasNext()) {
             String name=((FormBean)iter.next()).getAttributeValue("name"); //NOI18N

--- a/enterprise/websvc.core/nbproject/project.properties
+++ b/enterprise/websvc.core/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 spec.version.base=1.57.0
 
 javadoc.arch=${basedir}/arch.xml

--- a/extide/gradle/src/org/netbeans/modules/gradle/configurations/ConfigurationsPanel.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/configurations/ConfigurationsPanel.java
@@ -119,7 +119,7 @@ public class ConfigurationsPanel extends javax.swing.JPanel implements HelpCtx.P
     }
 
     private void createListModel() {
-        DefaultListModel model = new DefaultListModel();
+        DefaultListModel<GradleExecConfiguration> model = new DefaultListModel<>();
         for (GradleExecConfiguration c : handle.getConfigurations()) {
             model.addElement(c);
         }

--- a/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/SelectFolderPanel.java
+++ b/extide/o.apache.tools.ant.module/src/org/apache/tools/ant/module/wizards/shortcut/SelectFolderPanel.java
@@ -69,7 +69,7 @@ final class SelectFolderPanel extends JPanel implements DocumentListener {
         this.prop = prop;
         this.top = top;
         this.stripAmps = stripAmps;
-        DefaultListModel model = new DefaultListModel();
+        DefaultListModel<DataObject> model = new DefaultListModel<>();
         DataObject[] folders = findFolders(top);
         for (int i = 0; i < folders.length; i++) {
             model.addElement(folders[i]);

--- a/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
+++ b/ide/api.debugger/src/org/netbeans/api/debugger/DebuggerManager.java
@@ -160,14 +160,14 @@ public final class DebuggerManager implements ContextProvider {
     private DebuggerEngine                    currentEngine;
     private final List                        sessions = new ArrayList();
     private final Set                         engines = new HashSet ();
-    private final Vector                      breakpoints = new Vector ();
+    private final Vector<Breakpoint>          breakpoints = new Vector<>();
     private boolean                           breakpointsInitializing = false;
     private boolean                           breakpointsInitialized = false;
     private final Vector<Watch>               watches = new Vector<>();
     private boolean                           watchesInitialized = false;
     private ThreadLocal<Boolean>              watchesInitializing = new ThreadLocal<Boolean>();
     private SessionListener                   sessionListener = new SessionListener ();
-    private Vector                            listeners = new Vector ();
+    private Vector<DebuggerManagerListener>   listeners = new Vector<>();
     private final HashMap                     listenersMap = new HashMap ();
     private ActionsManager                    actionsManager = null;
     
@@ -507,13 +507,11 @@ public final class DebuggerManager implements ContextProvider {
      *
      * @param breakpoint a new breakpoint
      */
-    public void addBreakpoint (
-        Breakpoint breakpoint
-    ) {
+    public void addBreakpoint (Breakpoint breakpoint) {
         if (initBreakpoints (breakpoint)) {
             // do not add one breakpoint more than once.
             if (registerBreakpoint(breakpoint)) {
-                breakpoints.addElement (breakpoint);
+                breakpoints.addElement(breakpoint);
                 fireBreakpointCreated (breakpoint, null);
             }
         }
@@ -806,15 +804,12 @@ public final class DebuggerManager implements ContextProvider {
      * @param propertyName a name of property to listen on
      * @param l the debuggerManager listener to add
      */
-    public void addDebuggerListener (
-        String propertyName, 
-        DebuggerManagerListener l
-    ) {
+    public void addDebuggerListener(String propertyName, DebuggerManagerListener l) {
         synchronized (listenersMap) {
-            Vector listeners = (Vector) listenersMap.get (propertyName);
+            Vector<DebuggerManagerListener> listeners = (Vector<DebuggerManagerListener>)listenersMap.get(propertyName);
             if (listeners == null) {
-                listeners = new Vector ();
-                listenersMap.put (propertyName, listeners);
+                listeners = new Vector<>();
+                listenersMap.put(propertyName, listeners);
             }
             listeners.addElement (l);
         }

--- a/ide/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryParameter.java
+++ b/ide/bugzilla/src/org/netbeans/modules/bugzilla/query/QueryParameter.java
@@ -327,7 +327,7 @@ public abstract class QueryParameter {
             setParameterValues(values.toArray(new ParameterValue[values.size()]));
         }
         public void setParameterValues(ParameterValue[] values) {
-            DefaultListModel m = new DefaultListModel();
+            DefaultListModel<ParameterValue> m = new DefaultListModel<>();
             for (ParameterValue pv : values) {
                 m.addElement(pv);
             }

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/ui/AdjustConfigurationPanel.java
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/ui/AdjustConfigurationPanel.java
@@ -102,7 +102,7 @@ public class AdjustConfigurationPanel extends javax.swing.JPanel implements Prop
         }
 
         this.analyzers = analyzers;
-        DefaultComboBoxModel analyzerModel = new DefaultComboBoxModel();
+        DefaultComboBoxModel<AnalyzerFactory> analyzerModel = new DefaultComboBoxModel<>();
 
         for (AnalyzerFactory a : analyzers) {
             CustomizerProvider<Object, JComponent> cp = a.getCustomizerProvider();

--- a/ide/css.editor/src/org/netbeans/modules/css/editor/ui/CssRuleCreateActionDialog.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/ui/CssRuleCreateActionDialog.java
@@ -73,8 +73,7 @@ public class CssRuleCreateActionDialog extends javax.swing.JPanel {
             htmlTagsModel1.addElement(htmlTags[i]);
         }
 
-        DefaultComboBoxModel htmlTagsModel = new DefaultComboBoxModel();
-        //htmlTagsModel.addElement(NONE);
+        DefaultComboBoxModel<String> htmlTagsModel = new DefaultComboBoxModel<>();
         for( int i=0; i< htmlTags.length; i++){
             htmlTagsModel.addElement(htmlTags[i]);
         }

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/AutocompleteJComboBox.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/AutocompleteJComboBox.java
@@ -34,7 +34,7 @@ import org.openide.filesystems.FileObject;
 
 public class AutocompleteJComboBox extends JComboBox {
     
-    private static Comparator PROPERTY_COMPARATOR = new Comparator<String>() {
+    private static Comparator<String> PROPERTY_COMPARATOR = new Comparator<String>() {
         @Override
         public int compare(String s1, String s2) {
             //sort the vendor spec. props below the common ones

--- a/ide/css.visual/src/org/netbeans/modules/css/visual/SelectorsGroupEditor.java
+++ b/ide/css.visual/src/org/netbeans/modules/css/visual/SelectorsGroupEditor.java
@@ -62,7 +62,7 @@ public class SelectorsGroupEditor extends javax.swing.JPanel {
         String[] htmlTags = getHtmlTagNames();
 
         // Optional prefix
-        DefaultComboBoxModel htmlTagsModel1 = new DefaultComboBoxModel();
+        DefaultComboBoxModel<String> htmlTagsModel1 = new DefaultComboBoxModel<>();
         htmlTagsModel1.addElement(NONE);
         htmlTagsModel1.addElement("a:link");
         htmlTagsModel1.addElement("a:visited");

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/FromNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/FromNode.java
@@ -33,7 +33,7 @@ public class FromNode implements From {
 
     // A vector of generalized Table objects (JoinTables)
 
-    ArrayList _tableList;
+    List<JoinTable> _tableList;
 
 
     // Constructors
@@ -86,8 +86,9 @@ public class FromNode implements From {
 
     // Return the Table objects in the table list
 
-    ArrayList getTables() {
-        ArrayList tableRefs = new ArrayList();
+    List<Table> getTables() {
+        List<Table> tableRefs = new ArrayList<>();
+
         for (int i=0; i<_tableList.size(); i++)
             tableRefs.add(((JoinTableNode)_tableList.get(i)).getTable());
         return tableRefs;
@@ -113,7 +114,7 @@ public class FromNode implements From {
     }
 
     public JoinTable findJoinTable(String table1, String column1, String table2, String column2) {
-        ArrayList tableList = _tableList;
+        List<JoinTable> tableList = _tableList;
         for (int i=0; i<tableList.size(); i++) {
             JoinTableNode jt = (JoinTableNode) tableList.get(i);
             Expression cond = jt.getExpression();

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/GroupByNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/GroupByNode.java
@@ -32,7 +32,7 @@ public class GroupByNode implements GroupBy {
     // This will eventually include functions, but for now is simple columns
 
     // ToDo: consider replacing this with a HashMap
-    private List _columnList;
+    private List<Column> _columnList;
 
 
     // Constructor

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/OrderByNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/OrderByNode.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.db.sql.visualeditor.querymodel;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Collection;
 
 import org.netbeans.api.db.sql.support.SQLIdentifiers;
@@ -32,7 +33,7 @@ public class OrderByNode implements OrderBy {
 
     // A vector of generalized column objects (JoinTables)
 
-    ArrayList _sortSpecificationList;
+    List<SortSpecification> _sortSpecificationList;
 
 
     // Constructors
@@ -112,7 +113,7 @@ public class OrderByNode implements OrderBy {
         SortSpecification sortSpec = new SortSpecification(new ColumnNode(tableSpec, columnName), direction);
         // Insert the new one in an appropriate place
         if (_sortSpecificationList == null)
-            _sortSpecificationList = new ArrayList();
+            _sortSpecificationList = new ArrayList<>();
         _sortSpecificationList.add(order-1, sortSpec);
     }
 

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/QueryNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/QueryNode.java
@@ -171,7 +171,7 @@ public class QueryNode implements Query {
             ArrayList columns = new ArrayList();
 
             // Get the list of table objects from FROM
-            ArrayList tables = _from.getTables();
+            List<Table> tables = _from.getTables();
 
             // Iterate through it
             for (int i=0; i<tables.size(); i++) {

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/SelectNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/SelectNode.java
@@ -19,6 +19,7 @@
 package org.netbeans.modules.db.sql.visualeditor.querymodel;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Collection;
 
 import org.netbeans.api.db.sql.support.SQLIdentifiers;
@@ -31,7 +32,7 @@ public class SelectNode implements Select {
     // This will eventually include functions, but for now is simple columns
 
     // ToDo: consider replacing this with a HashMap
-    private ArrayList _selectItemList;
+    private List<Column>   _selectItemList;
     private String _quantifier;
 
 

--- a/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/WhereNode.java
+++ b/ide/db.sql.visualeditor/src/org/netbeans/modules/db/sql/visualeditor/querymodel/WhereNode.java
@@ -26,6 +26,7 @@ package org.netbeans.modules.db.sql.visualeditor.querymodel;
 // ptr, or a Where with null condition.
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Collection;
 
 import org.netbeans.api.db.sql.support.SQLIdentifiers;
@@ -82,7 +83,7 @@ public class WhereNode implements Where {
                 _cond = null;
         }
         else {
-            ArrayList column = new ArrayList();
+            List<Column> column = new ArrayList<>();
             _cond.getReferencedColumns(column);
             for (int i = 0; i < column.size(); i++) {
                 Column col = (Column)column.get(i);

--- a/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/dlg/AddDriverDialog.java
@@ -68,7 +68,7 @@ public final class AddDriverDialog extends javax.swing.JPanel {
         return ADD_DRIVER_DIALOG_HELPCTX;
     }
     
-    private DefaultListModel dlm;
+    private DefaultListModel<String> dlm;
     private List<URL> drvs = new LinkedList<URL>();
     private boolean customizer = false;
     private ProgressHandle progressHandle;
@@ -105,7 +105,7 @@ public final class AddDriverDialog extends javax.swing.JPanel {
         // without it, the preferred height is sometimes ignored during resize
         // progressContainerPanel.add(Box.createVerticalStrut(progressContainerPanel.getPreferredSize().height), BorderLayout.EAST);
         initAccessibility();
-        dlm = (DefaultListModel) drvList.getModel();
+        dlm = (DefaultListModel<String>) drvList.getModel();
 
         if (driver != null) {
             setDriver(driver);

--- a/ide/docker.ui/src/org/netbeans/modules/docker/ui/pull/DockerHubSearchPanel.java
+++ b/ide/docker.ui/src/org/netbeans/modules/docker/ui/pull/DockerHubSearchPanel.java
@@ -96,7 +96,7 @@ public class DockerHubSearchPanel extends javax.swing.JPanel {
                     // there is another search already running
                     return;
                 }
-                DefaultListModel model = new DefaultListModel();
+                DefaultListModel<DockerHubImageItem> model = new DefaultListModel<>();
                 for (DockerHubImageItem image : fresh) {
                     model.addElement(image);
                 }

--- a/ide/git/src/org/netbeans/modules/git/ui/repository/remote/RemoteRepository.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/repository/remote/RemoteRepository.java
@@ -394,7 +394,7 @@ public class RemoteRepository implements DocumentListener, ActionListener, ItemL
             @Override
             public void run() {
                 try {
-                    final DefaultComboBoxModel model = new DefaultComboBoxModel();
+                    final DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
                     
                     try {
                         List<ConnectionSettings> settings = GitModuleConfig.getDefault().getRecentConnectionSettings();

--- a/ide/git/src/org/netbeans/modules/git/ui/selectors/ItemSelector.java
+++ b/ide/git/src/org/netbeans/modules/git/ui/selectors/ItemSelector.java
@@ -76,7 +76,7 @@ public class ItemSelector<I extends Item> implements ListSelectionListener {
 
     public void setBranches(List<I> branches) {
         Collections.sort(branches);
-        DefaultListModel model = new DefaultListModel();
+        DefaultListModel<I> model = new DefaultListModel<>();
         for (I i : branches) {
             model.addElement(i);
             if (i.isDeletion()) {

--- a/ide/mercurial/src/org/netbeans/modules/mercurial/ui/repository/ChangesetPickerPanel.java
+++ b/ide/mercurial/src/org/netbeans/modules/mercurial/ui/repository/ChangesetPickerPanel.java
@@ -619,7 +619,7 @@ private void btnFetchAllActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
 
     private void applyFilter () {
         HgLogMessage selectedRevision = getSelectedRevision();
-        DefaultListModel targetsModel = new DefaultListModel();
+        DefaultListModel<HgLogMessage> targetsModel = new DefaultListModel<>();
         targetsModel.removeAllElements();
         HgLogMessage toSelectRevision = null;
         String filter = txtFilter.getText();

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/completion/CodeCompletionOptionsPanel.java
@@ -79,7 +79,7 @@ public class CodeCompletionOptionsPanel extends JPanel implements PropertyChange
             this.selector.addPropertyChangeListener(weakListener);
 
             // Languages combobox model
-            DefaultComboBoxModel model = new DefaultComboBoxModel();
+            DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
             ArrayList<String> mimeTypes = new ArrayList<String>();
             mimeTypes.addAll(selector.getMimeTypes());
             Collections.sort(mimeTypes, new LanguagesComparator());

--- a/ide/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveTabPanel.java
+++ b/ide/options.editor/src/org/netbeans/modules/options/editor/onsave/OnSaveTabPanel.java
@@ -84,7 +84,7 @@ public class OnSaveTabPanel extends JPanel implements PropertyChangeListener {
         if (this.selector != null) {
             this.weakListener = WeakListeners.propertyChange(this, this.selector);
             this.selector.addPropertyChangeListener(weakListener);
-            DefaultComboBoxModel model = new DefaultComboBoxModel();
+            DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
             String preSelectMimeType = null;
             for (String mimeType : this.selector.getMimeTypes()) {
                 model.addElement(mimeType);

--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectChooserAccessory.java
@@ -710,7 +710,7 @@ public class ProjectChooserAccessory extends javax.swing.JPanel
                 if (currentProjects != projects || cancel) {
                     return;
                 }
-                DefaultListModel listModel = new DefaultListModel();
+                DefaultListModel<String> listModel = new DefaultListModel<>();
                 // Put all the strings into the list model
                 for (String displayName : subprojectNames) {
                     listModel.addElement(displayName);

--- a/ide/projectui/src/org/netbeans/modules/project/ui/actions/StopBuildingAlert.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/actions/StopBuildingAlert.java
@@ -48,7 +48,7 @@ final class StopBuildingAlert extends JPanel {
     
     static List<BuildExecutionSupport.Item> selectProcessToKill(List<BuildExecutionSupport.Item> toStop) {
         // Add all threads, sorted by display name.
-        DefaultListModel model = new DefaultListModel();
+        DefaultListModel<BuildExecutionSupport.Item> model = new DefaultListModel<>();
         StopBuildingAlert alert = new StopBuildingAlert();
         final JList list = alert.buildsList;
         Comparator<BuildExecutionSupport.Item> comp = new Comparator<BuildExecutionSupport.Item>() {

--- a/ide/projectui/src/org/netbeans/modules/project/ui/groups/ManageGroupsPanel.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/groups/ManageGroupsPanel.java
@@ -50,7 +50,7 @@ public class ManageGroupsPanel extends javax.swing.JPanel implements PropertyCha
      */
     public ManageGroupsPanel() {
         initComponents();
-        DefaultListModel model = new DefaultListModel();
+        DefaultListModel<String> model = new DefaultListModel<>();
         String selectedValue = null;
         for (final Group g : Group.allGroups()) {
             model.addElement(g.getName());

--- a/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/SpellcheckerOptionsPanel.java
+++ b/ide/spellchecker/src/org/netbeans/modules/spellchecker/options/SpellcheckerOptionsPanel.java
@@ -126,7 +126,7 @@ public class SpellcheckerOptionsPanel extends javax.swing.JPanel {
             public void changedUpdate(DocumentEvent e) {}
         });
         List<String> cathegories = loadCategories ();
-        DefaultListModel model = new DefaultListModel ();
+        DefaultListModel<String> model = new DefaultListModel<>();
         for (String category : cathegories)
             model.addElement (category);
         lUseIn.setModel (model);
@@ -225,7 +225,7 @@ public class SpellcheckerOptionsPanel extends javax.swing.JPanel {
     
     private void updateUsedIn() {
         List<String> categories = loadCategories();
-        DefaultListModel model = new DefaultListModel();
+        DefaultListModel<String> model = new DefaultListModel<>();
         for (String category : categories) {
             model.addElement(category);
         }
@@ -233,8 +233,8 @@ public class SpellcheckerOptionsPanel extends javax.swing.JPanel {
     }
 
     private void updateLocales() {
-        DefaultListModel model = new DefaultListModel();
-        List<Locale> locales = new ArrayList<Locale>(Arrays.asList(DictionaryProviderImpl.getInstalledDictionariesLocales()));
+        DefaultListModel<Locale> model = new DefaultListModel<>();
+        List<Locale> locales = new ArrayList<>(Arrays.asList(DictionaryProviderImpl.getInstalledDictionariesLocales()));
 
         for (DictionaryDescription desc : addedDictionaries) {
             locales.add(desc.getLocale());
@@ -526,8 +526,8 @@ public class SpellcheckerOptionsPanel extends javax.swing.JPanel {
     }
 
     private ComboBoxModel getLocaleModel() {
-        DefaultComboBoxModel dlm = new DefaultComboBoxModel();
-        List<Locale> locales = new ArrayList<Locale>(Arrays.asList(Locale.getAvailableLocales()));
+        DefaultComboBoxModel<Locale> dlm = new DefaultComboBoxModel<>();
+        List<Locale> locales = new ArrayList<>(Arrays.asList(Locale.getAvailableLocales()));
         
         Collections.sort(locales, new LocaleComparator());
         

--- a/ide/spi.palette/nbproject/project.properties
+++ b/ide/spi.palette/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/ide/spi.palette/src/org/netbeans/modules/palette/ui/CategoryDescriptor.java
+++ b/ide/spi.palette/src/org/netbeans/modules/palette/ui/CategoryDescriptor.java
@@ -134,7 +134,7 @@ class CategoryDescriptor implements CategoryListener {
     }
     
     void computeItems() {
-        DefaultListModel newModel = new DefaultListModel();
+        DefaultListModel<Item> newModel = new DefaultListModel<>();
         Item[] items = category.getItems();
         if( items != null ) {
             for( int i=0; i<items.length; i++ ) {

--- a/ide/subversion/src/org/netbeans/modules/subversion/ui/diff/MultiDiffPanel.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/ui/diff/MultiDiffPanel.java
@@ -802,7 +802,8 @@ public class MultiDiffPanel extends javax.swing.JPanel implements ActionListener
     }
 
     private void addToModel (final RepositoryFile newItem, final JComboBox cmbDiffTree) {
-        DefaultComboBoxModel model = (DefaultComboBoxModel) cmbDiffTree.getModel();
+        DefaultComboBoxModel<RepositoryFile> model =
+                (DefaultComboBoxModel<RepositoryFile>) cmbDiffTree.getModel();
         for (int i = 0; i < model.getSize(); ++i) {
             final Object item = model.getElementAt(i);
             if (newItem.toString().equals(item.toString())) {

--- a/ide/subversion/src/org/netbeans/modules/subversion/ui/history/SearchHistoryPanel.java
+++ b/ide/subversion/src/org/netbeans/modules/subversion/ui/history/SearchHistoryPanel.java
@@ -799,12 +799,12 @@ class SearchHistoryPanel extends javax.swing.JPanel implements ExplorerManager.P
     }
 
     private void initializeFilter () {
-        DefaultComboBoxModel filterModel = new DefaultComboBoxModel();
+        DefaultComboBoxModel<FilterKind> filterModel = new DefaultComboBoxModel<>();
         filterModel.addElement(FilterKind.ALL);
         filterModel.addElement(FilterKind.ID);
         filterModel.addElement(FilterKind.MESSAGE);
         filterModel.addElement(FilterKind.USER);
-//        filterModel.addElement(FilterKind.FILE);
+
         cmbFilterKind.setModel(filterModel);
         cmbFilterKind.setSelectedItem(FilterKind.ALL);
         txtFilter.getDocument().addDocumentListener(this);

--- a/ide/versioning.util/src/org/netbeans/modules/versioning/util/FileSelector.java
+++ b/ide/versioning.util/src/org/netbeans/modules/versioning/util/FileSelector.java
@@ -133,7 +133,7 @@ public class FileSelector extends javax.swing.JPanel implements ListSelectionLis
 
     public boolean show(File[] files) {
         Arrays.sort(files);
-        DefaultListModel m = new DefaultListModel();
+        DefaultListModel<File> m = new DefaultListModel<>();
         for (File file : files) {
             m.addElement(file);
         }

--- a/java/java.project.ui/src/org/netbeans/spi/java/project/support/ui/IncludeExcludeVisualizerPanel.java
+++ b/java/java.project.ui/src/org/netbeans/spi/java/project/support/ui/IncludeExcludeVisualizerPanel.java
@@ -47,8 +47,8 @@ class IncludeExcludeVisualizerPanel extends JPanel implements HelpCtx.Provider {
         }
         public void changedUpdate(DocumentEvent e) {}
     };
-    private final DefaultListModel includedListModel = new DefaultListModel();
-    private final DefaultListModel excludedListModel = new DefaultListModel();
+    private final DefaultListModel<File> includedListModel = new DefaultListModel<>();
+    private final DefaultListModel<File> excludedListModel = new DefaultListModel<>();
     private String rootPrefix;
 
     @Override

--- a/java/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSProjectProperties.java
+++ b/java/javawebstart/src/org/netbeans/modules/javawebstart/ui/customizer/JWSProjectProperties.java
@@ -1010,7 +1010,7 @@ public class JWSProjectProperties /*implements TableModelListener*/ {
 
     private static ComboBoxModel createMixedCodeModel (final PropertyEvaluator eval) {
         assert eval != null;
-        final DefaultComboBoxModel model = new DefaultComboBoxModel();
+        final DefaultComboBoxModel<MixedCodeOptions> model = new DefaultComboBoxModel<>();
         for (MixedCodeOptions option : MixedCodeOptions.values()) {
             model.addElement(option);
         }

--- a/java/jshell.support/src/org/netbeans/modules/jshell/maven/MavenRunOptions.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/maven/MavenRunOptions.java
@@ -182,7 +182,7 @@ public class MavenRunOptions extends javax.swing.JPanel implements HelpCtx.Provi
     }
 
     private void setupConfigurations() {
-        DefaultComboBoxModel comModel = new DefaultComboBoxModel();
+        DefaultComboBoxModel<ModelHandle2.Configuration> comModel = new DefaultComboBoxModel<>();
         for (ModelHandle2.Configuration conf : handle.getConfigurations()) {
             comModel.addElement(conf);
         }

--- a/java/jshell.support/src/org/netbeans/modules/jshell/project/JShellOptions2.java
+++ b/java/jshell.support/src/org/netbeans/modules/jshell/project/JShellOptions2.java
@@ -91,7 +91,7 @@ public class JShellOptions2 extends javax.swing.JPanel implements ItemListener {
         this.project = project;
         initComponents();
         
-        DefaultComboBoxModel mdl = new DefaultComboBoxModel();
+        DefaultComboBoxModel<LoaderPolicy> mdl = new DefaultComboBoxModel<>();
         mdl.addElement(LoaderPolicy.SYSTEM);
         mdl.addElement(LoaderPolicy.CLASS);
         mdl.addElement(LoaderPolicy.EVAL);

--- a/java/maven.grammar/src/org/netbeans/modules/maven/codegen/NewPluginPanel.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/codegen/NewPluginPanel.java
@@ -562,7 +562,7 @@ public class NewPluginPanel extends javax.swing.JPanel implements ChangeListener
     }
 
     private void updateGoals() {
-        DefaultListModel m = (DefaultListModel) goalsList.getModel();
+        DefaultListModel<GoalEntry> m = (DefaultListModel<GoalEntry>) goalsList.getModel();
         m.clear();
 
         if (selVi != null) {

--- a/java/maven.graph/src/org/netbeans/modules/maven/graph/FixVersionConflictPanel.java
+++ b/java/maven.graph/src/org/netbeans/modules/maven/graph/FixVersionConflictPanel.java
@@ -202,7 +202,7 @@ public class FixVersionConflictPanel extends javax.swing.JPanel {
         addSetCheckChanged();
 
         List<ArtifactVersion> versions = getClashingVersions();
-        DefaultListModel model = new DefaultListModel();
+        DefaultListModel<ArtifactVersion> model = new DefaultListModel<>();
         for (ArtifactVersion av : versions) {
             model.addElement(av);
         }
@@ -219,7 +219,7 @@ public class FixVersionConflictPanel extends javax.swing.JPanel {
 
         Set<Artifact> exclTargets = eTargets.getAll();
         if (!exclTargets.isEmpty()) {
-            DefaultListModel lModel = new DefaultListModel();
+            DefaultListModel<ExclTargetEntry> lModel = new DefaultListModel<>();
             for (Artifact exc : exclTargets) {
                 lModel.addElement(new ExclTargetEntry(exc,
                         recs.exclusionTargets != null && recs.exclusionTargets.contains(exc)));

--- a/java/maven.repository/nbproject/project.properties
+++ b/java/maven.repository/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/java/maven/src/org/netbeans/modules/maven/TextValueCompleter.java
+++ b/java/maven/src/org/netbeans/modules/maven/TextValueCompleter.java
@@ -65,7 +65,7 @@ public class TextValueCompleter implements DocumentListener {
     private Pattern pattern;
     private Collection<String> completions;
     private JList completionList;
-    private DefaultListModel completionListModel;
+    private DefaultListModel<String> completionListModel;
     private JScrollPane listScroller;
     private Popup popup;
     private JTextField field;
@@ -96,7 +96,7 @@ public class TextValueCompleter implements DocumentListener {
             }
         };
         field.addCaretListener(caretListener);
-        completionListModel = new DefaultListModel();
+        completionListModel = new DefaultListModel<>();
         completionList = new JList(completionListModel);
         completionList.setFocusable(false);
         completionList.setPrototypeCellValue("lets have it at least this wide and add some more just in case"); //NOI18N

--- a/java/maven/src/org/netbeans/modules/maven/actions/CreateLibraryPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/actions/CreateLibraryPanel.java
@@ -67,12 +67,13 @@ public class CreateLibraryPanel extends javax.swing.JPanel {
     @Messages("NAME_Library=Library Name")
     CreateLibraryPanel(DependencyNode root) {
         initComponents();
-        DefaultComboBoxModel mdl = new DefaultComboBoxModel();
+        DefaultComboBoxModel<LibraryManager> mdl = new DefaultComboBoxModel<>();
         SwingValidationGroup.setComponentName(txtName, NAME_Library());
 
         for (LibraryManager manager : LibraryManager.getOpenManagers()) {
             mdl.addElement(manager);
         }
+
         comManager.setModel(mdl);
         comManager.addActionListener(new ActionListener() {
             public @Override void actionPerformed(ActionEvent e) {

--- a/java/maven/src/org/netbeans/modules/maven/configurations/ConfigurationsPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/configurations/ConfigurationsPanel.java
@@ -102,13 +102,10 @@ public class ConfigurationsPanel extends javax.swing.JPanel implements HelpCtx.P
 
     private void createListModel() {
 //        boolean isProfile = false;
-        DefaultListModel model = new DefaultListModel();
+        DefaultListModel<ModelHandle2.Configuration> model = new DefaultListModel<>();
         if (handle.getConfigurations() != null) {
             for (ModelHandle2.Configuration hndl : handle.getConfigurations()) {
                 model.addElement(hndl);
-//                if (hndl.isProfileBased()) {
-//                    isProfile = true;
-//                }
             }
         }
         lstConfigurations.setModel(model);

--- a/platform/core.windows/src/org/netbeans/core/windows/documentgroup/ManageGroupsPanel.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/documentgroup/ManageGroupsPanel.java
@@ -165,8 +165,8 @@ class ManageGroupsPanel extends javax.swing.JPanel {
 
     private void fillGroups() {
         List<DocumentGroupImpl> groups = GroupsManager.getDefault().getGroups();
-        DefaultListModel model = new DefaultListModel();
-        for( DocumentGroupImpl group : groups ) {
+        DefaultListModel<DocumentGroupImpl> model = new DefaultListModel<>();
+        for (DocumentGroupImpl group : groups) {
             model.addElement( group );
         }
         listGroups.setModel( model );

--- a/platform/core.windows/src/org/netbeans/core/windows/options/LafPanel.java
+++ b/platform/core.windows/src/org/netbeans/core/windows/options/LafPanel.java
@@ -76,7 +76,7 @@ public class LafPanel extends javax.swing.JPanel {
         });
         initLookAndFeel();
         lblRestart.setVisible(!NO_RESTART_ON_LAF_CHANGE);
-        DefaultComboBoxModel model = new DefaultComboBoxModel();
+        DefaultComboBoxModel<String> model = new DefaultComboBoxModel<>();
         for( LookAndFeelInfo li : lafs ) {
             model.addElement( li.getName() );
         }

--- a/platform/masterfs/src/org/netbeans/modules/masterfs/watcher/Watcher.java
+++ b/platform/masterfs/src/org/netbeans/modules/masterfs/watcher/Watcher.java
@@ -156,10 +156,10 @@ public final class Watcher extends BaseAnnotationProvider {
     }
 
     private class Ext<KEY> extends ProvidedExtensions implements Runnable {
-        private final ReferenceQueue<FileObject> REF = new ReferenceQueue<FileObject>();
+        private final ReferenceQueue<FileObject> REF = new ReferenceQueue<>();
         private final Notifier<KEY> impl;
         private final Object LOCK = new Object();
-        private final Set<NotifierKeyRef> references = new HashSet<NotifierKeyRef>();
+        private final Set<NotifierKeyRef<KEY>> references = new HashSet<>();
         private final Thread watcher;
         private volatile boolean shutdown;
         private int loggedRegisterExceptions = 0;
@@ -271,7 +271,7 @@ public final class Watcher extends BaseAnnotationProvider {
         final void unregister(FileObject fo) {
             assert !fo.isValid() || fo.isFolder() : "If valid, it should be a folder: " + fo + " clazz: " + fo.getClass();
             synchronized (LOCK) {
-                final NotifierKeyRef[] equalOne = new NotifierKeyRef[1];
+                final NotifierKeyRef<KEY>[] equalOne = new NotifierKeyRef[1];
                 NotifierKeyRef<KEY> kr = new NotifierKeyRef<KEY>(fo, null, null, impl) {
                     @Override
                     public boolean equals(Object obj) {
@@ -368,7 +368,7 @@ public final class Watcher extends BaseAnnotationProvider {
             watcher.join(1000);
         }
 
-        private Set<NotifierKeyRef> getReferences() {
+        private Set<NotifierKeyRef<KEY>> getReferences() {
             assert Thread.holdsLock(LOCK);
             return references;
         }
@@ -453,7 +453,7 @@ public final class Watcher extends BaseAnnotationProvider {
     private static Notifier<?> getNotifierForPlatform() {
         for (Item<Notifier> item : Lookup.getDefault().lookupResult(Notifier.class).allItems()) {
             try {
-                final Notifier notifier = item.getInstance();
+                final Notifier<?> notifier = item.getInstance();
                 if (notifier != null) {
                     NotifierAccessor.getDefault().start(notifier);
                     return notifier;

--- a/platform/openide.compat/src/org/openide/explorer/ExplorerActions.java
+++ b/platform/openide.compat/src/org/openide/explorer/ExplorerActions.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.text.MessageFormat;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -250,7 +251,7 @@ public class ExplorerActions {
                 // copy (#13418), cut (#13426). If one node is a parent of another,
                 // assume that the situation is sketchy and prevent it.
                 // For k==1 it is impossible so do not waste time on it.
-                HashMap allNodes = new HashMap(101);
+                Map allNodes = new HashMap(101);
 
                 for (i = 0; i < k; i++) {
                     if (!checkParents(path[i], allNodes)) {
@@ -341,7 +342,7 @@ public class ExplorerActions {
      * @param node the node to check
      * @return false if one of the nodes is parent of another
      */
-    private boolean checkParents(Node node, HashMap set) {
+    private boolean checkParents(Node node, Map set) {
         if (set.get(node) != null) {
             return false;
         }

--- a/platform/openide.execution.compat8/src/org/openide/execution/NbClassPathCompat.java
+++ b/platform/openide.execution.compat8/src/org/openide/execution/NbClassPathCompat.java
@@ -21,6 +21,7 @@ package org.openide.execution;
 
 import java.util.Enumeration;
 import java.util.LinkedList;
+import java.util.List;
 import org.openide.*;
 import org.openide.filesystems.EnvironmentNotSupportedException;
 import org.openide.filesystems.FileSystem;
@@ -65,7 +66,7 @@ public class NbClassPathCompat {
     @Deprecated
     public static NbClassPath createRepositoryPath (FileSystemCapability cap) {
         Thread.dumpStack();
-        final LinkedList res = new LinkedList ();
+        final List res = new LinkedList();
 
 
         final class Env extends FileSystem$Environment {


### PR DESCRIPTION
More work done on cleanup of raw type warnings.. Issues like this:

 [nb-javac] /home/bwalker/src/netbeans/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/ComponentBeanMultiple.java:242: warning: [rawtypes] found raw type: Map
 [nb-javac]         Map map =new java.util.HashMap();
 [nb-javac]         ^
 [nb-javac]   missing type arguments for generic class Map<K,V>
 [nb-javac]   where K,V are type-variables:
 [nb-javac]     K extends Object declared in interface Map
 [nb-javac]     V extends Object declared in interface Map

All work is done internal to methods and non-public interfaces..