### PR TITLE
LSP: various refactor bugfixes

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
@@ -180,7 +180,7 @@ public class JavaCompletionCollector implements CompletionCollector {
             return CompletionCollector.newBuilder(kwd)
                     .kind(Completion.Kind.Keyword)
                     .sortText(String.format("%04d%s", smartType ? 670 : 1670, kwd))
-                    .insertText(kwd + postfix)
+                    .insertText(postfix != null ? kwd + postfix : kwd)
                     .insertTextFormat(Completion.TextFormat.PlainText)
                     .build();
         }

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
@@ -1095,7 +1095,7 @@ public class JavaCompletionCollector implements CompletionCollector {
             if (t1.getKind().isPrimitive() && types.isSameType(types.boxedClass((PrimitiveType)t1).asType(), t2)) {
                 return true;
             }
-            return t2.getKind().isPrimitive() && types.isSameType(t1, types.boxedClass((PrimitiveType)t1).asType());
+            return t2.getKind().isPrimitive() && types.isSameType(t1, types.boxedClass((PrimitiveType)t2).asType());
         }
 
         private static boolean isOfKind(Element e, EnumSet<ElementKind> kinds) {

--- a/java/java.editor/src/org/netbeans/modules/java/editor/codegen/ToStringGenerator.java
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/codegen/ToStringGenerator.java
@@ -258,18 +258,20 @@ public class ToStringGenerator implements CodeGenerator {
         NewClassTree newStringBuilder = make.NewClass(null, Collections.emptyList(), stringBuilder, Collections.emptyList(), null);
         VariableTree variable = make.Variable(make.Modifiers(Collections.emptySet()), "sb", stringBuilder, newStringBuilder); // NOI18N
         statements.add(variable); // StringBuilder sb = new StringBuilder();
-
         IdentifierTree varName = make.Identifier(variable.getName());
+        statements.add(make.ExpressionStatement(createAppendInvocation( // sb.append("typeName{");
+                make,
+                varName,
+                Collections.singletonList(make.Literal(typeName + '{'))
+        )));
         boolean first = true;
         for (VariableElement variableElement : fields) {
             StringBuilder sb = new StringBuilder();
-            if (first) {
-                sb.append(typeName).append('{');
-            } else {
+            if (!first) {
                 sb.append(", "); // NOI18N
             }
             sb.append(variableElement.getSimpleName().toString()).append('=');
-            // sb.append("typeName{fieldName=").append(fieldName); or sb.append(", fieldName=").append(fieldName);
+            // sb.append("fieldName=").append(fieldName); or sb.append(", fieldName=").append(fieldName);
             statements.add(make.ExpressionStatement(createAppendInvocation(
                     make,
                     createAppendInvocation(

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ErrorFixesFakeHint.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ErrorFixesFakeHint.java
@@ -84,6 +84,7 @@ public class ErrorFixesFakeHint extends AbstractHint {
                 customizer = new SurroundWithTryCatchLog(node);
                 setRethrow(node, isRethrow(node));
                 setRethrowAsRuntimeException(node, isRethrowAsRuntimeException(node));
+                setPrintStackTrace(node, isPrintStackTrace(node));
                 setUseExceptions(node, isUseExceptions(node));
                 setUseLogger(node, isUseLogger(node));
                 break;
@@ -162,6 +163,14 @@ public class ErrorFixesFakeHint extends AbstractHint {
         p.putBoolean(SURROUND_USE_EXCEPTIONS, v);
     }
 
+    public static boolean isPrintStackTrace(Preferences p) {
+        return p.getBoolean(SURROUND_PRINT_STACK_TRACE, true);
+    }
+
+    public static void setPrintStackTrace(Preferences p, boolean v) {
+        p.putBoolean(SURROUND_PRINT_STACK_TRACE, v);
+    }
+
     public static boolean isRethrowAsRuntimeException(Preferences p) {
         return p.getBoolean(SURROUND_RETHROW_AS_RUNTIME, false);
     }
@@ -188,6 +197,7 @@ public class ErrorFixesFakeHint extends AbstractHint {
     
     public static final String LOCAL_VARIABLES_INPLACE = "create-local-variables-in-place"; // NOI18N
     public static final String SURROUND_USE_EXCEPTIONS = "surround-try-catch-org-openide-util-Exceptions"; // NOI18N
+    public static final String SURROUND_PRINT_STACK_TRACE = "surround-try-catch-printStackTrace"; // NOI18N
     public static final String SURROUND_RETHROW_AS_RUNTIME = "surround-try-catch-rethrow-runtime"; // NOI18N
     public static final String SURROUND_RETHROW = "surround-try-catch-rethrow"; // NOI18N
     public static final String SURROUND_USE_JAVA_LOGGER = "surround-try-catch-java-util-logging-Logger"; // NOI18N

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/MagicSurroundWithTryCatchFix.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/MagicSurroundWithTryCatchFix.java
@@ -444,6 +444,9 @@ final class MagicSurroundWithTryCatchFix extends JavaFix {
     }
 
     private static StatementTree createPrintStackTraceStatement(CompilationInfo info, TreeMaker make, String name) {
+        if (!ErrorFixesFakeHint.isPrintStackTrace(ErrorFixesFakeHint.getPreferences(info.getFileObject(), FixKind.SURROUND_WITH_TRY_CATCH))) {
+            return null;
+        }
         return make.ExpressionStatement(make.MethodInvocation(Collections.<ExpressionTree>emptyList(), make.MemberSelect(make.Identifier(name), "printStackTrace"), Collections.<ExpressionTree>emptyList()));
     }
 
@@ -466,7 +469,7 @@ final class MagicSurroundWithTryCatchFix extends JavaFix {
             logStatement = createPrintStackTraceStatement(info, make, name);
         }
 
-        return make.Catch(make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), name, make.Type(type), null), make.Block(Collections.singletonList(logStatement), false));
+        return make.Catch(make.Variable(make.Modifiers(EnumSet.noneOf(Modifier.class)), name, make.Type(type), null), make.Block(logStatement != null ? Collections.singletonList(logStatement) : Collections.emptyList(), false));
     }
 
     static List<CatchTree> createCatches(WorkingCopy info, TreeMaker make, List<TypeMirrorHandle> thandles, TreePath currentPath) {

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.form
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 
@@ -46,13 +46,13 @@
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Component id="logger" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="exceptions" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="printStackTrace" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="rethrowRuntime" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="rethrow" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="printStackTrace" alignment="0" min="-2" max="-2" attributes="0"/>
                       </Group>
                   </Group>
               </Group>
-              <EmptySpace pref="57" max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="221" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -66,17 +66,24 @@
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="logger" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Component id="printStackTrace" min="-2" max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="rethrowRuntime" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="rethrow" min="-2" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
-              <Component id="printStackTrace" min="-2" max="-2" attributes="0"/>
               <EmptySpace pref="134" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
   </Layout>
   <SubComponents>
+    <Component class="javax.swing.JLabel" name="jLabel1">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="org/netbeans/modules/java/hints/errors/Bundle.properties" key="SurroundWithTryCatchLog.jLabel1.text" replaceFormat="org.openide.util.NbBundle.getBundle({sourceFileName}.class).getString(&quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
     <Component class="javax.swing.JCheckBox" name="exceptions">
       <Properties>
         <Property name="selected" type="boolean" value="true"/>
@@ -111,18 +118,13 @@
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/java/hints/errors/Bundle.properties" key="SurroundWithTryCatchLog.printStackTrace.text" replaceFormat="org.openide.util.NbBundle.getBundle({sourceFileName}.class).getString(&quot;{key}&quot;)"/>
         </Property>
-        <Property name="enabled" type="boolean" value="false"/>
       </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="printStackTraceActionPerformed"/>
+      </Events>
       <AuxValues>
         <AuxValue name="generateMnemonicsCode" type="java.lang.Boolean" value="true"/>
       </AuxValues>
-    </Component>
-    <Component class="javax.swing.JLabel" name="jLabel1">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/java/hints/errors/Bundle.properties" key="SurroundWithTryCatchLog.jLabel1.text" replaceFormat="org.openide.util.NbBundle.getBundle({sourceFileName}.class).getString(&quot;{key}&quot;)"/>
-        </Property>
-      </Properties>
     </Component>
     <Component class="javax.swing.JCheckBox" name="rethrowRuntime">
       <Properties>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.java
@@ -35,6 +35,7 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
         this.p = p;
         exceptions.setSelected(ErrorFixesFakeHint.isUseExceptions(p));
         logger.setSelected(ErrorFixesFakeHint.isUseLogger(p));
+        printStackTrace.setSelected(ErrorFixesFakeHint.isPrintStackTrace(p));
         rethrowRuntime.setSelected(ErrorFixesFakeHint.isRethrowAsRuntimeException(p));
         rethrow.setSelected(ErrorFixesFakeHint.isRethrow(p));
     }
@@ -48,12 +49,14 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
     // <editor-fold defaultstate="collapsed" desc="Generated Code">//GEN-BEGIN:initComponents
     private void initComponents() {
 
+        jLabel1 = new javax.swing.JLabel();
         exceptions = new javax.swing.JCheckBox();
         logger = new javax.swing.JCheckBox();
         printStackTrace = new javax.swing.JCheckBox();
-        jLabel1 = new javax.swing.JLabel();
         rethrowRuntime = new javax.swing.JCheckBox();
         rethrow = new javax.swing.JCheckBox();
+
+        jLabel1.setText(org.openide.util.NbBundle.getBundle(SurroundWithTryCatchLog.class).getString("SurroundWithTryCatchLog.jLabel1.text")); // NOI18N
 
         exceptions.setSelected(true);
         org.openide.awt.Mnemonics.setLocalizedText(exceptions, org.openide.util.NbBundle.getBundle(SurroundWithTryCatchLog.class).getString("SurroundWithTryCatchLog.exceptions.text")); // NOI18N
@@ -73,9 +76,11 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
 
         printStackTrace.setSelected(true);
         org.openide.awt.Mnemonics.setLocalizedText(printStackTrace, org.openide.util.NbBundle.getBundle(SurroundWithTryCatchLog.class).getString("SurroundWithTryCatchLog.printStackTrace.text")); // NOI18N
-        printStackTrace.setEnabled(false);
-
-        jLabel1.setText(org.openide.util.NbBundle.getBundle(SurroundWithTryCatchLog.class).getString("SurroundWithTryCatchLog.jLabel1.text")); // NOI18N
+        printStackTrace.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                printStackTraceActionPerformed(evt);
+            }
+        });
 
         rethrowRuntime.setText(org.openide.util.NbBundle.getMessage(SurroundWithTryCatchLog.class, "SurroundWithTryCatchLog.rethrowRuntime.text")); // NOI18N
         rethrowRuntime.addActionListener(new java.awt.event.ActionListener() {
@@ -104,10 +109,10 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(logger)
                             .addComponent(exceptions)
+                            .addComponent(printStackTrace)
                             .addComponent(rethrowRuntime)
-                            .addComponent(rethrow)
-                            .addComponent(printStackTrace))))
-                .addContainerGap(57, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addComponent(rethrow))))
+                .addGap(221, 221, 221))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -119,11 +124,11 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(logger)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(printStackTrace)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(rethrowRuntime)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(rethrow)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addComponent(printStackTrace)
                 .addContainerGap(134, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
@@ -143,6 +148,10 @@ private void rethrowRuntimeActionPerformed(java.awt.event.ActionEvent evt) {//GE
 private void rethrowActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_rethrowActionPerformed
     ErrorFixesFakeHint.setRethrow(p, rethrow.isSelected());
 }//GEN-LAST:event_rethrowActionPerformed
+
+    private void printStackTraceActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_printStackTraceActionPerformed
+        ErrorFixesFakeHint.setPrintStackTrace(p, printStackTrace.isSelected());
+    }//GEN-LAST:event_printStackTraceActionPerformed
 
 
     // Variables declaration - do not modify//GEN-BEGIN:variables

--- a/java/java.lsp.server/nbcode/integration/release/config/Preferences/org/netbeans/modules/java/hints/default/org.netbeans.modules.java.hints.errors.ErrorFixesFakeHintSURROUND_WITH_TRY_CATCH.properties
+++ b/java/java.lsp.server/nbcode/integration/release/config/Preferences/org/netbeans/modules/java/hints/default/org.netbeans.modules.java.hints.errors.ErrorFixesFakeHintSURROUND_WITH_TRY_CATCH.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+surround-try-catch-java-util-logging-Logger=false
+surround-try-catch-org-openide-util-Exceptions=false
+surround-try-catch-printStackTrace=false
+surround-try-catch-rethrow=false
+surround-try-catch-rethrow-runtime=false

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
@@ -34,7 +34,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Properties;
 import javax.lang.model.element.ElementKind;
-import javax.swing.text.Document;
 import javax.swing.text.StyledDocument;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -128,8 +127,8 @@ public class Utils {
         }
     }
 
-    public static int getOffset(Document doc, Position pos) {
-        return LineDocumentUtils.getLineStartFromIndex((LineDocument) doc, pos.getLine()) + pos.getCharacter();
+    public static int getOffset(LineDocument doc, Position pos) {
+        return LineDocumentUtils.getLineStartFromIndex(doc, pos.getLine()) + pos.getCharacter();
     }
 
     public static synchronized String toUri(FileObject file) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ExtractSuperclassOrInterfaceRefactoring.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/ExtractSuperclassOrInterfaceRefactoring.java
@@ -176,7 +176,9 @@ public final class ExtractSuperclassOrInterfaceRefactoring extends CodeRefactori
                     String label = EXTRACT_SUPERCLASS_REFACTORING_COMMAND.equals(command) ? Bundle.DN_SelectClassName() : Bundle.DN_SelectInterfaceName();
                     String value = EXTRACT_SUPERCLASS_REFACTORING_COMMAND.equals(command) ? "NewClass" : "NewInterface";
                     client.showInputBox(new ShowInputBoxParams(label, value)).thenAccept(name -> {
-                        extract(client, uri, command, type, selected, name);
+                        if (name != null && !name.isEmpty()) {
+                            extract(client, uri, command, type, selected, name);
+                        }
                     });
                 }
             });

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1063,11 +1063,11 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
     public CompletableFuture<Either<Range, PrepareRenameResult>> prepareRename(PrepareRenameParams params) {
         // shortcut: if the projects are not yet initialized, return empty:
         if (server.openedProjects().getNow(null) == null) {
-            return CompletableFuture.completedFuture(Either.forLeft(null));
+            return CompletableFuture.completedFuture(null);
         }
         JavaSource source = getJavaSource(params.getTextDocument().getUri());
         if (source == null) {
-            return CompletableFuture.completedFuture(Either.forLeft(null));
+            return CompletableFuture.completedFuture(null);
         }
         CompletableFuture<Either<Range, PrepareRenameResult>> result = new CompletableFuture<>();
         try {

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -148,7 +148,6 @@ import org.netbeans.modules.java.hints.infrastructure.JavaErrorProvider;
 import org.netbeans.modules.java.source.BootClassPathUtil;
 import org.netbeans.modules.parsing.impl.indexing.implspi.CacheFolderProvider;
 import org.netbeans.spi.java.classpath.ClassPathProvider;
-import org.netbeans.spi.java.classpath.PathResourceImplementation;
 import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.netbeans.spi.java.queries.AnnotationProcessingQueryImplementation;
 import org.netbeans.spi.lsp.ErrorProvider;
@@ -340,7 +339,7 @@ public class ServerTest extends NbTestCase {
         server.getTextDocumentService().didChange(new DidChangeTextDocumentParams(id, Arrays.asList(new TextDocumentContentChangeEvent(new Range(new Position(0, closingBrace), new Position(0, closingBrace)), 0, "public String c(Object o) {\nreturn o;\n}"))));
         List<Diagnostic> diagnostics = assertDiags(diags, "Error:1:0-1:9"); //errors
         assertDiags(diags, "Error:1:0-1:9");//hints
-        List<Either<Command, CodeAction>> codeActions = server.getTextDocumentService().codeAction(new CodeActionParams(id, new Range(new Position(1, 0), new Position(1, 9)), new CodeActionContext(Arrays.asList(diagnostics.get(0))))).get();
+        List<Either<Command, CodeAction>> codeActions = server.getTextDocumentService().codeAction(new CodeActionParams(id, new Range(new Position(1, 4), new Position(1, 4)), new CodeActionContext(Arrays.asList(diagnostics.get(0))))).get();
         String log = codeActions.toString();
         assertTrue(log, codeActions.size() >= 2);
         assertTrue(log, codeActions.get(0).isRight());
@@ -627,7 +626,7 @@ public class ServerTest extends NbTestCase {
         List<Diagnostic> diagnostics = assertDiags(diags, "Warning:1:7-1:19");//hints
         VersionedTextDocumentIdentifier id = new VersionedTextDocumentIdentifier(1);
         id.setUri(toURI(src));
-        List<Either<Command, CodeAction>> codeActions = server.getTextDocumentService().codeAction(new CodeActionParams(id, new Range(new Position(1, 7), new Position(1, 19)), new CodeActionContext(Arrays.asList(diagnostics.get(0))))).get();
+        List<Either<Command, CodeAction>> codeActions = server.getTextDocumentService().codeAction(new CodeActionParams(id, new Range(new Position(1, 13), new Position(1, 13)), new CodeActionContext(Arrays.asList(diagnostics.get(0))))).get();
         String log = codeActions.toString();
         assertTrue(log, codeActions.size() >= 1);
         assertTrue(log, codeActions.get(0).isRight());
@@ -2014,7 +2013,6 @@ public class ServerTest extends NbTestCase {
         }
         VersionedTextDocumentIdentifier id = new VersionedTextDocumentIdentifier(src.toURI().toString(), 1);
         List<Either<Command, CodeAction>> codeActions = server.getTextDocumentService().codeAction(new CodeActionParams(id, new Range(new Position(2, 17), new Position(2, 17)), new CodeActionContext(diags[0]))).get();
-        assertTrue(codeActions.size() >= 1);
         Optional<CodeAction> generateMehtod =
                 codeActions.stream()
                            .filter(Either::isRight)
@@ -2036,7 +2034,7 @@ public class ServerTest extends NbTestCase {
                      fileChanges.get(0).getRange());
         assertEquals("\n" +
                      "    private String convertToString(int value) {\n" +
-                     "        throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n" +
+                     "        throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n" +
                      "    }\n",
                      fileChanges.get(0).getNewText());
     }
@@ -2100,8 +2098,7 @@ public class ServerTest extends NbTestCase {
             }
         }
         VersionedTextDocumentIdentifier id = new VersionedTextDocumentIdentifier(src.toURI().toString(), 1);
-        List<Either<Command, CodeAction>> codeActions = server.getTextDocumentService().codeAction(new CodeActionParams(id, new Range(new Position(1, 14), new Position(2, 14)), new CodeActionContext(diags[0]))).get();
-        assertTrue(codeActions.size() >= 2);
+        List<Either<Command, CodeAction>> codeActions = server.getTextDocumentService().codeAction(new CodeActionParams(id, new Range(new Position(1, 14), new Position(1, 14)), new CodeActionContext(diags[0]))).get();
         Optional<CodeAction> generateClass =
                 codeActions.stream()
                            .filter(Either::isRight)
@@ -2212,7 +2209,7 @@ public class ServerTest extends NbTestCase {
         assertEquals("\n" +
                      "    @Override\n" +
                      "    public void run() {\n" +
-                     "        throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n" +
+                     "        throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n" +
                      "    }\n",
                      fileChanges.get(0).getNewText());
     }
@@ -2302,7 +2299,7 @@ public class ServerTest extends NbTestCase {
                      fileChanges.get(0).getRange());
         assertEquals("            @Override\n" +
                      "            public void run() {\n" +
-                     "                throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n" +
+                     "                throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n" +
                      "            }\n",
                      fileChanges.get(0).getNewText());
     }
@@ -2390,7 +2387,7 @@ public class ServerTest extends NbTestCase {
                      fileChanges.get(0).getRange());
         assertEquals("        @Override\n" +
                      "        public void run() {\n" +
-                     "            throw new UnsupportedOperationException(\"Not supported yet.\"); //To change body of generated methods, choose Tools | Templates.\n" +
+                     "            throw new UnsupportedOperationException(\"Not supported yet.\"); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/GeneratedMethodBody\n" +
                      "        }\n",
                      fileChanges.get(0).getNewText());
     }
@@ -3734,12 +3731,12 @@ public class ServerTest extends NbTestCase {
         assertEquals("\n" +
                      "    @Override\n" +
                      "    protected void finalize() throws Throwable {\n" +
-                     "        super.finalize(); //To change body of generated methods, choose Tools | Templates.\n" +
+                     "        super.finalize(); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/OverriddenMethodBody\n" +
                      "    }\n" +
                      "\n" +
                      "    @Override\n" +
                      "    public String toString() {\n" +
-                     "        return super.toString(); //To change body of generated methods, choose Tools | Templates.\n" +
+                     "        return super.toString(); // Generated from nbfs://nbhost/SystemFileSystem/Templates/Classes/Code/OverriddenMethodBody\n" +
                      "    }\n",
                      fileChanges.get(0).getNewText());
     }
@@ -5172,7 +5169,7 @@ public class ServerTest extends NbTestCase {
                 codeActions.stream()
                            .filter(Either::isRight)
                            .map(Either::getRight)
-                           .filter(a -> a.getTitle().startsWith(Bundle.DN_SurroundWith("do { ...")))
+                           .filter(a -> a.getTitle().startsWith(Bundle.DN_SurroundWith("do")))
                            .findAny();
         assertTrue(surroundWith.isPresent());
         Command command = surroundWith.get().getCommand();

--- a/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveFileRefactoringPlugin.java
+++ b/java/refactoring.java/src/org/netbeans/modules/refactoring/java/plugins/MoveFileRefactoringPlugin.java
@@ -60,6 +60,8 @@ import org.openide.util.NbBundle;
     "# {0} - The file not of java type.",
     "ERR_NotJava=Selected element is not defined in a java file. {0}",
     "ERR_CannotMovePublicIntoSamePackage=Cannot move public class to the same package.",
+    "# {0} - Class name.",
+    "ERR_CannotMoveIntoItself=Cannot move {0} into itself.",
     "ERR_NoTargetFound=Cannot find the target to move to.",
     "# {0} - Class name.",
     "ERR_ClassToMoveClashes=Class \"{0}\" already exists in the target package.",
@@ -323,6 +325,9 @@ public class MoveFileRefactoringPlugin extends JavaRefactoringPlugin {
                 ElementHandle elementHandle = target.getElementHandle();
                 assert elementHandle != null;
                 TypeElement targetType = (TypeElement) elementHandle.resolve(javac);
+                if (targetType == resolveElement) {
+                    return new Problem(true, ERR_CannotMoveIntoItself(resolveElement.getSimpleName()));
+                }
                 List<? extends Element> enclosedElements = targetType.getEnclosedElements();
                 for (Element element : enclosedElements) {
                     switch (element.getKind()) {


### PR DESCRIPTION
* GR-33924: Code completion partially broken in method bodies in latest builds.
* GR-32319: Hover failed: ClassCastException: FilterDocument cannot be cast to LineDocument.
* GR-33740: Using .class on a type completes with null on the end.
* GR-31747: JUnit tests that fail to initialise lead to false success state.
* GR-33741: Quick fix for checked exception should not add java.util.logging.
* GR-33804: Null related message in Extract Superclass. 
* GR-33785: Try/catch block with resources.
* GR-33778: Can't rename constructor.
* GR-33807: Generate toString method default template.
* GR-33789: VSCode is accepting moving inner class inside itself.