### PR TITLE
[NETBEANS-5962] Remove default bgcolor for multiline Strings

### DIFF
--- a/java/java.editor/src/org/netbeans/modules/java/editor/resources/fontsColors.xml
+++ b/java/java.editor/src/org/netbeans/modules/java/editor/resources/fontsColors.xml
@@ -90,7 +90,7 @@
     <fontcolor name="mod-protected" />
     <fontcolor name="mod-public" />
     <fontcolor name="mod-keyword" default="keyword" />
-    <fontcolor name="mod-unindented-text-block" bgColor="EEDDDD" />
+    <fontcolor name="mod-unindented-text-block" />
     
     <!--currently not used:-->
 <!--    <fontcolor name="mod-type-parameter-declaration" bgColor="lightGray"/>


### PR DESCRIPTION
[NETBEANS-5962](https://issues.apache.org/jira/browse/NETBEANS-5962) Remove default bgcolor for multiline Strings - inherited and illegible on various editor themes. This was reported against FlatLaf Dark but it affects others too. This is a quick fix for 12.6 - need to consider how to display indents and make sure they work across all editor themes, in particular handling dark ones.

cc/ @arusinha @jlahoda 