### PR TITLE
NETBEANS-3042 Fixes Payara Server log formatting issue

### DIFF
--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/LogViewMgr.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/LogViewMgr.java
@@ -173,11 +173,11 @@ public class LogViewMgr {
      * Reads a newly included InputSreams.
      *
      * @param recognizers
-     * @param fromFile
+     * @param ignoreEof
      * @param instance
      * @param serverLogs
      */
-    public void readInputStreams(List<Recognizer> recognizers, boolean fromFile,
+    public void readInputStreams(List<Recognizer> recognizers, boolean ignoreEof,
             PayaraInstance instance, FetchLog... serverLogs) {
         synchronized (readers) {
             stopReaders();
@@ -185,7 +185,7 @@ public class LogViewMgr {
             for(FetchLog serverLog : serverLogs){
                 // LoggerRunnable will close the stream if necessary.
                 LoggerRunnable logger = new LoggerRunnable(recognizers,
-                        serverLog, fromFile, instance);
+                        serverLog, ignoreEof, instance);
                 readers.add(new WeakReference<>(logger));
                 Thread t = new Thread(logger);
                 t.start();
@@ -421,9 +421,8 @@ public class LogViewMgr {
 
                 // ignoreEof is true for log files and false for process streams.
                 // FIXME Should differentiate filter types more cleanly.
-                Filter filter = ignoreEof ? new LogFileFilter(localizedLevels) : 
-                    (uri.contains("]deployer:pfv3ee6") ? new LogFileFilter(localizedLevels) :new StreamFilter());
-                
+                Filter filter = ignoreEof ? new LogFileFilter(localizedLevels) : new StreamFilter();
+
                 // read from the input stream and put all the changes to the I/O window
                 char [] chars = new char[1024];
                 int len = 0;

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/StartTask.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/StartTask.java
@@ -545,7 +545,7 @@ public class StartTask extends BasicTask<TaskState> {
         // create a logger to the server's output stream so that a user
         // can observe the progress
         LogViewMgr logger = LogViewMgr.getInstance(instance.getProperty(PayaraModule.URL_ATTR));
-        logger.readInputStreams(recognizers, false, null,
+        logger.readInputStreams(recognizers, true, null,
                 new FetchLogSimple(instance.getProcess().getInputStream()),
                 new FetchLogSimple(instance.getProcess().getErrorStream()));
 


### PR DESCRIPTION
This PR fixes the log formatting issue (prepends **|#]** end of the line) by using the `LogFileFilter` which accepts the log in the following format:

````
[#|
    2008-07-20T16:59:11.738-0700|
    INFO|
    Payara10.0|
    org.jvnet.hk2.osgiadapter|
    _ThreadID=11;_ThreadName=Thread-6;org.glassfish.admin.config-api [1794];|
    Started bundle org.glassfish.admin.config-api [1794]
|#]
````
