### PR TITLE
update test for layerbuilder

### DIFF
--- a/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerBuilderTest.java
+++ b/platform/openide.filesystems/test/unit/src/org/openide/filesystems/annotations/LayerBuilderTest.java
@@ -81,8 +81,9 @@ public class LayerBuilderTest extends NbTestCase {
     private static String clean(String layer) {
         return layer.
                 replace('"', '\'').
-                replaceFirst("^<\\?xml version='1\\.0' encoding='UTF-8'\\?>\r?\n", "").
-                replaceFirst("^<!DOCTYPE [^>]+>\r?\n", "").
+                 // can be on same line try to remove only the element
+                replaceFirst("<\\?xml version='1\\.0' encoding='UTF-8'\\?>", "").
+                replaceFirst("<!DOCTYPE [^>]+>", "").
                 replaceAll("\r?\n *", "");
     }
 


### PR DESCRIPTION
on jenkins nodes layer generation is "wrong" and we have a 1 line xml declaration for xml and doctype,
clean method is not able to take this
`<?xml version='1.0' encoding='UTF-8'?><!DOCTYPE filesystem PUBLIC '-//NetBeans//DTD Filesystem 1.2//EN' 'http://www.netbeans.org/dtds/filesystem-1_2.dtd'>`

trying to change replacefirst so that it only remove what is inside <>

As it only happen on jenkins, I tested locally on allready test ok box and see no regression in test.

BTW not sure of the root cause