### PR TITLE
Enable antialiasing for test progressbar

### DIFF
--- a/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultBar.java
+++ b/ide/gsf.testrunner.ui/src/org/netbeans/modules/gsf/testrunner/ui/ResultBar.java
@@ -345,6 +345,7 @@ public final class ResultBar extends JComponent implements ActionListener{
         }
         // Step 1: render the text.
         Graphics2D textImageG = textImage.createGraphics();
+        GraphicsUtils.configureDefaultRenderingHints(textImageG);
         textImageG.setComposite(AlphaComposite.Clear);
         textImageG.fillRect(0, 0, w, h);
         textImageG.setComposite(AlphaComposite.SrcOver);
@@ -355,6 +356,7 @@ public final class ResultBar extends JComponent implements ActionListener{
         // Step 2: copy the image containing the text to dropShadowImage using
         // the blur effect, which generates a nice drop shadow.
         Graphics2D blurryImageG = dropShadowImage.createGraphics();
+        GraphicsUtils.configureDefaultRenderingHints(blurryImageG);
         blurryImageG.setComposite(AlphaComposite.Clear);
         blurryImageG.fillRect(0, 0, w, h);
         blurryImageG.setComposite(AlphaComposite.SrcOver);


### PR DESCRIPTION
Before (Only the progressbar is changed, see the text "Test passed: 100,00%"):

![Bildschirmfoto von 2021-09-30 19-40-22](https://user-images.githubusercontent.com/2179736/135505628-e89e3ced-5697-4951-ba8b-c0da5195e521.png)

After:

![Bildschirmfoto von 2021-09-30 19-44-32](https://user-images.githubusercontent.com/2179736/135505656-5f30afed-f910-4fae-bf51-ccfb8a5a652c.png)


