### PR TITLE
[NETBEANS-6087] Use the refactoring feature for private members of trait instead of the instant renamer

### DIFF
--- a/php/php.editor/src/org/netbeans/modules/php/editor/csl/InstantRenamerImpl.java
+++ b/php/php.editor/src/org/netbeans/modules/php/editor/csl/InstantRenamerImpl.java
@@ -32,6 +32,7 @@ import org.netbeans.modules.php.editor.api.elements.FieldElement;
 import org.netbeans.modules.php.editor.api.elements.MethodElement;
 import org.netbeans.modules.php.editor.api.elements.PhpElement;
 import org.netbeans.modules.php.editor.api.elements.TypeConstantElement;
+import org.netbeans.modules.php.editor.api.elements.TypeElement;
 import org.netbeans.modules.php.editor.model.Model;
 import org.netbeans.modules.php.editor.model.Occurence;
 import org.netbeans.modules.php.editor.model.Occurence.Accuracy;
@@ -75,13 +76,15 @@ public class InstantRenamerImpl implements InstantRenamer {
                     } else if (decl instanceof MethodElement) {
                         MethodElement meth = (MethodElement) decl;
                         PhpModifiers phpModifiers = meth.getPhpModifiers();
-                        if (phpModifiers.isPrivate()) {
+                        if (phpModifiers.isPrivate() && !meth.getType().isTrait()) {
+                            // NETBEANS-6087 private methods of trait are used in classes
                             return checkAll(caretOccurence);
                         }
                     } else if (decl instanceof FieldElement) {
                         FieldElement fld = (FieldElement) decl;
                         PhpModifiers phpModifiers = fld.getPhpModifiers();
-                        if (phpModifiers.isPrivate()) {
+                        if (phpModifiers.isPrivate() && !fld.getType().isTrait()) {
+                            // NETBEANS-6087 private field of trait are used in classes
                             return checkAll(caretOccurence);
                         }
                     } else if (decl instanceof TypeConstantElement) {

--- a/php/php.refactoring/src/org/netbeans/modules/refactoring/php/findusages/WhereUsedSupport.java
+++ b/php/php.refactoring/src/org/netbeans/modules/refactoring/php/findusages/WhereUsedSupport.java
@@ -55,6 +55,8 @@ import org.netbeans.modules.php.editor.model.ModelElement;
 import org.netbeans.modules.php.editor.model.ModelFactory;
 import org.netbeans.modules.php.editor.model.ModelUtils;
 import org.netbeans.modules.php.editor.model.Occurence;
+import org.netbeans.modules.php.editor.model.Scope;
+import org.netbeans.modules.php.editor.model.TraitScope;
 import org.netbeans.modules.php.editor.model.TypeScope;
 import org.netbeans.modules.php.editor.model.VariableName;
 import org.netbeans.modules.php.editor.parser.PHPParseResult;
@@ -244,7 +246,8 @@ public final class WhereUsedSupport {
             if (!variable.isGloballyVisible()) {
                 return Collections.singleton(mElement.getFileObject());
             }
-        } else if (mElement != null && mElement.getPhpModifiers().isPrivate()) {
+        } else if (mElement != null && mElement.getPhpModifiers().isPrivate() && !(mElement.getInScope() instanceof TraitScope)) {
+            // NETBEANS-6087 private members of trait are used in classes
             return Collections.singleton(mElement.getFileObject());
         }
 

--- a/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/index.php
+++ b/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/index.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+trait NetBeans6087Trait {
+
+    private int $privateField = 1;
+
+    private function privateMethod(): void
+    {
+        
+    }
+
+    public function testMethod()
+    {
+        $this->privateField;
+        $this->privateMethod();
+    }
+
+}

--- a/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/index.php.testNB6087_PrivateTraitField01.findUsages
+++ b/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/index.php.testNB6087_PrivateTraitField01.findUsages
@@ -1,0 +1,14 @@
+Display text: private int $<b>privateField</b> = 1;
+File name: index.php
+Name: $privateField
+Position: BEGIN: 859 END: 871
+
+Display text: $this-><b>privateField</b>;
+File name: index.php
+Name: $privateField
+Position: BEGIN: 997 END: 1009
+
+Display text: echo $this-><b>privateField</b>;
+File name: nb6087.php
+Name: $privateField
+Position: BEGIN: 929 END: 941

--- a/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/index.php.testNB6087_PrivateTraitField02.findUsages
+++ b/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/index.php.testNB6087_PrivateTraitField02.findUsages
@@ -1,0 +1,14 @@
+Display text: private int $<b>privateField</b> = 1;
+File name: index.php
+Name: $privateField
+Position: BEGIN: 859 END: 871
+
+Display text: $this-><b>privateField</b>;
+File name: index.php
+Name: $privateField
+Position: BEGIN: 997 END: 1009
+
+Display text: echo $this-><b>privateField</b>;
+File name: nb6087.php
+Name: $privateField
+Position: BEGIN: 929 END: 941

--- a/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/index.php.testNB6087_PrivateTraitMethod01.findUsages
+++ b/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/index.php.testNB6087_PrivateTraitMethod01.findUsages
@@ -1,0 +1,14 @@
+Display text: private function <b>privateMethod</b>(): void
+File name: index.php
+Name: privateMethod
+Position: BEGIN: 899 END: 912
+
+Display text: $this-><b>privateMethod</b>();
+File name: index.php
+Name: privateMethod
+Position: BEGIN: 1026 END: 1039
+
+Display text: $this-><b>privateMethod</b>();
+File name: nb6087.php
+Name: privateMethod
+Position: BEGIN: 958 END: 971

--- a/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/index.php.testNB6087_PrivateTraitMethod02.findUsages
+++ b/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/index.php.testNB6087_PrivateTraitMethod02.findUsages
@@ -1,0 +1,14 @@
+Display text: private function <b>privateMethod</b>(): void
+File name: index.php
+Name: privateMethod
+Position: BEGIN: 899 END: 912
+
+Display text: $this-><b>privateMethod</b>();
+File name: index.php
+Name: privateMethod
+Position: BEGIN: 1026 END: 1039
+
+Display text: $this-><b>privateMethod</b>();
+File name: nb6087.php
+Name: privateMethod
+Position: BEGIN: 958 END: 971

--- a/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/nb6087.php
+++ b/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/nb6087.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+class NetBeans6087Class {
+
+    use NetBeans6087Trait;
+
+    public function testMethod()
+    {
+        echo $this->privateField;
+        $this->privateMethod();
+    }
+
+}

--- a/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/nb6087.php.testNB6087_PrivateTraitField03.findUsages
+++ b/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/nb6087.php.testNB6087_PrivateTraitField03.findUsages
@@ -1,0 +1,14 @@
+Display text: private int $<b>privateField</b> = 1;
+File name: index.php
+Name: $privateField
+Position: BEGIN: 859 END: 871
+
+Display text: $this-><b>privateField</b>;
+File name: index.php
+Name: $privateField
+Position: BEGIN: 997 END: 1009
+
+Display text: echo $this-><b>privateField</b>;
+File name: nb6087.php
+Name: $privateField
+Position: BEGIN: 929 END: 941

--- a/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/nb6087.php.testNB6087_PrivateTraitMethod03.findUsages
+++ b/php/php.refactoring/test/unit/data/testfiles/findusages/testNB6087/nb6087.php.testNB6087_PrivateTraitMethod03.findUsages
@@ -1,0 +1,14 @@
+Display text: private function <b>privateMethod</b>(): void
+File name: index.php
+Name: privateMethod
+Position: BEGIN: 899 END: 912
+
+Display text: $this-><b>privateMethod</b>();
+File name: index.php
+Name: privateMethod
+Position: BEGIN: 1026 END: 1039
+
+Display text: $this-><b>privateMethod</b>();
+File name: nb6087.php
+Name: privateMethod
+Position: BEGIN: 958 END: 971

--- a/php/php.refactoring/test/unit/src/org/netbeans/modules/refactoring/php/findusages/WhereUsedSupportTest.java
+++ b/php/php.refactoring/test/unit/src/org/netbeans/modules/refactoring/php/findusages/WhereUsedSupportTest.java
@@ -248,4 +248,28 @@ public class WhereUsedSupportTest extends FindUsagesTestBase {
         findUsages("(new Two)->get^Two();");
     }
 
+    public void testNB6087_PrivateTraitMethod01() throws Exception {
+        findUsages("private function private^Method(): void");
+    }
+
+    public void testNB6087_PrivateTraitMethod02() throws Exception {
+        findUsages("$this->privateMetho^d();");
+    }
+
+    public void testNB6087_PrivateTraitMethod03() throws Exception {
+        findUsages("$this->privateMetho^d();", "nb6087.php");
+    }
+
+    public void testNB6087_PrivateTraitField01() throws Exception {
+        findUsages("private int $privateFi^eld = 1;");
+    }
+
+    public void testNB6087_PrivateTraitField02() throws Exception {
+        findUsages("$this->privateFie^ld;");
+    }
+
+    public void testNB6087_PrivateTraitField03() throws Exception {
+        findUsages("echo $this->privateFi^eld;", "nb6087.php");
+    }
+
 }


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/NETBEANS-6087
- Classes can also use private members of traits. If the declaration of the member is in another file, only member names in the same file are renamed using the instant renamer. So, we have to use the refactoring feature instead of it.

#### Screenshots

![netbeans-6087-1](https://user-images.githubusercontent.com/738383/138083486-6314d567-a603-4ced-9984-1c2be31e685f.png)

![netbeans-6087-2](https://user-images.githubusercontent.com/738383/138083510-6be8cdae-ba0b-4f48-b1d8-4d1191739371.png)

