### PR TITLE
[NETBEANS-6054] PHP Template missing Namespace option

### DIFF
--- a/php/php.project/src/org/netbeans/modules/php/project/resources/layer.xml
+++ b/php/php.project/src/org/netbeans/modules/php/project/resources/layer.xml
@@ -115,7 +115,7 @@
             <file name="PHPClass.php" url="nbresloc:/org/netbeans/modules/php/project/ui/resources/emptyClassPHP.php">
                 <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                 <attr name="displayName" bundlevalue="org.netbeans.modules.php.project.ui.wizards.Bundle#Templates/Scripting/PHPClass"/>
-                <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.php.project.ui.wizards.NewFileWizardIterator.withNamespace"/>
+                <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.php.project.ui.wizards.NewFileWizardIteratorWithNamespace.create"/>
                 <attr name="template" boolvalue="true"/>
                 <attr name="templateWizardURL" urlvalue="nbresloc:/org/netbeans/modules/php/project/ui/resources/emptyPHPClassDescription.html"/>
                 <attr name="templateCategory" stringvalue="PHP"/>
@@ -124,7 +124,7 @@
             <file name="PHPInterface.php" url="nbresloc:/org/netbeans/modules/php/project/ui/resources/emptyInterfacePHP.php">
                 <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                 <attr name="displayName" bundlevalue="org.netbeans.modules.php.project.ui.wizards.Bundle#Templates/Scripting/PHPInterface"/>
-                <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.php.project.ui.wizards.NewFileWizardIterator.withNamespace"/>
+                <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.php.project.ui.wizards.NewFileWizardIteratorWithNamespace.create"/>
                 <attr name="template" boolvalue="true"/>
                 <attr name="templateWizardURL" urlvalue="nbresloc:/org/netbeans/modules/php/project/ui/resources/emptyPHPInterfaceDescription.html"/>
                 <attr name="templateCategory" stringvalue="PHP"/>
@@ -133,7 +133,7 @@
             <file name="PHPTrait.php" url="nbresloc:/org/netbeans/modules/php/project/ui/resources/emptyTraitPHP.php">
                 <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                 <attr name="displayName" bundlevalue="org.netbeans.modules.php.project.ui.wizards.Bundle#Templates/Scripting/PHPTrait"/>
-                <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.php.project.ui.wizards.NewFileWizardIterator.withNamespace"/>
+                <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.php.project.ui.wizards.NewFileWizardIteratorWithNamespace.create"/>
                 <attr name="template" boolvalue="true"/>
                 <attr name="templateWizardURL" urlvalue="nbresloc:/org/netbeans/modules/php/project/ui/resources/emptyPHPTraitDescription.html"/>
                 <attr name="templateCategory" stringvalue="PHP"/>

--- a/php/php.project/src/org/netbeans/modules/php/project/ui/wizards/NewFileWizardIteratorWithNamespace.java
+++ b/php/php.project/src/org/netbeans/modules/php/project/ui/wizards/NewFileWizardIteratorWithNamespace.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.php.project.ui.wizards;
+
+import java.io.IOException;
+import java.util.Set;
+import javax.swing.event.ChangeListener;
+import org.openide.WizardDescriptor;
+
+public final class NewFileWizardIteratorWithNamespace implements WizardDescriptor.AsynchronousInstantiatingIterator<WizardDescriptor> {
+
+    private final NewFileWizardIterator delegate = NewFileWizardIterator.withNamespace();
+
+    private NewFileWizardIteratorWithNamespace() {
+    }
+
+    public static NewFileWizardIteratorWithNamespace create() {
+        return new NewFileWizardIteratorWithNamespace();
+    }
+
+    @Override
+    public Set instantiate() throws IOException {
+        return delegate.instantiate();
+    }
+
+    @Override
+    public void initialize(WizardDescriptor wizard) {
+        delegate.initialize(wizard);
+    }
+
+    @Override
+    public void uninitialize(WizardDescriptor wizard) {
+        delegate.uninitialize(wizard);
+    }
+
+    @Override
+    public WizardDescriptor.Panel<WizardDescriptor> current() {
+        return delegate.current();
+    }
+
+    @Override
+    public String name() {
+        return delegate.name();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return delegate.hasPrevious();
+    }
+
+    @Override
+    public void nextPanel() {
+        delegate.nextPanel();
+    }
+
+    @Override
+    public void previousPanel() {
+        delegate.previousPanel();
+    }
+
+    @Override
+    public void addChangeListener(ChangeListener l) {
+        delegate.addChangeListener(l);
+    }
+
+    @Override
+    public void removeChangeListener(ChangeListener l) {
+        delegate.removeChangeListener(l);
+    }
+
+}


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/NETBEANS-6054

Duplicated templates are saved as the following:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE attributes PUBLIC "-//NetBeans//DTD DefaultAttributes 1.0//EN" "http://www.netbeans.org/dtds/attributes-1_0.dtd">
<attributes version="1.0">
    <fileobject name="PHPClass_1.php">
        <attr name="displayName" stringvalue="PHP Class 1"/>
        <attr name="instantiatingIterator" newvalue="org.netbeans.modules.php.project.ui.wizards.NewFileWizardIterator"/>
        <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
        <attr name="template" boolvalue="true"/>
        <attr name="templateCategory" stringvalue="PHP"/>
        <attr name="templateWizardURL" urlvalue="nbresloc:/org/netbeans/modules/php/project/ui/resources/emptyPHPClassDescription.html"/>
    </fileobject>
    <fileobject name="PHPInterface_1.php">
        <attr name="displayName" stringvalue="PHP Interface 1"/>
        <attr name="instantiatingIterator" newvalue="org.netbeans.modules.php.project.ui.wizards.NewFileWizardIterator"/>
        ...
    </fileobject>
    <fileobject name="PHPTrait_1.php">
        <attr name="displayName" stringvalue="PHP Trait 1"/>
        <attr name="instantiatingIterator" newvalue="org.netbeans.modules.php.project.ui.wizards.NewFileWizardIterator"/>
        ...
    </fileobject>
</attributes>

```
The original template:
```xml
            <file name="PHPClass.php" url="nbresloc:/org/netbeans/modules/php/project/ui/resources/emptyClassPHP.php">
                <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
                <attr name="displayName" bundlevalue="org.netbeans.modules.php.project.ui.wizards.Bundle#Templates/Scripting/PHPClass"/>
                <attr name="instantiatingIterator" methodvalue="org.netbeans.modules.php.project.ui.wizards.NewFileWizardIterator.withNamespace"/>
                <attr name="template" boolvalue="true"/>
                <attr name="templateWizardURL" urlvalue="nbresloc:/org/netbeans/modules/php/project/ui/resources/emptyPHPClassDescription.html"/>
                <attr name="templateCategory" stringvalue="PHP"/>
                <attr name="position" intvalue="300"/>
            </file>
```
So, NewFileWizardIterator.withNamespace() is not invoked with the
duplicated template.

To avoid this, introduce NewFileWizardIteratorWithNamespace which has
the namespace panel by default as a new class.