### PR TITLE
Performance: groovy loads classes using FileSystems

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/GroovyIndexer.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/GroovyIndexer.java
@@ -18,7 +18,6 @@
  */
 package org.netbeans.modules.groovy.editor.api;
 
-import groovy.transform.PackageScope;
 import groovyjarjarasm.asm.Opcodes;
 import java.io.IOException;
 import java.net.URL;
@@ -41,15 +40,15 @@ import org.openide.filesystems.FileObject;
 import org.openide.util.Exceptions;
 import java.util.logging.Logger;
 import java.util.logging.Level;
-import org.codehaus.groovy.ast.ClassHelper;
-import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
 import org.netbeans.modules.csl.api.Modifier;
 import org.netbeans.modules.groovy.editor.api.lexer.LexUtilities;
 import org.netbeans.modules.groovy.editor.api.elements.ast.ASTField;
 import org.netbeans.modules.groovy.editor.api.elements.ast.ASTMethod;
 import org.netbeans.modules.groovy.editor.compiler.ClassNodeCache;
+import org.netbeans.modules.groovy.editor.compiler.PerfData;
 import org.netbeans.modules.groovy.editor.utils.GroovyUtils;
+
 import org.netbeans.modules.parsing.spi.indexing.EmbeddingIndexer;
 import org.netbeans.modules.parsing.spi.indexing.EmbeddingIndexerFactory;
 import org.netbeans.modules.parsing.spi.indexing.support.IndexDocument;
@@ -140,6 +139,8 @@ public class GroovyIndexer extends EmbeddingIndexer {
         long indexerThisStopTime = System.currentTimeMillis();
         long indexerThisRunTime = indexerThisStopTime - indexerThisStartTime;
         indexerRunTime += indexerThisRunTime;
+        
+        PerfData.global.addPerfCounter("Indexer time", indexerThisRunTime);
 
         LOG.log(Level.FINEST, "Indexed File                : {0}", r.getSnapshot().getSource().getFileObject());
         LOG.log(Level.FINEST, "Indexing time (ms)          : {0}", indexerThisRunTime);
@@ -229,11 +230,14 @@ public class GroovyIndexer extends EmbeddingIndexer {
                 return false;
             }
             ClassNodeCache.createThreadLocalInstance();
+            PerfData.global.clear();
             return super.scanStarted(context);
         }
 
         @Override
-        public void scanFinished(Context context) {            
+        public void scanFinished(Context context) {
+            PerfData.LOG.finer("***** Indexing statistics");
+            PerfData.global.dumpStatsAndMerge();
             ClassNodeCache.clearThreadLocalInstance();
             super.scanFinished(context);
         }

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
 import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -35,15 +35,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.BadLocationException;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.CompileUnit;
-import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.ModuleNode;
-import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.ErrorCollector;
@@ -72,7 +71,10 @@ import org.netbeans.modules.groovy.editor.compiler.error.GroovyError;
 import org.netbeans.modules.groovy.editor.utils.GroovyUtils;
 import org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId;
 import org.netbeans.modules.groovy.editor.api.lexer.LexUtilities;
+import org.netbeans.modules.groovy.editor.compiler.ClassNodeCache.ParsingClassLoader;
 import org.netbeans.modules.groovy.editor.compiler.ParsingCompilerCustomizer;
+import org.netbeans.modules.groovy.editor.compiler.PerfData;
+import org.netbeans.modules.groovy.editor.compiler.PerfStatCompilationUnit;
 import org.netbeans.modules.groovy.editor.compiler.SimpleTransformationCustomizer;
 import org.netbeans.modules.groovy.editor.compiler.error.CompilerErrorResolver;
 import org.netbeans.modules.parsing.api.Snapshot;
@@ -83,6 +85,7 @@ import org.netbeans.modules.parsing.spi.SourceModificationEvent;
 import org.netbeans.modules.parsing.spi.indexing.support.IndexingSupport;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 
@@ -141,6 +144,8 @@ public class GroovyParser extends Parser {
         assert lastResult != null : "getResult() called prior parse()"; //NOI18N
         return lastResult;
     }
+    
+    static Map<Integer, Long>    phaseCounters = new HashMap<>();
 
     @Override
     public void parse(Snapshot snapshot, Task task, SourceModificationEvent event) throws ParseException {
@@ -163,7 +168,17 @@ public class GroovyParser extends Parser {
                 errors.add(error);
             }
         };
-        lastResult = parseBuffer(context, Sanitize.NONE);
+        long t1 = System.currentTimeMillis();
+        try {
+            lastResult = parseBuffer(context, Sanitize.NONE);        
+        } catch (Throwable t) {
+            LOG.log(Level.SEVERE, "Error during parsing: ", t);
+        }
+        
+        long t2 = System.currentTimeMillis();
+        context.perfData.addPerfCounter("Total parsing time", t2 - t1);
+        context.perfData.dumpStatsAndMerge();
+
         if (lastResult != null) {
             lastResult.setErrors(errors);
         } else {
@@ -485,13 +500,12 @@ public class GroovyParser extends Parser {
      * Provides special processing: injects {@link StaticTypeCheckingVisitor} in {@link Phases.INSTRUCTION_SELECTION}
      * compilation phase. Also overrides ErrorCollector implementation with {@link NbGroovyErrorCollector}.
      */
-    static class CU extends CompilationUnit {
-
+    static class CU extends PerfStatCompilationUnit {
         /**
          * Disable type attribution for indexing now.
          */
         final boolean indexing;
-
+        
         StaticTypesTransformation typesXform = new StaticTypesTransformation() {
             @Override
             protected StaticTypeCheckingVisitor newVisitor(SourceUnit unit, ClassNode node) {
@@ -499,20 +513,14 @@ public class GroovyParser extends Parser {
             }
         };
 
-        public CU(boolean indexing, GroovyParser parser, CompilerConfiguration configuration, CodeSource security, GroovyClassLoader loader, GroovyClassLoader transformationLoader, ClasspathInfo cpInfo, ClassNodeCache classNodeCache) {
-            super(parser, configuration, security, loader, transformationLoader, cpInfo, classNodeCache);
+        public CU(boolean indexing, GroovyParser parser, CompilerConfiguration configuration, CodeSource security, GroovyClassLoader loader, 
+                GroovyClassLoader transformationLoader, ClasspathInfo cpInfo, ClassNodeCache classNodeCache, boolean isIndexing, Snapshot snap, PerfData perfData) {
+            super(perfData, parser, configuration, security, loader, transformationLoader, cpInfo, classNodeCache, isIndexing, snap);
             this.indexing = indexing;
             this.errorCollector = new NbGroovyErrorCollector(configuration);
         }
-
-        public CU(boolean indexing, GroovyParser parser, CompilerConfiguration configuration, CodeSource security, GroovyClassLoader loader, GroovyClassLoader transformationLoader, ClasspathInfo cpInfo, ClassNodeCache classNodeCache, boolean isIndexing) {
-            super(parser, configuration, security, loader, transformationLoader, cpInfo, classNodeCache, isIndexing);
-            this.indexing = indexing;
-            this.errorCollector = new NbGroovyErrorCollector(configuration);
-        }
-
         /**
-         * Inject static compilation transofmrations; apply them in the
+         * Inject static compilation transformation; apply them in the
          *
          * @param phase
          * @throws CompilationFailedException
@@ -527,14 +535,14 @@ public class GroovyParser extends Parser {
                 return;
             }
             typesXform.setCompilationUnit(this);
-            ClassNode annoClass = getClassNodeResolver().resolveName("groovy.transform.TypeChecked", this).getClassNode();
-            for (SourceUnit su : sources.values()) {
+            ClassNode annoClass = getClassNodeResolver().resolveName("groovy.transform.TypeChecked", this).getClassNode(); // NOI18N
+            runSourceVisitor("Parsing - static type analysis", (su) -> {    // NOI18N
                 for (ClassNode cn : su.getAST().getClasses()) {
                     AnnotationNode fakeTypeChecked = new AnnotationNode(annoClass);
                     cn.addAnnotation(fakeTypeChecked);
                     typesXform.visit(new ASTNode[]{fakeTypeChecked, cn}, su);
                 }
-            }
+            });
         }
     }
 
@@ -566,8 +574,10 @@ public class GroovyParser extends Parser {
         }
 
         String fileName = "";
+        String path = "";
         if (context.snapshot.getSource().getFileObject() != null) {
             fileName = context.snapshot.getSource().getFileObject().getNameExt();
+            path = context.snapshot.getSource().getFileObject().getPath();
         }
 
         FileObject fo = context.snapshot.getSource().getFileObject();
@@ -576,11 +586,13 @@ public class GroovyParser extends Parser {
         ClassPath sourcePath = fo == null ? ClassPath.EMPTY : ClassPath.getClassPath(fo, ClassPath.SOURCE);
         ClassPath transformPath = ClassPathSupport.createProxyClassPath(bootPath, compilePath);
         ClassPath cp = ClassPathSupport.createProxyClassPath(transformPath, sourcePath);
-
+        
         CompilerConfiguration configuration = new CompilerConfiguration();
         final ClassNodeCache classNodeCache = ClassNodeCache.get();
-        final GroovyClassLoader classLoader = classNodeCache.createResolveLoader(cp, configuration);
+        final ParsingClassLoader classLoader = classNodeCache.createResolveLoader(cp, configuration);
         final GroovyClassLoader transformationLoader = classNodeCache.createTransformationLoader(transformPath, configuration);
+
+        classNodeCache.setPerfData(context.perfData);
         ClasspathInfo cpInfo = ClasspathInfo.create(
                 // we should try to load everything by javac instead of classloader,
                 // but for now it is faster to use javac only for sources - not true
@@ -590,11 +602,28 @@ public class GroovyParser extends Parser {
                 compilePath == null ? ClassPath.EMPTY : compilePath,
                 sourcePath);        
         
+        if (LOG.isLoggable(Level.FINEST)) {
+            FileObject[] roots = cp.getRoots();
+            FileObject[] roots2 = new FileObject[roots.length];
+
+            for (int i = 0; i < roots.length; i++) {
+                if (FileUtil.isArchiveArtifact(roots[i])) {
+                    roots2[i] = FileUtil.getArchiveFile(roots[i]);
+                } else {
+                    roots2[i] = roots[i];
+                }
+            }
+            LOG.log(Level.FINEST, "Using compile path: {0}", 
+                    String.join("\n", Arrays.asList(roots2).stream().map(f -> "\t" + f.getPath()).collect(Collectors.toList()))
+            );
+        }
+
         boolean indexing = IndexingSupport.isIndexingTask(context.parserTask);
         configuration = makeConfiguration(configuration, context, indexing);
-        org.codehaus.groovy.control.CompilationUnit compilationUnit = new CU(indexing, this, configuration,
+        CU compilationUnit = new CU(indexing, this, configuration,
                 null, classLoader, transformationLoader, cpInfo, classNodeCache,
-                indexing);
+                indexing, context.snapshot, context.perfData);
+        classLoader.setUnit(compilationUnit);
         InputStream inputStream = new ByteArrayInputStream(source.getBytes());
         compilationUnit.addSource(fileName, inputStream);
         
@@ -738,7 +767,7 @@ public class GroovyParser extends Parser {
         }
 
         handleErrorCollector(compilationUnit.getErrorCollector(), context, module, ignoreErrors, sanitizing);
-
+        
         if (module != null) {
             context.sanitized = sanitizing;
             // FIXME parsing API
@@ -749,7 +778,7 @@ public class GroovyParser extends Parser {
             return sanitize(context, sanitizing);
         }
     }
-
+    
     private static void logParsingTime(Context context, long start, boolean cancelled) {
         long diff = System.currentTimeMillis() - start;
         long full = PARSING_TIME.addAndGet(diff);
@@ -904,6 +933,7 @@ public class GroovyParser extends Parser {
         private Sanitize sanitized = Sanitize.NONE;
         final List<ParsingCompilerCustomizer> compilerCustomizers;
         final ParsingCompilerCustomizer.Context customizerCtx;
+        final PerfData perfData = new PerfData();
 
         public Context(Snapshot snapshot, SourceModificationEvent event) {
             this.snapshot = snapshot;

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/NbClassNodeResolver.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/NbClassNodeResolver.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.compiler;
+
+import groovy.lang.GroovyClassLoader;
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Map;
+import org.codehaus.groovy.GroovyBugError;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.decompiled.AsmDecompiler;
+import org.codehaus.groovy.ast.decompiled.AsmReferenceResolver;
+import org.codehaus.groovy.ast.decompiled.ClassStub;
+import org.codehaus.groovy.ast.decompiled.DecompiledClassNode;
+import org.codehaus.groovy.classgen.Verifier;
+import org.codehaus.groovy.control.ClassNodeResolver;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.SourceUnit;
+
+/**
+ * A copy of {@link ClassNodeResolver}. I needed to use a different implementation of {@link #AsmReferenceResolver}, but
+ * it's used in a private method, so the call chain from the 1st public method up to that changed behaviour was copied.
+ * An alternative would be a protected factory method in Groovy.
+ * 
+ * @author sdedic
+ */
+public class NbClassNodeResolver extends ClassNodeResolver {
+    public LookupResult findClassNode(String name, org.codehaus.groovy.control.CompilationUnit compilationUnit) {
+        return tryAsLoaderClassOrScript(name, compilationUnit);
+    }
+
+    /**
+     * This method is used to realize the lookup of a class using the compilation
+     * unit class loader. Should no class be found we fall back to a script lookup.
+     * If a class is found we check if there is also a script and maybe use that
+     * one in case it is newer.<p/>
+     *
+     * Two class search strategies are possible: by ASM decompilation or by usual Java classloading.
+     * The latter is slower but is unavoidable for scripts executed in dynamic environments where
+     * the referenced classes might only be available in the classloader, not on disk.
+     */
+    private LookupResult tryAsLoaderClassOrScript(String name, org.codehaus.groovy.control.CompilationUnit compilationUnit) {
+        GroovyClassLoader loader = compilationUnit.getClassLoader();
+
+        Map<String, Boolean> options = compilationUnit.getConfiguration().getOptimizationOptions();
+        boolean useAsm = !Boolean.FALSE.equals(options.get("asmResolving"));
+        boolean useClassLoader = !Boolean.FALSE.equals(options.get("classLoaderResolving"));
+
+        LookupResult result = useAsm ? findDecompiled(name, compilationUnit, loader) : null;
+        if (result != null) {
+            return result;
+        }
+
+        if (!useClassLoader) {
+            return tryAsScript(name, compilationUnit, null);
+        }
+
+        return findByClassLoading(name, compilationUnit, loader);
+    }
+
+    /**
+     * Search for classes using class loading
+     */
+    private static LookupResult findByClassLoading(String name, org.codehaus.groovy.control.CompilationUnit compilationUnit, GroovyClassLoader loader) {
+        Class cls;
+        try {
+            // NOTE: it's important to do no lookup against script files
+            // here since the GroovyClassLoader would create a new CompilationUnit
+            cls = loader.loadClass(name, false, true);
+        } catch (ClassNotFoundException cnfe) {
+            LookupResult lr = tryAsScript(name, compilationUnit, null);
+            return lr;
+        } catch (CompilationFailedException cfe) {
+            throw new GroovyBugError("The lookup for " + name + " caused a failed compilation. There should not have been any compilation from this call.", cfe);
+        }
+        //TODO: the case of a NoClassDefFoundError needs a bit more research
+        // a simple recompilation is not possible it seems. The current class
+        // we are searching for is there, so we should mark that somehow.
+        // Basically the missing class needs to be completely compiled before
+        // we can again search for the current name.
+        /*catch (NoClassDefFoundError ncdfe) {
+            cachedClasses.put(name,SCRIPT);
+            return false;
+        }*/
+        if (cls == null) return null;
+        //NOTE: we might return false here even if we found a class,
+        //      because  we want to give a possible script a chance to
+        //      recompile. This can only be done if the loader was not
+        //      the instance defining the class.
+        ClassNode cn = ClassHelper.make(cls);
+        if (cls.getClassLoader() != loader) {
+            return tryAsScript(name, compilationUnit, cn);
+        }
+        return new LookupResult(null,cn);
+    }
+    
+    protected AsmReferenceResolver createReferencesResolver(org.codehaus.groovy.control.CompilationUnit unit) {
+        return new AsmReferenceResolver(this, unit);
+    }
+    
+    protected ClassStub parseClass(URL resource) throws IOException {
+        return AsmDecompiler.parseClass(resource);
+    }
+    
+    /**
+     * Search for classes using ASM decompiler
+     */
+    private LookupResult findDecompiled(String name, org.codehaus.groovy.control.CompilationUnit compilationUnit, GroovyClassLoader loader) {
+        ClassNode node = ClassHelper.make(name);
+        if (node.isResolved()) {
+            return new LookupResult(null, node);
+        }
+
+        DecompiledClassNode asmClass = null;
+        String fileName = name.replace('.', '/') + ".class";
+        URL resource = loader.getResource(fileName);
+        if (resource != null) {
+            try {
+                asmClass = new DecompiledClassNode(parseClass(resource), createReferencesResolver(compilationUnit));
+                if (!asmClass.getName().equals(name)) {
+                    // this may happen under Windows because getResource is case insensitive under that OS!
+                    asmClass = null;
+                }
+            } catch (IOException e) {
+                // fall through and attempt other search strategies
+            }
+        }
+
+        if (asmClass != null) {
+            if (isFromAnotherClassLoader(loader, fileName)) {
+                return tryAsScript(name, compilationUnit, asmClass);
+            }
+
+            return new LookupResult(null, asmClass);
+        }
+        return null;
+    }
+
+    private static boolean isFromAnotherClassLoader(GroovyClassLoader loader, String fileName) {
+        ClassLoader parent = loader.getParent();
+        return parent != null && parent.getResource(fileName) != null;
+    }
+
+    /**
+     * try to find a script using the compilation unit class loader.
+     */
+    private static LookupResult tryAsScript(String name, org.codehaus.groovy.control.CompilationUnit compilationUnit, ClassNode oldClass) {
+        LookupResult lr = null;
+        if (oldClass!=null) {
+            lr = new LookupResult(null, oldClass);
+        }
+        
+        if (name.startsWith("java.")) return lr;
+        //TODO: don't ignore inner static classes completely
+        if (name.indexOf('$') != -1) return lr;
+        
+        // try to find a script from classpath*/
+        GroovyClassLoader gcl = compilationUnit.getClassLoader();
+        URL url = null;
+        try {
+            url = gcl.getResourceLoader().loadGroovySource(name);
+        } catch (MalformedURLException e) {
+            // fall through and let the URL be null
+        }
+        if (url != null && ( oldClass==null || isSourceNewer(url, oldClass))) {
+            SourceUnit su = compilationUnit.addSource(url);
+            return new LookupResult(su,null);
+        }
+        return lr;
+    }
+
+    /**
+     * returns true if the source in URL is newer than the class
+     * NOTE: copied from GroovyClassLoader
+     */
+    private static boolean isSourceNewer(URL source, ClassNode cls) {
+        try {
+            long lastMod;
+
+            // Special handling for file:// protocol, as getLastModified() often reports
+            // incorrect results (-1)
+            if (source.getProtocol().equals("file")) {
+                // Coerce the file URL to a File
+                String path = source.getPath().replace('/', File.separatorChar).replace('|', ':');
+                File file = new File(path);
+                lastMod = file.lastModified();
+            } else {
+                URLConnection conn = source.openConnection();
+                lastMod = conn.getLastModified();
+                conn.getInputStream().close();
+            }
+            return lastMod > getTimeStamp(cls);
+        } catch (IOException e) {
+            // if the stream can't be opened, let's keep the old reference
+            return false;
+        }
+    }
+
+    /**
+     * get the time stamp of a class
+     * NOTE: copied from GroovyClassLoader
+     */
+    private static long getTimeStamp(ClassNode cls) {
+        if (!(cls instanceof DecompiledClassNode)) {
+            return Verifier.getTimestamp(cls.getTypeClass());
+        }
+
+        return ((DecompiledClassNode) cls).getCompilationTimeStamp();
+    }
+
+}

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/PerfData.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/PerfData.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.compiler;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.codehaus.groovy.control.Phases;
+
+/**
+ * Performance data collected from groovy parsing
+ * @author sdedic
+ */
+public class PerfData {
+    public static final Logger LOG = Logger.getLogger(PerfData.class.getName());
+    
+    public static PerfData global = new PerfData();
+    
+    private Map<Integer, Long> parserPhaseTime = new TreeMap<>();
+    private Map<String, Long> perfCounters = new TreeMap<>();
+    private Map<Integer, Map<String, Long>> visitorCounters = new TreeMap<>();
+    private int fileCount;
+    
+    private PerfData collector;
+
+    public PerfData() {
+        collector = global;
+    }
+
+    public void setCollector(PerfData collector) {
+        this.collector = collector;
+    }
+    
+    public void clear() {
+        parserPhaseTime.clear();
+        perfCounters.clear();
+        visitorCounters.clear();
+        fileCount = 0;
+    }
+    
+    public void addParserPhase(int phaseId, long time) {
+        parserPhaseTime.merge(phaseId, time, 
+                (a, b) -> a + b
+        );
+    }
+    
+    public void addVisitorTime(int stage, String visitorKey, long time) {
+        visitorCounters.computeIfAbsent(stage, (s) -> new HashMap<>()).
+            merge(visitorKey, time, (a, b) -> a + b);
+    }
+    
+    public void addPerfCounter(String id, long time) {
+        perfCounters.merge(id, time, (a, b) -> a + b);
+    }
+    
+    public void addPerfStats(PerfData other) {
+        fileCount++;
+        merge(other);
+    }
+    
+    public void merge(PerfData other) {
+        for (Integer i : other.parserPhaseTime.keySet()) {
+            addParserPhase(i, other.parserPhaseTime.get(i));
+        }
+        for (String s : other.perfCounters.keySet()) {
+            addPerfCounter(s, other.perfCounters.get(s));
+        }
+        for (int i = Phases.INITIALIZATION; i <= Phases.ALL; i++) {
+            Map<String, Long> vc = other.visitorCounters.get(i);
+            if (vc == null) {
+                continue;
+            }
+            for (String c : vc.keySet()) { 
+                addVisitorTime(i, c, vc.get(c));
+            }
+        }
+    }
+
+    static Map<Class, String> lambdaClassNames = new HashMap<>();
+    
+    public static String phaseToString(int phase) {
+        String s;
+        switch (phase) {
+            case Phases.INITIALIZATION: s = "initialization"; break;
+            case Phases.PARSING: s = "parsing"; break;
+            case Phases.CONVERSION: s = "conversion"; break;
+            case Phases.SEMANTIC_ANALYSIS: s = "semanticAnalysis"; break;
+            case Phases.CANONICALIZATION: s = "canonicalization"; break;
+            case Phases.INSTRUCTION_SELECTION: s = "instructionSelection"; break;
+            case Phases.CLASS_GENERATION: s = "classGeneration"; break;
+            case Phases.OUTPUT: s = "output"; break;
+            case Phases.FINALIZATION: s = "finalization"; break;
+            default: s = "" + phase; break;
+        }
+        return s;
+    }
+    
+    private boolean useAvg;
+    
+    public void dumpStatsAndMerge() {
+        if (fileCount == 0) {
+            fileCount = 1;
+        }
+        if (fileCount > 1) {
+            LOG.log(Level.FINER, "File count: {0}", fileCount);
+        }
+        useAvg = false;
+        dumpStats();
+        if (fileCount > 1) {
+           LOG.log(Level.FINER, "\n--- Average counters");
+           useAvg = true;
+           dumpStats();
+        }
+        LOG.log(Level.FINER, "------------------------------------------------\n\n");
+        if (this.collector != null) {
+            collector.addPerfStats(this);
+        }
+    }
+    
+    void dumpStats() {
+        if (parserPhaseTime.isEmpty()) {
+            return;
+        }
+        LOG.finer("Phase times:");
+        for (int i = 0; i <= Phases.ALL; i++) {
+            Long d = parserPhaseTime.get(i);
+            if (d == null) {
+                continue;
+            }
+            LOG.log(Level.FINER, "\t" + phaseToString(i) + ":\t" + avg(d));
+        }
+        
+        LOG.log(Level.FINER, "\nPhase - visitor statistics:");
+        for (int i = Phases.INITIALIZATION; i <= Phases.ALL; i++) {
+            Map<String, Long> vc = visitorCounters.get(i);
+            if (vc == null || vc.isEmpty()) {
+                continue;
+            }
+            LOG.log(Level.FINER, "Visitors from {0}", phaseToString(i));
+            List<String> visitors = new ArrayList<>(vc.keySet());
+            Collections.sort(visitors);
+            for (String c : visitors) {
+                LOG.log(Level.FINER, "\t{0}:\t{1}", new Object[] { c, avg(vc.get(c)) });
+            }
+        }
+        LOG.log(Level.FINER, "Performance counters:");
+        List<String> keys = new ArrayList<>(perfCounters.keySet());
+        Collections.sort(keys);
+        for (String s : keys) {
+            LOG.log(Level.FINER, "\t{0}:\t{1}", new Object[] { s, avg(perfCounters.get(s)) });
+        }
+    }
+    
+    private String avg(long time) {
+        if (!useAvg || fileCount < 2) {
+            return String.valueOf(time);
+        }
+        if (time / fileCount > 20) {
+            return String.valueOf(time / fileCount);
+        }
+        return String.format("%.2f", (float)time / fileCount);
+    }
+}

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/PerfStatCompilationUnit.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/PerfStatCompilationUnit.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.groovy.editor.compiler;
+
+import groovy.lang.GroovyClassLoader;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.security.CodeSource;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.GroovyClassVisitor;
+import org.codehaus.groovy.ast.decompiled.AsmReferenceResolver;
+import org.codehaus.groovy.classgen.GeneratorContext;
+import org.codehaus.groovy.classgen.VariableScopeVisitor;
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.CompilerConfiguration;
+import org.codehaus.groovy.control.Phases;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.tools.GroovyClass;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.java.source.ClasspathInfo;
+import org.netbeans.modules.groovy.editor.api.parser.GroovyParser;
+import org.netbeans.modules.groovy.editor.compiler.ClassNodeCache.ParsingClassLoader;
+import org.netbeans.modules.parsing.api.Snapshot;
+import org.openide.util.Exceptions;
+
+/**
+ * A helper class that adds performance statistics for Groovy compilation.
+ * This class is in between {@link CompilationUnit} and GroovyParser and after
+ * the perf optimizations are finished, it could be removed from the hierarchy.
+ * <p/>
+ * All perf counter logic, that would otherwise polute basic Groovy Parser should
+ * be centralized here.
+ *
+ * @author sdedic
+ */
+public class PerfStatCompilationUnit extends CompilationUnit {
+    private static final Logger PERFLOG = PerfData.LOG;
+
+    final long parsingStartTime;
+    final PerfData perfData;
+
+    int lastPhaseSeen = 0;
+    SortedMap<Integer, Long> phaseStartTime = new TreeMap<>();
+
+    public PerfStatCompilationUnit(PerfData perfData, GroovyParser parser, CompilerConfiguration configuration,
+            CodeSource security,
+            @NonNull final GroovyClassLoader loader,
+            @NonNull final GroovyClassLoader transformationLoader,
+            @NonNull final ClasspathInfo cpInfo,
+            @NonNull final ClassNodeCache classNodeCache, boolean isIndexing, Snapshot snapshot) {
+        super(parser, configuration, security, loader, transformationLoader, cpInfo, classNodeCache, isIndexing, snapshot);
+        this.parsingStartTime = System.currentTimeMillis();
+        this.perfData = perfData;
+        if (classLoader instanceof ParsingClassLoader) {
+            ((ParsingClassLoader)classLoader).setPerfData(perfData);
+        }
+        overrideClassNodeResolver();
+    }
+    
+    static final Method doPhaseOperation;
+    static final Field resolverVisitor;
+    
+    static {
+        Method m = null;
+        Field f = null;
+        try {
+            // PhaseOperation is private
+            Class c = Class.forName("org.codehaus.groovy.control.CompilationUnit$PhaseOperation"); // NOI18N
+            m = c.getDeclaredMethod("doPhaseOperation", org.codehaus.groovy.control.CompilationUnit.class); // NOI18N
+            m.setAccessible(true);
+            
+            c = org.codehaus.groovy.control.CompilationUnit.class;
+            f = c.getDeclaredField("resolve"); // NOI18N
+            f.setAccessible(true);
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(f, f.getModifiers() & ~Modifier.FINAL);
+        } catch (ReflectiveOperationException | SecurityException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        doPhaseOperation = m;
+        resolverVisitor = f;
+    }
+
+    private void overrideClassNodeResolver() {
+        if (!PERFLOG.isLoggable(Level.FINER)) {
+            return;
+        }
+        classNodeResolver = new NbClassNodeResolver() {
+            @Override
+            protected AsmReferenceResolver createReferencesResolver(org.codehaus.groovy.control.CompilationUnit unit) {
+                return new AsmReferenceResolver(this, PerfStatCompilationUnit.this) {
+                    @Override
+                    public ClassNode resolveClassNullable(String className) {
+                        long t = System.currentTimeMillis();
+                        ClassNode c;
+                        try {
+                            c = super.resolveClassNullable(className);
+                            return c;
+                        } finally {
+                            long t2 = System.currentTimeMillis();
+                            perfData.addVisitorTime(phase, "AsmReferenceResolver", t2 - t); // NOI18N
+                        }
+                    }
+                };
+            }
+        };
+        try {
+            resolverVisitor.set(this, createResolve());
+        } catch (ReflectiveOperationException ex) {
+            // will not be collected
+            ex.printStackTrace();
+        }
+    }
+
+    /**
+     * Inject static compilation transofmrations; apply them in the
+     *
+     * @param phase
+     * @throws CompilationFailedException
+     */
+    @Override
+    public void gotoPhase(int phase) throws CompilationFailedException {
+        super.gotoPhase(phase);
+        recordPhaseStart(phase);
+    }
+
+    protected void runSourceVisitor(String visitorName, Consumer<SourceUnit> callback) {
+        long t = System.currentTimeMillis();
+        try {
+            super.runSourceVisitor(visitorName, callback);
+        } finally {
+            long t2 = System.currentTimeMillis();
+            perfData.addVisitorTime(phase, visitorName, t2 - t);
+        }
+    }
+    
+    protected org.codehaus.groovy.control.CompilationUnit.ISourceUnitOperation createResolve() {
+        return (final SourceUnit source) -> {
+            int phase = getPhase();
+            recordPhaseStart(phase);
+            for (ClassNode classNode : source.getAST().getClasses()) {
+                long t = System.currentTimeMillis();
+                GroovyClassVisitor visitor = new VariableScopeVisitor(source);
+                visitor.visitClass(classNode);
+                long t2 = System.currentTimeMillis();
+                long d = t2 - t;
+                perfData.addVisitorTime(phase, visitor.getClass().getName(), d);
+
+                resolveVisitor.setClassNodeResolver(classNodeResolver);
+                resolveVisitor.startResolving(classNode, source);
+                long t3 = System.currentTimeMillis();
+                d = t3 -t2;
+                perfData.addVisitorTime(phase, resolveVisitor.getClass().getName(), d);
+            }
+        };
+    }
+
+    protected void recordPhaseStart(int phase) {
+        if (phase > lastPhaseSeen) {
+            // start of phase
+            long l = System.currentTimeMillis();
+            phaseStartTime.put(phase, l);
+            for (int i = phase - 1; i > lastPhaseSeen; i++) {
+                phaseStartTime.putIfAbsent(i, l);
+            }
+            lastPhaseSeen = phase;
+        }
+    }
+    
+    void logAndCollectPhaseStats() {
+        long end = System.currentTimeMillis();
+        int lastPhase = 0;
+
+        for (int i = Phases.INITIALIZATION; i < Phases.ALL; i++) {
+            Long phaseStart = phaseStartTime.get(i);
+            Long phaseEnd = phaseStartTime.get(i + 1);
+            if (phaseStart == null) {
+                if (lastPhase > 0) {
+                    continue;
+                }
+                phaseStart = parsingStartTime;
+            }
+            if (phaseStart != null) {
+                lastPhase = i;
+            }
+            if (phaseEnd == null || phaseStart == null) {
+                continue;
+            }
+            long diff = phaseEnd - phaseStart;
+            perfData.addParserPhase(i, diff);
+        }
+        if (lastPhase > 0) {
+            Long lastStart = phaseStartTime.get(lastPhase);
+            long diff = end - lastStart;
+            perfData.addParserPhase(lastPhase, diff);
+        }
+    }
+
+        
+    class TimingOp implements ISourceUnitOperation, IPrimaryClassNodeOperation, IGroovyClassOperation {
+
+        private final Object delegate;
+        private final String key;
+        private final int phase;
+
+        public TimingOp(Object delegate, int phase) {
+            this.delegate = delegate;
+            this.phase = phase;
+
+            String cn = delegate.getClass().getName();
+            if (cn.contains("$$Lambda")) { // NOI18N
+                StackTraceElement invokedFrom = null;
+                for (StackTraceElement ele : new Throwable().getStackTrace()) {
+                    boolean myClass = ele.getClassName().startsWith(GroovyParser.class.getName());
+                    if (!myClass) {
+                        invokedFrom = ele;
+                        break;
+                    }
+                }
+                key = invokedFrom != null ? invokedFrom.toString() : cn;
+            } else {
+                key = cn;
+            }
+        }
+
+        @Override
+        public void call(SourceUnit source) throws CompilationFailedException {
+            throw new UnsupportedOperationException("Should not be called."); // NOI18N
+        }
+
+        @Override
+        public void call(SourceUnit source, GeneratorContext context, ClassNode classNode) throws CompilationFailedException {
+            throw new UnsupportedOperationException("Should not be called."); // NOI18N
+        }
+
+        @SuppressWarnings("unchecked")
+        private <T extends Throwable> void sneakyThrow(Throwable exception) throws T {
+                throw (T) exception;
+        }        
+        
+        @Override
+        public void doPhaseOperation(org.codehaus.groovy.control.CompilationUnit unit) throws CompilationFailedException {
+            long t = System.currentTimeMillis();
+            recordPhaseStart(phase);
+            try {
+                try {
+                    doPhaseOperation.invoke(delegate, unit);
+                } catch (InvocationTargetException ex) {
+                    sneakyThrow(ex.getTargetException());
+                } catch (ReflectiveOperationException ex) {
+                    Exceptions.printStackTrace(ex);
+                }
+            } finally {
+                long t2 = System.currentTimeMillis();
+                perfData.addVisitorTime(getPhase(), key, t2 - t);
+            }
+        }
+
+        @Override
+        public boolean needSortedInput() {
+            if (delegate instanceof IPrimaryClassNodeOperation) {
+                return ((IPrimaryClassNodeOperation)delegate).needSortedInput();
+            }
+            throw new UnsupportedOperationException("Should not be called."); // NOI18N
+        }
+
+        @Override
+        public void call(GroovyClass groovyClass) throws CompilationFailedException {
+            throw new UnsupportedOperationException("Should not be called."); // NOI18N
+        }
+    }
+
+    static boolean shouldCollect() {
+        return PERFLOG.isLoggable(Level.FINER) && resolverVisitor != null;
+    } 
+
+    @Override
+    public void addNewPhaseOperation(ISourceUnitOperation op, int phase) {
+        super.addNewPhaseOperation(
+                shouldCollect() ? new TimingOp(op, phase) : op, 
+                phase);
+    }
+
+    @Override
+    public void addFirstPhaseOperation(IPrimaryClassNodeOperation op, int phase) {
+        super.addFirstPhaseOperation(
+                shouldCollect() ? new TimingOp(op, phase) : op, 
+                phase);
+    }
+
+    @Override
+    public void addPhaseOperation(IPrimaryClassNodeOperation op, int phase) {
+        super.addPhaseOperation(
+                shouldCollect() ? (IPrimaryClassNodeOperation)new TimingOp(op, phase) : op, 
+                phase);
+    }
+
+    @Override
+    public void addPhaseOperation(ISourceUnitOperation op, int phase) {
+        super.addPhaseOperation(
+                shouldCollect() ? (ISourceUnitOperation)new TimingOp(op, phase) : op, 
+                phase);
+    }
+
+    @Override
+    public void addPhaseOperation(IGroovyClassOperation op) {
+        super.addPhaseOperation(
+                shouldCollect() ? new TimingOp(op, phase) : op
+        );
+    }
+
+    @Override
+    public void compile(int throughPhase) throws CompilationFailedException {
+        String path = "";
+        if (mainSnapshot.getSource().getFileObject() != null) {
+            path = mainSnapshot.getSource().getFileObject().getPath();
+        }
+        PERFLOG.log(Level.FINER, "Parsing: {0}", path);
+        PERFLOG.log(Level.FINER, "Time from CU create up to now: {0}", System.currentTimeMillis() - parsingStartTime);
+        try {
+            super.compile(throughPhase);
+        } finally {
+            if (PERFLOG.isLoggable(Level.FINER)) {
+                PERFLOG.log(Level.FINER, "End Parsing: {0}", path);
+                logAndCollectPhaseStats();
+            }
+        }
+    }
+}

--- a/groovy/libs.groovy/nbproject/project.xml
+++ b/groovy/libs.groovy/nbproject/project.xml
@@ -53,6 +53,7 @@
                 <package>org.codehaus.groovy.ant</package>
                 <package>org.codehaus.groovy.antlr.parser</package>
                 <package>org.codehaus.groovy.ast</package>
+                <package>org.codehaus.groovy.ast.decompiled</package>
                 <package>org.codehaus.groovy.ast.expr</package>
                 <package>org.codehaus.groovy.ast.stmt</package>
                 <package>org.codehaus.groovy.ast.tools</package>
@@ -67,6 +68,7 @@
                 <package>org.codehaus.groovy.runtime</package>
                 <package>org.codehaus.groovy.runtime.callsite</package>
                 <package>org.codehaus.groovy.syntax</package>
+                <package>org.codehaus.groovy.tools</package>
                 <package>org.codehaus.groovy.transform</package>
                 <package>org.codehaus.groovy.transform.sc</package>
                 <package>org.codehaus.groovy.transform.trait</package>


### PR DESCRIPTION
This PR adds some performance counters and hacks that allow individual Groovy compiler's phases and visitors to be measured during parsing. Statistics are printed at the end of each parsing task and in case of indexing, summary and a per-file averages are printed after root's indexing completes.
The performance logs are enabled by setting `org.netbeans.modules.groovy.editor.compiler.PerfData` loglevel to `FINER` or more.

Next, the PR changes resource loading for Groovy:
- the resource is loaded using NB `ClassPath` (which uses FileSystems) rather than through `ClassPath.createClassLoader()`, which seems to be very slow.
- java classes are loaded from java indexer caches: this speeds up loading referenced classes from the project itself

As a result, the Groovy parsing is **about 5-10 times faster** (!), but there are still some Java parser invocations, so the overall indexer speedup is about 2-3x.