### PR TITLE
Fixed typo: runSingle presence depends on runClassName property.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
@@ -44,7 +44,7 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
         project.afterEvaluate(p -> {
             if (p.getPlugins().hasPlugin("java") 
                     && (project.getTasks().findByPath(RUN_SINGLE_TASK) == null)
-                    && project.hasProperty(RUN_SINGLE_CWD)){
+                    && project.hasProperty(RUN_SINGLE_MAIN)){
                 addTask(p);
             }
             if(p.hasProperty(RUN_SINGLE_JVM_ARGS)) {


### PR DESCRIPTION
This PR fixes typo introduced in #3326 that broke `runSingle` task, which is used by "run" or "debug" actions on a single file (a class with a psv main method).
