### PR TITLE
[NETBEANS-6115] UTF-8 input is broken in Maven project.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/CommandLineOutputHandler.java
@@ -24,12 +24,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.io.Writer;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -50,14 +51,15 @@ import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.modules.maven.api.output.OutputUtils;
 import org.netbeans.modules.maven.api.output.OutputVisitor;
 import org.netbeans.modules.maven.execute.AbstractMavenExecutor.ResumeFromFinder;
+
 import static org.netbeans.modules.maven.execute.AbstractOutputHandler.PRJ_EXECUTE;
 import static org.netbeans.modules.maven.execute.AbstractOutputHandler.SESSION_EXECUTE;
+
 import org.netbeans.modules.maven.execute.cmd.ExecMojo;
 import org.netbeans.modules.maven.execute.cmd.ExecProject;
 import org.netbeans.modules.maven.execute.cmd.ExecSession;
 import org.netbeans.modules.maven.options.MavenSettings;
 import org.netbeans.spi.project.ProjectContainerProvider;
-import org.netbeans.spi.project.SubprojectProvider;
 import org.openide.util.Exceptions;
 import org.openide.util.RequestProcessor;
 import org.openide.util.RequestProcessor.Task;
@@ -674,8 +676,8 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
 
     static class Input implements Runnable {
 
-        private InputOutput inputOutput;
-        private OutputStream str;
+        private final InputOutput inputOutput;
+        private final OutputStream str;
         private boolean stopIn = false;
 
         public Input(OutputStream out, InputOutput inputOutput) {
@@ -698,29 +700,21 @@ public class CommandLineOutputHandler extends AbstractOutputHandler {
 
         public @Override void run() {
             Reader in = inputOutput.getIn();
-            try {
+            try (Writer out = new OutputStreamWriter(str)) {
                 while (true) {
                     int read = in.read();
                     if (read != -1) {
-                        str.write(read);
-                        str.flush();
+                        out.write(read);
+                        out.flush();
                     } else {
-                        str.close();
                         return;
                     }
                     if (stopIn) {
                         return;
                     }
                 }
-
             } catch (IOException ex) {
                 ex.printStackTrace();
-            } finally {
-                try {
-                    str.close();
-                } catch (IOException ex) {
-                    ex.printStackTrace();
-                }
             }
         }
     }


### PR DESCRIPTION
Chars were written as bytes to a stream, ignoring the encoding.
By wrapping the stream in a writer, chars can now be encoded properly.

Chose to not specify the encoding so that the default can be used or
overwritten by -Dfile.encoding=UTF-8.

JDK 18+ uses UTF-8 as default, it will be probably best practice
to set the encoding to UTF-8 for most JDK 17 projects too, while using
the new 'native.encoding' property for edge cases.