### PR TITLE
[NETBEANS-6055] Prevent NPE form GradleDistributionManager

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
@@ -152,7 +152,7 @@ public final class GradleDistributionManager {
         File[] gradleLauncher = lib.listFiles((dir, name) -> {
             return name.startsWith("gradle-launcher-") && name.endsWith(".jar"); //NOI18N
         });
-        if (gradleLauncher.length != 1) {
+        if ((gradleLauncher == null) || (gradleLauncher.length != 1)) {
             throw new FileNotFoundException(lib.getAbsolutePath() + "lib/gradle-launcher-xxxx.jar not found or ambigous!"); //NOI18N
         }
         JarFile launcherJar = new JarFile(gradleLauncher[0]);

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDistributionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDistributionProviderImpl.java
@@ -105,7 +105,7 @@ public class GradleDistributionProviderImpl implements GradleDistributionProvide
                 try {
                     dist = mgr.distributionFromWrapper(project.getGradleFiles().getRootDir());
                 } catch (Exception ex) {
-                    LOGGER.log(Level.FINE, "Cannot evaulate Gradle Wrapper", ex); //NOI18N
+                    LOGGER.log(Level.INFO, "Cannot evaulate Gradle Wrapper", ex); //NOI18N
                 }
             }
 
@@ -113,7 +113,7 @@ public class GradleDistributionProviderImpl implements GradleDistributionProvide
                 try {
                     dist = mgr.distributionFromDir(new File(settings.getDistributionHome()));
                 } catch (IOException ex) {
-                    LOGGER.log(Level.FINE, "Cannot evaulate Gradle Distribution", ex); //NOI18N
+                    LOGGER.log(Level.INFO, "Cannot evaulate Gradle Distribution", ex); //NOI18N
                 }
             }
             if (dist == null) {


### PR DESCRIPTION
Fixed an NPE when no distribution dir found using a file location.