### PR TITLE
[NETBEANS-6235] Build of vscode extension fails

### DIFF
--- a/nbbuild/misc/prepare-bundles/src/main/java/org/netbeans/prepare/bundles/PrepareBundles.java
+++ b/nbbuild/misc/prepare-bundles/src/main/java/org/netbeans/prepare/bundles/PrepareBundles.java
@@ -102,6 +102,7 @@ public class PrepareBundles {
             Writer binariesList = new OutputStreamWriter(Files.newOutputStream(bundlesDir.resolve("binaries-list")), "UTF-8")) {
             for (Path module : ds) {
                 if (".bin".equals(module.getFileName().toString())) continue;
+                if (".package-lock.json".equals(module.getFileName().toString())) continue;
                 if ("@types".equals(module.getFileName().toString())) continue;
                 if ("@ungap".equals(module.getFileName().toString())) {
                     module = module.resolve("promise-all-settled");


### PR DESCRIPTION
This is simple fix for the situation, when newer version of npm is used during building VSCode extension. It filters out .packe-lock.json from the files that needs a license. 