### PR TITLE
Allow VSCode users to choose 'local' - e.g. per workspace userdir

### DIFF
--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -76,6 +76,19 @@
 					"default": false,
 					"description": "Enables verbose messages from the Apache NetBeans Language Server"
 				},
+				"netbeans.userdir": {
+					"description": "Keep settings and caches as 'global' or 'local' per workspace?",
+					"type": "string",
+					"enum": [
+						"global",
+						"local"
+					],
+					"enumDescriptions": [
+						"Share data between all workspaces (more effective)",
+						"Each workspace has its own data (more isolated)"
+					],
+					"default": "global"
+				},
 				"netbeans.conflict.check": {
 					"type": "boolean",
 					"default": true,

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -432,11 +432,27 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
         }, time);
     };
 
-    const beVerbose : boolean = workspace.getConfiguration('netbeans').get('verbose', false);
+    const netbeansConfig = workspace.getConfiguration('netbeans');
+    const beVerbose : boolean = netbeansConfig.get('verbose', false);
+    let userdir = netbeansConfig.get('userdir', 'global');
+    switch (userdir) {
+        case 'local':
+            if (context.storagePath) {
+                userdir = context.storagePath;
+                break;
+            }
+            // fallthru
+        case 'global':
+            userdir = context.globalStoragePath;
+            break;
+        default:
+            // assume storage is path on disk
+    }
+
     let info = {
         clusters : findClusters(context.extensionPath),
         extensionPath: context.extensionPath,
-        storagePath : context.globalStoragePath,
+        storagePath : userdir,
         jdkHome : specifiedJDK,
         verbose: beVerbose
     };


### PR DESCRIPTION
Some users of VSNetBeans complained that _Language server in VSCode is mixing contents from different workspaces._

> Sometimes I work with two checkouts of our repos, e.g. one on a brach that I'm currently actively working on, 
> and a second one to produce quick fixes, or to babysit a merge.
>
> If I open both workspaces at the same time, then the language server seems to mix up the symbols from 
> the two workspaces.
>
> ... searching for a class finds two copies. The second one (located in `src/...`) is the correct one from this workspace. 
> The first one (located in `~/git/.../...`) is from another workspace. In the second workspace it's the other way round 
> (i.e. the first one is correct and shows a project name, the second one shows a full path and is from the other workspace).
> 
> Closing the other workspace does not fix the issue, but restarting vscode does.

This PR offers the user to choose between _global_ and _local_ workspace. By using _local_ one gets new instance of the NetBeans Language server backend per each workspace.
