### PR TITLE
Deactivate broken xmlretriever test (client cert expired and a new one is not yet issued)

### DIFF
--- a/ide/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/impl/SecureURLResourceRetrieverTest.java
+++ b/ide/xml.retriever/test/unit/src/org/netbeans/modules/xml/retriever/impl/SecureURLResourceRetrieverTest.java
@@ -22,6 +22,7 @@ import javax.net.ssl.SSLHandshakeException;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.netbeans.junit.MockServices;
 import org.openide.util.Lookup;
@@ -77,6 +78,7 @@ public class SecureURLResourceRetrieverTest {
     }
 
     @Test
+    @Ignore("Client certificate expired and administrator of badssl.com has not issued updated certificates")
     public void shouldUseKeyStoreFromSystemProperties() throws Exception {
         System.setProperty("javax.net.debug", "ssl,keystore");
         System.setProperty("javax.net.ssl.keyStore", SecureURLResourceRetrieverTest.class.getResource("badssl.com-client.p12").getPath());


### PR DESCRIPTION
As @sdedic and @JaroslavTulach noticed the unittest fails and can't be fixed at this point in time:

https://github.com/chromium/badssl.com/issues/482