### PR TITLE
Handle any script's URI and provide script content when not readable from file.

### DIFF
--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/TruffleDVFrame.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/frames/models/TruffleDVFrame.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.debugger.jpda.truffle.frames.models;
 import java.io.InvalidObjectException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import org.netbeans.api.debugger.jpda.JPDADebugger;
 import org.netbeans.api.debugger.jpda.JPDAThread;
 import org.netbeans.modules.debugger.jpda.truffle.access.CurrentPCInfo;
@@ -77,15 +78,18 @@ public final class TruffleDVFrame implements DVFrame {
             return null;
         }
         Source source = sourcePosition.getSource();
-        URI uri = source.getURI();
-        if (uri != null && "file".equalsIgnoreCase(uri.getScheme())) {
-            return uri;
+        URL url = source.getUrl();
+        URI uri;
+        if (url != null) {
+            try {
+                uri = url.toURI();
+            } catch (URISyntaxException ex) {
+                uri = source.getURI();
+            }
+        } else {
+            uri = source.getURI();
         }
-        try {
-            return source.getUrl().toURI();
-        } catch (URISyntaxException ex) {
-            return null;
-        }
+        return uri;
     }
 
     @Override

--- a/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/Source.java
+++ b/java/debugger.jpda.truffle/src/org/netbeans/modules/debugger/jpda/truffle/source/Source.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.debugger.jpda.truffle.source;
 
 import com.sun.jdi.StringReference;
+import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -64,7 +65,7 @@ public final class Source {
         this.codeRef = codeRef;
         URL url = null;
         if (hostMethodName == null) {
-            if (uri == null || !"file".equalsIgnoreCase(uri.getScheme())) {
+            if (uri == null || !"file".equalsIgnoreCase(uri.getScheme()) || !fileIsReadable(uri)) { // NOI18N
                 try {
                     url = SourceFilesCache.get(jpda).getSourceFile(name, hash, uri, getContent());
                 } catch (IOException ex) {
@@ -85,6 +86,14 @@ public final class Source {
         this.uri = uri;
         this.mimeType = mimeType;
         this.hash = hash;
+    }
+
+    private static boolean fileIsReadable(URI uri) {
+        try {
+            return new File(uri).canRead();
+        } catch (IllegalArgumentException | SecurityException ex) {
+            return false;
+        }
     }
 
     public static Source getExistingSource(JPDADebugger debugger, long id) {


### PR DESCRIPTION
Handle possible exceptions thrown by `Paths.get(URI)` and provide a custom URL with the source content when the original file URL is not readable.