### PR TITLE
Enable Groovy by default in vscode and NBJLS.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientCapabilities.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientCapabilities.java
@@ -59,7 +59,7 @@ public final class NbCodeClientCapabilities {
     /**
      * Asks for groovy support. Temporary option, will be removed.
      */
-    private Boolean wantsGroovySupport;
+    private Boolean wantsGroovySupport = Boolean.TRUE;
 
     public ClientCapabilities getClientCapabilities() {
         return clientCaps;
@@ -94,11 +94,11 @@ public final class NbCodeClientCapabilities {
     }
 
     public void setWantGroovySupport(Boolean enableGroovy) {
-        this.wantsGroovySupport = enableGroovy;
+        this.wantsGroovySupport = enableGroovy == null ? Boolean.TRUE : enableGroovy;
     }
 
     public boolean wantsGroovySupport() {
-        return wantsGroovySupport != null && wantsGroovySupport.booleanValue();
+        return wantsGroovySupport.booleanValue();
     }
 
     private NbCodeClientCapabilities withCapabilities(ClientCapabilities caps) {

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -88,7 +88,7 @@
 				},
 				"netbeans.groovySupport.enabled": {
 					"type": "boolean",
-					"default": false,
+					"default": true,
 					"description": "Enables experimental Groovy and Spock support in Language Server"
 				}
 			}

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -540,7 +540,7 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
                 { language: 'properties', pattern: '**/{application,bootstrap}*.properties' },
                 { language: 'jackpot-hint' }
         ];
-        const enableGroovy : boolean = conf.get("netbeans.groovySupport.enabled") || false;
+        const enableGroovy : boolean = conf.get("netbeans.groovySupport.enabled") || true;
         if (enableGroovy) {
             documentSelectors.push({ language: 'groovy'});
         }


### PR DESCRIPTION
Groovy indexing was disabled because of its slowness, but that seems to be fixed, so let's retain the ability to disable the support if the user sees it as harmful, but enable by default.