### PR TITLE
[NETBEANS-5846] Minimal support of java-platfom Gradle projects.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectErrorNotifications.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectErrorNotifications.java
@@ -62,7 +62,7 @@ public class GradleProjectErrorNotifications {
         sb.append("<ul>");                                   //NOI18N
         for (Object element : elements) {
             sb.append("<li>");                               //NOI18N
-            String[] lines = element.toString().split("\n"); //NOI18N
+            String[] lines = String.valueOf(element).split("\n"); //NOI18N
             for (int i = 0; i < lines.length; i++) {
                 String line = lines[i];
                 sb.append(lineWrap(line, 78));

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/GradleConfiguration.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/GradleConfiguration.java
@@ -120,7 +120,10 @@ public final class GradleConfiguration implements Serializable, ModuleSearchSupp
     }
 
     public boolean isEmpty() {
-        return !canBeResolved || ((files == null || files.files.isEmpty()) && modules.isEmpty() && unresolved.isEmpty() && projects.isEmpty());
+        return ((files == null || files.files.isEmpty()) 
+                && modules.isEmpty() 
+                && unresolved.isEmpty() 
+                && projects.isEmpty());
     }
 
     @Override

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/JavaSEProjectIconProvider.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/JavaSEProjectIconProvider.java
@@ -44,6 +44,9 @@ public class JavaSEProjectIconProvider implements ProjectIconProvider {
     @StaticResource
     private static final String APPLICATION_BADGE = "org/netbeans/modules/gradle/java/resources/application-badge.png"; //NOI18
 
+    @StaticResource
+    private static final String LIBRARIES_BADGE = "org/netbeans/modules/gradle/java/resources/libraries-badge.png"; //NOI18
+
     final Project project;
 
     public JavaSEProjectIconProvider(Project project) {
@@ -60,6 +63,11 @@ public class JavaSEProjectIconProvider implements ProjectIconProvider {
                Image badge = ImageUtilities.loadImage(APPLICATION_BADGE);
                ret = ImageUtilities.mergeImages(ret, badge, 8, 8);
             }
+        }
+        if (plugins.contains("java-platform")) {    //NOI18N
+            ret = ImageUtilities.loadImage(GRADLE_JAVASE_ICON);
+            Image badge = ImageUtilities.loadImage(LIBRARIES_BADGE);
+            ret = ImageUtilities.mergeImages(ret, badge, 8, 8);                
         }
         return  ret;
     }


### PR DESCRIPTION
Slightly more than just disabling the warnings on java-platform Gradle projects.
Did some testing on the weekend including the test why api and some other configurations are not showing up in the UI.
Those are the configurations the users often use. It turned out that Gradle marks those configurations as non-resolvabe (canBeResolved property is false).
So I made some adjustments to let them displayed.
Before:
![image](https://user-images.githubusercontent.com/1381701/139724206-e6f8695f-5fad-488f-aad1-aa968a259781.png)

After:
![image](https://user-images.githubusercontent.com/1381701/139715983-96a444ab-bb32-448b-9de5-100962b6fa2d.png)
