### PR TITLE
[NETBEANS-6107] Bumped Gradle Tooling to 7.3-rc-1 with Java 17 support.

### DIFF
--- a/extide/gradle/nbproject/project.xml
+++ b/extide/gradle/nbproject/project.xml
@@ -30,7 +30,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>7</release-version>
-                        <specification-version>7.0</specification-version>
+                        <specification-version>7.3</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleDistributionManager.java
@@ -360,7 +360,7 @@ public final class GradleDistributionManager {
     File distributionBaseDir(URI downloadLocation, String version) {
         WrapperConfiguration conf = new WrapperConfiguration();
         conf.setDistribution(downloadLocation);
-        PathAssembler pa = new PathAssembler(gradleUserHome);
+        PathAssembler pa = new PathAssembler(gradleUserHome, null);
         PathAssembler.LocalDistribution dist = pa.getDistribution(conf);
         return new File(dist.getDistributionDir(), "gradle-" + version);
     }
@@ -566,7 +566,7 @@ public final class GradleDistributionManager {
             try {
                 WrapperConfiguration conf = new WrapperConfiguration();
                 conf.setDistribution(dist.getDistributionURI());
-                PathAssembler pa = new PathAssembler(gradleUserHome);
+                PathAssembler pa = new PathAssembler(gradleUserHome, null);
                 Install install = new Install(new Logger(true), this, pa);
                 install.createDist(conf);
             } catch (Exception ex) {

--- a/extide/libs.gradle/external/binaries-list
+++ b/extide/libs.gradle/external/binaries-list
@@ -14,4 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-DFC57AE4562914B649BF530C2D9BB22EC9677CF1 gradle-tooling-api-7.0.jar
+B2123DF25C938DD072C7D07716629AABEF0ABD10 gradle-tooling-api-7.3-rc-1.jar

--- a/extide/libs.gradle/external/gradle-tooling-api-7.3-rc-1-license.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-7.3-rc-1-license.txt
@@ -1,7 +1,7 @@
 Name: Gradle Wrapper
 Description: Gradle Tooling API
-Version: 7.0
-Files: gradle-tooling-api-7.0.jar
+Version: 7.3-rc-1
+Files: gradle-tooling-api-7.3-rc-1.jar
 License: Apache-2.0
 Origin: Gradle Inc.
 URL: https://gradle.org/

--- a/extide/libs.gradle/external/gradle-tooling-api-7.3-rc-1-notice.txt
+++ b/extide/libs.gradle/external/gradle-tooling-api-7.3-rc-1-notice.txt
@@ -5,4 +5,4 @@ This product includes software developed at
 Gradle Inc. (https://gradle.org/).
 
 This product includes/uses SLF4J (https://www.slf4j.org/)
-developed by QOS.ch, 2004-2020
+developed by QOS.ch, 2004-2021

--- a/extide/libs.gradle/manifest.mf
+++ b/extide/libs.gradle/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.libs.gradle/7
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/libs/gradle/Bundle.properties
-OpenIDE-Module-Specification-Version: 7.2
+OpenIDE-Module-Specification-Version: 7.3

--- a/extide/libs.gradle/nbproject/project.properties
+++ b/extide/libs.gradle/nbproject/project.properties
@@ -22,4 +22,4 @@ javac.compilerargs=-Xlint -Xlint:-serial
 # For more information, please see http://wiki.netbeans.org/SignatureTest
 sigtest.gen.fail.on.error=false
 
-release.external/gradle-tooling-api-7.0.jar=modules/gradle/gradle-tooling-api.jar
+release.external/gradle-tooling-api-7.3-rc-1.jar=modules/gradle/gradle-tooling-api.jar

--- a/extide/libs.gradle/nbproject/project.xml
+++ b/extide/libs.gradle/nbproject/project.xml
@@ -39,7 +39,7 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path>gradle/gradle-tooling-api.jar</runtime-relative-path>
-                <binary-origin>external/gradle-tooling-api-7.0.jar</binary-origin>
+                <binary-origin>external/gradle-tooling-api-7.3-rc-1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Well, this is just one another step closer to Java 17 support on Gradle Projects, hoping that 7.3 would eventually be released  before NetBeans 12.6. That means there would be another PR for 7.3 is yet to come. However having the RC1 in at least makes it testable.
I have not raised the minimal requirement for Java 17 from 7.2 yet.