### PR TITLE
Don't search for parent folders when there is .mxignore file

### DIFF
--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteFactory.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteFactory.java
@@ -63,7 +63,7 @@ public class SuiteFactory implements ProjectFactory2 {
         // Support the case where a subproject is directly opened. The mx
         // netbeans configuration generator generates java ant projects on the
         // subproject level. This is detected and overriden by this factory.
-        FileObject baseDir2 = fo.getParent() != null ? fo.getParent().getParent() : null;
+        FileObject baseDir2 = parentNoIgnore(parentNoIgnore(fo));
 
         if (baseDir2 != null) {
             final String mxDirName2 = "mx." + baseDir2.getNameExt();
@@ -72,6 +72,20 @@ public class SuiteFactory implements ProjectFactory2 {
         } else {
             return null;
         }
+    }
+
+    static FileObject parentNoIgnore(FileObject fo) {
+        if (fo == null) {
+            return null;
+        }
+        FileObject p = fo.getParent();
+        if (p == null) {
+            return null;
+        }
+        if (p.getFileObject(".mxignore") != null) { // NOI18N
+            return null;
+        }
+        return p;
     }
 
     @Override

--- a/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SuiteFactoryTest.java
+++ b/java/java.mx.project/test/unit/src/org/netbeans/modules/java/mx/project/SuiteFactoryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.mx.project;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public class SuiteFactoryTest {
+    
+    public SuiteFactoryTest() {
+    }
+
+    @Test
+    public void honorMxIgnoreFileWhenTraveringToParent() throws Exception {
+        FileObject root = FileUtil.createMemoryFileSystem().getRoot();
+        FileObject f1 = root.createFolder("f1");
+        FileObject f2 = f1.createData("x.txt");
+        FileObject ignore = f1.createData(".mxignore");
+        
+        FileObject p = SuiteFactory.parentNoIgnore(f2);
+        assertNull("Parent is ignored", p);
+    }
+    
+    @Test
+    public void simpleParentFound() throws Exception {
+        FileObject root = FileUtil.createMemoryFileSystem().getRoot();
+        FileObject f1 = root.createFolder("f1");
+        FileObject f2 = f1.createData("x.txt");
+        
+        FileObject p = SuiteFactory.parentNoIgnore(f2);
+        assertSame("Found the right parent", f1, p);
+    }
+    
+    @Test
+    public void rootHasNoParent() throws Exception {
+        FileObject root = FileUtil.createMemoryFileSystem().getRoot();
+        FileObject p = SuiteFactory.parentNoIgnore(root);
+        assertNull("No parent for root", p);
+    }
+    
+}


### PR DESCRIPTION
I am not able to work with IGV sources using Ant based NetBeans harness as their structure is:
```
IdealGraphVisualizer/nbproject
IdealGraphVisualizer/submodules/nbproject
mx.visualizer/suite.py
```
and the submodules are then recognized as the MX project. Avoiding such collision by honoring (already existing from previous versions) `IdealGraphVisualizer/.mxignore` file when traversing two folders up.

CCing @Ondrej-Douda 