### PR TITLE
[NETBEANS-6171] Interpret ClassCast as "interface unsupported"

### DIFF
--- a/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEngine.java
+++ b/ide/libs.graalsdk/src/org/netbeans/libs/graalsdk/impl/GraalEngine.java
@@ -173,13 +173,17 @@ final class GraalEngine implements ScriptEngine, Invocable {
 
     @Override
     public <T> T getInterface(Object thiz, Class<T> clasz) {
-        if (thiz instanceof Value) {
-            return ((Value) thiz).as(clasz);
-        }
-        Value v = factory.ctx.ctx().asValue(thiz);
-        T ret = v.as(clasz);
-        if (ret != null) {
-            return ret;
+        try {
+            if (thiz instanceof Value) {
+                return ((Value) thiz).as(clasz);
+            }
+            Value v = factory.ctx.ctx().asValue(thiz);
+            T ret = v.as(clasz);
+            if (ret != null) {
+                return ret;
+            }
+        } catch (ClassCastException ex) {
+            // the interface is not supported on the value object; ignore.
         }
         if (clasz.isInstance(thiz)) {
             return clasz.cast(thiz);


### PR DESCRIPTION
According to [GraalSDK documentation](https://docs.oracle.com/en/graalvm/enterprise/20/sdk/org/graalvm/polyglot/Value.html#as-java.lang.Class-), the `as` method may throw ClassCastException if the passed object does not fit into the supported cases; the [Invocable.getInterface](https://docs.oracle.com/javase/7/docs/api/javax/script/Invocable.html#getInterface(java.lang.Object,%20java.lang.Class)) however returns `null` in such case.
