### PR TITLE
[NETBEANS-6107] Allow to use Gradle 7.2 distributions on JDK17.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
@@ -96,6 +96,7 @@ public final class GradleDistributionManager {
         GradleVersion.version("6.3"), // JDK-14
         GradleVersion.version("6.7"), // JDK-15
         GradleVersion.version("7.0"), // JDK-16
+        GradleVersion.version("7.2"), // JDK-17
     };
     private static final int JAVA_VERSION;
 


### PR DESCRIPTION
If a project (i.e. a project created by Micronaut 3.0.3 wizard) specifies (e.g. `gradle/wrapper/gradle-wrapper.properties`) that Gradle 7.2 is to be used, and NB runs on JDK17, the IDE falls back to gradle 7.0 that fails to load system classes bcs of incompatible major class version.
