### PR TITLE
Handle generated sources during native image debugging.

### DIFF
--- a/java/gradle.java/nbproject/project.xml
+++ b/java/gradle.java/nbproject/project.xml
@@ -137,7 +137,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.58.1</specification-version>
+                        <specification-version>1.88</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/GradleSourcesImpl.java
@@ -107,7 +107,6 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
     private static final Map<String, String> COMMON_NAMES = new HashMap<>();
     public static final String SOURCE_TYPE_GROOVY    = "groovy";    //NOI18N
     public static final String SOURCE_TYPE_KOTLIN    = "kotlin";    //NOI18N
-    public static final String SOURCE_TYPE_GENERATED = "generated"; //NOI18N
 
     static {
         COMMON_NAMES.put("main.JAVA", "01main.java");
@@ -336,7 +335,7 @@ public class GradleSourcesImpl implements Sources, SourceGroupModifierImplementa
         switch (type) {
             case JavaProjectConstants.SOURCES_TYPE_JAVA: return EnumSet.of(SourceType.JAVA, SourceType.GROOVY);
             case JavaProjectConstants.SOURCES_TYPE_RESOURCES: return EnumSet.of(SourceType.RESOURCES);
-            case SOURCE_TYPE_GENERATED: return EnumSet.of(SourceType.GENERATED);
+            case JavaProjectConstants.SOURCES_TYPE_GENERATED: return EnumSet.of(SourceType.GENERATED);
             case SOURCE_TYPE_GROOVY: return EnumSet.of(SourceType.GROOVY); // Should be in the Groovy support module theoretically
             case SOURCE_TYPE_KOTLIN: return EnumSet.of(SourceType.KOTLIN);
         }

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/nodes/SourcesNodeFactory.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/nodes/SourcesNodeFactory.java
@@ -79,7 +79,7 @@ public final class SourcesNodeFactory implements NodeFactory {
             ret.addAll(Arrays.asList(srcs.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA)));
             ret.addAll(Arrays.asList(srcs.getSourceGroups(GradleSourcesImpl.SOURCE_TYPE_KOTLIN)));
             ret.addAll(Arrays.asList(srcs.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_RESOURCES)));
-            ret.addAll(Arrays.asList(srcs.getSourceGroups(GradleSourcesImpl.SOURCE_TYPE_GENERATED)));
+            ret.addAll(Arrays.asList(srcs.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_GENERATED)));
             ret.sort(Comparator.comparing(SourceGroup::getName));
             return ret;
         }

--- a/java/java.nativeimage.debugger/nbproject/project.xml
+++ b/java/java.nativeimage.debugger/nbproject/project.xml
@@ -76,7 +76,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.83</specification-version>
+                        <specification-version>1.88</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.project/apichanges.xml
+++ b/java/java.project/apichanges.xml
@@ -85,6 +85,18 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="GeneratedSourceType">
+            <api name="java_project"/>
+            <summary>Added a constant to mark generated sources with.</summary>
+            <version major="1" minor="88"/>
+            <date day="3" month="11" year="2021"/>
+            <author login="mentlicher"/>
+            <compatibility addition="yes"/>
+            <description>
+                Added <code>JavaProjectConstants.SOURCES_TYPE_GENERATED</code> constant witch represents type of source group with generated sources.
+            </description>
+            <class package="org.netbeans.api.java.project" name="JavaProjectConstants"/>
+        </change>
         <change id="ProjectPlatformNoPE">
             <api name="java_project"/>
             <summary>Added support for per-project platform for projects which don't use PropertyEvaluator.</summary>

--- a/java/java.project/manifest.mf
+++ b/java/java.project/manifest.mf
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.java.project/1
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/project/Bundle.properties
 OpenIDE-Module-Needs: javax.script.ScriptEngine.freemarker
-OpenIDE-Module-Specification-Version: 1.87
+OpenIDE-Module-Specification-Version: 1.88
 AutoUpdate-Show-In-Client: false
 

--- a/java/java.project/src/org/netbeans/api/java/project/JavaProjectConstants.java
+++ b/java/java.project/src/org/netbeans/api/java/project/JavaProjectConstants.java
@@ -47,6 +47,13 @@ public class JavaProjectConstants {
     public static final String SOURCES_TYPE_MODULES = "modules"; // NOI18N
 
     /**
+     * Generated root sources type.
+     * @see org.netbeans.api.project.Sources
+     * @since 1.88
+     */
+    public static final String SOURCES_TYPE_GENERATED = "generated"; // NOI18N
+
+    /**
      * Hint for <code>SourceGroupModifier</code> to create a <code>SourceGroup</code>
      * for main project codebase.
      * @see org.netbeans.api.project.SourceGroupModifier

--- a/java/maven/nbproject/project.xml
+++ b/java/maven/nbproject/project.xml
@@ -176,7 +176,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.62</specification-version>
+                        <specification-version>1.88</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/maven/src/org/netbeans/modules/maven/classpath/MavenSourcesImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/MavenSourcesImpl.java
@@ -78,7 +78,7 @@ import org.openide.util.Utilities;
 public class MavenSourcesImpl implements Sources, SourceGroupModifierImplementation, OtherSourcesExclude {
     public static final String TYPE_OTHER = "Resources"; //NOI18N
     public static final String TYPE_TEST_OTHER = "TestResources"; //NOI18N
-    public static final String TYPE_GEN_SOURCES = "GeneratedSources"; //NOI18N
+    public static final String TYPE_GEN_SOURCES = JavaProjectConstants.SOURCES_TYPE_GENERATED;
     public static final String NAME_PROJECTROOT = "ProjectRoot"; //NOI18N
     public static final String NAME_XDOCS = "XDocs"; //NOI18N
     public static final String NAME_SOURCE = "1SourceRoot"; //NOI18N


### PR DESCRIPTION
The native image debugger needs to be aware of project's sources to resolve the paths correctly.
We use `JavaProjectConstants.SOURCES_TYPE_JAVA` already, but that does not include generated sources. We need to add `JavaProjectConstants.SOURCES_TYPE_GENERATED` to be able to recognize generated sources.