### PR TITLE
[NETBEANS-5209] Document switcher popup not grouping by project on first use.

### DIFF
--- a/ide/core.multitabs.project/nbproject/project.properties
+++ b/ide/core.multitabs.project/nbproject/project.properties
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-javac.source=1.6
+javac.source=1.8
 javac.compilerargs=-Xlint -Xlint:-serial
 nbm.needs.restart=true
 spec.version.base=1.25.0

--- a/ide/core.multitabs.project/src/org/netbeans/core/multitabs/project/ProjectSupportImpl.java
+++ b/ide/core.multitabs.project/src/org/netbeans/core/multitabs/project/ProjectSupportImpl.java
@@ -44,7 +44,7 @@ import org.openide.windows.TopComponent;
 @ServiceProvider(service = ProjectSupport.class)
 public class ProjectSupportImpl extends ProjectSupport {
 
-    private static final Map<FileObject, Project> file2project = new WeakHashMap<FileObject, Project>(50);
+    private static final Map<FileObject, Project> file2project = new WeakHashMap<>(50);
     private static final RequestProcessor RP = new RequestProcessor("TabProjectBridge"); //NOI18N
     private static final ChangeSupport changeSupport = new ChangeSupport(RP);
     private static PropertyChangeListener projectsListener;
@@ -62,12 +62,7 @@ public class ProjectSupportImpl extends ProjectSupport {
         synchronized( changeSupport ) {
             changeSupport.addChangeListener(l);
             if( null == projectsListener ) {
-                projectsListener = new PropertyChangeListener() {
-                    @Override
-                    public void propertyChange(PropertyChangeEvent evt) {
-                        changeSupport.fireChange();
-                    }
-                };
+                projectsListener = (PropertyChangeEvent evt) -> changeSupport.fireChange();
                 OpenProjects.getDefault().addPropertyChangeListener( projectsListener );
             }
         }

--- a/ide/core.multitabs.project/src/org/netbeans/core/multitabs/project/ProjectSupportImpl.java
+++ b/ide/core.multitabs.project/src/org/netbeans/core/multitabs/project/ProjectSupportImpl.java
@@ -20,9 +20,7 @@ package org.netbeans.core.multitabs.project;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.WeakHashMap;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.project.FileOwnerQuery;
@@ -48,10 +46,9 @@ public class ProjectSupportImpl extends ProjectSupport {
 
     private static final Map<FileObject, Project> file2project = new WeakHashMap<FileObject, Project>(50);
     private static final RequestProcessor RP = new RequestProcessor("TabProjectBridge"); //NOI18N
-    private static final Set<FileObject> currentQueries = new HashSet<FileObject>(20);
     private static final ChangeSupport changeSupport = new ChangeSupport(RP);
     private static PropertyChangeListener projectsListener;
-    
+
     public ProjectSupportImpl() {
     }
 
@@ -102,40 +99,25 @@ public class ProjectSupportImpl extends ProjectSupport {
     @Override
     public ProjectProxy getProjectForTab( final TabData tab ) {
         Project p = null;
-        synchronized( file2project ) {
-            if( null != tab && tab.getComponent() instanceof TopComponent ) {
-                TopComponent tc = ( TopComponent ) tab.getComponent();
-                DataObject dob = tc.getLookup().lookup( DataObject.class );
-                if( null != dob ) {
-                    final FileObject fo = dob.getPrimaryFile();
-                    if( null != fo ) {
+        if( null != tab && tab.getComponent() instanceof TopComponent ) {
+            TopComponent tc = ( TopComponent ) tab.getComponent();
+            DataObject dob = tc.getLookup().lookup( DataObject.class );
+            if( null != dob ) {
+                final FileObject fo = dob.getPrimaryFile();
+                if( null != fo ) {
+                    synchronized( file2project ) {
                         p = file2project.get(fo);
                         if( null == p ) {
-                            if( currentQueries.contains(fo) ) {
-                                //there already is a file owner query for this file
-                                return null;
-                            } else {
-                                currentQueries.add(fo);
-                                RP.post(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        Project p = FileOwnerQuery.getOwner( fo );
-                                        if( null != p ) {
-                                            synchronized( file2project ) {
-                                                file2project.put( fo, p );
-                                                currentQueries.remove(fo);
-                                                changeSupport.fireChange();
-                                            }
-                                        }
-                                    }
-                                });
+                            p = FileOwnerQuery.getOwner( fo );
+                            if (null != p) {
+                                file2project.put(fo, p);
                             }
                         }
                     }
                 }
             }
-            return null == p ? null : createProxy( p );
         }
+        return null == p ? null : createProxy( p );
     }
 
     private static ProjectProxy createProxy( Project p ) {

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ButtonPopupSwitcher.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ButtonPopupSwitcher.java
@@ -87,8 +87,8 @@ final class ButtonPopupSwitcher implements MouseInputListener, AWTEventListener,
     
     private final DocumentSwitcherTable pTable;
     
-    private int x;
-    private int y;
+    private final int x;
+    private final int y;
 
     private boolean isDragging = true;
 
@@ -178,12 +178,9 @@ final class ButtonPopupSwitcher implements MouseInputListener, AWTEventListener,
         if (popup != null) {
             popup.removePopupMenuListener( this );
             final JPopupMenu popupToHide = popup;
-            SwingUtilities.invokeLater( new Runnable() {
-                @Override
-                public void run() {
-                    if( popupToHide.isVisible() )
-                        popupToHide.setVisible( false );
-                }
+            SwingUtilities.invokeLater(() -> {
+                if( popupToHide.isVisible() )
+                    popupToHide.setVisible( false );
             });
             popup.setVisible( false );
             popup = null;
@@ -279,20 +276,6 @@ final class ButtonPopupSwitcher implements MouseInputListener, AWTEventListener,
         }
     }
     
-    /**
-     * Was mouse upon the popup table when mouse action had been taken.
-     */
-    private boolean onSwitcherTable(MouseEvent e) {
-        Point p = e.getPoint();
-        //#118828
-        if (! (e.getSource() instanceof Component)) {
-            return false;
-        }
-        
-        p = SwingUtilities.convertPoint((Component) e.getSource(), p, pTable);
-        return pTable.contains(p);
-    }
-    
     @Override
     public void eventDispatched(AWTEvent event) {
         if (event.getSource() == this) {
@@ -365,12 +348,7 @@ final class ButtonPopupSwitcher implements MouseInputListener, AWTEventListener,
                     int tabIndex = controller.getTabModel().indexOf( tab );
                     if( tabIndex >= 0 ) {
                         if( controller.getTabModel().size() == 1 ) {
-                            SwingUtilities.invokeLater( new Runnable() {
-                                @Override
-                                public void run() {
-                                    hideCurrentPopup();
-                                }
-                            });
+                            SwingUtilities.invokeLater(this::hideCurrentPopup);
                         }
                         TabActionEvent tae = new TabActionEvent( this, TabbedContainer.COMMAND_CLOSE, tabIndex );
                         controller.postActionEvent( tae );
@@ -528,11 +506,11 @@ final class ButtonPopupSwitcher implements MouseInputListener, AWTEventListener,
                 currentProject = p;
             }
         }
-        return items.toArray( new Item[items.size()] );
+        return items.toArray( new Item[0] );
     }
 
     private class ActivatableTab implements SwitcherTableItem.Activatable {
-        private TabData tab;
+        private final TabData tab;
 
         private ActivatableTab(TabData tab) {
             this.tab = tab;

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectColorTabDecorator.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectColorTabDecorator.java
@@ -205,7 +205,7 @@ public class ProjectColorTabDecorator extends TabDecorator {
     }
 
     private static Color getColorForTab( TabData tab ) {
-        ProjectProxy p = ProjectSupport.getDefault().getProjectForTab( tab );
+        ProjectProxy p = ProjectSupport.getDefault().tryGetProjectForTab(tab);
         if( null != p ) {
             synchronized( project2color ) {
                 return project2color.get( p.getToken() );

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectColorTabDecorator.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/ProjectColorTabDecorator.java
@@ -49,20 +49,14 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service=TabDecorator.class)
 public class ProjectColorTabDecorator extends TabDecorator {
 
-    private static final Map<Object, Color> project2color = new WeakHashMap<Object, Color>(10);
-    private static final Map<TabData, Color> tab2color = new WeakHashMap<TabData, Color>(10);
+    private static final Map<Object, Color> project2color = new WeakHashMap<>(10);
+    private static final Map<TabData, Color> tab2color = new WeakHashMap<>(10);
     private static final List<Color> backGroundColors;
     private static Color foregroundColor;
-    private final static ChangeListener projectsListener = new ChangeListener() {
-
-        @Override
-        public void stateChanged(ChangeEvent e) {
-            updateColorMapping();
-        }
-    };
+    private final static ChangeListener projectsListener = (ChangeEvent e) -> updateColorMapping();
 
     static {
-        backGroundColors = new ArrayList<Color>( 10 );
+        backGroundColors = new ArrayList<>( 10 );
 
         // load background colors from UI defaults if available
         if (UIManager.getColor("nb.multitabs.project.1.background") != null) {
@@ -125,7 +119,7 @@ public class ProjectColorTabDecorator extends TabDecorator {
     public Color getBackground( TabData tab, boolean selected ) {
         if( selected || !Settings.getDefault().isSameProjectSameColor() )
             return null;
-        Color res = null;
+        Color res;
         synchronized( tab2color ) {
             res = tab2color.get( tab );
             if( null == res ) {
@@ -149,7 +143,7 @@ public class ProjectColorTabDecorator extends TabDecorator {
     public void paintAfter( TabData tab, Graphics g, Rectangle tabRect, boolean isSelected ) {
         if( !isSelected || !Settings.getDefault().isSameProjectSameColor() )
             return;
-        Color c = null;
+        Color c;
         synchronized( tab2color ) {
             c = tab2color.get( tab );
             if( null == c ) {
@@ -177,9 +171,9 @@ public class ProjectColorTabDecorator extends TabDecorator {
     private static void updateColorMapping() {
         ProjectProxy[] projects = ProjectSupport.getDefault().getOpenProjects();
         synchronized( project2color ) {
-            Map<Object, Color> oldColors = new HashMap<Object, Color>( project2color );
+            Map<Object, Color> oldColors = new HashMap<>( project2color );
             project2color.clear();
-            List<Color> availableColors = new ArrayList<Color>( backGroundColors );
+            List<Color> availableColors = new ArrayList<>( backGroundColors );
 
             for( ProjectProxy p : projects ) {
                 Color c = oldColors.get( p.getToken() );

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabLayoutManager.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabLayoutManager.java
@@ -28,6 +28,7 @@ import java.awt.event.ComponentListener;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import javax.swing.JComponent;
 import javax.swing.JTable;
 import javax.swing.SwingUtilities;
@@ -247,10 +248,12 @@ abstract class TabLayoutManager {
                 rowIndexes[i] = new ArrayList<Integer>( tabCount );
             }
 
+            Map<TabData, ProjectProxy> tab2Project = projectSupport.tryGetProjectsForTabs(tabModel.getTabs());
+
             for( int i=0; i<tabCount; i++ ) {
                 TabData td = tabModel.getTab( i );
 
-                ProjectProxy p = projectSupport.getProjectForTab( td );
+                ProjectProxy p = tab2Project.get(td);
                 int index = projects.indexOf( p );
                 if( index < 0 || index >= rowIndexes.length-1 || rowCount == 1 )
                     index = 0;

--- a/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabLayoutManager.java
+++ b/platform/core.multitabs/src/org/netbeans/core/multitabs/impl/TabLayoutManager.java
@@ -22,7 +22,6 @@ import java.awt.Container;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.util.ArrayList;
@@ -59,13 +58,7 @@ abstract class TabLayoutManager {
         this.rows = rows;
         this.container = container;
         this.tabModel = tabModel;
-        layoutTimer = new Timer( 350, new ActionListener() {
-
-            @Override
-            public void actionPerformed( ActionEvent e ) {
-                doLayout();
-            }
-        });
+        layoutTimer = new Timer(350, (ActionEvent e) -> doLayout());
         layoutTimer.setRepeats( false );
     }
 
@@ -212,7 +205,7 @@ abstract class TabLayoutManager {
                     }
                 }
             }
-            ArrayList<Integer> tabs = new ArrayList<Integer>( tabCount );
+            ArrayList<Integer> tabs = new ArrayList<>( tabCount );
             int prevTab = -1;
             for( int i=0; i<lastIndexInRow.length; i++ ) {
                 tabs.clear();
@@ -245,7 +238,7 @@ abstract class TabLayoutManager {
             final int rowCount = rows.size();
             List<Integer>[] rowIndexes = new ArrayList[rowCount];
             for( int i=0; i<rowCount; i++ ) {
-                rowIndexes[i] = new ArrayList<Integer>( tabCount );
+                rowIndexes[i] = new ArrayList<>( tabCount );
             }
 
             Map<TabData, ProjectProxy> tab2Project = projectSupport.tryGetProjectsForTabs(tabModel.getTabs());


### PR DESCRIPTION
issue:
1) tools -> options -> appearance -> doc tabs -> check sort opened docs by project
2) open some files, open the tab switcher popup on the upper right corner of the editor
3) you will notice first open does not group by projects as requested
4) open it again... should work now

fix for document switcher popup not grouping by project on first use:
- file owner query is now a blocking opperation with timeout
- under normal conditions the query returns a result right away
- if it doesn't for whatever reason it won't block the EDT due to the timeout
  - fallback is the regular tab list
- it fixes the issue as side effect + avoids repaint flickering of the original impl
