### PR TITLE
NETBEANS-5971 support Maven Wrapper (mvnw) in projects.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/MavenCommandLineExecutor.java
@@ -55,6 +55,7 @@ import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.extexecution.base.ExplicitProcessParameters;
 import org.netbeans.api.extexecution.base.Processes;
 import org.netbeans.api.extexecution.startup.StartupExtender;
@@ -618,15 +619,25 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
             }
         }
 
-        File mavenHome = EmbedderFactory.getEffectiveMavenHome();
-        if (MavenSettings.getDefault().isUseBestMaven()) {
-            File n = guessBestMaven(clonedConfig, ioput);
-            if (n != null) {
-                mavenHome = n;
-            }
+        Constructor constructeur;
+        File mavenHome = null;
+        File wrapper = null;
+        if (MavenSettings.getDefault().isPreferMavenWrapper()) {
+            wrapper = searchMavenWrapper(config);
         }
-        Constructor constructeur = new ShellConstructor(mavenHome);
-
+        if (wrapper != null) {
+            constructeur = new WrapperShellConstructor(wrapper);
+        } else {
+            mavenHome = EmbedderFactory.getEffectiveMavenHome();
+            if (MavenSettings.getDefault().isUseBestMaven()) {
+                File n = guessBestMaven(clonedConfig, ioput);
+                if (n != null) {
+                    mavenHome = n;
+                }
+            }
+            constructeur = new ShellConstructor(mavenHome);
+        }
+        
         List<String> cmdLine = createMavenExecutionCommand(clonedConfig, constructeur);
 
         //#228901 on windows, since u21 we must use cmd /c
@@ -983,5 +994,61 @@ public class MavenCommandLineExecutor extends AbstractMavenExecutor {
             }
         }
         return Places.getCacheSubdirectory("downloaded-mavens");
+    }
+    
+    private File searchMavenWrapper(RunConfig config) {
+        String fileName = Utilities.isWindows() ? "mvnw.cmd" : "mvnw"; //NOI18N
+        MavenProject project = config.getMavenProject();
+        while (project != null) {
+            File baseDir = project.getBasedir();
+            if (baseDir != null) {
+                File mvnw = new File(baseDir, fileName);
+                if (mvnw.exists()) {
+                    return mvnw;
+                }
+            }
+            project = project.getParent();
+        }
+        return null;
+    }
+
+    // part copied from ShellConstructor - @TODO consolidate here
+    private static class WrapperShellConstructor implements Constructor {
+
+        private final @NonNull File wrapper;
+
+        WrapperShellConstructor(@NonNull File wrapper) {
+            this.wrapper = wrapper;
+        }
+
+        @Override
+        public List<String> construct() {
+            //#164234
+            //if maven.bat file is in space containing path, we need to quote with simple quotes.
+            String quote = "\"";
+            List<String> toRet = new ArrayList<>();
+            toRet.add(quoteSpaces(wrapper.getAbsolutePath(), quote));
+
+            if (Utilities.isWindows()) { //#153101, since #228901 always on windows use cmd /c
+                toRet.add(0, "/c"); //NOI18N
+                toRet.add(0, "cmd"); //NOI18N
+            }
+            return toRet;
+        }
+
+        // we run the shell/bat script in the process, on windows we need to quote any spaces
+        //once/if we get rid of shell/bat execution, we might need to remove this
+        //#164234
+        private static String quoteSpaces(String val, String quote) {
+            if (Utilities.isWindows()) {
+                //since #228901 always quote
+                //#208065 not only space but a few other characters are to be quoted..
+                //if (val.indexOf(' ') != -1 || val.indexOf('=') != -1 || val.indexOf(";") != -1 || val.indexOf(",") != -1) { //NOI18N
+                return quote + val + quote;
+                //}
+            }
+            return val;
+        }
+
     }
 }

--- a/java/maven/src/org/netbeans/modules/maven/options/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/options/Bundle.properties
@@ -89,3 +89,4 @@ SettingsPanel.cbShowInfoLevel.toolTipText=Will print Maven output logging level 
 SettingsPanel.jLabel5.text=(NOT recommended, many features will be limited as a result)
 SettingsPanel.lblJdkHome.text=Default &JDK
 SettingsPanel.comManageJdks.text=Mana&ge Java Platforms
+SettingsPanel.cbPreferWrapper.text=Prefer Maven Wrapper that comes with project

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -72,6 +72,7 @@ public final class MavenSettings  {
     private static final String PROP_EXPERIMENTAL_ALTERNATE_LOCATION = "bestMavenAltLocation";
     private static final String PROP_VM_OPTIONS_WRAP = "vmOptionsWrap";
     private static final String PROP_DEFAULT_JDK = "defaultJdk";
+    private static final String PROP_PREFER_WRAPPER = "preferWrapper"; //NOI18N
 
     //these are from former versions (6.5) and are here only for conversion
     private static final String PROP_DEBUG = "showDebug"; // NOI18N
@@ -320,6 +321,14 @@ public final class MavenSettings  {
 
     public String getProjectNodeNamePattern() {
         return getPreferences().get(PROP_PROJECTNODE_NAME_PATTERN, null); //NOI18N
+    }
+    
+    public boolean isPreferMavenWrapper() {
+        return getPreferences().getBoolean(PROP_PREFER_WRAPPER, true);
+    }
+    
+    public void setPreferMavenWrapper(boolean preferWrapper) {
+        getPreferences().putBoolean(PROP_PREFER_WRAPPER, preferWrapper);
     }
 
     public boolean isUseBestMaven() {

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.form
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.form
@@ -510,17 +510,28 @@
                                   </Group>
                                   <Component id="cbSkipTests" alignment="0" min="-2" max="-2" attributes="0"/>
                               </Group>
-                              <EmptySpace min="0" pref="45" max="32767" attributes="0"/>
+                              <EmptySpace min="0" pref="55" max="32767" attributes="0"/>
                           </Group>
                           <Group type="102" attributes="0">
                               <Group type="103" groupAlignment="0" attributes="0">
-                                  <Group type="102" attributes="0">
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="lblOptions" min="-2" max="-2" attributes="0"/>
+                                      <EmptySpace max="-2" attributes="0"/>
+                                      <Component id="txtOptions" max="32767" attributes="0"/>
+                                      <EmptySpace max="-2" attributes="0"/>
+                                      <Component id="btnOptions" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
                                       <Group type="103" groupAlignment="0" attributes="0">
                                           <Component id="lblCommandLine" min="-2" max="-2" attributes="0"/>
                                           <Component id="lblJdkHome" min="-2" max="-2" attributes="0"/>
                                       </Group>
                                       <EmptySpace max="-2" attributes="0"/>
                                       <Group type="103" groupAlignment="0" attributes="0">
+                                          <Group type="102" attributes="0">
+                                              <Component id="cbPreferWrapper" min="-2" max="-2" attributes="0"/>
+                                              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                                          </Group>
                                           <Component id="comMavenHome" max="32767" attributes="0"/>
                                           <Group type="102" attributes="0">
                                               <Component id="comJdkHome" max="32767" attributes="0"/>
@@ -528,13 +539,6 @@
                                               <Component id="comManageJdks" min="-2" max="-2" attributes="0"/>
                                           </Group>
                                       </Group>
-                                  </Group>
-                                  <Group type="102" alignment="0" attributes="0">
-                                      <Component id="lblOptions" min="-2" max="-2" attributes="0"/>
-                                      <EmptySpace max="-2" attributes="0"/>
-                                      <Component id="txtOptions" max="32767" attributes="0"/>
-                                      <EmptySpace max="-2" attributes="0"/>
-                                      <Component id="btnOptions" min="-2" max="-2" attributes="0"/>
                                   </Group>
                               </Group>
                               <EmptySpace max="-2" attributes="0"/>
@@ -557,6 +561,8 @@
                       </Group>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="lblExternalVersion" min="-2" pref="14" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
+                      <Component id="cbPreferWrapper" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="3" attributes="0">
                           <Component id="lblJdkHome" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -745,6 +751,13 @@
               <Events>
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="comManageJdksActionPerformed"/>
               </Events>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="cbPreferWrapper">
+              <Properties>
+                <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+                  <ResourceString bundle="org/netbeans/modules/maven/options/Bundle.properties" key="SettingsPanel.cbPreferWrapper.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+                </Property>
+              </Properties>
             </Component>
           </SubComponents>
         </Container>

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
@@ -195,6 +195,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         rbOutputTabId.addActionListener(listener);
         rbOutputTabName.addActionListener(listener);
         cbDisableIndex.addActionListener(listener);
+        cbPreferWrapper.addActionListener(listener);
         cbUseBestMaven.addActionListener(listener);
         cbAlternateLocation.addActionListener(listener);
         cbAlternateLocation.addChangeListener(new ChangeListener() {
@@ -392,6 +393,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         lblJdkHome = new javax.swing.JLabel();
         comJdkHome = new javax.swing.JComboBox();
         comManageJdks = new javax.swing.JButton();
+        cbPreferWrapper = new javax.swing.JCheckBox();
         jScrollPane1 = new javax.swing.JScrollPane();
         lstCategory = new javax.swing.JList();
         lblCategory = new javax.swing.JLabel();
@@ -683,6 +685,8 @@ public class SettingsPanel extends javax.swing.JPanel {
             }
         });
 
+        org.openide.awt.Mnemonics.setLocalizedText(cbPreferWrapper, org.openide.util.NbBundle.getMessage(SettingsPanel.class, "SettingsPanel.cbPreferWrapper.text")); // NOI18N
+
         javax.swing.GroupLayout pnlExecutionLayout = new javax.swing.GroupLayout(pnlExecution);
         pnlExecution.setLayout(pnlExecutionLayout);
         pnlExecutionLayout.setHorizontalGroup(
@@ -710,26 +714,29 @@ public class SettingsPanel extends javax.swing.JPanel {
                                     .addComponent(btnGoals))
                                 .addGap(18, 18, 18))
                             .addComponent(cbSkipTests, javax.swing.GroupLayout.Alignment.LEADING))
-                        .addGap(0, 45, Short.MAX_VALUE))
+                        .addGap(0, 55, Short.MAX_VALUE))
                     .addGroup(pnlExecutionLayout.createSequentialGroup()
                         .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(pnlExecutionLayout.createSequentialGroup()
+                                .addComponent(lblOptions)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(txtOptions)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(btnOptions))
                             .addGroup(pnlExecutionLayout.createSequentialGroup()
                                 .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                                     .addComponent(lblCommandLine)
                                     .addComponent(lblJdkHome))
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                 .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addGroup(pnlExecutionLayout.createSequentialGroup()
+                                        .addComponent(cbPreferWrapper)
+                                        .addGap(0, 0, Short.MAX_VALUE))
                                     .addComponent(comMavenHome, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                                     .addGroup(pnlExecutionLayout.createSequentialGroup()
                                         .addComponent(comJdkHome, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(comManageJdks))))
-                            .addGroup(pnlExecutionLayout.createSequentialGroup()
-                                .addComponent(lblOptions)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(txtOptions)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(btnOptions)))
+                                        .addComponent(comManageJdks)))))
                         .addContainerGap())))
             .addGroup(pnlExecutionLayout.createSequentialGroup()
                 .addGap(119, 119, 119)
@@ -744,6 +751,8 @@ public class SettingsPanel extends javax.swing.JPanel {
                     .addComponent(comMavenHome, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(lblExternalVersion, javax.swing.GroupLayout.PREFERRED_SIZE, 14, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(cbPreferWrapper)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(pnlExecutionLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(lblJdkHome)
@@ -924,6 +933,7 @@ public class SettingsPanel extends javax.swing.JPanel {
     private javax.swing.JCheckBox cbCollapseSuccessFolds;
     private javax.swing.JCheckBox cbDisableIndex;
     private javax.swing.JCheckBox cbOutputTabShowConfig;
+    private javax.swing.JCheckBox cbPreferWrapper;
     private javax.swing.JComboBox cbProjectNodeNameMode;
     private javax.swing.JCheckBox cbReuse;
     private javax.swing.JCheckBox cbShowInfoLevel;
@@ -1107,6 +1117,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         cbReuse.setSelected(MavenSettings.getDefault().isReuseOutputTabs());
         cbCollapseSuccessFolds.setSelected(MavenSettings.getDefault().isCollapseSuccessFolds());
         cbOutputTabShowConfig.setSelected(MavenSettings.getDefault().isOutputTabShowConfig());
+        cbPreferWrapper.setSelected(MavenSettings.getDefault().isPreferMavenWrapper());
         cbUseBestMaven.setSelected(MavenSettings.getDefault().isUseBestMaven());
         cbAlternateLocation.setSelected(MavenSettings.getDefault().isUseBestMavenAltLocation());
         txtDirectory.setText(MavenSettings.getDefault().getBestMavenAltLocation());
@@ -1182,6 +1193,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         MavenSettings.getDefault().setReuseOutputTabs(cbReuse.isSelected());
         MavenSettings.getDefault().setCollapseSuccessFolds(cbCollapseSuccessFolds.isSelected());
         MavenSettings.getDefault().setOutputTabShowConfig(cbOutputTabShowConfig.isSelected());
+        MavenSettings.getDefault().setPreferMavenWrapper(cbPreferWrapper.isSelected());
         MavenSettings.getDefault().setUseBestMaven(cbUseBestMaven.isSelected());
         MavenSettings.getDefault().setUseBestMavenAltLocation(cbAlternateLocation.isSelected());
         if (cbAlternateLocation.isSelected()) {
@@ -1250,6 +1262,7 @@ public class SettingsPanel extends javax.swing.JPanel {
         isChanged |= MavenSettings.getDefault().isReuseOutputTabs() != cbReuse.isSelected();
         isChanged |= MavenSettings.getDefault().isCollapseSuccessFolds() != cbCollapseSuccessFolds.isSelected();
         isChanged |= MavenSettings.getDefault().isOutputTabShowConfig() != cbOutputTabShowConfig.isSelected();
+        isChanged |= MavenSettings.getDefault().isPreferMavenWrapper() != cbPreferWrapper.isSelected();
         isChanged |= MavenSettings.getDefault().isUseBestMaven() != cbUseBestMaven.isSelected();
         isChanged |= MavenSettings.getDefault().isUseBestMavenAltLocation() != cbAlternateLocation.isSelected();
         MavenSettings.OutputTabName name = rbOutputTabName.isSelected() ? MavenSettings.OutputTabName.PROJECT_NAME : MavenSettings.OutputTabName.PROJECT_ID;


### PR DESCRIPTION
Search for existence of mvnw(.cmd) in project basedir or a parent project basedir and prefer this over embedded / specified Maven if present.  Added global setting and UI mirroring Gradle setting for this.

Trying to keep this as a light touch implementation for now.  No UI to configure wrapper yet. Longer term should probably consider replacing the built-in experimental support for downloading Maven versions with UI to use the wrapper?

Work in progress - not tested on Windows yet!