### PR TITLE
NETBEANS-6153 installer jdk 11 fixes

### DIFF
--- a/nbbuild/installer/components/products/nb-javaee/nbproject/project.properties
+++ b/nbbuild/installer/components/products/nb-javaee/nbproject/project.properties
@@ -43,7 +43,7 @@ javac.classpath=\
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
-javac.source=1.5
+javac.source=1.6
 javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\

--- a/nbbuild/installer/components/products/nb-php/nbproject/project.properties
+++ b/nbbuild/installer/components/products/nb-php/nbproject/project.properties
@@ -42,7 +42,7 @@ javac.classpath=\
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
-javac.source=1.5
+javac.source=1.6
 javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\

--- a/nbi/infra/build/.common/common.properties
+++ b/nbi/infra/build/.common/common.properties
@@ -100,7 +100,7 @@ nb.target.build=jar
 #   global script
 # * ${nb.custom.tasks.cls} - points the netbeans project's build script to the 
 #   location of the built custom tasks
-nb.platform.home=-Dplatforms.JDK_1.5.home=${java.home}/..
+nb.platform.home=-Dplatforms.JDK_1.5.home=${java.home}
 nb.platform.home.macos=-Dplatforms.JDK_1.5.home=${java.home}
 nb.ignore.native=-Dignore.native=true
 nb.no.dependencies=-Dno.dependencies=true


### PR DESCRIPTION
Minors fixed to make installer works on jdk 11.
php and enterprise need a source of 1.6 minimum

javac and java are direct after jdk folder
