### PR TITLE
Selected range is ignored for CSS reformatting

### DIFF
--- a/ide/css.editor/src/org/netbeans/modules/css/editor/indent/CssIndentTask.java
+++ b/ide/css.editor/src/org/netbeans/modules/css/editor/indent/CssIndentTask.java
@@ -156,10 +156,21 @@ public class CssIndentTask implements IndentTask, Lookup.Provider {
         }
         Collections.reverse(newlinesMissing);
         for (int index : newlinesMissing) {
-            context.document().insertString(index, "\n", null);
+            if(isPositionInFormatRegions(index)) {
+                context.document().insertString(index, "\n", null);
+            }
         }
     }
 
+    private boolean isPositionInFormatRegions(int pos) {
+        for(Region r: context.indentRegions()) {
+            if(r.getStartOffset() <= pos && r.getEndOffset() > pos) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
     private int determineBlocklevel(TokenSequence<?> ts) {
         int blockLevel = 0;
         ts.moveStart();

--- a/ide/css.editor/test/unit/data/testfiles/partialformatting.css
+++ b/ide/css.editor/test/unit/data/testfiles/partialformatting.css
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* -------- DIRECT STYLES FOR TAGS-----------*/
+body {
+color: #333333; padding:0px; margin:0px;
+font-size: 0.7em;
+font-family: Verdana, 
+"Verdana CE",  
+Arial, 
+"Arial CE", 
+"Lucida Grande CE", lucida, "Helvetica CE", sans-serif;
+height:500px;
+}
+
+body.blue-bg {
+background-color:#b4dae0;
+background-image:url('/images/v6/body-bg.png');background-repeat:repeat-x;
+}

--- a/ide/css.editor/test/unit/data/testfiles/partialformatting.css.formatted
+++ b/ide/css.editor/test/unit/data/testfiles/partialformatting.css.formatted
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* -------- DIRECT STYLES FOR TAGS-----------*/
+body {
+color: #333333; padding:0px; margin:0px;
+font-size: 0.7em;
+font-family: Verdana, 
+"Verdana CE",  
+Arial, 
+"Arial CE", 
+"Lucida Grande CE", lucida, "Helvetica CE", sans-serif;
+height:500px;
+}
+
+body.blue-bg {
+    background-color:#b4dae0;
+    background-image:url('/images/v6/body-bg.png');
+    background-repeat:repeat-x;
+}

--- a/ide/css.editor/test/unit/data/testfiles/partialformatting.css.formatted2
+++ b/ide/css.editor/test/unit/data/testfiles/partialformatting.css.formatted2
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* -------- DIRECT STYLES FOR TAGS-----------*/
+body {
+    color: #333333;
+    padding:0px;
+    margin:0px;
+font-size: 0.7em;
+font-family: Verdana, 
+"Verdana CE",  
+Arial, 
+"Arial CE", 
+"Lucida Grande CE", lucida, "Helvetica CE", sans-serif;
+height:500px;
+}
+
+body.blue-bg {
+background-color:#b4dae0;
+background-image:url('/images/v6/body-bg.png');background-repeat:repeat-x;
+}

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/CssIndenterTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/CssIndenterTest.java
@@ -27,6 +27,7 @@ import javax.swing.text.DefaultEditorKit;
 import javax.swing.text.Document;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+import org.netbeans.api.actions.Closable;
 import org.netbeans.api.editor.mimelookup.MimePath;
 import org.netbeans.api.editor.mimelookup.test.MockMimeLookup;
 import org.netbeans.api.html.lexer.HTMLTokenId;
@@ -42,6 +43,7 @@ import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.loaders.DataObject;
 import org.openide.util.Exceptions;
+import org.openide.util.Lookup;
 
 public class CssIndenterTest extends TestBase {
 
@@ -181,6 +183,32 @@ public class CssIndenterTest extends TestBase {
         reformatFileContents("testfiles/netbeans.css", new IndentPrefs(4, 4));
     }
 
+    public void testPartitialFormatting() throws Exception {
+        IndentPrefs preferences = new IndentPrefs(4, 4);
+        String file = "testfiles/partialformatting.css";
+        
+        FileObject fo = getTestFile(file);
+        assertNotNull(fo);
+        BaseDocument doc = getDocument(fo);
+        assertNotNull(doc);
+
+        Formatter formatter = getFormatter(preferences);
+
+        setupDocumentIndentation(doc, preferences);
+        format(doc, formatter, 1056, 1173, false);
+
+        String after = doc.getText(0, doc.getLength());
+        assertDescriptionMatches(file, after, false, ".formatted");
+
+        DataObject.find(fo).getLookup().lookup(Closable.class).close();
+        
+        doc = getDocument(fo);
+        setupDocumentIndentation(doc, preferences);
+        format(doc, formatter, 857, 904, false);
+        after = doc.getText(0, doc.getLength());
+        assertDescriptionMatches(file, after, false, ".formatted2");
+    }
+    
     public void testIndentation() throws Exception {
         // property indentation:
         insertNewline("a{^background: red;\n  }\n", "a{\n    ^background: red;\n  }\n", null);


### PR DESCRIPTION
Without this change the hole file is always formatted and a selected
range is ignored.