### PR TITLE
Fixing the configure hint sub-fix to work more properly for per-project hint settings.

### DIFF
--- a/ide/spi.editor.hints.projects/src/org/netbeans/modules/editor/hints/projects/settings/FileHintPreferencesProviderImpl.java
+++ b/ide/spi.editor.hints.projects/src/org/netbeans/modules/editor/hints/projects/settings/FileHintPreferencesProviderImpl.java
@@ -18,11 +18,15 @@
  */
 package org.netbeans.modules.editor.hints.projects.settings;
 
+import java.awt.Toolkit;
 import java.util.prefs.Preferences;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.modules.editor.hints.settings.friend.FileHintPreferencesProvider;
 import org.netbeans.spi.editor.hints.projects.ProjectSettings;
+import org.netbeans.spi.project.ui.CustomizerProvider;
+import org.netbeans.spi.project.ui.CustomizerProvider2;
+import org.netbeans.spi.project.ui.support.ProjectCustomizer;
 import org.openide.filesystems.FileObject;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -44,6 +48,33 @@ public class FileHintPreferencesProviderImpl implements FileHintPreferencesProvi
         if (settings == null || !settings.getUseProjectSettings()) return null;
         
         return settings.getProjectSettings(mimeType);
+    }
+
+    @Override
+    public boolean openFilePreferences(FileObject file, String mimeType, String hintId) {
+        Project prj = FileOwnerQuery.getOwner(file);
+
+        if (prj == null) return false;
+
+        ProjectSettings settings = prj.getLookup().lookup(ProjectSettings.class);
+
+        if (settings == null || !settings.getUseProjectSettings()) return false;
+
+        CustomizerProvider2 customizer2 = prj.getLookup().lookup(CustomizerProvider2.class);
+
+        if (customizer2 != null) {
+            customizer2.showCustomizer("editor.hints", null);
+        } else {
+            CustomizerProvider customizer = prj.getLookup().lookup(CustomizerProvider.class);
+
+            if (customizer != null) {
+                customizer.showCustomizer();
+            } else {
+                Toolkit.getDefaultToolkit().beep();
+            }
+        }
+
+        return true;
     }
 
 }

--- a/ide/spi.editor.hints.projects/src/org/netbeans/modules/editor/hints/projects/settings/OpenGlobalPreferencesImpl.java
+++ b/ide/spi.editor.hints.projects/src/org/netbeans/modules/editor/hints/projects/settings/OpenGlobalPreferencesImpl.java
@@ -16,19 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.editor.hints.settings.friend;
+package org.netbeans.modules.editor.hints.projects.settings;
 
-import java.util.prefs.Preferences;
-import org.openide.filesystems.FileObject;
+import org.netbeans.api.options.OptionsDisplayer;
+import org.netbeans.modules.editor.hints.settings.friend.OpenGlobalPreferences;
+import org.openide.util.lookup.ServiceProvider;
 
 /**
  *
  * @author lahvac
  */
-public interface FileHintPreferencesProvider {
-    
-    //TODO: change listener - requires Result?
-    public Preferences getFilePreferences(FileObject file, String mimeType);
-    public boolean openFilePreferences(FileObject file, String mimeType, String hintId);
+@ServiceProvider(service=OpenGlobalPreferences.class)
+public class OpenGlobalPreferencesImpl implements OpenGlobalPreferences {
+
+    @Override
+    public boolean openFilePreferences(String mimeType, String hintId) {
+        OptionsDisplayer.getDefault().open("Editor/Hints/" + mimeType + "/" + hintId);
+        return true;
+    }
 
 }

--- a/ide/spi.editor.hints/apichanges.xml
+++ b/ide/spi.editor.hints/apichanges.xml
@@ -83,6 +83,18 @@ is the proper place.
 
     <changes>
 
+        <change id="open-settings">
+             <api name="EditorHintsSPI"/>
+             <summary>Added FileHintPreferences.openFilePreferences to open settings</summary>
+             <version major="1" minor="56"/>
+             <date day="11" month="9" year="2021"/>
+             <author login="jlahoda"/>
+             <compatibility addition="yes" binary="compatible" deletion="no" deprecation="no" modification="no" semantic="compatible" source="compatible"/>
+             <description>
+                 Added FileHintPreferences.openFilePreferences that opens hints settings.
+             </description>
+             <class name="FileHintPreferences" package="org.netbeans.spi.editor.hints.settings"/>
+        </change>
         <change id="per-project-hints">
              <api name="EditorHintsSPI"/>
              <summary>Added a new overload for ErrorDescriptionFactory.createErrorDescription taking PositionBounds</summary>

--- a/ide/spi.editor.hints/manifest.mf
+++ b/ide/spi.editor.hints/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.spi.editor.hints/0
-OpenIDE-Module-Implementation-Version: 7
+OpenIDE-Module-Implementation-Version: 8
 OpenIDE-Module-Layer: org/netbeans/modules/editor/hints/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/editor/hints/resources/Bundle.properties
 OpenIDE-Module-Install: org/netbeans/modules/editor/hints/HintsModule.class

--- a/ide/spi.editor.hints/nbproject/project.properties
+++ b/ide/spi.editor.hints/nbproject/project.properties
@@ -18,6 +18,6 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
-spec.version.base=1.55.0
+spec.version.base=1.56.0
 
 test.config.stableBTD.includes=**/*Test.class

--- a/ide/spi.editor.hints/src/org/netbeans/modules/editor/hints/settings/friend/OpenGlobalPreferences.java
+++ b/ide/spi.editor.hints/src/org/netbeans/modules/editor/hints/settings/friend/OpenGlobalPreferences.java
@@ -18,17 +18,10 @@
  */
 package org.netbeans.modules.editor.hints.settings.friend;
 
-import java.util.prefs.Preferences;
-import org.openide.filesystems.FileObject;
-
 /**
  *
  * @author lahvac
  */
-public interface FileHintPreferencesProvider {
-    
-    //TODO: change listener - requires Result?
-    public Preferences getFilePreferences(FileObject file, String mimeType);
-    public boolean openFilePreferences(FileObject file, String mimeType, String hintId);
-
+public interface OpenGlobalPreferences {
+    public boolean openFilePreferences(String mimeType, String hintId);
 }

--- a/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/settings/FileHintPreferences.java
+++ b/ide/spi.editor.hints/src/org/netbeans/spi/editor/hints/settings/FileHintPreferences.java
@@ -24,6 +24,7 @@ import java.util.prefs.Preferences;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
 import org.netbeans.modules.editor.hints.settings.friend.FileHintPreferencesProvider;
+import org.netbeans.modules.editor.hints.settings.friend.OpenGlobalPreferences;
 import org.openide.filesystems.FileObject;
 import org.openide.util.ChangeSupport;
 import org.openide.util.Lookup;
@@ -62,6 +63,30 @@ public class FileHintPreferences {
         throw new IllegalStateException("Must have some working GlobalHintPreferencesProvider!");
     }
     
+    /**Open hint settings for the specific file and hint. Will open either the
+     * global or project-specific settings.
+     *
+     * @param file file for which the settings should be opened
+     * @param preferencesMimeType mime type for which the settings should be opened
+     * @param hintId hint id that should be opened
+     * @since 1.56
+     */
+    public static void openFilePreferences(FileObject file, String preferencesMimeType, String hintId) {
+        for (FileHintPreferencesProvider p : Lookup.getDefault().lookupAll(FileHintPreferencesProvider.class)) {
+            if (p.openFilePreferences(file, preferencesMimeType, hintId)) {
+                return ;
+            }
+        }
+
+        for (OpenGlobalPreferences p : Lookup.getDefault().lookupAll(OpenGlobalPreferences.class)) {
+            if (p.openFilePreferences(preferencesMimeType, hintId)) {
+                return ;
+            }
+        }
+
+        throw new IllegalStateException("Must have some working GlobalHintPreferencesProvider!");
+    }
+
     private static final ChangeSupport cs = new ChangeSupport(FileHintPreferences.class);
     
     /**Register listener to be notified about any change in the hints settings.


### PR DESCRIPTION
When selecting "Configure ... Hint" in the editor, when per project hints settings are in effect, the project settings should be open rather than the global settings.