### PR TITLE
maven daemon support

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/cmd/ShellConstructor.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/cmd/ShellConstructor.java
@@ -20,6 +20,8 @@
 package org.netbeans.modules.maven.execute.cmd;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import org.netbeans.api.annotations.common.NonNull;
@@ -39,24 +41,28 @@ public class ShellConstructor implements Constructor {
 
     @Override
     public List<String> construct() {
+
+        // use mvnd if its the home of a daemon
+        String ex = Files.exists(Paths.get(mavenHome.getPath(), "bin", "mvnd")) ? "mvnd" : "mvn"; //NOI18N
+
         //#164234
         //if maven.bat file is in space containing path, we need to quote with simple quotes.
         String quote = "\"";
-        List<String> toRet = new ArrayList<String>();
-        String ex = "mvn"; //NOI18N
+        List<String> toRet = new ArrayList<>();
+
         if (Utilities.isWindows()) {
             String version = MavenSettings.getCommandLineMavenVersion(mavenHome);
             if (null == version) {
-                ex = "mvn.bat"; // NOI18N
+                ex += ".bat"; // NOI18N
             } else {
                 String[] v = version.split("\\."); // NOI18N
                 int major = Integer.parseInt(v[0]);
                 int minor = Integer.parseInt(v[1]);
                 // starting with 3.3.0 maven stop using .bat file
                 if ((major < 3) || (major == 3 && minor < 3)) {
-                    ex = "mvn.bat"; //NOI18N
+                    ex += ".bat"; //NOI18N
                 } else {
-                    ex = "mvn.cmd"; //NOI18N
+                    ex += ".cmd"; //NOI18N
                 }
             }
         }

--- a/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/MavenSettings.java
@@ -22,10 +22,12 @@ package org.netbeans.modules.maven.options;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -35,6 +37,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.netbeans.api.annotations.common.CheckForNull;
@@ -466,37 +470,37 @@ public final class MavenSettings  {
     }
     
     public static @CheckForNull String getCommandLineMavenVersion(File mavenHome) {
-        File[] jars = new File(mavenHome, "lib").listFiles(new FilenameFilter() { // NOI18N
-            public @Override boolean accept(File dir, String name) {
-                return name.endsWith(".jar"); // NOI18N
+
+        Path lib = Paths.get(mavenHome.getPath(), "lib");        // mvn layout  // NOI18N
+        if (!Files.exists(lib)) {
+            lib = Paths.get(mavenHome.getPath(), "mvn", "lib");  // mvnd layout // NOI18N
+            if (!Files.exists(lib)) {
+                return null;
             }
-        });
-        if (jars == null) {
-            return null;
         }
-        for (File jar : jars) {
-            try {
-                // Prefer to use this rather than raw ZipFile since URLMapper since ArchiveURLMapper will cache JARs:
-                FileObject entry = URLMapper.findFileObject(new URL(FileUtil.urlForArchiveOrDir(jar), "META-INF/maven/org.apache.maven/maven-core/pom.properties")); // NOI18N
-                if (entry != null) {
-                    InputStream is = entry.getInputStream();
-                    try {
-                        Properties properties = new Properties();
-                        properties.load(is);
-                        return properties.getProperty("version"); // NOI18N
-                    } finally {
-                        is.close();
+
+        try {
+            try (Stream<Path> jars = Files.list(lib).filter(file -> file.toString().endsWith(".jar"))) {  // NOI18N
+                for (Path jar : jars.collect(Collectors.toList())) {
+                    // Prefer to use this rather than raw ZipFile since URLMapper since ArchiveURLMapper will cache JARs:
+                    FileObject entry = URLMapper.findFileObject(
+                            new URL(FileUtil.urlForArchiveOrDir(jar.toFile()), "META-INF/maven/org.apache.maven/maven-core/pom.properties")); // NOI18N
+                    if (entry != null) {
+                        try (InputStream is = entry.getInputStream()) {
+                            Properties properties = new Properties();
+                            properties.load(is);
+                            return properties.getProperty("version"); // NOI18N
+                        }
                     }
                 }
-            } catch (IOException x) {
-                // ignore for now
             }
-        }
+        } catch (IOException ignored) {}
+
         return null;
     }
 
     private static List<String> searchMavenRuntimes(String[] paths, boolean stopOnFirstValid) {
-        List<String> runtimes = new ArrayList<String>();
+        List<String> runtimes = new ArrayList<>();
         for (String path : paths) {
             File file = new File(path);
             path = FileUtil.normalizeFile(file).getAbsolutePath();
@@ -530,7 +534,7 @@ public final class MavenSettings  {
         String mavenHome = System.getenv("MAVEN_HOME"); // NOI18N
         String m2Home = System.getenv("M2_HOME"); // NOI18N
 
-        List<String> mavenEnvDirs = new ArrayList<String>();
+        List<String> mavenEnvDirs = new ArrayList<>();
         if (mavenHome != null) {
             mavenEnvDirs.add(mavenHome);
         }
@@ -557,7 +561,7 @@ public final class MavenSettings  {
     }
     
     public List<String> getUserDefinedMavenRuntimes() {
-        List<String> runtimes = new ArrayList<String>();
+        List<String> runtimes = new ArrayList<>();
 
         String defaultRuntimePath = getDefaultExternalMavenRuntime();
         String runtimesPref = getPreferences().get(PROP_MAVEN_RUNTIMES, null);

--- a/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
+++ b/java/maven/src/org/netbeans/modules/maven/options/SettingsPanel.java
@@ -25,6 +25,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -304,9 +306,8 @@ public class SettingsPanel extends javax.swing.JPanel {
 
         if (path != null) {
             path = path.trim();
-            File fil = new File(path);
             String ver = null;
-            if (fil.exists() && new File(fil, "bin" + File.separator + "mvn").exists()) { //NOI18N
+            if (Files.exists(Paths.get(path, "bin"))) { //NOI18N
                 ver = MavenSettings.getCommandLineMavenVersion(new File(path));
             }
 


### PR DESCRIPTION
added minimal support for https://github.com/mvndaemon/mvnd

maven home has the following layout:
```
bin/mvn
lib/*.jar
```

while mvnd home looks like:
```
bin/mvnd
mvn/  <- bundled maven home
```
This PR allows users to set a mvnd home as a maven home, NetBeans will then use mvnd and also be able to query the maven version from the bundled maven home.

did a little bit of manual testing and it seems that everything is working fine.

potentially related jira issue:
https://issues.apache.org/jira/browse/NETBEANS-4746