### PR TITLE
Filter jvm-options based on VM name

### DIFF
--- a/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
+++ b/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
@@ -1241,13 +1241,12 @@ meth public java.util.Optional<java.lang.Short> getMinor()
 meth public java.util.Optional<java.lang.Short> getSubMinor()
 meth public java.util.Optional<java.lang.Short> getUpdate()
 meth public java.util.Optional<java.lang.String> getVendor()
-meth public java.util.Optional<java.lang.String> getVM()
 meth public short getMajor()
 meth public static boolean isCorrectJDK(java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>,java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>)
 meth public static boolean isCorrectJDK(org.netbeans.modules.payara.tooling.data.JDKVersion,java.util.Optional<java.lang.String>,java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>,java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>)
 meth public static org.netbeans.modules.payara.tooling.data.JDKVersion getDefaultPlatformVersion()
 meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String)
-meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String,java.lang.String,java.lang.String)
+meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String,java.lang.String)
 supr java.lang.Object
 hfds DEFAULT_VALUE,IDE_JDK_VERSION,MAJOR_INDEX,MINOR_INDEX,SUBMINOR_INDEX,UPDATE_INDEX,VERSION_MATCHER,major,minor,subminor,update,vendor
 

--- a/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
+++ b/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
@@ -1241,12 +1241,13 @@ meth public java.util.Optional<java.lang.Short> getMinor()
 meth public java.util.Optional<java.lang.Short> getSubMinor()
 meth public java.util.Optional<java.lang.Short> getUpdate()
 meth public java.util.Optional<java.lang.String> getVendor()
+meth public java.util.Optional<java.lang.String> getVM()
 meth public short getMajor()
 meth public static boolean isCorrectJDK(java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>,java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>)
 meth public static boolean isCorrectJDK(org.netbeans.modules.payara.tooling.data.JDKVersion,java.util.Optional<java.lang.String>,java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>,java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>)
 meth public static org.netbeans.modules.payara.tooling.data.JDKVersion getDefaultPlatformVersion()
 meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String)
-meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String,java.lang.String)
+meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String,java.lang.String,java.lang.String)
 supr java.lang.Object
 hfds DEFAULT_VALUE,IDE_JDK_VERSION,MAJOR_INDEX,MINOR_INDEX,SUBMINOR_INDEX,UPDATE_INDEX,VERSION_MATCHER,major,minor,subminor,update,vendor
 

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/JDKVersion.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/JDKVersion.java
@@ -47,6 +47,11 @@ public final class JDKVersion {
      */
     private final Optional<String> vendor;
 
+    /**
+     * JDK vm
+     */
+    private final Optional<String> vm;
+
     private final static int MAJOR_INDEX = 0;
     private final static int MINOR_INDEX = 1;
     private final static int SUBMINOR_INDEX = 2;
@@ -58,21 +63,23 @@ public final class JDKVersion {
 
     private static final Short DEFAULT_VALUE = 0;
 
-    private JDKVersion(String version, String vendor) {
+    private JDKVersion(String version, String vendor, String vm) {
         short[] versions = parseVersions(version);
         this.major = versions[MAJOR_INDEX];
         this.minor = Optional.ofNullable(versions[MINOR_INDEX]);
         this.subminor = Optional.ofNullable(versions[SUBMINOR_INDEX]);
         this.update = Optional.ofNullable(versions[UPDATE_INDEX]);
         this.vendor = Optional.ofNullable(vendor);
+        this.vm = Optional.ofNullable(vm);
     }
 
-    JDKVersion(Short major, Optional<Short> minor, Optional<Short> subminor, Optional<Short> update, Optional<String> vendor) {
+    JDKVersion(Short major, Optional<Short> minor, Optional<Short> subminor, Optional<Short> update, Optional<String> vendor, Optional<String> vm) {
         this.major = major;
         this.minor = minor;
         this.subminor = subminor;
         this.update = update;
         this.vendor = vendor;
+        this.vm = vm;
     }
 
     /**
@@ -112,12 +119,21 @@ public final class JDKVersion {
     }
 
     /**
-     * Get JDK Vendor.
+     * Get JDK Vendor name.
      *
      * @return JDK vendor.
      */
     public Optional<String> getVendor() {
         return vendor;
+    }
+
+    /**
+     * Get JDK VM name.
+     *
+     * @return JDK vm.
+     */
+    public Optional<String> getVM() {
+        return vm;
     }
 
     public boolean gt(JDKVersion version) {
@@ -241,15 +257,15 @@ public final class JDKVersion {
 
     public static JDKVersion toValue(String version) {
         if (version != null && version.matches(VERSION_MATCHER)) {
-            return new JDKVersion(version, null);
+            return new JDKVersion(version, null, null);
         } else {
             return null;
         }
     }
 
-    public static JDKVersion toValue(String version, String vendor) {
+    public static JDKVersion toValue(String version, String vendor, String vm) {
         if (version != null && version.matches(VERSION_MATCHER)) {
-            return new JDKVersion(version, vendor);
+            return new JDKVersion(version, vendor, vm);
         } else {
             return null;
         }
@@ -259,15 +275,12 @@ public final class JDKVersion {
         return IDE_JDK_VERSION;
     }
 
-    public static boolean isCorrectJDK(JDKVersion jdkVersion, Optional<String> vendor, Optional<JDKVersion> minVersion, Optional<JDKVersion> maxVersion) {
+    public static boolean isCorrectJDK(JDKVersion jdkVersion, Optional<String> vendorOrVM, Optional<JDKVersion> minVersion, Optional<JDKVersion> maxVersion) {
         boolean correctJDK = true;
 
-        if (vendor.isPresent()) {
-            if (jdkVersion.getVendor().isPresent()) {
-                correctJDK = jdkVersion.getVendor().get().contains(vendor.get());
-            } else {
-                correctJDK = false;
-            }
+        if (vendorOrVM.isPresent()) {
+            correctJDK = jdkVersion.getVendor().map(vendor -> vendor.contains(vendorOrVM.get())).orElse(false)
+                    || jdkVersion.getVM().map(vm -> vm.contains(vendorOrVM.get())).orElse(false);
         }
         if (correctJDK && minVersion.isPresent()) {
             correctJDK = jdkVersion.ge(minVersion.get());
@@ -288,6 +301,7 @@ public final class JDKVersion {
 
     private static void initialize() {
         String vendor = System.getProperty("java.vendor"); // NOI18N
+        String vm = System.getProperty("java.vm.name"); // NOI18N
         /*
             In JEP 223 java.specification.version will be a single number versioning , not a dotted versioning . 
             For JDK 8:
@@ -308,7 +322,8 @@ public final class JDKVersion {
                 Optional.of(versions[MINOR_INDEX]),
                 Optional.of(versions[SUBMINOR_INDEX]),
                 Optional.of(versions[UPDATE_INDEX]),
-                Optional.of(vendor)
+                Optional.of(vendor),
+                Optional.of(vm)
         );
     }
 

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/JDKVersion.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/JDKVersion.java
@@ -263,6 +263,14 @@ public final class JDKVersion {
         }
     }
 
+    public static JDKVersion toValue(String version, String vendor) {
+        if (version != null && version.matches(VERSION_MATCHER)) {
+            return new JDKVersion(version, vendor, null);
+        } else {
+            return null;
+        }
+    }
+
     public static JDKVersion toValue(String version, String vendor, String vm) {
         if (version != null && version.matches(VERSION_MATCHER)) {
             return new JDKVersion(version, vendor, vm);

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/StartupArgsEntity.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/data/StartupArgsEntity.java
@@ -187,7 +187,8 @@ public class StartupArgsEntity implements StartupArgs {
                     if (javaVersionLine != null) {
                         javaVersion = JDKVersion.toValue(
                                 javaVersionLine.substring(javaVersionLine.indexOf("\"") + 1, javaVersionLine.lastIndexOf("\"")), // NOI18N
-                                implementorLine != null ? implementorLine.substring(implementorLine.indexOf("\"") + 1, implementorLine.lastIndexOf("\"")) : null // NOI18N
+                                implementorLine != null ? implementorLine.substring(implementorLine.indexOf("\"") + 1, implementorLine.lastIndexOf("\"")) : null, // NOI18N
+                                null
                         );
                     }
                 } catch (IOException ex) {

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/ServerTasks.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/ServerTasks.java
@@ -167,7 +167,7 @@ public class ServerTasks {
         List<String> optList
                 = jvmConfigReader.getJvmOptions()
                         .stream()
-                        .filter(fullOption -> JDKVersion.isCorrectJDK(javaVersion, fullOption.vendor, fullOption.minVersion, fullOption.maxVersion))
+                        .filter(fullOption -> JDKVersion.isCorrectJDK(javaVersion, fullOption.vendorOrVM, fullOption.minVersion, fullOption.maxVersion))
                         .map(fullOption -> fullOption.option)
                         .collect(toList());
 

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/parser/JvmConfigReader.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/parser/JvmConfigReader.java
@@ -201,6 +201,8 @@ public class JvmConfigReader extends NodeListener implements XMLReader {
     public static class JvmOption {
 
         public final String option;
+        @Deprecated
+        public final Optional<String> vendor;
         public final Optional<String> vendorOrVM;
         public final Optional<JDKVersion> minVersion;
         public final Optional<JDKVersion> maxVersion;
@@ -217,6 +219,7 @@ public class JvmConfigReader extends NodeListener implements XMLReader {
 
         public JvmOption(String option) {
             Matcher matcher = PATTERN.matcher(option);
+            this.vendor = Optional.empty();
             if (matcher.matches()) {
                 if (matcher.group(1).contains("-")  // NOI18N
                         && Character.isLetter(matcher.group(1).charAt(0))) {
@@ -239,6 +242,7 @@ public class JvmConfigReader extends NodeListener implements XMLReader {
 
         public JvmOption(String option, String minVersion, String maxVersion) {
             this.option = option;
+            this.vendor = Optional.empty();
             this.vendorOrVM = Optional.empty();
             this.minVersion = Optional.ofNullable(JDKVersion.toValue(minVersion));
             this.maxVersion = Optional.ofNullable(JDKVersion.toValue(maxVersion));

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/parser/JvmConfigReader.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/server/parser/JvmConfigReader.java
@@ -201,7 +201,7 @@ public class JvmConfigReader extends NodeListener implements XMLReader {
     public static class JvmOption {
 
         public final String option;
-        public final Optional<String> vendor;
+        public final Optional<String> vendorOrVM;
         public final Optional<JDKVersion> minVersion;
         public final Optional<JDKVersion> maxVersion;
 
@@ -221,17 +221,17 @@ public class JvmConfigReader extends NodeListener implements XMLReader {
                 if (matcher.group(1).contains("-")  // NOI18N
                         && Character.isLetter(matcher.group(1).charAt(0))) {
                     String[] parts = matcher.group(1).split("-"); // NOI18N
-                    this.vendor = Optional.ofNullable(parts[0]);
+                    this.vendorOrVM = Optional.ofNullable(parts[0]);
                     this.minVersion = Optional.ofNullable(JDKVersion.toValue(parts[1]));
                 } else {
-                    this.vendor = Optional.empty();
+                    this.vendorOrVM = Optional.empty();
                     this.minVersion = Optional.ofNullable(JDKVersion.toValue(matcher.group(1)));
                 }
                 this.maxVersion = Optional.ofNullable(JDKVersion.toValue(matcher.group(2)));
                 this.option = matcher.group(3);
             } else {
                 this.option = option;
-                this.vendor = Optional.empty();
+                this.vendorOrVM = Optional.empty();
                 this.minVersion = Optional.empty();
                 this.maxVersion = Optional.empty();
             }
@@ -239,7 +239,7 @@ public class JvmConfigReader extends NodeListener implements XMLReader {
 
         public JvmOption(String option, String minVersion, String maxVersion) {
             this.option = option;
-            this.vendor = Optional.empty();
+            this.vendorOrVM = Optional.empty();
             this.minVersion = Optional.ofNullable(JDKVersion.toValue(minVersion));
             this.maxVersion = Optional.ofNullable(JDKVersion.toValue(maxVersion));
         }

--- a/enterprise/payara.tooling/test/unit/src/org/netbeans/modules/payara/tooling/data/JDKVersionTest.java
+++ b/enterprise/payara.tooling/test/unit/src/org/netbeans/modules/payara/tooling/data/JDKVersionTest.java
@@ -40,23 +40,23 @@ public class JDKVersionTest {
     public void parseJDKVersion() {
         Map<String, JDKVersion> jdkVersions = new HashMap<>();
         jdkVersions.put("1.8",
-                new JDKVersion((short) 1, Optional.of((short) 8), Optional.of((short) 0), Optional.of((short) 0), Optional.empty()));
+                new JDKVersion((short) 1, Optional.of((short) 8), Optional.of((short) 0), Optional.of((short) 0), Optional.empty(), Optional.empty()));
         jdkVersions.put("1.8.0",
-                new JDKVersion((short) 1, Optional.of((short) 8), Optional.of((short) 0), Optional.of((short) 0), Optional.empty()));
+                new JDKVersion((short) 1, Optional.of((short) 8), Optional.of((short) 0), Optional.of((short) 0), Optional.empty(), Optional.empty()));
         jdkVersions.put("1.8.0u121",
-                new JDKVersion((short) 1, Optional.of((short) 8), Optional.of((short) 0), Optional.of((short) 121), Optional.empty()));
+                new JDKVersion((short) 1, Optional.of((short) 8), Optional.of((short) 0), Optional.of((short) 121), Optional.empty(), Optional.empty()));
         jdkVersions.put("1.8.0_191",
-                new JDKVersion((short) 1, Optional.of((short) 8), Optional.of((short) 0), Optional.of((short) 191), Optional.empty()));
+                new JDKVersion((short) 1, Optional.of((short) 8), Optional.of((short) 0), Optional.of((short) 191), Optional.empty(), Optional.empty()));
         jdkVersions.put("1.8.0_232-ea-8u232-b09-0ubuntu1-b09",
-                new JDKVersion((short) 1, Optional.of((short) 8), Optional.of((short) 0), Optional.of((short) 232), Optional.empty()));
+                new JDKVersion((short) 1, Optional.of((short) 8), Optional.of((short) 0), Optional.of((short) 232), Optional.empty(), Optional.empty()));
         jdkVersions.put("9",
-                new JDKVersion((short) 9, Optional.of((short) 0), Optional.of((short) 0), Optional.of((short) 0), Optional.empty()));
+                new JDKVersion((short) 9, Optional.of((short) 0), Optional.of((short) 0), Optional.of((short) 0), Optional.empty(), Optional.empty()));
         jdkVersions.put("11.0.6",
-                new JDKVersion((short) 11, Optional.of((short) 0), Optional.of((short) 6), Optional.of((short) 0), Optional.empty()));
+                new JDKVersion((short) 11, Optional.of((short) 0), Optional.of((short) 6), Optional.of((short) 0), Optional.empty(), Optional.empty()));
         jdkVersions.put("11.0.6_234",
-                new JDKVersion((short) 11, Optional.of((short) 0), Optional.of((short) 6), Optional.of((short) 234), Optional.empty()));
+                new JDKVersion((short) 11, Optional.of((short) 0), Optional.of((short) 6), Optional.of((short) 234), Optional.empty(), Optional.empty()));
         jdkVersions.put("11.0.6u234",
-                new JDKVersion((short) 11, Optional.of((short) 0), Optional.of((short) 6), Optional.of((short) 234), Optional.empty()));
+                new JDKVersion((short) 11, Optional.of((short) 0), Optional.of((short) 6), Optional.of((short) 234), Optional.empty(), Optional.empty()));
 
         for (Entry<String, JDKVersion> version : jdkVersions.entrySet()) {
             assertTrue(JDKVersion.toValue(version.getKey()).equals(version.getValue()), version.getKey());


### PR DESCRIPTION
Payara Platform 5.2021.8 support HotSwap Agent via DCEVM which is activated by jvm-options in domain.xml.

With the introduction of the HotSwap feature, JVM Options in domain.xml need to be filtered out based on the JVM name.

For e.g: In the following snippet Azul is the vendor name and Dynamic Code Evolution is the VM name both JVM options should be activated based on the Vendor or VM name.

````
<jvm-options>[Azul-1.8.0u222|1.8.0u260]-XX:+UseOpenJSSE</jvm-options>
<jvm-options>[9|]-Djdk.attach.allowAttachSelf=true</jvm-options>
<jvm-options>[Dynamic Code Evolution-11.0.10|]-XX:HotswapAgent=core</jvm-options>
<jvm-options>[Dynamic Code Evolution-11.0.10|]-Xlog:redefine+class*=info</jvm-options>
````