### PR TITLE
Parallelize computing biggest objects by retained size

### DIFF
--- a/profiler/lib.profiler/build.xml
+++ b/profiler/lib.profiler/build.xml
@@ -46,6 +46,7 @@
                     <or>
                         <equals arg1="${javac.source}" arg2="1.5"/>
                         <equals arg1="${javac.source}" arg2="1.7"/>
+                        <equals arg1="${javac.source}" arg2="1.8"/>
                     </or>
                 </not>
             </condition>

--- a/profiler/lib.profiler/nbproject/project.properties
+++ b/profiler/lib.profiler/nbproject/project.properties
@@ -45,6 +45,6 @@ nbm.executable.files=\
     lib/deployed/**/hpux*/lib*.sl,\
     remote-pack-defs/*.sh
 
-javac.source=1.7
-javac.target=1.7
+javac.source=1.8
+javac.target=8
 bootclasspath.prepend=${build.dir}/disable-release

--- a/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapTest.java
+++ b/profiler/lib.profiler/test/unit/src/org/netbeans/lib/profiler/heap/HeapTest.java
@@ -172,11 +172,27 @@ public class HeapTest {
      */
     @Test
     public void testGetBiggestObjectsByRetainedSize() {
-        List result = heap.getBiggestObjectsByRetainedSize(2);
+        List<Instance> result = heap.getBiggestObjectsByRetainedSize(2);
+        assertFalse("Empty biggest object list", result.isEmpty());
         Instance i1 = (Instance) result.get(0);
+        assertNotNull("No first instance for " + result.get(0) + " in " + result, i1);
         Instance i2 = (Instance) result.get(1);
-        assertEquals(52283, i1.getRetainedSize());
-        assertEquals(52082, i2.getRetainedSize());
+        assertNotNull("No second instance for " + result.get(1) + " in " + result, i2);
+        assertEquals("Wrong id for next-to-largest in " + idsAndSizes(result),
+                52082, i2.getRetainedSize());
+        assertEquals("Wrong id for largest in " + idsAndSizes(result),
+                52283, i1.getRetainedSize());
+    }
+
+    private String idsAndSizes(List<Instance> result) {
+        StringBuilder sb = new StringBuilder();
+        for (Instance in : result) {
+            if (sb.length() != 0) {
+                sb.append(",");
+            }
+            sb.append(in.getInstanceId()).append(":").append(in.getRetainedSize()).append(":").append(in.getJavaClass().getName());
+        }
+        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
Once in a great while you encounter a problem that's a textbook example of what ForkJoinTask is for...

I find myself frequently analyzing 64Gb heap dumps, and computing retained sizes, if it manages to complete at all, takes around _six days_.  In a world with zero contention, this would cut that to 12 hours.  Still not ideal, but at least practically useful if you really want to answer the question.

Had to update the source and target version to JDK 8.