### PR TITLE
ConvertTextBlockToString warning should be a hint/suggestion

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertTextBlockToString.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertTextBlockToString.java
@@ -28,6 +28,7 @@ import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.lexer.TokenSequence;
 import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.Fix;
+import org.netbeans.spi.editor.hints.Severity;
 import org.netbeans.spi.java.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.java.hints.Hint;
 import org.netbeans.spi.java.hints.HintContext;
@@ -35,15 +36,15 @@ import org.netbeans.spi.java.hints.JavaFix;
 import org.netbeans.spi.java.hints.TriggerTreeKind;
 import org.openide.util.NbBundle.Messages;
 
-@Hint(displayName = "#DN_ConvertTextBlockToString", description = "#DESC_ConvertTextBlockToString", category = "general", minSourceVersion = "13")
+@Hint(displayName = "#DN_ConvertTextBlockToString", description = "#DESC_ConvertTextBlockToString", category = "suggestions", minSourceVersion = "13", hintKind = Hint.Kind.ACTION, severity = Severity.HINT)
 @Messages({
     "DN_ConvertTextBlockToString=Convert Text block to String",
-    "DESC_ConvertTextBlockToString=Text Block may not be supported in older versions of java older then 13"
+    "DESC_ConvertTextBlockToString=Converts java 15 Text Blocks back to regular Strings."
 })
 public class ConvertTextBlockToString {
 
     @TriggerTreeKind(Tree.Kind.STRING_LITERAL)
-    @Messages("ERR_ConvertTextBlockToString=Text block may not be supported")//NOI18N
+    @Messages("ERR_ConvertTextBlockToString=Text block can be converted to String")//NOI18N
     public static ErrorDescription computeWarning(HintContext ctx) {
         TokenSequence<?> ts = ctx.getInfo().getTokenHierarchy().tokenSequence();
         if (ts == null) {


### PR DESCRIPTION
Text Blocks are in java since 15. Converted the inspection into a hint so that it doesn't show up as warning and moved it to the suggestion category.