### PR TITLE
[jackpot] for-loop to function should be an inline hint instead of a warning

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/ForLoopToFunctionalHint.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/mapreduce/ForLoopToFunctionalHint.java
@@ -26,10 +26,10 @@ import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.StatementTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
-import javax.lang.model.SourceVersion;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.Fix;
+import org.netbeans.spi.editor.hints.Severity;
 import org.netbeans.spi.java.hints.ErrorDescriptionFactory;
 import org.netbeans.spi.java.hints.Hint;
 import org.netbeans.spi.java.hints.HintContext;
@@ -37,8 +37,7 @@ import org.netbeans.spi.java.hints.JavaFix;
 import org.netbeans.spi.java.hints.TriggerTreeKind;
 import org.openide.util.NbBundle.Messages;
 
-@Hint(displayName = "#DN_ForLoopToFunctionalHint", description = "#DESC_ForLoopToFunctionalHint", category = "general",
-        minSourceVersion = "8")
+@Hint(displayName = "#DN_ForLoopToFunctionalHint", description = "#DESC_ForLoopToFunctionalHint", category = "general", severity = Severity.HINT, minSourceVersion = "8")
 @Messages({
     "DN_ForLoopToFunctionalHint=Use Functional Operations",
     "DESC_ForLoopToFunctionalHint=Use functional operations instead of imperative style loop."

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/mapreduce/ForLoopToFunctionalHintTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/mapreduce/ForLoopToFunctionalHintTest.java
@@ -56,7 +56,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("12:8-12:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("12:8-12:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -126,7 +126,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("12:8-12:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("12:8-12:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -180,7 +180,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("22:8-22:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("22:8-22:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("/*\n"
                 + " * To change this template, choose Tools | Templates\n"
@@ -237,7 +237,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("12:8-12:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("12:8-12:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -288,7 +288,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("12:8-12:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("12:8-12:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -341,7 +341,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("12:8-12:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("12:8-12:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -398,7 +398,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("12:8-12:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("12:8-12:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -455,7 +455,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("12:8-12:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("12:8-12:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -519,7 +519,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("12:8-12:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("12:8-12:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -583,7 +583,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("14:8-14:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("14:8-14:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -658,7 +658,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("12:8-12:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("12:8-12:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -725,7 +725,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("14:8-14:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("14:8-14:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -787,7 +787,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("14:8-14:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("14:8-14:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -859,7 +859,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("14:8-14:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("14:8-14:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package testdemo;\n"
                 + "\n"
@@ -928,7 +928,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("17:8-17:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("17:8-17:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package javatargettempapp;\n"
                 + "\n"
@@ -990,7 +990,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("17:8-17:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("17:8-17:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package javatargettempapp;\n"
                 + "\n"
@@ -1052,7 +1052,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("17:8-17:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("17:8-17:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("package javatargettempapp;\n"
                 + "\n"
@@ -1124,7 +1124,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("23:8-23:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("23:8-23:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("/*\n"
                 + " * To change this template, choose Tools | Templates\n"
@@ -1202,7 +1202,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("23:8-23:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("23:8-23:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("/*\n"
                 + " * To change this template, choose Tools | Templates\n"
@@ -1274,7 +1274,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("23:8-23:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("23:8-23:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("/*\n"
                 + " * To change this template, choose Tools | Templates\n"
@@ -1341,7 +1341,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .findWarning("23:8-23:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint())
+                .findWarning("23:8-23:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint())
                 .applyFix()
                 .assertOutput("/*\n"
                 + " * To change this template, choose Tools | Templates\n"
@@ -1406,7 +1406,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .assertNotContainsWarnings("23:8-23:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint());
+                .assertNotContainsWarnings("23:8-23:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint());
     }
 
     public void testNoHintDueToNEF() throws Exception {
@@ -1651,7 +1651,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .assertWarnings("15:8-15:11:verifier:" + Bundle.ERR_ForLoopToFunctionalHint());
+                .assertWarnings("15:8-15:11:hint:" + Bundle.ERR_ForLoopToFunctionalHint());
     }
 
     public void testNoHintDueToMethodThrowingException() throws Exception {
@@ -1789,7 +1789,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .assertNotContainsWarnings("23:8-23:11:verifier:Can use functional operation");
+                .assertNotContainsWarnings("23:8-23:11:hint:Can use functional operation");
 
     }
 
@@ -1832,7 +1832,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .assertNotContainsWarnings("23:8-23:11:verifier:Can use functional operation");
+                .assertNotContainsWarnings("23:8-23:11:hint:Can use functional operation");
 
     }
 
@@ -1873,7 +1873,7 @@ public class ForLoopToFunctionalHintTest extends NbTestCase {
                 + "}")
                 .sourceLevel("1.8")
                 .run(ForLoopToFunctionalHint.class)
-                .assertNotContainsWarnings("23:8-23:11:verifier:Can use functional operation");
+                .assertNotContainsWarnings("23:8-23:11:hint:Can use functional operation");
 
     }
     


### PR DESCRIPTION
changed the default to hint at current line.