### PR TITLE
Exclude less (@{}) and scss (#{}) string interpolation from formatting

### DIFF
--- a/ide/css.editor/nbproject/project.properties
+++ b/ide/css.editor/nbproject/project.properties
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+auxiliary.org-netbeans-modules-css-prep.less_2e_configured=true
+auxiliary.org-netbeans-modules-css-prep.sass_2e_configured=true
 release.external/css21-spec.zip=docs/css21-spec.zip
 release.external/css3-spec.zip=docs/css3-spec.zip
 

--- a/ide/css.editor/test/unit/data/testfiles/case005.less
+++ b/ide/css.editor/test/unit/data/testfiles/case005.less
@@ -1,0 +1,1 @@
+.@{my-selector} { font-weight: bold; line-height: 40px; margin: 0 auto; }

--- a/ide/css.editor/test/unit/data/testfiles/case005.less.formatted
+++ b/ide/css.editor/test/unit/data/testfiles/case005.less.formatted
@@ -1,0 +1,5 @@
+.@{my-selector} {
+    font-weight: bold;
+    line-height: 40px;
+    margin: 0 auto;
+}

--- a/ide/css.editor/test/unit/data/testfiles/case006.scss
+++ b/ide/css.editor/test/unit/data/testfiles/case006.scss
@@ -1,0 +1,6 @@
+@mixin corner-icon($name, $top-or-bottom, $left-or-right) {
+    .icon-#{$name} {
+        background-image: url("/icons/#{$name}.svg"); position: absolute;
+        #{$top-or-bottom}: 0; #{$left-or-right}: 0;
+    }
+}

--- a/ide/css.editor/test/unit/data/testfiles/case006.scss.formatted
+++ b/ide/css.editor/test/unit/data/testfiles/case006.scss.formatted
@@ -1,0 +1,8 @@
+@mixin corner-icon($name, $top-or-bottom, $left-or-right) {
+    .icon-#{$name} {
+        background-image: url("/icons/#{$name}.svg");
+        position: absolute;
+        #{$top-or-bottom}: 0;
+        #{$left-or-right}: 0;
+    }
+}

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/CssIndenterTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/CssIndenterTest.java
@@ -186,7 +186,7 @@ public class CssIndenterTest extends TestBase {
     public void testPartitialFormatting() throws Exception {
         IndentPrefs preferences = new IndentPrefs(4, 4);
         String file = "testfiles/partialformatting.css";
-        
+
         FileObject fo = getTestFile(file);
         assertNotNull(fo);
         BaseDocument doc = getDocument(fo);
@@ -201,14 +201,14 @@ public class CssIndenterTest extends TestBase {
         assertDescriptionMatches(file, after, false, ".formatted");
 
         DataObject.find(fo).getLookup().lookup(Closable.class).close();
-        
+
         doc = getDocument(fo);
         setupDocumentIndentation(doc, preferences);
         format(doc, formatter, 857, 904, false);
         after = doc.getText(0, doc.getLength());
         assertDescriptionMatches(file, after, false, ".formatted2");
     }
-    
+
     public void testIndentation() throws Exception {
         // property indentation:
         insertNewline("a{^background: red;\n  }\n", "a{\n    ^background: red;\n  }\n", null);

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/LessIndenterTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/LessIndenterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.css.editor.indent;
+
+import org.netbeans.modules.css.editor.test.*;
+import org.netbeans.modules.csl.api.Formatter;
+import org.netbeans.modules.csl.api.test.CslTestBase;
+import org.netbeans.modules.csl.spi.DefaultLanguageConfig;
+import org.netbeans.modules.css.editor.csl.CssLanguage;
+
+
+public class LessIndenterTest extends CslTestBase {
+
+    private static final String PROP_MIME_TYPE = "mimeType"; //NOI18N
+
+    public LessIndenterTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected DefaultLanguageConfig getPreferredLanguage() {
+        return new CssLanguage();
+    }
+
+    @Override
+    protected String getPreferredMimeType() {
+        return "text/less";
+    }
+
+    @Override
+    public Formatter getFormatter(IndentPrefs preferences) {
+        return null;
+    }
+
+    public void testFormattingCase5() throws Exception {
+        reformatFileContents("testfiles/case005.less", new IndentPrefs(4, 4));
+    }
+
+}

--- a/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/ScssIndenterTest.java
+++ b/ide/css.editor/test/unit/src/org/netbeans/modules/css/editor/indent/ScssIndenterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.css.editor.indent;
+
+import org.netbeans.editor.BaseDocument;
+import org.netbeans.modules.csl.api.Formatter;
+import org.netbeans.modules.csl.api.test.CslTestBase;
+import org.netbeans.modules.csl.spi.DefaultLanguageConfig;
+import org.netbeans.modules.css.editor.csl.CssLanguage;
+import org.netbeans.modules.css.lib.TestUtil;
+import org.netbeans.modules.parsing.api.Source;
+import org.openide.filesystems.FileObject;
+
+
+public class ScssIndenterTest extends CslTestBase {
+
+    private static final String PROP_MIME_TYPE = "mimeType"; //NOI18N
+
+    public ScssIndenterTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected DefaultLanguageConfig getPreferredLanguage() {
+        return new CssLanguage();
+    }
+
+    @Override
+    protected String getPreferredMimeType() {
+        return "text/scss";
+    }
+
+    @Override
+    public Formatter getFormatter(IndentPrefs preferences) {
+        return null;
+    }
+
+    public void testFormattingCase6() throws Exception {
+        reformatFileContents("testfiles/case006.scss", new IndentPrefs(4, 4));
+    }
+
+}


### PR DESCRIPTION
If not excluded, the braces are split into multiple lines and invalidated.