### PR TITLE
Return a copy instead of cached array

### DIFF
--- a/ide/api.java.classpath/src/org/netbeans/api/java/classpath/ClassPath.java
+++ b/ide/api.java.classpath/src/org/netbeans/api/java/classpath/ClassPath.java
@@ -241,7 +241,7 @@ public final class ClassPath {
         long current;
         synchronized (this) {
             if (rootsCache != null) {
-                return this.rootsCache;
+                return rootsCache.clone();
             }
             current = this.invalidRoots;
         }
@@ -256,9 +256,9 @@ public final class ClassPath {
                 if (rootsCache == null || rootsListener == null) {
                     attachRootsListener();
                     listenOnRoots(rootPairs);
-                    this.rootsCache = roots;
+                    this.rootsCache = roots.clone();
                 } else {
-                    roots = this.rootsCache;
+                    roots = rootsCache.clone();
                 }
             }
         }


### PR DESCRIPTION
During some implementation I've mindlessly modified the result of `ClassPath.getRoots()` call ... and then spent more than 5 hours by hunting down the bug since it wasn't originally obvious, but "sometimes" the parser stopped to resolving symbols against the classpath. "sometimes" = when the added (debugging) code run and modified the ClassPath caches for all IDE.
I think making the code fool-proof is worth the array-copy overhead...