### PR TITLE
Updated Collection.toArray() refactoring

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/perf/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/perf/Bundle.properties
@@ -75,12 +75,12 @@ FIX_NoBooleanConstructorBoolean=Remove Boolean constructor invocation
 FIX_NoBooleanConstructorString=Remove Boolean constructor invocation
 
 DN_org.netbeans.modules.java.hints.perf.InitialCapacity.collections=Collections without initial capacity
-DESC_org.netbeans.modules.java.hints.perf.InitialCapacity.collections=Looks for instatiations of collections with missing initial capacity. Only collections backed-up with an array are tested.
-ERR_InitialCapacity_collections=Instantianting collection without specified initial capacity
+DESC_org.netbeans.modules.java.hints.perf.InitialCapacity.collections=Looks for instantiations of collections with missing initial capacity. Only collections backed-up with an array are tested.
+ERR_InitialCapacity_collections=Instantiating collection without specified initial capacity
 
 DN_org.netbeans.modules.java.hints.perf.InitialCapacity.stringBuilder=StringBuilder without initial capacity
 DESC_org.netbeans.modules.java.hints.perf.InitialCapacity.stringBuilder=Looks for instantiations of StringBuilder or StringBuffer with missing initial capacity.
-ERR_InitialCapacity_stringBuilder=Instantianting StringBuilder or StringBuffer without specified capacity
+ERR_InitialCapacity_stringBuilder=Instantiating StringBuilder or StringBuffer without specified capacity
 
 DN_org.netbeans.modules.java.hints.perf.Tiny.enumSet=Set replaceable with EnumSet
 DESC_org.netbeans.modules.java.hints.perf.Tiny.enumSet=Finds instantiations of Sets that can be replaced with EnumSet
@@ -90,10 +90,14 @@ ERR_Tiny_enumSet=Set can be replaced with java.util.EnumSet
 ERR_Tiny_enumMap=Map can be replaced with java.util.EnumMap
 FIX_Tiny_enumMap=Replace Map with java.util.EnumMap
 
-DN_org.netbeans.modules.java.hints.perf.Tiny.collectionsToArray=Zero element array passed to Collection.toArray
-DESC_org.netbeans.modules.java.hints.perf.Tiny.collectionsToArray=Passing zero element array to Collection.toArray may affect performance
-ERR_Tiny_collectionsToArray=Zero element array passed to Collection.toArray
-FIX_Tiny_collectionsToArray=Pass array of length equal to the size of the collection
+DN_org.netbeans.modules.java.hints.perf.Tiny.collectionsToArray=Inefficient Collection.toArray
+DESC_org.netbeans.modules.java.hints.perf.Tiny.collectionsToArray=<p>Passing new T[0] or T[]::new to Collection.toArray has \
+    better performance on modern JVMs than the allocation of a new empty array (new T[collection.size()]) since the JVM can \
+    return a copy directly without having to zero it out first.</p> \
+    <p>T[]::new is also more concise and often considered best practice on Java 11 and later.</p>
+ERR_Tiny_collectionsToArray=New array created just to be passed to Collection.toArray
+FIX_Tiny_collectionsToArrayByZeroArray=Change to new {0}[0]
+FIX_Tiny_collectionsToArrayByMethodRef=Change to {0}::new
 
 DN_ReplaceBufferByString=Replace StringBuffer/StringBuilder by String
 DESC_ReplaceBufferByString=The hint will find and offer to replace instances of <b>StringBuffer</b> or <b>StringBuilder</b> \

--- a/java/java.hints/src/org/netbeans/modules/java/hints/perf/Tiny.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/perf/Tiny.java
@@ -164,25 +164,34 @@ public class Tiny {
         final String literal = ctx.getInfo().getText().substring(start, end);
 
         Fix f = new JavaFix(ctx.getInfo(), toSearch) {
-@Override protected String getText() {
-return NbBundle.getMessage(Tiny.class, "FIX_LengthOneStringIndexOf");
-}
-@Override protected void performRewrite(TransformationContext ctx) {
-WorkingCopy wc = ctx.getWorkingCopy();
-TreePath tp = ctx.getPath();
-String content;
+            @Override
+            protected String getText() {
+                return NbBundle.getMessage(Tiny.class, "FIX_LengthOneStringIndexOf");
+            }
 
-if ("'".equals(data)) content = "\\'";
-else if ("\"".equals(data)) content = "\"";
-else {
-content = literal;
-if (content.length() > 0 && content.charAt(0) == '"') content = content.substring(1);
-if (content.length() > 0 && content.charAt(content.length() - 1) == '"') content = content.substring(0, content.length() - 1);
-}
+            @Override
+            protected void performRewrite(TransformationContext ctx) {
+                WorkingCopy wc = ctx.getWorkingCopy();
+                TreePath tp = ctx.getPath();
+                String content;
 
-wc.rewrite(tp.getLeaf(), wc.getTreeMaker().Identifier("'" + content + "'"));
-}
-}.toEditorFix();
+                if ("'".equals(data)) {
+                    content = "\\'";
+                } else if ("\"".equals(data)) {
+                    content = "\"";
+                } else {
+                    content = literal;
+                    if (content.length() > 0 && content.charAt(0) == '"') {
+                        content = content.substring(1);
+                    }
+                    if (content.length() > 0 && content.charAt(content.length() - 1) == '"') {
+                        content = content.substring(0, content.length() - 1);
+                    }
+                }
+
+                wc.rewrite(tp.getLeaf(), wc.getTreeMaker().Identifier("'" + content + "'"));
+            }
+        }.toEditorFix();
         
         String displayName = NbBundle.getMessage(Tiny.class, "ERR_LengthOneStringIndexOf", literal);
         
@@ -398,7 +407,7 @@ wc.rewrite(tp.getLeaf(), wc.getTreeMaker().Identifier("'" + content + "'"));
                 JavaFixUtilities.rewriteFix(ctx, Bundle.FIX_RedundantToString(), ctx.getPath(), "$v"));
     }
     
-    private static final Map<TypeKind, String[]> PARSE_METHODS = new HashMap<TypeKind, String[]>(7);
+    private static final Map<TypeKind, String[]> PARSE_METHODS = new HashMap<>(7);
     static {
         PARSE_METHODS.put(TypeKind.BOOLEAN, new String[] { "Boolean", "parseBoolean" }); // NOI18N
         PARSE_METHODS.put(TypeKind.BYTE, new String[] { "Byte", "parseByte"}); // NOI18N

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/TinyTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/perf/TinyTest.java
@@ -475,7 +475,7 @@ public class TinyTest extends NbTestCase {
                 .input("package test;\n" +
                        "public class Test {\n" +
                        "     private String[] test(java.util.Collection<String> col) {\n" +
-                       "         return col.toArray(new String[0]);\n" +
+                       "         return col.toArray(new String[col.size()]);\n" +
                        "     }\n" +
                        "}\n")
                 .run(Tiny.class)
@@ -485,7 +485,7 @@ public class TinyTest extends NbTestCase {
                 .assertOutput("package test;\n" +
                               "public class Test {\n" +
                               "     private String[] test(java.util.Collection<String> col) {\n" +
-                              "         return col.toArray(new String[col.size()]);\n" +
+                              "         return col.toArray(new String[0]);\n" +
                               "     }\n" +
                               "}\n");
     }


### PR DESCRIPTION
The performance inspection currently advises to refactor `col.toArray(new T[0])` into `col.toArray(new T[col.size])` which is exactly the wrong way around for modern Java[1].

Updated it to refactor to `T[]::new` on JDK 11+ and `new T[0]` for older JDKs (determined by the project src lvl).


[1] https://shipilev.net/blog/2016/arrays-wisdom-ancients/#_conclusion