### PR TITLE
Prevent NullPointerException in CPP LanguageServerImpl

### DIFF
--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/LanguageServerImpl.java
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/LanguageServerImpl.java
@@ -89,7 +89,7 @@ public class LanguageServerImpl implements LanguageServerProvider {
         String ccls = Utils.getCCLSPath();
         String clangd = Utils.getCLANGDPath();
         if (ccls != null || clangd != null) {
-            return prj2Server.compute(prj, (p, pair) -> {
+            Pair<Process, LanguageServerDescription> serverEntry = prj2Server.compute(prj, (p, pair) -> {
                 if (pair != null && pair.first().isAlive()) {
                     return pair;
                 }
@@ -139,7 +139,11 @@ public class LanguageServerImpl implements LanguageServerProvider {
                     LOG.log(Level.FINE, null, ex);
                     return null;
                 }
-            }).second();
+            });
+            if(serverEntry != null) {
+                return serverEntry.second();
+            }
+            return null;
         }
         return null;
     }


### PR DESCRIPTION
There are various scenarios where the start routine for the language
server could result in a null value. If on that value Pair#second is
called, this results in a direct NullPointerException being raised.

The value needs to be checked first before the #second invocation is
done.