### PR TITLE
Add Collection/Map.size() > 0 case to isEmpty() refactoring.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/perf/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/perf/Bundle.properties
@@ -23,14 +23,16 @@ FIX_manual-array-copy-coll=Replace with Collection.addAll(Arrays.asList(...))
 ERR_manual-array-copy=Manual array copy
 FIX_manual-array-copy=Replace with System.arraycopy
 
-DN_org.netbeans.modules.java.hints.perf.SizeEqualsZero=Usage of .size() == 0
-DESC_org.netbeans.modules.java.hints.perf.SizeEqualsZero=Use .isEmpty() or !.isEmpty() instead of .size() == 0 or .size() != 0 where possible.
-ERR_SizeEqualsZero=Usage of .size() == 0 can be replaced with .isEmpty()
-ERR_SizeEqualsZeroNeg=Usage of .size() != 0 can be replaced with !.isEmpty()
-FIX_UseIsEmpty=Use .isEmpty() instead of .size() == 0
-FIX_UseIsEmptyNeg=Use .isEmpty() instead of .size() != 0
-LBL_org.netbeans.modules.java.hints.perf.SizeEqualsZero.CHECK_NOT_EQUALS=Also check for .size() != 0
-TP_org.netbeans.modules.java.hints.perf.SizeEqualsZero.CHECK_NOT_EQUALS=Should this hint also report occurrences of ".size() != 0"?
+DN_org.netbeans.modules.java.hints.perf.SizeEqualsZero=Usage of [Collection|Map].size() == 0
+DESC_org.netbeans.modules.java.hints.perf.SizeEqualsZero=Use [Collection|Map].isEmpty() instead of .size() == 0 and !.isEmpty() instead of .size() != 0 or .size() > 0 where possible.
+ERR_SizeEqualsZero={0}.size() == 0 can be replaced with {0}.isEmpty()
+ERR_SizeEqualsZeroNeg={0}.size() != 0 can be replaced with !{0}.isEmpty()
+ERR_SizeGreaterZeroNeg={0}.size() > 0 can be replaced with !{0}.isEmpty()
+FIX_SizeEqualsZero=Change to {0}.isEmpty()
+FIX_SizeEqualsZeroNeg=Change to !{0}.isEmpty()
+FIX_SizeGreaterZeroNeg=Change to !{0}.isEmpty()
+LBL_org.netbeans.modules.java.hints.perf.SizeEqualsZero.CHECK_NOT_EQUALS=Also check for .size() != 0 and .size() > 0
+TP_org.netbeans.modules.java.hints.perf.SizeEqualsZero.CHECK_NOT_EQUALS=Should this hint also report occurrences of ".size() != 0" and ".size() > 0"?
 
 DN_org.netbeans.modules.java.hints.perf.Tiny.stringConstructor=String constructor
 DESC_org.netbeans.modules.java.hints.perf.Tiny.stringConstructor=Use of java.lang.String constructor is usually useless.

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/Bundle_test.properties
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/Bundle_test.properties
@@ -23,8 +23,10 @@ FIX_manual-array-copy=FIX_manual-array-copy
 ERR_StringConstructor=new String(...)
 ERR_SizeEqualsZero=.size() == 0
 ERR_SizeEqualsZeroNeg=.size() != 0
-FIX_UseIsEmpty=.size() == 0 => .isEmpty()
-FIX_UseIsEmptyNeg=.size() != 0 => !.isEmpty()
+ERR_SizeGreaterZeroNeg=.size() > 0
+FIX_SizeEqualsZero=.size() == 0 => .isEmpty()
+FIX_SizeEqualsZeroNeg=.size() != 0 => !.isEmpty()
+FIX_SizeGreaterZeroNeg=.size() > 0 => !.isEmpty()
 ERR_StringConstructor=new String(...)
 FIX_StringConstructor=Remove new String(...)
 ERR_StringEqualsEmpty=$string.equals("")

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/SizeEqualsZeroTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/SizeEqualsZeroTest.java
@@ -30,7 +30,7 @@ import org.netbeans.modules.java.hints.test.api.HintTest.HintOutput;
 public class SizeEqualsZeroTest {
 
     @Test
-    public void testSimple1() throws Exception {
+    public void testEqualsZero() throws Exception {
         final HintOutput output = HintTest.create()
                 .input("test/Test.java",
                        "package test;\n" +
@@ -67,7 +67,7 @@ public class SizeEqualsZeroTest {
     }
 
     @Test
-    public void testSimple2() throws Exception {
+    public void testNotEqualsZero() throws Exception {
         final HintOutput output = HintTest.create()
                 .input("package test;\n" +
                        "import java.util.List;" +
@@ -104,6 +104,43 @@ public class SizeEqualsZeroTest {
     }
 
     @Test
+    public void testGreaterZero() throws Exception {
+        final HintOutput output = HintTest.create()
+                .input("package test;\n" +
+                       "import java.util.List;" +
+                       "public class Test {\n" +
+                       "     private void test(List l) {\n" +
+                       "         boolean b = l.size() > 0;\n" +
+                       "         boolean b2 = 0 < l.size();\n" +
+                       "     }\n" +
+                       "}\n")
+                .preference(SizeEqualsZero.CHECK_NOT_EQUALS, true)
+                .run(SizeEqualsZero.class);
+        output.findWarning("3:21-3:33:verifier:.size() > 0")
+                .applyFix()
+                .assertCompilable()
+                .assertOutput("package test;\n" +
+                        "import java.util.List;" +
+                        "public class Test {\n" +
+                        "     private void test(List l) {\n" +
+                        "         boolean b = !l.isEmpty();\n" +
+                        "         boolean b2 = 0 < l.size();\n" +
+                        "     }\n" +
+                        "}\n");
+        output.findWarning("4:22-4:34:verifier:.size() > 0")
+                .applyFix()
+                .assertCompilable()
+                .assertOutput("package test;\n" +
+                        "import java.util.List;" +
+                        "public class Test {\n" +
+                        "     private void test(List l) {\n" +
+                        "         boolean b = !l.isEmpty();\n" +
+                        "         boolean b2 = !l.isEmpty();\n" +
+                        "     }\n" +
+                        "}\n");
+    }
+
+    @Test
     public void testCollection() throws Exception {
         final HintOutput output = HintTest.create()
                 .input("test/Test.java",
@@ -113,6 +150,7 @@ public class SizeEqualsZeroTest {
                        "     private void test() {\n" +
                        "         boolean b = size() == 0;\n" +
                        "         boolean b2 = 0 != size();\n" +
+                       "         boolean b3 = 0 < size();\n" +
                        "     }\n" +
                        "}\n")
                 .run(SizeEqualsZero.class);
@@ -125,6 +163,7 @@ public class SizeEqualsZeroTest {
                        "     private void test() {\n" +
                        "         boolean b = isEmpty();\n" +
                        "         boolean b2 = 0 != size();\n" +
+                       "         boolean b3 = 0 < size();\n" +
                        "     }\n" +
                        "}\n");
         output.findWarning("4:22-4:33:verifier:.size() != 0")
@@ -136,6 +175,19 @@ public class SizeEqualsZeroTest {
                        "     private void test() {\n" +
                        "         boolean b = isEmpty();\n" +
                        "         boolean b2 = !isEmpty();\n" +
+                       "         boolean b3 = 0 < size();\n" +
+                       "     }\n" +
+                       "}\n");
+        output.findWarning("5:22-5:32:verifier:.size() > 0")
+                .applyFix()
+                .assertCompilable()
+                .assertOutput("package test;\n" +
+                       "import java.util.ArrayList;" +
+                       "public class Test extends ArrayList {\n" +
+                       "     private void test() {\n" +
+                       "         boolean b = isEmpty();\n" +
+                       "         boolean b2 = !isEmpty();\n" +
+                       "         boolean b3 = !isEmpty();\n" +
                        "     }\n" +
                        "}\n");
     }
@@ -150,6 +202,7 @@ public class SizeEqualsZeroTest {
                        "     private void test() {\n" +
                        "         boolean b = size() == 0;\n" +
                        "         boolean b2 = 0 != size();\n" +
+                       "         boolean b3 = size() > 0;\n" +
                        "     }\n" +
                        "}\n")
                 .run(SizeEqualsZero.class);
@@ -162,6 +215,7 @@ public class SizeEqualsZeroTest {
                        "     private void test() {\n" +
                        "         boolean b = isEmpty();\n" +
                        "         boolean b2 = 0 != size();\n" +
+                       "         boolean b3 = size() > 0;\n" +
                        "     }\n" +
                        "}\n");
         output.findWarning("4:22-4:33:verifier:.size() != 0")
@@ -173,6 +227,19 @@ public class SizeEqualsZeroTest {
                        "     private void test() {\n" +
                        "         boolean b = isEmpty();\n" +
                        "         boolean b2 = !isEmpty();\n" +
+                       "         boolean b3 = size() > 0;\n" +
+                       "     }\n" +
+                       "}\n");
+        output.findWarning("5:22-5:32:verifier:.size() > 0")
+                .applyFix()
+                .assertCompilable()
+                .assertOutput("package test;\n" +
+                       "import java.util.HashMap;" +
+                       "public class Test extends HashMap {\n" +
+                       "     private void test() {\n" +
+                       "         boolean b = isEmpty();\n" +
+                       "         boolean b2 = !isEmpty();\n" +
+                       "         boolean b3 = !isEmpty();\n" +
                        "     }\n" +
                        "}\n");
     }
@@ -193,6 +260,11 @@ public class SizeEqualsZeroTest {
                        "     public boolean isEmpty() {\n" +
                        "         return !(0 != size());\n" +
                        "     }\n" +
+                       "}\n" +
+                       "class EntirelyDifferentTest extends HashMap {\n" +
+                       "     public boolean isEmpty() {\n" +
+                       "         return !(0 < size());\n" +
+                       "     }\n" +
                        "}\n")
                 .run(SizeEqualsZero.class)
                 .assertWarnings();
@@ -207,6 +279,7 @@ public class SizeEqualsZeroTest {
                        "     private void test(List l) {\n" +
                        "         boolean b = l.size() != 0;\n" +
                        "         boolean b2 = 0 != l.size();\n" +
+                       "         boolean b3 = 0 < l.size();\n" +
                        "     }\n" +
                        "}\n")
                 .preference(SizeEqualsZero.CHECK_NOT_EQUALS, false)


### PR DESCRIPTION
SizeEqualsZero perf inspection currently only triggers on size() == 0 and size() != 0. Added the case for size() > 0 which I sometimes encounter in the wild.
 + size() > 0 case is handled like the size() != 0 case in the UI (same check box)
 + updated the warning/fix/desc text accordingly and made it a little bit more dynamic