### PR TITLE
fixes reponse code check for http status code 301 moved permanently;

### DIFF
--- a/platform/core.ui/src/org/netbeans/core/ui/options/general/GeneralOptionsModel.java
+++ b/platform/core.ui/src/org/netbeans/core/ui/options/general/GeneralOptionsModel.java
@@ -308,8 +308,11 @@ class GeneralOptionsModel {
         httpConnection.setConnectTimeout(5000);
         httpConnection.connect();
 
-        if (httpConnection.getResponseCode() == HttpURLConnection.HTTP_OK || 
-                httpConnection.getResponseCode() == HttpURLConnection.HTTP_MOVED_TEMP) {
+        int responseCode = httpConnection.getResponseCode();
+
+        if (responseCode == HttpURLConnection.HTTP_OK || 
+            responseCode == HttpURLConnection.HTTP_MOVED_TEMP ||
+            responseCode == HttpURLConnection.HTTP_MOVED_PERM) {
             result = true;
         }
 


### PR DESCRIPTION
If you are testing the connection in the settings it fails with `Connection failed (null)` despite setting the option to _No Proxy_

The method responsible for only checks for `HTTP OK (200)` and `HTTP MOVED TEMPORARILY (302)` despite http://netbeans.org (`ProxySettings.HTTP_CONNECTION_TEST_URL`) responding back `HTTP MOVED PERMANENTLY 301`.

![image](https://user-images.githubusercontent.com/20691668/132052318-fa354d7b-09af-43e1-92c7-593df9aaf381.png)
