### PR TITLE
[NETBEANS-5734] Add details for Glassfish 6.2.1 server and improve version detection

### DIFF
--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/Bundle.properties
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/Bundle.properties
@@ -160,6 +160,7 @@ STR_501_SERVER_NAME=GlassFish Server 5.0.1
 STR_510_SERVER_NAME=GlassFish Server 5.1.0
 STR_6_SERVER_NAME=GlassFish Server 6
 STR_610_SERVER_NAME=GlassFish Server 6.1
+STR_621_SERVER_NAME=GlassFish Server 6.2.1
 
 # CommonServerSupport.java
 MSG_FLAKEY_NETWORK=<html>Network communication problem<br/>Could not establish \

--- a/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
+++ b/enterprise/glassfish.common/src/org/netbeans/modules/glassfish/common/ServerDetails.java
@@ -224,6 +224,17 @@ public enum ServerDetails {
         "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.1.0/glassfish-6.1.0.zip", // NOI18N
         "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.1.0/glassfish-6.1.0.zip", // NOI18N
         "http://www.eclipse.org/legal/epl-2.0" //NOI18N
+    ),
+
+    /**
+     * details for an instance of GlassFish Server 6.2.1
+     */
+    GLASSFISH_SERVER_6_2_1(NbBundle.getMessage(ServerDetails.class, "STR_621_SERVER_NAME", new Object[]{}), // NOI18N
+        "deployer:gfv610ee9", // NOI18N
+        621,
+        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.1/glassfish-6.2.1.zip", // NOI18N
+        "https://repo1.maven.org/maven2/org/glassfish/main/distributions/glassfish/6.2.1/glassfish-6.2.1.zip", // NOI18N
+        "http://www.eclipse.org/legal/epl-2.0" //NOI18N
     );
 
     /**
@@ -235,6 +246,7 @@ public enum ServerDetails {
     public static WizardDescriptor.InstantiatingIterator
             getInstantiatingIterator() {
         return new ServerWizardIterator(new ServerDetails[]{
+                    GLASSFISH_SERVER_6_2_1,
                     GLASSFISH_SERVER_6_1_0,
                     GLASSFISH_SERVER_6,
                     GLASSFISH_SERVER_5_1_0,
@@ -252,6 +264,7 @@ public enum ServerDetails {
                     GLASSFISH_SERVER_3_0_1,
                     GLASSFISH_SERVER_3},
                 new ServerDetails[]{
+                    GLASSFISH_SERVER_6_2_1,
                     GLASSFISH_SERVER_6_1_0,
                     GLASSFISH_SERVER_6,
                     GLASSFISH_SERVER_5_1_0,
@@ -298,6 +311,7 @@ public enum ServerDetails {
                 case GF_5_1_0:   return GLASSFISH_SERVER_5_1_0.getVersion();
                 case GF_6:       return GLASSFISH_SERVER_6.getVersion();
                 case GF_6_1_0:   return GLASSFISH_SERVER_6_1_0.getVersion();
+                case GF_6_2_1:   return GLASSFISH_SERVER_6_2_1.getVersion();
                 default:         return -1;
             }
         }

--- a/enterprise/glassfish.common/test/unit/src/org/netbeans/modules/glassfish/spi/UtilsTest.java
+++ b/enterprise/glassfish.common/test/unit/src/org/netbeans/modules/glassfish/spi/UtilsTest.java
@@ -60,6 +60,7 @@ public class UtilsTest extends NbTestCase {
         // Create dummy file to test version matcher - Apache policy makes it
         // difficult to have "jar" files in the repository, even if they are
         // just files, containing a newline ...
+        Files.createDirectories(dataDir.toPath().resolve("subdir"));
         Files.write(dataDir.toPath().resolve("nottaDir-4_1_2.jar"), new byte[] {'\n'}, CREATE, WRITE);
         Files.write(dataDir.toPath().resolve("subdir/nottaDir-5.0.jar"), new byte[] {'\n'}, CREATE, WRITE);
     }

--- a/enterprise/glassfish.tooling/nbproject/project.properties
+++ b/enterprise/glassfish.tooling/nbproject/project.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.7
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/GlassFishVersion.java
@@ -18,12 +18,13 @@
  */
 package org.netbeans.modules.glassfish.tooling.data;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
-import org.netbeans.modules.glassfish.tooling.logging.Logger;
 import org.netbeans.modules.glassfish.tooling.utils.EnumUtils;
 import org.openide.util.Parameters;
 
@@ -83,7 +84,9 @@ public enum GlassFishVersion {
     /** GlassFish 6. */
     GF_6       ((short) 6, (short) 0, (short) 0, (short) 0, GlassFishVersion.GF_6_STR),
     /** GlassFish 6.1.0 */
-    GF_6_1_0       ((short) 6, (short) 1, (short) 0, (short) 0, GlassFishVersion.GF_6_1_0_STR);
+    GF_6_1_0       ((short) 6, (short) 1, (short) 0, (short) 0, GlassFishVersion.GF_6_1_0_STR),
+    /** GlassFish 6.2.1 */
+    GF_6_2_1       ((short) 6, (short) 2, (short) 1, (short) 0, GlassFishVersion.GF_6_2_1_STR);
     ////////////////////////////////////////////////////////////////////////////
     // Class attributes                                                       //
     ////////////////////////////////////////////////////////////////////////////
@@ -201,6 +204,10 @@ public enum GlassFishVersion {
     static final String GF_6_1_0_STR = "6.1.0";
     /** Additional <code>String</code> representations of GF_6_1_0 value. */
     static final String GF_6_1_0_STR_NEXT[] = {"6.1", "6.1.0"};
+    /** A <code>String</code> representation of GF_6_1_0 value. */
+    static final String GF_6_2_1_STR = "6.2.1";
+    /** Additional <code>String</code> representations of GF_6_2_1 value. */
+    static final String GF_6_2_1_STR_NEXT[] = {"6.2.1"};
 
     /**
      * Stored <code>String</code> values for backward <code>String</code>
@@ -232,6 +239,7 @@ public enum GlassFishVersion {
         initStringValuesMapFromArray(GF_5_1_0, GF_5_1_0_STR_NEXT);
         initStringValuesMapFromArray(GF_6, GF_6_STR_NEXT);
         initStringValuesMapFromArray(GF_6_1_0, GF_6_1_0_STR_NEXT);
+        initStringValuesMapFromArray(GF_6_2_1, GF_6_2_1_STR_NEXT);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -272,48 +280,54 @@ public enum GlassFishVersion {
         GlassFishVersion version
                 = stringValuesMap.get(versionStr.toUpperCase(Locale.ENGLISH));
         if (version == null) {
-            String[] versionNumbers = versionStr.split("\\"+SEPARATOR);
-            for (int i = versionNumbers.length - 1;
-                    version == null && i > 0; i--) {
-                int versionStrLen = i - 1;
-                for (int j = 0; j < i; j++) {
-                    versionStrLen += versionNumbers[j].length();
+            List<Integer> versionNumbers = new ArrayList<>(4);
+
+            String[] versionParts = versionStr.split("[^0-9.]", 2);
+            String[] versionNumberStrings = versionParts[0].split("\\.");
+            for (int i = 0; i < Math.min(4, versionNumberStrings.length); i++) {
+                try {
+                    int value = Integer.parseInt(versionNumberStrings[i]);
+                    versionNumbers.add(value);
+                } catch (NumberFormatException ex) {
+                    break;
                 }
-                StringBuilder sb = new StringBuilder(versionStrLen);
-                for (int j = 0; j < i; j++) {
-                    if (j > 0) {
-                        sb.append(SEPARATOR);
-                    }
-                    try {
-                        Integer.parseInt(versionNumbers[j]);
-                        sb.append(versionNumbers[j]);
-                    } catch (NumberFormatException ex) {
-                        break;
-                    }
-                }
-                version = stringValuesMap.get(sb.toString().toUpperCase(Locale.ENGLISH));
             }
-            if (version == null) {
-                // fallback attempt
-                int dot = versionStr.indexOf('.');
-                if (dot > 0) {
-                    try {
-                        int major = Integer.parseInt(versionStr.substring(0, dot));
-                        // this needs enum to be properly ordered latest versions last
-                        for (GlassFishVersion v : values()) {
-                            if (v.major <= major) {
-                                version = v;
-                            } else if (v.major > major) {
-                                break;
-                            }
-                        }
-                    } catch (NumberFormatException ex) {
-                        // noop
-                    }
+
+            for (int i = versionNumbers.size(); i < 4; i++ ) {
+                versionNumbers.add(0);
+            }
+
+            GlassFishVersion candidates[] = values();
+            for(int i = candidates.length - 1; i >= 0; i--) {
+                if(gfvSmallerOrEqual(candidates[i], versionNumbers)) {
+                    version = candidates[i];
+                    break;
                 }
             }
         }
         return version;
+    }
+
+    private static boolean gfvSmallerOrEqual(GlassFishVersion gfv, List<Integer> versionNumbers) {
+        if (gfv.getMajor() < versionNumbers.get(0)) {
+            return true;
+        } else if (gfv.getMajor() == versionNumbers.get(0)) {
+            if (gfv.getMinor() < versionNumbers.get(1)) {
+                return true;
+            } else if (gfv.getMinor() == versionNumbers.get(1)) {
+                if(gfv.getUpdate() < versionNumbers.get(2)) {
+                    return true;
+                } else if (gfv.getUpdate() == versionNumbers.get(2)) {
+                    return gfv.getBuild() <= versionNumbers.get(3);
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/ConfigBuilderProvider.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/ConfigBuilderProvider.java
@@ -82,11 +82,18 @@ public class ConfigBuilderProvider {
     /** Library builder configuration since GlassFish 6.1.0. */
     private static final Config.Next CONFIG_V6_1_0
             = new Config.Next(GlassFishVersion.GF_6_1_0,
-            ConfigBuilderProvider.class.getResource("GlassFishV6_1_0.xml"));
+                    ConfigBuilderProvider.class.getResource("GlassFishV6_1_0.xml"));
+
+    /** Library builder configuration since GlassFish 6.2.1. */
+    private static final Config.Next CONFIG_V6_2_1
+            = new Config.Next(GlassFishVersion.GF_6_2_1,
+                    ConfigBuilderProvider.class.getResource("GlassFishV6_2_1.xml"));
 
     /** Library builder configuration for GlassFish cloud. */
     private static final Config config
-            = new Config(CONFIG_V3, CONFIG_V4, CONFIG_V4_1, CONFIG_V5, CONFIG_V5_0_1, CONFIG_V5_1, CONFIG_V6, CONFIG_V6_1_0);
+            = new Config(CONFIG_V3, CONFIG_V4, CONFIG_V4_1, CONFIG_V5, 
+                         CONFIG_V5_0_1, CONFIG_V5_1, CONFIG_V6, CONFIG_V6_1_0,
+                         CONFIG_V6_2_1);
 
     /** Builders array for each server instance. */
     private static final Map<GlassFishServer, ConfigBuilder> builders

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_1.xml
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/GlassFishV6_2_1.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<server>
+    <tools lib="lib">
+        <asadmin jar="client/appserver-cli.jar"/>
+    </tools>
+    <java version="11">
+        <platform version="11"/>
+        <platform version="17"/>
+    </java>
+    <javaee version="1.8">
+        <profile version="1.3" type="full"/>
+        <profile version="1.4" type="full"/>
+        <profile version="1.5" type="full"/>
+        <profile version="1.6" type="web"/>
+        <profile version="1.6" type="full" check="full"/>
+        <profile version="1.7" type="web"/>
+        <profile version="1.7" type="full" check="full"/>
+        <profile version="1.8" type="web"/>
+        <profile version="1.8" type="full" check="full"/>
+        <profile version="8.0.0" type="web"/>
+        <profile version="8.0.0" type="full" check="full"/>
+        <profile version="9.0.0" type="web"/>
+        <profile version="9.0.0" type="full" check="full"/>
+        <module type="war"/>
+        <module type="car" check="full"/>
+        <module type="ear" check="full"/>
+        <module type="ejb" check="full"/>
+        <module type="rar" check="full"/>
+        <check name="full">
+            <file path="appclient-server-core.jar"/>
+        </check>
+    </javaee>
+    <library id="Java EE">
+        <classpath>
+            <fileset dir="modules">
+                <include name="jakarta\..+\.jar"/>
+                <include name="jakarta.validation-api-3.0.0.jar"/>
+                <include name="jakarta.enterprise.cdi-api-3.0.0.jar"/>
+                <include name="jaxb-osgi.jar"/>
+                <include name="jaxr-api-osgi.jar"/>
+                <include name="jaxrpc-api-osgi.jar"/>
+                <include name="webservices-osgi.jar"/>
+                <include name="weld-osgi-bundle.jar"/>
+            </fileset>
+            <fileset dir="modules/endorsed">
+                <include name=".+\.jar"/>
+            </fileset>
+            <fileset dir="../mq/lib">
+                <include name="jaxm-api.jar"/>
+            </fileset>
+        </classpath>
+        <javadocs>
+            <lookup path="docs/jakartaee9-doc-api.jar"/>
+        </javadocs>
+        <sources>
+        </sources>
+    </library>
+    <library id="Jersey 2">
+        <classpath>
+            <fileset dir="modules">
+                <include name="guava.+\.jar"/>
+                <include name="jackson.+\.jar"/>
+                <!-- include name="javax.ws.+\.jar"/ -->
+                <include name="jersey.+\.jar"/>
+                <include name="jettison.*\.jar"/>
+            </fileset>
+        </classpath>
+        <javadocs>
+            <link url="https://repo1.maven.org/maven2/org/glassfish/jersey/jersey-documentation/3.0.1/jersey-documentation-3.0.1-docbook.zip"/>
+        </javadocs>
+        <sources>
+        </sources>
+    </library>
+    <library id="JAX-RS">
+        <classpath>
+            <fileset dir="modules">
+                <include name="jakarta.ws.rs-api.jar"/>
+            </fileset>
+        </classpath>
+        <javadocs>
+        </javadocs>
+        <sources>
+        </sources>
+    </library>
+</server>

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/JavaSEPlatform.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/server/config/JavaSEPlatform.java
@@ -51,15 +51,17 @@ public enum JavaSEPlatform {
     /** JavaSE 11. */
     v11,
     /** JavaSE 16. */
-    v16;
-    
+    v16,
+    /** JavaSE 17. */
+    v17;
+
     ////////////////////////////////////////////////////////////////////////////
     // Class attributes                                                       //
     ////////////////////////////////////////////////////////////////////////////
 
     /** GlassFish JavaEE platform enumeration length. */
     public static final int length = JavaSEPlatform.values().length;
-    
+
     /** JavaEE platform version elements separator character. */
     public static final char SEPARATOR = '.';
 
@@ -91,10 +93,12 @@ public enum JavaSEPlatform {
     static final String V11_STR = "11";
 
     /**  A <code>String</code> representation of v16 value. */
-    static final String V16_STR = "16";    
-    
-    
-    /** 
+    static final String V16_STR = "16";
+
+    /**  A <code>String</code> representation of v17 value. */
+    static final String V17_STR = "17";
+
+    /**
      * Stored <code>String</code> values for backward <code>String</code>
      * conversion.
      */
@@ -153,9 +157,10 @@ public enum JavaSEPlatform {
             case v1_6:     return V1_6_STR;
             case v1_7:     return V1_7_STR;
             case v1_8:     return V1_8_STR;
-            case v11:     return V11_STR;            
-            case v16:     return V16_STR;                   
-                        
+            case v11:      return V11_STR;
+            case v16:      return V16_STR;
+            case v17:      return V17_STR;
+
             // This is unrecheable. Being here means this class does not handle
             // all possible values correctly.
             default:   throw new ServerConfigException(


### PR DESCRIPTION
With Glassfish 6.2.1 support for JDK 17 was added, so meta data for
that version was added.

The version detection was improved in the following way:

If an exact match is found, that entry is used. Else the list of
server definitions is iterated from highest to lowest. The highest
definition, where the version number is lower than or equal to the
target version is used to configure the server.

As an example: If you try to configure Glassfish 6.2.2, it will not
find an exact match. Instead 6.2.1 is matched. Prior to this change,
the configuration for 6.0 would have been chosen.