### PR TITLE
Remove check that blows up when the LSP or DAP server is reset.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspSession.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/LspSession.java
@@ -53,9 +53,6 @@ public final class LspSession {
      * Set the launched LSP server.
      */
     void setLspServer(NbLspServer lspServer) {
-        if (lspServer != null && this.lspServer != null) {
-            throw new IllegalStateException("LSP server is set already");
-        }
         setServerLookup(lspServer, lspServices);
         this.lspServer = lspServer;
     }
@@ -64,9 +61,6 @@ public final class LspSession {
      * Set the launched DAP server.
      */
     void setDapServer(NbProtocolServer dapServer) {
-        if (dapServer != null && this.dapServer != null) {
-            throw new IllegalStateException("DAP server is set already");
-        }
         setServerLookup(dapServer, dapServices);
         this.dapServer = dapServer;
     }


### PR DESCRIPTION
When a DAP server is reset, following exception is thrown:
```
java.lang.IllegalStateException: DAP server is set already
	at org.netbeans.modules.java.lsp.server.LspSession.setDapServer(LspSession.java:68)
[catch] at org.netbeans.modules.java.lsp.server.ConnectionSpec$2.run(ConnectionSpec.java:144)
```
That check should not be necessary as the lookup content is updated with the new session.