### PR TITLE
ant clean fix for javacc java file

### DIFF
--- a/ide/db.sql.visualeditor/build.xml
+++ b/ide/db.sql.visualeditor/build.xml
@@ -29,7 +29,7 @@
     <target name="clean" depends="projectized-common.clean">
       <delete>
 	<fileset dir="src/org/netbeans/modules/db/sql/visualeditor/parser">
-	  <include name="ide/*.java" />
+	  <include name="*.java" />
         </fileset>
       </delete>
     </target>


### PR DESCRIPTION
Was compiling on a very very old clone and java file generated from javacc were old 3.2 and not deleted.
Should be more rebuildable