### PR TITLE
[jackpot] Rewrite "String::replaceAll with dot" inspection to apply to more cases and methods

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/bugs/Bundle.properties
@@ -25,10 +25,11 @@ DN_AnnotationsNotRuntime_instanceof={0} does not have runtime Retention, the con
 DN_org.netbeans.modules.java.hints.bugs.AnnotationsNotRuntime=Annotations without runtime Retention
 DESC_org.netbeans.modules.java.hints.bugs.AnnotationsNotRuntime=Warns about reflective access to annotations with CLASS or SOURCE retentions
 
-DN_org.netbeans.modules.java.hints.bugs.Tiny.stringReplaceAllDot=String.replaceAll(".", )
-DESC_org.netbeans.modules.java.hints.bugs.Tiny.stringReplaceAllDot=Finds occurrences of calls to String.replaceAll(".", $target), which would replace all characters of the source string with $target.
-ERR_string-replace-all-dot=Call to String.replaceAll(".", $target) is probably undesired
-FIX_string-replace-all-dot=Replace with call to String.replaceAll("\\.", $target)
+DN_org.netbeans.modules.java.hints.bugs.Tiny.singleCharRegex=Single Char Regex
+DESC_org.netbeans.modules.java.hints.bugs.Tiny.singleCharRegex=Finds occurrences of single regex control characters \
+    used as parameter for methods expecting regular expressions and quotes those.
+ERR_single-char-regex=Using a single regex control character as regex is probably undesired
+FIX_single-char-regex=Escape character for regex usage
 
 DN_org.netbeans.modules.java.hints.bugs.CastVSInstanceOf=Incompatible cast/instanceof
 DESC_org.netbeans.modules.java.hints.bugs.CastVSInstanceOf=Incompatible cast surrounded with incompatible instanceof

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/Bundle_test.properties
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/Bundle_test.properties
@@ -22,8 +22,8 @@ DN_AnnotationsNotRuntime_instanceof={0} instanceof
 DN_RegExp=Invalid regular expression
 ERR_CastVSInstanceOf=CastVSInstanceOf
 
-ERR_string-replace-all-dot=ERR_string-replace-all-dot
-FIX_string-replace-all-dot=FIX_string-replace-all-dot
+ERR_single-char-regex=ERR_single-char-regex
+FIX_single-char-regex=FIX_single-char-regex
 
 ERR_newObject=new Object
 

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/TinyTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/bugs/TinyTest.java
@@ -38,7 +38,7 @@ public class TinyTest extends NbTestCase {
         super(name);
     }
 
-    public void testPositive1() throws Exception {
+    public void testSingleCharRegexPositive1() throws Exception {
         HintTest
                 .create()
                 .input("package test;\n" +
@@ -48,8 +48,8 @@ public class TinyTest extends NbTestCase {
                        "    }\n" +
                        "}\n")
                 .run(Tiny.class)
-                .findWarning("3:23-3:26:verifier:ERR_string-replace-all-dot")
-                .applyFix("FIX_string-replace-all-dot")
+                .findWarning("3:23-3:26:verifier:ERR_single-char-regex")
+                .applyFix("FIX_single-char-regex")
                 .assertCompilable()
                 .assertOutput("package test;\n" +
                               "public class Test {\n" +
@@ -59,13 +59,37 @@ public class TinyTest extends NbTestCase {
                               "}\n");
     }
 
-    public void testNegative1() throws Exception {
+    public void testSingleCharRegexPositive2() throws Exception {
+        HintTest
+                .create()
+                .input("package test;\n" +
+                       "public class Test {\n" +
+                       "    public void test(String[] args) {\n" +
+                       "        \"a\".split(\"$\");\n" +
+                       "    }\n" +
+                       "}\n")
+                .run(Tiny.class)
+                .findWarning("3:18-3:21:verifier:ERR_single-char-regex")
+                .applyFix("FIX_single-char-regex")
+                .assertCompilable()
+                .assertOutput("package test;\n" +
+                              "public class Test {\n" +
+                              "    public void test(String[] args) {\n" +
+                              "        \"a\".split(\"\\\\$\");\n" +
+                              "     }\n" +
+                              "}\n");
+    }
+
+    public void testSingleCharRegexNegative1() throws Exception {
         HintTest
                 .create()
                 .input("package test;\n" +
                        "public class Test {\n" +
                        "    public void test(String[] args) {\n" +
                        "        \"a\".replaceAll(\",\", \"/\");\n" +
+                       "        \"a\".replaceFirst(\"$$\", \"/\");\n" +
+                       "        String foo = \"foo\";\n" +
+                       "        \"a\".split(foo);\n" +
                        "    }\n" +
                        "}\n")
                 .run(Tiny.class)


### PR DESCRIPTION
The "String.replaceAll(".", )" probable-bug inspection was limited to the '.' character and the `replaceAll` method.

This PR rewrites it to apply to more single-char Strings consisting of a single regex control character and to more methods which expect regexes.

examples:
```
"f.o.o".replaceAll(".",  "")
=>
"f.o.o".replaceAll("\\.",  "")

"f$o$o".split("$")
=>
"f$o$o".split("\\$")

str.replaceFirst("(", "[")
=>
str.replaceFirst("\\(", "[")
```