### PR TITLE
[NETBEANS-6130] - Fix wrong Groovy version in ant library

### DIFF
--- a/groovy/libs.groovy/src/org/netbeans/modules/libs/groovy/Bundle.properties
+++ b/groovy/libs.groovy/src/org/netbeans/modules/libs/groovy/Bundle.properties
@@ -16,5 +16,5 @@
 # under the License.
 OpenIDE-Module-Name=Groovy Binaries
 
-groovy=Groovy 2.5.11
-groovy-ant=Groovy Ant 2.5.11
+groovy=Groovy 3.0.8
+groovy-ant=Groovy Ant 3.0.8


### PR DESCRIPTION
Wrong version number in the library.

It is 2.5.11
![NETBEANS-6130](https://user-images.githubusercontent.com/9832133/137394772-3e7546b3-d0fa-41ce-9a74-69f11b8bf4d9.png)

Should be 3.0.8
