### PR TITLE
[NETBEANS-6127] Do not parallelize notifyToBeResumedNoFire(), because it runs under a lock.

### DIFF
--- a/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDADebuggerImpl.java
+++ b/java/debugger.jpda/src/org/netbeans/modules/debugger/jpda/JPDADebuggerImpl.java
@@ -1893,20 +1893,16 @@ public class JPDADebuggerImpl extends JPDADebugger {
     public void notifyToBeResumedAllNoFire(Set<ThreadReference> ignoredThreads) {
         List<? extends JPDAThreadImpl> threads = threadsTranslation.getTranslated((o) ->
                 (o instanceof JPDAThreadImpl && (ignoredThreads == null || !ignoredThreads.contains(o))) ? (JPDAThreadImpl) o : null);
-        int n = threads.size();
-        if (n > 0) {
-            processInParallel(n, (i) -> {
-                JPDAThreadImpl thread = threads.get(i);
-                int status = thread.getState();
-                boolean invalid = (status == JPDAThread.STATE_NOT_STARTED ||
-                                   status == JPDAThread.STATE_UNKNOWN ||
-                                   status == JPDAThread.STATE_ZOMBIE);
-                if (!invalid) {
-                    thread.notifyToBeResumedNoFire();
-                } else if (status == JPDAThread.STATE_UNKNOWN || status == JPDAThread.STATE_ZOMBIE) {
-                    threadsTranslation.remove(thread.getThreadReference());
-                }
-            });
+        for (JPDAThreadImpl thread : threads) {
+            int status = thread.getState();
+            boolean invalid = (status == JPDAThread.STATE_NOT_STARTED ||
+                               status == JPDAThread.STATE_UNKNOWN ||
+                               status == JPDAThread.STATE_ZOMBIE);
+            if (!invalid) {
+                thread.notifyToBeResumedNoFire();
+            } else if (status == JPDAThread.STATE_UNKNOWN || status == JPDAThread.STATE_ZOMBIE) {
+                threadsTranslation.remove(thread.getThreadReference());
+            }
         }
     }
     


### PR DESCRIPTION
When all threads are suspended as a result of an event (e.g. a breakpoint that suspends all threads), we notify all instances of `JPDAThreadImpl` about the suspension (via `JPDADebuggerImpl.notifyToBeResumedAllNoFire()` method) under debugger write lock.
To update its state, the `JPDAThreadImpl` acquires debugger read lock. As long as it's run synchronously, there's no issue as the read lock can be acquired under the write lock. But when we parallelized the calls to individual threads to improve performance on slow connection, we suddenly tried to acquire the debugger read lock on a new thread. With the original thread still holding the write lock. This has led to a deadlock.

The solution is to notify the threads synchronously again.