### PR TITLE
Handle invalid package.json only containing a single string

### DIFF
--- a/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ClientSideProjectConvertor.java
+++ b/webcommon/web.clientproject/src/org/netbeans/modules/web/clientproject/ClientSideProjectConvertor.java
@@ -109,7 +109,7 @@ public final class ClientSideProjectConvertor implements ProjectConvertor {
             if (name instanceof String) {
                 return (String) name;
             }
-        } catch (ParseException | IOException ex) {
+        } catch (ParseException | IOException | ClassCastException ex) {
             LOGGER.log(Level.FINE, jsonFile.getPath(), ex);
         }
         return null;


### PR DESCRIPTION
If package.json is a string (invalid format) a ClassCastException is
raised and not a ParseException. The ClassCastException should be
handled identically to the other fatal exceptions.