### PR TITLE
[NETBEANS-6068] Add back SOURCES_TYPE_JAVA into GroovySources

### DIFF
--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/api/GroovySources.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/api/GroovySources.java
@@ -22,6 +22,7 @@ package org.netbeans.modules.groovy.support.api;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.netbeans.api.java.project.JavaProjectConstants;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.Sources;
 
@@ -60,6 +61,7 @@ public class GroovySources {
     public static List<SourceGroup> getGroovySourceGroups(Sources sources) {
         List<SourceGroup> result = new ArrayList<SourceGroup>();
         result.addAll(Arrays.asList(sources.getSourceGroups(GroovySources.SOURCES_TYPE_GROOVY)));
+        result.addAll(Arrays.asList(sources.getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA)));
         result.addAll(Arrays.asList(sources.getSourceGroups(GroovySources.SOURCES_TYPE_GRAILS)));
         result.addAll(Arrays.asList(sources.getSourceGroups(GroovySources.SOURCES_TYPE_GRAILS_UNKNOWN)));
         return result;


### PR DESCRIPTION
[NETBEANS-6068] Add back SOURCES_TYPE_JAVA into GroovySources::getGroovySourceGroups

This change added as part of [NETBEANS-4975](https://issues.apache.org/jira/browse/NETBEANS-4975) seems to be a cause of some issues reported in [NETBEANS-6068](https://issues.apache.org/jira/browse/NETBEANS-6068).

@lkishalmi could you take a look at this, which reverts a part of #2507 I'm not sure of the reasoning for this change, and I don't use Groovy much, but as it was raised as a potential blocker for 12.6 I had a look.  This seems to at least to be the cause of some exceptions mentioned in NETBEANS-6068