### PR TITLE
Concentrating I/O access into JavaIoFile private class

### DIFF
--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/AbstractLongMap.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/AbstractLongMap.java
@@ -205,12 +205,6 @@ abstract class AbstractLongMap {
         return index;
     }
     
-    private static boolean isLinux() {
-        String osName = System.getProperty("os.name");  // NOI18N
-        
-        return osName.endsWith("Linux"); // NOI18N
-    }
-
     abstract Entry createEntry(long index);
     
     abstract Entry createEntry(long index,long value);
@@ -316,7 +310,7 @@ abstract class AbstractLongMap {
                     file.seek(newOffset);
                     file.readFully(buf,0,getBufferSize(newOffset));
                 } catch (IOException ex) {
-                    ex.printStackTrace();
+                    Systems.printStackTrace(ex);
                 }
 
                 offset = newOffset;
@@ -350,7 +344,7 @@ abstract class AbstractLongMap {
     
     private static class MemoryMappedData implements Data {
         
-        private static final FileChannel.MapMode MAP_MODE = isLinux() ? FileChannel.MapMode.PRIVATE : FileChannel.MapMode.READ_WRITE;
+        private static final FileChannel.MapMode MAP_MODE = Systems.isLinux() ? FileChannel.MapMode.PRIVATE : FileChannel.MapMode.READ_WRITE;
 
         //~ Instance fields ------------------------------------------------------------------------------------------------------
 

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/AbstractLongMap.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/AbstractLongMap.java
@@ -63,7 +63,7 @@ abstract class AbstractLongMap {
         fileSize = keys * ENTRY_SIZE;
         tempFile = cacheDir.createTempFile("NBProfiler", ".map"); // NOI18N
 
-        RandomAccessFile file = new RandomAccessFile(tempFile, "rw"); // NOI18N
+        RandomAccessFile file = tempFile.newRandomAccessFile("rw"); // NOI18N
         if (Boolean.getBoolean("org.netbeans.lib.profiler.heap.zerofile")) {    // NOI18N
             byte[] zeros = new byte[512*1024];
             while(file.length()<fileSize) {
@@ -187,7 +187,7 @@ abstract class AbstractLongMap {
         KEY_SIZE = ID_SIZE;
         ENTRY_SIZE = KEY_SIZE + VALUE_SIZE;
         fileSize = keys * ENTRY_SIZE;
-        RandomAccessFile file = new RandomAccessFile(tempFile, "rw"); // NOI18N
+        RandomAccessFile file = tempFile.newRandomAccessFile("rw"); // NOI18N
         setDumpBuffer(file);
         cacheDirectory = cacheDir;
     }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/CacheDirectory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/CacheDirectory.java
@@ -31,16 +31,19 @@ class CacheDirectory {
     private static final String DIR_EXT = ".hwcache";   // NOI18N
     private static final String DUMP_AUX_FILE = "NBProfiler.nphd";   // NOI18N
     
+    private final File.Factory io;
     private File cacheDirectory;
     
-    static CacheDirectory getHeapDumpCacheDirectory(File heapDump) {
+    static CacheDirectory getHeapDumpCacheDirectory(File.Factory io, File heapDump) {
         String dumpName = heapDump.getName();
         File parent = heapDump.getParentFile();
-        File dir = new File(parent, dumpName+DIR_EXT);
-        return new CacheDirectory(dir);
+        File dir = io.newFile(parent, dumpName+DIR_EXT);
+        return new CacheDirectory(io, dir);
     }
     
-    CacheDirectory(File cacheDir) {
+    CacheDirectory(File.Factory io, File cacheDir) {
+        io.getClass();
+        this.io = io;
         cacheDirectory = cacheDir;
         if (cacheDir != null) {
             if (!cacheDir.exists()) {
@@ -58,17 +61,17 @@ class CacheDirectory {
         File newFile;
         
         if (isTemporary()) {
-            newFile = File.createTempFile(prefix, suffix);
+            newFile = io.createTempFile(prefix, suffix, null);
             newFile.deleteOnExit();
         } else {
-            newFile = File.createTempFile(prefix, suffix, cacheDirectory);
+            newFile = io.createTempFile(prefix, suffix, cacheDirectory);
         }
         return newFile;
     }
     
     File getHeapDumpAuxFile() {
         assert !isTemporary();
-        return new File(cacheDirectory, DUMP_AUX_FILE);
+        return io.newFile(cacheDirectory, DUMP_AUX_FILE);
     }
     
     boolean isTemporary() {
@@ -76,12 +79,12 @@ class CacheDirectory {
     }
 
     File getCacheFile(String fileName) throws FileNotFoundException {
-        File f = new File(fileName);
+        File f = io.newFile(fileName);
         if (isFileRW(f)) {
             return f;
         }
         // try to find file in cache directory
-        f = new File(cacheDirectory, f.getName());
+        f = io.newFile(cacheDirectory, f.getName());
         if (isFileRW(f)) {
             return f;
         }
@@ -89,12 +92,12 @@ class CacheDirectory {
     }
 
     File getHeapFile(String fileName) throws FileNotFoundException {
-        File f = new File(fileName);
+        File f = io.newFile(fileName);
         if (isFileR(f)) {
             return f;
         }
         // try to find heap dump file next to cache directory
-        f = new File(cacheDirectory.getParentFile(), f.getName());
+        f = io.newFile(cacheDirectory.getParentFile(), f.getName());
         if (isFileR(f)) {
             return f;
         }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/CacheDirectory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/CacheDirectory.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.lib.profiler.heap;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/CacheDirectory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/CacheDirectory.java
@@ -108,10 +108,4 @@ class CacheDirectory {
     private static boolean isFileRW(File f) {
         return isFileR(f) && f.canWrite();
     }
-
-    private static boolean isLinux() {
-        String osName = System.getProperty("os.name");  // NOI18N
-
-        return osName.endsWith("Linux"); // NOI18N
-    }
 }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDump.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/ClassDump.java
@@ -40,9 +40,6 @@ import java.util.Set;
  * @author Tomas Hurka
  */
 class ClassDump extends HprofObject implements JavaClass {
-    //~ Static fields/initializers -----------------------------------------------------------------------------------------------
-    
-    private static final boolean DEBUG = false;
     private static final Set CANNOT_CONTAIN_ITSELF = new HashSet(Arrays.asList(new String[] {
         "java.lang.String",         // NOI18N
         "java.lang.StringBuffer",   // NOI18N
@@ -178,8 +175,8 @@ class ClassDump extends HprofObject implements JavaClass {
             }
         }
 
-        if (DEBUG) {
-            System.out.println("Class " + getName() + " Col " + instancesList.size() + " instances " + getInstancesCount()); // NOI18N
+        if (Systems.DEBUG) {
+            Systems.debug("Class " + getName() + " Col " + instancesList.size() + " instances " + getInstancesCount()); // NOI18N
         }
 
         return instancesList;
@@ -429,8 +426,8 @@ class ClassDump extends HprofObject implements JavaClass {
         instances++;
         if (firstInstanceOffset == 0) {
             firstInstanceOffset = offset;
-            if (DEBUG) {
-                System.out.println("First instance :"+getName()+" "+offset/1024/1024); // NOI18N
+            if (Systems.DEBUG) {
+                Systems.debug("First instance :"+getName()+" "+offset/1024/1024); // NOI18N
             }
         }
     }
@@ -451,8 +448,8 @@ class ClassDump extends HprofObject implements JavaClass {
                 }
             }
         }
-        if (DEBUG) {
-            if (instances>10) System.out.println(getName()+" cannot contain itself "+instances);    // NOI18N
+        if (Systems.DEBUG) {
+            if (instances>10) Systems.debug(getName()+" cannot contain itself "+instances);    // NOI18N
         }
         return false;
     }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/DominatorTree.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/DominatorTree.java
@@ -80,7 +80,7 @@ class DominatorTree {
                 switchParents();
             } while (changed || !igonoreDirty);
         } catch (IOException ex) {
-            ex.printStackTrace();
+            Systems.printStackTrace(ex);
         }
         deleteBuffers();
         dirtySet = new LongSet();
@@ -101,13 +101,13 @@ class DominatorTree {
 //        List<Long> oldDomIds = new ArrayList();
 //        List<Long> newDomIds = new ArrayList();
 
-//System.out.println("New level, dirtyset size: "+dirtySet.size());
+//Systems.debug("New level, dirtyset size: "+dirtySet.size());
         for (;;) {
             long instanceId = readLong();
             if (instanceId == 0) {  // end of level
                 if (additionalIndex >= additionalIds.size()) {
                     if (additionalIndex>0) {
-//System.out.println("Additional instances "+additionalIndex);
+//Systems.debug("Additional instances "+additionalIndex);
                     }
                     break;
                 }
@@ -159,17 +159,17 @@ class DominatorTree {
             dirtySetSameSize++;
         }
         dirtySet = newDirtySet;
-//System.out.println("Processed: "+processedId);
-//System.out.println("Changed:   "+changedId);
-//System.out.println("-------------------");
+//Systems.debug("Processed: "+processedId);
+//Systems.debug("Changed:   "+changedId);
+//Systems.debug("-------------------");
 //printObjs(changedIds,oldDomIds,newDomIds, addedBynewDirtySet, changedIdx);
-//System.out.println("-------------------");
+//Systems.debug("-------------------");
         return changed;
     }
         
     private void updateAdditionalIds(final long instanceId, final List<Long> additionalIds) {
         Instance i = heap.getInstanceByID(instanceId);
-//System.out.println("Inspecting "+printInstance(instanceIdObj));
+//Systems.debug("Inspecting "+printInstance(instanceIdObj));
         if (i != null) {
             for (Object v : i.getFieldValues()) {
                 if (v instanceof ObjectFieldValue) {
@@ -180,7 +180,7 @@ class DominatorTree {
                         long idomO = map.get(idp);
                         if (idomO > 0) {
                             additionalIds.add(idO);
-//System.out.println("  Adding "+printInstance(idO));
+//Systems.debug("  Adding "+printInstance(idO));
                         }
                     }
                 }
@@ -332,7 +332,7 @@ class DominatorTree {
             m.put(number,text);
         }
         for (Integer in : m.keySet()) {
-            System.out.println(m.get(in));
+            Systems.debug(m.get(in));
         }
     }
     

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/File.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/File.java
@@ -18,186 +18,45 @@
  */
 package org.netbeans.lib.profiler.heap;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
 
-final class File {
-    static class Factory {
-        File newFile(File parent, String relative) {
-            return new File(this, parent, relative);
-        }
-
-        File newFile(String fileName) {
-            return new File(this, fileName);
-        }
-
-        File newFile(java.io.File real) {
-            return new File(this, real);
-        }
-
-        File createTempFile(String prefix, String suffix, File cacheDirectory) throws IOException {
-            if (cacheDirectory == null) {
-                return newFile(java.io.File.createTempFile(prefix, suffix));
-            } else {
-                return newFile(java.io.File.createTempFile(prefix, suffix, cacheDirectory.delegate));
-            }
-        }
+abstract class File {
+    interface Factory {
+        File newFile(File parent, String relative);
+        File newFile(String fileName);
+        File newFile(java.io.File real);
+        File createTempFile(String prefix, String suffix, File cacheDirectory) throws IOException;
     }
 
     final Factory io;
-    final java.io.File delegate;
 
-    private File(Factory io, File parent, String relative) {
-        this(io, new java.io.File(parent.delegate, relative));
-    }
-
-    private File(Factory io, String fileName) {
-        this(io, new java.io.File(fileName));
-    }
-
-    private File(Factory io, java.io.File real) {
+    File(Factory io) {
         this.io = io;
-        this.delegate = real;
     }
 
-
-    String getAbsolutePath() {
-        return delegate.getAbsolutePath();
-    }
-
-    String getName() {
-        return delegate.getName();
-    }
-
-    File getParentFile() {
-        return io.newFile(delegate.getParentFile());
-    }
-
-    boolean exists() {
-        return delegate.exists();
-    }
-
-    boolean mkdir() {
-        return delegate.mkdir();
-    }
-
-    void deleteOnExit() {
-        delegate.deleteOnExit();
-    }
-
-    boolean isDirectory() {
-        return delegate.isDirectory();
-    }
-
-    boolean canRead() {
-        return delegate.canRead();
-    }
-
-    boolean canWrite() {
-        return delegate.canWrite();
-    }
-
-    boolean isFile() {
-        return delegate.isFile();
-    }
-
-    long length() {
-        return delegate.length();
-    }
-
-    boolean delete() {
-        return delegate.delete();
-    }
-
-    boolean renameTo(File bufferFile) {
-        return delegate.renameTo(bufferFile.delegate);
-    }
-
-    RandomAccessFile newRandomAccessFile(String mode) throws FileNotFoundException {
-        return new RandomAccessFile(this, mode);
-    }
-
-    DataOutputStream newDataOutputStream(int bufferSize) throws FileNotFoundException {
-        return new DataOutputStream(new BufferedOutputStream(new FileOutputStream(delegate), bufferSize));
-    }
-
-    DataInputStream newDataInputStream(int bufferLength) throws FileNotFoundException {
-        return new DataInputStream(new BufferedInputStream(new FileInputStream(delegate), bufferLength));
-    }
-
-    ByteBuffer mmapReadOnly() throws IOException {
-        FileInputStream fis = new FileInputStream(delegate);
-        FileChannel channel = fis.getChannel();
-        ByteBuffer d = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
-        channel.close();
-        return d;
-    }
-
-    ByteBuffer force(FileChannel.MapMode mode, ByteBuffer buf) throws IOException {
-        if (mode == FileChannel.MapMode.PRIVATE) {
-            java.io.File newBufferFile = new java.io.File(delegate.getAbsolutePath()+".new"); // NOI18N
-            int length = buf.capacity();
-            new FileOutputStream(newBufferFile).getChannel().write(buf);
-            delegate.delete();
-            newBufferFile.renameTo(delegate);
-            return newRandomAccessFile("rw").mmap(mode, length, true); // NOI18N
-        } else {
-            ((MappedByteBuffer)buf).force();
-            return buf;
-        }
-    }
-
-    ByteBuffer[] mmapReadOnlyAsBuffers(long[] length, long bufferSize, long bufferExt) throws IOException {
-        FileInputStream fis = new FileInputStream(delegate);
-        try (FileChannel channel = fis.getChannel()) {
-            length[0] = channel.size();
-            ByteBuffer[] buffers = new ByteBuffer[(int) (((length[0] + bufferSize) - 1) / bufferSize)];
-
-            for (int i = 0; i < buffers.length; i++) {
-                long position = i * bufferSize;
-                long size = Math.min(bufferSize + bufferExt, length[0] - position);
-                buffers[i] = channel.map(FileChannel.MapMode.READ_ONLY, position, size);
-            }
-            return buffers;
-        }
-    }
-
-    ByteBuffer[] force(FileChannel.MapMode MAP_MODE, ByteBuffer[] dumpBuffer, long bufferSize, long bufferExt, long entrySize) throws IOException {
-        if (MAP_MODE == FileChannel.MapMode.PRIVATE) {
-            java.io.File newBufferFile = new java.io.File(getAbsolutePath()+".new"); // NOI18N
-            long length = delegate.length();
-            FileChannel channel = new FileOutputStream(newBufferFile).getChannel();
-            int offset_start = 0;
-
-            for (int i = 0; i < dumpBuffer.length; i++) {
-                ByteBuffer buf = dumpBuffer[i];
-                long offset_end = (((i+1)*bufferSize)/entrySize)*entrySize + entrySize;
-
-                if (offset_end > length) {
-                    offset_end = length;
-                }
-                buf.limit((int)(offset_end - i*bufferSize));
-                buf.position(offset_start);
-                channel.write(buf);
-                offset_start = (int)(offset_end - (i+1)*bufferSize);
-            }
-            delegate.delete();
-            newBufferFile.renameTo(delegate);
-            return newRandomAccessFile("rw").mmapAsBuffers(MAP_MODE, length, bufferSize, bufferExt); // NOI18N
-        } else {
-            for (ByteBuffer buf : dumpBuffer) {
-                ((MappedByteBuffer)buf).force();
-            }
-            return dumpBuffer;
-        }
-    }
+    abstract String getAbsolutePath();
+    abstract String getName();
+    abstract File getParentFile();
+    abstract boolean exists();
+    abstract boolean mkdir();
+    abstract void deleteOnExit();
+    abstract boolean isDirectory();
+    abstract boolean canRead();
+    abstract boolean canWrite();
+    abstract boolean isFile();
+    abstract long length();
+    abstract boolean delete();
+    abstract boolean renameTo(File bufferFile);
+    abstract RandomAccessFile newRandomAccessFile(String mode) throws FileNotFoundException;
+    abstract DataOutputStream newDataOutputStream(int bufferSize) throws FileNotFoundException;
+    abstract DataInputStream newDataInputStream(int bufferLength) throws FileNotFoundException;
+    abstract ByteBuffer mmapReadOnly() throws IOException;
+    abstract ByteBuffer force(MapMode mode, ByteBuffer buf) throws IOException;
+    abstract ByteBuffer[] mmapReadOnlyAsBuffers(long[] length, long bufferSize, long bufferExt) throws IOException;
+    abstract ByteBuffer[] force(MapMode mode, ByteBuffer[] dumpBuffer, long bufferSize, long bufferExt, long entrySize) throws IOException;
 }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/File.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/File.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.lib.profiler.heap;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+
+final class File {
+    final java.io.File delegate;
+
+    File(File parent, String relative) {
+        this(new java.io.File(parent.delegate, relative));
+    }
+
+    File(String fileName) {
+        this(new java.io.File(fileName));
+    }
+
+    File(java.io.File real) {
+        this.delegate = real;
+    }
+
+    static File createTempFile(String prefix, String suffix) throws IOException {
+        return new File(java.io.File.createTempFile(prefix, suffix));
+    }
+
+    static File createTempFile(String prefix, String suffix, File cacheDirectory) throws IOException {
+        return new File(java.io.File.createTempFile(prefix, suffix, cacheDirectory.delegate));
+    }
+
+    String getAbsolutePath() {
+        return delegate.getAbsolutePath();
+    }
+
+    String getName() {
+        return delegate.getName();
+    }
+
+    File getParentFile() {
+        return new File(delegate.getParentFile());
+    }
+
+    boolean exists() {
+        return delegate.exists();
+    }
+
+    boolean mkdir() {
+        return delegate.mkdir();
+    }
+
+    void deleteOnExit() {
+        delegate.deleteOnExit();
+    }
+
+    boolean isDirectory() {
+        return delegate.isDirectory();
+    }
+
+    boolean canRead() {
+        return delegate.canRead();
+    }
+
+    boolean canWrite() {
+        return delegate.canWrite();
+    }
+
+    boolean isFile() {
+        return delegate.isFile();
+    }
+
+    long length() {
+        return delegate.length();
+    }
+
+    boolean delete() {
+        return delegate.delete();
+    }
+
+    boolean renameTo(File bufferFile) {
+        return delegate.renameTo(bufferFile.delegate);
+    }
+
+    DataOutputStream newDataOutputStream(int bufferSize) throws FileNotFoundException {
+        return new DataOutputStream(new BufferedOutputStream(new FileOutputStream(delegate), bufferSize));
+    }
+
+    DataInputStream newDataInputStream(int bufferLength) throws FileNotFoundException {
+        return new DataInputStream(new BufferedInputStream(new FileInputStream(delegate), bufferLength));
+    }
+
+    ByteBuffer mmapReadOnly() throws IOException {
+        FileInputStream fis = new FileInputStream(delegate);
+        FileChannel channel = fis.getChannel();
+        ByteBuffer d = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
+        channel.close();
+        return d;
+    }
+
+    ByteBuffer force(FileChannel.MapMode mode, ByteBuffer buf) throws IOException {
+        if (mode == FileChannel.MapMode.PRIVATE) {
+            java.io.File newBufferFile = new java.io.File(delegate.getAbsolutePath()+".new"); // NOI18N
+            int length = buf.capacity();
+            new FileOutputStream(newBufferFile).getChannel().write(buf);
+            delegate.delete();
+            newBufferFile.renameTo(delegate);
+            return new RandomAccessFile(this, "rw").mmap(mode, length, true); // NOI18N
+        } else {
+            ((MappedByteBuffer)buf).force();
+            return buf;
+        }
+    }
+
+    ByteBuffer[] mmapReadOnlyAsBuffers(long[] length, long bufferSize, long bufferExt) throws IOException {
+        FileInputStream fis = new FileInputStream(delegate);
+        try (FileChannel channel = fis.getChannel()) {
+            length[0] = channel.size();
+            ByteBuffer[] buffers = new ByteBuffer[(int) (((length[0] + bufferSize) - 1) / bufferSize)];
+
+            for (int i = 0; i < buffers.length; i++) {
+                long position = i * bufferSize;
+                long size = Math.min(bufferSize + bufferExt, length[0] - position);
+                buffers[i] = channel.map(FileChannel.MapMode.READ_ONLY, position, size);
+            }
+            return buffers;
+        }
+    }
+
+    ByteBuffer[] force(FileChannel.MapMode MAP_MODE, ByteBuffer[] dumpBuffer, long bufferSize, long bufferExt, long entrySize) throws IOException {
+        if (MAP_MODE == FileChannel.MapMode.PRIVATE) {
+            java.io.File newBufferFile = new java.io.File(getAbsolutePath()+".new"); // NOI18N
+            long length = delegate.length();
+            FileChannel channel = new FileOutputStream(newBufferFile).getChannel();
+            int offset_start = 0;
+
+            for (int i = 0; i < dumpBuffer.length; i++) {
+                ByteBuffer buf = dumpBuffer[i];
+                long offset_end = (((i+1)*bufferSize)/entrySize)*entrySize + entrySize;
+
+                if (offset_end > length) {
+                    offset_end = length;
+                }
+                buf.limit((int)(offset_end - i*bufferSize));
+                buf.position(offset_start);
+                channel.write(buf);
+                offset_start = (int)(offset_end - (i+1)*bufferSize);
+            }
+            delegate.delete();
+            newBufferFile.renameTo(delegate);
+            return new RandomAccessFile(this, "rw").mmapAsBuffers(MAP_MODE, length, bufferSize, bufferExt); // NOI18N
+        } else {
+            for (ByteBuffer buf : dumpBuffer) {
+                ((MappedByteBuffer)buf).force();
+            }
+            return dumpBuffer;
+        }
+    }
+}

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
@@ -61,8 +61,9 @@ public class HeapFactory {
      */
     public static Heap createHeap(java.io.File heapDump, int segment)
                            throws FileNotFoundException, IOException {
-        File hd = new File(heapDump);
-        CacheDirectory cacheDir = CacheDirectory.getHeapDumpCacheDirectory(hd);
+        File.Factory io = new File.Factory();
+        File hd = io.newFile(heapDump);
+        CacheDirectory cacheDir = CacheDirectory.getHeapDumpCacheDirectory(io, hd);
         if (!cacheDir.isTemporary()) {
             File savedDump = cacheDir.getHeapDumpAuxFile();
 
@@ -91,7 +92,8 @@ public class HeapFactory {
      * @since 1.122
      */
     public static Heap createHeap(ByteBuffer buffer, int segment) throws IOException {
-        return new HprofHeap(buffer, segment, new CacheDirectory(null));
+        File.Factory io = new File.Factory();
+        return new HprofHeap(buffer, segment, new CacheDirectory(io, null));
     }
     
     static Heap loadHeap(CacheDirectory cacheDir)

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
@@ -19,13 +19,9 @@
 
 package org.netbeans.lib.profiler.heap;
 
-import java.io.BufferedInputStream;
 import java.io.DataInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
 
 
@@ -46,7 +42,7 @@ public class HeapFactory {
      * @throws java.io.FileNotFoundException if heapDump file does not exist
      * @throws java.io.IOException if I/O error occurred while accessing heapDump file
      */
-    public static Heap createHeap(File heapDump) throws FileNotFoundException, IOException {
+    public static Heap createHeap(java.io.File heapDump) throws FileNotFoundException, IOException {
         return createHeap(heapDump, 0);
     }
 
@@ -63,9 +59,10 @@ public class HeapFactory {
      * @throws java.io.FileNotFoundException if heapDump file does not exist
      * @throws java.io.IOException if I/O error occurred while accessing heapDump file
      */
-    public static Heap createHeap(File heapDump, int segment)
+    public static Heap createHeap(java.io.File heapDump, int segment)
                            throws FileNotFoundException, IOException {
-        CacheDirectory cacheDir = CacheDirectory.getHeapDumpCacheDirectory(heapDump);
+        File hd = new File(heapDump);
+        CacheDirectory cacheDir = CacheDirectory.getHeapDumpCacheDirectory(hd);
         if (!cacheDir.isTemporary()) {
             File savedDump = cacheDir.getHeapDumpAuxFile();
 
@@ -78,7 +75,7 @@ public class HeapFactory {
                 }
             }
         }
-        return new HprofHeap(heapDump, segment, cacheDir);
+        return new HprofHeap(hd, segment, cacheDir);
 
     }
 
@@ -101,8 +98,7 @@ public class HeapFactory {
     static Heap loadHeap(CacheDirectory cacheDir)
                            throws FileNotFoundException, IOException {
         File savedDump = cacheDir.getHeapDumpAuxFile();
-        InputStream is = new BufferedInputStream(new FileInputStream(savedDump), 64*1024);
-        DataInputStream dis = new DataInputStream(is);
+        DataInputStream dis = savedDump.newDataInputStream(64*1024);
         Heap heap = new HprofHeap(dis, cacheDir);
         dis.close();
         return heap;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
@@ -70,8 +70,7 @@ public class HeapFactory {
                 try {
                     return loadHeap(cacheDir);
                 } catch (IOException ex) {
-                    System.err.println("Loading heap dump "+heapDump+" from cache failed.");
-                    ex.printStackTrace(System.err);
+                    Systems.printStackTrace("Loading heap dump "+heapDump+" from cache failed.", ex);
                 }
             }
         }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
@@ -61,9 +61,8 @@ public class HeapFactory {
      */
     public static Heap createHeap(java.io.File heapDump, int segment)
                            throws FileNotFoundException, IOException {
-        File.Factory io = new File.Factory();
-        File hd = io.newFile(heapDump);
-        CacheDirectory cacheDir = CacheDirectory.getHeapDumpCacheDirectory(io, hd);
+        File hd = JavaIoFile.IO.newFile(heapDump);
+        CacheDirectory cacheDir = CacheDirectory.getHeapDumpCacheDirectory(JavaIoFile.IO, hd);
         if (!cacheDir.isTemporary()) {
             File savedDump = cacheDir.getHeapDumpAuxFile();
 
@@ -92,8 +91,7 @@ public class HeapFactory {
      * @since 1.122
      */
     public static Heap createHeap(ByteBuffer buffer, int segment) throws IOException {
-        File.Factory io = new File.Factory();
-        return new HprofHeap(buffer, segment, new CacheDirectory(io, null));
+        return new HprofHeap(buffer, segment, new CacheDirectory(JavaIoFile.IO, null));
     }
     
     static Heap loadHeap(CacheDirectory cacheDir)

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofByteBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofByteBuffer.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.lib.profiler.heap;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Date;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofByteBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofByteBuffer.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.ResourceBundle;
+import static org.netbeans.lib.profiler.heap.Systems.DEBUG;
 
 
 /**
@@ -40,7 +41,6 @@ abstract class HprofByteBuffer {
     static final int JAVA_PROFILE_1_0_2 = 2;
     static final int JAVA_PROFILE_1_0_3 = 3;
     static final int MINIMAL_SIZE = 30;
-    static final boolean DEBUG = false;
 
     //~ Instance fields ----------------------------------------------------------------------------------------------------------
 
@@ -134,7 +134,7 @@ abstract class HprofByteBuffer {
         String magic = readStringNull(offset, MINIMAL_SIZE);
 
         if (DEBUG) {
-            System.out.println("Magic " + magic); // NOI18N
+            Systems.debug("Magic " + magic); // NOI18N
         }
 
         if (magic1.equals(magic)) {
@@ -145,7 +145,7 @@ abstract class HprofByteBuffer {
             version = JAVA_PROFILE_1_0_3;
         } else {
             if (DEBUG) {
-                System.out.println("Invalid version"); // NOI18N
+                Systems.debug("Invalid version"); // NOI18N
             }
 
             String errText = ResourceBundle.getBundle("org/netbeans/lib/profiler/heap/Bundle")
@@ -159,11 +159,11 @@ abstract class HprofByteBuffer {
         offset[0] += 8;
 
         if (DEBUG) {
-            System.out.println("ID " + idSize); // NOI18N
+            Systems.debug("ID " + idSize); // NOI18N
         }
 
         if (DEBUG) {
-            System.out.println("Date " + new Date(time).toString()); // NOI18N
+            Systems.debug("Date " + new Date(time).toString()); // NOI18N
         }
 
         headerSize = offset[0];

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFileBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFileBuffer.java
@@ -20,9 +20,7 @@
 package org.netbeans.lib.profiler.heap;
 
 import java.io.EOFException;
-import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 
 
 /**

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFileBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFileBuffer.java
@@ -114,7 +114,7 @@ class HprofFileBuffer extends HprofByteBuffer {
                 fis.seek(position);
                 fis.readFully(chars);
             } catch (IOException ex) {
-                ex.printStackTrace();
+                Systems.printStackTrace(ex);
             }
         }
     }
@@ -148,11 +148,11 @@ class HprofFileBuffer extends HprofByteBuffer {
             fis.seek(newBufferStart);
             fis.readFully(dumpBuffer);
 
-            //System.out.println("Reading at "+newBufferStart+" size "+dumpBuffer.length+" thread "+Thread.currentThread().getName());
+            //Systems.debug("Reading at "+newBufferStart+" size "+dumpBuffer.length+" thread "+Thread.currentThread().getName());
         } catch (EOFException ex) {
             // ignore
         } catch (IOException ex) {
-            ex.printStackTrace();
+            Systems.printStackTrace(ex);
         }
 
         bufferStartOffset = newBufferStart;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFileBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofFileBuffer.java
@@ -47,7 +47,7 @@ class HprofFileBuffer extends HprofByteBuffer {
     //~ Constructors -------------------------------------------------------------------------------------------------------------
 
     HprofFileBuffer(File dumpFile) throws IOException {
-        fis = new RandomAccessFile(dumpFile, "r");
+        fis = dumpFile.newRandomAccessFile("r");
         length = fis.length();
         bufferStartOffset = Long.MAX_VALUE;
         readHeader();

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
@@ -19,12 +19,9 @@
 
 package org.netbeans.lib.profiler.heap;
 
-import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -319,7 +316,7 @@ class HprofHeap implements Heap {
             try {
                 DataOutputStream out;
                 File outFile = cacheDirectory.getHeapDumpAuxFile();
-                out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(outFile), 32768));
+                out = outFile.newDataOutputStream(32768);
                 writeToStream(out);
                 out.close();
             } catch (IOException ex) {
@@ -327,7 +324,7 @@ class HprofHeap implements Heap {
             }
         }
     }
-    
+
     void writeToStream(DataOutputStream out) throws IOException {
         out.writeUTF(SNAPSHOT_ID);
         out.writeInt(SNAPSHOT_VERSION);

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
@@ -494,7 +494,7 @@ class HprofHeap implements Heap {
             return;
         }
 
-        HeapProgress.progressStart();
+        Progress.Handle handle = Progress.COMPUTE_INSTANCES.start();
         ClassDumpSegment classDumpBounds = getClassDumpSegment();
         int idSize = dumpBuffer.getIDSize();
         long[] offset = new long[] { allInstanceDumpBounds.startOffset };
@@ -535,12 +535,12 @@ class HprofHeap implements Heap {
                 instanceEntry.setIndex(classDump.getInstancesCount());
                 classDumpBounds.addInstanceSize(classDump, tag, start);
             }
-            HeapProgress.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
+            handle.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
         }
         instancesCountComputed = true;
         writeToFile();
+        handle.close();
         }
-        HeapProgress.progressFinish();
     }
 
     List findReferencesFor(long instanceId) {
@@ -611,7 +611,7 @@ class HprofHeap implements Heap {
             return;
         }
 
-        HeapProgress.progressStart();
+        Progress.Handle handle = Progress.COMPUTE_REFERENCES.start();
         ClassDumpSegment classDumpBounds = getClassDumpSegment();
         int idSize = dumpBuffer.getIDSize();
         long[] offset = new long[] { allInstanceDumpBounds.startOffset };
@@ -663,7 +663,7 @@ class HprofHeap implements Heap {
                     }
                 }
             }
-            HeapProgress.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
+            handle.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
         }
         
         Iterator classesIt = getClassDumpSegment().createClassCollection().iterator();
@@ -692,8 +692,8 @@ class HprofHeap implements Heap {
         idToOffsetMap.flush();
         referencesComputed = true;
         writeToFile();
+        handle.close();
         }
-        HeapProgress.progressFinish();        
     }
     
     void computeRetainedSize() {
@@ -1220,7 +1220,7 @@ class HprofHeap implements Heap {
             return;
         }
 
-        HeapProgress.progressStart();
+        Progress.Handle handle = Progress.FILL_HEAP_TAG_BOUNDS.start();
         heapTagBounds = new TagBounds[0x100];
 
         long[] offset = new long[] { heapDumpSegment.startOffset + 1 + 4 + 4 };
@@ -1248,7 +1248,7 @@ class HprofHeap implements Heap {
             if ((tag == CLASS_DUMP) || (tag == INSTANCE_DUMP) || (tag == OBJECT_ARRAY_DUMP) || (tag == PRIMITIVE_ARRAY_DUMP)) {
                 idMapSize++;
             }
-            HeapProgress.progress(counter,heapDumpSegment.startOffset,start,heapDumpSegment.endOffset);
+            handle.progress(counter,heapDumpSegment.startOffset,start,heapDumpSegment.endOffset);
         }
 
         TagBounds instanceDumpBounds = heapTagBounds[INSTANCE_DUMP];
@@ -1256,7 +1256,7 @@ class HprofHeap implements Heap {
         TagBounds primArrayDumpBounds = heapTagBounds[PRIMITIVE_ARRAY_DUMP];
         allInstanceDumpBounds = instanceDumpBounds.union(objArrayDumpBounds);
         allInstanceDumpBounds = allInstanceDumpBounds.union(primArrayDumpBounds);
-        HeapProgress.progressFinish();
+        handle.close();
     }
 
     private void fillTagBounds(long tagStart) throws IOException {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofHeap.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
+import static org.netbeans.lib.profiler.heap.Systems.DEBUG;
 
 /**
  *
@@ -92,7 +93,6 @@ class HprofHeap implements Heap {
     static final int SHORT = 9;
     static final int INT = 10;
     static final int LONG = 11;
-    private static final boolean DEBUG = false;
 
     private static final String SNAPSHOT_ID = "NBPHD";
     private static final int SNAPSHOT_VERSION  = 2;
@@ -320,7 +320,7 @@ class HprofHeap implements Heap {
                 writeToStream(out);
                 out.close();
             } catch (IOException ex) {
-                ex.printStackTrace(System.err);
+                Systems.printStackTrace(ex);
             }
         }
     }
@@ -640,7 +640,7 @@ class HprofHeap implements Heap {
                             if (entry != null) {
                                 entry.addReference(instanceId);
                             } else {
-                                //    System.err.println("instance entry:" + Long.toHexString(outId));
+                                //    Systems.debug("instance entry:" + Long.toHexString(outId));
                             }
                         }
                     }
@@ -659,7 +659,7 @@ class HprofHeap implements Heap {
                     if (entry != null) {
                         entry.addReference(instanceId);
                     } else {
-                        //    System.err.println("bad array entry:" + Long.toHexString(outId));
+                        //    Systems.debug("bad array entry:" + Long.toHexString(outId));
                     }
                 }
             }
@@ -681,7 +681,7 @@ class HprofHeap implements Heap {
                     if (outId != 0) {
                         LongMap.Entry entry = idToOffsetMap.get(outId);
                         if (entry == null) {
-                            //    System.err.println("instance entry:" + Long.toHexString(outId));
+                            //    Systems.debug("instance entry:" + Long.toHexString(outId));
                             continue;
                         }
                         entry.addReference(classDump.getJavaClassId());
@@ -813,7 +813,7 @@ class HprofHeap implements Heap {
             case ROOT_UNKNOWN:
 
                 if (DEBUG) {
-                    System.out.println("Tag ROOT_UNKNOWN"); // NOI18N
+                    Systems.debug("Tag ROOT_UNKNOWN"); // NOI18N
                 }
 
                 size = idSize;
@@ -823,7 +823,7 @@ class HprofHeap implements Heap {
             case ROOT_JNI_GLOBAL:
 
                 if (DEBUG) {
-                    System.out.println("Tag ROOT_JNI_GLOBAL"); // NOI18N
+                    Systems.debug("Tag ROOT_JNI_GLOBAL"); // NOI18N
                 }
 
                 size = 2 * idSize;
@@ -831,7 +831,7 @@ class HprofHeap implements Heap {
                 break;
             case ROOT_JNI_LOCAL: {
                 if (DEBUG) {
-                    System.out.print("Tag ROOT_JNI_LOCAL"); // NOI18N
+                    Systems.debug("Tag ROOT_JNI_LOCAL"); // NOI18N
 
                     long objId = dumpBuffer.getID(position);
                     position += idSize;
@@ -841,7 +841,7 @@ class HprofHeap implements Heap {
 
                     int frameNum = dumpBuffer.getInt(position);
                     position += 4;
-                    System.out.println(" Object ID " + objId + " Thread serial " + threadSerial + " Frame num " + frameNum); // NOI18N
+                    Systems.debug(" Object ID " + objId + " Thread serial " + threadSerial + " Frame num " + frameNum); // NOI18N
                 }
 
                 size = idSize + (2 * 4);
@@ -851,13 +851,13 @@ class HprofHeap implements Heap {
             case ROOT_JAVA_FRAME:
 
                 if (DEBUG) {
-                    System.out.println("Tag ROOT_JAVA_FRAME"); // NOI18N
+                    Systems.debug("Tag ROOT_JAVA_FRAME"); // NOI18N
                     int threadSerial = dumpBuffer.getInt(position);
                     position += 4;
 
                     int frameNum = dumpBuffer.getInt(position);
                     position += 4;
-                    System.out.println(" Thread serial " + threadSerial + " Frame num " + frameNum); // NOI18N
+                    Systems.debug(" Thread serial " + threadSerial + " Frame num " + frameNum); // NOI18N
                 }
 
                 size = idSize + (2 * 4);
@@ -866,7 +866,7 @@ class HprofHeap implements Heap {
             case ROOT_NATIVE_STACK:
 
                 if (DEBUG) {
-                    System.out.println("Tag ROOT_NATIVE_STACK"); // NOI18N
+                    Systems.debug("Tag ROOT_NATIVE_STACK"); // NOI18N
                 }
 
                 size = idSize + 4;
@@ -875,7 +875,7 @@ class HprofHeap implements Heap {
             case ROOT_STICKY_CLASS:
 
                 if (DEBUG) {
-                    System.out.println("Tag ROOT_STICKY_CLASS"); // NOI18N
+                    Systems.debug("Tag ROOT_STICKY_CLASS"); // NOI18N
                 }
 
                 size = idSize;
@@ -884,7 +884,7 @@ class HprofHeap implements Heap {
             case ROOT_THREAD_BLOCK:
 
                 if (DEBUG) {
-                    System.out.println("Tag ROOT_THREAD_BLOCK"); // NOI18N
+                    Systems.debug("Tag ROOT_THREAD_BLOCK"); // NOI18N
                 }
 
                 size = idSize + 4;
@@ -893,7 +893,7 @@ class HprofHeap implements Heap {
             case ROOT_MONITOR_USED:
 
                 if (DEBUG) {
-                    System.out.println("Tag ROOT_MONITOR_USED"); // NOI18N
+                    Systems.debug("Tag ROOT_MONITOR_USED"); // NOI18N
                 }
 
                 size = idSize;
@@ -902,7 +902,7 @@ class HprofHeap implements Heap {
             case ROOT_THREAD_OBJECT:
 
                 if (DEBUG) {
-                    System.out.println("Tag ROOT_THREAD_OBJECT"); // NOI18N
+                    Systems.debug("Tag ROOT_THREAD_OBJECT"); // NOI18N
                 }
 
                 size = idSize + (2 * 4);
@@ -915,7 +915,7 @@ class HprofHeap implements Heap {
                 int ifSize;
 
                 if (DEBUG) {
-                    System.out.println("Tag CLASS_DUMP, start offset " + tagOffset); // NOI18N
+                    Systems.debug("Tag CLASS_DUMP, start offset " + tagOffset); // NOI18N
 
                     long classId = dumpBuffer.getID(position);
                     position += idSize;
@@ -945,10 +945,10 @@ class HprofHeap implements Heap {
                     cpoolSize = readConstantPool(offset);
                     sfSize = readStaticFields(offset);
                     ifSize = readInstanceFields(offset);
-                    System.out.println("ClassId " + classId + " stack Serial " + stackSerial + " Super ID " + superId       // NOI18N
+                    Systems.debug("ClassId " + classId + " stack Serial " + stackSerial + " Super ID " + superId       // NOI18N
                                        + " ClassLoader ID " + classLoaderId + " signers " + signersId + " Protect Dom Id "  // NOI18N
                                        + protDomainId + " Size " + instSize);                                               // NOI18N
-                    System.out.println(" Cpool " + cpoolSize + " Static fields " + sfSize + " Instance fileds " + ifSize);  // NOI18N
+                    Systems.debug(" Cpool " + cpoolSize + " Static fields " + sfSize + " Instance fileds " + ifSize);  // NOI18N
                 } else {
                     offset[0] = position + constantSize;
                     cpoolSize = readConstantPool(offset);
@@ -963,7 +963,7 @@ class HprofHeap implements Heap {
                 int fieldSize;
 
                 if (DEBUG) {
-                    System.out.println("Tag INSTANCE_DUMP"); // NOI18N
+                    Systems.debug("Tag INSTANCE_DUMP"); // NOI18N
 
                     long objId = dumpBuffer.getID(position);
                     position += idSize;
@@ -975,7 +975,7 @@ class HprofHeap implements Heap {
                     position += idSize;
                     fieldSize = dumpBuffer.getInt(position);
                     position += 4;
-                    System.out.println("Obj ID " + objId + " Stack serial " + stackSerial + " Class ID " + classId
+                    Systems.debug("Obj ID " + objId + " Stack serial " + stackSerial + " Class ID " + classId
                                        + " Field size " + fieldSize); // NOI18N
                 } else {
                     fieldSize = dumpBuffer.getInt(position + idSize + 4 + idSize);
@@ -989,7 +989,7 @@ class HprofHeap implements Heap {
                 long elements;
 
                 if (DEBUG) {
-                    System.out.println("Tag OBJECT_ARRAY_DUMP"); // NOI18N
+                    Systems.debug("Tag OBJECT_ARRAY_DUMP"); // NOI18N
 
                     long objId = dumpBuffer.getID(position);
                     position += idSize;
@@ -1004,12 +1004,12 @@ class HprofHeap implements Heap {
 
                     int dataSize = 0;
 
-                    System.out.println("Obj ID " + objId + " Stack serial " + stackSerial + " Elements " + elements // NOI18N
+                    Systems.debug("Obj ID " + objId + " Stack serial " + stackSerial + " Elements " + elements // NOI18N
                                            + " Type " + classId); // NOI18N
 
                     for (int i = 0; i < elements; i++) {
                         dataSize += dumpBuffer.getIDSize();
-                        System.out.println("Instance ID " + dumpBuffer.getID(position)); // NOI18N
+                        Systems.debug("Instance ID " + dumpBuffer.getID(position)); // NOI18N
                         position += idSize;
                     }
                 } else {
@@ -1025,7 +1025,7 @@ class HprofHeap implements Heap {
                 byte type;
 
                 if (DEBUG) {
-                    System.out.println("Tag PRIMITINE_ARRAY_DUMP"); // NOI18N
+                    Systems.debug("Tag PRIMITINE_ARRAY_DUMP"); // NOI18N
 
                     long objId = dumpBuffer.getID(position);
                     position += idSize;
@@ -1037,7 +1037,7 @@ class HprofHeap implements Heap {
                     type = dumpBuffer.get(position++);
 
                     int dataSize = 0;
-                    System.out.println("Obj ID " + objId + " Stack serial " + stackSerial + " Elements " + elements + " Type " + type); // NOI18N
+                    Systems.debug("Obj ID " + objId + " Stack serial " + stackSerial + " Elements " + elements + " Type " + type); // NOI18N
 
                     for (int i = 0; i < elements; i++) {
                         dataSize += getValueSize(type);
@@ -1061,13 +1061,13 @@ class HprofHeap implements Heap {
             case HEAP_DUMP_INFO: {
 
                 if (DEBUG) {
-                    System.out.println("Tag HPROF_HEAP_DUMP_INFO"); // NOI18N
+                    Systems.debug("Tag HPROF_HEAP_DUMP_INFO"); // NOI18N
                     int heapId = dumpBuffer.getInt(position);
                     position += 4;
 
                     long stringID = dumpBuffer.getID(position);
                     position += idSize;
-                    System.out.println(" Dump info id " + heapId + " String ID " + stringID); // NOI18N
+                    Systems.debug(" Dump info id " + heapId + " String ID " + stringID); // NOI18N
                 }
 
                 size = 4 + idSize;
@@ -1077,7 +1077,7 @@ class HprofHeap implements Heap {
             case ROOT_INTERNED_STRING: {
 
                 if (DEBUG) {
-                    System.out.println("Tag HPROF_ROOT_INTERNED_STRING"); // NOI18N
+                    Systems.debug("Tag HPROF_ROOT_INTERNED_STRING"); // NOI18N
                 }
 
                 size = idSize;
@@ -1087,7 +1087,7 @@ class HprofHeap implements Heap {
             case ROOT_FINALIZING: {
 
                 if (DEBUG) {
-                    System.out.println("Tag HPROF_ROOT_FINALIZING"); // NOI18N
+                    Systems.debug("Tag HPROF_ROOT_FINALIZING"); // NOI18N
                 }
 
                 size = idSize;
@@ -1097,7 +1097,7 @@ class HprofHeap implements Heap {
             case ROOT_DEBUGGER: {
 
                 if (DEBUG) {
-                    System.out.println("Tag HPROF_ROOT_DEBUGGER"); // NOI18N
+                    Systems.debug("Tag HPROF_ROOT_DEBUGGER"); // NOI18N
                 }
 
                 size = idSize;
@@ -1107,7 +1107,7 @@ class HprofHeap implements Heap {
             case ROOT_REFERENCE_CLEANUP: {
 
                 if (DEBUG) {
-                    System.out.println("Tag HPROF_ROOT_REFERENCE_CLEANUP"); // NOI18N
+                    Systems.debug("Tag HPROF_ROOT_REFERENCE_CLEANUP"); // NOI18N
                 }
 
                 size = idSize;
@@ -1117,7 +1117,7 @@ class HprofHeap implements Heap {
             case ROOT_VM_INTERNAL: {
 
                 if (DEBUG) {
-                    System.out.println("Tag HPROF_ROOT_VM_INTERNAL"); // NOI18N
+                    Systems.debug("Tag HPROF_ROOT_VM_INTERNAL"); // NOI18N
                 }
 
                 size = idSize;
@@ -1127,7 +1127,7 @@ class HprofHeap implements Heap {
             case ROOT_JNI_MONITOR: {
 
                 if (DEBUG) {
-                    System.out.println("Tag HPROF_ROOT_JNI_MONITOR"); // NOI18N
+                    Systems.debug("Tag HPROF_ROOT_JNI_MONITOR"); // NOI18N
                 }
 
                 size = idSize;
@@ -1137,7 +1137,7 @@ class HprofHeap implements Heap {
             case UNREACHABLE: {
 
                 if (DEBUG) {
-                    System.out.println("Tag HPROF_UNREACHABLE"); // NOI18N
+                    Systems.debug("Tag HPROF_UNREACHABLE"); // NOI18N
                 }
 
                 size = idSize;
@@ -1318,7 +1318,7 @@ class HprofHeap implements Heap {
                 offset[0] += dumpBuffer.getIDSize();
 
                 byte type = dumpBuffer.get(offset[0]++);
-                System.out.println("Instance field name ID " + nameId + " Type " + type); // NOI18N
+                Systems.debug("Instance field name ID " + nameId + " Type " + type); // NOI18N
             }
         } else {
             offset[0] += (fields * (dumpBuffer.getIDSize() + 1));
@@ -1337,7 +1337,7 @@ class HprofHeap implements Heap {
         for (int i = 0; i < fields; i++) {
             if (DEBUG) {
                 long nameId = dumpBuffer.getID(offset[0]);
-                System.out.print("Static field name ID " + nameId + " "); // NOI18N
+                Systems.debug("Static field name ID " + nameId + " "); // NOI18N
             }
 
             offset[0] += idSize;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofMappedByteBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HprofMappedByteBuffer.java
@@ -19,13 +19,8 @@
 
 package org.netbeans.lib.profiler.heap;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
 
 
 /**
@@ -40,7 +35,7 @@ class HprofMappedByteBuffer extends HprofByteBuffer {
     //~ Constructors -------------------------------------------------------------------------------------------------------------
 
     HprofMappedByteBuffer(File dumpFile) throws IOException {
-        this(mmap(dumpFile));
+        this(dumpFile.mmapReadOnly());
     }
 
     HprofMappedByteBuffer(ByteBuffer buffer) throws IOException {
@@ -83,13 +78,5 @@ class HprofMappedByteBuffer extends HprofByteBuffer {
     synchronized void get(long position, byte[] chars) {
         dumpBuffer.position((int) position);
         dumpBuffer.get(chars);
-    }
-
-    private static MappedByteBuffer mmap(File dumpFile) throws IOException, FileNotFoundException {
-        FileInputStream fis = new FileInputStream(dumpFile);
-        FileChannel channel = fis.getChannel();
-        MappedByteBuffer d = channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
-        channel.close();
-        return d;
     }
 }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/JavaIoFile.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/JavaIoFile.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.lib.profiler.heap;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+
+final class JavaIoFile extends File {
+    static final Factory IO = new Factory() {
+        @Override
+        public File newFile(File parent, String relative) {
+            return new JavaIoFile(this, (JavaIoFile) parent, relative);
+        }
+
+        @Override
+        public File newFile(String fileName) {
+            return new JavaIoFile(this, fileName);
+        }
+
+        @Override
+        public File newFile(java.io.File real) {
+            return new JavaIoFile(this, real);
+        }
+
+        @Override
+        public File createTempFile(String prefix, String suffix, File cacheDirectory) throws IOException {
+            if (cacheDirectory == null) {
+                return newFile(java.io.File.createTempFile(prefix, suffix));
+            } else {
+                return newFile(java.io.File.createTempFile(prefix, suffix, ((JavaIoFile)cacheDirectory).delegate));
+            }
+        }
+    };
+
+    final java.io.File delegate;
+
+    private JavaIoFile(Factory io, JavaIoFile parent, String relative) {
+        this(io, new java.io.File(parent.delegate, relative));
+    }
+
+    private JavaIoFile(Factory io, String fileName) {
+        this(io, new java.io.File(fileName));
+    }
+
+    private JavaIoFile(Factory io, java.io.File real) {
+        super(io);
+        this.delegate = real;
+    }
+
+
+    @Override
+    String getAbsolutePath() {
+        return delegate.getAbsolutePath();
+    }
+
+    @Override
+    String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    File getParentFile() {
+        return io.newFile(delegate.getParentFile());
+    }
+
+    @Override
+    boolean exists() {
+        return delegate.exists();
+    }
+
+    @Override
+    boolean mkdir() {
+        return delegate.mkdir();
+    }
+
+    @Override
+    void deleteOnExit() {
+        delegate.deleteOnExit();
+    }
+
+    @Override
+    boolean isDirectory() {
+        return delegate.isDirectory();
+    }
+
+    @Override
+    boolean canRead() {
+        return delegate.canRead();
+    }
+
+    @Override
+    boolean canWrite() {
+        return delegate.canWrite();
+    }
+
+    @Override
+    boolean isFile() {
+        return delegate.isFile();
+    }
+
+    @Override
+    long length() {
+        return delegate.length();
+    }
+
+    @Override
+    boolean delete() {
+        return delegate.delete();
+    }
+
+    @Override
+    boolean renameTo(File bufferFile) {
+        if (bufferFile instanceof JavaIoFile) {
+            return delegate.renameTo(((JavaIoFile) bufferFile).delegate);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    RandomAccessFile newRandomAccessFile(String mode) throws FileNotFoundException {
+        return new RandomAccess(this, mode);
+    }
+
+    @Override
+    DataOutputStream newDataOutputStream(int bufferSize) throws FileNotFoundException {
+        return new DataOutputStream(new BufferedOutputStream(new FileOutputStream(delegate), bufferSize));
+    }
+
+    @Override
+    DataInputStream newDataInputStream(int bufferLength) throws FileNotFoundException {
+        return new DataInputStream(new BufferedInputStream(new FileInputStream(delegate), bufferLength));
+    }
+
+    @Override
+    ByteBuffer mmapReadOnly() throws IOException {
+        try (FileChannel channel = new FileInputStream(delegate).getChannel()) {
+            return channel.map(FileChannel.MapMode.READ_ONLY, 0, channel.size());
+        }
+    }
+
+    @Override
+    ByteBuffer force(FileChannel.MapMode mode, ByteBuffer buf) throws IOException {
+        if (mode == FileChannel.MapMode.PRIVATE) {
+            java.io.File newBufferFile = new java.io.File(delegate.getAbsolutePath()+".new"); // NOI18N
+            int length = buf.capacity();
+            new FileOutputStream(newBufferFile).getChannel().write(buf);
+            delegate.delete();
+            newBufferFile.renameTo(delegate);
+            return newRandomAccessFile("rw").mmap(mode, length, true); // NOI18N
+        } else {
+            ((MappedByteBuffer)buf).force();
+            return buf;
+        }
+    }
+
+    @Override
+    ByteBuffer[] mmapReadOnlyAsBuffers(long[] length, long bufferSize, long bufferExt) throws IOException {
+        FileInputStream fis = new FileInputStream(delegate);
+        try (FileChannel channel = fis.getChannel()) {
+            length[0] = channel.size();
+            ByteBuffer[] buffers = new ByteBuffer[(int) (((length[0] + bufferSize) - 1) / bufferSize)];
+
+            for (int i = 0; i < buffers.length; i++) {
+                long position = i * bufferSize;
+                long size = Math.min(bufferSize + bufferExt, length[0] - position);
+                buffers[i] = channel.map(FileChannel.MapMode.READ_ONLY, position, size);
+            }
+            return buffers;
+        }
+    }
+
+    @Override
+    ByteBuffer[] force(FileChannel.MapMode MAP_MODE, ByteBuffer[] dumpBuffer, long bufferSize, long bufferExt, long entrySize) throws IOException {
+        if (MAP_MODE == FileChannel.MapMode.PRIVATE) {
+            java.io.File newBufferFile = new java.io.File(getAbsolutePath()+".new"); // NOI18N
+            long length = delegate.length();
+            FileChannel channel = new FileOutputStream(newBufferFile).getChannel();
+            int offset_start = 0;
+
+            for (int i = 0; i < dumpBuffer.length; i++) {
+                ByteBuffer buf = dumpBuffer[i];
+                long offset_end = (((i+1)*bufferSize)/entrySize)*entrySize + entrySize;
+
+                if (offset_end > length) {
+                    offset_end = length;
+                }
+                buf.limit((int)(offset_end - i*bufferSize));
+                buf.position(offset_start);
+                channel.write(buf);
+                offset_start = (int)(offset_end - (i+1)*bufferSize);
+            }
+            delegate.delete();
+            newBufferFile.renameTo(delegate);
+            return newRandomAccessFile("rw").mmapAsBuffers(MAP_MODE, length, bufferSize, bufferExt); // NOI18N
+        } else {
+            for (ByteBuffer buf : dumpBuffer) {
+                ((MappedByteBuffer)buf).force();
+            }
+            return dumpBuffer;
+        }
+    }
+
+    private static final class RandomAccess extends RandomAccessFile {
+
+        private final java.io.RandomAccessFile delegate;
+
+        RandomAccess(JavaIoFile file, String mode) throws FileNotFoundException {
+            super();
+            this.delegate = new java.io.RandomAccessFile(file.delegate, mode);
+        }
+
+        @Override
+        long length() throws IOException {
+            return delegate.length();
+        }
+
+        @Override
+        void write(byte[] arr) throws IOException {
+            delegate.write(arr);
+        }
+
+        @Override
+        void write(byte[] arr, int off, int len) throws IOException {
+            delegate.write(arr, off, len);
+        }
+
+        @Override
+        void setLength(long fileSize) throws IOException {
+            delegate.setLength(fileSize);
+        }
+
+        @Override
+        void seek(long newOffset) throws IOException {
+            delegate.seek(newOffset);
+        }
+
+        @Override
+        void readFully(byte[] buf, int off, int len) throws IOException {
+            delegate.readFully(buf, off, len);
+        }
+
+        @Override
+        void readFully(byte[] buf) throws IOException {
+            delegate.readFully(buf);
+        }
+
+        @Override
+        long readLong() throws IOException {
+            return delegate.readLong();
+        }
+
+        @Override
+        ByteBuffer mmap(FileChannel.MapMode mode, long size, boolean close) throws IOException {
+            FileChannel ch = delegate.getChannel();
+            try {
+                return ch.map(mode, 0, size);
+            } finally {
+                if (close) {
+                    ch.close();
+                }
+            }
+        }
+
+        @Override
+        ByteBuffer[] mmapAsBuffers(FileChannel.MapMode mode, long length, long BUFFER_SIZE, long BUFFER_EXT) throws IOException {
+            try (final FileChannel channel = delegate.getChannel()) {
+                ByteBuffer[] dumpBuffer = new ByteBuffer[(int) (((length + BUFFER_SIZE) - 1) / BUFFER_SIZE)];
+                for (int i = 0; i < dumpBuffer.length; i++) {
+                    long position = i * BUFFER_SIZE;
+                    long size = Math.min(BUFFER_SIZE + BUFFER_EXT, length - position);
+                    dumpBuffer[i] = channel.map(mode, position, size);
+                }
+                return dumpBuffer;
+            }
+        }
+    }
+}

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/LongBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/LongBuffer.java
@@ -164,7 +164,7 @@ class LongBuffer {
             }
         } else {
             writeStream.flush();
-            RandomAccessFile raf = new RandomAccessFile(backingFile,"r");
+            RandomAccessFile raf = backingFile.newRandomAccessFile("r");
             long offset = raf.length();
             while(offset > 0) {
                 offset-=8;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/LongBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/LongBuffer.java
@@ -19,16 +19,10 @@
 
 package org.netbeans.lib.profiler.heap;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 
 
 /**
@@ -129,7 +123,7 @@ class LongBuffer {
                 if (readStream != null) {
                     readStream.close();
                 }
-                readStream = new DataInputStream(new BufferedInputStream(new FileInputStream(backingFile), buffer.length * 8));
+                readStream = backingFile.newDataInputStream(buffer.length * 8);
                 readStreamClosed = false;
             } catch (IOException ex) {
                 ex.printStackTrace();
@@ -149,7 +143,7 @@ class LongBuffer {
         }
 
         if (writeStream == null) {
-            writeStream = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(backingFile), buffer.length * 8));
+            writeStream = backingFile.newDataOutputStream(buffer.length * 8);
 
             for (int i = 0; i < buffer.length; i++) {
                 writeStream.writeLong(buffer[i]);

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/LongBuffer.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/LongBuffer.java
@@ -107,7 +107,7 @@ class LongBuffer {
             try {
                 writeStream.close();
             } catch (IOException ex) {
-                ex.printStackTrace();
+                Systems.printStackTrace(ex);
             }
         }
 
@@ -126,7 +126,7 @@ class LongBuffer {
                 readStream = backingFile.newDataInputStream(buffer.length * 8);
                 readStreamClosed = false;
             } catch (IOException ex) {
-                ex.printStackTrace();
+                Systems.printStackTrace(ex);
             }
         }
     }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/LongMap.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/LongMap.java
@@ -97,7 +97,7 @@ class LongMap extends AbstractLongMap {
                 try {
                     referenceList.putFirst(getReferencesPointer(),instanceId);
                 } catch (IOException ex) {
-                    ex.printStackTrace();
+                    Systems.printStackTrace(ex);
                 }
             }
         }
@@ -113,7 +113,7 @@ class LongMap extends AbstractLongMap {
                     return ref;
                 }
             } catch (IOException ex) {
-                ex.printStackTrace();
+                Systems.printStackTrace(ex);
             }
             return 0L;
         }
@@ -137,7 +137,7 @@ class LongMap extends AbstractLongMap {
                     }
                 }
             } catch (IOException ex) {
-                ex.printStackTrace();
+                Systems.printStackTrace(ex);
             }
         }
         
@@ -154,7 +154,7 @@ class LongMap extends AbstractLongMap {
                 try {
                     return referenceList.getNumbersIterator(ref);
                 } catch (IOException ex) {
-                    ex.printStackTrace();
+                    Systems.printStackTrace(ex);
                 }
             }
             return LongIterator.EMPTY_ITERATOR;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NearestGCRoot.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NearestGCRoot.java
@@ -109,7 +109,7 @@ class NearestGCRoot {
                 computeOneLevel(processedClasses);
             } while (hasMoreLevels());
         } catch (IOException ex) {
-            ex.printStackTrace();
+            Systems.printStackTrace(ex);
         }
 
         deleteBuffers();
@@ -190,7 +190,7 @@ class NearestGCRoot {
                 fieldValues = instance.getFieldValues();
             } else {
                 if (instance == null) {
-                    System.err.println("HeapWalker Warning - null instance for " + heap.dumpBuffer.getID(instanceOffset + 1)); // NOI18N
+                    Systems.debug("HeapWalker Warning - null instance for " + heap.dumpBuffer.getID(instanceOffset + 1)); // NOI18N
                     continue;
                 }
                 throw new IllegalArgumentException("Illegal type " + instance.getClass()); // NOI18N
@@ -371,10 +371,10 @@ class NearestGCRoot {
 
     LongBuffer getLeaves() {
         computeGCRoots();
-//System.out.println("Multi par.  "+multiParentsCount);
-//System.out.println("Leaves      "+leavesCount);
-//System.out.println("Tree obj.   "+heap.idToOffsetMap.treeObj);
-//System.out.println("First level "+firstLevel);
+//Systems.debug("Multi par.  "+multiParentsCount);
+//Systems.debug("Leaves      "+leavesCount);
+//Systems.debug("Tree obj.   "+heap.idToOffsetMap.treeObj);
+//Systems.debug("First level "+firstLevel);
         return leaves;
     }
     

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NearestGCRoot.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NearestGCRoot.java
@@ -90,7 +90,7 @@ class NearestGCRoot {
         if (gcRootsComputed) {
             return;
         }
-        HeapProgress.progressStart();
+        Progress.Handle handle = Progress.COMPUTE_GC_ROOTS.start();
         if (!initHotSpotReference()) {
             if (!initSVMReference()) {
                 throw new IllegalArgumentException("reference field not found"); // NOI18N
@@ -106,7 +106,7 @@ class NearestGCRoot {
 
             do {
                 switchBuffers();
-                computeOneLevel(processedClasses);
+                computeOneLevel(processedClasses, handle);
             } while (hasMoreLevels());
         } catch (IOException ex) {
             Systems.printStackTrace(ex);
@@ -116,7 +116,7 @@ class NearestGCRoot {
         heap.idToOffsetMap.flush();
         gcRootsComputed = true;
         heap.writeToFile();
-        HeapProgress.progressFinish();
+        handle.close();
     }
 
     private boolean initHotSpotReference() {
@@ -148,7 +148,7 @@ class NearestGCRoot {
         return false;
     }
 
-    private void computeOneLevel(Set processedClasses) throws IOException {
+    private void computeOneLevel(Set processedClasses, Progress.Handle handle) throws IOException {
         int idSize = heap.dumpBuffer.getIDSize();
         for (;;) {
             Instance instance;
@@ -160,7 +160,7 @@ class NearestGCRoot {
             if (instanceOffset == 0L) { // end of level
                 break;
             }
-            HeapProgress.progress(processedInstances++,allInstances);
+            handle.progress(processedInstances++,allInstances);
             instance = heap.getInstanceByOffset(new long[] {instanceOffset});
             if (instance instanceof ObjectArrayInstance) {
                 ObjectArrayDump array = (ObjectArrayDump) instance;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NumberList.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NumberList.java
@@ -148,7 +148,7 @@ class NumberList {
             }
             offset = getOffsetToNextBlock(block);
             if (offset == 0L) {
-                System.out.println("Error - number not found at end");
+                Systems.debug("Error - number not found at end");
                 return;
             }
         }
@@ -190,7 +190,7 @@ class NumberList {
                 mappedSize = Math.min(blockSize*blocks, Integer.MAX_VALUE-blockSize+1);
                 buf = data.mmap(FileChannel.MapMode.READ_WRITE, mappedSize, false);
             } catch (IOException ex) {
-                ex.printStackTrace();
+                Systems.printStackTrace(ex);
             }
         }
     }
@@ -201,7 +201,7 @@ class NumberList {
             blockCache.clear();
             mmapData();
         } catch (IOException ex) {
-            ex.printStackTrace();
+            Systems.printStackTrace(ex);
         }
     }
     
@@ -373,7 +373,7 @@ class NumberList {
                 try {
                     nextNumber();
                 } catch (IOException ex) {
-                    ex.printStackTrace();
+                    Systems.printStackTrace(ex);
                     nextNumber = 0;
                 }
                 return num;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NumberList.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NumberList.java
@@ -21,10 +21,8 @@ package org.netbeans.lib.profiler.heap;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
-import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.MappedByteBuffer;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,7 +46,7 @@ class NumberList {
     private final Map/*offset,block*/ blockCache;
     private final Set dirtyBlocks;
     private long blocks;
-    private MappedByteBuffer buf;
+    private ByteBuffer buf;
     private long mappedSize;
     private CacheDirectory cacheDirectory;
     
@@ -190,7 +188,7 @@ class NumberList {
         if (buf == null) {
             try {
                 mappedSize = Math.min(blockSize*blocks, Integer.MAX_VALUE-blockSize+1);
-                buf = data.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, mappedSize);
+                buf = data.mmap(FileChannel.MapMode.READ_WRITE, mappedSize, false);
             } catch (IOException ex) {
                 ex.printStackTrace();
             }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NumberList.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/NumberList.java
@@ -56,7 +56,7 @@ class NumberList {
     
     NumberList(int elSize, CacheDirectory cacheDir) throws IOException {
         dataFile = cacheDir.createTempFile("NBProfiler", ".ref"); // NOI18N
-        data = new RandomAccessFile(dataFile, "rw"); // NOI18N
+        data = dataFile.newRandomAccessFile("rw"); // NOI18N
         numberSize = elSize;
         blockCache = new BlockLRUCache();
         dirtyBlocks = new HashSet(100000);
@@ -338,7 +338,7 @@ class NumberList {
         
         cacheDirectory = cacheDir;
         dataFile = cacheDirectory.getCacheFile(dis.readUTF());
-        data = new RandomAccessFile(dataFile, "rw"); // NOI18N
+        data = dataFile.newRandomAccessFile("rw"); // NOI18N
         numberSize = dis.readInt();
         blocks = dis.readLong();
         mmaped = dis.readBoolean();

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/Progress.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/Progress.java
@@ -43,14 +43,18 @@ enum Progress {
         }
     }
 
-    synchronized static void notifyUpdates(Handle h, int type) {
+    private synchronized static void notifyUpdates(Handle h, Type type) {
         for (Listener onChange : listeners) {
             switch (type) {
-                case 1: onChange.started(h); break;
-                case 2: onChange.progress(h); break;
+                case STARTED: onChange.started(h); break;
+                case PROGRESS: onChange.progress(h); break;
                 default: onChange.finished(h);
             }
         }
+    }
+
+    private enum Type {
+        STARTED, PROGRESS, FINISHED;
     }
 
     static interface Listener {
@@ -67,7 +71,7 @@ enum Progress {
 
         private Handle(Progress type) {
             this.type = type;
-            notifyUpdates(this, 1);
+            notifyUpdates(this, Type.STARTED);
         }
 
         void progress(long value, long endValue) {
@@ -83,14 +87,14 @@ enum Progress {
 
         @Override
         public void close() {
-            notifyUpdates(this, 2);
+            notifyUpdates(this, Type.FINISHED);
         }
 
         private void doProgress(long value, long startOffset, long endOffset) {
             this.value = value;
             this.endOffset = endOffset;
             this.startOffset = startOffset;
-            notifyUpdates(this, 1);
+            notifyUpdates(this, Type.PROGRESS);
         }
 
         long getValue() {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/Progress.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/Progress.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.lib.profiler.heap;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+enum Progress {
+    COMPUTE_INSTANCES,
+    COMPUTE_REFERENCES,
+    FILL_HEAP_TAG_BOUNDS,
+    COMPUTE_GC_ROOTS;
+
+    Handle start() {
+        return new Handle(this);
+    }
+
+    private static List<Listener> listeners = Collections.emptyList();
+    synchronized static void register(Listener onChange) {
+        if (listeners.isEmpty()) {
+            listeners = Collections.singletonList(onChange);
+        } else {
+            List<Listener> copy = new ArrayList<>(listeners);
+            copy.add(onChange);
+            listeners = copy;
+        }
+    }
+
+    synchronized static void notifyUpdates(Handle h, int type) {
+        for (Listener onChange : listeners) {
+            switch (type) {
+                case 1: onChange.started(h); break;
+                case 2: onChange.progress(h); break;
+                default: onChange.finished(h);
+            }
+        }
+    }
+
+    static interface Listener {
+        void started(Handle h);
+        void progress(Handle h);
+        void finished(Handle h);
+    }
+
+    static final class Handle implements AutoCloseable {
+        final Progress type;
+        private long value;
+        private long startOffset;
+        private long endOffset;
+
+        private Handle(Progress type) {
+            this.type = type;
+            notifyUpdates(this, 1);
+        }
+
+        void progress(long value, long endValue) {
+            progress(value, 0, value, endValue);
+        }
+
+        void progress(long counter, long startOffset, long value, long endOffset) {
+            // keep this method short so that it can be inlined
+            if (counter % 100000 == 0) {
+                doProgress(value, startOffset, endOffset);
+            }
+        }
+
+        @Override
+        public void close() {
+            notifyUpdates(this, 2);
+        }
+
+        private void doProgress(long value, long startOffset, long endOffset) {
+            this.value = value;
+            this.endOffset = endOffset;
+            this.startOffset = startOffset;
+            notifyUpdates(this, 1);
+        }
+
+        long getValue() {
+            return value;
+        }
+
+        long getStartOffset() {
+            return startOffset;
+        }
+
+        long getEndOffset() {
+            return endOffset;
+        }
+    }
+}

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/RandomAccessFile.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/RandomAccessFile.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.lib.profiler.heap;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+final class RandomAccessFile {
+    private final java.io.RandomAccessFile delegate;
+
+    RandomAccessFile(File file, String mode) throws FileNotFoundException {
+        this.delegate = new java.io.RandomAccessFile(file.delegate, mode);
+    }
+
+    long length() throws IOException {
+        return delegate.length();
+    }
+
+    void write(byte[] arr) throws IOException {
+        delegate.write(arr);
+    }
+
+    void write(byte[] arr, int off, int len) throws IOException {
+        delegate.write(arr, off, len);;
+    }
+
+    void setLength(long fileSize) throws IOException {
+        delegate.setLength(fileSize);
+    }
+
+    void seek(long newOffset) throws IOException {
+        delegate.seek(newOffset);
+    }
+
+    void readFully(byte[] buf, int off, int len) throws IOException {
+        delegate.readFully(buf, off, len);
+    }
+
+    void readFully(byte[] buf) throws IOException {
+        delegate.readFully(buf);
+    }
+
+    long readLong() throws IOException {
+        return delegate.readLong();
+    }
+
+    ByteBuffer mmap(FileChannel.MapMode mode, long size, boolean close) throws IOException {
+        FileChannel ch = delegate.getChannel();
+        try {
+            return ch.map(mode, 0, size);
+        } finally {
+            if (close) {
+                ch.close();
+            }
+        }
+    }
+
+    ByteBuffer[] mmapAsBuffers(FileChannel.MapMode mode, long length, long BUFFER_SIZE, long BUFFER_EXT) throws IOException {
+        try (FileChannel channel = delegate.getChannel()) {
+            ByteBuffer[] dumpBuffer = new ByteBuffer[(int) (((length + BUFFER_SIZE) - 1) / BUFFER_SIZE)];
+            for (int i = 0; i < dumpBuffer.length; i++) {
+                long position = i * BUFFER_SIZE;
+                long size = Math.min(BUFFER_SIZE + BUFFER_EXT, length - position);
+                dumpBuffer[i] = channel.map(mode, position, size);
+            }
+            return dumpBuffer;
+        }
+    }
+}

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/RandomAccessFile.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/RandomAccessFile.java
@@ -18,70 +18,19 @@
  */
 package org.netbeans.lib.profiler.heap;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
-final class RandomAccessFile {
-    private final java.io.RandomAccessFile delegate;
-
-    RandomAccessFile(File file, String mode) throws FileNotFoundException {
-        this.delegate = new java.io.RandomAccessFile(file.delegate, mode);
-    }
-
-    long length() throws IOException {
-        return delegate.length();
-    }
-
-    void write(byte[] arr) throws IOException {
-        delegate.write(arr);
-    }
-
-    void write(byte[] arr, int off, int len) throws IOException {
-        delegate.write(arr, off, len);;
-    }
-
-    void setLength(long fileSize) throws IOException {
-        delegate.setLength(fileSize);
-    }
-
-    void seek(long newOffset) throws IOException {
-        delegate.seek(newOffset);
-    }
-
-    void readFully(byte[] buf, int off, int len) throws IOException {
-        delegate.readFully(buf, off, len);
-    }
-
-    void readFully(byte[] buf) throws IOException {
-        delegate.readFully(buf);
-    }
-
-    long readLong() throws IOException {
-        return delegate.readLong();
-    }
-
-    ByteBuffer mmap(FileChannel.MapMode mode, long size, boolean close) throws IOException {
-        FileChannel ch = delegate.getChannel();
-        try {
-            return ch.map(mode, 0, size);
-        } finally {
-            if (close) {
-                ch.close();
-            }
-        }
-    }
-
-    ByteBuffer[] mmapAsBuffers(FileChannel.MapMode mode, long length, long BUFFER_SIZE, long BUFFER_EXT) throws IOException {
-        try (FileChannel channel = delegate.getChannel()) {
-            ByteBuffer[] dumpBuffer = new ByteBuffer[(int) (((length + BUFFER_SIZE) - 1) / BUFFER_SIZE)];
-            for (int i = 0; i < dumpBuffer.length; i++) {
-                long position = i * BUFFER_SIZE;
-                long size = Math.min(BUFFER_SIZE + BUFFER_EXT, length - position);
-                dumpBuffer[i] = channel.map(mode, position, size);
-            }
-            return dumpBuffer;
-        }
-    }
+abstract class RandomAccessFile {
+    abstract long length() throws IOException;
+    abstract void write(byte[] arr) throws IOException;
+    abstract void write(byte[] arr, int off, int len) throws IOException;
+    abstract void setLength(long fileSize) throws IOException;
+    abstract void seek(long newOffset) throws IOException;
+    abstract void readFully(byte[] buf, int off, int len) throws IOException;
+    abstract void readFully(byte[] buf) throws IOException;
+    abstract long readLong() throws IOException;
+    abstract ByteBuffer mmap(FileChannel.MapMode mode, long size, boolean close) throws IOException;
+    abstract ByteBuffer[] mmapAsBuffers(FileChannel.MapMode mode, long length, long BUFFER_SIZE, long BUFFER_EXT) throws IOException;
 }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StackFrameSegment.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StackFrameSegment.java
@@ -114,7 +114,7 @@ class StackFrameSegment extends TagBounds {
                     idToFrame.put(frameIDMask, new Long(start));
                 }
             }
-//            System.out.println("idToFrame size:"+idToFrame.size());
+//            Systems.debug("idToFrame size:"+idToFrame.size());
         }
     }
     

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StackTraceSegment.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StackTraceSegment.java
@@ -107,7 +107,7 @@ class StackTraceSegment extends TagBounds {
                     serialNumToStackTrace.put(serialNumberMask, new Long(start));
                 }
             }
-//            System.out.println("serialNumToStackTrace size:"+serialNumToStackTrace.size());
+//            Systems.debug("serialNumToStackTrace size:"+serialNumToStackTrace.size());
         }
     }
 }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StringSegment.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/StringSegment.java
@@ -84,7 +84,7 @@ class StringSegment extends TagBounds {
         try {
             s = new String(chars, "UTF-8"); // NOI18N
         } catch (UnsupportedEncodingException ex) {
-            ex.printStackTrace();
+            Systems.printStackTrace(ex);
         }
 
         return s;

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/Systems.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/Systems.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.lib.profiler.heap;
+
+final class Systems {
+
+    //~ Static fields/initializers -----------------------------------------------------------------------------------------------
+    static final boolean DEBUG = false;
+
+    static boolean isLinux() {
+        String osName = System.getProperty("os.name"); // NOI18N
+        return osName.endsWith("Linux"); // NOI18N
+    }
+
+    private Systems() {
+    }
+    
+    static void printStackTrace(Throwable t) {
+        t.printStackTrace();
+    }
+
+    static void printStackTrace(String msg, Throwable t) {
+        System.err.println(msg);
+        t.printStackTrace(System.err);
+    }
+
+    static void debug(String msg) {
+        System.err.println(msg);
+    }
+}

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/Systems.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/Systems.java
@@ -22,7 +22,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 final class Systems {
-    private static final Logger LOG = Logger.getLogger(System.class.getPackage().getName());
+    private static final Logger LOG = Logger.getLogger(Systems.class.getName());
     static final boolean DEBUG = LOG.isLoggable(Level.FINE);
 
     static boolean isLinux() {

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/Systems.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/Systems.java
@@ -18,10 +18,12 @@
  */
 package org.netbeans.lib.profiler.heap;
 
-final class Systems {
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-    //~ Static fields/initializers -----------------------------------------------------------------------------------------------
-    static final boolean DEBUG = false;
+final class Systems {
+    private static final Logger LOG = Logger.getLogger(System.class.getPackage().getName());
+    static final boolean DEBUG = LOG.isLoggable(Level.FINE);
 
     static boolean isLinux() {
         String osName = System.getProperty("os.name"); // NOI18N
@@ -32,15 +34,14 @@ final class Systems {
     }
     
     static void printStackTrace(Throwable t) {
-        t.printStackTrace();
+        printStackTrace(null, t);
     }
 
     static void printStackTrace(String msg, Throwable t) {
-        System.err.println(msg);
-        t.printStackTrace(System.err);
+        LOG.log(Level.FINE, msg, t);
     }
 
     static void debug(String msg) {
-        System.err.println(msg);
+        LOG.log(Level.FINE, msg);
     }
 }

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/TreeObject.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/TreeObject.java
@@ -59,14 +59,14 @@ class TreeObject {
             do {
                 switchBuffers();
                 changed = computeOneLevel();
-//System.out.println("Tree obj.   "+heap.idToOffsetMap.treeObj);
-//if (changed) System.out.println("Next level  "+nextLevelSize);
+//Systems.debug("Tree obj.   "+heap.idToOffsetMap.treeObj);
+//if (changed) Systems.debug("Next level  "+nextLevelSize);
             } while (changed);
         } catch (IOException ex) {
-            ex.printStackTrace();
+            Systems.printStackTrace(ex);
         }
         deleteBuffers();
-//System.out.println("Done!");
+//Systems.debug("Done!");
     }
     
     private boolean computeOneLevel() throws IOException {
@@ -109,7 +109,7 @@ class TreeObject {
                 fieldValues = instance.getFieldValues();
             } else {
                 if (instance == null) {
-                    System.err.println("HeapWalker Warning - null instance for " + instanceId); // NOI18N
+                    Systems.debug("HeapWalker Warning - null instance for " + instanceId); // NOI18N
                     continue;
                 }
                 throw new IllegalArgumentException("Illegal type " + instance.getClass()); // NOI18N


### PR DESCRIPTION
In the quest to [make the Heap library work without file access](https://github.com/apache/netbeans/pull/3148) I am refactoring the code logic to be `java.io.File` and `java.io.RandomAccessFile` free. The commit a69dca3 creates two package private classes `File` and `RandomAccessFile` (naming is chosen to minimize the size of the diff) and moves all the I/O code into them. The rest of the code stays untouched as much as possible.

There are other two <!-- GR-30646 & GR-30645 -->problems:
*  lib.profiler is calling into `SwingUtilities.invokeLater` - eliminated by ab8b1e5 - the idea is to keep compatibility of `HeapProgress`, but unless somebody (e.g. a Swing UI of profiler) calls it, the class is not going to initialize
*  lib.profiler is using `ex.printStackTrace()` - 1998eb2  solves it the same way as I/O access - e.g. by moving the calls into `Systems` package private class