### PR TITLE
[jackpot] Updates to autoboxing inspections

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/Utilities.java
@@ -1751,7 +1751,7 @@ public class Utilities {
         }
     }
 
-    private static final Set<String> PRIMITIVE_NAMES = new HashSet<String>(7);
+    private static final Set<String> PRIMITIVE_NAMES = new HashSet<String>(8);
     
     static {
         PRIMITIVE_NAMES.add("java.lang.Integer"); // NOI18N

--- a/java/java.hints/src/org/netbeans/modules/java/hints/perf/Bundle.properties
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/perf/Bundle.properties
@@ -114,11 +114,15 @@ DN_RedundantToString=Redundant String.toString()
 DESC_RedundantToString=Reports calls of String.toString(), which is entirely useless, the String can be used directly.
 
 DN_UnnecessaryTempFromString=Unnecessary temporary during conversion from String
-DESC_UnnecessaryTempFromString=Finds occurrences of <i>new Integer("111").intValue()</i> and similar constructions, where the \
-    boxed instance is created just to parse the String parameter. Boxing types have <i>parseXXX</i> methods, which perform the \
-    conversion without creating the temporary instance.
+DESC_UnnecessaryTempFromString=Finds occurrences of <i>Integer.valueOf($string)</i> and similar constructions, which \
+    are assigned to primitive types and replaces it with <i>Integer.parseInt($string)</i> (vice versa for assignments to boxed types), \
+    to remove unnecessary temporary boxing.
 
 DN_UnnecessaryTempToString=Unnecessary temporary during conversion to String
-DESC_UnnecessaryTempToString=Finds places like <i>new Integer(11).toString()</i> where a temporary boxed instance is created to \
+DESC_UnnecessaryTempToString=Finds places like <i>Integer.valueOf(11).toString()</i> where a temporary boxed instance is created to \
     just produce a String representation of a primitive. The boxed types have <i>toString()</i> static method just for that purpose.
 
+DN_BoxedPrimitiveConstruction=Boxed Primitive instantiation
+DESC_BoxedPrimitiveConstruction=Replace the usage of deprecated boxed primitive constructors (new Integer("5")) \
+    with their corresponding factory methods (Integer.valueOf("5")). This inspection can be used in conjunction with \
+    <i>Unnecessary temporary during conversion from String</i>, to suggest <i>parseXXX()</i> instead of <i>valueOf()</i> where applicable.

--- a/java/java.hints/src/org/netbeans/modules/java/hints/perf/Tiny.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/perf/Tiny.java
@@ -22,12 +22,15 @@ package org.netbeans.modules.java.hints.perf;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.NewArrayTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.util.TreePath;
+import com.sun.source.util.Trees;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -39,6 +42,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
@@ -61,6 +65,10 @@ import org.netbeans.spi.java.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.java.hints.JavaFix.TransformationContext;
 import org.netbeans.spi.java.hints.JavaFixUtilities;
 import org.openide.util.NbBundle;
+
+import static com.sun.source.tree.Tree.Kind.METHOD_INVOCATION;
+import static com.sun.source.tree.Tree.Kind.NEW_CLASS;
+import static javax.lang.model.type.TypeKind.EXECUTABLE;
 
 /**
  *
@@ -431,22 +439,32 @@ public class Tiny {
     }
     
     @TriggerPatterns({
-        @TriggerPattern(value = "new java.lang.Byte($v).byteValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "new java.lang.Double($v).doubleValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "new java.lang.Float($v).floatValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "new java.lang.Integer($v).intValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "new java.lang.Long($v).longValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "new java.lang.Short($v).shortValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "new java.lang.Boolean($v).booleanValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        
-        
-        @TriggerPattern(value = "java.lang.Byte.valueOf($v).byteValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "java.lang.Double.valueOf($v).doubleValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "java.lang.Float.valueOf($v).floatValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "java.lang.Integer.valueOf($v).intValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "java.lang.Long.valueOf($v).longValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "java.lang.Short.valueOf($v).shortValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
-        @TriggerPattern(value = "java.lang.Boolean.valueOf($v).booleanValue()", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Integer.parseInt($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Byte.parseByte($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Short.parseShort($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Long.parseLong($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Float.parseFloat($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Double.parseDouble($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Boolean.parseBoolean($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+
+        @TriggerPattern(value = "java.lang.Integer.parseInt($s, $r)", constraints = {@ConstraintVariableType(variable = "$s", type = "java.lang.String"), @ConstraintVariableType(variable = "$r", type = "int")}),
+        @TriggerPattern(value = "java.lang.Byte.parseByte($s, $r)", constraints = {@ConstraintVariableType(variable = "$s", type = "java.lang.String"), @ConstraintVariableType(variable = "$r", type = "int")}),
+        @TriggerPattern(value = "java.lang.Short.parseShort($s, $r)", constraints = {@ConstraintVariableType(variable = "$s", type = "java.lang.String"), @ConstraintVariableType(variable = "$r", type = "int")}),
+        @TriggerPattern(value = "java.lang.Long.parseLong($s, $r)", constraints = {@ConstraintVariableType(variable = "$s", type = "java.lang.String"), @ConstraintVariableType(variable = "$r", type = "int")}),
+
+
+        @TriggerPattern(value = "java.lang.Byte.valueOf($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Double.valueOf($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Float.valueOf($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Integer.valueOf($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Long.valueOf($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Short.valueOf($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+        @TriggerPattern(value = "java.lang.Boolean.valueOf($v)", constraints = @ConstraintVariableType(variable = "$v", type = "java.lang.String")),
+
+        @TriggerPattern(value = "java.lang.Byte.valueOf($v, $r)", constraints = {@ConstraintVariableType(variable = "$v", type = "java.lang.String"), @ConstraintVariableType(variable = "$r", type = "int")}),
+        @TriggerPattern(value = "java.lang.Integer.valueOf($v, $r)", constraints = {@ConstraintVariableType(variable = "$v", type = "java.lang.String"), @ConstraintVariableType(variable = "$r", type = "int")}),
+        @TriggerPattern(value = "java.lang.Long.valueOf($v, $r)", constraints = {@ConstraintVariableType(variable = "$v", type = "java.lang.String"), @ConstraintVariableType(variable = "$r", type = "int")}),
+        @TriggerPattern(value = "java.lang.Short.valueOf($v, $r)", constraints = {@ConstraintVariableType(variable = "$v", type = "java.lang.String"), @ConstraintVariableType(variable = "$r", type = "int")}),
     })
     @NbBundle.Messages({
         "TEXT_UnnecessaryTempFromString=Unnecessary temporary when converting from String",
@@ -462,36 +480,79 @@ public class Tiny {
         suppressWarnings = "UnnecessaryTemporaryOnConversionFromString" 
     )
     public static ErrorDescription unnecessaryTempFromString(HintContext ctx) {
-        TypeMirror resType = ctx.getInfo().getTrees().getTypeMirror(ctx.getPath());
-        if (resType == null) {
+
+        String type;
+        String method;
+
+        // determine if the destination is primitive
+        TypeMirror destType = getDestinationType(ctx, ctx.getPath());
+        TypeMirror srcType = ctx.getInfo().getTrees().getTypeMirror(ctx.getPath());
+
+        if (srcType == null || destType == null) {
             return null;
+        } else if (destType.getKind().isPrimitive() && !srcType.getKind().isPrimitive()) {
+            srcType = ctx.getInfo().getTypes().unboxedType(srcType);
+            String[] replacement = PARSE_METHODS.get(srcType.getKind());
+            type = replacement[0];
+            method = replacement[1];
+        } else if (!destType.getKind().isPrimitive() && srcType.getKind().isPrimitive()) {
+            type = PARSE_METHODS.get(srcType.getKind())[0];
+            method = "valueOf";  // NOI18N
+        } else {
+            return null;  // nothing to do, a different rule handles .intValue() boxing problems
         }
-        if (resType.getKind() == TypeKind.BOOLEAN) {
-            if (ctx.getInfo().getSourceVersion().compareTo(SourceVersion.RELEASE_5) < 0) {
-                // might alter new Boolean($v) to Boolean.valueOf($v), but that's all we can do. JDK < 5 has no 
-                // primitive-valued pasre* method for booleans.
-                return null;
+
+        if (srcType.getKind() == TypeKind.BOOLEAN && ctx.getInfo().getSourceVersion().compareTo(SourceVersion.RELEASE_5) < 0) {
+            return null;  // JDK < 5 has no primitive-valued pasre* method for booleans.
+        }
+
+        Fix fix = JavaFixUtilities.rewriteFix(ctx, Bundle.FIX_UnnecessaryTempFromString1(type, method), ctx.getPath(), type + "." + method + "($v)"); // NOI18N
+        return ErrorDescriptionFactory.forTree(ctx, ctx.getPath(), Bundle.TEXT_UnnecessaryTempFromString(), fix); // NOI18N
+    }
+
+    private static TypeMirror getDestinationType(HintContext ctx, TreePath path) {
+
+        TreePath parent = path.getParentPath();
+        Tree parentLeaf = parent.getLeaf();
+        Tree leaf = path.getLeaf();
+
+        Trees trees = ctx.getInfo().getTrees();
+
+        if (parentLeaf.getKind() == METHOD_INVOCATION) {
+
+            MethodInvocationTree met = (MethodInvocationTree) parentLeaf;
+            int index = met.getArguments().indexOf(leaf);
+            return paramTypeOfExecutable(trees.getTypeMirror(new TreePath(path, met.getMethodSelect())), index);
+        } else if (parentLeaf.getKind() == NEW_CLASS) {
+
+            NewClassTree nct = (NewClassTree) parentLeaf;
+            int index = nct.getArguments().indexOf(leaf);
+            return paramTypeOfExecutable(trees.getElement(new TreePath(path, nct)).asType(), index);
+        } else {
+
+            int pos = (int) trees.getSourcePositions().getStartPosition(path.getCompilationUnit(), leaf);
+            List<? extends TypeMirror> type = CreateElementUtilities.resolveType(
+                    EnumSet.noneOf(ElementKind.class), ctx.getInfo(), parent, leaf, pos, new TypeMirror[1], new int[1]);
+
+            if (!type.isEmpty()) {
+                return type.get(0);
             }
         }
-        String[] arr = PARSE_METHODS.get(resType.getKind());
-        if (arr == null) {
-            return null; // just in case
+
+        return null;
+    }
+
+    private static TypeMirror paramTypeOfExecutable(TypeMirror executable, int index) {
+        if (index != -1 && executable != null && executable.getKind() == EXECUTABLE) {
+            List<? extends TypeMirror> paramTypes = ((ExecutableType) executable).getParameterTypes();
+            if (paramTypes.size() > index) {
+                return paramTypes.get(index);
+            }
         }
-        return ErrorDescriptionFactory.forTree(ctx, ctx.getPath(), Bundle.TEXT_UnnecessaryTempFromString(),
-                JavaFixUtilities.rewriteFix(ctx, Bundle.FIX_UnnecessaryTempFromString1(arr[0], arr[1]), ctx.getPath(),
-                arr[0] + "." + arr[1] + "($v)")); // NOI18N
+        return null;
     }
     
     @TriggerPatterns({
-        @TriggerPattern(value = "new java.lang.Byte($v).toString()", constraints = @ConstraintVariableType(variable = "$v", type = "int")),
-        @TriggerPattern(value = "new java.lang.Double($v).toString()", constraints = @ConstraintVariableType(variable = "$v", type = "double")),
-        @TriggerPattern(value = "new java.lang.Float($v).toString()", constraints = @ConstraintVariableType(variable = "$v", type = "float")),
-        @TriggerPattern(value = "new java.lang.Integer($v).toString()", constraints = @ConstraintVariableType(variable = "$v", type = "int")),
-        @TriggerPattern(value = "new java.lang.Long($v).toString()", constraints = @ConstraintVariableType(variable = "$v", type = "long")),
-        @TriggerPattern(value = "new java.lang.Short($v).toString()", constraints = @ConstraintVariableType(variable = "$v", type = "int")),
-        @TriggerPattern(value = "new java.lang.Boolean($v).toString()", constraints = @ConstraintVariableType(variable = "$v", type = "boolean")),
-        
-        
         @TriggerPattern(value = "java.lang.Byte.valueOf($v).toString()", constraints = @ConstraintVariableType(variable = "$v", type = "int")),
         @TriggerPattern(value = "java.lang.Double.valueOf($v).toString()", constraints = @ConstraintVariableType(variable = "$v", type = "double")),
         @TriggerPattern(value = "java.lang.Float.valueOf($v).toString()", constraints = @ConstraintVariableType(variable = "$v", type = "float")),
@@ -523,7 +584,37 @@ public class Tiny {
             return null; // just in case
         }
         return ErrorDescriptionFactory.forTree(ctx, ctx.getPath(), Bundle.TEXT_UnnecessaryTempFromString(),
-                JavaFixUtilities.rewriteFix(ctx, Bundle.FIX_UnnecessaryTempToString(arr[0]), ctx.getPath(),
-                arr[0] + ".toString($v)")); // NOI18N
+                JavaFixUtilities.rewriteFix(ctx, Bundle.FIX_UnnecessaryTempToString(arr[0]), ctx.getPath(), arr[0] + ".toString($v)")); // NOI18N
+    }
+
+    // TODO move to jdk package?
+    @TriggerPatterns({
+        @TriggerPattern(value = "new java.lang.Byte($v)"),
+        @TriggerPattern(value = "new java.lang.Double($v)"),
+        @TriggerPattern(value = "new java.lang.Float($v)"),
+        @TriggerPattern(value = "new java.lang.Integer($v)"),
+        @TriggerPattern(value = "new java.lang.Long($v)"),
+        @TriggerPattern(value = "new java.lang.Short($v)"),
+        @TriggerPattern(value = "new java.lang.Boolean($v)"),
+    })
+    @NbBundle.Messages({
+        "TEXT_BoxedPrimitiveConstruction=Replace usage of deprecated boxed primitive constructors with factory methods.",
+        "# {0} - wrapper type simple name",
+        "FIX_BoxedPrimitiveConstruction=Replace with {0}.valueOf()",
+    })
+    @Hint(
+        displayName = "#DN_BoxedPrimitiveConstruction",
+        description = "#DESC_BoxedPrimitiveConstruction",
+        enabled = true,
+        category = "rules15",
+        suppressWarnings = "BoxedPrimitiveConstruction"
+    )
+    public static ErrorDescription boxedPrimitiveConstruction(HintContext ctx) {
+        TypeMirror resType = ctx.getInfo().getTrees().getTypeMirror(ctx.getPath());
+        if (resType == null) {
+            return null;
+        }
+        return ErrorDescriptionFactory.forTree(ctx, ctx.getPath(), Bundle.TEXT_BoxedPrimitiveConstruction(),
+                JavaFixUtilities.rewriteFix(ctx, Bundle.FIX_BoxedPrimitiveConstruction(resType), ctx.getPath(), resType + ".valueOf($v)")); // NOI18N
     }
 }


### PR DESCRIPTION
* repurposed a dusty perf rule to suggest `Boxed.valueOf() -> Boxed.parseType()` refactoring where applicable
  * added reverse case
  * added rules for overloaded method variants
* extracted some functionality into a new rule which has the lone purpose to get rid of deprecated boxed primitive construction
* some rules overlapped with other inspections, removed those to keep things simple.
  * this might mean however that some inspections have to be applied multiple times, since one fix could trigger another

example:
```java
    private static void a(Integer i) {}
    private static void b(String foo, int i) {}
    private static void c(String foo, double a, long i) {}

    public static void test() {
        
        a(Integer.valueOf(""));                             // do nothing
        b("abcd", Integer.valueOf("1"));                    // => parseInt()
        b("abcd", Integer.valueOf("1").intValue());         // => remove .intValue() => parseInt()
        c("asdf", Float.valueOf("1"), Long.valueOf("1"));   // => parseFloat() and => parseLong()
        
        
        ArrayList<Object> arrayList = new ArrayList<>(Integer.valueOf("6")); // => parseInt()
        arrayList.get(Integer.valueOf("1"));                                 // => parseInt()
        
        
        float prim1 = Float.parseFloat("5");        // do nothing
        prim1 = Float.valueOf("6");                 // => parseFloat()
        prim1 = Float.valueOf("6").floatValue();    // => remove .floatValue() => parseFloat()
        prim1 = Float.parseFloat("6");              // do nothing
        
        Float boxed1 = Float.parseFloat("5");       // => valueOf()
        boxed1 = Float.valueOf("6");                // do nothing
        boxed1 = Float.valueOf("6").floatValue();   // => remove .floatValue()
        boxed1 = Float.parseFloat("6");             // => valueOf()

        byte b = new Byte("5").byteValue();     // => remove .byteValue() => valueOf() => parseByte()

        // short form and AIC works too
        Executors.newFixedThreadPool(1).submit(() -> {
            return Integer.parseInt("1");         // => valueOf()
        });
        ....
    }
```

todo/future
* ~tests~
* getDestinationType() covers hopefully the most common cases but this might not be enough
  * potentially useful utility method if made accessible from hint files (but that is for later)
* might be cleaner to put all boxing-related rules into the same package and display those in the same category in the UI too, they are currently all over the place (potential future task)