### PR TITLE
Library to process Heap dumps without accessing java.io.File

### DIFF
--- a/profiler/lib.profiler/manifest.mf
+++ b/profiler/lib.profiler/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.lib.profiler/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/lib/profiler/Bundle.properties
-OpenIDE-Module-Specification-Version: 1.121
+OpenIDE-Module-Specification-Version: 1.122
 

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
@@ -92,7 +92,7 @@ public class HeapFactory {
      * @return implementation of {@link Heap} corresponding to the memory dump
      * passed in the {@code buffer} parameter
      * @throws IOException if the access to the buffer fails or data are corrupted
-     * @since 2.2
+     * @since 1.122
      */
     public static Heap createHeap(ByteBuffer buffer, int segment) throws IOException {
         return new HprofHeap(buffer, segment, new CacheDirectory(null));

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 
 /**
@@ -79,6 +80,22 @@ public class HeapFactory {
         }
         return new HprofHeap(heapDump, segment, cacheDir);
 
+    }
+
+    /** Factory method for processing heap dumps in memory. When heap data
+     * aren't available on disk, but only in memory, create a {@link ByteBuffer}
+     * from them and use this factory method to create their {@link Heap}
+     * representation.
+     * 
+     * @param buffer data representing the heap dump
+     * @param segment select corresponding dump from multi-dump file
+     * @return implementation of {@link Heap} corresponding to the memory dump
+     * passed in the {@code buffer} parameter
+     * @throws IOException if the access to the buffer fails or data are corrupted
+     * @since 2.2
+     */
+    public static Heap createHeap(ByteBuffer buffer, int segment) throws IOException {
+        return new HprofHeap(buffer, segment, new CacheDirectory(null));
     }
     
     static Heap loadHeap(CacheDirectory cacheDir)

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofByteBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofByteBuffer.java
@@ -21,6 +21,7 @@ package org.netbeans.lib.profiler.heap;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.ResourceBundle;
 
@@ -76,6 +77,10 @@ abstract class HprofByteBuffer {
 
             throw ex;
         }
+    }
+
+    static HprofByteBuffer createHprofByteBuffer(ByteBuffer bb) throws IOException {
+        return new HprofMappedByteBuffer(bb);
     }
 
     abstract char getChar(long index);

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -121,11 +122,11 @@ class HprofHeap implements Heap {
     private boolean retainedSizeByClassComputed;
     private final Object retainedSizeByClassLock = new Object();
     private int idMapSize;
-    private int segment;
+    private final int segment;
 
     // for serialization
-    File heapDumpFile;
-    CacheDirectory cacheDirectory;
+    final File heapDumpFile;
+    final CacheDirectory cacheDirectory;
     
     //~ Constructors -------------------------------------------------------------------------------------------------------------
 
@@ -144,6 +145,23 @@ class HprofHeap implements Heap {
         nearestGCRoot = new NearestGCRoot(this);
         gcRoots = new HprofGCRoots(this);
         heapDumpFile = dumpFile;
+    }
+
+    HprofHeap(ByteBuffer bb, int seg, CacheDirectory cacheDir) throws IOException {
+        cacheDirectory = cacheDir;
+        dumpBuffer = HprofByteBuffer.createHprofByteBuffer(bb);
+        segment = seg;
+        fillTagBounds(dumpBuffer.getHeaderSize());
+        heapDumpSegment = computeHeapDumpStart();
+
+        if (heapDumpSegment != null) {
+            fillHeapTagBounds();
+        }
+
+        idToOffsetMap = new LongMap(idMapSize,dumpBuffer.getIDSize(),dumpBuffer.getFoffsetSize(), cacheDirectory);
+        nearestGCRoot = new NearestGCRoot(this);
+        gcRoots = new HprofGCRoots(this);
+        heapDumpFile = null;
     }
 
     //~ Methods ------------------------------------------------------------------------------------------------------------------

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofMappedByteBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofMappedByteBuffer.java
@@ -21,7 +21,9 @@ package org.netbeans.lib.profiler.heap;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 
@@ -33,16 +35,17 @@ import java.nio.channels.FileChannel;
 class HprofMappedByteBuffer extends HprofByteBuffer {
     //~ Instance fields ----------------------------------------------------------------------------------------------------------
 
-    private MappedByteBuffer dumpBuffer;
+    private final ByteBuffer dumpBuffer;
 
     //~ Constructors -------------------------------------------------------------------------------------------------------------
 
     HprofMappedByteBuffer(File dumpFile) throws IOException {
-        FileInputStream fis = new FileInputStream(dumpFile);
-        FileChannel channel = fis.getChannel();
-        length = channel.size();
-        dumpBuffer = channel.map(FileChannel.MapMode.READ_ONLY, 0, length);
-        channel.close();
+        this(mmap(dumpFile));
+    }
+
+    HprofMappedByteBuffer(ByteBuffer buffer) throws IOException {
+        this.dumpBuffer = buffer;
+        this.length = buffer.capacity();
         readHeader();
     }
 
@@ -80,5 +83,13 @@ class HprofMappedByteBuffer extends HprofByteBuffer {
     synchronized void get(long position, byte[] chars) {
         dumpBuffer.position((int) position);
         dumpBuffer.get(chars);
+    }
+
+    private static MappedByteBuffer mmap(File dumpFile) throws IOException, FileNotFoundException {
+        FileInputStream fis = new FileInputStream(dumpFile);
+        FileChannel channel = fis.getChannel();
+        MappedByteBuffer d = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
+        channel.close();
+        return d;
     }
 }

--- a/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapFromBufferTest.java
+++ b/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapFromBufferTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.lib.profiler.heap;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import org.junit.Before;
+
+public class HeapFromBufferTest extends HeapTest {
+    public HeapFromBufferTest() {
+    }
+
+    @Before
+    public void setUp() throws IOException, URISyntaxException {
+        URL url = getClass().getResource("heap_dump.bin");
+        File heapFile = new File(url.toURI());
+        ByteBuffer buffer = ByteBuffer.allocate((int) heapFile.length());
+        try (FileChannel ch = new FileInputStream(heapFile).getChannel()) {
+            while (buffer.remaining() > 0) {
+                int len = ch.read(buffer);
+                if (len == -1) {
+                    break;
+                }
+            }
+        }
+        heap = HeapFactory.createHeap(buffer, 0);
+    }
+
+}

--- a/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapSegmentTest.java
+++ b/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapSegmentTest.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -32,7 +31,6 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.netbeans.lib.profiler.heap.HeapUtils.HprofGenerator;
 

--- a/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapTest.java
+++ b/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapTest.java
@@ -45,9 +45,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TimeZone;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -56,18 +54,9 @@ import static org.junit.Assert.*;
  * @author Tomas Hurka
  */
 public class HeapTest {
-
-    private Heap heap;
+    Heap heap;
 
     public HeapTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
     }
 
     @Before


### PR DESCRIPTION
Certain environments are special and do not provide direct access to the filesystem. As such I cannot use `java.io.File`, `java.io.FileInputStream` & co. Yet processing `.hprof` files may be needed even in such environments. Let's provide an API to load an `.hprof` file content from a `ByteBuffer`. The other issue is `CachedDirectory` - it cannot be used either, as it is directly accessing the filesystem. As far as I can say the current code seems to be ready to work without `CachedDirectory`, this PR just provides a way to request cache-less mode via a new API method.