### PR TITLE
[NETBEANS-5783] Make sure that getDisplayName() is non null in Gradle Projects.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/queries/Info.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/queries/Info.java
@@ -69,7 +69,11 @@ public final class Info implements ProjectInformation, PropertyChangeListener {
 
     @Override
     public String getName() {
+        final NbGradleProject nb = NbGradleProject.get(project);
         GradleBaseProject prj = GradleBaseProject.get(project);
+        if (!nb.isGradleProjectLoaded() || prj == null || prj.getName() == null) {
+            return project.getProjectDirectory().getNameExt();
+        }
 
         String ret = prj.isRoot() ? prj.getName() : prj.getRootDir().getName() + prj.getPath();
         return ret;

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/AbstractGradleProjectTestCase.java
@@ -87,6 +87,11 @@ public class AbstractGradleProjectTestCase extends NbTestCase {
         }).get();
     }
     
+    protected void dumpProject(Project project){
+        NbGradleProjectImpl impl = (NbGradleProjectImpl) project;
+        impl.dumpProject();
+    }
+    
     protected FileObject createGradleProject(String path, String buildScript, String settingsScript) throws IOException {
         FileObject ret = FileUtil.toFileObject(getWorkDir());
         if (path != null) {


### PR DESCRIPTION
Tried to reproduce the behavior with tests, but was not able to. I've closed some possible paths making sure that the Gradle Project does not return ```null``` as DisplayName or Name.