### PR TITLE
Consider the reported trustlevel of the KeyStoreProvider when querying KeyStores

### DIFF
--- a/platform/autoupdate.services/build.xml
+++ b/platform/autoupdate.services/build.xml
@@ -84,14 +84,18 @@
         <delete file="${validation-store}" />
         <genkey
             keystore="${validation-store}"
-            alias="demo-key" storepass="password"
+            alias="demo-key"
+            storepass="password"
+            keyalg="RSA"
             dname="CN=Demo Key, OU=NetBeans, O=Apache.org, C=US"
         />
         <property name="unvalidation-store" value="${build.test.unit.classes.dir}/org/netbeans/api/autoupdate/data/test-unvalidate-keystore.jks" />
         <delete file="${unvalidation-store}" />
         <genkey
             keystore="${unvalidation-store}"
-            alias="demo-key-unvalidated" storepass="password"
+            alias="demo-key-unvalidated"
+            storepass="password"
+            keyalg="RSA"
             dname="CN=Demo Key (unvalidated), OU=NetBeans, O=Apache.org, C=US"
         />
         <touch file="${build.dir}/Dummy.class" />

--- a/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
+++ b/platform/autoupdate.services/src/org/netbeans/modules/autoupdate/services/Utilities.java
@@ -122,9 +122,11 @@ public class Utilities {
             List<KeyStore> kss = new ArrayList<>();
 
             for (KeyStoreProvider provider : c) {
-                KeyStore ks = provider.getKeyStore();
-                if (ks != null) {
-                    kss.add(ks);
+                if (provider.getTrustLevel() == trustLevel) {
+                    KeyStore ks = provider.getKeyStore();
+                    if (ks != null) {
+                        kss.add(ks);
+                    }
                 }
             }
 

--- a/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UtilitiesTest.java
+++ b/platform/autoupdate.services/test/unit/src/org/netbeans/modules/autoupdate/services/UtilitiesTest.java
@@ -18,12 +18,68 @@
  */
 package org.netbeans.modules.autoupdate.services;
 
+import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import org.junit.Test;
+import static java.util.Arrays.asList;
+import java.util.HashSet;
 import static org.junit.Assert.*;
+import org.junit.Test;
+import org.netbeans.core.startup.MainLookup;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.spi.autoupdate.KeyStoreProvider;
+import org.netbeans.spi.autoupdate.KeyStoreProvider.TrustLevel;
 
-public class UtilitiesTest {
+public class UtilitiesTest extends NbTestCase {
+
+    private static final KeyStore trustedKeyStore;
+    private static final KeyStoreProvider trustedKeyStoreProvider;
+    private static final KeyStore validCAKeyStore;
+    private static final KeyStoreProvider validCAKeyStoreProvider;
+    private static final KeyStore defaultKeyStore;
+    private static final KeyStoreProvider defaultKeyStoreProvider;
+    static {
+        try {
+            trustedKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustedKeyStoreProvider = new KeyStoreProvider() {
+                @Override
+                public KeyStore getKeyStore() {
+                    return trustedKeyStore;
+                }
+
+                @Override
+                public TrustLevel getTrustLevel() {
+                    return TrustLevel.TRUST;
+                }
+            };
+            validCAKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            validCAKeyStoreProvider = new KeyStoreProvider() {
+                @Override
+                public KeyStore getKeyStore() {
+                    return validCAKeyStore;
+                }
+
+                @Override
+                public TrustLevel getTrustLevel() {
+                    return KeyStoreProvider.TrustLevel.VALIDATE_CA;
+                }
+            };
+            defaultKeyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            defaultKeyStoreProvider = new KeyStoreProvider() {
+                @Override
+                public KeyStore getKeyStore() {
+                    return defaultKeyStore;
+                }
+            };
+        } catch (KeyStoreException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public UtilitiesTest(String name) {
+        super(name);
+    }
 
     @Test
     public void testHexEncode() throws NoSuchAlgorithmException {
@@ -41,5 +97,31 @@ public class UtilitiesTest {
         assertArrayEquals(
             hash,
             Utilities.hexDecode("cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"));
+    }
+
+    @Test
+    public void testTrustLevel() {
+        MainLookup.register(trustedKeyStoreProvider);
+        MainLookup.register(validCAKeyStoreProvider);
+        MainLookup.register(defaultKeyStoreProvider);
+        try {
+            // the default trust level is trusted - so both the keystore provider
+            // with the level explicitly set to trusted and the one without a
+            // trustlevel should be returned
+            assertEquals(
+                    new HashSet<>(asList(defaultKeyStore, trustedKeyStore)),
+                    new HashSet<>(Utilities.getKeyStore(TrustLevel.TRUST))
+            );
+            // Only the validCAKeyStoreProvider is on level VALIDATE_CA so
+            // the keystore validCAKeyStore should be returned
+            assertEquals(
+                    new HashSet<>(asList(validCAKeyStore)),
+                    new HashSet<>(Utilities.getKeyStore(TrustLevel.VALIDATE_CA))
+            );
+        } finally {
+            MainLookup.unregister(trustedKeyStoreProvider);
+            MainLookup.unregister(validCAKeyStoreProvider);
+            MainLookup.unregister(defaultKeyStoreProvider);
+        }
     }
 }


### PR DESCRIPTION
Utilities#getKeyStore needs to check the supplied trustlevel against
the trustlevel reported by the KeyStoreProvider. Else all keystores
are returned for all levels and thus all KeyStores are reported on
level TRUST.