### PR TITLE
LSP: Various Surround With refactoring fixes.

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/Bundle.properties
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/Bundle.properties
@@ -89,6 +89,10 @@ remove-surround-code-remain=Remove Surrounding Code (part to keep)
 # Code Templates
 CT_iff=if (<b>exp</b>) { ...| }
 CT_ifelse=if (<b>exp</b>) { ...| } else { ... }
+CT_sw=switch (<b>exp</b>) { ...| }
+CT_trycatch=try { ...| } catch(Exception e) { ... }
+CT_trycatchfin=try { ...| } catch(Exception e) { ... } finally { ... }
+CT_tryfin=try { ...| } finally { ... }
 CT_form=for (Map.Entry&lt;KeyType, ValueType&gt; <b>entry</b> : <b>map</b>.entrySet()) { ...
 CT_bcom=/* ... */
 

--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultAbbrevs.xml
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/DefaultAbbrevs.xml
@@ -58,7 +58,7 @@
     <codetemplate abbreviation="serr" contexts="BLOCK,CASE,LABELED_STATEMENT,DO_WHILE_LOOP,ENHANCED_FOR_LOOP,FOR_LOOP,IF,WHILE_LOOP,LAMBDA_EXPRESSION"><code><![CDATA[System.err.println("${cursor}");]]></code></codetemplate> 
     <codetemplate abbreviation="sout" contexts="BLOCK,CASE,LABELED_STATEMENT,DO_WHILE_LOOP,ENHANCED_FOR_LOOP,FOR_LOOP,IF,WHILE_LOOP,LAMBDA_EXPRESSION"><code><![CDATA[System.out.println("${cursor}");]]></code></codetemplate> 
     <codetemplate abbreviation="st"><code><![CDATA[${no-indent}static ]]></code></codetemplate> 
-    <codetemplate abbreviation="sw" contexts="BLOCK,CASE,LABELED_STATEMENT,DO_WHILE_LOOP,ENHANCED_FOR_LOOP,FOR_LOOP,IF,WHILE_LOOP,LAMBDA_EXPRESSION">
+    <codetemplate abbreviation="sw" contexts="BLOCK,CASE,LABELED_STATEMENT,DO_WHILE_LOOP,ENHANCED_FOR_LOOP,FOR_LOOP,IF,WHILE_LOOP,LAMBDA_EXPRESSION" descriptionId="CT_sw">
         <code>
 <![CDATA[switch (${var instanceof="java.lang.Enum"}) {
     case ${val completionInvoke}:
@@ -91,7 +91,13 @@
     } while (${expr instanceof="boolean" default="true"});
 ]]></code></codetemplate>
 
-    <codetemplate abbreviation="sy"><code><![CDATA[${no-indent}synchronized ]]></code></codetemplate> 
+    <codetemplate abbreviation="sy" contexts="BLOCK,CASE,LABELED_STATEMENT,DO_WHILE_LOOP,ENHANCED_FOR_LOOP,FOR_LOOP,IF,WHILE_LOOP,LAMBDA_EXPRESSION">
+        <code>
+<![CDATA[synchronized (${OBJ instanceof="java.lang.Object" default="this"}) {
+    ${selection}${cursor}
+}]]>
+        </code>
+    </codetemplate>
     <codetemplate abbreviation="tds"><code><![CDATA[Thread.dumpStack();]]></code></codetemplate> 
     <codetemplate abbreviation="th"><code><![CDATA[${no-indent}throws ]]></code></codetemplate> 
     <codetemplate abbreviation="En"><code><![CDATA[${no-indent}Enumeration]]></code></codetemplate> 
@@ -250,11 +256,31 @@
 ]]>
         </code>
     </codetemplate>
-    <codetemplate abbreviation="trycatch" contexts="BLOCK,CASE,LABELED_STATEMENT,DO_WHILE_LOOP,ENHANCED_FOR_LOOP,FOR_LOOP,IF,WHILE_LOOP,LAMBDA_EXPRESSION">
+    <codetemplate abbreviation="trycatch" contexts="BLOCK,CASE,LABELED_STATEMENT,DO_WHILE_LOOP,ENHANCED_FOR_LOOP,FOR_LOOP,IF,WHILE_LOOP,LAMBDA_EXPRESSION" descriptionId="CT_trycatch">
         <code>
 <![CDATA[try {
     ${selection}${cursor}
-} ${CATCH_STMTS uncaughtExceptionCatchStatements default="catch (Exception e) {}" editable=false}
+} ${CATCH_STMTS uncaughtExceptionCatchStatements default="catch (Exception e) {
+}" editable=false}
+]]>
+        </code>
+    </codetemplate>
+    <codetemplate abbreviation="trycatchfin" contexts="BLOCK,CASE,LABELED_STATEMENT,DO_WHILE_LOOP,ENHANCED_FOR_LOOP,FOR_LOOP,IF,WHILE_LOOP,LAMBDA_EXPRESSION" descriptionId="CT_trycatchfin">
+        <code>
+<![CDATA[try {
+    ${selection}${cursor}
+} ${CATCH_STMTS uncaughtExceptionCatchStatements default="catch (Exception e) {
+}" editable=false} finally {
+}
+]]>
+        </code>
+    </codetemplate>
+    <codetemplate abbreviation="tryfin" contexts="BLOCK,CASE,LABELED_STATEMENT,DO_WHILE_LOOP,ENHANCED_FOR_LOOP,FOR_LOOP,IF,WHILE_LOOP,LAMBDA_EXPRESSION" descriptionId="CT_tryfin">
+        <code>
+<![CDATA[try {
+    ${selection}${cursor}
+} finally {
+}
 ]]>
         </code>
     </codetemplate>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/SurroundWithHint.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/SurroundWithHint.java
@@ -89,11 +89,12 @@ public final class SurroundWithHint extends CodeActionsProvider {
     private static final Pattern SNIPPET_HINT_PATTERN = Pattern.compile("([-\\w]++)(?:\\s*=\\s*(\\\"([^\\\"]*)\\\"|[-\\w]++))?");
     private static final String UNCAUGHT_EXCEPTION_CATCH_STATEMENTS = "uncaughtExceptionCatchStatements";
     private static final Set<String> TO_FILTER = Collections.singleton("fcom");
-    private static final Set<String> TO_SHOW = Collections.unmodifiableSet(new HashSet(Arrays.asList("bcom", "dowhile", "iff", "fore", "trycatch", "whilexp")));
+    private static final Set<String> TO_SHOW = Collections.unmodifiableSet(new HashSet(Arrays.asList("bcom", "dowhile", "iff", "fore", "sy", "trycatch", "whilexp")));
 
     @Override
     @NbBundle.Messages({
         "DN_SurroundWith=Surround with {0}",
+        "DN_SurroundWithAll=Surround with ...",
     })
     public List<CodeAction> getCodeActions(ResultIterator resultIterator, CodeActionParams params) throws Exception {
         CompilationController info = CompilationController.get(resultIterator.getParserResult());
@@ -145,7 +146,7 @@ public final class SurroundWithHint extends CodeActionsProvider {
             }
         }
         if (items.size() > codeActions.size()) {
-            codeActions.add(createCodeAction(Bundle.DN_SurroundWith(DOTS), CodeActionKind.RefactorRewrite, COMMAND_SURROUND_WITH, items));
+            codeActions.add(createCodeAction(Bundle.DN_SurroundWithAll(), CodeActionKind.RefactorRewrite, COMMAND_SURROUND_WITH, items));
         }
         return codeActions;
     }

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -288,6 +288,23 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             ]);
         }
     }));
+    context.subscriptions.push(commands.registerCommand('java.surround.with', async (items) => {
+        const selected: any = await window.showQuickPick(items, { placeHolder: 'Surround with ...' });
+        if (selected) {
+            if (selected.userData.edit && selected.userData.edit.changes) {
+                let edit = new vscode.WorkspaceEdit();
+                Object.keys(selected.userData.edit.changes).forEach(key => {
+                    edit.set(vscode.Uri.parse(key), selected.userData.edit.changes[key].map((change: any) => {
+                        let start = new vscode.Position(change.range.start.line, change.range.start.character);
+                        let end = new vscode.Position(change.range.end.line, change.range.end.character);
+                        return new vscode.TextEdit(new vscode.Range(start, end), change.newText);
+                    }));
+                });
+                await workspace.applyEdit(edit);
+            }
+            await commands.executeCommand(selected.userData.command.command, ...(selected.userData.command.arguments || []));
+        }
+    }));
     const runDebug = async (noDebug: boolean, testRun: boolean, uri: string, methodName?: string, launchConfiguration?: string) => {
         const docUri = uri ? vscode.Uri.file(uri) : window.activeTextEditor?.document.uri;
         if (docUri) {


### PR DESCRIPTION
- Problem with too complex surround with menu fixed - original menu narrowed down couple of most common items only, the rest is available on generic `Surround with ...` invocation.
- Surround with try produces broken code - fixed
- Entries for `try/catch` and `try/catch/finally` added