### PR TITLE
Switch to FlatLaf Light as default look and feel for IDE

### DIFF
--- a/nb/ide.branding/build.xml
+++ b/nb/ide.branding/build.xml
@@ -110,5 +110,11 @@ Contributor(s): Vincent Brabant, Maxym Mykhalchuk
       <branding name="nb"/>
     </locjar>
 
+    <locjar warnMissingDir="true"
+      basedir="o.n.swing.plaf/src"
+      jarfile="${cluster}/modules/org-netbeans-swing-plaf.jar">
+      <branding name="nb"/>
+    </locjar>
+
   </target>
 </project>

--- a/nb/ide.branding/o.n.swing.plaf/src/org/netbeans/swing/plaf/Bundle_nb.properties
+++ b/nb/ide.branding/o.n.swing.plaf/src/org/netbeans/swing/plaf/Bundle_nb.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+LookAndFeelClassName=com.formdev.flatlaf.FlatLightLaf

--- a/nb/ide.branding/src/org/netbeans/modules/ide/branding/layer.xml
+++ b/nb/ide.branding/src/org/netbeans/modules/ide/branding/layer.xml
@@ -33,4 +33,8 @@
             </file>
         </folder>
     </folder>
+
+    <folder name="Editors">
+      <attr name="currentFontColorProfile" stringvalue="FlatLaf Light" />
+    </folder>
 </filesystem>


### PR DESCRIPTION
Switch to FlatLaf Light as default look and feel, and editor profile, for the IDE.  This is the simplest approach using nb/ide.branding, so keeps the existing defaults for the platform, and the laf used for the upgrader dialog.

Related to discussion at https://lists.apache.org/thread/9v3tlz8klqs93c1z6s0kvg03tr8w6kdx