### PR TITLE
CheckRegexp hint causes all lines with regexp shown with a warning

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/CheckRegex.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/CheckRegex.java
@@ -38,6 +38,7 @@ import javax.swing.SwingUtilities;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.spi.editor.hints.ErrorDescription;
+import org.netbeans.spi.editor.hints.Severity;
 import org.netbeans.spi.java.hints.ConstraintVariableType;
 import org.netbeans.spi.java.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.java.hints.Hint;
@@ -47,7 +48,7 @@ import org.netbeans.spi.java.hints.TriggerPattern;
 import org.netbeans.spi.java.hints.TriggerPatterns;
 import org.openide.util.NbBundle.Messages;
 
-@Hint(displayName = "#DN_CheckRegex", description = "#DESC_CheckRegex", category = "general")
+@Hint(displayName = "#DN_CheckRegex", description = "#DESC_CheckRegex", category = "general", severity = Severity.HINT)
 @Messages({
     "DN_CheckRegex=Check Regular Expression",
     "DESC_CheckRegex=Check Regular Expression"

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/CheckRegexTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/CheckRegexTest.java
@@ -34,7 +34,7 @@ public class CheckRegexTest {
                         + "    }\n"
                         + "}\n")
                 .run(CheckRegex.class)
-                .assertWarnings("4:34-4:41:verifier:" + Bundle.ERR_CheckRegex());
+                .assertWarnings("4:34-4:41:hint:" + Bundle.ERR_CheckRegex());
     }
     
     @Test
@@ -48,7 +48,7 @@ public class CheckRegexTest {
                         + "    }\n"
                         + "}\n")
                 .run(CheckRegex.class)
-                .assertWarnings("4:34-4:41:verifier:" + Bundle.ERR_CheckRegex());
+                .assertWarnings("4:34-4:41:hint:" + Bundle.ERR_CheckRegex());
     }
     
 }


### PR DESCRIPTION
The severity of the CheckRegexp of VERIFIER causes all lines in source
files containing a regexp to be marked as warning. This is invalid, as
the regexp are perfectly ok.

The severity is reduced to HINT. That way the hint is readily available
when the regexp is under the cursor, but does not clutter the whole
file.