### PR TITLE
[NETBEANS-6008] Update FlatLaf from 1.5 to 1.6.1

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-D5AD617D7C328784145B05F7C8F030DB2DE5234E com.formdev:flatlaf:1.5
+DF181FADB3050FE3CF38A13C519D56E69329CEE3 com.formdev:flatlaf:1.6.1

--- a/platform/libs.flatlaf/external/flatlaf-1.6.1-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-1.6.1-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 1.5
-Files: flatlaf-1.5.jar
+Version: 1.6.1
+Files: flatlaf-1.6.1.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-1.5.jar=modules/ext/flatlaf-1.5.jar
+release.external/flatlaf-1.6.1.jar=modules/ext/flatlaf-1.6.1.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-1.5.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-1.5.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-1.6.1.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-1.6.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
FlatLaf 1.6 fixes some regressions, that cause problems in NetBeans platform application:
https://issues.apache.org/jira/browse/NETBEANS-6008

FlatLaf 1.6.1 fixes a problem that may crash NetBeans on startup on Windows 10 when running on **Java 8**:

~~~
Exception in thread "AWT-EventQueue-0" java.lang.UnsatisfiedLinkError: 
   Native Library jawt.dll already loaded in another classloader
~~~

A NetBeans user reported this directly to me.
Was not yet able to reproduce it. 
Seems to depend on the system or on installed software.