### PR TITLE
Fix test failures in Groovy.editor

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/api/parser/GroovyParser.java
@@ -528,6 +528,9 @@ public class GroovyParser extends Parser {
         @Override
         public void gotoPhase(int phase) throws CompilationFailedException {
             super.gotoPhase(phase);
+            if (phase > Phases.CONVERSION) {
+                ((NbGroovyErrorCollector)errorCollector).setDisableErrors(true);
+            }
             if (phase != Phases.INSTRUCTION_SELECTION) {
                 return;
             }
@@ -640,7 +643,6 @@ public class GroovyParser extends Parser {
             start = System.currentTimeMillis();
         }
         NbGroovyErrorCollector coll = (NbGroovyErrorCollector)compilationUnit.getErrorCollector();
-        coll.setDisableErrors(true);
         try {
             try {
                 PerfData.withPerfData(context.perfData, () -> {

--- a/groovy/groovy.editor/test/unit/data/testfiles/BookmarkController.groovy.indexed
+++ b/groovy/groovy.editor/test/unit/data/testfiles/BookmarkController.groovy.indexed
@@ -19,7 +19,35 @@ Searchable Keys:
   field : updateNotes;java.lang.Object;00;true
   fqn : BookmarkController
   method : addTags(Bookmark);java.lang.Object;02
+  method : getCreate;java.lang.Object;01
+  method : getDelete;java.lang.Object;01
+  method : getDeliciousService;DeliciousService;01
+  method : getEdit;java.lang.Object;01
+  method : getList;java.lang.Object;01
+  method : getMetaClass;groovy.lang.MetaClass;01
+  method : getParams;java.util.Map;01
+  method : getPreview;java.lang.Object;01
+  method : getSave;java.lang.Object;01
+  method : getScaffold;java.lang.Object;01
+  method : getSearch;java.lang.Object;01
+  method : getSuggestTag;java.lang.Object;01
   method : getSuggestions(java.lang.Object,java.lang.Object);java.lang.Object;02
+  method : getUpdate;java.lang.Object;01
+  method : getUpdateNotes;java.lang.Object;01
   method : printParams(java.lang.Object,java.lang.Object);java.lang.Object;02
+  method : setCreate(java.lang.Object);void;01
+  method : setDelete(java.lang.Object);void;01
+  method : setDeliciousService(DeliciousService);void;01
+  method : setEdit(java.lang.Object);void;01
+  method : setList(java.lang.Object);void;01
+  method : setMetaClass(groovy.lang.MetaClass);void;01
+  method : setParams(java.util.Map);void;01
+  method : setPreview(java.lang.Object);void;01
+  method : setSave(java.lang.Object);void;01
+  method : setScaffold(java.lang.Object);void;01
+  method : setSearch(java.lang.Object);void;01
+  method : setSuggestTag(java.lang.Object);void;01
+  method : setUpdate(java.lang.Object);void;01
+  method : setUpdateNotes(java.lang.Object);void;01
 
 Not Searchable Keys:

--- a/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
+++ b/ide/csl.api/test/unit/src/org/netbeans/modules/csl/api/test/CslTestBase.java
@@ -1820,7 +1820,7 @@ public abstract class CslTestBase extends NbTestCase {
         );
 
         try {
-            ParserManager.parse(Collections.singleton(testSource), new UserTask() {
+            class UT extends UserTask implements IndexingTask {
                 public @Override void run(ResultIterator resultIterator) throws Exception {
                     Parser.Result r = resultIterator.getParserResult();
                     assertTrue(r instanceof ParserResult);
@@ -1830,7 +1830,8 @@ public abstract class CslTestBase extends NbTestCase {
 
                     SPIAccessor.getInstance().index(indexer, indexable, r, context);
                 }
-            });
+            }
+            ParserManager.parse(Collections.singleton(testSource), new UT());
         } finally {
             DocumentIndex index = SPIAccessor.getInstance().getIndexFactory(context).getIndex(context.getIndexFolder());
             if (index != null) {
@@ -1877,7 +1878,7 @@ public abstract class CslTestBase extends NbTestCase {
 
         final Boolean result [] = new Boolean [] { null };
         Source testSource = getTestSource(fo);
-        ParserManager.parse(Collections.singleton(testSource), new UserTask() {
+        class UT extends UserTask implements IndexingTask {
             public @Override void run(ResultIterator resultIterator) throws Exception {
                 Parser.Result r = resultIterator.getParserResult();
                 EmbeddingIndexer indexer = factory.createIndexer(
@@ -1885,7 +1886,8 @@ public abstract class CslTestBase extends NbTestCase {
                     r.getSnapshot());
                 result[0] = Boolean.valueOf(indexer != null);
             }
-        });
+        }
+        ParserManager.parse(Collections.singleton(testSource), new UT());
 
         assertNotNull(result[0]);
         assertEquals(isIndexable, result[0].booleanValue());
@@ -4789,7 +4791,7 @@ public abstract class CslTestBase extends NbTestCase {
 
         public void waitForScanToFinish() {
             try {
-                latch.await(60000, TimeUnit.MILLISECONDS);
+                latch.await(600000, TimeUnit.MILLISECONDS);
                 if (latch.getCount() > 0) {
                     fail("Waiting for classpath scanning to finish timed out");
                 }


### PR DESCRIPTION
Merge of #3175 has introduced bugs - test failures. It turned out that in that PR merge process, I didn't check properly Travis :-/
So this PR:
* only suppresses errors after parsing phase. There is an 'error recovery' that handles errors thrown from the parsing. This bug failed some tests.
* updates `BookmarkController.groovy.indexed` golden file: originally, the compiler failed on non-existent imported symbol and did not proceed to phase 6-7 where accessor methods are generated
* used `IndexingTask` marker API to indicate indexing is in progress; groovy.editor will not run static analysis that may produce additional errors: this is the original behaviour.