### PR TITLE
If unenter is not available (on older javac versions), print the error into a log, rather than into System.err

### DIFF
--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -121,6 +121,8 @@ import org.openide.util.Exceptions;
  */
 public final class TreeUtilities {
     
+    private static final Logger LOG = Logger.getLogger(TreeUtilities.class.getName());
+
     /**{@link Kind}s that are represented by {@link ClassTree}.
      * 
      * @since 0.67
@@ -932,7 +934,7 @@ public final class TreeUtilities {
             Method m = Enter.class.getDeclaredMethod("unenter", JCCompilationUnit.class, JCTree.class);
             m.invoke(Enter.instance(ctx), cut, tree);
         } catch (Throwable t) {
-            t.printStackTrace();
+            LOG.log(Level.FINE, null, t);
         }
     }
 


### PR DESCRIPTION
Currently, if unenter fails (most likely because it is missing on a given version of JDK, like 11), an error is printed into System.err. This patch changes that to a `Log`. When we upgrade the baseline javac, then this should become a direct method call, I believe, but if there will be another RC of 12.6, it might be nice to not print the errors into System.err.