### PR TITLE
Build Java cluster on JDK17

### DIFF
--- a/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/SourceLevelQueryImplTest.java
+++ b/apisupport/apisupport.ant/test/unit/src/org/netbeans/modules/apisupport/project/queries/SourceLevelQueryImplTest.java
@@ -37,7 +37,7 @@ public class SourceLevelQueryImplTest extends TestBase {
         String path = "java/junit/src/org/netbeans/modules/junit/api/JUnitSettings.java";
         FileObject f = nbRoot().getFileObject(path);
         assertNotNull("found " + path, f);
-        assertEquals("1.6 used for an average module", "1.6", SourceLevelQuery.getSourceLevel(f));
+        assertEquals("1.8 used for an average module", "1.8", SourceLevelQuery.getSourceLevel(f));
     }
     
 }

--- a/extide/o.apache.tools.ant.module/build.xml
+++ b/extide/o.apache.tools.ant.module/build.xml
@@ -35,7 +35,7 @@
                 <path path="${src-bridge.cp}"/>
             </classpath>
         </depend>
-        <javac srcdir="src-bridge" destdir="build/bridge-classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" source="1.6" target="1.6" includeantruntime="false">
+        <javac srcdir="src-bridge" destdir="build/bridge-classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" release="8" includeantruntime="false">
             <classpath>
                 <path path="${src-bridge.cp}"/>
             </classpath>

--- a/harness/apisupport.harness/build.xml
+++ b/harness/apisupport.harness/build.xml
@@ -50,7 +50,7 @@
 
     <target name="compile-jnlp-launcher" depends="init,compile">
         <mkdir dir="${build.dir}/jnlp-launcher-classes"/>
-        <nb-javac srcdir="jnlp-src" destdir="${build.dir}/jnlp-launcher-classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" source="1.6" target="1.6" includeantruntime="false">
+        <nb-javac srcdir="jnlp-src" destdir="${build.dir}/jnlp-launcher-classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" release="8" includeantruntime="false">
             <classpath>
                 <path path="${jnlp.cp}"/>
             </classpath>

--- a/harness/apisupport.harness/nbproject/project.properties
+++ b/harness/apisupport.harness/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 jnlp.cp=\
     ${o.n.bootstrap.dir}/lib/boot.jar:\
     ${openide.modules.dir}/lib/org-openide-modules.jar:\

--- a/harness/jemmy/nbproject/project.properties
+++ b/harness/jemmy/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 release.external/jemmy-2.3.1.1.jar=modules/ext/jemmy-2.3.1.1.jar
 release.external/jemmy-2.3.1.1-doc.zip=docs/jemmy-2.3.1.1-doc.zip
 release.external/jemmy-2.3.1.1-src.zip=docs/jemmy-2.3.1.1-src.zip

--- a/harness/libs.nbi.ant/nbproject/project.properties
+++ b/harness/libs.nbi.ant/nbproject/project.properties
@@ -15,10 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
+javac.target=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 extra.module.files=\
     modules/ext/nbi-ant-tasks.jar,\
     modules/ext/nbi-registries-management.jar,\
     nbi/
 nbm.module.author=Dmitry Lipin
+

--- a/harness/libs.nbi.engine/nbproject/project.properties
+++ b/harness/libs.nbi.engine/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 extra.module.files=modules/ext/nbi-engine.jar
 nbm.module.author=Dmitry Lipin

--- a/ide/csl.api/anttask/build.xml
+++ b/ide/csl.api/anttask/build.xml
@@ -33,7 +33,7 @@
 
   <target name="compile">
     <mkdir dir="build/classes"/>
-    <javac srcdir="src" destdir="build/classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" target="1.6" source="1.6" >
+    <javac srcdir="src" destdir="build/classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" release="8" >
 	  <classpath>
                 <!-- cmdline Ant -->
                 <pathelement location="${ant.core.lib}"/>

--- a/ide/db/build.xml
+++ b/ide/db/build.xml
@@ -32,7 +32,7 @@
 
     <target name="compile-lib" depends="init,fake-jdbc-40">
         <mkdir dir="${build.dir}/lib-classes" />
-        <javac target="${javac.target}" srcdir="libsrc" destdir="${build.dir}/lib-classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" source="1.6">
+        <javac release="8" srcdir="libsrc" destdir="${build.dir}/lib-classes" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}">
             <classpath>
                 <pathelement path="${lib.cp}"/>
             </classpath>
@@ -50,7 +50,7 @@
             public class RowIdLifetime {}
         </echo>
         <mkdir dir="${fake-jdbc-40.build}"/>
-        <javac target="${javac.target}" source="1.7" srcdir="${fake-jdbc-40.src}" destdir="${fake-jdbc-40.build}"/>
+        <javac release="8" srcdir="${fake-jdbc-40.src}" destdir="${fake-jdbc-40.build}"/>
     </target>
 
     <target name="jar-lib" depends="compile-lib">

--- a/java/ant.browsetask/build.xml
+++ b/java/ant.browsetask/build.xml
@@ -25,7 +25,7 @@
 
     <target name="nblib" depends="init">
         <mkdir dir="build/antclasses"/>
-        <javac srcdir="antsrc" destdir="build/antclasses" debug="${build.compiler.debug}" deprecation="${build.compiler.deprecation}" source="1.6" target="1.8" includeantruntime="false">
+        <javac srcdir="antsrc" destdir="build/antclasses" debug="${build.compiler.debug}" deprecation="${build.compiler.deprecation}" release="8" includeantruntime="false">
             <classpath>
                 <pathelement path="${antsrc.cp}"/>
             </classpath>

--- a/java/debugger.jpda.ant/build.xml
+++ b/java/debugger.jpda.ant/build.xml
@@ -25,7 +25,7 @@
 
     <target name="nblib" depends="init">
         <mkdir dir="build/antclasses"/>
-        <javac srcdir="antsrc" destdir="build/antclasses" source="1.6" target="1.6" debug="true" deprecation="true">
+        <javac srcdir="antsrc" destdir="build/antclasses" source="1.8" target="1.8" debug="true" deprecation="true">
             <classpath>
                 <path refid="cp"/>
                 <pathelement location="${ant.jar}"/>

--- a/java/form.nb/nbproject/project.properties
+++ b/java/form.nb/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 spec.version.base=0.33.0
 requires.nb.javac=true

--- a/java/form.refactoring/nbproject/project.properties
+++ b/java/form.refactoring/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 spec.version.base=0.32.0
 requires.nb.javac=true

--- a/java/form/nbproject/project.properties
+++ b/java/form/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 extra.module.files=modules/ext/AbsoluteLayout.jar
-javac.source=1.7
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 spec.version.base=1.72.0
 test-unit-sys-prop.org.netbeans.modules.form.layoutdesign.test=0

--- a/java/i18n/nbproject/project.properties
+++ b/java/i18n/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 disable.qa-functional.tests=true
 

--- a/java/j2ee.metadata/nbproject/project.properties
+++ b/java/j2ee.metadata/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint:unchecked
 
 javadoc.arch=${basedir}/arch.xml

--- a/java/java.source.ant/build.xml
+++ b/java/java.source.ant/build.xml
@@ -25,7 +25,7 @@
 
     <target name="nblib" depends="init">
         <mkdir dir="build/antclasses"/>
-        <javac srcdir="antsrc" destdir="build/antclasses" source="1.6" target="1.6" debug="true" deprecation="true">
+        <javac srcdir="antsrc" destdir="build/antclasses" release="8" debug="true" deprecation="true">
             <classpath>
                 <path refid="cp"/>
                 <pathelement location="${ant.jar}"/>

--- a/java/java.testrunner.ant/nbproject/project.properties
+++ b/java/java.testrunner.ant/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/java/java.testrunner/nbproject/project.properties
+++ b/java/java.testrunner/nbproject/project.properties
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 requires.nb.javac=true

--- a/java/javawebstart/AntTasks/nbproject/project.properties
+++ b/java/javawebstart/AntTasks/nbproject/project.properties
@@ -53,7 +53,7 @@ javac.deprecation=false
 javac.external.vm=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.6
+javac.source=1.8
 javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\

--- a/java/javawebstart/nbproject/project.properties
+++ b/java/javawebstart/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.7
+javac.source=1.8
 extra.module.files=ant/extra/org-netbeans-modules-javawebstart-anttasks.jar
 jnlp.indirect.jars=ant/extra/org-netbeans-modules-javawebstart-anttasks.jar
 requires.nb.javac=true

--- a/java/junit/nbproject/project.properties
+++ b/java/junit/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/java/maven.checkstyle/nbproject/project.properties
+++ b/java/maven.checkstyle/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/java/maven.coverage/nbproject/project.properties
+++ b/java/maven.coverage/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 nbm.homepage=http://wiki.netbeans.org/MavenCodeCoverage
 nbm.module.author=Jesse Glick <jglick@netbeans.org>

--- a/java/maven.hints/nbproject/project.properties
+++ b/java/maven.hints/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 #javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/java/maven.indexer.ui/nbproject/project.properties
+++ b/java/maven.indexer.ui/nbproject/project.properties
@@ -16,6 +16,6 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/java/maven.junit/nbproject/project.properties
+++ b/java/maven.junit/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/java/maven.kit/nbproject/project.properties
+++ b/java/maven.kit/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/java/maven.osgi/nbproject/project.properties
+++ b/java/maven.osgi/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 test.config.stableBTD.includes=**/*Test.class

--- a/java/maven.persistence/nbproject/project.properties
+++ b/java/maven.persistence/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/java/maven.refactoring/nbproject/project.properties
+++ b/java/maven.refactoring/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 requires.nb.javac=true

--- a/java/maven.search/nbproject/project.properties
+++ b/java/maven.search/nbproject/project.properties
@@ -16,5 +16,6 @@
 # under the License.
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
+

--- a/java/maven.spring/nbproject/project.properties
+++ b/java/maven.spring/nbproject/project.properties
@@ -16,5 +16,6 @@
 # under the License.
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
+

--- a/java/websvc.jaxws21/nbproject/project.properties
+++ b/java/websvc.jaxws21/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 jnlp.indirect.jars=\
     modules/ext/jaxws22/FastInfoset.jar,\
     modules/ext/jaxws22/gmbal-api-only.jar,\

--- a/java/websvc.jaxws21api/nbproject/project.properties
+++ b/java/websvc.jaxws21api/nbproject/project.properties
@@ -18,7 +18,7 @@
 is.autoload=true
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 jnlp.indirect.jars=\
     modules/ext/jaxws22/api/jaxws-api.jar,\
     modules/ext/jaxws22/api/jsr181-api.jar,\

--- a/java/xml.jaxb/nbproject/project.properties
+++ b/java/xml.jaxb/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 # added to classpath for compilation of unit tests
 #test.unit.cp.extra=../../junit/external/junit-4.1.jar
 # added to classpath for running of unit tests

--- a/javafx/javafx2.platform/nbproject/project.properties
+++ b/javafx/javafx2.platform/nbproject/project.properties
@@ -14,5 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
+

--- a/javafx/javafx2.scenebuilder/nbproject/project.properties
+++ b/javafx/javafx2.scenebuilder/nbproject/project.properties
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 requires.nb.javac=true
 

--- a/nb/updatecenters/build.xml
+++ b/nb/updatecenters/build.xml
@@ -35,7 +35,7 @@
       <tempfile destdir="${build.dir}" prefix="sign" suffix=".ks" property="netbeans.bundled.ks" deleteonexit="true" />
       <tempfile destdir="${build.dir}" prefix="sign" suffix=".cert" property="netbeans.bundled.cert" deleteonexit="true"/>
       <genkey
-        keystore="${netbeans.bundled.ks}"
+        keystore="${netbeans.bundled.ks}" keyalg="RSA"
         alias="netbeans-bundled" storepass="${netbeans.bundled.ks}"
         dname="CN=Ant Group, OU=NetBeans, O=Apache.org, C=US"
       />

--- a/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/CustomJavac.java
@@ -66,21 +66,30 @@ public class CustomJavac extends Javac {
 
     @Override
     public void execute() throws BuildException {
-        String tgr = getTarget();
-        if (tgr.matches("\\d+")) {
-            tgr = "1." + tgr;
-        }
-        if (!isBootclasspathOptionUsed()) {
-            setRelease(tgr.substring(2));
-        }
-        String src = getSource();
-        if (src.matches("\\d+")) {
-            src = "1." + src;
-        }
-        if (!JavaEnvUtils.isAtLeastJavaVersion(src)) {
-            log("Cannot handle -source " + src + " from this VM; forking " + maybeFork, Project.MSG_WARN);
-            super.setFork(true);
-            super.setExecutable(maybeFork);
+        String release = getRelease();
+        if (release == null || release.isEmpty()) {
+            String tgr = getTarget();
+            if (tgr.matches("\\d+")) {
+                tgr = "1." + tgr;
+            }
+            if (!isBootclasspathOptionUsed()) {
+                setRelease(tgr.substring(2));
+            }
+            String src = getSource();
+            if (src.matches("\\d+")) {
+                src = "1." + src;
+            }
+            if (!JavaEnvUtils.isAtLeastJavaVersion(src)) {
+                log("Cannot handle -source " + src + " from this VM; forking " + maybeFork, Project.MSG_WARN);
+                super.setFork(true);
+                super.setExecutable(maybeFork);
+            }
+        } else {
+            if (!JavaEnvUtils.isAtLeastJavaVersion(release)) {
+                log("Cannot handle -release " + release + " from this VM; forking " + maybeFork, Project.MSG_WARN);
+                super.setFork(true);
+                super.setExecutable(maybeFork);
+            }
         }
         generatedClassesDir = new File(getDestdir().getParentFile(), getDestdir().getName() + "-generated");
         if (!usingExplicitIncludes) {
@@ -205,7 +214,7 @@ public class CustomJavac extends Javac {
         File d = getDestdir();
         if (!d.isDirectory()) {
             return;
-}
+        }
         FileSet classes = new FileSet();
         classes.setDir(d);
         classes.setIncludes("**/*$*.class");

--- a/nbi/engine/build.xml
+++ b/nbi/engine/build.xml
@@ -188,14 +188,9 @@
     </target>
 
     <target name="probe" depends="init">
-        <available property="probe.javac.source" value="1.6" classname="java.lang.Module"/>
-        <available property="probe.javac.target" value="1.6" classname="java.lang.Module"/>
-        <available property="probe.javac.source" value="1.6" file="${nbjdk.home}/bin/jmod"/>
-        <available property="probe.javac.target" value="1.6" file="${nbjdk.home}/bin/jmod"/>
-        <property name="probe.javac.source" value="1.4"/>
-        <property name="probe.javac.target" value="1.4"/>
+        <property name="probe.javac.release" value="8"/>
         <mkdir dir="${build.classes.dir}/org/netbeans/installer/utils/applications/"/>
-        <javac srcdir="probesrc" destdir="${build.classes.dir}/org/netbeans/installer/utils/applications/" source="${probe.javac.source}" debug="true" deprecation="true" target="${probe.javac.target}"/>
+        <javac srcdir="probesrc" destdir="${build.classes.dir}/org/netbeans/installer/utils/applications/" release="${probe.javac.release}" debug="true" deprecation="true"/>
     </target>
 
 </project>

--- a/nbi/infra/build/.ant-lib/nbproject/project.properties
+++ b/nbi/infra/build/.ant-lib/nbproject/project.properties
@@ -54,7 +54,7 @@ javac.compilerargs=-Xlint:unchecked
 javac.deprecation=true
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.6
+javac.source=1.8
 javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\

--- a/nbi/infra/lib/registries-management/nbproject/project.properties
+++ b/nbi/infra/lib/registries-management/nbproject/project.properties
@@ -52,7 +52,7 @@ javac.compilerargs=
 javac.deprecation=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.6
+javac.source=1.8
 javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\

--- a/nbi/infra/utils/file-renamer/nbproject/project.properties
+++ b/nbi/infra/utils/file-renamer/nbproject/project.properties
@@ -42,7 +42,7 @@ javac.classpath=
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
-javac.source=1.6
+javac.source=1.8
 javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\

--- a/nbi/infra/utils/port-occupation/nbproject/project.properties
+++ b/nbi/infra/utils/port-occupation/nbproject/project.properties
@@ -44,7 +44,7 @@ javac.classpath=
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false
-javac.source=1.6
+javac.source=1.8
 javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\

--- a/platform/applemenu/nbproject/project.properties
+++ b/platform/applemenu/nbproject/project.properties
@@ -16,8 +16,9 @@
 # under the License.
 
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 nbm.needs.restart=true
 is.eager=true
 cp.extra=external/orange-extensions-1.3.1.jar
 bootclasspath.prepend=${build.dir}/desktop-classes-classes
+

--- a/profiler/debugger.jpda.heapwalk/nbproject/project.properties
+++ b/profiler/debugger.jpda.heapwalk/nbproject/project.properties
@@ -18,5 +18,5 @@
 cp.extra=${tools.jar}
 is.eager=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 javadoc.arch=${basedir}/arch.xml

--- a/profiler/lib.profiler.charts/nbproject/project.properties
+++ b/profiler/lib.profiler.charts/nbproject/project.properties
@@ -16,4 +16,5 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
+

--- a/profiler/maven.profiler/nbproject/project.properties
+++ b/profiler/maven.profiler/nbproject/project.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/profiler/profiler.api/nbproject/project.properties
+++ b/profiler/profiler.api/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 requires.nb.javac=true
 
 test-unit-sys-prop.java.awt.headless=true

--- a/profiler/profiler.freeform/nbproject/project.properties
+++ b/profiler/profiler.freeform/nbproject/project.properties
@@ -17,4 +17,5 @@
 
 is.eager=true
 
-javac.source=1.6
+javac.source=1.8
+

--- a/profiler/profiler.j2se/nbproject/project.properties
+++ b/profiler/profiler.j2se/nbproject/project.properties
@@ -16,7 +16,7 @@
 # under the License.
 
 is.eager=true
-javac.source=1.6
+javac.source=1.8
 requires.nb.javac=true
 
 test-unit-sys-prop.java.awt.headless=true

--- a/profiler/profiler.kit/nbproject/project.properties
+++ b/profiler/profiler.kit/nbproject/project.properties
@@ -14,5 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
+

--- a/profiler/profiler.nbimpl/build.xml
+++ b/profiler/profiler.nbimpl/build.xml
@@ -25,7 +25,7 @@
     
     <target name="nblib" depends="init">
         <mkdir dir="build/antclasses"/>
-        <javac srcdir="antsrc" destdir="build/antclasses" debug="${build.compiler.debug}" deprecation="${build.compiler.deprecation}" source="1.6" target="1.6" includeantruntime="false">
+        <javac srcdir="antsrc" destdir="build/antclasses" debug="${build.compiler.debug}" deprecation="${build.compiler.deprecation}" release="8" includeantruntime="false">
             <classpath>
                 <pathelement path="${antsrc.cp}"/>
             </classpath>

--- a/profiler/profiler.nbimpl/nbproject/project.properties
+++ b/profiler/profiler.nbimpl/nbproject/project.properties
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.6
+javac.source=1.8
 requires.nb.javac=true
 
 antsrc.cp=\

--- a/profiler/profiler.nbmodule/nbproject/project.properties
+++ b/profiler/profiler.nbmodule/nbproject/project.properties
@@ -17,4 +17,5 @@
 
 is.eager=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
+

--- a/profiler/profiler.oql.language/nbproject/project.properties
+++ b/profiler/profiler.oql.language/nbproject/project.properties
@@ -18,4 +18,5 @@ auxiliary.org-netbeans-modules-editor-indent.CodeStyle.project.tab-size=8
 auxiliary.org-netbeans-modules-editor-indent.CodeStyle.project.text-limit-width=80
 auxiliary.org-netbeans-modules-editor-indent.CodeStyle.usedProfile=default
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
+

--- a/profiler/profiler.ppoints/nbproject/project.properties
+++ b/profiler/profiler.ppoints/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/profiler/profiler.snaptracer/nbproject/project.properties
+++ b/profiler/profiler.snaptracer/nbproject/project.properties
@@ -15,4 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.6
+javac.source=1.8
+

--- a/profiler/profiler.utilities/nbproject/project.properties
+++ b/profiler/profiler.utilities/nbproject/project.properties
@@ -16,6 +16,7 @@
 # under the License.
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 
 test.config.stableBTD.includes=**/*Test.class
+

--- a/webcommon/cordova/cordovaprojectupdate/nbproject/project.properties
+++ b/webcommon/cordova/cordovaprojectupdate/nbproject/project.properties
@@ -53,7 +53,7 @@ javac.compilerargs=
 javac.deprecation=false
 javac.processorpath=\
     ${javac.classpath}
-javac.source=1.6
+javac.source=1.8
 javac.target=1.8
 javac.test.classpath=\
     ${javac.classpath}:\

--- a/webcommon/javascript2.jquery/nbproject/project.properties
+++ b/webcommon/javascript2.jquery/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 
 jnlp.verify.excludes=docs/jquery-api.xml,docs/jquery-propertyNames.xml

--- a/webcommon/javascript2.react/nbproject/project.properties
+++ b/webcommon/javascript2.react/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 

--- a/webcommon/libs.jstestdriver/build.xml
+++ b/webcommon/libs.jstestdriver/build.xml
@@ -25,7 +25,7 @@
 
     <target name="ext-compile" depends="build-init">
         <mkdir dir="build/extclasses"/>
-        <javac srcdir="extsrc" destdir="build/extclasses" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" source="1.6" target="1.8">
+        <javac srcdir="extsrc" destdir="build/extclasses" deprecation="${build.compiler.deprecation}" debug="${build.compiler.debug}" release="8">
             <classpath>
                 <path path="${module.classpath}"/>
                 <path location="${cluster}/${module.jar}"/>

--- a/webcommon/libs.jstestdriver/nbproject/project.properties
+++ b/webcommon/libs.jstestdriver/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial
-javac.source=1.6
+javac.source=1.8
 release.build/external/libs.jstestdriver-ext.jar=modules/ext/libs.jstestdriver-ext.jar
 
 # last version used: JsTestDriver-1.3.5.jar

--- a/webcommon/netserver/nbproject/project.properties
+++ b/webcommon/netserver/nbproject/project.properties
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 is.autoload=true
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/web.client.kit/nbproject/project.properties
+++ b/webcommon/web.client.kit/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/webcommon/web.inspect/nbproject/project.properties
+++ b/webcommon/web.inspect/nbproject/project.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-javac.source=1.6
+javac.source=1.8


### PR DESCRIPTION
Changes required to build the java cluster on JDK17 (15 is the latest version NetBeans can be built with right now). I omitted the other clusters to keep the diff smaller.

This won't make the tests work - that would be a larger issue.


note:
this does not include the Gradle version upgrade required to build on JDK17, since 7.3 it is still in the rc phase.
see ~~https://github.com/apache/netbeans/pull/3322~~ https://github.com/apache/netbeans/pull/3326 for the gradle update
