### PR TITLE
Performance optimizations to speed up remote debugging.

### DIFF
--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JDIExceptionReporter.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JDIExceptionReporter.java
@@ -31,7 +31,8 @@ import org.openide.util.Exceptions;
  */
 public final class JDIExceptionReporter {
 
-    private static final Logger logger = Logger.getLogger("org.netbeans.modules.debugger.jpda.jdi");    // NOI18N
+    private static final Logger LOGGER = Logger.getLogger("org.netbeans.modules.debugger.jpda.jdi");    // NOI18N
+    private static final Level LOGLEVEL = Level.FINER;
 
     public static final Object RET_VOID = new Object();
 
@@ -46,14 +47,14 @@ public final class JDIExceptionReporter {
     }
 
     public static boolean isLoggable() {
-        return logger.isLoggable(java.util.logging.Level.FINER);
+        return LOGGER.isLoggable(java.util.logging.Level.SEVERE);
     }
 
     public static void logCallStart(String className, String methodName, String msg, Object[] args) {
         try {
-            logger.log(java.util.logging.Level.FINER, msg, args);
+            LOGGER.log(LOGLEVEL, msg, args);
         } catch (Exception exc) {
-            logger.log(java.util.logging.Level.FINER, "Logging of "+className+"."+methodName+"() threw exception:", exc);
+            LOGGER.log(LOGLEVEL, "Logging of "+className+"."+methodName+"() threw exception:", exc);
         }
         callStartTime.set(System.nanoTime());
     }
@@ -62,10 +63,13 @@ public final class JDIExceptionReporter {
         long t2 = System.nanoTime();
         long t1 = callStartTime.get();
         callStartTime.remove();
-        logger.log(java.util.logging.Level.FINER, "          {0}.{1}() returned after {2} ns, return value = {3}",
+        LOGGER.log(LOGLEVEL, "          {0}.{1}() returned after {2} ns, return value = {3}",
                    new Object[] {className, methodName, (t2 - t1), (RET_VOID == ret) ? "void" : ret});
         if (ret instanceof Throwable) {
-            logger.log(Level.FINER, "", (Throwable) ret);
+            LOGGER.log(LOGLEVEL, "", (Throwable) ret);
+        }
+        if ((t2 - t1) > 100_000_000) {
+            LOGGER.log(LOGLEVEL, "", new RuntimeException("TooLongCall"));
         }
     }
 

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDADebuggerImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDADebuggerImpl.java
@@ -60,8 +60,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.security.auth.Refreshable;
@@ -107,10 +110,12 @@ import org.netbeans.modules.debugger.jpda.jdi.IllegalThreadStateExceptionWrapper
 import org.netbeans.modules.debugger.jpda.jdi.IntegerValueWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.InternalExceptionWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.InvalidStackFrameExceptionWrapper;
+import org.netbeans.modules.debugger.jpda.jdi.LocalVariableWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.MirrorWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.ObjectCollectedExceptionWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.StackFrameWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.ThreadReferenceWrapper;
+import org.netbeans.modules.debugger.jpda.jdi.TypeComponentWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.VMDisconnectedExceptionWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.ValueWrapper;
 import org.netbeans.modules.debugger.jpda.jdi.VirtualMachineWrapper;
@@ -184,6 +189,8 @@ public class JPDADebuggerImpl extends JPDADebugger {
     private final Map<Long, String>     markedObjects = new LinkedHashMap<Long, String>();
     private final Map<String, ObjectVariable> markedObjectLabels = new LinkedHashMap<String, ObjectVariable>();
     private final Map<ClassType, List>  allInterfacesMap = new WeakHashMap<ClassType, List>();
+    private static final int            RP_THROUGHPUT = 10;
+    private final RequestProcessor      rpCreateThreads = new RequestProcessor(JPDADebuggerImpl.class.getName()+"_newJPDAThreads", RP_THROUGHPUT); // NOI18N
 
     private StackFrame      altCSF = null;  //PATCH 48174
 
@@ -1163,11 +1170,21 @@ public class JPDADebuggerImpl extends JPDADebugger {
         }
     }
 
+    private Method stringLengthMethod;
+    private Method stringSubstringMethod;
+    private final Object stringMethodsLock = new Object();
+
     private Value cutLength(StringReference sr, int maxLength, ThreadReference tr) throws InvalidExpressionException {
         try {
             Method stringLengthMethod;
-                stringLengthMethod = ClassTypeWrapper.concreteMethodByName(
-                        (ClassType) ValueWrapper.type (sr), "length", "()I"); // NOI18N
+            synchronized (stringMethodsLock) {
+                stringLengthMethod = this.stringLengthMethod;
+                if (stringLengthMethod == null) {
+                    stringLengthMethod = ClassTypeWrapper.concreteMethodByName(
+                            (ClassType) ValueWrapper.type (sr), "length", "()I"); // NOI18N
+                    this.stringLengthMethod = stringLengthMethod;
+                }
+            }
             List<Value> emptyArgs = Collections.emptyList();
             IntegerValue lengthValue = (IntegerValue) org.netbeans.modules.debugger.jpda.expr.TreeEvaluator.
                 invokeVirtual (
@@ -1178,8 +1195,15 @@ public class JPDADebuggerImpl extends JPDADebugger {
                     this
                 );
                 if (IntegerValueWrapper.value(lengthValue) > maxLength) {
-                    Method subStringMethod = ClassTypeWrapper.concreteMethodByName(
-                            (ClassType) ValueWrapper.type (sr), "substring", "(II)Ljava/lang/String;");  // NOI18N
+                    Method subStringMethod;
+                    synchronized (stringMethodsLock) {
+                        subStringMethod = this.stringSubstringMethod;
+                        if (subStringMethod == null) {
+                            subStringMethod = ClassTypeWrapper.concreteMethodByName(
+                                (ClassType) ValueWrapper.type (sr), "substring", "(II)Ljava/lang/String;");  // NOI18N
+                            this.stringSubstringMethod = subStringMethod;
+                        }
+                    }
                     if (subStringMethod != null) {
                         sr = (StringReference) org.netbeans.modules.debugger.jpda.expr.TreeEvaluator.
                             invokeVirtual (
@@ -1201,34 +1225,25 @@ public class JPDADebuggerImpl extends JPDADebugger {
     }
 
     public static String getGenericSignature (TypeComponent component) {
-        if (tcGenericSignatureMethod == null) {
-            return null;
-        }
         try {
-            return (String) tcGenericSignatureMethod.invoke
-                (component, new Object[0]);
-        } catch (IllegalAccessException e) {
-            Exceptions.printStackTrace(e);
-            return null;    // should not happen
-        } catch (InvocationTargetException e) {
-            Exceptions.printStackTrace(e);
-            return null;    // should not happen
+            return TypeComponentWrapper.genericSignature(component);
+        } catch (InternalExceptionWrapper ex) {
+            Exceptions.printStackTrace(ex);
+        } catch (VMDisconnectedExceptionWrapper ex) {
+            // Disconnected
         }
+        return null;
     }
 
     public static String getGenericSignature (LocalVariable component) {
-        if (lvGenericSignatureMethod == null) {
-            return null;
-        }
         try {
-            return (String) lvGenericSignatureMethod.invoke(component, new Object[0]);
-        } catch (IllegalAccessException e) {
-            Exceptions.printStackTrace(e);
-            return null;    // should not happen
-        } catch (InvocationTargetException e) {
-            Exceptions.printStackTrace(e);
-            return null;    // should not happen
+            return LocalVariableWrapper.genericSignature(component);
+        } catch (InternalExceptionWrapper ex) {
+            Exceptions.printStackTrace(ex);
+        } catch (VMDisconnectedExceptionWrapper ex) {
+            // Disconnected
         }
+        return null;
     }
 
     public VirtualMachine getVirtualMachine () {
@@ -1270,7 +1285,6 @@ public class JPDADebuggerImpl extends JPDADebugger {
             canBeModified = null; // Reset the can be modified flag
         }
 
-        initGenericsSupport ();
         EditorContextBridge.getContext().createTimeStamp(this);
 
 
@@ -1854,20 +1868,21 @@ public class JPDADebuggerImpl extends JPDADebugger {
     }
 
     public void notifyToBeResumedAll() {
-        Collection threads = threadsTranslation.getTranslated();
-        for (Iterator it = threads.iterator(); it.hasNext(); ) {
-            Object threadOrGroup = it.next();
-            if (threadOrGroup instanceof JPDAThreadImpl) {
-                int status = ((JPDAThreadImpl) threadOrGroup).getState();
+        List<? extends JPDAThreadImpl> threads = threadsTranslation.getTranslated((o) -> (o instanceof JPDAThreadImpl) ? (JPDAThreadImpl) o : null);
+        int n = threads.size();
+        if (n > 0) {
+            processInParallel(n, (i) -> {
+                JPDAThreadImpl thread = threads.get(i);
+                int status = thread.getState();
                 boolean invalid = (status == JPDAThread.STATE_NOT_STARTED ||
                                    status == JPDAThread.STATE_UNKNOWN ||
                                    status == JPDAThread.STATE_ZOMBIE);
                 if (!invalid) {
-                    ((JPDAThreadImpl) threadOrGroup).notifyToBeResumed();
+                    thread.notifyToBeResumed();
                 } else if (status == JPDAThread.STATE_UNKNOWN || status == JPDAThread.STATE_ZOMBIE) {
-                    threadsTranslation.remove(((JPDAThreadImpl) threadOrGroup).getThreadReference());
+                    threadsTranslation.remove(thread.getThreadReference());
                 }
-            }
+            });
         }
     }
 
@@ -1876,21 +1891,22 @@ public class JPDADebuggerImpl extends JPDADebugger {
     }
     
     public void notifyToBeResumedAllNoFire(Set<ThreadReference> ignoredThreads) {
-        Collection threads = threadsTranslation.getTranslated();
-        for (Iterator it = threads.iterator(); it.hasNext(); ) {
-            Object threadOrGroup = it.next();
-            if (threadOrGroup instanceof JPDAThreadImpl &&
-                    (ignoredThreads == null || !ignoredThreads.contains(threadOrGroup))) {
-                int status = ((JPDAThreadImpl) threadOrGroup).getState();
+        List<? extends JPDAThreadImpl> threads = threadsTranslation.getTranslated((o) ->
+                (o instanceof JPDAThreadImpl && (ignoredThreads == null || !ignoredThreads.contains(o))) ? (JPDAThreadImpl) o : null);
+        int n = threads.size();
+        if (n > 0) {
+            processInParallel(n, (i) -> {
+                JPDAThreadImpl thread = threads.get(i);
+                int status = thread.getState();
                 boolean invalid = (status == JPDAThread.STATE_NOT_STARTED ||
                                    status == JPDAThread.STATE_UNKNOWN ||
                                    status == JPDAThread.STATE_ZOMBIE);
                 if (!invalid) {
-                    ((JPDAThreadImpl) threadOrGroup).notifyToBeResumedNoFire();
+                    thread.notifyToBeResumedNoFire();
                 } else if (status == JPDAThread.STATE_UNKNOWN || status == JPDAThread.STATE_ZOMBIE) {
-                    threadsTranslation.remove(((JPDAThreadImpl) threadOrGroup).getThreadReference());
+                    threadsTranslation.remove(thread.getThreadReference());
                 }
-            }
+            });
         }
     }
     
@@ -1916,16 +1932,24 @@ public class JPDADebuggerImpl extends JPDADebugger {
                     //  Re-fire the changes
                     @Override
                     public void propertyChange(PropertyChangeEvent evt) {
-                        String propertyName = evt.getPropertyName();
-                        if (ThreadsCache.PROP_THREAD_STARTED.equals(propertyName)) {
-                            firePropertyChange(PROP_THREAD_STARTED, null, getThread((ThreadReference) evt.getNewValue()));
-                        }
-                        if (ThreadsCache.PROP_THREAD_DIED.equals(propertyName)) {
-                            firePropertyChange(PROP_THREAD_DIED, getThread((ThreadReference) evt.getOldValue()), null);
-                        }
-                        if (ThreadsCache.PROP_GROUP_ADDED.equals(propertyName)) {
-                            firePropertyChange(PROP_THREAD_GROUP_ADDED, null, getThreadGroup((ThreadGroupReference) evt.getNewValue()));
-                        }
+                        rpCreateThreads.post(() -> {
+                            String propertyName = evt.getPropertyName();
+                            if (ThreadsCache.PROP_THREAD_STARTED.equals(propertyName)) {
+                                JPDAThreadImpl thread = getThread((ThreadReference) evt.getNewValue());
+                                if (!thread.getName().contains(ThreadsCache.THREAD_NAME_FILTER_PATTERN)) {
+                                    firePropertyChange(PROP_THREAD_STARTED, null, thread);
+                                }
+                            }
+                            if (ThreadsCache.PROP_THREAD_DIED.equals(propertyName)) {
+                                JPDAThreadImpl thread = getThread((ThreadReference) evt.getOldValue());
+                                if (!thread.getName().contains(ThreadsCache.THREAD_NAME_FILTER_PATTERN)) {
+                                    firePropertyChange(PROP_THREAD_DIED, thread, null);
+                                }
+                            }
+                            if (ThreadsCache.PROP_GROUP_ADDED.equals(propertyName)) {
+                                firePropertyChange(PROP_THREAD_GROUP_ADDED, null, getThreadGroup((ThreadGroupReference) evt.getNewValue()));
+                            }
+                        });
                     }
                 });
             }
@@ -1961,11 +1985,61 @@ public class JPDADebuggerImpl extends JPDADebugger {
             }
         }
         int n = threadList.size();
-        List<JPDAThread> threads = new ArrayList<JPDAThread>(n);
-        for (int i = 0; i < n; i++) {
-            threads.add(getThread(threadList.get(i)));
+        final List<ThreadReference> tl = threadList;
+
+        // Create threads in parallel.
+        // Constructor of JPDAThreadImpl calls getName() and getStatus(), which take time on slow connection during remote debugging.
+        List<JPDAThread> threads = new ArrayList<>(n);
+        if (n > 0) {
+            AtomicBoolean filteredThreads = new AtomicBoolean(false);
+            processInParallel(n, (i) -> {
+                JPDAThreadImpl thread = getThread(tl.get(i));
+                if (!thread.getName().contains(ThreadsCache.THREAD_NAME_FILTER_PATTERN)) {
+                    threads.set(i, thread);
+                } else {
+                    threads.set(i, null);
+                    filteredThreads.set(true);
+                }
+            });
+            if (filteredThreads.get()) {
+                Iterator<JPDAThread> it = threads.iterator();
+                while (it.hasNext()) {
+                    if (it.next() == null) {
+                        it.remove();
+                    }
+                }
+            }
         }
         return Collections.unmodifiableList(threads);
+    }
+
+    private void processInParallel(int n, Consumer<Integer> task) {
+        // Run by chunks:
+        int chunks = Math.min(RP_THROUGHPUT, n);
+        int chn = n / chunks + ((n % chunks) > 0 ? 1 : 0);
+        class TranslateThreads implements Runnable {
+
+            private final int ch;
+
+            private TranslateThreads(int ch) {
+                this.ch = ch;
+            }
+
+            @Override
+            public void run() {
+                int i0 = ch*chn;
+                for (int i = i0; i < i0 + chn && i < n; i++) {
+                    task.accept(i);
+                }
+            }
+        }
+        RequestProcessor.Task[] tasks = new RequestProcessor.Task[chunks];
+        for (int ch = 0; ch < chunks; ch++) {
+            tasks[ch] = rpCreateThreads.post(new TranslateThreads(ch));
+        }
+        for (int ch = 0; ch < chunks; ch++) {
+            tasks[ch].waitFinished();
+        }
     }
 
     public JPDAThreadGroup[] getTopLevelThreadGroups() {
@@ -2134,43 +2208,6 @@ public class JPDADebuggerImpl extends JPDADebugger {
 
 
     // private helper methods ..................................................
-
-    private static final java.util.regex.Pattern jvmVersionPattern =
-            java.util.regex.Pattern.compile ("(\\d+)\\.(\\d+)\\.(\\d+)(_\\d+)?(-\\w+)?");
-    private static java.lang.reflect.Method  tcGenericSignatureMethod;
-    private static java.lang.reflect.Method  lvGenericSignatureMethod;
-
-
-    private void initGenericsSupport () {
-        tcGenericSignatureMethod = null;
-        if (Bootstrap.virtualMachineManager ().minorInterfaceVersion () >= 5) {
-            VirtualMachine vm;
-            synchronized (virtualMachineLock) {
-                vm = virtualMachine;
-            }
-            if (vm == null) {
-                return ;
-            }
-            try {
-                java.util.regex.Matcher m = jvmVersionPattern.matcher(VirtualMachineWrapper.version(vm));
-                if (m.matches ()) {
-                    int minor = Integer.parseInt (m.group (2));
-                    if (minor >= 5) {
-                        try {
-                            tcGenericSignatureMethod = TypeComponent.class.
-                                getMethod ("genericSignature", new Class [0]);
-                            lvGenericSignatureMethod = LocalVariable.class.
-                                getMethod ("genericSignature", new Class [0]);
-                        } catch (NoSuchMethodException e) {
-                            // the method is not available, ignore generics
-                        }
-                    }
-                }
-            } catch (InternalExceptionWrapper e) {
-            } catch (VMDisconnectedExceptionWrapper e) {
-            }
-        }
-    }
 
     private PropertyChangeEvent setStateNoFire (int state) {
         int o;

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/SingleThreadWatcher.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/SingleThreadWatcher.java
@@ -32,11 +32,14 @@ public class SingleThreadWatcher implements Runnable {
 
     private static final int DELAY = 3000;
 
-    private JPDAThreadImpl t;
+    private final JPDAThreadImpl t;
     private Task watchTask;
 
     public SingleThreadWatcher(JPDAThreadImpl t) {
         this.t = t;
+        if (!Boolean.valueOf(Bundle.USE_JPDA_DEADLOCK_DETECTOR())) {
+            return;
+        }
         //System.err.println("\nnew SingleThreadWatcher("+t+")");
         watchTask = t.getDebugger().getRequestProcessor().post(this, DELAY);
     }

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepActionProvider.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/actions/StepActionProvider.java
@@ -605,6 +605,9 @@ implements Executor {
             return 0;
         } catch (InternalExceptionWrapper iex) {
             return 0;
+        } catch (IndexOutOfBoundsException iobe) {
+            // no frames on stack
+            return 0;
         } catch (InvalidStackFrameExceptionWrapper iex) {
             return 0;
         } catch (ObjectCollectedExceptionWrapper iex) {

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAThreadGroupImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/JPDAThreadGroupImpl.java
@@ -24,6 +24,7 @@ import com.sun.jdi.ThreadGroupReference;
 import com.sun.jdi.ThreadReference;
 
 import com.sun.jdi.VMDisconnectedException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.netbeans.api.debugger.jpda.JPDAThread;
@@ -84,8 +85,14 @@ public class JPDAThreadGroupImpl implements JPDAThreadGroup {
         List<ThreadReference> l = tc.getThreads(tgr);
         int i, k = l.size ();
         JPDAThreadImpl[] ts = new JPDAThreadImpl[k];
-        for (i = 0; i < k; i++) {
-            ts [i] = debugger.getThread(l.get (i));
+        i = 0;
+        for (ThreadReference t : l) {
+            JPDAThreadImpl thread = debugger.getThread(t);
+            if (thread.getName().contains(ThreadsCache.THREAD_NAME_FILTER_PATTERN)) {
+                ts = Arrays.copyOf(ts, k - 1);
+            } else {
+                ts[i++] = thread;
+            }
         }
         return ts;
     }

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/models/ThreadsCache.java
@@ -149,28 +149,12 @@ public class ThreadsCache implements Executor {
     
     private synchronized void init() throws VMDisconnectedExceptionWrapper, InternalExceptionWrapper {
         allThreads = new ArrayList<ThreadReference>(VirtualMachineWrapper.allThreads(vm));
-        filterThreads(allThreads);
     }
     
-    private void filterThreads(List<ThreadReference> threads) {
-        for (int i = 0; i < threads.size(); i++) {
-            ThreadReference tr = threads.get(i);
-            try {
-                if (ThreadReferenceWrapper.name(tr).contains(THREAD_NAME_FILTER_PATTERN)) {
-                    threads.remove(i);
-                    i--;
-                }
-            } catch (Exception ex) {
-                // continue
-            }
-        }
-    }
-
     private void initGroups(ThreadGroupReference group) {
         try {
             List<ThreadGroupReference> groups = new ArrayList<>(ThreadGroupReferenceWrapper.threadGroups0(group));
             List<ThreadReference> threads = new ArrayList<>(ThreadGroupReferenceWrapper.threads0(group));
-            filterThreads(threads);
             groupMap.put(group, groups);
             threadMap.put(group, threads);
             for (ThreadGroupReference g : groups) {
@@ -562,7 +546,6 @@ public class ThreadsCache implements Executor {
             } catch (VMDisconnectedExceptionWrapper vmdex) {
                 return ;
             }
-            filterThreads(allThreadsNew);
 
             newThreads = new ArrayList<ThreadReference>(allThreadsNew);
             newThreads.removeAll(allThreads);

--- a/java/java.lsp.server/manifest.mf
+++ b/java/java.lsp.server/manifest.mf
@@ -3,4 +3,5 @@ AutoUpdate-Show-In-Client: true
 OpenIDE-Module: org.netbeans.modules.java.lsp.server
 OpenIDE-Module-Implementation-Version: 1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/lsp/server/Bundle.properties
+OpenIDE-Module-Layer: org/netbeans/modules/java/lsp/server/layer.xml
 

--- a/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-debugger-jpda.jar/org/netbeans/modules/debugger/jpda/Bundle.properties
+++ b/java/java.lsp.server/nbcode/branding/modules/org-netbeans-modules-debugger-jpda.jar/org/netbeans/modules/debugger/jpda/Bundle.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+USE_JPDA_DEADLOCK_DETECTOR=false

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lsp4j.debug.Capabilities;
@@ -100,6 +102,9 @@ import org.openide.util.RequestProcessor;
  */
 public final class NbProtocolServer implements IDebugProtocolServer, LspSession.ScheduledServer {
 
+    private static final Logger LOGGER = Logger.getLogger(NbProtocolServer.class.getName());
+    private static final Level LOGLEVEL = Level.FINE;
+
     private final DebugAdapterContext context;
     private final NbLaunchRequestHandler launchRequestHandler = new NbLaunchRequestHandler();
     private final NbAttachRequestHandler attachRequestHandler = new NbAttachRequestHandler();
@@ -107,6 +112,7 @@ public final class NbProtocolServer implements IDebugProtocolServer, LspSession.
     private final NbBreakpointsRequestHandler breakpointsRequestHandler = new NbBreakpointsRequestHandler();
     private final NbVariablesRequestHandler variablesRequestHandler = new NbVariablesRequestHandler();
     private final RequestProcessor evaluationRP = new RequestProcessor(NbProtocolServer.class.getName(), 3);
+    private final RequestProcessor threadsRP = new RequestProcessor(NbProtocolServer.class.getName(), 1);
     private boolean initialized = false;
     private Future<Void> runningServer;
 
@@ -284,72 +290,78 @@ public final class NbProtocolServer implements IDebugProtocolServer, LspSession.
 
     @Override
     public CompletableFuture<StackTraceResponse> stackTrace(StackTraceArguments args) {
-        CompletableFuture<StackTraceResponse> future = new CompletableFuture<>();
         if (context.getDebugSession() == null) {
+            CompletableFuture<StackTraceResponse> future = new CompletableFuture<>();
             ErrorUtilities.completeExceptionally(future, "Debug Session doesn't exist.", ResponseErrorCode.InvalidParams);
+            return future;
         } else {
-            List<StackFrame> result = new ArrayList<>();
-            int cnt = 0;
-            DVThread dvThread = context.getThreadsProvider().getThread(args.getThreadId());
-            if (dvThread != null) {
-                cnt = dvThread.getFrameCount();
-                int from = args.getStartFrame() != null ? args.getStartFrame() : 0;
-                int to = args.getLevels() != null ? from + args.getLevels() : Integer.MAX_VALUE;
-                List<DVFrame> stackFrames = dvThread.getFrames(from, to);
-                for (DVFrame frame : stackFrames) {
-                    int frameId = context.getThreadsProvider().getThreadObjects().addObject(args.getThreadId(), new NbFrame(args.getThreadId(), frame));
-                    int line = frame.getLine();
-                    if (line < 0) { // unknown
-                        line = 0;
-                    }
-                    int column = frame.getColumn();
-                    if (column < 0) { // unknown
-                        column = 0;
-                    }
-                    StackFrame stackFrame = new StackFrame();
-                    stackFrame.setId(frameId);
-                    stackFrame.setName(frame.getName());
-                    URI sourceURI = frame.getSourceURI();
-                    if (sourceURI != null) {
-                        Source source = new Source();
-                        String scheme = sourceURI.getScheme();
-                        if (null == scheme || scheme.isEmpty() || "file".equalsIgnoreCase(scheme)) {
-                            source.setName(Paths.get(sourceURI).getFileName().toString());
-                            source.setPath(sourceURI.getPath());
-                            source.setSourceReference(0);
-                        } else {
-                            int ref = context.createSourceReference(sourceURI, frame.getSourceMimeType());
-                            String path = sourceURI.getPath();
-                            if (path == null) {
-                                path = sourceURI.getSchemeSpecificPart();
-                            }
-                            if (path != null) {
-                                int sepIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf(File.separatorChar));
-                                source.setName(path.substring(sepIndex + 1));
-                                if ("jar".equalsIgnoreCase(scheme)) {
-                                    try {
-                                        path = new URI(path).getPath();
-                                    } catch (URISyntaxException ex) {
-                                        // ignore, we just tried
-                                    }
-                                }
-                                source.setPath(path);
-                            }
-                            source.setSourceReference(ref);
+            return CompletableFuture.supplyAsync(() -> {
+                LOGGER.log(LOGLEVEL, "stackTrace() START");
+                long t1 = System.nanoTime();
+                List<StackFrame> result = new ArrayList<>();
+                int cnt = 0;
+                DVThread dvThread = context.getThreadsProvider().getThread(args.getThreadId());
+                if (dvThread != null) {
+                    cnt = dvThread.getFrameCount();
+                    int from = args.getStartFrame() != null ? args.getStartFrame() : 0;
+                    int to = args.getLevels() != null ? from + args.getLevels() : Integer.MAX_VALUE;
+                    List<DVFrame> stackFrames = dvThread.getFrames(from, to);
+                    for (DVFrame frame : stackFrames) {
+                        int frameId = context.getThreadsProvider().getThreadObjects().addObject(args.getThreadId(), new NbFrame(args.getThreadId(), frame));
+                        int line = frame.getLine();
+                        if (line < 0) { // unknown
+                            line = 0;
                         }
-                        stackFrame.setSource(source);
+                        int column = frame.getColumn();
+                        if (column < 0) { // unknown
+                            column = 0;
+                        }
+                        StackFrame stackFrame = new StackFrame();
+                        stackFrame.setId(frameId);
+                        stackFrame.setName(frame.getName());
+                        URI sourceURI = frame.getSourceURI();
+                        if (sourceURI != null) {
+                            Source source = new Source();
+                            String scheme = sourceURI.getScheme();
+                            if (null == scheme || scheme.isEmpty() || "file".equalsIgnoreCase(scheme)) {
+                                source.setName(Paths.get(sourceURI).getFileName().toString());
+                                source.setPath(sourceURI.getPath());
+                                source.setSourceReference(0);
+                            } else {
+                                int ref = context.createSourceReference(sourceURI, frame.getSourceMimeType());
+                                String path = sourceURI.getPath();
+                                if (path == null) {
+                                    path = sourceURI.getSchemeSpecificPart();
+                                }
+                                if (path != null) {
+                                    int sepIndex = Math.max(path.lastIndexOf('/'), path.lastIndexOf(File.separatorChar));
+                                    source.setName(path.substring(sepIndex + 1));
+                                    if ("jar".equalsIgnoreCase(scheme)) {
+                                        try {
+                                            path = new URI(path).getPath();
+                                        } catch (URISyntaxException ex) {
+                                            // ignore, we just tried
+                                        }
+                                    }
+                                    source.setPath(path);
+                                }
+                                source.setSourceReference(ref);
+                            }
+                            stackFrame.setSource(source);
+                        }
+                        stackFrame.setLine(line);
+                        stackFrame.setColumn(column);
+                        result.add(stackFrame);
                     }
-                    stackFrame.setLine(line);
-                    stackFrame.setColumn(column);
-                    result.add(stackFrame);
                 }
-            }
-            StackTraceResponse response = new StackTraceResponse();
-            response.setStackFrames(result.toArray(new StackFrame[result.size()]));
-            response.setTotalFrames(cnt);
-            future.complete(response);
+                StackTraceResponse response = new StackTraceResponse();
+                response.setStackFrames(result.toArray(new StackFrame[result.size()]));
+                response.setTotalFrames(cnt);
+                long t2 = System.nanoTime();
+                LOGGER.log(LOGLEVEL, "stackTrace() END after {0} ns", (t2 - t1));
+                return response;
+            }, threadsRP);
         }
-        return future;
     }
 
     @Override
@@ -427,22 +439,28 @@ public final class NbProtocolServer implements IDebugProtocolServer, LspSession.
 
     @Override
     public CompletableFuture<ThreadsResponse> threads() {
-        CompletableFuture<ThreadsResponse> future = new CompletableFuture<>();
         if (context.getDebugSession() == null) {
+            CompletableFuture<ThreadsResponse> future = new CompletableFuture<>();
             ErrorUtilities.completeExceptionally(future, "Debug Session doesn't exist.", ResponseErrorCode.InvalidParams);
+            return future;
         } else {
-            List<org.eclipse.lsp4j.debug.Thread> result = new ArrayList<>();
-            context.getThreadsProvider().visitThreads((id, dvThread) -> {
-                org.eclipse.lsp4j.debug.Thread thread = new org.eclipse.lsp4j.debug.Thread();
-                thread.setId(id);
-                thread.setName(dvThread.getName());
-                result.add(thread);
-            });
-            ThreadsResponse response = new ThreadsResponse();
-            response.setThreads(result.toArray(new org.eclipse.lsp4j.debug.Thread[result.size()]));
-            future.complete(response);
+            return CompletableFuture.supplyAsync(() -> {
+                LOGGER.log(LOGLEVEL, "threads() START");
+                long t1 = System.nanoTime();
+                List<org.eclipse.lsp4j.debug.Thread> result = new ArrayList<>();
+                context.getThreadsProvider().visitThreads((id, dvThread) -> {
+                    org.eclipse.lsp4j.debug.Thread thread = new org.eclipse.lsp4j.debug.Thread();
+                    thread.setId(id);
+                    thread.setName(dvThread.getName());
+                    result.add(thread);
+                });
+                ThreadsResponse response = new ThreadsResponse();
+                response.setThreads(result.toArray(new org.eclipse.lsp4j.debug.Thread[result.size()]));
+                long t2 = System.nanoTime();
+                LOGGER.log(LOGLEVEL, "threads() END after {0} ns", (t2 - t1));
+                return response;
+            }, threadsRP);
         }
-        return future;
     }
     
     private EvaluateResponse passToApplication(String args) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/layer.xml
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/layer.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN" "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
+<filesystem>
+    <folder name="Debugger">
+        <file name="org-netbeans-modules-debugger-jpda-ui-CurrentThreadAnnotationListener.instance_hidden"/>
+        <folder name="netbeans-JPDASession">
+            <!--file name="org-netbeans-modules-debugger-jpda-ui-focus-FocusSuspendController.instance_hidden"/-->
+        </folder>
+    </folder>
+</filesystem>


### PR DESCRIPTION
Remote debugging over slow connections (about 180ms to 200ms per single JDI call that involves JDWP communication over the globe) has a significant impact on debugger experience.

A speed up is achieved by removal of unused functionality, by caching and by parallelization of requests.