### PR TITLE
[NETBEANS-6114] Restore automatic constructor completion functionality.

### DIFF
--- a/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateInsertHandler.java
+++ b/ide/editor.codetemplates/src/org/netbeans/lib/editor/codetemplates/CodeTemplateInsertHandler.java
@@ -226,6 +226,10 @@ public final class CodeTemplateInsertHandler implements TextRegionManagerListene
         }
         // Insert the template into document
         insertTemplate();
+
+        if (masterParameters.stream().noneMatch(param -> param.isEditable())) {
+            SwingUtilities.invokeLater(Completion.get()::showCompletion);
+        }
     }
 
     void checkInsertTextBuilt() {
@@ -320,7 +324,7 @@ public final class CodeTemplateInsertHandler implements TextRegionManagerListene
                 CodeTemplateParameterImpl masterImpl = CodeTemplateParameterImpl.get(master);
                 if (CodeTemplateParameter.CURSOR_PARAMETER_NAME.equals(master.getName())) {
                     // Add explicit ${cursor} as last into text sync group to jump to it by TAB as last param
-                    caretTextRegion = masterImpl.textRegion(); 
+                    caretTextRegion = masterImpl.textRegion();
                 } else {
                     textSyncGroup.addTextSync(masterImpl.textRegion().textSync());
                 }
@@ -503,7 +507,7 @@ public final class CodeTemplateInsertHandler implements TextRegionManagerListene
             }
         }
     }
-    
+
     void release() {
         synchronized (this) {
             if (released) {


### PR DESCRIPTION
After successful classtype completion, a new auto-completion should
appear for constructor selection, without having to press ctrl+space again.

Regression since 12.3.

took me a while to find this. Had to git bisect to find a9871c5085106f1ffd6c1c7ec594774185cf69d6 which introduced this small regression.

It seems to work fine, I keep this as draft until I did a bit more manual testing.

example:

```java
new ArrayL
```
press ctrl+space, enter
```java

new ArrayList<>
```
should show a completion window for the constructors without having to press ctrl+space again, since the completion is not finished.
