### PR TITLE
Avoid ClassLoader resource lookups

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
@@ -639,11 +639,15 @@ public class GroovyParser extends Parser {
             PARSING_COUNT.incrementAndGet();
             start = System.currentTimeMillis();
         }
-
+        NbGroovyErrorCollector coll = (NbGroovyErrorCollector)compilationUnit.getErrorCollector();
+        coll.setDisableErrors(true);
         try {
             try {
-                compilationUnit.compile(Phases.CLASS_GENERATION);
-                NbGroovyErrorCollector coll = (NbGroovyErrorCollector)compilationUnit.getErrorCollector();
+                PerfData.withPerfData(context.perfData, () -> {
+                    compilationUnit.compile(Phases.CLASS_GENERATION);
+                    return null;
+                });
+                coll.setDisableErrors(false);
                 // PENDING: there are too many spurious errors from static type analysis (now). Let's make the errors
                 // a dev-only feature fow now.
                 if (STATIC_ERRORS) {

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/NbGroovyErrorCollector.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/NbGroovyErrorCollector.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +76,8 @@ class NbGroovyErrorCollector extends ErrorCollector {
      */
     private boolean showStaticCompileErrors;
     private boolean showFilteredErrors;
+    
+    private boolean disableErrors;
     
     /**
      * Cached combined errors.s
@@ -170,14 +173,28 @@ class NbGroovyErrorCollector extends ErrorCollector {
         super.failIfErrors();
     }
 
+    public boolean isDisableErrors() {
+        return disableErrors;
+    }
+
+    public void setDisableErrors(boolean disableErrors) {
+        this.disableErrors = disableErrors;
+    }
+
     @Override
     public boolean hasErrors() {
+        if (disableErrors) {
+            return false;
+        }
         List<? extends Message> errs = getErrors();
         return errs != null && !errs.isEmpty();
     }
 
     @Override
     public List<? extends Message> getErrors() {
+        if (disableErrors) {
+            return Collections.emptyList();
+        }
         return showStaticCompileErrors ? getAllErrors() : super.getErrors();
     }
 
@@ -189,6 +206,9 @@ class NbGroovyErrorCollector extends ErrorCollector {
 
     @Override
     public int getErrorCount() {
+        if (disableErrors) {
+            return 0;
+        }
         List<? extends Message> errs = getErrors();
         return errs.size();
     }
@@ -217,6 +237,9 @@ class NbGroovyErrorCollector extends ErrorCollector {
     }
     
     public List<Message> getAllErrors() {
+        if (disableErrors) {
+            return Collections.emptyList();
+        }
         if (combinedErrors == null) {
             List<? extends Message> base = super.getErrors();
             combinedErrors = new ArrayList<>();

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/CompilationUnit.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/CompilationUnit.java
@@ -128,6 +128,10 @@ public class CompilationUnit extends org.codehaus.groovy.control.CompilationUnit
                 throw new CancellationException();
             }
 
+            if (cache.isNonExistent(name)) {
+                return null;
+            }
+            
             ClassNode classNode = cache.get(name);
             if (classNode != null) {
                 return classNode;
@@ -143,10 +147,6 @@ public class CompilationUnit extends org.codehaus.groovy.control.CompilationUnit
                 return classNode;
             }
 
-            if (cache.isNonExistent(name)) {
-                return null;
-            }
-            
             classNode = classResolver.apply(name);
             if (classNode != null) {
                 cache.put(name, classNode);

--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/PerfStatCompilationUnit.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/PerfStatCompilationUnit.java
@@ -235,7 +235,7 @@ public class PerfStatCompilationUnit extends CompilationUnit {
             if (cn.contains("$$Lambda")) { // NOI18N
                 StackTraceElement invokedFrom = null;
                 for (StackTraceElement ele : new Throwable().getStackTrace()) {
-                    boolean myClass = ele.getClassName().startsWith(GroovyParser.class.getName());
+                    boolean myClass = ele.getClassName().startsWith(PerfStatCompilationUnit.class.getName());
                     if (!myClass) {
                         invokedFrom = ele;
                         break;


### PR DESCRIPTION
I've missed yet another resource lookup through ClassLoader.  In the case of `NbClassNodeResolver`, alll resources were loaded by the parent (= `ClassLoaderSupport` created by `ClassPath`) of the GroovyclassLoader (= `ParsingClassLoader`) so the resource lookup through ClassPath's classloader is completely unnecessary. in addition, loadByClassLoading was set to false, so I've deleted the relevant part of the code.

i also completely disabled error failures in compilation phases; Groovy tends to bail out on trivial errors (like imported symbol not exists) and will skip later more interesting compilation phases which attribute the tree.