### PR TITLE
Payara Server UI disabled on the failed startup

### DIFF
--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/StartTask.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/StartTask.java
@@ -572,9 +572,10 @@ public class StartTask extends BasicTask<TaskState> {
             return change.fireOperationStateChanged();
         }
         if (!PayaraState.isOnline(instance)) {
-              return fireOperationStateChanged(
-                      TaskState.FAILED, TaskEvent.CMD_FAILED,
-                      "StartTask.startDAS.startFailed", instanceName);
+            PayaraStatus.suspend(instance);
+            return fireOperationStateChanged(
+                    TaskState.FAILED, TaskEvent.CMD_FAILED,
+                    "StartTask.startDAS.startFailed", instanceName);
         } else {
             return startClusterOrInstance(adminHost, adminPort);
         }


### PR DESCRIPTION
This is the bug fix PR that re-enables the Payara Server UI after server startup action failed.

Follow the steps to reproduce the issue in Apache NetBeans 12.5 or older version:
- Add corrupted (you may remove a few Jakarta jars from `payara5/glassfish/modules` directory) Payara Server to the Apache NetBeans.
- Right-click on the registred Payara Server and press `Start` to start the Server
- Apache NetBeans waits for the server to startup by checking Admin Ports in the background
- After timeout (300 sec), error message popups with the failed server status
- Now right-click on the Payara Server. `Start`, `Start in Debug Mode` and `Start in Profile Mode` should be disabled. And the workaround was either to restart the NetBeans instance or re-register the Payara Server instance.

