### PR TITLE
Do not persist breakpoints and watches when debugging through LSP server.

### DIFF
--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/PersistenceManager.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/breakpoints/PersistenceManager.java
@@ -43,8 +43,17 @@ import org.netbeans.spi.debugger.DebuggerServiceRegistration;
 @DebuggerServiceRegistration(types={LazyDebuggerManagerListener.class})
 public class PersistenceManager implements LazyDebuggerManagerListener {
     
+    private boolean areBreakpointsPersisted() {
+        Properties p = Properties.getDefault ().getProperties ("debugger");
+        p = p.getProperties("persistence");
+        return p.getBoolean("breakpoints", true);
+    }
+    
     @Override
     public Breakpoint[] initBreakpoints () {
+        if (!areBreakpointsPersisted()) {
+            return new Breakpoint[]{};
+        }
         Properties p = Properties.getDefault ().getProperties ("debugger").
             getProperties (DebuggerManager.PROP_BREAKPOINTS);
         Breakpoint[] breakpoints = (Breakpoint[]) p.getArray (
@@ -81,6 +90,9 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
     
     @Override
     public void breakpointAdded (Breakpoint breakpoint) {
+        if (!areBreakpointsPersisted()) {
+            return ;
+        }
         if (breakpoint instanceof CPPLiteBreakpoint) {
             Properties p = Properties.getDefault ().getProperties ("debugger").
                 getProperties (DebuggerManager.PROP_BREAKPOINTS);
@@ -94,6 +106,9 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
 
     @Override
     public void breakpointRemoved (Breakpoint breakpoint) {
+        if (!areBreakpointsPersisted()) {
+            return ;
+        }
         if (breakpoint instanceof CPPLiteBreakpoint) {
             Properties p = Properties.getDefault ().getProperties ("debugger").
                 getProperties (DebuggerManager.PROP_BREAKPOINTS);

--- a/ide/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/io/PersistenceManager.java
+++ b/ide/javascript2.debug/src/org/netbeans/modules/javascript2/debug/breakpoints/io/PersistenceManager.java
@@ -50,6 +50,12 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
 
     private static final String JS_PROPERTY = "JS";
     
+    private boolean areBreakpointsPersisted() {
+        Properties p = Properties.getDefault ().getProperties ("debugger");
+        p = p.getProperties("persistence");
+        return p.getBoolean("breakpoints", true);
+    }
+    
     @Override
     public String[] getProperties() {
         return new String [] {
@@ -60,6 +66,9 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
 
     @Override
     public Breakpoint[] initBreakpoints() {
+        if (!areBreakpointsPersisted()) {
+            return new Breakpoint[]{};
+        }
         Properties p = Properties.getDefault ().getProperties ("debugger").
             getProperties (DebuggerManager.PROP_BREAKPOINTS);
         Breakpoint[] breakpoints = (Breakpoint[]) p.getArray (
@@ -85,6 +94,9 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
 
     @Override
     public void breakpointAdded(Breakpoint breakpoint) {
+        if (!areBreakpointsPersisted()) {
+            return ;
+        }
         if (breakpoint instanceof JSLineBreakpoint) {
             Properties p = Properties.getDefault ().getProperties ("debugger").
                 getProperties (DebuggerManager.PROP_BREAKPOINTS);
@@ -98,6 +110,9 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
 
     @Override
     public void breakpointRemoved(Breakpoint breakpoint) {
+        if (!areBreakpointsPersisted()) {
+            return ;
+        }
         if (breakpoint instanceof JSLineBreakpoint) {
             Properties p = Properties.getDefault ().getProperties ("debugger").
                 getProperties (DebuggerManager.PROP_BREAKPOINTS);

--- a/ide/spi.debugger.ui/apichanges.xml
+++ b/ide/spi.debugger.ui/apichanges.xml
@@ -276,6 +276,23 @@
         <class package="org.netbeans.spi.debugger.ui" name="DebuggingView"/>
     </change>
 
+    <change id="debugger.persistence">
+        <api name="DebuggerCoreSPI"/>
+        <summary>Add a way not to persist breakpoints and watches.</summary>
+        <version major="2" minor="72"/>
+        <date day="04" month="10" year="2021"/>
+        <author login="entlicher"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" semantic="compatible"/>
+	<description>
+            Class <code>org.netbeans.api.debugger.Properties</code> is used to persistently store
+            debugger settings. In order to be able to decide which particular settings should be
+            persistent and which not, <code>debugger.persistence</code> properties namespace is
+            introduced. In particular, <code>debugger.persistence.breakpoints</code> boolean property
+            determines the persistence of breakpoints and <code>debugger.persistence.watches</code>
+            boolean property determines the persistence of watches.
+        </description>
+    </change>
+
 </changes>
 
   <!-- Now the surrounding HTML text and document structure: -->

--- a/ide/spi.debugger.ui/arch.xml
+++ b/ide/spi.debugger.ui/arch.xml
@@ -110,6 +110,15 @@ Registrations in standard Lookup:
 <li><api name="org.netbeans.spi.debugger.ui.BreakpointType.ContextAware.createService" group="lookup" type="import" category="official" url="@org-netbeans-api-debugger@"/> Loads all breakpoint type providers.</li>
 <li><api name="org.netbeans.modules.debugger.ui.registry.ColumnModelContextAware.createService" group="lookup" type="import" category="official" url="@org-netbeans-api-debugger@"/> Loads all column models registered for specific view (according to the path).</li>
 </ul>
+Persistent properties stored through org.netbeans.api.debugger.Properties:
+<ul>
+<li><api name="debugger" group="property" type="export" category="official" url="@org-netbeans-api-debugger@"/>The main namespace for debugger properties.</li>
+<li><api name="debugger.persistence" group="property" type="import" category="official" url="@org-netbeans-api-debugger@"/>The main namespace for debugger persistence settings. Used for configuration of individual services to determine what is to be stored persistently.</li>
+<li><api name="debugger.persistence.watches" group="property" type="import" category="official" url="@org-netbeans-api-debugger@"/>This property may contain a boolean value that determines whether a list of watches should be stored persistently. True when undefined.</li>
+<li><api name="debugger.persistence.breakpoints" group="property" type="import" category="official" url="@org-netbeans-api-debugger@"/>This property may contain a boolean value that determines whether a list of breakpoints should be stored persistently. True when undefined.</li>
+<li><api name="debugger.watches" group="property" type="import" category="private"/>This property contains a list of watches.</li>
+<li><api name="debugger.breakpoints" group="property" type="import" category="official"/>This property contains a list of breakpoints</li>
+</ul>
 
 </answer>
         

--- a/ide/spi.debugger.ui/manifest.mf
+++ b/ide/spi.debugger.ui/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.spi.debugger.ui/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/debugger/ui/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/debugger/resources/mf-layer.xml
-OpenIDE-Module-Specification-Version: 2.71
+OpenIDE-Module-Specification-Version: 2.72
 OpenIDE-Module-Provides: org.netbeans.spi.debugger.ui
 OpenIDE-Module-Install: org/netbeans/modules/debugger/ui/DebuggerModule.class

--- a/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/PersistenceManager.java
+++ b/ide/spi.debugger.ui/src/org/netbeans/modules/debugger/ui/PersistenceManager.java
@@ -44,7 +44,16 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
         return new Breakpoint [0];
     }
     
+    private boolean areWatchesPersisted() {
+        Properties p = Properties.getDefault ().getProperties ("debugger");
+        p = p.getProperties("persistence");
+        return p.getBoolean("watches", true);
+    }
+    
     public void initWatches () {
+        if (!areWatchesPersisted()) {
+            return ;
+        }
         // As a side-effect, creates the watches. WatchesReader is triggered.
         Properties p = Properties.getDefault ().getProperties ("debugger");
         Watch[] watches = (Watch[]) p.getArray (
@@ -74,6 +83,9 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
     }
     
     public void watchAdded (Watch watch) {
+        if (!areWatchesPersisted()) {
+            return ;
+        }
         Properties p = Properties.getDefault ().getProperties ("debugger");
         p.setArray (
             DebuggerManager.PROP_WATCHES, 
@@ -87,6 +99,9 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
     }
     
     public void watchRemoved (Watch watch) {
+        if (!areWatchesPersisted()) {
+            return ;
+        }
         Properties p = Properties.getDefault ().getProperties ("debugger");
         p.setArray (
             DebuggerManager.PROP_WATCHES, 

--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/PersistenceManager.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/breakpoints/PersistenceManager.java
@@ -63,8 +63,17 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
         instanceRef = new WeakReference<PersistenceManager>(this);
     }
     
+    private boolean areBreakpointsPersisted() {
+        Properties p = Properties.getDefault ().getProperties ("debugger");
+        p = p.getProperties("persistence");
+        return p.getBoolean("breakpoints", true);
+    }
+    
     @Override
     public synchronized Breakpoint[] initBreakpoints () {
+        if (!areBreakpointsPersisted()) {
+            return new Breakpoint[]{};
+        }
         Properties p = Properties.getDefault ().getProperties ("debugger").
             getProperties (DebuggerManager.PROP_BREAKPOINTS);
         Breakpoint[] breakpoints = (Breakpoint[]) p.getArray (
@@ -126,6 +135,9 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
     
     @Override
     public void breakpointAdded (Breakpoint breakpoint) {
+        if (!areBreakpointsPersisted()) {
+            return ;
+        }
         if (breakpoint instanceof JPDABreakpoint &&
                 !((JPDABreakpoint) breakpoint).isHidden ()) {
             synchronized (this) {
@@ -145,6 +157,9 @@ public class PersistenceManager implements LazyDebuggerManagerListener {
 
     @Override
     public void breakpointRemoved (Breakpoint breakpoint) {
+        if (!areBreakpointsPersisted()) {
+            return ;
+        }
         if (breakpoint instanceof JPDABreakpoint &&
                 !((JPDABreakpoint) breakpoint).isHidden ()) {
             synchronized (this) {

--- a/java/java.lsp.server/nbcode/integration/nbproject/project.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/project.xml
@@ -35,6 +35,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.api.debugger</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.64</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.progress</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspDebuggerOptions.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/LspDebuggerOptions.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbcode.integration;
+
+import org.netbeans.api.debugger.Properties;
+import org.netbeans.spi.debugger.DebuggerServiceRegistration;
+
+/**
+ * Set the default debugger persistence to false.
+ *
+ * @author Martin Entlicher
+ */
+@DebuggerServiceRegistration(types={org.netbeans.api.debugger.Properties.Initializer.class})
+public class LspDebuggerOptions implements Properties.Initializer {
+
+    private static final String PERSISTENCE_BREAKPOINTS = "debugger.persistence.breakpoints"; // NOI18N
+    private static final String PERSISTENCE_WATCHES = "debugger.persistence.watches"; // NOI18N
+
+    @Override
+    public String[] getSupportedPropertyNames() {
+        return new String[] {
+            PERSISTENCE_BREAKPOINTS,
+            PERSISTENCE_WATCHES,
+        };
+    }
+
+    @Override
+    public Object getDefaultPropertyValue(String propertyName) {
+        if (propertyName.startsWith("debugger.persistence")) {      // NOI18N
+            return false;
+        } else {
+            return null;
+        }
+    }
+    
+}

--- a/java/java.lsp.server/nbcode/integration/test/unit/src/org/netbeans/modules/nbcode/integration/VerifyDebuggerPersistence.java
+++ b/java/java.lsp.server/nbcode/integration/test/unit/src/org/netbeans/modules/nbcode/integration/VerifyDebuggerPersistence.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbcode.integration;
+
+import org.netbeans.api.debugger.Properties;
+import org.netbeans.junit.NbTestCase;
+
+/**
+ * Verify that debugger does not store persistently stuff that is set through VSCode client.
+ */
+public class VerifyDebuggerPersistence extends NbTestCase {
+
+    public VerifyDebuggerPersistence(String name) {
+        super(name);
+    }
+
+    public void testBreakpointsPersistenceSetting() {
+        boolean p = Properties.getDefault().getProperties("debugger").getProperties("persistence").getBoolean("breakpoints", true);
+        assertFalse(p);
+    }
+
+    public void testWatchesPersistenceSetting() {
+        boolean p = Properties.getDefault().getProperties("debugger").getProperties("persistence").getBoolean("watches", true);
+        assertFalse(p);
+    }
+
+}

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -441,7 +441,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>2.70</specification-version>
+                        <specification-version>2.72</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
Debugger has it's own `Properties` API for settings persistence.
We use it in LSP to override the default for breakpoints and watches persistence.