### PR TITLE
enable encoding compatibility mode to avoid problems on JDK18 due to JEP 400.

### DIFF
--- a/nb/ide.launcher/netbeans.conf
+++ b/nb/ide.launcher/netbeans.conf
@@ -63,7 +63,7 @@ netbeans_default_cachedir="${DEFAULT_CACHEDIR_ROOT}/@@metabuild.RawVersion@@"
 # (see: https://issues.apache.org/jira/browse/NETBEANS-1344)
 #
 
-netbeans_default_options="-J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dsun.zip.disableMemoryMapping=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions"
+netbeans_default_options="-J-Dfile.encoding=COMPAT -J-XX:+UseStringDeduplication -J-Xss2m @@metabuild.logcli@@ -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dsun.java2d.dpiaware=true -J-Dsun.zip.disableMemoryMapping=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.extbrowser.manual_chrome_plugin_install=yes @@metabuild.jms-flags@@ -J-XX:+IgnoreUnrecognizedVMOptions"
 
 # Default location of JDK:
 # (set by installer or commented out if launcher should decide)


### PR DESCRIPTION
JDK 18 makes UTF-8 the default. ~~For consistency reasons we should probably set `-Dfile.encoding=UTF-8` now on all JDKs to catch problems early, otherwise NB could behave differently dependent on which JDK it is launched on.~~ (Too late for that)

if issues are encountered we could temporarily set `-Dfile.encoding=COMPAT` till they are resolved.

[1] https://openjdk.java.net/jeps/400
[2] https://inside.java/2021/10/04/the-default-charset-jep400/
