### PR TITLE
Fixes creation of a Glassfish deployment descriptor

### DIFF
--- a/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/Utils.java
+++ b/enterprise/glassfish.eecommon/src/org/netbeans/modules/glassfish/eecommon/api/Utils.java
@@ -30,6 +30,8 @@ import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.glassfish.eecommon.api.config.J2eeModuleHelper;
 import org.netbeans.modules.j2ee.dd.api.common.RootInterface;
 import org.netbeans.modules.j2ee.dd.api.common.VersionNotSupportedException;
+import org.netbeans.modules.j2ee.dd.api.ejb.EjbJar;
+import org.netbeans.modules.j2ee.dd.api.web.WebApp;
 import org.netbeans.modules.j2ee.deployment.devmodules.api.J2eeModule;
 import org.netbeans.modules.j2ee.deployment.devmodules.spi.J2eeModuleProvider;
 import org.openide.filesystems.FileObject;
@@ -177,30 +179,10 @@ public final class Utils {
     }
     
     public static FileObject getSunDDFromProjectsModuleVersion(J2eeModule mod, String sunDDFileName) {
-        FileObject retVal = null;
-        String suffix = "-java_ee_5/";
-        if (null != mod) {
-            String modVer = mod.getModuleVersion();
-            J2eeModule.Type t = mod.getType();
-            // ejb 2.0, 2.1, 3.0, 3.1
-            // web 2.3, 2.4, 2.5, 3.0
-            // appcli 1.3, 1.4, 5.0, 6.0
-            // ear 1.3, 1.4, 5, 6
-            if (modVer.equals("6") || modVer.equals("6.0") || modVer.endsWith("1.6") || modVer.equals("3.1")) {
-                suffix = "-java_ee/";
-            } else if (modVer.equals("3.0")) {
-                if (J2eeModule.Type.WAR.equals(t)) {
-                    suffix = "-java_ee/";
-                }
-            } else if (modVer.equals("1.4") || modVer.equals("2.4") || modVer.equals("2.1")) {
-                suffix = "-j2ee_1_4/";
-            } else if (modVer.equals("2.0") || modVer.equals("2.3") || modVer.equals("1.3")) {
-                suffix = "-j2ee_1_3/";
-            }
-        }
+        FileObject retVal;
+        String suffix = "-java_ee/";
         String resource = "org-netbeans-modules-glassfish-eecommon-ddtemplates" + suffix + sunDDFileName; // NOI18N
         retVal = FileUtil.getConfigFile(resource);
-        
         return retVal;
     }
     

--- a/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/share/configbean/templates/SunDDVisualPanel.java
+++ b/enterprise/j2ee.sun.ddui/src/org/netbeans/modules/j2ee/sun/share/configbean/templates/SunDDVisualPanel.java
@@ -41,6 +41,7 @@ public final class SunDDVisualPanel extends JPanel {
     private String sunDDFileName;
     private File sunDDFile;
     private File sunDDLocation;
+    private static final String STANDARD_DD_NAME = "web.xml";
 
     public SunDDVisualPanel() {
         initComponents();
@@ -58,10 +59,10 @@ public final class SunDDVisualPanel extends JPanel {
         J2eeModule j2eeModule = provider.getJ2eeModule();
         sunDDFileName = getConfigFileName(j2eeModule,provider.getServerInstanceID());
 
-        // Calculate location:
-        sunDDFile = (sunDDFileName != null) ? j2eeModule.getDeploymentConfigurationFile(sunDDFileName) : null;
-        sunDDLocation = (sunDDFile != null) ? sunDDFile.getParentFile() : null;
-        
+        // Calculate location:        
+        sunDDLocation = j2eeModule.getDeploymentConfigurationFile(STANDARD_DD_NAME).getParentFile();
+        sunDDFile = (sunDDFileName != null) ? new File(sunDDLocation, sunDDFileName) : null;
+
         // initialize visual components
         textFileName.setText(sunDDFileName); // NOI18N
         textProjectName.setText(ProjectUtils.getInformation(project).getDisplayName());


### PR DESCRIPTION
This is a bug fix PR that fixes the creation of `glassfish-web.xml` deployment descriptor.

**Issue 1:**

If the server is not assigned to the project then glassfish-web.xml path is incorrect.

- Server attached then descriptor path: webapp/WEB-INF/glassfish-web.xml
- Server is not attached then the descriptor path: webapp/glassfish-web.xml

Fixed by checking the relative path of standard DD `web.xml`.

**Issue 2:**

Old Java EE and J2EE `glassfish-web.xml` templates no more exist and check for WebApp version 4.0 not added to `getSunDDFromProjectsModuleVersion` which skips the creation of `glassfish-web.xml`.

Fixed by returning the template `org-netbeans-modules-glassfish-eecommon-ddtemplates-java_ee/glassfish-web.xml`.



