### PR TITLE
Snapshot of APIs as of 12.6

### DIFF
--- a/apisupport/apisupport.ant/nbproject/org-netbeans-modules-apisupport-ant.sig
+++ b/apisupport/apisupport.ant/nbproject/org-netbeans-modules-apisupport-ant.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.85
+#Version 2.86
 
 CLSS public java.lang.Object
 cons public init()

--- a/apisupport/apisupport.installer/nbproject/org-netbeans-modules-apisupport-installer.sig
+++ b/apisupport/apisupport.installer/nbproject/org-netbeans-modules-apisupport-installer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.36
+#Version 1.37
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/apisupport/apisupport.project/nbproject/org-netbeans-modules-apisupport-project.sig
+++ b/apisupport/apisupport.project/nbproject/org-netbeans-modules-apisupport-project.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.89
+#Version 1.90
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/cpplite/cpplite.debugger/nbproject/org-netbeans-modules-cpplite-debugger.sig
+++ b/cpplite/cpplite.debugger/nbproject/org-netbeans-modules-cpplite-debugger.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.5
+#Version 1.6
 
 CLSS public java.lang.Object
 cons public init()

--- a/cpplite/cpplite.editor/nbproject/org-netbeans-modules-cpplite-editor.sig
+++ b/cpplite/cpplite.editor/nbproject/org-netbeans-modules-cpplite-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.4
+#Version 1.5
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/api.web.webmodule/nbproject/org-netbeans-api-web-webmodule.sig
+++ b/enterprise/api.web.webmodule/nbproject/org-netbeans-api-web-webmodule.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.51
+#Version 1.52
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/enterprise/cloud.common/nbproject/org-netbeans-modules-cloud-common.sig
+++ b/enterprise/cloud.common/nbproject/org-netbeans-modules-cloud-common.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.24
+#Version 1.25
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/el.lexer/nbproject/org-netbeans-modules-el-lexer.sig
+++ b/enterprise/el.lexer/nbproject/org-netbeans-modules-el-lexer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.40
+#Version 1.41
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/glassfish.common/nbproject/org-netbeans-modules-glassfish-common.sig
+++ b/enterprise/glassfish.common/nbproject/org-netbeans-modules-glassfish-common.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.87
+#Version 1.88
 
 CLSS public abstract java.awt.Component
 cons protected init()
@@ -1500,6 +1500,7 @@ fld public final static org.netbeans.modules.glassfish.common.ServerDetails GLAS
 fld public final static org.netbeans.modules.glassfish.common.ServerDetails GLASSFISH_SERVER_5_1_0
 fld public final static org.netbeans.modules.glassfish.common.ServerDetails GLASSFISH_SERVER_6
 fld public final static org.netbeans.modules.glassfish.common.ServerDetails GLASSFISH_SERVER_6_1_0
+fld public final static org.netbeans.modules.glassfish.common.ServerDetails GLASSFISH_SERVER_6_2_1
 meth public boolean isInstalledInDirectory(java.io.File)
 meth public int getVersion()
 meth public java.lang.String getDirectUrl()

--- a/enterprise/glassfish.eecommon/nbproject/org-netbeans-modules-glassfish-eecommon.sig
+++ b/enterprise/glassfish.eecommon/nbproject/org-netbeans-modules-glassfish-eecommon.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.50.0
+#Version 1.51.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/glassfish.javaee/nbproject/org-netbeans-modules-glassfish-javaee.sig
+++ b/enterprise/glassfish.javaee/nbproject/org-netbeans-modules-glassfish-javaee.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.54
+#Version 1.55
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/glassfish.tooling/nbproject/org-netbeans-modules-glassfish-tooling.sig
+++ b/enterprise/glassfish.tooling/nbproject/org-netbeans-modules-glassfish-tooling.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.20
+#Version 1.21
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable
@@ -1395,6 +1395,7 @@ fld public final static org.netbeans.modules.glassfish.tooling.data.GlassFishVer
 fld public final static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion GF_5_1_0
 fld public final static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion GF_6
 fld public final static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion GF_6_1_0
+fld public final static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion GF_6_2_1
 meth public boolean equals(org.netbeans.modules.glassfish.tooling.data.GlassFishVersion)
 meth public boolean equalsMajorMinor(org.netbeans.modules.glassfish.tooling.data.GlassFishVersion)
 meth public java.lang.String toFullString()
@@ -1415,7 +1416,7 @@ meth public static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion 
 meth public static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion valueOf(java.lang.String)
 meth public static org.netbeans.modules.glassfish.tooling.data.GlassFishVersion[] values()
 supr java.lang.Enum<org.netbeans.modules.glassfish.tooling.data.GlassFishVersion>
-hfds GF_1_STR,GF_1_STR_NEXT,GF_2_1_1_STR,GF_2_1_1_STR_NEXT,GF_2_1_STR,GF_2_1_STR_NEXT,GF_2_STR,GF_2_STR_NEXT,GF_3_0_1_STR,GF_3_0_1_STR_NEXT,GF_3_1_1_STR,GF_3_1_1_STR_NEXT,GF_3_1_2_2_STR,GF_3_1_2_3_STR,GF_3_1_2_4_STR,GF_3_1_2_5_STR,GF_3_1_2_STR,GF_3_1_2_STR_NEXT,GF_3_1_STR,GF_3_1_STR_NEXT,GF_3_STR,GF_3_STR_NEXT,GF_4_0_1_STR,GF_4_0_1_STR_NEXT,GF_4_1_1_STR,GF_4_1_1_STR_NEXT,GF_4_1_2_STR,GF_4_1_2_STR_NEXT,GF_4_1_STR,GF_4_1_STR_NEXT,GF_4_STR,GF_4_STR_NEXT,GF_5_0_1_STR,GF_5_0_1_STR_NEXT,GF_5_1_0_STR,GF_5_1_0_STR_NEXT,GF_5_STR,GF_5_STR_NEXT,GF_6_1_0_STR,GF_6_1_0_STR_NEXT,GF_6_STR,GF_6_STR_NEXT,build,major,minor,stringValuesMap,update,value
+hfds GF_1_STR,GF_1_STR_NEXT,GF_2_1_1_STR,GF_2_1_1_STR_NEXT,GF_2_1_STR,GF_2_1_STR_NEXT,GF_2_STR,GF_2_STR_NEXT,GF_3_0_1_STR,GF_3_0_1_STR_NEXT,GF_3_1_1_STR,GF_3_1_1_STR_NEXT,GF_3_1_2_2_STR,GF_3_1_2_3_STR,GF_3_1_2_4_STR,GF_3_1_2_5_STR,GF_3_1_2_STR,GF_3_1_2_STR_NEXT,GF_3_1_STR,GF_3_1_STR_NEXT,GF_3_STR,GF_3_STR_NEXT,GF_4_0_1_STR,GF_4_0_1_STR_NEXT,GF_4_1_1_STR,GF_4_1_1_STR_NEXT,GF_4_1_2_STR,GF_4_1_2_STR_NEXT,GF_4_1_STR,GF_4_1_STR_NEXT,GF_4_STR,GF_4_STR_NEXT,GF_5_0_1_STR,GF_5_0_1_STR_NEXT,GF_5_1_0_STR,GF_5_1_0_STR_NEXT,GF_5_STR,GF_5_STR_NEXT,GF_6_1_0_STR,GF_6_1_0_STR_NEXT,GF_6_2_1_STR,GF_6_2_1_STR_NEXT,GF_6_STR,GF_6_STR_NEXT,build,major,minor,stringValuesMap,update,value
 
 CLSS public org.netbeans.modules.glassfish.tooling.data.IdeContext
 cons public init()
@@ -1694,7 +1695,7 @@ meth public static java.net.URL getBuilderConfig(org.netbeans.modules.glassfish.
 meth public static org.netbeans.modules.glassfish.tooling.server.config.ConfigBuilder getBuilder(org.netbeans.modules.glassfish.tooling.data.GlassFishServer)
 meth public static void destroyBuilder(org.netbeans.modules.glassfish.tooling.data.GlassFishServer)
 supr java.lang.Object
-hfds CONFIG_V3,CONFIG_V4,CONFIG_V4_1,CONFIG_V5,CONFIG_V5_0_1,CONFIG_V5_1,CONFIG_V6,CONFIG_V6_1_0,builders,config
+hfds CONFIG_V3,CONFIG_V4,CONFIG_V4_1,CONFIG_V5,CONFIG_V5_0_1,CONFIG_V5_1,CONFIG_V6,CONFIG_V6_1_0,CONFIG_V6_2_1,builders,config
 
 CLSS public org.netbeans.modules.glassfish.tooling.server.config.ConfigUtils
 cons public init()
@@ -1802,6 +1803,7 @@ fld public final static char SEPARATOR = '.'
 fld public final static int length
 fld public final static org.netbeans.modules.glassfish.tooling.server.config.JavaSEPlatform v11
 fld public final static org.netbeans.modules.glassfish.tooling.server.config.JavaSEPlatform v16
+fld public final static org.netbeans.modules.glassfish.tooling.server.config.JavaSEPlatform v17
 fld public final static org.netbeans.modules.glassfish.tooling.server.config.JavaSEPlatform v1_1
 fld public final static org.netbeans.modules.glassfish.tooling.server.config.JavaSEPlatform v1_2
 fld public final static org.netbeans.modules.glassfish.tooling.server.config.JavaSEPlatform v1_3
@@ -1815,7 +1817,7 @@ meth public static org.netbeans.modules.glassfish.tooling.server.config.JavaSEPl
 meth public static org.netbeans.modules.glassfish.tooling.server.config.JavaSEPlatform valueOf(java.lang.String)
 meth public static org.netbeans.modules.glassfish.tooling.server.config.JavaSEPlatform[] values()
 supr java.lang.Enum<org.netbeans.modules.glassfish.tooling.server.config.JavaSEPlatform>
-hfds V11_STR,V16_STR,V1_1_STR,V1_2_STR,V1_3_STR,V1_4_STR,V1_5_STR,V1_6_STR,V1_7_STR,V1_8_STR,stringValuesMap
+hfds V11_STR,V16_STR,V17_STR,V1_1_STR,V1_2_STR,V1_3_STR,V1_4_STR,V1_5_STR,V1_6_STR,V1_7_STR,V1_8_STR,stringValuesMap
 
 CLSS public org.netbeans.modules.glassfish.tooling.server.config.JavaSESet
 cons public init(java.util.List<java.lang.String>,java.lang.String)

--- a/enterprise/j2ee.api.ejbmodule/nbproject/org-netbeans-modules-j2ee-api-ejbmodule.sig
+++ b/enterprise/j2ee.api.ejbmodule/nbproject/org-netbeans-modules-j2ee-api-ejbmodule.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.50
+#Version 1.51
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/j2ee.clientproject/nbproject/org-netbeans-modules-j2ee-clientproject.sig
+++ b/enterprise/j2ee.clientproject/nbproject/org-netbeans-modules-j2ee-clientproject.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.59.0
+#Version 1.60.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/j2ee.common/nbproject/org-netbeans-modules-j2ee-common.sig
+++ b/enterprise/j2ee.common/nbproject/org-netbeans-modules-j2ee-common.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.116
+#Version 1.117
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/j2ee.core/nbproject/org-netbeans-modules-j2ee-core.sig
+++ b/enterprise/j2ee.core/nbproject/org-netbeans-modules-j2ee-core.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.38
+#Version 1.39
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/j2ee.dd.webservice/nbproject/org-netbeans-modules-j2ee-dd-webservice.sig
+++ b/enterprise/j2ee.dd.webservice/nbproject/org-netbeans-modules-j2ee-dd-webservice.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44
+#Version 1.45
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/j2ee.dd/nbproject/org-netbeans-modules-j2ee-dd.sig
+++ b/enterprise/j2ee.dd/nbproject/org-netbeans-modules-j2ee-dd.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.53.0
+#Version 1.54.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/j2ee.ejbcore/nbproject/org-netbeans-modules-j2ee-ejbcore.sig
+++ b/enterprise/j2ee.ejbcore/nbproject/org-netbeans-modules-j2ee-ejbcore.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.64
+#Version 1.65
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/j2ee.ejbjarproject/nbproject/org-netbeans-modules-j2ee-ejbjarproject.sig
+++ b/enterprise/j2ee.ejbjarproject/nbproject/org-netbeans-modules-j2ee-ejbjarproject.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.66
+#Version 1.67
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/j2ee.sun.appsrv/nbproject/org-netbeans-modules-j2ee-sun-appsrv.sig
+++ b/enterprise/j2ee.sun.appsrv/nbproject/org-netbeans-modules-j2ee-sun-appsrv.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.48.0
+#Version 1.49.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/j2ee.sun.dd/nbproject/org-netbeans-modules-j2ee-sun-dd.sig
+++ b/enterprise/j2ee.sun.dd/nbproject/org-netbeans-modules-j2ee-sun-dd.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46.0
+#Version 1.47.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/j2ee.sun.ddui/nbproject/org-netbeans-modules-j2ee-sun-ddui.sig
+++ b/enterprise/j2ee.sun.ddui/nbproject/org-netbeans-modules-j2ee-sun-ddui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.49.0
+#Version 1.50.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/j2eeapis/nbproject/org-netbeans-modules-j2eeapis.sig
+++ b/enterprise/j2eeapis/nbproject/org-netbeans-modules-j2eeapis.sig
@@ -1,3 +1,3 @@
 #Signature file v4.1
-#Version 1.45
+#Version 1.46
 

--- a/enterprise/j2eeserver/nbproject/org-netbeans-modules-j2eeserver.sig
+++ b/enterprise/j2eeserver/nbproject/org-netbeans-modules-j2eeserver.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.124.0
+#Version 1.125.0
 
 CLSS public java.io.IOException
 cons public init()

--- a/enterprise/javaee.project/nbproject/org-netbeans-modules-javaee-project.sig
+++ b/enterprise/javaee.project/nbproject/org-netbeans-modules-javaee-project.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.32
+#Version 1.33
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/enterprise/javaee.resources/nbproject/org-netbeans-modules-javaee-resources.sig
+++ b/enterprise/javaee.resources/nbproject/org-netbeans-modules-javaee-resources.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.23
+#Version 1.24
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/javaee.specs.support/nbproject/org-netbeans-modules-javaee-specs-support.sig
+++ b/enterprise/javaee.specs.support/nbproject/org-netbeans-modules-javaee-specs-support.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.38
+#Version 1.39
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/jellytools.enterprise/nbproject/org-netbeans-modules-jellytools-enterprise.sig
+++ b/enterprise/jellytools.enterprise/nbproject/org-netbeans-modules-jellytools-enterprise.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.39
+#Version 3.40
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/jsp.lexer/nbproject/org-netbeans-modules-jsp-lexer.sig
+++ b/enterprise/jsp.lexer/nbproject/org-netbeans-modules-jsp-lexer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.38
+#Version 1.39
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/libs.amazon/nbproject/org-netbeans-libs-amazon.sig
+++ b/enterprise/libs.amazon/nbproject/org-netbeans-libs-amazon.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.23
+#Version 1.24
 
 CLSS public com.amazonaws.AbortedException
 cons public init()

--- a/enterprise/libs.elimpl/nbproject/org-netbeans-libs-elimpl.sig
+++ b/enterprise/libs.elimpl/nbproject/org-netbeans-libs-elimpl.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.32.0
+#Version 1.33.0
 
 CLSS public com.sun.el.ExpressionFactoryImpl
 cons public init()

--- a/enterprise/libs.glassfish_logging/nbproject/org-netbeans-libs-glassfish_logging.sig
+++ b/enterprise/libs.glassfish_logging/nbproject/org-netbeans-libs-glassfish_logging.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.38.0
+#Version 1.39.0
 
 CLSS public abstract interface com.sun.org.apache.commons.logging.Log
 meth public abstract boolean isDebugEnabled()

--- a/enterprise/maven.j2ee/nbproject/org-netbeans-modules-maven-j2ee.sig
+++ b/enterprise/maven.j2ee/nbproject/org-netbeans-modules-maven-j2ee.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.74
+#Version 1.75
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/payara.common/nbproject/org-netbeans-modules-payara-common.sig
+++ b/enterprise/payara.common/nbproject/org-netbeans-modules-payara-common.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.8
+#Version 2.9
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/payara.eecommon/nbproject/org-netbeans-modules-payara-eecommon.sig
+++ b/enterprise/payara.eecommon/nbproject/org-netbeans-modules-payara-eecommon.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.9.0
+#Version 2.10.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/payara.micro/nbproject/org-netbeans-modules-payara-micro.sig
+++ b/enterprise/payara.micro/nbproject/org-netbeans-modules-payara-micro.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.8
+#Version 2.9
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
+++ b/enterprise/payara.tooling/nbproject/org-netbeans-modules-payara-tooling.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.8
+#Version 2.9
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable
@@ -1240,6 +1240,7 @@ meth public java.lang.String toString()
 meth public java.util.Optional<java.lang.Short> getMinor()
 meth public java.util.Optional<java.lang.Short> getSubMinor()
 meth public java.util.Optional<java.lang.Short> getUpdate()
+meth public java.util.Optional<java.lang.String> getVM()
 meth public java.util.Optional<java.lang.String> getVendor()
 meth public short getMajor()
 meth public static boolean isCorrectJDK(java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>,java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion>)
@@ -1247,8 +1248,9 @@ meth public static boolean isCorrectJDK(org.netbeans.modules.payara.tooling.data
 meth public static org.netbeans.modules.payara.tooling.data.JDKVersion getDefaultPlatformVersion()
 meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String)
 meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String,java.lang.String)
+meth public static org.netbeans.modules.payara.tooling.data.JDKVersion toValue(java.lang.String,java.lang.String,java.lang.String)
 supr java.lang.Object
-hfds DEFAULT_VALUE,IDE_JDK_VERSION,MAJOR_INDEX,MINOR_INDEX,SUBMINOR_INDEX,UPDATE_INDEX,VERSION_MATCHER,major,minor,subminor,update,vendor
+hfds DEFAULT_VALUE,IDE_JDK_VERSION,MAJOR_INDEX,MINOR_INDEX,SUBMINOR_INDEX,UPDATE_INDEX,VERSION_MATCHER,major,minor,subminor,update,vendor,vm
 
 CLSS public final !enum org.netbeans.modules.payara.tooling.data.PayaraAdminInterface
 fld public final static org.netbeans.modules.payara.tooling.data.PayaraAdminInterface HTTP
@@ -2166,6 +2168,8 @@ cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.String,java.lang.String)
 fld public final java.lang.String option
 fld public final java.util.Optional<java.lang.String> vendor
+ anno 0 java.lang.Deprecated()
+fld public final java.util.Optional<java.lang.String> vendorOrVM
 fld public final java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion> maxVersion
 fld public final java.util.Optional<org.netbeans.modules.payara.tooling.data.JDKVersion> minVersion
 meth public boolean equals(java.lang.Object)

--- a/enterprise/servletjspapi/nbproject/org-netbeans-modules-servletjspapi.sig
+++ b/enterprise/servletjspapi/nbproject/org-netbeans-modules-servletjspapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.43.0
+#Version 1.44.0
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/enterprise/web.beans/nbproject/org-netbeans-modules-web-beans.sig
+++ b/enterprise/web.beans/nbproject/org-netbeans-modules-web-beans.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.32
+#Version 2.33
 
 CLSS public java.beans.FeatureDescriptor
 cons public init()

--- a/enterprise/web.core/nbproject/org-netbeans-modules-web-core.sig
+++ b/enterprise/web.core/nbproject/org-netbeans-modules-web-core.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.45.0
+#Version 2.46.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/web.el/nbproject/org-netbeans-modules-web-el.sig
+++ b/enterprise/web.el/nbproject/org-netbeans-modules-web-el.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.65
+#Version 1.66
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/web.jsf.navigation/nbproject/org-netbeans-modules-web-jsf-navigation.sig
+++ b/enterprise/web.jsf.navigation/nbproject/org-netbeans-modules-web-jsf-navigation.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.39
+#Version 2.40
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/web.jsf/nbproject/org-netbeans-modules-web-jsf.sig
+++ b/enterprise/web.jsf/nbproject/org-netbeans-modules-web-jsf.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.82.0
+#Version 1.83.0
 
 CLSS public abstract interface java.beans.PropertyChangeListener
 intf java.util.EventListener

--- a/enterprise/web.jsf12/nbproject/org-netbeans-modules-web-jsf12.sig
+++ b/enterprise/web.jsf12/nbproject/org-netbeans-modules-web-jsf12.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.37.0
+#Version 1.38.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/web.jsf12ri/nbproject/org-netbeans-modules-web-jsf12ri.sig
+++ b/enterprise/web.jsf12ri/nbproject/org-netbeans-modules-web-jsf12ri.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.37.0
+#Version 1.38.0
 
 CLSS public com.sun.faces.RIConstants
 fld public final static java.lang.Class[] EMPTY_CLASS_ARGS

--- a/enterprise/web.jsf20/nbproject/org-netbeans-modules-web-jsf20.sig
+++ b/enterprise/web.jsf20/nbproject/org-netbeans-modules-web-jsf20.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46.0
+#Version 1.47.0
 
 CLSS public com.sun.faces.RIConstants
 fld public final static int FLOW_DEFINITION_ID_SUFFIX_LENGTH

--- a/enterprise/web.jsfapi/nbproject/org-netbeans-modules-web-jsfapi.sig
+++ b/enterprise/web.jsfapi/nbproject/org-netbeans-modules-web-jsfapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.47
+#Version 1.48
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/web.jspparser/nbproject/org-netbeans-modules-web-jspparser.sig
+++ b/enterprise/web.jspparser/nbproject/org-netbeans-modules-web-jspparser.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.42
+#Version 3.43
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/web.project/nbproject/org-netbeans-modules-web-project.sig
+++ b/enterprise/web.project/nbproject/org-netbeans-modules-web-project.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.87.0
+#Version 1.88.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/weblogic.common/nbproject/org-netbeans-modules-weblogic-common.sig
+++ b/enterprise/weblogic.common/nbproject/org-netbeans-modules-weblogic-common.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.27
+#Version 1.28
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/websvc.clientapi/nbproject/org-netbeans-modules-websvc-clientapi.sig
+++ b/enterprise/websvc.clientapi/nbproject/org-netbeans-modules-websvc-clientapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.45
+#Version 1.46
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/websvc.core/nbproject/org-netbeans-modules-websvc-core.sig
+++ b/enterprise/websvc.core/nbproject/org-netbeans-modules-websvc-core.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.57.0
+#Version 1.58.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/websvc.design/nbproject/org-netbeans-modules-websvc-design.sig
+++ b/enterprise/websvc.design/nbproject/org-netbeans-modules-websvc-design.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.38
+#Version 1.39
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/websvc.jaxws.lightapi/nbproject/org-netbeans-modules-websvc-jaxws-lightapi.sig
+++ b/enterprise/websvc.jaxws.lightapi/nbproject/org-netbeans-modules-websvc-jaxws-lightapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.35
+#Version 1.36
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/websvc.jaxwsapi/nbproject/org-netbeans-modules-websvc-jaxwsapi.sig
+++ b/enterprise/websvc.jaxwsapi/nbproject/org-netbeans-modules-websvc-jaxwsapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.39
+#Version 1.40
 
 CLSS public java.beans.FeatureDescriptor
 cons public init()

--- a/enterprise/websvc.jaxwsmodel/nbproject/org-netbeans-modules-websvc-jaxwsmodel.sig
+++ b/enterprise/websvc.jaxwsmodel/nbproject/org-netbeans-modules-websvc-jaxwsmodel.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.43
+#Version 1.44
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/websvc.manager/nbproject/org-netbeans-modules-websvc-manager.sig
+++ b/enterprise/websvc.manager/nbproject/org-netbeans-modules-websvc-manager.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.41
+#Version 1.42
 
 CLSS public abstract interface java.awt.datatransfer.Transferable
 meth public abstract boolean isDataFlavorSupported(java.awt.datatransfer.DataFlavor)

--- a/enterprise/websvc.projectapi/nbproject/org-netbeans-modules-websvc-projectapi.sig
+++ b/enterprise/websvc.projectapi/nbproject/org-netbeans-modules-websvc-projectapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.35
+#Version 1.36
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/websvc.rest/nbproject/org-netbeans-modules-websvc-rest.sig
+++ b/enterprise/websvc.rest/nbproject/org-netbeans-modules-websvc-rest.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.43
+#Version 1.44
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/websvc.restapi/nbproject/org-netbeans-modules-websvc-restapi.sig
+++ b/enterprise/websvc.restapi/nbproject/org-netbeans-modules-websvc-restapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.49
+#Version 1.50
 
 CLSS public abstract interface java.io.Serializable
 

--- a/enterprise/websvc.restlib/nbproject/org-netbeans-modules-websvc-restlib.sig
+++ b/enterprise/websvc.restlib/nbproject/org-netbeans-modules-websvc-restlib.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.21
+#Version 2.22
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/enterprise/websvc.utilities/nbproject/org-netbeans-modules-websvc-utilities.sig
+++ b/enterprise/websvc.utilities/nbproject/org-netbeans-modules-websvc-utilities.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.38
+#Version 1.39
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/enterprise/websvc.websvcapi/nbproject/org-netbeans-modules-websvc-websvcapi.sig
+++ b/enterprise/websvc.websvcapi/nbproject/org-netbeans-modules-websvc-websvcapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44
+#Version 1.45
 
 CLSS public java.lang.Object
 cons public init()

--- a/enterprise/websvc.wsstackapi/nbproject/org-netbeans-modules-websvc-wsstackapi.sig
+++ b/enterprise/websvc.wsstackapi/nbproject/org-netbeans-modules-websvc-wsstackapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.36
+#Version 1.37
 
 CLSS public abstract interface java.io.Serializable
 

--- a/extide/gradle/nbproject/org-netbeans-modules-gradle.sig
+++ b/extide/gradle/nbproject/org-netbeans-modules-gradle.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.15
+#Version 2.21
 
 CLSS public abstract interface java.io.Serializable
 
@@ -919,9 +919,11 @@ hfds TEMPLATE_BUILD,TEMPLATE_PROPS,TEMPLATE_SETTINGS,buildTemplate,templateParam
 CLSS public final org.netbeans.modules.gradle.spi.newproject.TemplateOperation
 cons public init()
 cons public init(org.netbeans.api.progress.ProgressHandle)
+innr public abstract InitOperation
 innr public abstract interface static ProjectConfigurator
 intf java.lang.Runnable
 meth public java.util.Set<org.openide.filesystems.FileObject> getImportantFiles()
+meth public org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitOperation createGradleInit(java.io.File,java.lang.String)
 meth public void addConfigureProject(java.io.File,org.netbeans.modules.gradle.spi.newproject.TemplateOperation$ProjectConfigurator)
 meth public void addProjectPreload(java.io.File)
 meth public void addWrapperInit(java.io.File)
@@ -934,7 +936,16 @@ meth public void openFromTemplate(java.lang.String,java.io.File,java.util.Map<ja
 meth public void run()
 supr java.lang.Object
 hfds handle,importantFiles,steps
-hcls ConfigureProjectStep,CopyFromFileTemplate,CopyFromTemplate,CreateDirStep,InitGradleWrapper,OperationStep,PreloadProject
+hcls ConfigureProjectStep,CopyFromFileTemplate,CopyFromTemplate,CreateDirStep,InitGradleWrapper,InitStep,OperationStep,PreloadProject
+
+CLSS public abstract org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitOperation
+ outer org.netbeans.modules.gradle.spi.newproject.TemplateOperation
+meth public abstract org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitOperation basePackage(java.lang.String)
+meth public abstract org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitOperation dsl(java.lang.String)
+meth public abstract org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitOperation projectName(java.lang.String)
+meth public abstract org.netbeans.modules.gradle.spi.newproject.TemplateOperation$InitOperation testFramework(java.lang.String)
+meth public final void add()
+supr java.lang.Object
 
 CLSS public abstract interface static org.netbeans.modules.gradle.spi.newproject.TemplateOperation$ProjectConfigurator
  outer org.netbeans.modules.gradle.spi.newproject.TemplateOperation

--- a/extide/libs.gradle/nbproject/org-netbeans-modules-libs-gradle.sig
+++ b/extide/libs.gradle/nbproject/org-netbeans-modules-libs-gradle.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 7.1
+#Version 7.3
 
 CLSS public abstract interface java.io.Serializable
 
@@ -50,6 +50,7 @@ meth public boolean isWriteDependencyLocks()
 meth public int getMaxWorkerCount()
 meth public int hashCode()
 meth public java.io.File getBuildFile()
+ anno 0 java.lang.Deprecated()
  anno 0 org.gradle.internal.impldep.javax.annotation.Nullable()
 meth public java.io.File getCurrentDir()
 meth public java.io.File getGradleUserHomeDir()
@@ -58,6 +59,7 @@ meth public java.io.File getProjectCacheDir()
 meth public java.io.File getProjectDir()
  anno 0 org.gradle.internal.impldep.javax.annotation.Nullable()
 meth public java.io.File getSettingsFile()
+ anno 0 java.lang.Deprecated()
  anno 0 org.gradle.internal.impldep.javax.annotation.Nullable()
 meth public java.lang.String toString()
 meth public java.util.List<java.io.File> getAllInitScripts()
@@ -83,6 +85,7 @@ meth public void includeBuild(java.io.File)
 meth public void setBuildCacheDebugLogging(boolean)
 meth public void setBuildCacheEnabled(boolean)
 meth public void setBuildFile(java.io.File)
+ anno 0 java.lang.Deprecated()
  anno 1 org.gradle.internal.impldep.javax.annotation.Nullable()
 meth public void setBuildScan(boolean)
 meth public void setConfigureOnDemand(boolean)
@@ -116,6 +119,7 @@ meth public void setRefreshDependencies(boolean)
 meth public void setRefreshKeys(boolean)
 meth public void setRerunTasks(boolean)
 meth public void setSettingsFile(java.io.File)
+ anno 0 java.lang.Deprecated()
  anno 1 org.gradle.internal.impldep.javax.annotation.Nullable()
 meth public void setShowStacktrace(org.gradle.api.logging.configuration.ShowStacktrace)
 meth public void setSystemPropertiesArgs(java.util.Map<java.lang.String,java.lang.String>)

--- a/extide/o.apache.tools.ant.module/nbproject/org-apache-tools-ant-module.sig
+++ b/extide/o.apache.tools.ant.module/nbproject/org-apache-tools-ant-module.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.97.0
+#Version 3.98.0
 
 CLSS public java.beans.FeatureDescriptor
 cons public init()

--- a/extide/options.java/nbproject/org-netbeans-modules-options-java.sig
+++ b/extide/options.java/nbproject/org-netbeans-modules-options-java.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.27
+#Version 1.28
 
 CLSS public java.lang.Object
 cons public init()

--- a/groovy/groovy.editor/nbproject/org-netbeans-modules-groovy-editor.sig
+++ b/groovy/groovy.editor/nbproject/org-netbeans-modules-groovy-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.79
+#Version 1.81
 
 CLSS public abstract interface java.io.Serializable
 
@@ -526,6 +526,7 @@ CLSS public org.netbeans.modules.groovy.editor.api.AstPath
 cons public init()
 cons public init(org.codehaus.groovy.ast.ASTNode,int,int)
 cons public init(org.codehaus.groovy.ast.ASTNode,int,org.netbeans.editor.BaseDocument)
+cons public init(org.codehaus.groovy.ast.ASTNode,int,org.netbeans.editor.BaseDocument,boolean)
 cons public init(org.codehaus.groovy.ast.ASTNode,org.codehaus.groovy.ast.ASTNode)
 intf java.lang.Iterable<org.codehaus.groovy.ast.ASTNode>
 meth public boolean find(org.codehaus.groovy.ast.ASTNode,org.codehaus.groovy.ast.ASTNode)
@@ -680,7 +681,7 @@ meth public void visitUnaryPlusExpression(org.codehaus.groovy.ast.expr.UnaryPlus
 meth public void visitVariableExpression(org.codehaus.groovy.ast.expr.VariableExpression)
 meth public void visitWhileLoop(org.codehaus.groovy.ast.stmt.WhileStatement)
 supr org.codehaus.groovy.ast.ClassCodeVisitorSupport
-hfds LOG,column,line,path,sourceUnit
+hfds LOG,column,line,outermost,path,sourceUnit
 
 CLSS public org.netbeans.modules.groovy.editor.api.StructureAnalyzer
 cons public init()
@@ -748,6 +749,7 @@ innr public static NewVarItem
 innr public static PackageItem
 innr public static TypeItem
 meth public boolean equals(java.lang.Object)
+meth public int getSortPrioOverride()
 meth public int hashCode()
 meth public java.lang.String getName()
 meth public java.lang.String toString()
@@ -759,7 +761,7 @@ meth public static org.netbeans.modules.groovy.editor.api.completion.CompletionI
 meth public static org.netbeans.modules.groovy.editor.api.completion.CompletionItem forJavaMethod(java.lang.String,java.lang.String,java.util.List<java.lang.String>,java.lang.String,java.util.Set<javax.lang.model.element.Modifier>,int,boolean,boolean)
 meth public static org.netbeans.modules.groovy.editor.api.completion.CompletionItem forJavaMethod(java.lang.String,java.lang.String,java.util.List<java.lang.String>,javax.lang.model.type.TypeMirror,java.util.Set<javax.lang.model.element.Modifier>,int,boolean,boolean)
 supr org.netbeans.modules.csl.spi.DefaultCompletionProposal
-hfds LOG,groovyIcon,javaIcon,newConstructorIcon
+hfds LOG,groovyIcon,javaIcon,newConstructorIcon,sortOverride
 hcls DynamicMethodItem,JavaMethodItem
 
 CLSS public static org.netbeans.modules.groovy.editor.api.completion.CompletionItem$ConstructorItem
@@ -1024,6 +1026,7 @@ fld public final int lexOffset
 fld public final org.netbeans.editor.BaseDocument doc
 fld public java.util.Set<org.netbeans.modules.groovy.editor.completion.AccessLevel> access
 fld public org.codehaus.groovy.ast.ClassNode declaringClass
+fld public org.codehaus.groovy.ast.ClassNode rawDseclaringClass
 fld public org.netbeans.modules.groovy.editor.api.AstPath path
 fld public org.netbeans.modules.groovy.editor.api.completion.CaretLocation location
 fld public org.netbeans.modules.groovy.editor.api.completion.util.CompletionSurrounding context
@@ -1031,6 +1034,8 @@ fld public org.netbeans.modules.groovy.editor.api.completion.util.DotCompletionC
 meth public boolean isBehindDot()
 meth public boolean isBehindImportStatement()
 meth public boolean isNameOnly()
+meth public boolean isStaticMembers()
+meth public int getAddSortOverride()
 meth public int getAnchor()
 meth public java.lang.String getPrefix()
 meth public java.lang.String getTypeName()
@@ -1038,11 +1043,13 @@ meth public org.codehaus.groovy.ast.ClassNode getSurroundingClass()
 meth public org.netbeans.modules.csl.spi.ParserResult getParserResult()
 meth public org.openide.filesystems.FileObject getSourceFile()
 meth public void init()
+meth public void setAddSortOverride(int)
 meth public void setAnchor(int)
+meth public void setDeclaringClass(org.codehaus.groovy.ast.ClassNode,boolean)
 meth public void setPrefix(java.lang.String)
 meth public void setTypeName(java.lang.String)
 supr java.lang.Object
-hfds anchor,nameOnly,parserResult,prefix,sourceFile,typeName
+hfds addSortOverride,anchor,nameOnly,parserResult,prefix,sourceFile,staticMembers,typeName
 
 CLSS public org.netbeans.modules.groovy.editor.api.completion.util.CompletionSurrounding
 cons public init(org.netbeans.api.lexer.Token<org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId>,org.netbeans.api.lexer.Token<org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId>,org.netbeans.api.lexer.Token<org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId>,org.netbeans.api.lexer.Token<org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId>,org.netbeans.api.lexer.Token<org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId>,org.netbeans.api.lexer.Token<org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId>,org.netbeans.api.lexer.Token<org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId>,org.netbeans.api.lexer.TokenSequence<org.netbeans.modules.groovy.editor.api.lexer.GroovyTokenId>)
@@ -1065,6 +1072,7 @@ meth public static boolean isFieldNameDefinition(org.netbeans.modules.groovy.edi
 meth public static boolean isVariableNameDefinition(org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext)
 meth public static java.util.List<java.lang.String> getProperties(org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext)
 meth public static java.util.List<org.codehaus.groovy.ast.ClassNode> getDeclaredClasses(org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext)
+meth public static org.codehaus.groovy.ast.ASTNode getSurroundingClassMember(org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext)
 meth public static org.codehaus.groovy.ast.ASTNode getSurroundingMethodOrClosure(org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext)
 meth public static org.codehaus.groovy.ast.ClassNode getSurroundingClassNode(org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext)
 meth public static org.codehaus.groovy.ast.ModuleNode getSurroundingModuleNode(org.netbeans.modules.groovy.editor.api.completion.util.CompletionContext)
@@ -1151,6 +1159,7 @@ CLSS public final org.netbeans.modules.groovy.editor.api.elements.ast.ASTField
 cons public init(org.codehaus.groovy.ast.FieldNode,java.lang.String,boolean)
 meth public boolean isProperty()
 meth public java.lang.String getName()
+meth public java.lang.String getSignature()
 meth public java.lang.String getType()
 meth public java.util.Set<org.netbeans.modules.csl.api.Modifier> getModifiers()
 meth public org.netbeans.modules.csl.api.ElementKind getKind()
@@ -1642,8 +1651,8 @@ meth public void cancel()
 meth public void parse(org.netbeans.modules.parsing.api.Snapshot,org.netbeans.modules.parsing.api.Task,org.netbeans.modules.parsing.spi.SourceModificationEvent) throws org.netbeans.modules.parsing.spi.ParseException
 meth public void removeChangeListener(javax.swing.event.ChangeListener)
 supr org.netbeans.modules.parsing.spi.Parser
-hfds LOG,PARSING_COUNT,PARSING_TIME,cancelled,lastResult,maximumParsingTime
-hcls ParseErrorHandler
+hfds LOG,PARSING_COUNT,PARSING_TIME,STATIC_ERRORS,cancelled,lastResult,maximumParsingTime,phaseCounters
+hcls CU,ParseErrorHandler
 
 CLSS public final static org.netbeans.modules.groovy.editor.api.parser.GroovyParser$Context
  outer org.netbeans.modules.groovy.editor.api.parser.GroovyParser
@@ -1653,7 +1662,7 @@ meth public java.lang.String getSanitizedSource()
 meth public java.lang.String toString()
 meth public org.netbeans.modules.csl.api.OffsetRange getSanitizedRange()
 supr java.lang.Object
-hfds caretOffset,compilerCustomizers,customizerCtx,document,errorHandler,errorOffset,event,parserTask,sanitized,sanitizedContents,sanitizedRange,sanitizedSource,snapshot,source
+hfds caretOffset,compilerCustomizers,customizerCtx,document,errorHandler,errorOffset,event,parserTask,perfData,sanitized,sanitizedContents,sanitizedRange,sanitizedSource,snapshot,source
 
 CLSS public final static !enum org.netbeans.modules.groovy.editor.api.parser.GroovyParser$Sanitize
  outer org.netbeans.modules.groovy.editor.api.parser.GroovyParser
@@ -1673,6 +1682,9 @@ CLSS public org.netbeans.modules.groovy.editor.api.parser.GroovyParserResult
 meth protected void invalidate()
 meth public java.lang.String getSanitizedContents()
 meth public java.util.List<? extends org.netbeans.modules.csl.api.Error> getDiagnostics()
+meth public org.codehaus.groovy.ast.ClassNode resolveClassName(java.lang.String)
+ anno 0 org.netbeans.api.annotations.common.CheckForNull()
+ anno 1 org.netbeans.api.annotations.common.NonNull()
 meth public org.codehaus.groovy.control.ErrorCollector getErrorCollector()
 meth public org.netbeans.modules.csl.api.OffsetRange getSanitizedRange()
 meth public org.netbeans.modules.groovy.editor.api.StructureAnalyzer$AnalysisResult getStructure()
@@ -1682,7 +1694,7 @@ meth public void setErrors(java.util.Collection<? extends org.netbeans.modules.c
 meth public void setStructure(org.netbeans.modules.groovy.editor.api.StructureAnalyzer$AnalysisResult)
  anno 1 org.netbeans.api.annotations.common.NonNull()
 supr org.netbeans.modules.csl.spi.ParserResult
-hfds analysisResult,errorCollector,errors,parser,rootElement,sanitized,sanitizedContents,sanitizedRange
+hfds analysisResult,errorCollector,errors,nbCollector,parser,rootElement,sanitized,sanitizedContents,sanitizedRange,unit
 
 CLSS public org.netbeans.modules.groovy.editor.api.parser.GroovyVirtualSourceProvider
 cons public init()

--- a/groovy/groovy.support/nbproject/org-netbeans-modules-groovy-support.sig
+++ b/groovy/groovy.support/nbproject/org-netbeans-modules-groovy-support.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.52
+#Version 1.54
 
 CLSS public java.lang.Object
 cons public init()
@@ -27,6 +27,7 @@ supr java.lang.Object
 CLSS public final org.netbeans.modules.groovy.support.api.GroovySettings
 fld public final static java.lang.String GROOVY_DOC_PROPERTY = "groovy.doc"
 fld public final static java.lang.String GROOVY_OPTIONS_CATEGORY = "Advanced/org-netbeans-modules-groovy-support-api-GroovySettings"
+meth public boolean isHonourAccessModifiers()
 meth public java.lang.String getDisplayName()
 meth public java.lang.String getGroovyDoc()
 meth public java.lang.String getTooltip()
@@ -35,8 +36,9 @@ meth public static org.netbeans.modules.groovy.support.api.GroovySettings getIns
 meth public void addPropertyChangeListener(java.beans.PropertyChangeListener)
 meth public void removePropertyChangeListener(java.beans.PropertyChangeListener)
 meth public void setGroovyDoc(java.lang.String)
+meth public void setHonourAccessModifiers(boolean)
 supr org.netbeans.spi.options.AdvancedOption
-hfds GROOVY_DOC,instance,propertyChangeSupport
+hfds ACCESS_MODIFIERS,DEFAULT_ACCESS_MODIFIERS,GROOVY_DOC,instance,propertyChangeSupport
 
 CLSS public org.netbeans.modules.groovy.support.api.GroovySources
 cons public init()

--- a/groovy/libs.groovy/nbproject/org-netbeans-modules-libs-groovy.sig
+++ b/groovy/libs.groovy/nbproject/org-netbeans-modules-libs-groovy.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.13
+#Version 2.14
 
 CLSS public abstract interface !annotation groovy.beans.Bindable
  anno 0 java.lang.annotation.Documented()
@@ -7544,6 +7544,52 @@ supr java.lang.Object
 hfds colorScheme,commandSpec,err,executionExceptionHandler,executionResult,executionStrategy,exitCodeExceptionMapper,factory,interpreter,out,parameterExceptionHandler,tracer
 hcls AbbreviationMatcher,Assert,AutoHelpMixin,BuiltIn,ColoredStackTraceWriter,CosineSimilarity,DefaultFactory,DefaultHelpFactory,Interpreter,LookBehind,NoCompletionCandidates,NoDefaultProvider,NoVersionProvider,NullParameterConsumer,PositionalParametersSorter,TraceLevel,Tracer
 
+CLSS public abstract interface static !annotation groovyjarjarpicocli.CommandLine$Command
+ outer groovyjarjarpicocli.CommandLine
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE, LOCAL_VARIABLE, FIELD, PACKAGE, METHOD])
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault boolean abbreviateSynopsis()
+meth public abstract !hasdefault boolean addMethodSubcommands()
+meth public abstract !hasdefault boolean helpCommand()
+meth public abstract !hasdefault boolean hidden()
+meth public abstract !hasdefault boolean mixinStandardHelpOptions()
+meth public abstract !hasdefault boolean showAtFileInUsageHelp()
+meth public abstract !hasdefault boolean showDefaultValues()
+meth public abstract !hasdefault boolean showEndOfOptionsDelimiterInUsageHelp()
+meth public abstract !hasdefault boolean sortOptions()
+meth public abstract !hasdefault boolean subcommandsRepeatable()
+meth public abstract !hasdefault boolean usageHelpAutoWidth()
+meth public abstract !hasdefault char requiredOptionMarker()
+meth public abstract !hasdefault int exitCodeOnExecutionException()
+meth public abstract !hasdefault int exitCodeOnInvalidInput()
+meth public abstract !hasdefault int exitCodeOnSuccess()
+meth public abstract !hasdefault int exitCodeOnUsageHelp()
+meth public abstract !hasdefault int exitCodeOnVersionHelp()
+meth public abstract !hasdefault int usageHelpWidth()
+meth public abstract !hasdefault java.lang.Class<? extends groovyjarjarpicocli.CommandLine$IDefaultValueProvider> defaultValueProvider()
+meth public abstract !hasdefault java.lang.Class<? extends groovyjarjarpicocli.CommandLine$IVersionProvider> versionProvider()
+meth public abstract !hasdefault java.lang.Class<?>[] subcommands()
+meth public abstract !hasdefault java.lang.String commandListHeading()
+meth public abstract !hasdefault java.lang.String descriptionHeading()
+meth public abstract !hasdefault java.lang.String exitCodeListHeading()
+meth public abstract !hasdefault java.lang.String footerHeading()
+meth public abstract !hasdefault java.lang.String headerHeading()
+meth public abstract !hasdefault java.lang.String name()
+meth public abstract !hasdefault java.lang.String optionListHeading()
+meth public abstract !hasdefault java.lang.String parameterListHeading()
+meth public abstract !hasdefault java.lang.String resourceBundle()
+meth public abstract !hasdefault java.lang.String separator()
+meth public abstract !hasdefault java.lang.String synopsisHeading()
+meth public abstract !hasdefault java.lang.String synopsisSubcommandLabel()
+meth public abstract !hasdefault java.lang.String[] aliases()
+meth public abstract !hasdefault java.lang.String[] customSynopsis()
+meth public abstract !hasdefault java.lang.String[] description()
+meth public abstract !hasdefault java.lang.String[] exitCodeList()
+meth public abstract !hasdefault java.lang.String[] footer()
+meth public abstract !hasdefault java.lang.String[] header()
+meth public abstract !hasdefault java.lang.String[] version()
+
 CLSS public abstract interface static groovyjarjarpicocli.CommandLine$IVersionProvider
  outer groovyjarjarpicocli.CommandLine
 meth public abstract java.lang.String[] getVersion() throws java.lang.Exception
@@ -10237,6 +10283,50 @@ meth public void setClassScope(org.codehaus.groovy.ast.ClassNode)
 meth public void setInStaticContext(boolean)
 supr java.lang.Object
 hfds classScope,declaredVariables,inStaticContext,parent,referencedClassVariables,referencedLocalVariables
+
+CLSS public abstract org.codehaus.groovy.ast.decompiled.AsmDecompiler
+cons public init()
+meth public static org.codehaus.groovy.ast.decompiled.ClassStub parseClass(java.net.URL) throws java.io.IOException
+supr java.lang.Object
+hcls AnnotationReader,DecompilingVisitor,StubCache
+
+CLSS public org.codehaus.groovy.ast.decompiled.AsmReferenceResolver
+cons public init(org.codehaus.groovy.control.ClassNodeResolver,org.codehaus.groovy.control.CompilationUnit)
+meth public java.lang.Class resolveJvmClass(java.lang.String)
+meth public org.codehaus.groovy.ast.ClassNode resolveClass(java.lang.String)
+meth public org.codehaus.groovy.ast.ClassNode resolveClassNullable(java.lang.String)
+meth public org.codehaus.groovy.ast.ClassNode resolveType(groovyjarjarasm.asm.Type)
+supr java.lang.Object
+hfds resolver,unit
+
+CLSS public org.codehaus.groovy.ast.decompiled.ClassStub
+cons public init(java.lang.String,int,java.lang.String,java.lang.String,java.lang.String[])
+supr java.lang.Object
+hfds accessModifiers,className,fields,innerClassModifiers,interfaceNames,methods,signature,superName
+
+CLSS public org.codehaus.groovy.ast.decompiled.DecompiledClassNode
+cons public init(org.codehaus.groovy.ast.decompiled.ClassStub,org.codehaus.groovy.ast.decompiled.AsmReferenceResolver)
+meth public boolean isResolved()
+meth public boolean isUsingGenerics()
+meth public java.lang.Class getTypeClass()
+meth public java.lang.String setName(java.lang.String)
+meth public java.util.List<org.codehaus.groovy.ast.AnnotationNode> getAnnotations()
+meth public java.util.List<org.codehaus.groovy.ast.AnnotationNode> getAnnotations(org.codehaus.groovy.ast.ClassNode)
+meth public java.util.List<org.codehaus.groovy.ast.ConstructorNode> getDeclaredConstructors()
+meth public java.util.List<org.codehaus.groovy.ast.FieldNode> getFields()
+meth public java.util.List<org.codehaus.groovy.ast.MethodNode> getDeclaredMethods(java.lang.String)
+meth public java.util.List<org.codehaus.groovy.ast.MethodNode> getMethods()
+meth public long getCompilationTimeStamp()
+meth public org.codehaus.groovy.ast.ClassNode getUnresolvedSuperClass(boolean)
+meth public org.codehaus.groovy.ast.ClassNode[] getInterfaces()
+meth public org.codehaus.groovy.ast.ClassNode[] getUnresolvedInterfaces(boolean)
+meth public org.codehaus.groovy.ast.FieldNode getDeclaredField(java.lang.String)
+meth public org.codehaus.groovy.ast.GenericsType[] getGenericsTypes()
+meth public void setGenericsPlaceHolder(boolean)
+meth public void setRedirect(org.codehaus.groovy.ast.ClassNode)
+meth public void setUsingGenerics(boolean)
+supr org.codehaus.groovy.ast.ClassNode
+hfds classData,membersInitialized,resolver,supersInitialized
 
 CLSS public org.codehaus.groovy.ast.expr.AnnotationConstantExpression
 cons public init(org.codehaus.groovy.ast.AnnotationNode)
@@ -25120,6 +25210,241 @@ meth public static void makePostfix(org.codehaus.groovy.syntax.CSTNode,boolean)
 meth public static void makePrefix(org.codehaus.groovy.syntax.CSTNode,boolean)
 supr java.lang.Object
 hfds DESCRIPTIONS,KEYWORDS,LOOKUP,TEXTS
+
+CLSS public org.codehaus.groovy.tools.Compiler
+cons public init()
+cons public init(org.codehaus.groovy.control.CompilerConfiguration)
+fld public final static org.codehaus.groovy.tools.Compiler DEFAULT
+meth public void compile(java.io.File)
+meth public void compile(java.io.File[])
+meth public void compile(java.lang.String,java.lang.String)
+meth public void compile(java.lang.String[])
+supr java.lang.Object
+hfds configuration
+
+CLSS public org.codehaus.groovy.tools.DgmConverter
+cons public init()
+intf groovyjarjarasm.asm.Opcodes
+meth protected static void loadParameters(org.codehaus.groovy.reflection.CachedMethod,int,groovyjarjarasm.asm.MethodVisitor)
+meth public static void main(java.lang.String[]) throws java.io.IOException
+supr java.lang.Object
+
+CLSS public org.codehaus.groovy.tools.ErrorReporter
+cons public init(java.lang.Throwable)
+cons public init(java.lang.Throwable,boolean)
+meth protected void dispatch(java.lang.Throwable,boolean)
+meth protected void println(java.lang.String)
+meth protected void println(java.lang.StringBuffer)
+meth protected void report(java.lang.Exception,boolean)
+meth protected void report(java.lang.Throwable,boolean)
+meth protected void report(org.codehaus.groovy.GroovyExceptionInterface,boolean)
+meth protected void report(org.codehaus.groovy.control.CompilationFailedException,boolean)
+meth protected void stacktrace(java.lang.Throwable,boolean)
+meth public void write(java.io.PrintStream)
+meth public void write(java.io.PrintWriter)
+supr java.lang.Object
+hfds base,debug,output
+
+CLSS public org.codehaus.groovy.tools.FileSystemCompiler
+cons public init(org.codehaus.groovy.control.CompilerConfiguration)
+cons public init(org.codehaus.groovy.control.CompilerConfiguration,org.codehaus.groovy.control.CompilationUnit)
+innr public static CompilationOptions
+innr public static VersionProvider
+meth public static boolean validateFiles(java.lang.String[])
+meth public static groovyjarjarpicocli.CommandLine configureParser(org.codehaus.groovy.tools.FileSystemCompiler$CompilationOptions)
+meth public static int checkFiles(java.lang.String[])
+meth public static void commandLineCompile(java.lang.String[]) throws java.lang.Exception
+meth public static void commandLineCompile(java.lang.String[],boolean) throws java.lang.Exception
+meth public static void commandLineCompileWithErrorHandling(java.lang.String[],boolean)
+meth public static void deleteRecursive(java.io.File)
+meth public static void displayHelp()
+meth public static void displayHelp(java.io.PrintWriter)
+meth public static void displayVersion()
+meth public static void displayVersion(java.io.PrintWriter)
+meth public static void doCompilation(org.codehaus.groovy.control.CompilerConfiguration,org.codehaus.groovy.control.CompilationUnit,java.lang.String[]) throws java.lang.Exception
+meth public static void doCompilation(org.codehaus.groovy.control.CompilerConfiguration,org.codehaus.groovy.control.CompilationUnit,java.lang.String[],boolean) throws java.lang.Exception
+meth public static void main(java.lang.String[])
+meth public void compile(java.io.File[]) throws java.lang.Exception
+meth public void compile(java.lang.String[]) throws java.lang.Exception
+supr java.lang.Object
+hfds displayStackTraceOnError,unit
+
+CLSS public static org.codehaus.groovy.tools.FileSystemCompiler$CompilationOptions
+ outer org.codehaus.groovy.tools.FileSystemCompiler
+cons public init()
+meth public java.lang.String[] generateFileNames()
+meth public org.codehaus.groovy.control.CompilerConfiguration toCompilerConfiguration() throws java.io.IOException
+supr java.lang.Object
+hfds classpath,compileStatic,configScript,encoding,files,flags,helpRequested,indy,javacOptionsMap,jointCompilation,parameterMetadata,previewFeatures,printStack,scriptBaseClass,sourcepath,targetDir,temp,typeChecked,versionRequested
+
+CLSS public static org.codehaus.groovy.tools.FileSystemCompiler$VersionProvider
+ outer org.codehaus.groovy.tools.FileSystemCompiler
+cons public init()
+intf groovyjarjarpicocli.CommandLine$IVersionProvider
+meth public java.lang.String[] getVersion()
+supr java.lang.Object
+
+CLSS public org.codehaus.groovy.tools.GrapeMain
+cons public init()
+intf groovy.lang.GroovyObject
+intf java.lang.Runnable
+meth public !varargs static void main(java.lang.String[])
+meth public groovy.lang.MetaClass getMetaClass()
+meth public java.util.List<java.lang.String> getUnmatched()
+meth public void run()
+meth public void setMetaClass(groovy.lang.MetaClass)
+meth public void setUnmatched(java.util.List<java.lang.String>)
+supr java.lang.Object
+hfds debug,info,parser,properties,quiet,resolvers,unmatched,verbose,warn
+hcls HelpOptionsMixin,Install,ListCommand,Resolve,Uninstall,VersionProvider
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$Install$_run_closure1
+cons public init(java.lang.Object,java.lang.Object)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Object call(java.lang.String)
+meth public java.lang.Object doCall(java.lang.String)
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$ListCommand$_run_closure1
+cons public init(java.lang.Object,java.lang.Object,groovy.lang.Reference,groovy.lang.Reference)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Integer getModuleCount()
+meth public java.lang.Integer getVersionCount()
+meth public java.lang.Object call(java.lang.String,java.util.Map)
+meth public java.lang.Object doCall(java.lang.String,java.util.Map)
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$ListCommand$_run_closure1$_closure2
+cons public init(java.lang.Object,java.lang.Object,groovy.lang.Reference,groovy.lang.Reference,groovy.lang.Reference)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Integer getModuleCount()
+meth public java.lang.Integer getVersionCount()
+meth public java.lang.Object call(java.lang.String,java.util.List<java.lang.String>)
+meth public java.lang.Object doCall(java.lang.String,java.util.List<java.lang.String>)
+meth public java.lang.String getGroupName()
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$Resolve$_run_closure1
+cons public init(java.lang.Object,java.lang.Object,groovy.lang.Reference)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Object doCall(java.lang.Object)
+meth public java.lang.Object getResults()
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$Uninstall$_run_closure1
+cons public init(java.lang.Object,java.lang.Object)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Object call(java.lang.String,java.util.Map)
+meth public java.lang.Object doCall(java.lang.String,java.util.Map)
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$Uninstall$_run_closure1$_closure4
+cons public init(java.lang.Object,java.lang.Object,groovy.lang.Reference)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Object call(java.lang.String,java.util.List<java.lang.String>)
+meth public java.lang.Object doCall(java.lang.String,java.util.List<java.lang.String>)
+meth public java.lang.String getGroupName()
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$Uninstall$_run_closure2
+cons public init(java.lang.Object,java.lang.Object)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Object call(java.lang.String,java.util.Map)
+meth public java.lang.Object doCall(java.lang.String,java.util.Map)
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$Uninstall$_run_closure2$_closure5
+cons public init(java.lang.Object,java.lang.Object,groovy.lang.Reference)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Object call(java.lang.String,java.util.List<java.lang.String>)
+meth public java.lang.Object doCall(java.lang.String,java.util.List<java.lang.String>)
+meth public java.lang.String getGroupName()
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$Uninstall$_run_closure3
+cons public init(java.lang.Object,java.lang.Object)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Object call(java.lang.String,java.util.Map)
+meth public java.lang.Object doCall(java.lang.String,java.util.Map)
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$_init_closure3
+cons public init(java.lang.Object,java.lang.Object)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Object call(java.lang.Object,java.lang.Object)
+meth public java.lang.Object doCall(java.lang.Object,java.lang.Object)
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$_main_closure1
+cons public init(java.lang.Object,java.lang.Object)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Object call(java.lang.Object,java.lang.Object)
+meth public java.lang.Object doCall(java.lang.Object,java.lang.Object)
+supr groovy.lang.Closure
+
+CLSS public final org.codehaus.groovy.tools.GrapeMain$_main_closure2
+cons public init(java.lang.Object,java.lang.Object)
+intf org.codehaus.groovy.runtime.GeneratedClosure
+meth public java.lang.Object call(java.lang.Object,java.lang.Object)
+meth public java.lang.Object doCall(java.lang.Object,java.lang.Object)
+supr groovy.lang.Closure
+
+CLSS public org.codehaus.groovy.tools.GrapeUtil
+cons public init()
+meth public static java.util.Map<java.lang.String,java.lang.Object> getIvyParts(java.lang.String)
+supr java.lang.Object
+
+CLSS public org.codehaus.groovy.tools.GroovyClass
+cons public init(java.lang.String,byte[])
+fld public final static org.codehaus.groovy.tools.GroovyClass[] EMPTY_ARRAY
+meth public byte[] getBytes()
+meth public java.lang.String getName()
+supr java.lang.Object
+hfds bytes,name
+
+CLSS public org.codehaus.groovy.tools.GroovyStarter
+cons public init()
+meth public static void main(java.lang.String[])
+meth public static void rootLoader(java.lang.String[])
+supr java.lang.Object
+
+CLSS public org.codehaus.groovy.tools.LoaderConfiguration
+cons public init()
+meth public java.lang.String getMainClass()
+meth public java.net.URL[] getClassPathUrls()
+meth public java.util.List<java.lang.String> getGrabUrls()
+meth public void addClassPath(java.lang.String)
+meth public void addFile(java.io.File)
+meth public void addFile(java.lang.String)
+meth public void configure(java.io.InputStream) throws java.io.IOException
+meth public void setMainClass(java.lang.String)
+meth public void setRequireMain(boolean)
+supr java.lang.Object
+hfds ALL_WILDCARD,CONFIGSCRIPT_PREFIX,GRAB_PREFIX,LOAD_PREFIX,MAIN_PREFIX,MATCH_ALL,MATCH_FILE_NAME,PROP_PREFIX,WILDCARD,classPath,configScripts,grabList,main,requireMain
+
+CLSS public org.codehaus.groovy.tools.RootLoader
+cons public init(java.net.URL[],java.lang.ClassLoader)
+cons public init(org.codehaus.groovy.tools.LoaderConfiguration)
+meth protected java.lang.Class findClass(java.lang.String) throws java.lang.ClassNotFoundException
+meth protected java.lang.Class loadClass(java.lang.String,boolean) throws java.lang.ClassNotFoundException
+meth public java.net.URL getResource(java.lang.String)
+meth public void addURL(java.net.URL)
+supr java.net.URLClassLoader
+hfds EMPTY_URL_ARRAY,ORG_W3C_DOM_NODE,customClasses
+
+CLSS public org.codehaus.groovy.tools.StringHelper
+cons public init()
+meth public static java.lang.String[] tokenizeUnquoted(java.lang.String)
+supr java.lang.Object
+hfds DOUBLE_QUOTE,EMPTY_STRING_ARRAY,SINGLE_QUOTE,SPACE
+
+CLSS public abstract org.codehaus.groovy.tools.Utilities
+cons public init()
+meth public static boolean isJavaIdentifier(java.lang.String)
+meth public static java.lang.String eol()
+meth public static java.lang.String repeatString(java.lang.String,int)
+supr java.lang.Object
+hfds INVALID_JAVA_IDENTIFIERS,eol
 
 CLSS public org.codehaus.groovy.transform.ASTTestTransformation
 cons public init()

--- a/harness/jellytools.platform/nbproject/org-netbeans-modules-jellytools-platform.sig
+++ b/harness/jellytools.platform/nbproject/org-netbeans-modules-jellytools-platform.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.42
+#Version 3.43
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/harness/jemmy/nbproject/org-netbeans-modules-jemmy.sig
+++ b/harness/jemmy/nbproject/org-netbeans-modules-jemmy.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.40
+#Version 3.41
 
 CLSS public abstract java.awt.AWTEvent
 cons public init(java.awt.Event)

--- a/harness/nbjunit/nbproject/org-netbeans-modules-nbjunit.sig
+++ b/harness/nbjunit/nbproject/org-netbeans-modules-nbjunit.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.103
+#Version 1.104
 
 CLSS public java.io.IOException
 cons public init()

--- a/harness/o.n.insane/nbproject/org-netbeans-insane.sig
+++ b/harness/o.n.insane/nbproject/org-netbeans-insane.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.42.0
+#Version 1.43.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/api.debugger/nbproject/org-netbeans-api-debugger.sig
+++ b/ide/api.debugger/nbproject/org-netbeans-api-debugger.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.68
+#Version 1.69
 
 CLSS public abstract interface java.beans.PropertyChangeListener
 intf java.util.EventListener

--- a/ide/api.java.classpath/nbproject/org-netbeans-api-java-classpath.sig
+++ b/ide/api.java.classpath/nbproject/org-netbeans-api-java-classpath.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.67
+#Version 1.68
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/api.lsp/nbproject/org-netbeans-api-lsp.sig
+++ b/ide/api.lsp/nbproject/org-netbeans-api-lsp.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.5
+#Version 1.6
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/api.xml.ui/nbproject/org-netbeans-api-xml-ui.sig
+++ b/ide/api.xml.ui/nbproject/org-netbeans-api-xml-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.57
+#Version 1.58
 
 CLSS public java.beans.FeatureDescriptor
 cons public init()

--- a/ide/api.xml/nbproject/org-netbeans-api-xml.sig
+++ b/ide/api.xml/nbproject/org-netbeans-api-xml.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.57
+#Version 1.58
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/bugtracking.commons/nbproject/org-netbeans-modules-bugtracking-commons.sig
+++ b/ide/bugtracking.commons/nbproject/org-netbeans-modules-bugtracking-commons.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.21
+#Version 1.22
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/bugtracking/nbproject/org-netbeans-modules-bugtracking.sig
+++ b/ide/bugtracking/nbproject/org-netbeans-modules-bugtracking.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.122
+#Version 1.123
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/bugzilla/nbproject/org-netbeans-modules-bugzilla.sig
+++ b/ide/bugzilla/nbproject/org-netbeans-modules-bugzilla.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.90
+#Version 1.91
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/code.analysis/nbproject/org-netbeans-modules-code-analysis.sig
+++ b/ide/code.analysis/nbproject/org-netbeans-modules-code-analysis.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.39
+#Version 1.40
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/core.browser/nbproject/org-netbeans-core-browser.sig
+++ b/ide/core.browser/nbproject/org-netbeans-core-browser.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.41.0
+#Version 1.42.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/core.ide/nbproject/org-netbeans-core-ide.sig
+++ b/ide/core.ide/nbproject/org-netbeans-core-ide.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.54
+#Version 1.55
 
 CLSS public abstract interface java.lang.annotation.Annotation
 meth public abstract boolean equals(java.lang.Object)

--- a/ide/csl.api/nbproject/org-netbeans-modules-csl-api.sig
+++ b/ide/csl.api/nbproject/org-netbeans-modules-csl-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.69.0
+#Version 2.70.0
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/ide/csl.types/nbproject/org-netbeans-modules-csl-types.sig
+++ b/ide/csl.types/nbproject/org-netbeans-modules-csl-types.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.13
+#Version 1.14
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/css.editor/nbproject/org-netbeans-modules-css-editor.sig
+++ b/ide/css.editor/nbproject/org-netbeans-modules-css-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.81
+#Version 1.82
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/css.lib/nbproject/org-netbeans-modules-css-lib.sig
+++ b/ide/css.lib/nbproject/org-netbeans-modules-css-lib.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.96
+#Version 1.97
 
 CLSS public abstract interface java.io.Serializable
 
@@ -397,6 +397,7 @@ fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_ERROR
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_EXTEND
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_EXTEND_ONLY_SELECTOR
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_FOR
+fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_FORWARD
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_FUNCTION
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_GLOBAL
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_IF
@@ -404,6 +405,7 @@ fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_INCLUDE
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_MIXIN
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_OPTIONAL
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_RETURN
+fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_USE
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_VAR
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_WARN
 fld public final static org.netbeans.modules.css.lib.api.CssTokenId SASS_WHILE
@@ -590,6 +592,12 @@ fld public final static org.netbeans.modules.css.lib.api.NodeType sass_error
 fld public final static org.netbeans.modules.css.lib.api.NodeType sass_extend
 fld public final static org.netbeans.modules.css.lib.api.NodeType sass_extend_only_selector
 fld public final static org.netbeans.modules.css.lib.api.NodeType sass_for
+fld public final static org.netbeans.modules.css.lib.api.NodeType sass_forward
+fld public final static org.netbeans.modules.css.lib.api.NodeType sass_forward_as
+fld public final static org.netbeans.modules.css.lib.api.NodeType sass_forward_hide
+fld public final static org.netbeans.modules.css.lib.api.NodeType sass_forward_show
+fld public final static org.netbeans.modules.css.lib.api.NodeType sass_forward_with
+fld public final static org.netbeans.modules.css.lib.api.NodeType sass_forward_with_declaration
 fld public final static org.netbeans.modules.css.lib.api.NodeType sass_function_declaration
 fld public final static org.netbeans.modules.css.lib.api.NodeType sass_function_name
 fld public final static org.netbeans.modules.css.lib.api.NodeType sass_function_return
@@ -601,6 +609,10 @@ fld public final static org.netbeans.modules.css.lib.api.NodeType sass_map_pair
 fld public final static org.netbeans.modules.css.lib.api.NodeType sass_map_pairs
 fld public final static org.netbeans.modules.css.lib.api.NodeType sass_nested_properties
 fld public final static org.netbeans.modules.css.lib.api.NodeType sass_selector_interpolation_exp
+fld public final static org.netbeans.modules.css.lib.api.NodeType sass_use
+fld public final static org.netbeans.modules.css.lib.api.NodeType sass_use_as
+fld public final static org.netbeans.modules.css.lib.api.NodeType sass_use_with
+fld public final static org.netbeans.modules.css.lib.api.NodeType sass_use_with_declaration
 fld public final static org.netbeans.modules.css.lib.api.NodeType sass_while
 fld public final static org.netbeans.modules.css.lib.api.NodeType selector
 fld public final static org.netbeans.modules.css.lib.api.NodeType selectorsGroup

--- a/ide/css.model/nbproject/org-netbeans-modules-css-model.sig
+++ b/ide/css.model/nbproject/org-netbeans-modules-css-model.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44
+#Version 1.45
 
 CLSS public abstract interface java.beans.PropertyChangeListener
 intf java.util.EventListener

--- a/ide/css.visual/nbproject/org-netbeans-modules-css-visual.sig
+++ b/ide/css.visual/nbproject/org-netbeans-modules-css-visual.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.45
+#Version 3.46
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/db.core/nbproject/org-netbeans-modules-db-core.sig
+++ b/ide/db.core/nbproject/org-netbeans-modules-db-core.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.50
+#Version 1.51
 
 CLSS public java.beans.FeatureDescriptor
 cons public init()

--- a/ide/db.dataview/nbproject/org-netbeans-modules-db-dataview.sig
+++ b/ide/db.dataview/nbproject/org-netbeans-modules-db-dataview.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46
+#Version 1.47
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/db.metadata.model/nbproject/org-netbeans-modules-db-metadata-model.sig
+++ b/ide/db.metadata.model/nbproject/org-netbeans-modules-db-metadata-model.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.24
+#Version 1.25
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/db.mysql/nbproject/org-netbeans-modules-db-mysql.sig
+++ b/ide/db.mysql/nbproject/org-netbeans-modules-db-mysql.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.41.0
+#Version 0.42.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/db.sql.editor/nbproject/org-netbeans-modules-db-sql-editor.sig
+++ b/ide/db.sql.editor/nbproject/org-netbeans-modules-db-sql-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.49.0
+#Version 1.50.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/db.sql.visualeditor/nbproject/org-netbeans-modules-db-sql-visualeditor.sig
+++ b/ide/db.sql.visualeditor/nbproject/org-netbeans-modules-db-sql-visualeditor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.45.0
+#Version 2.46.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/db/nbproject/org-netbeans-modules-db.sig
+++ b/ide/db/nbproject/org-netbeans-modules-db.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.79.0
+#Version 1.80.0
 
 CLSS public java.beans.FeatureDescriptor
 cons public init()

--- a/ide/dbapi/nbproject/org-netbeans-modules-dbapi.sig
+++ b/ide/dbapi/nbproject/org-netbeans-modules-dbapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.47.0
+#Version 1.48.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/derby/nbproject/org-netbeans-modules-derby.sig
+++ b/ide/derby/nbproject/org-netbeans-modules-derby.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.53
+#Version 1.54
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/diff/nbproject/org-netbeans-modules-diff.sig
+++ b/ide/diff/nbproject/org-netbeans-modules-diff.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.64.0
+#Version 1.65.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/dlight.nativeexecution.nb/nbproject/org-netbeans-modules-dlight-nativeexecution-nb.sig
+++ b/ide/dlight.nativeexecution.nb/nbproject/org-netbeans-modules-dlight-nativeexecution-nb.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.13
+#Version 1.14
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/dlight.nativeexecution/nbproject/org-netbeans-modules-dlight-nativeexecution.sig
+++ b/ide/dlight.nativeexecution/nbproject/org-netbeans-modules-dlight-nativeexecution.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.52.0
+#Version 1.53.0
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/ide/dlight.terminal/nbproject/org-netbeans-modules-dlight-terminal.sig
+++ b/ide/dlight.terminal/nbproject/org-netbeans-modules-dlight-terminal.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.36.0
+#Version 1.37.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/docker.api/nbproject/org-netbeans-modules-docker-api.sig
+++ b/ide/docker.api/nbproject/org-netbeans-modules-docker-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.33
+#Version 1.34
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/ide/editor.bracesmatching/nbproject/org-netbeans-modules-editor-bracesmatching.sig
+++ b/ide/editor.bracesmatching/nbproject/org-netbeans-modules-editor-bracesmatching.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.52.0
+#Version 1.53.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/editor.breadcrumbs/nbproject/org-netbeans-modules-editor-breadcrumbs.sig
+++ b/ide/editor.breadcrumbs/nbproject/org-netbeans-modules-editor-breadcrumbs.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.30
+#Version 1.31
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/editor.codetemplates/nbproject/org-netbeans-modules-editor-codetemplates.sig
+++ b/ide/editor.codetemplates/nbproject/org-netbeans-modules-editor-codetemplates.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.56.0
+#Version 1.58.0
 
 CLSS public java.lang.Object
 cons public init()
@@ -77,6 +77,7 @@ CLSS public abstract interface static org.netbeans.lib.editor.codetemplates.spi.
  outer org.netbeans.lib.editor.codetemplates.spi.CodeTemplateFilter
  anno 0 org.netbeans.spi.editor.mimelookup.MimeLocation(java.lang.Class<? extends org.netbeans.spi.editor.mimelookup.InstanceProvider> instanceProviderClass=class org.netbeans.spi.editor.mimelookup.InstanceProvider, java.lang.String subfolderName="CodeTemplateFilterFactories")
 meth public abstract org.netbeans.lib.editor.codetemplates.spi.CodeTemplateFilter createFilter(javax.swing.text.JTextComponent,int)
+meth public org.netbeans.lib.editor.codetemplates.spi.CodeTemplateFilter createFilter(javax.swing.text.Document,int,int)
 
 CLSS public final org.netbeans.lib.editor.codetemplates.spi.CodeTemplateInsertRequest
 meth public boolean isInserted()

--- a/ide/editor.completion/nbproject/org-netbeans-modules-editor-completion.sig
+++ b/ide/editor.completion/nbproject/org-netbeans-modules-editor-completion.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.57.0
+#Version 1.58.0
 
 CLSS public abstract interface !annotation java.lang.FunctionalInterface
  anno 0 java.lang.annotation.Documented()

--- a/ide/editor.deprecated.pre65formatting/nbproject/org-netbeans-modules-editor-deprecated-pre65formatting.sig
+++ b/ide/editor.deprecated.pre65formatting/nbproject/org-netbeans-modules-editor-deprecated-pre65formatting.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44.0
+#Version 1.45.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/editor.document/nbproject/org-netbeans-modules-editor-document.sig
+++ b/ide/editor.document/nbproject/org-netbeans-modules-editor-document.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.22.0
+#Version 1.23.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/editor.errorstripe.api/nbproject/org-netbeans-modules-editor-errorstripe-api.sig
+++ b/ide/editor.errorstripe.api/nbproject/org-netbeans-modules-editor-errorstripe-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.45.0
+#Version 2.46.0
 
 CLSS public abstract interface java.lang.Comparable<%0 extends java.lang.Object>
 meth public abstract int compareTo({java.lang.Comparable%0})

--- a/ide/editor.fold/nbproject/org-netbeans-modules-editor-fold.sig
+++ b/ide/editor.fold/nbproject/org-netbeans-modules-editor-fold.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.58
+#Version 1.59
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/editor.guards/nbproject/org-netbeans-modules-editor-guards.sig
+++ b/ide/editor.guards/nbproject/org-netbeans-modules-editor-guards.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46
+#Version 1.47
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/editor.indent.project/nbproject/org-netbeans-modules-editor-indent-project.sig
+++ b/ide/editor.indent.project/nbproject/org-netbeans-modules-editor-indent-project.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.35
+#Version 1.36
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/editor.indent.support/nbproject/org-netbeans-modules-editor-indent-support.sig
+++ b/ide/editor.indent.support/nbproject/org-netbeans-modules-editor-indent-support.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.55
+#Version 1.56
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/editor.indent/nbproject/org-netbeans-modules-editor-indent.sig
+++ b/ide/editor.indent/nbproject/org-netbeans-modules-editor-indent.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.56
+#Version 1.57
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/editor.lib/nbproject/org-netbeans-modules-editor-lib.sig
+++ b/ide/editor.lib/nbproject/org-netbeans-modules-editor-lib.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 4.20.0
+#Version 4.21.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/editor.lib2/nbproject/org-netbeans-modules-editor-lib2.sig
+++ b/ide/editor.lib2/nbproject/org-netbeans-modules-editor-lib2.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.33.0
+#Version 2.34.0
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/ide/editor.plain.lib/nbproject/org-netbeans-modules-editor-plain-lib.sig
+++ b/ide/editor.plain.lib/nbproject/org-netbeans-modules-editor-plain-lib.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46
+#Version 1.47
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/editor.settings.lib/nbproject/org-netbeans-modules-editor-settings-lib.sig
+++ b/ide/editor.settings.lib/nbproject/org-netbeans-modules-editor-settings-lib.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.64.0
+#Version 1.65.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/editor.settings.storage/nbproject/org-netbeans-modules-editor-settings-storage.sig
+++ b/ide/editor.settings.storage/nbproject/org-netbeans-modules-editor-settings-storage.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.65.0
+#Version 1.66.0
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/ide/editor.settings/nbproject/org-netbeans-modules-editor-settings.sig
+++ b/ide/editor.settings/nbproject/org-netbeans-modules-editor-settings.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.70
+#Version 1.71
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/editor.structure/nbproject/org-netbeans-modules-editor-structure.sig
+++ b/ide/editor.structure/nbproject/org-netbeans-modules-editor-structure.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.60.0
+#Version 1.61.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/editor.tools.storage/nbproject/org-netbeans-modules-editor-tools-storage.sig
+++ b/ide/editor.tools.storage/nbproject/org-netbeans-modules-editor-tools-storage.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.21
+#Version 1.22
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/editor.util/nbproject/org-netbeans-modules-editor-util.sig
+++ b/ide/editor.util/nbproject/org-netbeans-modules-editor-util.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.78
+#Version 1.79
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/editor/nbproject/org-netbeans-modules-editor.sig
+++ b/ide/editor/nbproject/org-netbeans-modules-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.100.0
+#Version 1.101.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/extbrowser/nbproject/org-netbeans-modules-extbrowser.sig
+++ b/ide/extbrowser/nbproject/org-netbeans-modules-extbrowser.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.66
+#Version 1.67
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/extexecution.base/nbproject/org-netbeans-modules-extexecution-base.sig
+++ b/ide/extexecution.base/nbproject/org-netbeans-modules-extexecution-base.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.19
+#Version 1.20
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable
@@ -142,17 +142,21 @@ meth public !varargs java.util.List<java.lang.String> getAllArguments(java.lang.
 meth public boolean isArgReplacement()
 meth public boolean isEmpty()
 meth public boolean isLauncherArgReplacement()
+meth public java.io.File getWorkingDirectory()
+ anno 0 org.netbeans.api.annotations.common.CheckForNull()
 meth public java.util.List<java.lang.String> getAllArguments(java.util.List<java.lang.String>)
  anno 0 org.netbeans.api.annotations.common.NonNull()
 meth public java.util.List<java.lang.String> getArguments()
 meth public java.util.List<java.lang.String> getLauncherArguments()
+meth public java.util.Map<java.lang.String,java.lang.String> getEnvironmentVariables()
+ anno 0 org.netbeans.api.annotations.common.NonNull()
 meth public static org.netbeans.api.extexecution.base.ExplicitProcessParameters buildExplicitParameters(java.util.Collection<? extends org.netbeans.api.extexecution.base.ExplicitProcessParameters>)
 meth public static org.netbeans.api.extexecution.base.ExplicitProcessParameters buildExplicitParameters(org.openide.util.Lookup)
  anno 0 org.netbeans.api.annotations.common.NonNull()
 meth public static org.netbeans.api.extexecution.base.ExplicitProcessParameters empty()
 meth public static org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder builder()
 supr java.lang.Object
-hfds EMPTY,arguments,launcherArguments,position,replaceArgs,replaceLauncherArgs
+hfds EMPTY,arguments,environmentVars,launcherArguments,position,replaceArgs,replaceLauncherArgs,workingDirectory
 
 CLSS public final static org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder
  outer org.netbeans.api.extexecution.base.ExplicitProcessParameters
@@ -168,6 +172,8 @@ meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder
  anno 1 org.netbeans.api.annotations.common.NullAllowed()
 meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder combine(org.netbeans.api.extexecution.base.ExplicitProcessParameters)
  anno 1 org.netbeans.api.annotations.common.NullAllowed()
+meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder environmentVariable(java.lang.String,java.lang.String)
+meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder environmentVariables(java.util.Map<java.lang.String,java.lang.String>)
 meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder launcherArg(java.lang.String)
  anno 1 org.netbeans.api.annotations.common.NullAllowed()
 meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder launcherArgs(java.util.List<java.lang.String>)
@@ -175,8 +181,9 @@ meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder
 meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder position(int)
 meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder replaceArgs(boolean)
 meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder replaceLauncherArgs(boolean)
+meth public org.netbeans.api.extexecution.base.ExplicitProcessParameters$Builder workingDirectory(java.io.File)
 supr java.lang.Object
-hfds arguments,launcherArguments,position,replaceArgs,replaceLauncherArgs
+hfds arguments,environmentVars,launcherArguments,position,replaceArgs,replaceLauncherArgs,workingDirectory
 
 CLSS public abstract interface org.netbeans.api.extexecution.base.ParametrizedRunnable<%0 extends java.lang.Object>
 meth public abstract void run({org.netbeans.api.extexecution.base.ParametrizedRunnable%0})

--- a/ide/extexecution/nbproject/org-netbeans-modules-extexecution.sig
+++ b/ide/extexecution/nbproject/org-netbeans-modules-extexecution.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.62
+#Version 1.63
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/ide/git/nbproject/org-netbeans-modules-git.sig
+++ b/ide/git/nbproject/org-netbeans-modules-git.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.35.0
+#Version 1.36.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/gototest/nbproject/org-netbeans-modules-gototest.sig
+++ b/ide/gototest/nbproject/org-netbeans-modules-gototest.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46
+#Version 1.47
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/gsf.codecoverage/nbproject/org-netbeans-modules-gsf-codecoverage.sig
+++ b/ide/gsf.codecoverage/nbproject/org-netbeans-modules-gsf-codecoverage.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.45
+#Version 1.46
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/gsf.testrunner.ui/nbproject/org-netbeans-modules-gsf-testrunner-ui.sig
+++ b/ide/gsf.testrunner.ui/nbproject/org-netbeans-modules-gsf-testrunner-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.26
+#Version 1.29.0
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener
@@ -182,6 +182,11 @@ meth public boolean isTestClass(org.openide.nodes.Node)
 meth public final void debugTestMethod(org.openide.nodes.Node)
 supr java.lang.Object
 hfds command,singleMethod,singleMethodTask
+
+CLSS public final org.netbeans.modules.gsf.testrunner.ui.api.TestMethodFinder
+cons public init()
+meth public static java.util.Map<org.openide.filesystems.FileObject,java.util.Collection<org.netbeans.modules.gsf.testrunner.ui.api.TestMethodController$TestMethod>> findTestMethods(java.lang.Iterable<org.openide.filesystems.FileObject>,java.util.function.BiConsumer<org.openide.filesystems.FileObject,java.util.Collection<org.netbeans.modules.gsf.testrunner.ui.api.TestMethodController$TestMethod>>)
+supr java.lang.Object
 
 CLSS public org.netbeans.modules.gsf.testrunner.ui.api.TestMethodNode
 cons protected init(org.netbeans.modules.gsf.testrunner.api.Testcase,org.netbeans.api.project.Project,org.openide.util.Lookup)

--- a/ide/gsf.testrunner/nbproject/org-netbeans-modules-gsf-testrunner.sig
+++ b/ide/gsf.testrunner/nbproject/org-netbeans-modules-gsf-testrunner.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.24
+#Version 2.26
 
 CLSS public abstract java.awt.Component
 cons protected init()
@@ -862,10 +862,11 @@ meth public org.netbeans.modules.gsf.testrunner.api.Testcase getCurrentTestCase(
 meth public void addOutput(java.lang.String)
 meth public void addSuite(org.netbeans.modules.gsf.testrunner.api.TestSuite)
 meth public void addTestCase(org.netbeans.modules.gsf.testrunner.api.Testcase)
+meth public void finishSuite(org.netbeans.modules.gsf.testrunner.api.TestSuite)
 meth public void setRerunHandler(org.netbeans.modules.gsf.testrunner.api.RerunHandler)
 meth public void setStartingMsg(java.lang.String)
 supr java.lang.Object
-hfds failuresCount,fileLocator,name,output,project,projectURI,rerunHandler,sessionType,startingMsg,testSuites
+hfds failuresCount,fileLocator,name,output,project,projectURI,rerunHandler,sessionType,startingMsg,suiteIdxs,testSuites
 
 CLSS public final static org.netbeans.modules.gsf.testrunner.api.TestSession$SessionResult
  outer org.netbeans.modules.gsf.testrunner.api.TestSession

--- a/ide/html.editor.lib/nbproject/org-netbeans-modules-html-editor-lib.sig
+++ b/ide/html.editor.lib/nbproject/org-netbeans-modules-html-editor-lib.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.45
+#Version 3.46
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/ide/html.editor/nbproject/org-netbeans-modules-html-editor.sig
+++ b/ide/html.editor/nbproject/org-netbeans-modules-html-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.69
+#Version 2.70
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/ide/html.indexing/nbproject/org-netbeans-modules-html-indexing.sig
+++ b/ide/html.indexing/nbproject/org-netbeans-modules-html-indexing.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.3
+#Version 1.4
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/html.lexer/nbproject/org-netbeans-modules-html-lexer.sig
+++ b/ide/html.lexer/nbproject/org-netbeans-modules-html-lexer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.51
+#Version 1.52
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/html.parser/nbproject/org-netbeans-modules-html-parser.sig
+++ b/ide/html.parser/nbproject/org-netbeans-modules-html-parser.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.47.0
+#Version 1.48.0
 
 CLSS public com.ibm.icu.impl.Assert
 cons public init()

--- a/ide/html/nbproject/org-netbeans-modules-html.sig
+++ b/ide/html/nbproject/org-netbeans-modules-html.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.74
+#Version 1.75
 
 CLSS public java.beans.FeatureDescriptor
 cons public init()

--- a/ide/hudson.ui/nbproject/org-netbeans-modules-hudson-ui.sig
+++ b/ide/hudson.ui/nbproject/org-netbeans-modules-hudson-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.24
+#Version 1.25
 
 CLSS public java.io.IOException
 cons public init()

--- a/ide/hudson/nbproject/org-netbeans-modules-hudson.sig
+++ b/ide/hudson/nbproject/org-netbeans-modules-hudson.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.26
+#Version 2.27
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/javascript2.debug.ui/nbproject/org-netbeans-modules-javascript2-debug-ui.sig
+++ b/ide/javascript2.debug.ui/nbproject/org-netbeans-modules-javascript2-debug-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.16
+#Version 1.17
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/javascript2.debug/nbproject/org-netbeans-modules-javascript2-debug.sig
+++ b/ide/javascript2.debug/nbproject/org-netbeans-modules-javascript2-debug.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.31
+#Version 1.32
 
 CLSS public abstract interface java.beans.BeanInfo
 fld public final static int ICON_COLOR_16x16 = 1

--- a/ide/jellytools.ide/nbproject/org-netbeans-modules-jellytools-ide.sig
+++ b/ide/jellytools.ide/nbproject/org-netbeans-modules-jellytools-ide.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.46.0
+#Version 3.47.0
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/ide/jumpto/nbproject/org-netbeans-modules-jumpto.sig
+++ b/ide/jumpto/nbproject/org-netbeans-modules-jumpto.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.68.0
+#Version 1.69.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/languages/nbproject/org-netbeans-modules-languages.sig
+++ b/ide/languages/nbproject/org-netbeans-modules-languages.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.134.0
+#Version 1.135.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/lexer/nbproject/org-netbeans-modules-lexer.sig
+++ b/ide/lexer/nbproject/org-netbeans-modules-lexer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.76.0
+#Version 1.77.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/lib.terminalemulator/nbproject/org-netbeans-lib-terminalemulator.sig
+++ b/ide/lib.terminalemulator/nbproject/org-netbeans-lib-terminalemulator.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.50
+#Version 1.51
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/libs.antlr3.runtime/nbproject/org-netbeans-libs-antlr3-runtime.sig
+++ b/ide/libs.antlr3.runtime/nbproject/org-netbeans-libs-antlr3-runtime.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.34.0
+#Version 1.35.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/libs.antlr4.runtime/nbproject/org-netbeans-libs-antlr4-runtime.sig
+++ b/ide/libs.antlr4.runtime/nbproject/org-netbeans-libs-antlr4-runtime.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.14.0
+#Version 1.15.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/libs.c.kohlschutter.junixsocket/nbproject/libs-c-kohlschutter-junixsocket.sig
+++ b/ide/libs.c.kohlschutter.junixsocket/nbproject/libs-c-kohlschutter-junixsocket.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.28
+#Version 2.29
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/ide/libs.commons_compress/nbproject/org-netbeans-libs-commons_compress.sig
+++ b/ide/libs.commons_compress/nbproject/org-netbeans-libs-commons_compress.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.19.0
+#Version 0.20.0
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/ide/libs.commons_net/nbproject/org-netbeans-libs-commons_net.sig
+++ b/ide/libs.commons_net/nbproject/org-netbeans-libs-commons_net.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.35.0
+#Version 2.36.0
 
 CLSS public java.io.IOException
 cons public init()

--- a/ide/libs.flexmark/nbproject/org-netbeans-libs-flexmark.sig
+++ b/ide/libs.flexmark/nbproject/org-netbeans-libs-flexmark.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.6
+#Version 1.7
 
 CLSS public java.io.IOException
 cons public init()

--- a/ide/libs.git/nbproject/org-netbeans-libs-git.sig
+++ b/ide/libs.git/nbproject/org-netbeans-libs-git.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46
+#Version 1.47
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/libs.graalsdk/nbproject/org-netbeans-libs-graalsdk.sig
+++ b/ide/libs.graalsdk/nbproject/org-netbeans-libs-graalsdk.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.13
+#Version 1.14
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/libs.ini4j/nbproject/org-netbeans-libs-ini4j.sig
+++ b/ide/libs.ini4j/nbproject/org-netbeans-libs-ini4j.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.47
+#Version 1.48
 
 CLSS public java.io.IOException
 cons public init()

--- a/ide/libs.jaxb/nbproject/org-netbeans-libs-jaxb.sig
+++ b/ide/libs.jaxb/nbproject/org-netbeans-libs-jaxb.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44
+#Version 1.45
 
 CLSS public final com.sun.codemodel.ClassType
 fld public final static com.sun.codemodel.ClassType ANNOTATION_TYPE_DECL

--- a/ide/libs.jcodings/nbproject/org-netbeans-libs-jcodings.sig
+++ b/ide/libs.jcodings/nbproject/org-netbeans-libs-jcodings.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.2
+#Version 0.3
 
 CLSS public abstract interface java.lang.Cloneable
 

--- a/ide/libs.jsch.agentproxy/nbproject/org-netbeans-libs-jsch-agentproxy.sig
+++ b/ide/libs.jsch.agentproxy/nbproject/org-netbeans-libs-jsch-agentproxy.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.27
+#Version 0.28
 
 CLSS public com.jcraft.jsch.agentproxy.AgentProxy
 cons public init(com.jcraft.jsch.agentproxy.Connector)
@@ -205,7 +205,7 @@ meth public void writeField(java.lang.String)
 meth public void writeField(java.lang.String,java.lang.Object)
 supr java.lang.Object
 hfds LOG,PLACEHOLDER_MEMORY,actualAlignType,alignType,array,autoRead,autoWrite,busy,encoding,fieldOrder,layoutInfo,memory,nativeStrings,readCalled,reads,size,structAlignment,structFields,typeInfo,typeMapper
-hcls AutoAllocated,FFIType,LayoutInfo,StructureSet
+hcls AutoAllocated,FFIType,LayoutInfo,NativeStringTracking,StructureSet
 
 CLSS public abstract interface com.sun.jna.platform.win32.BaseTSD
 innr public static DWORD_PTR
@@ -228,6 +228,7 @@ intf com.sun.jna.platform.win32.WinNT
 intf com.sun.jna.platform.win32.WinUser
 intf com.sun.jna.win32.StdCallLibrary
 meth public abstract boolean AttachThreadInput(com.sun.jna.platform.win32.WinDef$DWORD,com.sun.jna.platform.win32.WinDef$DWORD,boolean)
+meth public abstract boolean BringWindowToTop(com.sun.jna.platform.win32.WinDef$HWND)
 meth public abstract boolean CloseWindow(com.sun.jna.platform.win32.WinDef$HWND)
 meth public abstract boolean DestroyIcon(com.sun.jna.platform.win32.WinDef$HICON)
 meth public abstract boolean DestroyWindow(com.sun.jna.platform.win32.WinDef$HWND)
@@ -294,10 +295,12 @@ meth public abstract com.sun.jna.platform.win32.WinDef$HWND GetActiveWindow()
 meth public abstract com.sun.jna.platform.win32.WinDef$HWND GetAncestor(com.sun.jna.platform.win32.WinDef$HWND,int)
 meth public abstract com.sun.jna.platform.win32.WinDef$HWND GetDesktopWindow()
 meth public abstract com.sun.jna.platform.win32.WinDef$HWND GetForegroundWindow()
+meth public abstract com.sun.jna.platform.win32.WinDef$HWND GetParent(com.sun.jna.platform.win32.WinDef$HWND)
 meth public abstract com.sun.jna.platform.win32.WinDef$HWND GetWindow(com.sun.jna.platform.win32.WinDef$HWND,com.sun.jna.platform.win32.WinDef$DWORD)
 meth public abstract com.sun.jna.platform.win32.WinDef$HWND SetFocus(com.sun.jna.platform.win32.WinDef$HWND)
 meth public abstract com.sun.jna.platform.win32.WinDef$HWND SetParent(com.sun.jna.platform.win32.WinDef$HWND,com.sun.jna.platform.win32.WinDef$HWND)
 meth public abstract com.sun.jna.platform.win32.WinDef$LRESULT CallNextHookEx(com.sun.jna.platform.win32.WinUser$HHOOK,int,com.sun.jna.platform.win32.WinDef$WPARAM,com.sun.jna.platform.win32.WinDef$LPARAM)
+meth public abstract com.sun.jna.platform.win32.WinDef$LRESULT CallWindowProc(com.sun.jna.Pointer,com.sun.jna.platform.win32.WinDef$HWND,int,com.sun.jna.platform.win32.WinDef$WPARAM,com.sun.jna.platform.win32.WinDef$LPARAM)
 meth public abstract com.sun.jna.platform.win32.WinDef$LRESULT DefWindowProc(com.sun.jna.platform.win32.WinDef$HWND,int,com.sun.jna.platform.win32.WinDef$WPARAM,com.sun.jna.platform.win32.WinDef$LPARAM)
 meth public abstract com.sun.jna.platform.win32.WinDef$LRESULT DispatchMessage(com.sun.jna.platform.win32.WinUser$MSG)
 meth public abstract com.sun.jna.platform.win32.WinDef$LRESULT SendMessage(com.sun.jna.platform.win32.WinDef$HWND,int,com.sun.jna.platform.win32.WinDef$WPARAM,com.sun.jna.platform.win32.WinDef$LPARAM)
@@ -5112,7 +5115,7 @@ fld public final static int IO_REPARSE_TAG_MOUNT_POINT = -1610612733
 fld public final static int IO_REPARSE_TAG_SIS = -2147483641
 fld public final static int IO_REPARSE_TAG_SYMLINK = -1610612724
 fld public final static int IO_REPARSE_TAG_WIM = -2147483640
-fld public final static int KEY_ALL_ACCESS = 2031679
+fld public final static int KEY_ALL_ACCESS = 983103
 fld public final static int KEY_CREATE_LINK = 32
 fld public final static int KEY_CREATE_SUB_KEY = 4
 fld public final static int KEY_ENUMERATE_SUB_KEYS = 8
@@ -5213,12 +5216,21 @@ fld public final static int MAXLONG = 2147483647
 fld public final static int MAXSHORT = 32767
 fld public final static int MAXWORD = 65535
 fld public final static int MAX_ACL_REVISION = 4
+fld public final static int MEM_COALESCE_PLACEHOLDERS = 1
 fld public final static int MEM_COMMIT = 4096
+fld public final static int MEM_DECOMMIT = 16384
 fld public final static int MEM_FREE = 65536
 fld public final static int MEM_IMAGE = 16777216
+fld public final static int MEM_LARGE_PAGES = 536870912
 fld public final static int MEM_MAPPED = 262144
+fld public final static int MEM_PHYSICAL = 4194304
+fld public final static int MEM_PRESERVE_PLACEHOLDER = 2
 fld public final static int MEM_PRIVATE = 131072
+fld public final static int MEM_RELEASE = 32768
 fld public final static int MEM_RESERVE = 8192
+fld public final static int MEM_RESET = 524288
+fld public final static int MEM_RESET_UNDO = 16777216
+fld public final static int MEM_TOP_DOWN = 1048576
 fld public final static int MINCHAR = 128
 fld public final static int MINLONG = -2147483648
 fld public final static int MINSHORT = 32768
@@ -5270,7 +5282,7 @@ fld public final static int REG_HIVE_EXACT_FILE_GROWTH = 128
 fld public final static int REG_HIVE_NO_RM = 256
 fld public final static int REG_HIVE_SINGLE_LOG = 512
 fld public final static int REG_LATEST_FORMAT = 2
-fld public final static int REG_LEGAL_CHANGE_FILTER = 15
+fld public final static int REG_LEGAL_CHANGE_FILTER = 268435471
 fld public final static int REG_LEGAL_OPTION = 15
 fld public final static int REG_LINK = 6
 fld public final static int REG_MULTI_SZ = 7
@@ -5279,6 +5291,7 @@ fld public final static int REG_NOTIFY_CHANGE_ATTRIBUTES = 2
 fld public final static int REG_NOTIFY_CHANGE_LAST_SET = 4
 fld public final static int REG_NOTIFY_CHANGE_NAME = 1
 fld public final static int REG_NOTIFY_CHANGE_SECURITY = 8
+fld public final static int REG_NOTIFY_THREAD_AGNOSTIC = 268435456
 fld public final static int REG_NO_COMPRESSION = 4
 fld public final static int REG_NO_LAZY_FLUSH = 4
 fld public final static int REG_OPENED_EXISTING_KEY = 2
@@ -5615,8 +5628,10 @@ innr public static SYSTEM_POWER_LEVEL
 innr public static SYSTEM_POWER_POLICY
 innr public static TOKEN_GROUPS
 innr public static TOKEN_OWNER
+innr public static TOKEN_PRIMARY_GROUP
 innr public static TOKEN_PRIVILEGES
 innr public static TOKEN_USER
+innr public static UNKNOWN_RELATIONSHIP
 intf com.sun.jna.platform.win32.BaseTSD
 intf com.sun.jna.platform.win32.WinBase
 intf com.sun.jna.platform.win32.WinDef
@@ -5998,6 +6013,7 @@ fld public final static int WS_VISIBLE = 268435456
 fld public final static int WS_VSCROLL = 2097152
 innr public abstract interface static HOOKPROC
 innr public abstract interface static LowLevelKeyboardProc
+innr public abstract interface static LowLevelMouseProc
 innr public abstract interface static MONITORENUMPROC
 innr public abstract interface static WNDENUMPROC
 innr public abstract interface static WinEventProc
@@ -6019,6 +6035,7 @@ innr public static MONITORINFO
 innr public static MONITORINFOEX
 innr public static MOUSEINPUT
 innr public static MSG
+innr public static MSLLHOOKSTRUCT
 innr public static RAWINPUTDEVICELIST
 innr public static SIZE
 innr public static WINDOWINFO

--- a/ide/libs.json_simple/nbproject/org-netbeans-libs-json_simple.sig
+++ b/ide/libs.json_simple/nbproject/org-netbeans-libs-json_simple.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.25
+#Version 0.26
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/libs.lucene/nbproject/org-netbeans-libs-lucene.sig
+++ b/ide/libs.lucene/nbproject/org-netbeans-libs-lucene.sig
@@ -1,3 +1,3 @@
 #Signature file v4.1
-#Version 3.32
+#Version 3.33
 

--- a/ide/libs.smack/nbproject/org-netbeans-libs-smack.sig
+++ b/ide/libs.smack/nbproject/org-netbeans-libs-smack.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.39
+#Version 3.40
 
 CLSS public final com.jcraft.jzlib.Deflate
 supr java.lang.Object

--- a/ide/libs.snakeyaml_engine/nbproject/org-netbeans-libs-snakeyaml_engine.sig
+++ b/ide/libs.snakeyaml_engine/nbproject/org-netbeans-libs-snakeyaml_engine.sig
@@ -1,3 +1,3 @@
 #Signature file v4.1
-#Version 5.17
+#Version 2.3
 

--- a/ide/libs.svnClientAdapter/nbproject/org-netbeans-libs-svnClientAdapter.sig
+++ b/ide/libs.svnClientAdapter/nbproject/org-netbeans-libs-svnClientAdapter.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.53
+#Version 1.54
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/ide/libs.truffleapi/nbproject/org-netbeans-libs-truffleapi.sig
+++ b/ide/libs.truffleapi/nbproject/org-netbeans-libs-truffleapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.13
+#Version 1.14
 
 CLSS public final com.oracle.truffle.api.ArrayUtils
 meth public !varargs static int indexOf(byte[],int,int,byte[])

--- a/ide/libs.xerces/nbproject/org-netbeans-libs-xerces.sig
+++ b/ide/libs.xerces/nbproject/org-netbeans-libs-xerces.sig
@@ -1,3 +1,3 @@
 #Signature file v4.1
-#Version 1.51.0
+#Version 1.52.0
 

--- a/ide/lsp.client/nbproject/org-netbeans-modules-lsp-client.sig
+++ b/ide/lsp.client/nbproject/org-netbeans-modules-lsp-client.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.12.0
+#Version 1.13.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/mercurial/nbproject/org-netbeans-modules-mercurial.sig
+++ b/ide/mercurial/nbproject/org-netbeans-modules-mercurial.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.55.0
+#Version 1.56.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/mylyn.util/nbproject/org-netbeans-modules-mylyn-util.sig
+++ b/ide/mylyn.util/nbproject/org-netbeans-modules-mylyn-util.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.49
+#Version 1.50
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/nativeimage.api/nbproject/org-netbeans-modules-nativeimage-api.sig
+++ b/ide/nativeimage.api/nbproject/org-netbeans-modules-nativeimage-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.3
+#Version 0.5
 
 CLSS public abstract interface java.io.Serializable
 
@@ -119,7 +119,10 @@ meth public java.util.Map<org.netbeans.modules.nativeimage.api.SourceInfo,java.u
  anno 0 org.netbeans.api.annotations.common.CheckForNull()
 meth public java.util.Map<org.netbeans.modules.nativeimage.api.SourceInfo,java.util.List<org.netbeans.modules.nativeimage.api.Symbol>> listVariables(java.lang.String,boolean,int)
  anno 0 org.netbeans.api.annotations.common.CheckForNull()
+meth public java.util.concurrent.CompletableFuture<java.lang.Void> attach(java.lang.String,long,java.lang.String,java.util.function.Consumer<org.netbeans.api.debugger.DebuggerEngine>)
 meth public java.util.concurrent.CompletableFuture<java.lang.Void> start(java.util.List<java.lang.String>,java.io.File,java.lang.String,java.lang.String,org.netbeans.api.extexecution.ExecutionDescriptor,java.util.function.Consumer<org.netbeans.api.debugger.DebuggerEngine>)
+ anno 0 java.lang.Deprecated()
+meth public java.util.concurrent.CompletableFuture<java.lang.Void> start(org.netbeans.modules.nativeimage.api.debug.StartDebugParameters,java.util.function.Consumer<org.netbeans.api.debugger.DebuggerEngine>)
 meth public java.util.concurrent.CompletableFuture<org.netbeans.modules.nativeimage.api.debug.NIVariable> evaluateAsync(java.lang.String,java.lang.String,org.netbeans.modules.nativeimage.api.debug.NIFrame)
 meth public org.netbeans.api.debugger.Breakpoint addLineBreakpoint(java.lang.Object,org.netbeans.modules.nativeimage.api.debug.NILineBreakpointDescriptor)
 meth public org.netbeans.modules.nativeimage.api.debug.NIVariable evaluate(java.lang.String,java.lang.String,org.netbeans.modules.nativeimage.api.debug.NIFrame) throws org.netbeans.modules.nativeimage.api.debug.EvaluateException
@@ -179,10 +182,32 @@ meth public abstract org.netbeans.modules.nativeimage.api.debug.NIVariable getPa
 meth public abstract org.netbeans.modules.nativeimage.api.debug.NIVariable[] getChildren(int,int)
 meth public org.netbeans.modules.nativeimage.api.debug.NIVariable[] getChildren()
 
+CLSS public final org.netbeans.modules.nativeimage.api.debug.StartDebugParameters
+innr public final static Builder
+meth public java.io.File getWorkingDirectory()
+meth public java.lang.String getDebugger()
+meth public java.lang.String getDisplayName()
+meth public java.util.List<java.lang.String> getCommand()
+meth public org.netbeans.api.extexecution.ExecutionDescriptor getExecutionDescriptor()
+meth public org.openide.util.Lookup getContextLookup()
+meth public static org.netbeans.modules.nativeimage.api.debug.StartDebugParameters$Builder newBuilder(java.util.List<java.lang.String>)
+supr java.lang.Object
+hfds command,contextLookup,debugger,displayName,executionDescriptor,workingDirectory
+
+CLSS public final static org.netbeans.modules.nativeimage.api.debug.StartDebugParameters$Builder
+ outer org.netbeans.modules.nativeimage.api.debug.StartDebugParameters
+meth public org.netbeans.modules.nativeimage.api.debug.StartDebugParameters build()
+meth public org.netbeans.modules.nativeimage.api.debug.StartDebugParameters$Builder debugger(java.lang.String)
+meth public org.netbeans.modules.nativeimage.api.debug.StartDebugParameters$Builder displayName(java.lang.String)
+meth public org.netbeans.modules.nativeimage.api.debug.StartDebugParameters$Builder executionDescriptor(org.netbeans.api.extexecution.ExecutionDescriptor)
+meth public org.netbeans.modules.nativeimage.api.debug.StartDebugParameters$Builder lookup(org.openide.util.Lookup)
+meth public org.netbeans.modules.nativeimage.api.debug.StartDebugParameters$Builder workingDirectory(java.io.File)
+supr java.lang.Object
+hfds command,contextLookup,debugger,displayName,executionDescriptor,workingDirectory
+
 CLSS public abstract interface org.netbeans.modules.nativeimage.spi.debug.NIDebuggerProvider
 meth public abstract java.lang.String getVersion()
 meth public abstract java.lang.String readMemory(java.lang.String,long,int)
-meth public abstract java.util.concurrent.CompletableFuture<java.lang.Void> start(java.util.List<java.lang.String>,java.io.File,java.lang.String,java.lang.String,org.netbeans.api.extexecution.ExecutionDescriptor,java.util.function.Consumer<org.netbeans.api.debugger.DebuggerEngine>)
 meth public abstract java.util.concurrent.CompletableFuture<org.netbeans.modules.nativeimage.api.debug.NIVariable> evaluateAsync(java.lang.String,java.lang.String,org.netbeans.modules.nativeimage.api.debug.NIFrame)
 meth public abstract org.netbeans.api.debugger.Breakpoint addLineBreakpoint(java.lang.Object,org.netbeans.modules.nativeimage.api.debug.NILineBreakpointDescriptor)
 meth public abstract void removeBreakpoint(java.lang.Object)
@@ -191,6 +216,10 @@ meth public abstract void setVariablesDisplayer(org.netbeans.modules.nativeimage
 meth public java.util.List<org.netbeans.modules.nativeimage.api.Location> listLocations(java.lang.String)
 meth public java.util.Map<org.netbeans.modules.nativeimage.api.SourceInfo,java.util.List<org.netbeans.modules.nativeimage.api.Symbol>> listFunctions(java.lang.String,boolean,int)
 meth public java.util.Map<org.netbeans.modules.nativeimage.api.SourceInfo,java.util.List<org.netbeans.modules.nativeimage.api.Symbol>> listVariables(java.lang.String,boolean,int)
+meth public java.util.concurrent.CompletableFuture<java.lang.Void> attach(java.lang.String,long,java.lang.String,java.util.function.Consumer<org.netbeans.api.debugger.DebuggerEngine>)
+meth public java.util.concurrent.CompletableFuture<java.lang.Void> start(java.util.List<java.lang.String>,java.io.File,java.lang.String,java.lang.String,org.netbeans.api.extexecution.ExecutionDescriptor,java.util.function.Consumer<org.netbeans.api.debugger.DebuggerEngine>)
+ anno 0 java.lang.Deprecated()
+meth public java.util.concurrent.CompletableFuture<java.lang.Void> start(org.netbeans.modules.nativeimage.api.debug.StartDebugParameters,java.util.function.Consumer<org.netbeans.api.debugger.DebuggerEngine>)
 
 CLSS public abstract interface org.netbeans.modules.nativeimage.spi.debug.NIDebuggerServiceProvider
 meth public abstract org.netbeans.modules.nativeimage.spi.debug.NIDebuggerProvider create()

--- a/ide/o.apache.xml.resolver/nbproject/org-apache-xml-resolver.sig
+++ b/ide/o.apache.xml.resolver/nbproject/org-apache-xml-resolver.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44.0
+#Version 1.45.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/o.openidex.util/nbproject/org-openidex-util.sig
+++ b/ide/o.openidex.util/nbproject/org-openidex-util.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.60
+#Version 3.61
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/options.editor/nbproject/org-netbeans-modules-options-editor.sig
+++ b/ide/options.editor/nbproject/org-netbeans-modules-options-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.73
+#Version 1.74
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/parsing.api/nbproject/org-netbeans-modules-parsing-api.sig
+++ b/ide/parsing.api/nbproject/org-netbeans-modules-parsing-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.20.0
+#Version 9.21.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/parsing.indexing/nbproject/org-netbeans-modules-parsing-indexing.sig
+++ b/ide/parsing.indexing/nbproject/org-netbeans-modules-parsing-indexing.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.22.0
+#Version 9.23.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/parsing.lucene/nbproject/org-netbeans-modules-parsing-lucene.sig
+++ b/ide/parsing.lucene/nbproject/org-netbeans-modules-parsing-lucene.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.49.0
+#Version 2.50.0
 
 CLSS public java.io.IOException
 cons public init()

--- a/ide/project.ant.compat8/nbproject/org-netbeans-modules-project-ant-compat8.sig
+++ b/ide/project.ant.compat8/nbproject/org-netbeans-modules-project-ant-compat8.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.80
+#Version 1.81
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/project.ant.ui/nbproject/org-netbeans-modules-project-ant-ui.sig
+++ b/ide/project.ant.ui/nbproject/org-netbeans-modules-project-ant-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.78
+#Version 1.79
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/project.ant/nbproject/org-netbeans-modules-project-ant.sig
+++ b/ide/project.ant/nbproject/org-netbeans-modules-project-ant.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.80
+#Version 1.81
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/project.indexingbridge/nbproject/org-netbeans-modules-project-indexingbridge.sig
+++ b/ide/project.indexingbridge/nbproject/org-netbeans-modules-project-indexingbridge.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.30
+#Version 1.31
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/project.libraries.ui/nbproject/org-netbeans-modules-project-libraries-ui.sig
+++ b/ide/project.libraries.ui/nbproject/org-netbeans-modules-project-libraries-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.65
+#Version 1.66
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/project.libraries/nbproject/org-netbeans-modules-project-libraries.sig
+++ b/ide/project.libraries/nbproject/org-netbeans-modules-project-libraries.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.66
+#Version 1.67
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/project.spi.intern/nbproject/org-netbeans-modules-project-spi-intern.sig
+++ b/ide/project.spi.intern/nbproject/org-netbeans-modules-project-spi-intern.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.16
+#Version 1.17
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/projectapi/nbproject/org-netbeans-modules-projectapi.sig
+++ b/ide/projectapi/nbproject/org-netbeans-modules-projectapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.81
+#Version 1.82
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/projectui/nbproject/org-netbeans-modules-projectui.sig
+++ b/ide/projectui/nbproject/org-netbeans-modules-projectui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.72.0
+#Version 1.73.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/projectuiapi.base/nbproject/org-netbeans-modules-projectuiapi-base.sig
+++ b/ide/projectuiapi.base/nbproject/org-netbeans-modules-projectuiapi-base.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.98.0
+#Version 1.99.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/projectuiapi/nbproject/org-netbeans-modules-projectuiapi.sig
+++ b/ide/projectuiapi/nbproject/org-netbeans-modules-projectuiapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.101.0
+#Version 1.102.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/properties.syntax/nbproject/org-netbeans-modules-properties-syntax.sig
+++ b/ide/properties.syntax/nbproject/org-netbeans-modules-properties-syntax.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.63
+#Version 1.64
 
 CLSS public abstract interface java.io.Externalizable
 intf java.io.Serializable

--- a/ide/properties/nbproject/org-netbeans-modules-properties.sig
+++ b/ide/properties/nbproject/org-netbeans-modules-properties.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.68
+#Version 1.69
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/refactoring.api/nbproject/org-netbeans-modules-refactoring-api.sig
+++ b/ide/refactoring.api/nbproject/org-netbeans-modules-refactoring-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.60.0
+#Version 1.61.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/schema2beans/nbproject/org-netbeans-modules-schema2beans.sig
+++ b/ide/schema2beans/nbproject/org-netbeans-modules-schema2beans.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.60
+#Version 1.61
 
 CLSS public abstract interface java.beans.BeanInfo
 fld public final static int ICON_COLOR_16x16 = 1

--- a/ide/selenium2.server/nbproject/org-netbeans-modules-selenium2-server.sig
+++ b/ide/selenium2.server/nbproject/org-netbeans-modules-selenium2-server.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.16
+#Version 1.17
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/selenium2/nbproject/org-netbeans-modules-selenium2.sig
+++ b/ide/selenium2/nbproject/org-netbeans-modules-selenium2.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.18
+#Version 1.19
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/server/nbproject/org-netbeans-modules-server.sig
+++ b/ide/server/nbproject/org-netbeans-modules-server.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46
+#Version 1.47
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/servletapi/nbproject/org-netbeans-modules-servletapi.sig
+++ b/ide/servletapi/nbproject/org-netbeans-modules-servletapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.52
+#Version 1.53
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/ide/spellchecker.apimodule/nbproject/org-netbeans-modules-spellchecker-apimodule.sig
+++ b/ide/spellchecker.apimodule/nbproject/org-netbeans-modules-spellchecker-apimodule.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.38
+#Version 1.39
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/spi.debugger.ui/nbproject/org-netbeans-spi-debugger-ui.sig
+++ b/ide/spi.debugger.ui/nbproject/org-netbeans-spi-debugger-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.69
+#Version 2.72
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener
@@ -28,6 +28,14 @@ meth public java.lang.String toString()
 meth public static <%0 extends java.lang.Enum<{%%0}>> {%%0} valueOf(java.lang.Class<{%%0}>,java.lang.String)
 supr java.lang.Object
 
+CLSS public java.lang.Exception
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.Throwable
+
 CLSS public java.lang.Object
 cons public init()
 meth protected java.lang.Object clone() throws java.lang.CloneNotSupportedException
@@ -41,6 +49,28 @@ meth public final void wait(long) throws java.lang.InterruptedException
 meth public final void wait(long,int) throws java.lang.InterruptedException
 meth public int hashCode()
 meth public java.lang.String toString()
+
+CLSS public java.lang.Throwable
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+intf java.io.Serializable
+meth public final java.lang.Throwable[] getSuppressed()
+meth public final void addSuppressed(java.lang.Throwable)
+meth public java.lang.StackTraceElement[] getStackTrace()
+meth public java.lang.String getLocalizedMessage()
+meth public java.lang.String getMessage()
+meth public java.lang.String toString()
+meth public java.lang.Throwable fillInStackTrace()
+meth public java.lang.Throwable getCause()
+meth public java.lang.Throwable initCause(java.lang.Throwable)
+meth public void printStackTrace()
+meth public void printStackTrace(java.io.PrintStream)
+meth public void printStackTrace(java.io.PrintWriter)
+meth public void setStackTrace(java.lang.StackTraceElement[])
+supr java.lang.Object
 
 CLSS public abstract interface java.lang.annotation.Annotation
 meth public abstract boolean equals(java.lang.Object)
@@ -296,6 +326,7 @@ innr public abstract interface static DVThreadGroup
 innr public abstract static DVSupport
 innr public final static DVFilter
 innr public final static Deadlock
+innr public final static PopException
 meth public org.openide.windows.TopComponent getViewTC()
 meth public static org.netbeans.spi.debugger.ui.DebuggingView getDefault()
 supr java.lang.Object
@@ -350,6 +381,7 @@ meth public abstract java.net.URI getSourceURI()
 meth public abstract org.netbeans.spi.debugger.ui.DebuggingView$DVThread getThread()
 meth public abstract void makeCurrent()
 meth public java.lang.String getSourceMimeType()
+meth public void popOff() throws org.netbeans.spi.debugger.ui.DebuggingView$PopException
 
 CLSS public abstract static org.netbeans.spi.debugger.ui.DebuggingView$DVSupport
  outer org.netbeans.spi.debugger.ui.DebuggingView
@@ -432,6 +464,11 @@ CLSS public final static org.netbeans.spi.debugger.ui.DebuggingView$Deadlock
 meth public java.util.Collection<org.netbeans.spi.debugger.ui.DebuggingView$DVThread> getThreads()
 supr java.lang.Object
 hfds threads
+
+CLSS public final static org.netbeans.spi.debugger.ui.DebuggingView$PopException
+ outer org.netbeans.spi.debugger.ui.DebuggingView
+cons public init(java.lang.String)
+supr java.lang.Exception
 
 CLSS public final org.netbeans.spi.debugger.ui.EditorContextDispatcher
 fld public final static java.lang.String PROP_EDITOR = "editor"

--- a/ide/spi.editor.hints.projects/nbproject/org-netbeans-spi-editor-hints-projects.sig
+++ b/ide/spi.editor.hints.projects/nbproject/org-netbeans-spi-editor-hints-projects.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.24.0
+#Version 1.25.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/spi.editor.hints/nbproject/org-netbeans-spi-editor-hints.sig
+++ b/ide/spi.editor.hints/nbproject/org-netbeans-spi-editor-hints.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.55.0
+#Version 1.56.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/spi.navigator/nbproject/org-netbeans-spi-navigator.sig
+++ b/ide/spi.navigator/nbproject/org-netbeans-spi-navigator.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.51
+#Version 1.52
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/spi.palette/nbproject/org-netbeans-spi-palette.sig
+++ b/ide/spi.palette/nbproject/org-netbeans-spi-palette.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.59
+#Version 1.60
 
 CLSS public abstract interface java.io.Externalizable
 intf java.io.Serializable

--- a/ide/spi.tasklist/nbproject/org-netbeans-spi-tasklist.sig
+++ b/ide/spi.tasklist/nbproject/org-netbeans-spi-tasklist.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.48.0
+#Version 1.49.0
 
 CLSS public abstract interface java.lang.Iterable<%0 extends java.lang.Object>
 meth public abstract java.util.Iterator<{java.lang.Iterable%0}> iterator()

--- a/ide/spi.viewmodel/nbproject/org-netbeans-spi-viewmodel.sig
+++ b/ide/spi.viewmodel/nbproject/org-netbeans-spi-viewmodel.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.64
+#Version 1.65
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/subversion/nbproject/org-netbeans-modules-subversion.sig
+++ b/ide/subversion/nbproject/org-netbeans-modules-subversion.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.54.0
+#Version 1.55.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/swing.validation/nbproject/org-netbeans-modules-swing-validation.sig
+++ b/ide/swing.validation/nbproject/org-netbeans-modules-swing-validation.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.45
+#Version 1.46
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/target.iterator/nbproject/org-netbeans-modules-target-iterator.sig
+++ b/ide/target.iterator/nbproject/org-netbeans-modules-target-iterator.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.37
+#Version 1.38
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/team.commons/nbproject/org-netbeans-modules-team-commons.sig
+++ b/ide/team.commons/nbproject/org-netbeans-modules-team-commons.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.63
+#Version 1.64
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/terminal.nb/nbproject/org-netbeans-modules-terminal-nb.sig
+++ b/ide/terminal.nb/nbproject/org-netbeans-modules-terminal-nb.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.13
+#Version 1.14
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/terminal/nbproject/org-netbeans-modules-terminal.sig
+++ b/ide/terminal/nbproject/org-netbeans-modules-terminal.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.40
+#Version 1.41
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/textmate.lexer/nbproject/org-netbeans-modules-textmate-lexer.sig
+++ b/ide/textmate.lexer/nbproject/org-netbeans-modules-textmate-lexer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.13.0
+#Version 1.14.0
 
 CLSS public abstract interface java.lang.annotation.Annotation
 meth public abstract boolean equals(java.lang.Object)

--- a/ide/utilities.project/nbproject/org-netbeans-modules-utilities-project.sig
+++ b/ide/utilities.project/nbproject/org-netbeans-modules-utilities-project.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.51
+#Version 1.52
 
 CLSS public abstract interface org.netbeans.modules.search.project.spi.CompatibilityUtils
 meth public abstract org.netbeans.api.search.provider.SearchInfo getSearchInfoForLookup(org.openide.util.Lookup)

--- a/ide/utilities/nbproject/org-netbeans-modules-utilities.sig
+++ b/ide/utilities/nbproject/org-netbeans-modules-utilities.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.74
+#Version 1.75
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/versioning.core/nbproject/org-netbeans-modules-versioning-core.sig
+++ b/ide/versioning.core/nbproject/org-netbeans-modules-versioning-core.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44.0
+#Version 1.45.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/versioning.ui/nbproject/org-netbeans-modules-versioning-ui.sig
+++ b/ide/versioning.ui/nbproject/org-netbeans-modules-versioning-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.35.0
+#Version 1.36.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/versioning.util/nbproject/org-netbeans-modules-versioning-util.sig
+++ b/ide/versioning.util/nbproject/org-netbeans-modules-versioning-util.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.83.0
+#Version 1.84.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/versioning/nbproject/org-netbeans-modules-versioning.sig
+++ b/ide/versioning/nbproject/org-netbeans-modules-versioning.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.60.0
+#Version 1.61.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/web.browser.api/nbproject/org-netbeans-modules-web-browser-api.sig
+++ b/ide/web.browser.api/nbproject/org-netbeans-modules-web-browser-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.58
+#Version 1.59
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/web.common.ui/nbproject/org-netbeans-modules-web-common-ui.sig
+++ b/ide/web.common.ui/nbproject/org-netbeans-modules-web-common-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.14
+#Version 1.15
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/web.common/nbproject/org-netbeans-modules-web-common.sig
+++ b/ide/web.common/nbproject/org-netbeans-modules-web-common.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.112
+#Version 1.113
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/web.indent/nbproject/org-netbeans-modules-web-indent.sig
+++ b/ide/web.indent/nbproject/org-netbeans-modules-web-indent.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.33
+#Version 1.34
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/web.webkit.debugging/nbproject/org-netbeans-modules-web-webkit-debugging.sig
+++ b/ide/web.webkit.debugging/nbproject/org-netbeans-modules-web-webkit-debugging.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.66
+#Version 1.67
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/xml.axi/nbproject/org-netbeans-modules-xml-axi.sig
+++ b/ide/xml.axi/nbproject/org-netbeans-modules-xml-axi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46
+#Version 1.47
 
 CLSS public abstract interface java.beans.PropertyChangeListener
 intf java.util.EventListener

--- a/ide/xml.catalog.ui/nbproject/org-netbeans-modules-xml-catalog-ui.sig
+++ b/ide/xml.catalog.ui/nbproject/org-netbeans-modules-xml-catalog-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.16.0
+#Version 2.17.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/xml.catalog/nbproject/org-netbeans-modules-xml-catalog.sig
+++ b/ide/xml.catalog/nbproject/org-netbeans-modules-xml-catalog.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.17.0
+#Version 3.18.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/ide/xml.core/nbproject/org-netbeans-modules-xml-core.sig
+++ b/ide/xml.core/nbproject/org-netbeans-modules-xml-core.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.56.0
+#Version 1.57.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/xml.jaxb.api/nbproject/org-netbeans-modules-xml-jaxb-api.sig
+++ b/ide/xml.jaxb.api/nbproject/org-netbeans-modules-xml-jaxb-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.39
+#Version 1.40
 
 CLSS public java.awt.datatransfer.DataFlavor
 cons public init()

--- a/ide/xml.lexer/nbproject/org-netbeans-modules-xml-lexer.sig
+++ b/ide/xml.lexer/nbproject/org-netbeans-modules-xml-lexer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.43
+#Version 1.44
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/xml.multiview/nbproject/org-netbeans-modules-xml-multiview.sig
+++ b/ide/xml.multiview/nbproject/org-netbeans-modules-xml-multiview.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.51.0
+#Version 1.52.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/xml.retriever/nbproject/org-netbeans-modules-xml-retriever.sig
+++ b/ide/xml.retriever/nbproject/org-netbeans-modules-xml-retriever.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44
+#Version 1.45
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/xml.schema.completion/nbproject/org-netbeans-modules-xml-schema-completion.sig
+++ b/ide/xml.schema.completion/nbproject/org-netbeans-modules-xml-schema-completion.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44
+#Version 1.45
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/xml.schema.model/nbproject/org-netbeans-modules-xml-schema-model.sig
+++ b/ide/xml.schema.model/nbproject/org-netbeans-modules-xml-schema-model.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.45.0
+#Version 1.46.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/xml.tax/nbproject/org-netbeans-modules-xml-tax.sig
+++ b/ide/xml.tax/nbproject/org-netbeans-modules-xml-tax.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.57.0
+#Version 1.58.0
 
 CLSS public abstract interface java.beans.BeanInfo
 fld public final static int ICON_COLOR_16x16 = 1

--- a/ide/xml.text.obsolete90/nbproject/org-netbeans-modules-xml-text-obsolete90.sig
+++ b/ide/xml.text.obsolete90/nbproject/org-netbeans-modules-xml-text-obsolete90.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.13.0
+#Version 1.14.0
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/ide/xml.text/nbproject/org-netbeans-modules-xml-text.sig
+++ b/ide/xml.text/nbproject/org-netbeans-modules-xml-text.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.72.0
+#Version 1.73.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/xml.tools/nbproject/org-netbeans-modules-xml-tools.sig
+++ b/ide/xml.tools/nbproject/org-netbeans-modules-xml-tools.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.56
+#Version 1.57
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/ide/xml.wsdl.model/nbproject/org-netbeans-modules-xml-wsdl-model.sig
+++ b/ide/xml.wsdl.model/nbproject/org-netbeans-modules-xml-wsdl-model.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46.0
+#Version 1.47.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/xml.xam/nbproject/org-netbeans-modules-xml-xam.sig
+++ b/ide/xml.xam/nbproject/org-netbeans-modules-xml-xam.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.45.0
+#Version 1.46.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/ide/xml.xdm/nbproject/org-netbeans-modules-xml-xdm.sig
+++ b/ide/xml.xdm/nbproject/org-netbeans-modules-xml-xdm.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.47.0
+#Version 1.48.0
 
 CLSS public abstract interface java.beans.PropertyChangeListener
 intf java.util.EventListener

--- a/ide/xml/nbproject/org-netbeans-modules-xml.sig
+++ b/ide/xml/nbproject/org-netbeans-modules-xml.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46
+#Version 1.47
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/java/ant.freeform/nbproject/org-netbeans-modules-ant-freeform.sig
+++ b/java/ant.freeform/nbproject/org-netbeans-modules-ant-freeform.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.59
+#Version 1.60
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/api.debugger.jpda/nbproject/org-netbeans-api-debugger-jpda.sig
+++ b/java/api.debugger.jpda/nbproject/org-netbeans-api-debugger-jpda.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.22
+#Version 3.23
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/api.java/nbproject/org-netbeans-api-java.sig
+++ b/java/api.java/nbproject/org-netbeans-api-java.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.79
+#Version 1.80
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/api.maven/nbproject/org-netbeans-api-maven.sig
+++ b/java/api.maven/nbproject/org-netbeans-api-maven.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.19
+#Version 1.20
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/classfile/nbproject/org-netbeans-modules-classfile.sig
+++ b/java/classfile/nbproject/org-netbeans-modules-classfile.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.65
+#Version 1.66
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/java/dbschema/nbproject/org-netbeans-modules-dbschema.sig
+++ b/java/dbschema/nbproject/org-netbeans-modules-dbschema.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.54.0
+#Version 1.55.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/java/debugger.jpda.js/nbproject/org-netbeans-modules-debugger-jpda-js.sig
+++ b/java/debugger.jpda.js/nbproject/org-netbeans-modules-debugger-jpda-js.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.23
+#Version 1.24
 
 CLSS public abstract interface java.beans.PropertyChangeListener
 intf java.util.EventListener

--- a/java/debugger.jpda.projects/nbproject/org-netbeans-modules-debugger-jpda-projects.sig
+++ b/java/debugger.jpda.projects/nbproject/org-netbeans-modules-debugger-jpda-projects.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.53
+#Version 1.54
 
 CLSS public abstract interface !annotation java.lang.FunctionalInterface
  anno 0 java.lang.annotation.Documented()

--- a/java/debugger.jpda.truffle/nbproject/org-netbeans-modules-debugger-jpda-truffle.sig
+++ b/java/debugger.jpda.truffle/nbproject/org-netbeans-modules-debugger-jpda-truffle.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.10
+#Version 1.11
 
 CLSS public java.lang.Object
 cons public init()
@@ -76,7 +76,12 @@ hfds breakpointsToDisable,breakpointsToEnable,groupName,hitCountFilter,hitCountF
 CLSS public org.netbeans.modules.debugger.jpda.truffle.breakpoints.TruffleLineBreakpoint
 cons public init(java.net.URL,int)
 cons public init(org.netbeans.modules.javascript2.debug.EditorLineHandler)
+meth public final boolean isSuspend()
+meth public final java.lang.String getPrintText()
+meth public final void setPrintText(java.lang.String)
+meth public final void setSuspend(boolean)
 supr org.netbeans.modules.javascript2.debug.breakpoints.JSLineBreakpoint
+hfds printText,suspend
 hcls FixedLineHandler
 
 CLSS public final org.netbeans.modules.debugger.jpda.truffle.frames.TruffleStackFrame

--- a/java/debugger.jpda.ui/nbproject/org-netbeans-modules-debugger-jpda-ui.sig
+++ b/java/debugger.jpda.ui/nbproject/org-netbeans-modules-debugger-jpda-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.67
+#Version 1.68
 
 CLSS public abstract java.awt.Component
 cons protected init()
@@ -1320,6 +1320,7 @@ meth public java.net.URI getSourceURI()
 meth public org.netbeans.api.debugger.jpda.CallStackFrame getCallStackFrame()
 meth public org.netbeans.spi.debugger.ui.DebuggingView$DVThread getThread()
 meth public void makeCurrent()
+meth public void popOff() throws org.netbeans.spi.debugger.ui.DebuggingView$PopException
 supr java.lang.Object
 hfds stackFrame,thread
 
@@ -1503,6 +1504,7 @@ innr public abstract interface static DVThreadGroup
 innr public abstract static DVSupport
 innr public final static DVFilter
 innr public final static Deadlock
+innr public final static PopException
 meth public org.openide.windows.TopComponent getViewTC()
 meth public static org.netbeans.spi.debugger.ui.DebuggingView getDefault()
 supr java.lang.Object
@@ -1517,6 +1519,7 @@ meth public abstract java.net.URI getSourceURI()
 meth public abstract org.netbeans.spi.debugger.ui.DebuggingView$DVThread getThread()
 meth public abstract void makeCurrent()
 meth public java.lang.String getSourceMimeType()
+meth public void popOff() throws org.netbeans.spi.debugger.ui.DebuggingView$PopException
 
 CLSS public abstract static org.netbeans.spi.debugger.ui.DebuggingView$DVSupport
  outer org.netbeans.spi.debugger.ui.DebuggingView

--- a/java/debugger.jpda/nbproject/org-netbeans-modules-debugger-jpda.sig
+++ b/java/debugger.jpda/nbproject/org-netbeans-modules-debugger-jpda.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.121.0
+#Version 1.122.0
 
 CLSS public abstract interface com.sun.source.tree.TreeVisitor<%0 extends java.lang.Object, %1 extends java.lang.Object>
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitAnnotatedType(com.sun.source.tree.AnnotatedTypeTree,{com.sun.source.tree.TreeVisitor%1})
@@ -19,6 +19,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitCompilationUnit(co
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitCompoundAssignment(com.sun.source.tree.CompoundAssignmentTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitConditionalExpression(com.sun.source.tree.ConditionalExpressionTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitContinue(com.sun.source.tree.ContinueTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitDefaultCaseLabel(com.sun.source.tree.DefaultCaseLabelTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitDoWhileLoop(com.sun.source.tree.DoWhileLoopTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitEmptyStatement(com.sun.source.tree.EmptyStatementTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitEnhancedForLoop(com.sun.source.tree.EnhancedForLoopTree,{com.sun.source.tree.TreeVisitor%1})
@@ -26,6 +27,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitErroneous(com.sun.
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitExports(com.sun.source.tree.ExportsTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitExpressionStatement(com.sun.source.tree.ExpressionStatementTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitForLoop(com.sun.source.tree.ForLoopTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitGuardedPattern(com.sun.source.tree.GuardedPatternTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitIdentifier(com.sun.source.tree.IdentifierTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitIf(com.sun.source.tree.IfTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitImport(com.sun.source.tree.ImportTree,{com.sun.source.tree.TreeVisitor%1})
@@ -47,6 +49,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitOther(com.sun.sour
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitPackage(com.sun.source.tree.PackageTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParameterizedType(com.sun.source.tree.ParameterizedTypeTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParenthesized(com.sun.source.tree.ParenthesizedTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParenthesizedPattern(com.sun.source.tree.ParenthesizedPatternTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitPrimitiveType(com.sun.source.tree.PrimitiveTypeTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitProvides(com.sun.source.tree.ProvidesTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitRequires(com.sun.source.tree.RequiresTree,{com.sun.source.tree.TreeVisitor%1})
@@ -97,6 +100,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitCompilationUnit(com.sun.sou
 meth public {com.sun.source.util.TreeScanner%0} visitCompoundAssignment(com.sun.source.tree.CompoundAssignmentTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitConditionalExpression(com.sun.source.tree.ConditionalExpressionTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitContinue(com.sun.source.tree.ContinueTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitDefaultCaseLabel(com.sun.source.tree.DefaultCaseLabelTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitDoWhileLoop(com.sun.source.tree.DoWhileLoopTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitEmptyStatement(com.sun.source.tree.EmptyStatementTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitEnhancedForLoop(com.sun.source.tree.EnhancedForLoopTree,{com.sun.source.util.TreeScanner%1})
@@ -104,6 +108,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitErroneous(com.sun.source.tr
 meth public {com.sun.source.util.TreeScanner%0} visitExports(com.sun.source.tree.ExportsTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitExpressionStatement(com.sun.source.tree.ExpressionStatementTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitForLoop(com.sun.source.tree.ForLoopTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitGuardedPattern(com.sun.source.tree.GuardedPatternTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitIdentifier(com.sun.source.tree.IdentifierTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitIf(com.sun.source.tree.IfTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitImport(com.sun.source.tree.ImportTree,{com.sun.source.util.TreeScanner%1})
@@ -125,6 +130,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitOther(com.sun.source.tree.T
 meth public {com.sun.source.util.TreeScanner%0} visitPackage(com.sun.source.tree.PackageTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitParameterizedType(com.sun.source.tree.ParameterizedTypeTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitParenthesized(com.sun.source.tree.ParenthesizedTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitParenthesizedPattern(com.sun.source.tree.ParenthesizedPatternTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitPrimitiveType(com.sun.source.tree.PrimitiveTypeTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitProvides(com.sun.source.tree.ProvidesTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitRequires(com.sun.source.tree.RequiresTree,{com.sun.source.util.TreeScanner%1})
@@ -725,6 +731,7 @@ meth public abstract void breakpointReached(org.netbeans.api.debugger.jpda.event
 
 CLSS public org.netbeans.api.java.source.support.ErrorAwareTreePathScanner<%0 extends java.lang.Object, %1 extends java.lang.Object>
 cons public init()
+meth public {org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0} visitCase(com.sun.source.tree.CaseTree,{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1})
 meth public {org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0} visitErroneous(com.sun.source.tree.ErroneousTree,{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1})
 supr com.sun.source.util.TreePathScanner<{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0},{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1}>
 
@@ -831,7 +838,7 @@ meth public static void logCallEnd(java.lang.String,java.lang.String,java.lang.O
 meth public static void logCallStart(java.lang.String,java.lang.String,java.lang.String,java.lang.Object[])
 meth public static void report(com.sun.jdi.InternalException)
 supr java.lang.Object
-hfds callStartTime,logger
+hfds LOGGER,LOGLEVEL,callStartTime
 
 CLSS public org.netbeans.modules.debugger.jpda.JPDADebuggerImpl
 cons public init(org.netbeans.spi.debugger.ContextProvider)
@@ -936,7 +943,7 @@ meth public void setSuspend(int)
 meth public void suspend()
 meth public void waitRunning() throws org.netbeans.api.debugger.jpda.DebuggerStartException
 supr org.netbeans.api.debugger.jpda.JPDADebugger
-hfds COMPUTING_INTERFACES,LOCK2,SINGLE_THREAD_STEPPING,allInterfacesMap,altCSF,attachingCookie,breakpointsActive,canBeModified,canBeModifiedLock,compoundSmartSteppingListener,currentCallStackFrame,currentSuspendedNoFireThread,currentThread,currentThreadAndFrameLock,deadlockDetector,doContinue,engineContext,expressionPool,finishing,interestedThreadGroups,io,javaEngineProvider,jsr45EngineProviders,jvmVersionPattern,languages,localsTranslation,logger,lookupProvider,lvGenericSignatureMethod,markedObjectLabels,markedObjects,methodCallsUnsupportedExc,operator,pcs,preferredTopFrame,ptd,singleThreadStepResumeDecision,smartSteppingFilter,starting,state,stateLock,stepInterruptByBptResumeDecision,suspend,tcGenericSignatureMethod,threadsCache,threadsCollector,threadsCollectorLock,threadsTranslation,throwable,virtualMachine,virtualMachineLock,vmSuspended
+hfds COMPUTING_INTERFACES,LOCK2,RP_THROUGHPUT,SINGLE_THREAD_STEPPING,allInterfacesMap,altCSF,attachingCookie,breakpointsActive,canBeModified,canBeModifiedLock,compoundSmartSteppingListener,currentCallStackFrame,currentSuspendedNoFireThread,currentThread,currentThreadAndFrameLock,deadlockDetector,doContinue,engineContext,expressionPool,finishing,interestedThreadGroups,io,javaEngineProvider,jsr45EngineProviders,languages,localsTranslation,logger,lookupProvider,markedObjectLabels,markedObjects,methodCallsUnsupportedExc,operator,pcs,preferredTopFrame,ptd,rpCreateThreads,singleThreadStepResumeDecision,smartSteppingFilter,starting,state,stateLock,stepInterruptByBptResumeDecision,stringLengthMethod,stringMethodsLock,stringSubstringMethod,suspend,threadsCache,threadsCollector,threadsCollectorLock,threadsTranslation,throwable,virtualMachine,virtualMachineLock,vmSuspended
 hcls DebuggerReentrantReadWriteLock,PeriodicThreadsDump
 
 CLSS public org.netbeans.modules.debugger.jpda.JPDAStepImpl
@@ -1616,6 +1623,7 @@ hcls ArtificialMirror,BooleanVal,Break,ByteVal,CharVal,CommandMirror,Continue,Do
 
 CLSS public org.netbeans.modules.debugger.jpda.expr.InvocationExceptionTranslated
 cons public init(com.sun.jdi.InvocationException,org.netbeans.modules.debugger.jpda.JPDADebuggerImpl)
+cons public init(org.netbeans.api.debugger.jpda.ObjectVariable,org.netbeans.modules.debugger.jpda.JPDADebuggerImpl)
 meth public java.lang.StackTraceElement[] getStackTrace()
 meth public java.lang.String getLocalizedMessage()
 meth public java.lang.String getMessage()
@@ -2926,6 +2934,7 @@ supr org.netbeans.modules.debugger.jpda.models.AbstractObjectVariable
 hfds logger,value,valueLock,valueRetrieved,valueSet
 
 CLSS public final org.netbeans.modules.debugger.jpda.models.ObjectTranslation
+meth public <%0 extends java.lang.Object> java.util.List<? extends {%%0}> getTranslated(java.util.function.Function<java.lang.Object,{%%0}>)
 meth public java.lang.Object translate(com.sun.jdi.Mirror)
 meth public java.lang.Object translate(com.sun.jdi.Mirror,java.lang.Object)
 meth public java.lang.Object translateExisting(com.sun.jdi.Mirror)
@@ -2936,6 +2945,7 @@ meth public static org.netbeans.modules.debugger.jpda.models.ObjectTranslation c
 meth public void remove(com.sun.jdi.Mirror)
 supr java.lang.Object
 hfds LOCALS_ID,THREAD_ID,cache,debugger,threadCache,translationID
+hcls TranslationFuture
 
 CLSS public org.netbeans.modules.debugger.jpda.models.ReturnVariableImpl
 cons public init(org.netbeans.modules.debugger.jpda.JPDADebuggerImpl,com.sun.jdi.Value,java.lang.String,java.lang.String)

--- a/java/gradle.java/nbproject/org-netbeans-modules-gradle-java.sig
+++ b/java/gradle.java/nbproject/org-netbeans-modules-gradle-java.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.14
+#Version 1.15
 
 CLSS public abstract interface java.io.Serializable
 
@@ -73,6 +73,7 @@ meth public final java.util.Collection<java.io.File> getAvailableDirs()
 meth public final java.util.Collection<java.io.File> getAvailableDirs(boolean)
 meth public final java.util.Set<java.io.File> getGroovyDirs()
 meth public final java.util.Set<java.io.File> getJavaDirs()
+meth public final java.util.Set<java.io.File> getKotlinDirs()
 meth public final java.util.Set<java.io.File> getResourcesDirs()
 meth public final java.util.Set<java.io.File> getScalaDirs()
 meth public int hashCode()
@@ -123,6 +124,7 @@ CLSS public final static !enum org.netbeans.modules.gradle.java.api.GradleJavaSo
 fld public final static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet$SourceType GENERATED
 fld public final static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet$SourceType GROOVY
 fld public final static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet$SourceType JAVA
+fld public final static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet$SourceType KOTLIN
 fld public final static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet$SourceType RESOURCES
 fld public final static org.netbeans.modules.gradle.java.api.GradleJavaSourceSet$SourceType SCALA
 meth public java.lang.String toString()
@@ -132,6 +134,8 @@ supr java.lang.Enum<org.netbeans.modules.gradle.java.api.GradleJavaSourceSet$Sou
 
 CLSS public final org.netbeans.modules.gradle.java.api.ProjectActions
 fld public static java.lang.String TOKEN_JAVAEXEC_ARGS
+fld public static java.lang.String TOKEN_JAVAEXEC_CWD
+fld public static java.lang.String TOKEN_JAVAEXEC_ENV
 fld public static java.lang.String TOKEN_JAVAEXEC_JVMARGS
 supr java.lang.Object
 

--- a/java/i18n/nbproject/org-netbeans-modules-i18n.sig
+++ b/java/i18n/nbproject/org-netbeans-modules-i18n.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.66
+#Version 1.67
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/java/j2ee.core.utilities/nbproject/org-netbeans-modules-j2ee-core-utilities.sig
+++ b/java/j2ee.core.utilities/nbproject/org-netbeans-modules-j2ee-core-utilities.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46
+#Version 1.47
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/j2ee.eclipselink/nbproject/org-netbeans-modules-j2ee-eclipselink.sig
+++ b/java/j2ee.eclipselink/nbproject/org-netbeans-modules-j2ee-eclipselink.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.45
+#Version 1.46
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/j2ee.jpa.verification/nbproject/org-netbeans-modules-j2ee-jpa-verification.sig
+++ b/java/j2ee.jpa.verification/nbproject/org-netbeans-modules-j2ee-jpa-verification.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.48
+#Version 1.49
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/j2ee.metadata.model.support/nbproject/org-netbeans-modules-j2ee-metadata-model-support.sig
+++ b/java/j2ee.metadata.model.support/nbproject/org-netbeans-modules-j2ee-metadata-model-support.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44
+#Version 1.45
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/j2ee.metadata/nbproject/org-netbeans-modules-j2ee-metadata.sig
+++ b/java/j2ee.metadata/nbproject/org-netbeans-modules-j2ee-metadata.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.45
+#Version 1.46
 
 CLSS public java.io.IOException
 cons public init()

--- a/java/j2ee.persistence/nbproject/org-netbeans-modules-j2ee-persistence.sig
+++ b/java/j2ee.persistence/nbproject/org-netbeans-modules-j2ee-persistence.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.67.0
+#Version 1.68.0
 
 CLSS public abstract java.awt.Component
 cons protected init()
@@ -934,6 +934,7 @@ CLSS public abstract interface org.eclipse.persistence.jpa.jpql.tools.spi.IMappi
 intf java.lang.Comparable<org.eclipse.persistence.jpa.jpql.tools.spi.IMapping>
 meth public abstract boolean hasAnnotation(java.lang.Class<? extends java.lang.annotation.Annotation>)
 meth public abstract boolean isCollection()
+meth public abstract boolean isEmbeddable()
 meth public abstract boolean isProperty()
 meth public abstract boolean isRelationship()
 meth public abstract boolean isTransient()
@@ -1699,6 +1700,7 @@ cons public init(org.netbeans.modules.j2ee.persistence.spi.jpql.ManagedType,org.
 intf org.eclipse.persistence.jpa.jpql.tools.spi.IMapping
 meth public boolean hasAnnotation(java.lang.Class<? extends java.lang.annotation.Annotation>)
 meth public boolean isCollection()
+meth public boolean isEmbeddable()
 meth public boolean isProperty()
 meth public boolean isRelationship()
 meth public boolean isTransient()

--- a/java/j2ee.persistenceapi/nbproject/org-netbeans-modules-j2ee-persistenceapi.sig
+++ b/java/j2ee.persistenceapi/nbproject/org-netbeans-modules-j2ee-persistenceapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.49.0
+#Version 1.50.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.api.common/nbproject/org-netbeans-modules-java-api-common.sig
+++ b/java/java.api.common/nbproject/org-netbeans-modules-java-api-common.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.136
+#Version 1.137
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/java/java.completion/nbproject/org-netbeans-modules-java-completion.sig
+++ b/java/java.completion/nbproject/org-netbeans-modules-java-completion.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.21.0
+#Version 1.22.0
 
 CLSS public abstract interface java.io.Serializable
 
@@ -143,29 +143,38 @@ cons public init()
 fld public final static int PATTERN_MATCHING_INSTANCEOF_PREVIEW_JDK_VERSION = 15
 fld public final static java.lang.String BINDING_PATTERN = "BINDING_PATTERN"
 fld public final static java.lang.String BINDING_VARIABLE = "BINDING_VARIABLE"
+fld public final static java.lang.String DEFAULT_CASE_LABEL = "DEFAULT_CASE_LABEL"
+fld public final static java.lang.String GUARDED_PATTERN = "GUARDED_PATTERN"
+fld public final static java.lang.String NULL_LITERAL = "NULL_LITERAL"
+fld public final static java.lang.String PARENTHESIZED_PATTERN = "PARENTHESIZED_PATTERN"
 fld public final static java.lang.String RECORD = "RECORD"
 fld public final static java.lang.String SWITCH_EXPRESSION = "SWITCH_EXPRESSION"
 fld public final static java.lang.String YIELD = "YIELD"
 meth public static <%0 extends com.sun.source.tree.Tree> boolean isRecord({%%0})
 meth public static <%0 extends java.lang.Throwable> java.lang.RuntimeException throwAny(java.lang.Throwable) throws {%%0}
 meth public static boolean isJDKVersionRelease16_Or_Above()
+meth public static boolean isJDKVersionRelease17_Or_Above()
 meth public static boolean isJDKVersionSupportEnablePreview()
 meth public static boolean isRecord(javax.lang.model.element.Element)
 meth public static boolean isRecordComponent(javax.lang.model.element.Element)
 meth public static boolean isRecordComponent(javax.lang.model.element.ElementKind)
 meth public static boolean isRuleCase(com.sun.source.tree.CaseTree)
 meth public static com.sun.source.doctree.ReferenceTree getRefrenceTree(com.sun.tools.javac.tree.DocTreeMaker,com.sun.source.tree.ExpressionTree,java.lang.CharSequence,java.util.List<? extends com.sun.source.tree.Tree>,com.sun.tools.javac.util.Names,java.util.List<com.sun.tools.javac.tree.JCTree>)
+meth public static com.sun.source.tree.ExpressionTree getGuardedExpression(com.sun.source.tree.Tree)
 meth public static com.sun.source.tree.ExpressionTree getValue(com.sun.source.tree.BreakTree)
 meth public static com.sun.source.tree.ExpressionTree getYieldValue(com.sun.source.tree.Tree)
 meth public static com.sun.source.tree.ModuleTree getModule(com.sun.source.tree.CompilationUnitTree)
 meth public static com.sun.source.tree.Tree SwitchExpression(com.sun.tools.javac.tree.TreeMaker,com.sun.source.tree.ExpressionTree,java.util.List<? extends com.sun.source.tree.CaseTree>)
 meth public static com.sun.source.tree.Tree getBindingPatternType(com.sun.source.tree.Tree)
 meth public static com.sun.source.tree.Tree getBody(com.sun.source.tree.CaseTree)
+meth public static com.sun.source.tree.Tree getGuardedPattern(com.sun.source.tree.Tree)
+meth public static com.sun.source.tree.Tree getParenthesizedPattern(com.sun.source.tree.Tree)
 meth public static com.sun.source.tree.Tree getPattern(com.sun.source.tree.InstanceOfTree)
 meth public static com.sun.source.tree.Tree getTarget(com.sun.source.tree.Tree)
 meth public static java.util.List<? extends com.sun.source.tree.CaseTree> getCases(com.sun.source.tree.Tree)
 meth public static java.util.List<? extends com.sun.source.tree.ExpressionTree> getExpressions(com.sun.source.tree.CaseTree)
 meth public static java.util.List<? extends com.sun.source.tree.ExpressionTree> getExpressions(com.sun.source.tree.Tree)
+meth public static java.util.List<? extends com.sun.source.tree.Tree> getLabels(com.sun.source.tree.CaseTree)
 meth public static java.util.List<? extends com.sun.source.tree.Tree> getPermits(com.sun.source.tree.ClassTree)
 meth public static java.util.List<? extends com.sun.source.tree.Tree> getPermits(com.sun.tools.javac.tree.JCTree$JCClassDecl)
 meth public static javax.lang.model.element.Element toRecordComponent(javax.lang.model.element.Element)

--- a/java/java.freeform/nbproject/org-netbeans-modules-java-freeform.sig
+++ b/java/java.freeform/nbproject/org-netbeans-modules-java-freeform.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.56
+#Version 1.57
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.graph/nbproject/org-netbeans-modules-java-graph.sig
+++ b/java/java.graph/nbproject/org-netbeans-modules-java-graph.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.13
+#Version 1.14
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.hints.declarative.test/nbproject/org-netbeans-modules-java-hints-declarative-test.sig
+++ b/java/java.hints.declarative.test/nbproject/org-netbeans-modules-java-hints-declarative-test.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.29.0
+#Version 1.30.0
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/java/java.hints.legacy.spi/nbproject/org-netbeans-modules-java-hints-legacy-spi.sig
+++ b/java/java.hints.legacy.spi/nbproject/org-netbeans-modules-java-hints-legacy-spi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.29.0
+#Version 1.30.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/java.hints.test/nbproject/org-netbeans-modules-java-hints-test.sig
+++ b/java/java.hints.test/nbproject/org-netbeans-modules-java-hints-test.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.32.0
+#Version 1.33.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.hints/nbproject/org-netbeans-modules-java-hints.sig
+++ b/java/java.hints/nbproject/org-netbeans-modules-java-hints.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.96.0
+#Version 1.97.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.j2sedeploy/nbproject/org-netbeans-modules-java-j2sedeploy.sig
+++ b/java/java.j2sedeploy/nbproject/org-netbeans-modules-java-j2sedeploy.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.25
+#Version 1.26
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.j2seplatform/nbproject/org-netbeans-modules-java-j2seplatform.sig
+++ b/java/java.j2seplatform/nbproject/org-netbeans-modules-java-j2seplatform.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.56
+#Version 1.57
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.j2seproject/nbproject/org-netbeans-modules-java-j2seproject.sig
+++ b/java/java.j2seproject/nbproject/org-netbeans-modules-java-j2seproject.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.100.0
+#Version 1.101.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/java.lexer/nbproject/org-netbeans-modules-java-lexer.sig
+++ b/java/java.lexer/nbproject/org-netbeans-modules-java-lexer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.48
+#Version 1.49
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/java.lsp.server/nbproject/org-netbeans-modules-java-lsp-server.sig
+++ b/java/java.lsp.server/nbproject/org-netbeans-modules-java-lsp-server.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.9.0
+#Version 1.10.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.nativeimage.debugger/nbproject/org-netbeans-modules-java-nativeimage-debugger.sig
+++ b/java/java.nativeimage.debugger/nbproject/org-netbeans-modules-java-nativeimage-debugger.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.2
+#Version 0.4
 
 CLSS public java.lang.Object
 cons public init()
@@ -16,6 +16,9 @@ meth public int hashCode()
 meth public java.lang.String toString()
 
 CLSS public final org.netbeans.modules.java.nativeimage.debugger.api.NIDebugRunner
+meth public static org.netbeans.modules.nativeimage.api.debug.NIDebugger attach(java.io.File,long,java.lang.String,org.netbeans.api.project.Project,java.util.function.Consumer<org.netbeans.api.debugger.DebuggerEngine>)
 meth public static org.netbeans.modules.nativeimage.api.debug.NIDebugger start(java.io.File,java.util.List<java.lang.String>,java.lang.String,org.netbeans.api.project.Project,java.lang.String,org.netbeans.api.extexecution.ExecutionDescriptor,java.util.function.Consumer<org.netbeans.api.debugger.DebuggerEngine>)
+ anno 0 java.lang.Deprecated()
+meth public static org.netbeans.modules.nativeimage.api.debug.NIDebugger start(java.io.File,org.netbeans.modules.nativeimage.api.debug.StartDebugParameters,org.netbeans.api.project.Project,java.util.function.Consumer<org.netbeans.api.debugger.DebuggerEngine>)
 supr java.lang.Object
 

--- a/java/java.platform.ui/nbproject/org-netbeans-modules-java-platform-ui.sig
+++ b/java/java.platform.ui/nbproject/org-netbeans-modules-java-platform-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.55
+#Version 1.56
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.platform/nbproject/org-netbeans-modules-java-platform.sig
+++ b/java/java.platform/nbproject/org-netbeans-modules-java-platform.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.55
+#Version 1.56
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.preprocessorbridge/nbproject/org-netbeans-modules-java-preprocessorbridge.sig
+++ b/java/java.preprocessorbridge/nbproject/org-netbeans-modules-java-preprocessorbridge.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.62.0
+#Version 1.63.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/java.project.ui/nbproject/org-netbeans-modules-java-project-ui.sig
+++ b/java/java.project.ui/nbproject/org-netbeans-modules-java-project-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.88
+#Version 1.89
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/java/java.project/nbproject/org-netbeans-modules-java-project.sig
+++ b/java/java.project/nbproject/org-netbeans-modules-java-project.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.85
+#Version 1.86
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/java/java.source.base/nbproject/org-netbeans-modules-java-source-base.sig
+++ b/java/java.source.base/nbproject/org-netbeans-modules-java-source-base.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.52.0
+#Version 2.53.0
 
 CLSS public abstract interface com.sun.source.tree.TreeVisitor<%0 extends java.lang.Object, %1 extends java.lang.Object>
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitAnnotatedType(com.sun.source.tree.AnnotatedTypeTree,{com.sun.source.tree.TreeVisitor%1})
@@ -19,6 +19,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitCompilationUnit(co
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitCompoundAssignment(com.sun.source.tree.CompoundAssignmentTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitConditionalExpression(com.sun.source.tree.ConditionalExpressionTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitContinue(com.sun.source.tree.ContinueTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitDefaultCaseLabel(com.sun.source.tree.DefaultCaseLabelTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitDoWhileLoop(com.sun.source.tree.DoWhileLoopTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitEmptyStatement(com.sun.source.tree.EmptyStatementTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitEnhancedForLoop(com.sun.source.tree.EnhancedForLoopTree,{com.sun.source.tree.TreeVisitor%1})
@@ -26,6 +27,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitErroneous(com.sun.
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitExports(com.sun.source.tree.ExportsTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitExpressionStatement(com.sun.source.tree.ExpressionStatementTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitForLoop(com.sun.source.tree.ForLoopTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitGuardedPattern(com.sun.source.tree.GuardedPatternTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitIdentifier(com.sun.source.tree.IdentifierTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitIf(com.sun.source.tree.IfTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitImport(com.sun.source.tree.ImportTree,{com.sun.source.tree.TreeVisitor%1})
@@ -47,6 +49,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitOther(com.sun.sour
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitPackage(com.sun.source.tree.PackageTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParameterizedType(com.sun.source.tree.ParameterizedTypeTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParenthesized(com.sun.source.tree.ParenthesizedTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParenthesizedPattern(com.sun.source.tree.ParenthesizedPatternTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitPrimitiveType(com.sun.source.tree.PrimitiveTypeTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitProvides(com.sun.source.tree.ProvidesTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitRequires(com.sun.source.tree.RequiresTree,{com.sun.source.tree.TreeVisitor%1})
@@ -97,6 +100,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitCompilationUnit(com.sun.sou
 meth public {com.sun.source.util.TreeScanner%0} visitCompoundAssignment(com.sun.source.tree.CompoundAssignmentTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitConditionalExpression(com.sun.source.tree.ConditionalExpressionTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitContinue(com.sun.source.tree.ContinueTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitDefaultCaseLabel(com.sun.source.tree.DefaultCaseLabelTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitDoWhileLoop(com.sun.source.tree.DoWhileLoopTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitEmptyStatement(com.sun.source.tree.EmptyStatementTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitEnhancedForLoop(com.sun.source.tree.EnhancedForLoopTree,{com.sun.source.util.TreeScanner%1})
@@ -104,6 +108,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitErroneous(com.sun.source.tr
 meth public {com.sun.source.util.TreeScanner%0} visitExports(com.sun.source.tree.ExportsTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitExpressionStatement(com.sun.source.tree.ExpressionStatementTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitForLoop(com.sun.source.tree.ForLoopTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitGuardedPattern(com.sun.source.tree.GuardedPatternTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitIdentifier(com.sun.source.tree.IdentifierTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitIf(com.sun.source.tree.IfTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitImport(com.sun.source.tree.ImportTree,{com.sun.source.util.TreeScanner%1})
@@ -125,6 +130,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitOther(com.sun.source.tree.T
 meth public {com.sun.source.util.TreeScanner%0} visitPackage(com.sun.source.tree.PackageTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitParameterizedType(com.sun.source.tree.ParameterizedTypeTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitParenthesized(com.sun.source.tree.ParenthesizedTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitParenthesizedPattern(com.sun.source.tree.ParenthesizedPatternTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitPrimitiveType(com.sun.source.tree.PrimitiveTypeTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitProvides(com.sun.source.tree.ProvidesTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitRequires(com.sun.source.tree.RequiresTree,{com.sun.source.util.TreeScanner%1})
@@ -1327,6 +1333,8 @@ meth public com.sun.source.tree.BreakTree Break(java.lang.CharSequence)
 meth public com.sun.source.tree.CaseTree Case(com.sun.source.tree.ExpressionTree,java.util.List<? extends com.sun.source.tree.StatementTree>)
 meth public com.sun.source.tree.CaseTree Case(java.util.List<? extends com.sun.source.tree.ExpressionTree>,com.sun.source.tree.Tree)
 meth public com.sun.source.tree.CaseTree CaseMultipleLabels(java.util.List<? extends com.sun.source.tree.ExpressionTree>,java.util.List<? extends com.sun.source.tree.StatementTree>)
+meth public com.sun.source.tree.CaseTree CasePatterns(java.util.List<? extends com.sun.source.tree.Tree>,com.sun.source.tree.Tree)
+meth public com.sun.source.tree.CaseTree CasePatterns(java.util.List<? extends com.sun.source.tree.Tree>,java.util.List<? extends com.sun.source.tree.StatementTree>)
 meth public com.sun.source.tree.CaseTree addCaseStatement(com.sun.source.tree.CaseTree,com.sun.source.tree.StatementTree)
 meth public com.sun.source.tree.CaseTree insertCaseStatement(com.sun.source.tree.CaseTree,int,com.sun.source.tree.StatementTree)
 meth public com.sun.source.tree.CaseTree removeCaseStatement(com.sun.source.tree.CaseTree,com.sun.source.tree.StatementTree)
@@ -1633,7 +1641,7 @@ meth public javax.lang.model.type.TypeMirror reattributeTree(com.sun.source.tree
 meth public org.netbeans.api.lexer.TokenSequence<org.netbeans.api.java.lexer.JavaTokenId> tokensFor(com.sun.source.tree.Tree)
 meth public org.netbeans.api.lexer.TokenSequence<org.netbeans.api.java.lexer.JavaTokenId> tokensFor(com.sun.source.tree.Tree,com.sun.source.util.SourcePositions)
 supr java.lang.Object
-hfds ESCAPE_ENCODE,ESCAPE_UNENCODE,EXOTIC_ESCAPE,IGNORE_TOKENS,VARIABLE_CAN_OWN_VARIABLES,handler,info
+hfds ESCAPE_ENCODE,ESCAPE_UNENCODE,EXOTIC_ESCAPE,IGNORE_TOKENS,LOG,VARIABLE_CAN_OWN_VARIABLES,handler,info
 hcls DummyJFO,NBScope,NoImports,ParserSourcePositions,UncaughtExceptionsVisitor,UnrelatedTypeMirrorSet
 
 CLSS public final org.netbeans.api.java.source.TypeMirrorHandle<%0 extends javax.lang.model.type.TypeMirror>
@@ -1797,11 +1805,13 @@ hfds canceled,internalCanceled
 
 CLSS public org.netbeans.api.java.source.support.ErrorAwareTreePathScanner<%0 extends java.lang.Object, %1 extends java.lang.Object>
 cons public init()
+meth public {org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0} visitCase(com.sun.source.tree.CaseTree,{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1})
 meth public {org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0} visitErroneous(com.sun.source.tree.ErroneousTree,{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1})
 supr com.sun.source.util.TreePathScanner<{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0},{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1}>
 
 CLSS public org.netbeans.api.java.source.support.ErrorAwareTreeScanner<%0 extends java.lang.Object, %1 extends java.lang.Object>
 cons public init()
+meth public {org.netbeans.api.java.source.support.ErrorAwareTreeScanner%0} visitCase(com.sun.source.tree.CaseTree,{org.netbeans.api.java.source.support.ErrorAwareTreeScanner%1})
 meth public {org.netbeans.api.java.source.support.ErrorAwareTreeScanner%0} visitErroneous(com.sun.source.tree.ErroneousTree,{org.netbeans.api.java.source.support.ErrorAwareTreeScanner%1})
 supr com.sun.source.util.TreeScanner<{org.netbeans.api.java.source.support.ErrorAwareTreeScanner%0},{org.netbeans.api.java.source.support.ErrorAwareTreeScanner%1}>
 

--- a/java/java.source.compat8/nbproject/org-netbeans-modules-java-source-compat8.sig
+++ b/java/java.source.compat8/nbproject/org-netbeans-modules-java-source-compat8.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.16
+#Version 9.17
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.source.queries/nbproject/org-netbeans-modules-java-source-queries.sig
+++ b/java/java.source.queries/nbproject/org-netbeans-modules-java-source-queries.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.31
+#Version 1.32
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/java.source/nbproject/org-netbeans-modules-java-source.sig
+++ b/java/java.source/nbproject/org-netbeans-modules-java-source.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.177.0
+#Version 0.178.0
 
 CLSS public abstract interface com.sun.source.tree.TreeVisitor<%0 extends java.lang.Object, %1 extends java.lang.Object>
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitAnnotatedType(com.sun.source.tree.AnnotatedTypeTree,{com.sun.source.tree.TreeVisitor%1})
@@ -19,6 +19,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitCompilationUnit(co
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitCompoundAssignment(com.sun.source.tree.CompoundAssignmentTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitConditionalExpression(com.sun.source.tree.ConditionalExpressionTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitContinue(com.sun.source.tree.ContinueTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitDefaultCaseLabel(com.sun.source.tree.DefaultCaseLabelTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitDoWhileLoop(com.sun.source.tree.DoWhileLoopTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitEmptyStatement(com.sun.source.tree.EmptyStatementTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitEnhancedForLoop(com.sun.source.tree.EnhancedForLoopTree,{com.sun.source.tree.TreeVisitor%1})
@@ -26,6 +27,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitErroneous(com.sun.
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitExports(com.sun.source.tree.ExportsTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitExpressionStatement(com.sun.source.tree.ExpressionStatementTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitForLoop(com.sun.source.tree.ForLoopTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitGuardedPattern(com.sun.source.tree.GuardedPatternTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitIdentifier(com.sun.source.tree.IdentifierTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitIf(com.sun.source.tree.IfTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitImport(com.sun.source.tree.ImportTree,{com.sun.source.tree.TreeVisitor%1})
@@ -47,6 +49,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitOther(com.sun.sour
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitPackage(com.sun.source.tree.PackageTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParameterizedType(com.sun.source.tree.ParameterizedTypeTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParenthesized(com.sun.source.tree.ParenthesizedTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParenthesizedPattern(com.sun.source.tree.ParenthesizedPatternTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitPrimitiveType(com.sun.source.tree.PrimitiveTypeTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitProvides(com.sun.source.tree.ProvidesTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitRequires(com.sun.source.tree.RequiresTree,{com.sun.source.tree.TreeVisitor%1})
@@ -97,6 +100,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitCompilationUnit(com.sun.sou
 meth public {com.sun.source.util.TreeScanner%0} visitCompoundAssignment(com.sun.source.tree.CompoundAssignmentTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitConditionalExpression(com.sun.source.tree.ConditionalExpressionTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitContinue(com.sun.source.tree.ContinueTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitDefaultCaseLabel(com.sun.source.tree.DefaultCaseLabelTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitDoWhileLoop(com.sun.source.tree.DoWhileLoopTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitEmptyStatement(com.sun.source.tree.EmptyStatementTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitEnhancedForLoop(com.sun.source.tree.EnhancedForLoopTree,{com.sun.source.util.TreeScanner%1})
@@ -104,6 +108,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitErroneous(com.sun.source.tr
 meth public {com.sun.source.util.TreeScanner%0} visitExports(com.sun.source.tree.ExportsTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitExpressionStatement(com.sun.source.tree.ExpressionStatementTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitForLoop(com.sun.source.tree.ForLoopTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitGuardedPattern(com.sun.source.tree.GuardedPatternTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitIdentifier(com.sun.source.tree.IdentifierTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitIf(com.sun.source.tree.IfTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitImport(com.sun.source.tree.ImportTree,{com.sun.source.util.TreeScanner%1})
@@ -125,6 +130,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitOther(com.sun.source.tree.T
 meth public {com.sun.source.util.TreeScanner%0} visitPackage(com.sun.source.tree.PackageTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitParameterizedType(com.sun.source.tree.ParameterizedTypeTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitParenthesized(com.sun.source.tree.ParenthesizedTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitParenthesizedPattern(com.sun.source.tree.ParenthesizedPatternTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitPrimitiveType(com.sun.source.tree.PrimitiveTypeTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitProvides(com.sun.source.tree.ProvidesTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitRequires(com.sun.source.tree.RequiresTree,{com.sun.source.util.TreeScanner%1})
@@ -1332,6 +1338,8 @@ meth public com.sun.source.tree.BreakTree Break(java.lang.CharSequence)
 meth public com.sun.source.tree.CaseTree Case(com.sun.source.tree.ExpressionTree,java.util.List<? extends com.sun.source.tree.StatementTree>)
 meth public com.sun.source.tree.CaseTree Case(java.util.List<? extends com.sun.source.tree.ExpressionTree>,com.sun.source.tree.Tree)
 meth public com.sun.source.tree.CaseTree CaseMultipleLabels(java.util.List<? extends com.sun.source.tree.ExpressionTree>,java.util.List<? extends com.sun.source.tree.StatementTree>)
+meth public com.sun.source.tree.CaseTree CasePatterns(java.util.List<? extends com.sun.source.tree.Tree>,com.sun.source.tree.Tree)
+meth public com.sun.source.tree.CaseTree CasePatterns(java.util.List<? extends com.sun.source.tree.Tree>,java.util.List<? extends com.sun.source.tree.StatementTree>)
 meth public com.sun.source.tree.CaseTree addCaseStatement(com.sun.source.tree.CaseTree,com.sun.source.tree.StatementTree)
 meth public com.sun.source.tree.CaseTree insertCaseStatement(com.sun.source.tree.CaseTree,int,com.sun.source.tree.StatementTree)
 meth public com.sun.source.tree.CaseTree removeCaseStatement(com.sun.source.tree.CaseTree,com.sun.source.tree.StatementTree)
@@ -1638,7 +1646,7 @@ meth public javax.lang.model.type.TypeMirror reattributeTree(com.sun.source.tree
 meth public org.netbeans.api.lexer.TokenSequence<org.netbeans.api.java.lexer.JavaTokenId> tokensFor(com.sun.source.tree.Tree)
 meth public org.netbeans.api.lexer.TokenSequence<org.netbeans.api.java.lexer.JavaTokenId> tokensFor(com.sun.source.tree.Tree,com.sun.source.util.SourcePositions)
 supr java.lang.Object
-hfds ESCAPE_ENCODE,ESCAPE_UNENCODE,EXOTIC_ESCAPE,IGNORE_TOKENS,VARIABLE_CAN_OWN_VARIABLES,handler,info
+hfds ESCAPE_ENCODE,ESCAPE_UNENCODE,EXOTIC_ESCAPE,IGNORE_TOKENS,LOG,VARIABLE_CAN_OWN_VARIABLES,handler,info
 hcls DummyJFO,NBScope,NoImports,ParserSourcePositions,UncaughtExceptionsVisitor,UnrelatedTypeMirrorSet
 
 CLSS public final org.netbeans.api.java.source.TypeMirrorHandle<%0 extends javax.lang.model.type.TypeMirror>
@@ -1866,11 +1874,13 @@ hcls ChangeListenerImpl
 
 CLSS public org.netbeans.api.java.source.support.ErrorAwareTreePathScanner<%0 extends java.lang.Object, %1 extends java.lang.Object>
 cons public init()
+meth public {org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0} visitCase(com.sun.source.tree.CaseTree,{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1})
 meth public {org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0} visitErroneous(com.sun.source.tree.ErroneousTree,{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1})
 supr com.sun.source.util.TreePathScanner<{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0},{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1}>
 
 CLSS public org.netbeans.api.java.source.support.ErrorAwareTreeScanner<%0 extends java.lang.Object, %1 extends java.lang.Object>
 cons public init()
+meth public {org.netbeans.api.java.source.support.ErrorAwareTreeScanner%0} visitCase(com.sun.source.tree.CaseTree,{org.netbeans.api.java.source.support.ErrorAwareTreeScanner%1})
 meth public {org.netbeans.api.java.source.support.ErrorAwareTreeScanner%0} visitErroneous(com.sun.source.tree.ErroneousTree,{org.netbeans.api.java.source.support.ErrorAwareTreeScanner%1})
 supr com.sun.source.util.TreeScanner<{org.netbeans.api.java.source.support.ErrorAwareTreeScanner%0},{org.netbeans.api.java.source.support.ErrorAwareTreeScanner%1}>
 

--- a/java/java.sourceui/nbproject/org-netbeans-modules-java-sourceui.sig
+++ b/java/java.sourceui/nbproject/org-netbeans-modules-java-sourceui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.59.0
+#Version 1.60.0
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/java/java.testrunner.ant/nbproject/org-netbeans-modules-java-testrunner-ant.sig
+++ b/java/java.testrunner.ant/nbproject/org-netbeans-modules-java-testrunner-ant.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.15
+#Version 1.16
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/java.testrunner.ui/nbproject/org-netbeans-modules-java-testrunner-ui.sig
+++ b/java/java.testrunner.ui/nbproject/org-netbeans-modules-java-testrunner-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.17
+#Version 1.18
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/java/java.testrunner/nbproject/org-netbeans-modules-java-testrunner.sig
+++ b/java/java.testrunner/nbproject/org-netbeans-modules-java-testrunner.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.33
+#Version 1.34
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/javaee.injection/nbproject/org-netbeans-modules-javaee-injection.sig
+++ b/java/javaee.injection/nbproject/org-netbeans-modules-javaee-injection.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.19
+#Version 1.20
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/jellytools.java/nbproject/org-netbeans-modules-jellytools-java.sig
+++ b/java/jellytools.java/nbproject/org-netbeans-modules-jellytools-java.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.43
+#Version 3.44
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/java/junit.ui/nbproject/org-netbeans-modules-junit-ui.sig
+++ b/java/junit.ui/nbproject/org-netbeans-modules-junit-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.20
+#Version 1.21
 
 CLSS public java.beans.FeatureDescriptor
 cons public init()

--- a/java/junit/nbproject/org-netbeans-modules-junit.sig
+++ b/java/junit/nbproject/org-netbeans-modules-junit.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.87
+#Version 2.88
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/lib.nbjshell/nbproject/org-netbeans-lib-nbjshell.sig
+++ b/java/lib.nbjshell/nbproject/org-netbeans-lib-nbjshell.sig
@@ -1,3 +1,3 @@
 #Signature file v4.1
-#Version 1.15
+#Version 1.16
 

--- a/java/libs.cglib/nbproject/org-netbeans-libs-cglib.sig
+++ b/java/libs.cglib/nbproject/org-netbeans-libs-cglib.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.39
+#Version 1.40
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/libs.corba.omgapi/nbproject/org-netbeans-modules-libs-corba-omgapi.sig
+++ b/java/libs.corba.omgapi/nbproject/org-netbeans-modules-libs-corba-omgapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.8
+#Version 1.9
 
 CLSS public com.sun.corba.ee.org.omg.CORBA.GetPropertyAction
 cons public init(java.lang.String)

--- a/java/libs.jshell.compile/nbproject/org-netbeans-libs-jshell-compile.sig
+++ b/java/libs.jshell.compile/nbproject/org-netbeans-libs-jshell-compile.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.19.0
+#Version 1.20.0
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/java/maven.embedder/nbproject/org-netbeans-modules-maven-embedder.sig
+++ b/java/maven.embedder/nbproject/org-netbeans-modules-maven-embedder.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.66
+#Version 2.67
 
 CLSS public abstract interface !annotation com.google.common.annotations.Beta
  anno 0 com.google.common.annotations.GwtCompatible(boolean emulated=false, boolean serializable=false)

--- a/java/maven.grammar/nbproject/org-netbeans-modules-maven-grammar.sig
+++ b/java/maven.grammar/nbproject/org-netbeans-modules-maven-grammar.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.60.0
+#Version 1.61.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/maven.indexer.ui/nbproject/org-netbeans-modules-maven-indexer-ui.sig
+++ b/java/maven.indexer.ui/nbproject/org-netbeans-modules-maven-indexer-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.47
+#Version 2.48
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/maven.indexer/nbproject/org-netbeans-modules-maven-indexer.sig
+++ b/java/maven.indexer/nbproject/org-netbeans-modules-maven-indexer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.53
+#Version 2.54
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/java/maven.model/nbproject/org-netbeans-modules-maven-model.sig
+++ b/java/maven.model/nbproject/org-netbeans-modules-maven-model.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.57
+#Version 1.58
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/maven/nbproject/org-netbeans-modules-maven.sig
+++ b/java/maven/nbproject/org-netbeans-modules-maven.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.150
+#Version 2.151
 
 CLSS public abstract java.awt.Component
 cons protected init()
@@ -1160,6 +1160,7 @@ hcls AccessorImpl,FCHSL
 
 CLSS public org.netbeans.modules.maven.api.PluginPropertyUtils
 innr public abstract interface static ConfigurationBuilder
+innr public final static PluginConfigPathParams
 meth public static <%0 extends java.lang.Object> {%%0} getPluginPropertyBuildable(org.apache.maven.project.MavenProject,java.lang.String,java.lang.String,java.lang.String,org.netbeans.modules.maven.api.PluginPropertyUtils$ConfigurationBuilder<{%%0}>)
  anno 1 org.netbeans.api.annotations.common.NonNull()
  anno 2 org.netbeans.api.annotations.common.NonNull()
@@ -1260,6 +1261,11 @@ meth public static java.lang.String[] getReportPluginPropertyList(org.netbeans.a
  anno 4 org.netbeans.api.annotations.common.NonNull()
  anno 5 org.netbeans.api.annotations.common.NonNull()
  anno 6 org.netbeans.api.annotations.common.NullAllowed()
+meth public static java.util.List<org.apache.maven.artifact.Artifact> getPluginPathProperty(org.netbeans.api.project.Project,org.netbeans.modules.maven.api.PluginPropertyUtils$PluginConfigPathParams,boolean,java.util.List<org.apache.maven.artifact.resolver.ArtifactResolutionException>)
+ anno 0 org.netbeans.api.annotations.common.CheckForNull()
+ anno 1 org.netbeans.api.annotations.common.NonNull()
+ anno 2 org.netbeans.api.annotations.common.NonNull()
+ anno 4 org.netbeans.api.annotations.common.NullAllowed()
 meth public static java.util.Properties getPluginPropertyParameter(org.apache.maven.project.MavenProject,java.lang.String,java.lang.String,java.lang.String,java.lang.String)
  anno 0 org.netbeans.api.annotations.common.CheckForNull()
  anno 1 org.netbeans.api.annotations.common.NonNull()
@@ -1282,11 +1288,27 @@ meth public static org.codehaus.plexus.component.configurator.expression.Express
  anno 1 org.netbeans.api.annotations.common.NonNull()
 supr java.lang.Object
 hfds CONTEXT_EXPRESSION_EVALUATOR,DUMMY_EVALUATOR,LIFECYCLE_PLUGINS
-hcls ExternalDefaultBuilder
+hcls DependencyListBuilder,ExternalDefaultBuilder
 
 CLSS public abstract interface static org.netbeans.modules.maven.api.PluginPropertyUtils$ConfigurationBuilder<%0 extends java.lang.Object>
  outer org.netbeans.modules.maven.api.PluginPropertyUtils
 meth public abstract {org.netbeans.modules.maven.api.PluginPropertyUtils$ConfigurationBuilder%0} build(org.codehaus.plexus.util.xml.Xpp3Dom,org.codehaus.plexus.component.configurator.expression.ExpressionEvaluator)
+
+CLSS public final static org.netbeans.modules.maven.api.PluginPropertyUtils$PluginConfigPathParams
+ outer org.netbeans.modules.maven.api.PluginPropertyUtils
+cons public init(java.lang.String,java.lang.String,java.lang.String,java.lang.String)
+meth public java.lang.String getArtifactType()
+meth public java.lang.String getDefaultScope()
+meth public java.lang.String getGoal()
+meth public java.lang.String getPathItemName()
+meth public java.lang.String getPathProperty()
+meth public java.lang.String getPluginArtifactId()
+meth public java.lang.String getPluginGroupId()
+meth public void setArtifactType(java.lang.String)
+meth public void setDefaultScope(java.lang.String)
+meth public void setGoal(java.lang.String)
+supr java.lang.Object
+hfds artifactType,defaultScope,goal,pathItemName,pathProperty,pluginArtifactId,pluginGroupId
 
 CLSS public abstract interface org.netbeans.modules.maven.api.ProjectProfileHandler
 meth public abstract java.util.List<java.lang.String> getActiveProfiles(boolean)
@@ -1955,6 +1977,7 @@ meth public static org.openide.execution.ExecutorTask executeMaven(org.netbeans.
 meth public void run()
 supr org.netbeans.modules.maven.execute.AbstractMavenExecutor
 hfds ENV_JAVAHOME,ENV_PREFIX,INTERNAL_PREFIX,KEY_UUID,LOGGER,NETBEANS_MAVEN_COMMAND_LINE,RP,UPDATE_INDEX_RP,VER17,preProcess,preProcessUUID,process,processUUID
+hcls WrapperShellConstructor
 
 CLSS public static org.netbeans.modules.maven.execute.MavenCommandLineExecutor$ExecuteMaven
  outer org.netbeans.modules.maven.execute.MavenCommandLineExecutor

--- a/java/projectimport.eclipse.core/nbproject/org-netbeans-modules-projectimport-eclipse-core.sig
+++ b/java/projectimport.eclipse.core/nbproject/org-netbeans-modules-projectimport-eclipse-core.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.43
+#Version 2.44
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/refactoring.java/nbproject/org-netbeans-modules-refactoring-java.sig
+++ b/java/refactoring.java/nbproject/org-netbeans-modules-refactoring-java.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.74.0
+#Version 1.75.0
 
 CLSS public abstract interface com.sun.source.doctree.DocTreeVisitor<%0 extends java.lang.Object, %1 extends java.lang.Object>
 meth public abstract {com.sun.source.doctree.DocTreeVisitor%0} visitAttribute(com.sun.source.doctree.AttributeTree,{com.sun.source.doctree.DocTreeVisitor%1})
@@ -57,6 +57,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitCompilationUnit(co
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitCompoundAssignment(com.sun.source.tree.CompoundAssignmentTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitConditionalExpression(com.sun.source.tree.ConditionalExpressionTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitContinue(com.sun.source.tree.ContinueTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitDefaultCaseLabel(com.sun.source.tree.DefaultCaseLabelTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitDoWhileLoop(com.sun.source.tree.DoWhileLoopTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitEmptyStatement(com.sun.source.tree.EmptyStatementTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitEnhancedForLoop(com.sun.source.tree.EnhancedForLoopTree,{com.sun.source.tree.TreeVisitor%1})
@@ -64,6 +65,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitErroneous(com.sun.
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitExports(com.sun.source.tree.ExportsTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitExpressionStatement(com.sun.source.tree.ExpressionStatementTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitForLoop(com.sun.source.tree.ForLoopTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitGuardedPattern(com.sun.source.tree.GuardedPatternTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitIdentifier(com.sun.source.tree.IdentifierTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitIf(com.sun.source.tree.IfTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitImport(com.sun.source.tree.ImportTree,{com.sun.source.tree.TreeVisitor%1})
@@ -85,6 +87,7 @@ meth public abstract {com.sun.source.tree.TreeVisitor%0} visitOther(com.sun.sour
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitPackage(com.sun.source.tree.PackageTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParameterizedType(com.sun.source.tree.ParameterizedTypeTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParenthesized(com.sun.source.tree.ParenthesizedTree,{com.sun.source.tree.TreeVisitor%1})
+meth public abstract {com.sun.source.tree.TreeVisitor%0} visitParenthesizedPattern(com.sun.source.tree.ParenthesizedPatternTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitPrimitiveType(com.sun.source.tree.PrimitiveTypeTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitProvides(com.sun.source.tree.ProvidesTree,{com.sun.source.tree.TreeVisitor%1})
 meth public abstract {com.sun.source.tree.TreeVisitor%0} visitRequires(com.sun.source.tree.RequiresTree,{com.sun.source.tree.TreeVisitor%1})
@@ -135,6 +138,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitCompilationUnit(com.sun.sou
 meth public {com.sun.source.util.TreeScanner%0} visitCompoundAssignment(com.sun.source.tree.CompoundAssignmentTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitConditionalExpression(com.sun.source.tree.ConditionalExpressionTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitContinue(com.sun.source.tree.ContinueTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitDefaultCaseLabel(com.sun.source.tree.DefaultCaseLabelTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitDoWhileLoop(com.sun.source.tree.DoWhileLoopTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitEmptyStatement(com.sun.source.tree.EmptyStatementTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitEnhancedForLoop(com.sun.source.tree.EnhancedForLoopTree,{com.sun.source.util.TreeScanner%1})
@@ -142,6 +146,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitErroneous(com.sun.source.tr
 meth public {com.sun.source.util.TreeScanner%0} visitExports(com.sun.source.tree.ExportsTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitExpressionStatement(com.sun.source.tree.ExpressionStatementTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitForLoop(com.sun.source.tree.ForLoopTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitGuardedPattern(com.sun.source.tree.GuardedPatternTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitIdentifier(com.sun.source.tree.IdentifierTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitIf(com.sun.source.tree.IfTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitImport(com.sun.source.tree.ImportTree,{com.sun.source.util.TreeScanner%1})
@@ -163,6 +168,7 @@ meth public {com.sun.source.util.TreeScanner%0} visitOther(com.sun.source.tree.T
 meth public {com.sun.source.util.TreeScanner%0} visitPackage(com.sun.source.tree.PackageTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitParameterizedType(com.sun.source.tree.ParameterizedTypeTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitParenthesized(com.sun.source.tree.ParenthesizedTree,{com.sun.source.util.TreeScanner%1})
+meth public {com.sun.source.util.TreeScanner%0} visitParenthesizedPattern(com.sun.source.tree.ParenthesizedPatternTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitPrimitiveType(com.sun.source.tree.PrimitiveTypeTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitProvides(com.sun.source.tree.ProvidesTree,{com.sun.source.util.TreeScanner%1})
 meth public {com.sun.source.util.TreeScanner%0} visitRequires(com.sun.source.tree.RequiresTree,{com.sun.source.util.TreeScanner%1})
@@ -257,6 +263,7 @@ meth public abstract void run({org.netbeans.api.java.source.Task%0}) throws java
 
 CLSS public org.netbeans.api.java.source.support.ErrorAwareTreePathScanner<%0 extends java.lang.Object, %1 extends java.lang.Object>
 cons public init()
+meth public {org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0} visitCase(com.sun.source.tree.CaseTree,{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1})
 meth public {org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0} visitErroneous(com.sun.source.tree.ErroneousTree,{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1})
 supr com.sun.source.util.TreePathScanner<{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%0},{org.netbeans.api.java.source.support.ErrorAwareTreePathScanner%1}>
 

--- a/java/selenium2.java/nbproject/org-netbeans-modules-selenium2-java.sig
+++ b/java/selenium2.java/nbproject/org-netbeans-modules-selenium2-java.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.15
+#Version 1.16
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/spi.debugger.jpda.ui/nbproject/org-netbeans-spi-debugger-jpda-ui.sig
+++ b/java/spi.debugger.jpda.ui/nbproject/org-netbeans-spi-debugger-jpda-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.16
+#Version 3.17
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/spi.java.hints/nbproject/org-netbeans-spi-java-hints.sig
+++ b/java/spi.java.hints/nbproject/org-netbeans-spi-java-hints.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44.0
+#Version 1.45.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/spring.beans/nbproject/org-netbeans-modules-spring-beans.sig
+++ b/java/spring.beans/nbproject/org-netbeans-modules-spring-beans.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.53.0
+#Version 1.54.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/testng/nbproject/org-netbeans-modules-testng.sig
+++ b/java/testng/nbproject/org-netbeans-modules-testng.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.33
+#Version 2.34
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/websvc.jaxws21/nbproject/org-netbeans-modules-websvc-jaxws21.sig
+++ b/java/websvc.jaxws21/nbproject/org-netbeans-modules-websvc-jaxws21.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.45
+#Version 1.46
 
 CLSS public abstract com.sun.codemodel.CodeWriter
 cons public init()

--- a/java/websvc.jaxws21api/nbproject/org-netbeans-modules-websvc-jaxws21api.sig
+++ b/java/websvc.jaxws21api/nbproject/org-netbeans-modules-websvc-jaxws21api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.45
+#Version 1.46
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/websvc.saas.codegen.java/nbproject/org-netbeans-modules-websvc-saas-codegen-java.sig
+++ b/java/websvc.saas.codegen.java/nbproject/org-netbeans-modules-websvc-saas-codegen-java.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.43
+#Version 1.44
 
 CLSS public java.lang.Object
 cons public init()

--- a/java/whitelist/nbproject/org-netbeans-modules-whitelist.sig
+++ b/java/whitelist/nbproject/org-netbeans-modules-whitelist.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.36
+#Version 1.37
 
 CLSS public abstract interface java.io.Serializable
 

--- a/java/xml.jaxb/nbproject/org-netbeans-modules-xml-jaxb.sig
+++ b/java/xml.jaxb/nbproject/org-netbeans-modules-xml-jaxb.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.43
+#Version 1.44
 
 CLSS public abstract interface org.netbeans.modules.xml.jaxb.spi.JAXBWizModuleConstants
 fld public final static java.lang.String CATALOG_FILE = "jaxb.catalog.file"

--- a/javafx/javafx2.editor/nbproject/org-netbeans-modules-javafx2-editor.sig
+++ b/javafx/javafx2.editor/nbproject/org-netbeans-modules-javafx2-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.34.0
+#Version 1.35.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/javafx/javafx2.platform/nbproject/org-netbeans-modules-javafx2-platform.sig
+++ b/javafx/javafx2.platform/nbproject/org-netbeans-modules-javafx2-platform.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.39
+#Version 1.40
 
 CLSS public abstract interface java.io.Serializable
 

--- a/javafx/javafx2.project/nbproject/org-netbeans-modules-javafx2-project.sig
+++ b/javafx/javafx2.project/nbproject/org-netbeans-modules-javafx2-project.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.43
+#Version 1.44
 
 CLSS public java.lang.Object
 cons public init()

--- a/php/languages.neon/nbproject/org-netbeans-modules-languages-neon.sig
+++ b/php/languages.neon/nbproject/org-netbeans-modules-languages-neon.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.35
+#Version 1.36
 
 CLSS public abstract interface java.lang.annotation.Annotation
 meth public abstract boolean equals(java.lang.Object)

--- a/php/libs.javacup/nbproject/org-netbeans-libs-javacup.sig
+++ b/php/libs.javacup/nbproject/org-netbeans-libs-javacup.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.37.0
+#Version 1.38.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/php/php.api.annotation/nbproject/org-netbeans-modules-php-api-annotation.sig
+++ b/php/php.api.annotation/nbproject/org-netbeans-modules-php-api-annotation.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.31
+#Version 0.32
 
 CLSS public java.lang.Object
 cons public init()

--- a/php/php.api.documentation/nbproject/org-netbeans-modules-php-api-documentation.sig
+++ b/php/php.api.documentation/nbproject/org-netbeans-modules-php-api-documentation.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.26
+#Version 0.27
 
 CLSS public java.lang.Object
 cons public init()

--- a/php/php.api.editor/nbproject/org-netbeans-modules-php-api-editor.sig
+++ b/php/php.api.editor/nbproject/org-netbeans-modules-php-api-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.39
+#Version 0.40
 
 CLSS public java.lang.Object
 cons public init()

--- a/php/php.api.executable/nbproject/org-netbeans-modules-php-api-executable.sig
+++ b/php/php.api.executable/nbproject/org-netbeans-modules-php-api-executable.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.43
+#Version 0.44
 
 CLSS public abstract interface java.io.Serializable
 

--- a/php/php.api.framework/nbproject/org-netbeans-modules-php-api-framework.sig
+++ b/php/php.api.framework/nbproject/org-netbeans-modules-php-api-framework.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.38
+#Version 0.39
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/php/php.api.phpmodule/nbproject/org-netbeans-modules-php-api-phpmodule.sig
+++ b/php/php.api.phpmodule/nbproject/org-netbeans-modules-php-api-phpmodule.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.77
+#Version 2.78
 
 CLSS public abstract interface java.io.Serializable
 

--- a/php/php.api.templates/nbproject/org-netbeans-modules-php-api-templates.sig
+++ b/php/php.api.templates/nbproject/org-netbeans-modules-php-api-templates.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.22
+#Version 0.23
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/php/php.api.testing/nbproject/org-netbeans-modules-php-api-testing.sig
+++ b/php/php.api.testing/nbproject/org-netbeans-modules-php-api-testing.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.32
+#Version 0.33
 
 CLSS public abstract interface java.io.Serializable
 

--- a/php/php.composer/nbproject/org-netbeans-modules-php-composer.sig
+++ b/php/php.composer/nbproject/org-netbeans-modules-php-composer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.43
+#Version 0.44
 
 CLSS public java.lang.Object
 cons public init()

--- a/php/php.editor/nbproject/org-netbeans-modules-php-editor.sig
+++ b/php/php.editor/nbproject/org-netbeans-modules-php-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.4.0
+#Version 2.5.0
 
 CLSS public abstract interface java.beans.PropertyChangeListener
 intf java.util.EventListener
@@ -1461,11 +1461,13 @@ meth public static org.netbeans.modules.php.editor.model.NamespaceScope getNames
  anno 0 org.netbeans.api.annotations.common.CheckForNull()
 meth public static org.netbeans.modules.php.editor.model.NamespaceScope getNamespaceScope(org.netbeans.modules.php.editor.model.ModelElement)
  anno 0 org.netbeans.api.annotations.common.CheckForNull()
+meth public static org.netbeans.modules.php.editor.model.NamespaceScope getNamespaceScope(org.netbeans.modules.php.editor.parser.PHPParseResult,int)
 meth public static org.netbeans.modules.php.editor.model.NamespaceScope getNamespaceScope(org.netbeans.modules.php.editor.parser.astnodes.NamespaceDeclaration,org.netbeans.modules.php.editor.model.FileScope)
 meth public static org.netbeans.modules.php.editor.model.TypeScope getTypeScope(org.netbeans.modules.php.editor.model.ModelElement)
  anno 0 org.netbeans.api.annotations.common.CheckForNull()
 supr java.lang.Object
 hfds LOGGER,RP
+hcls NamespaceDeclarationVisitor
 
 CLSS public abstract interface static org.netbeans.modules.php.editor.model.ModelUtils$ElementFilter<%0 extends org.netbeans.modules.php.editor.model.ModelElement>
  outer org.netbeans.modules.php.editor.model.ModelUtils

--- a/php/php.project/nbproject/org-netbeans-modules-php-project.sig
+++ b/php/php.project/nbproject/org-netbeans-modules-php-project.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.152
+#Version 2.153
 
 CLSS public abstract interface java.beans.PropertyChangeListener
 intf java.util.EventListener

--- a/platform/api.annotations.common/nbproject/org-netbeans-api-annotations-common.sig
+++ b/platform/api.annotations.common/nbproject/org-netbeans-api-annotations-common.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.41
+#Version 1.42
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/api.htmlui/nbproject/org-netbeans-api-htmlui.sig
+++ b/platform/api.htmlui/nbproject/org-netbeans-api-htmlui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.20
+#Version 1.21
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/api.intent/nbproject/org-netbeans-api-intent.sig
+++ b/platform/api.intent/nbproject/org-netbeans-api-intent.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.15
+#Version 1.16
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/api.io/nbproject/org-netbeans-api-io.sig
+++ b/platform/api.io/nbproject/org-netbeans-api-io.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.16
+#Version 1.17
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/platform/api.progress.compat8/nbproject/org-netbeans-api-progress-compat8.sig
+++ b/platform/api.progress.compat8/nbproject/org-netbeans-api-progress-compat8.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.60
+#Version 1.61
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/api.progress.nb/nbproject/org-netbeans-api-progress-nb.sig
+++ b/platform/api.progress.nb/nbproject/org-netbeans-api-progress-nb.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.61
+#Version 1.62
 
 CLSS public abstract interface java.lang.AutoCloseable
 meth public abstract void close() throws java.lang.Exception

--- a/platform/api.progress/nbproject/org-netbeans-api-progress.sig
+++ b/platform/api.progress/nbproject/org-netbeans-api-progress.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.61
+#Version 1.62
 
 CLSS public abstract interface java.lang.AutoCloseable
 meth public abstract void close() throws java.lang.Exception

--- a/platform/api.scripting/nbproject/org-netbeans-api-scripting.sig
+++ b/platform/api.scripting/nbproject/org-netbeans-api-scripting.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.10
+#Version 1.11
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/api.search/nbproject/org-netbeans-api-search.sig
+++ b/platform/api.search/nbproject/org-netbeans-api-search.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.34
+#Version 1.35
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/api.templates/nbproject/org-netbeans-api-templates.sig
+++ b/platform/api.templates/nbproject/org-netbeans-api-templates.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.21
+#Version 1.22
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/api.visual/nbproject/org-netbeans-api-visual.sig
+++ b/platform/api.visual/nbproject/org-netbeans-api-visual.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.61
+#Version 2.62
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/autoupdate.services/nbproject/org-netbeans-modules-autoupdate-services.sig
+++ b/platform/autoupdate.services/nbproject/org-netbeans-modules-autoupdate-services.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.68
+#Version 1.69
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/autoupdate.ui/nbproject/org-netbeans-modules-autoupdate-ui.sig
+++ b/platform/autoupdate.ui/nbproject/org-netbeans-modules-autoupdate-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.59
+#Version 1.60
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/core.multitabs/nbproject/org-netbeans-core-multitabs.sig
+++ b/platform/core.multitabs/nbproject/org-netbeans-core-multitabs.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.25.0
+#Version 1.26.0
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/platform/core.multiview/nbproject/org-netbeans-core-multiview.sig
+++ b/platform/core.multiview/nbproject/org-netbeans-core-multiview.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.57
+#Version 1.58
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/core.netigso/nbproject/org-netbeans-core-netigso.sig
+++ b/platform/core.netigso/nbproject/org-netbeans-core-netigso.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44
+#Version 1.45
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/core.network/nbproject/org-netbeans-core-network.sig
+++ b/platform/core.network/nbproject/org-netbeans-core-network.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.25
+#Version 1.26
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/core.startup.base/nbproject/org-netbeans-core-startup-base.sig
+++ b/platform/core.startup.base/nbproject/org-netbeans-core-startup-base.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.75.0
+#Version 1.76.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/core.startup/nbproject/org-netbeans-core-startup.sig
+++ b/platform/core.startup/nbproject/org-netbeans-core-startup.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.75.0
+#Version 1.76.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/core.windows/nbproject/org-netbeans-core-windows.sig
+++ b/platform/core.windows/nbproject/org-netbeans-core-windows.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.98
+#Version 2.99
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/platform/editor.mimelookup/nbproject/org-netbeans-modules-editor-mimelookup.sig
+++ b/platform/editor.mimelookup/nbproject/org-netbeans-modules-editor-mimelookup.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.53
+#Version 1.54
 
 CLSS public abstract interface !annotation java.lang.Deprecated
  anno 0 java.lang.annotation.Documented()

--- a/platform/favorites/nbproject/org-netbeans-modules-favorites.sig
+++ b/platform/favorites/nbproject/org-netbeans-modules-favorites.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.59
+#Version 1.60
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/javahelp/nbproject/org-netbeans-modules-javahelp.sig
+++ b/platform/javahelp/nbproject/org-netbeans-modules-javahelp.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.54
+#Version 2.55
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/keyring.fallback/nbproject/org-netbeans-modules-keyring-fallback.sig
+++ b/platform/keyring.fallback/nbproject/org-netbeans-modules-keyring-fallback.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.21
+#Version 1.22
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/keyring/nbproject/org-netbeans-modules-keyring.sig
+++ b/platform/keyring/nbproject/org-netbeans-modules-keyring.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.37
+#Version 1.38
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/lib.uihandler/nbproject/org-netbeans-lib-uihandler.sig
+++ b/platform/lib.uihandler/nbproject/org-netbeans-lib-uihandler.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.58
+#Version 1.59
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/libs.batik.read/nbproject/org-netbeans-libs-batik-read.sig
+++ b/platform/libs.batik.read/nbproject/org-netbeans-libs-batik-read.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.6.0
+#Version 1.7.0
 
 CLSS public java.awt.Color
 cons public init(float,float,float)

--- a/platform/libs.flatlaf/nbproject/org-netbeans-libs-flatlaf.sig
+++ b/platform/libs.flatlaf/nbproject/org-netbeans-libs-flatlaf.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.7
+#Version 1.8
 
 CLSS public abstract interface com.formdev.flatlaf.FlatClientProperties
 fld public final static java.lang.String BUTTON_TYPE = "JButton.buttonType"
@@ -154,6 +154,7 @@ supr com.formdev.flatlaf.FlatLightLaf
 
 CLSS public abstract com.formdev.flatlaf.FlatLaf
 cons public init()
+fld public final static java.lang.Object NULL_VALUE
 innr public abstract interface static DisabledIconProvider
 meth protected java.util.List<java.lang.Class<?>> getLafClassesForDefaultsLoading()
 meth protected java.util.Properties getAdditionalDefaults()
@@ -182,6 +183,7 @@ meth public static void registerCustomDefaultsSource(java.lang.String)
 meth public static void registerCustomDefaultsSource(java.lang.String,java.lang.ClassLoader)
 meth public static void repaintAllFramesAndDialogs()
 meth public static void revalidateAndRepaintAllFramesAndDialogs()
+meth public static void runWithUIDefaultsGetter(java.util.function.Function<java.lang.Object,java.lang.Object>,java.lang.Runnable)
 meth public static void setUseNativeWindowDecorations(boolean)
 meth public static void showMnemonics(java.awt.Component)
 meth public static void unregisterCustomDefaultsSource(java.io.File)
@@ -190,10 +192,12 @@ meth public static void unregisterCustomDefaultsSource(java.lang.String,java.lan
 meth public static void updateUI()
 meth public static void updateUILater()
 meth public void initialize()
+meth public void registerUIDefaultsGetter(java.util.function.Function<java.lang.Object,java.lang.Object>)
 meth public void uninitialize()
+meth public void unregisterUIDefaultsGetter(java.util.function.Function<java.lang.Object,java.lang.Object>)
 supr javax.swing.plaf.basic.BasicLookAndFeel
-hfds DESKTOPFONTHINTS,aquaLoaded,customDefaultsSources,desktopPropertyListener,desktopPropertyName,desktopPropertyName2,mnemonicHandler,oldPopupFactory,postInitialization,updateUIPending
-hcls ActiveFont,ImageIconUIResource
+hfds DESKTOPFONTHINTS,aquaLoaded,customDefaultsSources,desktopPropertyListener,desktopPropertyName,desktopPropertyName2,mnemonicHandler,oldPopupFactory,postInitialization,uiDefaultsGetters,updateUIPending
+hcls ActiveFont,FlatUIDefaults,ImageIconUIResource
 
 CLSS public abstract interface static com.formdev.flatlaf.FlatLaf$DisabledIconProvider
  outer com.formdev.flatlaf.FlatLaf
@@ -321,7 +325,9 @@ CLSS public com.formdev.flatlaf.util.ColorFunctions
 cons public init()
 innr public abstract interface static ColorFunction
 innr public static Fade
+innr public static HSLChange
 innr public static HSLIncreaseDecrease
+innr public static Mix
 meth public !varargs static java.awt.Color applyFunctions(java.awt.Color,com.formdev.flatlaf.util.ColorFunctions$ColorFunction[])
 meth public static float clamp(float)
 meth public static java.awt.Color mix(java.awt.Color,java.awt.Color,float)
@@ -340,6 +346,16 @@ meth public java.lang.String toString()
 meth public void apply(float[])
 supr java.lang.Object
 
+CLSS public static com.formdev.flatlaf.util.ColorFunctions$HSLChange
+ outer com.formdev.flatlaf.util.ColorFunctions
+cons public init(int,float)
+fld public final float value
+fld public final int hslIndex
+intf com.formdev.flatlaf.util.ColorFunctions$ColorFunction
+meth public java.lang.String toString()
+meth public void apply(float[])
+supr java.lang.Object
+
 CLSS public static com.formdev.flatlaf.util.ColorFunctions$HSLIncreaseDecrease
  outer com.formdev.flatlaf.util.ColorFunctions
 cons public init(int,boolean,float,boolean,boolean)
@@ -350,6 +366,16 @@ fld public final float amount
 fld public final int hslIndex
 intf com.formdev.flatlaf.util.ColorFunctions$ColorFunction
 meth protected boolean shouldInverse(float[])
+meth public java.lang.String toString()
+meth public void apply(float[])
+supr java.lang.Object
+
+CLSS public static com.formdev.flatlaf.util.ColorFunctions$Mix
+ outer com.formdev.flatlaf.util.ColorFunctions
+cons public init(java.awt.Color,float)
+fld public final float weight
+fld public final java.awt.Color color2
+intf com.formdev.flatlaf.util.ColorFunctions$ColorFunction
 meth public java.lang.String toString()
 meth public void apply(float[])
 supr java.lang.Object

--- a/platform/libs.javafx/nbproject/org-netbeans-libs-javafx.sig
+++ b/platform/libs.javafx/nbproject/org-netbeans-libs-javafx.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.20
+#Version 2.21
 
 CLSS public abstract interface !annotation com.sun.javafx.beans.IDProperty
  anno 0 java.lang.annotation.Documented()

--- a/platform/libs.jna.platform/nbproject/org-netbeans-libs-jna-platform.sig
+++ b/platform/libs.jna.platform/nbproject/org-netbeans-libs-jna-platform.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.8
+#Version 2.9
 
 CLSS public abstract interface com.sun.jna.AltCallingConvention
 
@@ -22485,8 +22485,6 @@ meth public java.awt.im.InputMethodRequests getInputMethodRequests()
 meth public java.awt.image.ColorModel getColorModel()
 meth public java.awt.image.VolatileImage createVolatileImage(int,int)
 meth public java.awt.image.VolatileImage createVolatileImage(int,int,java.awt.ImageCapabilities) throws java.awt.AWTException
-meth public java.awt.peer.ComponentPeer getPeer()
- anno 0 java.lang.Deprecated()
 meth public java.beans.PropertyChangeListener[] getPropertyChangeListeners()
 meth public java.beans.PropertyChangeListener[] getPropertyChangeListeners(java.lang.String)
 meth public java.lang.String getName()

--- a/platform/libs.jna/nbproject/org-netbeans-libs-jna.sig
+++ b/platform/libs.jna/nbproject/org-netbeans-libs-jna.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.8
+#Version 2.9
 
 CLSS public abstract interface com.sun.jna.AltCallingConvention
 

--- a/platform/libs.jsr223/nbproject/org-netbeans-libs-jsr223.sig
+++ b/platform/libs.jsr223/nbproject/org-netbeans-libs-jsr223.sig
@@ -1,3 +1,3 @@
 #Signature file v4.1
-#Version 1.48
+#Version 1.49
 

--- a/platform/libs.junit4/nbproject/org-netbeans-libs-junit4.sig
+++ b/platform/libs.junit4/nbproject/org-netbeans-libs-junit4.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.31
+#Version 1.32
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/libs.junit5/nbproject/org-netbeans-libs-junit5.sig
+++ b/platform/libs.junit5/nbproject/org-netbeans-libs-junit5.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.10
+#Version 1.11
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/libs.osgi/nbproject/org-netbeans-libs-osgi.sig
+++ b/platform/libs.osgi/nbproject/org-netbeans-libs-osgi.sig
@@ -1,3 +1,3 @@
 #Signature file v4.1
-#Version 1.35
+#Version 1.36
 

--- a/platform/libs.testng/nbproject/org-netbeans-libs-testng.sig
+++ b/platform/libs.testng/nbproject/org-netbeans-libs-testng.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.27
+#Version 1.28
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/masterfs.ui/nbproject/org-netbeans-modules-masterfs-ui.sig
+++ b/platform/masterfs.ui/nbproject/org-netbeans-modules-masterfs-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.16.0
+#Version 2.17.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/masterfs/nbproject/org-netbeans-modules-masterfs.sig
+++ b/platform/masterfs/nbproject/org-netbeans-modules-masterfs.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.68.0
+#Version 2.69.0
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/netbinox/nbproject/org-netbeans-modules-netbinox.sig
+++ b/platform/netbinox/nbproject/org-netbeans-modules-netbinox.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.54
+#Version 1.55
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/platform/o.n.bootstrap/nbproject/org-netbeans-bootstrap.sig
+++ b/platform/o.n.bootstrap/nbproject/org-netbeans-bootstrap.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.91
+#Version 2.92
 
 CLSS public java.awt.datatransfer.Clipboard
 cons public init(java.lang.String)

--- a/platform/o.n.core/nbproject/org-netbeans-core.sig
+++ b/platform/o.n.core/nbproject/org-netbeans-core.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.64
+#Version 3.65
 
 CLSS public abstract java.awt.Component
 cons protected init()
@@ -883,7 +883,7 @@ meth public void removePropertyChangeListener(java.beans.PropertyChangeListener)
 meth public void setAsText(java.lang.String)
 meth public void setValue(java.lang.Object)
 supr java.lang.Object
-hfds AQUA,GTK,antialias,awtColorNames,awtColors,awtGenerate,gtkAA,hintsMap,superColor,support,swingColorNames,swingColors,systemColorNames,systemColors,systemGenerate
+hfds GTK,awtColorNames,awtColors,awtGenerate,gtkAA,superColor,support,swingColorNames,swingColors,systemColorNames,systemColors,systemGenerate
 hcls NbColorChooser,NbColorChooserPanel,SuperColor,SuperColorSelectionModel
 
 CLSS public org.netbeans.beaninfo.editors.DateEditor
@@ -1007,7 +1007,7 @@ meth public void removePropertyChangeListener(java.beans.PropertyChangeListener)
 meth public void setAsText(java.lang.String)
 meth public void setValue(java.lang.Object)
 supr java.lang.Object
-hfds antialias,font,fontName,fonts,gtkAA,sizes,styles,support
+hfds font,fontName,fonts,sizes,styles,support
 hcls FontPanel
 
 CLSS public org.netbeans.beaninfo.editors.HtmlBrowser

--- a/platform/o.n.swing.outline/nbproject/org-netbeans-swing-outline.sig
+++ b/platform/o.n.swing.outline/nbproject/org-netbeans-swing-outline.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.47
+#Version 1.48
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/platform/o.n.swing.plaf/nbproject/org-netbeans-swing-plaf.sig
+++ b/platform/o.n.swing.plaf/nbproject/org-netbeans-swing-plaf.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.55
+#Version 1.56
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/o.n.swing.tabcontrol/nbproject/org-netbeans-swing-tabcontrol.sig
+++ b/platform/o.n.swing.tabcontrol/nbproject/org-netbeans-swing-tabcontrol.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.69
+#Version 1.70
 
 CLSS public abstract java.awt.AWTEvent
 cons public init(java.awt.Event)

--- a/platform/openide.actions/nbproject/org-openide-actions.sig
+++ b/platform/openide.actions/nbproject/org-openide-actions.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 6.52
+#Version 6.53
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/platform/openide.awt/nbproject/org-openide-awt.sig
+++ b/platform/openide.awt/nbproject/org-openide-awt.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 7.81
+#Version 7.82
 
 CLSS public java.awt.Canvas
 cons public init()
@@ -1734,6 +1734,11 @@ meth public java.awt.Dimension preferredLayoutSize(java.awt.Container)
 meth public void layoutContainer(java.awt.Container)
 supr java.awt.FlowLayout
 hfds serialVersionUID
+
+CLSS public final org.openide.awt.GraphicsUtils
+meth public static void configureDefaultRenderingHints(java.awt.Graphics)
+supr java.lang.Object
+hfds antialias,gtkAA,hintsMap
 
 CLSS public org.openide.awt.HtmlBrowser
 cons public init()

--- a/platform/openide.compat/nbproject/org-openide-compat.sig
+++ b/platform/openide.compat/nbproject/org-openide-compat.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 6.53
+#Version 6.54
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/platform/openide.dialogs/nbproject/org-openide-dialogs.sig
+++ b/platform/openide.dialogs/nbproject/org-openide-dialogs.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 7.55
+#Version 7.56
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/openide.execution.compat8/nbproject/org-openide-execution-compat8.sig
+++ b/platform/openide.execution.compat8/nbproject/org-openide-execution-compat8.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.15
+#Version 9.16
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/platform/openide.execution/nbproject/org-openide-execution.sig
+++ b/platform/openide.execution/nbproject/org-openide-execution.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.16
+#Version 9.17
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/platform/openide.explorer/nbproject/org-openide-explorer.sig
+++ b/platform/openide.explorer/nbproject/org-openide-explorer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 6.75
+#Version 6.76
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/platform/openide.filesystems.compat8/nbproject/org-openide-filesystems-compat8.sig
+++ b/platform/openide.filesystems.compat8/nbproject/org-openide-filesystems-compat8.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.22
+#Version 9.23
 
 CLSS public java.io.IOException
 cons public init()

--- a/platform/openide.filesystems.nb/nbproject/org-openide-filesystems-nb.sig
+++ b/platform/openide.filesystems.nb/nbproject/org-openide-filesystems-nb.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.23
+#Version 9.24
 
 CLSS public java.io.IOException
 cons public init()

--- a/platform/openide.filesystems/nbproject/org-openide-filesystems.sig
+++ b/platform/openide.filesystems/nbproject/org-openide-filesystems.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.25
+#Version 9.26
 
 CLSS public java.io.IOException
 cons public init()

--- a/platform/openide.io/nbproject/org-openide-io.sig
+++ b/platform/openide.io/nbproject/org-openide-io.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.62
+#Version 1.63
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/platform/openide.loaders/nbproject/org-openide-loaders.sig
+++ b/platform/openide.loaders/nbproject/org-openide-loaders.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 7.83
+#Version 7.84
 
 CLSS public java.awt.Canvas
 cons public init()
@@ -2571,6 +2571,11 @@ meth public java.awt.Dimension preferredLayoutSize(java.awt.Container)
 meth public void layoutContainer(java.awt.Container)
 supr java.awt.FlowLayout
 hfds serialVersionUID
+
+CLSS public final org.openide.awt.GraphicsUtils
+meth public static void configureDefaultRenderingHints(java.awt.Graphics)
+supr java.lang.Object
+hfds antialias,gtkAA,hintsMap
 
 CLSS public org.openide.awt.HtmlBrowser
 cons public init()

--- a/platform/openide.modules/nbproject/org-openide-modules.sig
+++ b/platform/openide.modules/nbproject/org-openide-modules.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 7.61
+#Version 7.62
 
 CLSS public abstract interface java.io.Externalizable
 intf java.io.Serializable

--- a/platform/openide.nodes/nbproject/org-openide-nodes.sig
+++ b/platform/openide.nodes/nbproject/org-openide-nodes.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 7.58
+#Version 7.59
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/platform/openide.options/nbproject/org-openide-options.sig
+++ b/platform/openide.options/nbproject/org-openide-options.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 6.50
+#Version 6.51
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/platform/openide.text/nbproject/org-openide-text.sig
+++ b/platform/openide.text/nbproject/org-openide-text.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 6.81
+#Version 6.82
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/platform/openide.util.enumerations/nbproject/org-openide-util-enumerations.sig
+++ b/platform/openide.util.enumerations/nbproject/org-openide-util-enumerations.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 6.46
+#Version 6.47
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/openide.util.lookup/nbproject/org-openide-util-lookup.sig
+++ b/platform/openide.util.lookup/nbproject/org-openide-util-lookup.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 8.47
+#Version 8.48
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/openide.util.ui/nbproject/org-openide-util-ui.sig
+++ b/platform/openide.util.ui/nbproject/org-openide-util-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.21
+#Version 9.22
 
 CLSS public java.awt.datatransfer.Clipboard
 cons public init(java.lang.String)

--- a/platform/openide.util/nbproject/org-openide-util.sig
+++ b/platform/openide.util/nbproject/org-openide-util.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 9.21
+#Version 9.22
 
 CLSS public abstract interface java.io.Closeable
 intf java.lang.AutoCloseable

--- a/platform/openide.windows/nbproject/org-openide-windows.sig
+++ b/platform/openide.windows/nbproject/org-openide-windows.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 6.90
+#Version 6.91
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/platform/options.api/nbproject/org-netbeans-modules-options-api.sig
+++ b/platform/options.api/nbproject/org-netbeans-modules-options-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.58
+#Version 1.59
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/options.keymap/nbproject/org-netbeans-modules-options-keymap.sig
+++ b/platform/options.keymap/nbproject/org-netbeans-modules-options-keymap.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.50
+#Version 1.51
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/print/nbproject/org-netbeans-modules-print.sig
+++ b/platform/print/nbproject/org-netbeans-modules-print.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 7.39
+#Version 7.40
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/queries/nbproject/org-netbeans-modules-queries.sig
+++ b/platform/queries/nbproject/org-netbeans-modules-queries.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.56
+#Version 1.57
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/sampler/nbproject/org-netbeans-modules-sampler.sig
+++ b/platform/sampler/nbproject/org-netbeans-modules-sampler.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.27
+#Version 1.28
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/sendopts/nbproject/org-netbeans-modules-sendopts.sig
+++ b/platform/sendopts/nbproject/org-netbeans-modules-sendopts.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.49
+#Version 2.50
 
 CLSS public abstract interface java.io.Serializable
 

--- a/platform/settings/nbproject/org-netbeans-modules-settings.sig
+++ b/platform/settings/nbproject/org-netbeans-modules-settings.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.62
+#Version 1.63
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/spi.actions/nbproject/org-netbeans-modules-spi-actions.sig
+++ b/platform/spi.actions/nbproject/org-netbeans-modules-spi-actions.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.41
+#Version 1.42
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/platform/spi.quicksearch/nbproject/org-netbeans-spi-quicksearch.sig
+++ b/platform/spi.quicksearch/nbproject/org-netbeans-spi-quicksearch.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.40
+#Version 1.41
 
 CLSS public java.lang.Object
 cons public init()

--- a/platform/uihandler/nbproject/org-netbeans-modules-uihandler.sig
+++ b/platform/uihandler/nbproject/org-netbeans-modules-uihandler.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.48
+#Version 2.49
 
 CLSS public java.lang.Object
 cons public init()

--- a/profiler/lib.profiler.charts/nbproject/org-netbeans-lib-profiler-charts.sig
+++ b/profiler/lib.profiler.charts/nbproject/org-netbeans-lib-profiler-charts.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.43
+#Version 1.44
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/profiler/lib.profiler.common/nbproject/org-netbeans-lib-profiler-common.sig
+++ b/profiler/lib.profiler.common/nbproject/org-netbeans-lib-profiler-common.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.60
+#Version 1.61
 
 CLSS public java.lang.Object
 cons public init()

--- a/profiler/lib.profiler.ui/nbproject/org-netbeans-lib-profiler-ui.sig
+++ b/profiler/lib.profiler.ui/nbproject/org-netbeans-lib-profiler-ui.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.159
+#Version 1.160
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/profiler/lib.profiler/nbproject/org-netbeans-lib-profiler.sig
+++ b/profiler/lib.profiler/nbproject/org-netbeans-lib-profiler.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.121
+#Version 1.123
 
 CLSS public abstract interface java.io.Serializable
 
@@ -1175,13 +1175,14 @@ CLSS public org.netbeans.lib.profiler.heap.HeapFactory
 cons public init()
 meth public static org.netbeans.lib.profiler.heap.Heap createHeap(java.io.File) throws java.io.IOException
 meth public static org.netbeans.lib.profiler.heap.Heap createHeap(java.io.File,int) throws java.io.IOException
+meth public static org.netbeans.lib.profiler.heap.Heap createHeap(java.nio.ByteBuffer,int) throws java.io.IOException
 supr java.lang.Object
 
 CLSS public final org.netbeans.lib.profiler.heap.HeapProgress
 fld public final static int PROGRESS_MAX = 1000
 meth public static javax.swing.BoundedRangeModel getProgress()
 supr java.lang.Object
-hfds progressThreadLocal
+hfds listener,progressThreadLocal
 hcls ModelInfo
 
 CLSS public abstract interface org.netbeans.lib.profiler.heap.HeapSummary

--- a/profiler/profiler.api/nbproject/org-netbeans-modules-profiler-api.sig
+++ b/profiler/profiler.api/nbproject/org-netbeans-modules-profiler-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.63
+#Version 1.64
 
 CLSS public abstract interface java.io.Serializable
 

--- a/profiler/profiler.attach/nbproject/org-netbeans-modules-profiler-attach.sig
+++ b/profiler/profiler.attach/nbproject/org-netbeans-modules-profiler-attach.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.34
+#Version 2.35
 
 CLSS public java.lang.Object
 cons public init()

--- a/profiler/profiler.heapwalker/nbproject/org-netbeans-modules-profiler-heapwalker.sig
+++ b/profiler/profiler.heapwalker/nbproject/org-netbeans-modules-profiler-heapwalker.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.125
+#Version 1.126
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/profiler/profiler.nbimpl/nbproject/org-netbeans-modules-profiler-nbimpl.sig
+++ b/profiler/profiler.nbimpl/nbproject/org-netbeans-modules-profiler-nbimpl.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.38
+#Version 1.39
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/profiler/profiler.oql/nbproject/org-netbeans-modules-profiler-oql.sig
+++ b/profiler/profiler.oql/nbproject/org-netbeans-modules-profiler-oql.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 2.31
+#Version 2.32
 
 CLSS public abstract interface java.io.Serializable
 

--- a/profiler/profiler.ppoints/nbproject/org-netbeans-modules-profiler-ppoints.sig
+++ b/profiler/profiler.ppoints/nbproject/org-netbeans-modules-profiler-ppoints.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.37
+#Version 1.38
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/profiler/profiler.projectsupport/nbproject/org-netbeans-modules-profiler-projectsupport.sig
+++ b/profiler/profiler.projectsupport/nbproject/org-netbeans-modules-profiler-projectsupport.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.46
+#Version 1.47
 
 CLSS public java.lang.Object
 cons public init()

--- a/profiler/profiler.snaptracer/nbproject/org-netbeans-modules-profiler-snaptracer.sig
+++ b/profiler/profiler.snaptracer/nbproject/org-netbeans-modules-profiler-snaptracer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.37
+#Version 1.38
 
 CLSS public abstract interface java.awt.event.ActionListener
 intf java.util.EventListener

--- a/profiler/profiler.utilities/nbproject/org-netbeans-modules-profiler-utilities.sig
+++ b/profiler/profiler.utilities/nbproject/org-netbeans-modules-profiler-utilities.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.50
+#Version 1.51
 
 CLSS public java.lang.Object
 cons public init()

--- a/profiler/profiler/nbproject/org-netbeans-modules-profiler.sig
+++ b/profiler/profiler/nbproject/org-netbeans-modules-profiler.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 3.42
+#Version 3.43
 
 CLSS public abstract java.awt.Component
 cons protected init()

--- a/webcommon/api.knockout/nbproject/org-netbeans-api-knockout.sig
+++ b/webcommon/api.knockout/nbproject/org-netbeans-api-knockout.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.14
+#Version 1.15
 
 CLSS public java.lang.Object
 cons public init()

--- a/webcommon/cordova.platforms/nbproject/org-netbeans-modules-cordova-platforms.sig
+++ b/webcommon/cordova.platforms/nbproject/org-netbeans-modules-cordova-platforms.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.49
+#Version 1.50
 
 CLSS public java.lang.Object
 cons public init()

--- a/webcommon/html.knockout/nbproject/org-netbeans-modules-html-knockout.sig
+++ b/webcommon/html.knockout/nbproject/org-netbeans-modules-html-knockout.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.23
+#Version 1.24
 
 CLSS public abstract interface java.io.Serializable
 

--- a/webcommon/javascript.nodejs/nbproject/org-netbeans-modules-javascript-nodejs.sig
+++ b/webcommon/javascript.nodejs/nbproject/org-netbeans-modules-javascript-nodejs.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.42
+#Version 0.43
 
 CLSS public java.lang.Object
 cons public init()

--- a/webcommon/javascript.v8debug/nbproject/org-netbeans-modules-javascript-v8debug.sig
+++ b/webcommon/javascript.v8debug/nbproject/org-netbeans-modules-javascript-v8debug.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.23.0
+#Version 1.24.0
 
 CLSS public java.lang.Object
 cons public init()

--- a/webcommon/javascript2.doc/nbproject/org-netbeans-modules-javascript2-doc.sig
+++ b/webcommon/javascript2.doc/nbproject/org-netbeans-modules-javascript2-doc.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.12
+#Version 1.13
 
 CLSS public abstract interface java.io.Serializable
 

--- a/webcommon/javascript2.editor/nbproject/org-netbeans-modules-javascript2-editor.sig
+++ b/webcommon/javascript2.editor/nbproject/org-netbeans-modules-javascript2-editor.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.87
+#Version 0.88
 
 CLSS public abstract interface java.io.Serializable
 

--- a/webcommon/javascript2.json/nbproject/org-netbeans-modules-javascript2-json.sig
+++ b/webcommon/javascript2.json/nbproject/org-netbeans-modules-javascript2-json.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.16
+#Version 1.17
 
 CLSS public java.lang.Object
 cons public init()

--- a/webcommon/javascript2.knockout/nbproject/org-netbeans-modules-javascript2-knockout.sig
+++ b/webcommon/javascript2.knockout/nbproject/org-netbeans-modules-javascript2-knockout.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.23
+#Version 1.24
 
 CLSS public java.lang.Object
 cons public init()

--- a/webcommon/javascript2.lexer/nbproject/org-netbeans-modules-javascript2-lexer.sig
+++ b/webcommon/javascript2.lexer/nbproject/org-netbeans-modules-javascript2-lexer.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.19
+#Version 1.20
 
 CLSS public abstract interface java.io.Serializable
 

--- a/webcommon/javascript2.model/nbproject/org-netbeans-modules-javascript2-model.sig
+++ b/webcommon/javascript2.model/nbproject/org-netbeans-modules-javascript2-model.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.17
+#Version 1.18
 
 CLSS public abstract com.oracle.js.parser.ir.visitor.NodeVisitor<%0 extends com.oracle.js.parser.ir.LexicalContext>
 cons public init({com.oracle.js.parser.ir.visitor.NodeVisitor%0})

--- a/webcommon/javascript2.nodejs/nbproject/org-netbeans-modules-javascript2-nodejs.sig
+++ b/webcommon/javascript2.nodejs/nbproject/org-netbeans-modules-javascript2-nodejs.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 0.25
+#Version 0.26
 
 CLSS public abstract interface org.netbeans.modules.javascript2.nodejs.spi.NodeJsSupport
 meth public abstract boolean isSupportEnabled()

--- a/webcommon/javascript2.types/nbproject/org-netbeans-modules-javascript2-types.sig
+++ b/webcommon/javascript2.types/nbproject/org-netbeans-modules-javascript2-types.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.13
+#Version 1.14
 
 CLSS public java.lang.Object
 cons public init()

--- a/webcommon/lib.v8debug/nbproject/org-netbeans-lib-v8debug.sig
+++ b/webcommon/lib.v8debug/nbproject/org-netbeans-lib-v8debug.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.29
+#Version 1.30
 
 CLSS public abstract interface java.io.Serializable
 

--- a/webcommon/libs.graaljs/nbproject/org-netbeans-libs-graaljs.sig
+++ b/webcommon/libs.graaljs/nbproject/org-netbeans-libs-graaljs.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.13
+#Version 1.14
 
 CLSS public abstract com.oracle.js.parser.AbstractParser
 cons protected init(com.oracle.js.parser.Source,com.oracle.js.parser.ErrorManager,boolean,int)

--- a/webcommon/libs.jstestdriver/nbproject/org-netbeans-libs-jstestdriver.sig
+++ b/webcommon/libs.jstestdriver/nbproject/org-netbeans-libs-jstestdriver.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.23
+#Version 1.24
 
 CLSS public abstract interface java.io.Serializable
 

--- a/webcommon/libs.nashorn/nbproject/org-netbeans-libs-nashorn.sig
+++ b/webcommon/libs.nashorn/nbproject/org-netbeans-libs-nashorn.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.47
+#Version 1.48
 
 CLSS public abstract com.oracle.js.parser.AbstractParser
 cons protected init(com.oracle.js.parser.Source,com.oracle.js.parser.ErrorManager,boolean,int)

--- a/webcommon/libs.plist/nbproject/org-netbeans-libs-plist.sig
+++ b/webcommon/libs.plist/nbproject/org-netbeans-libs-plist.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.20
+#Version 1.21
 
 CLSS public final com.dd.plist.ASCIIPropertyListParser
 fld public final static char ARRAY_BEGIN_TOKEN = '('

--- a/webcommon/netserver/nbproject/org-netbeans-modules-netserver.sig
+++ b/webcommon/netserver/nbproject/org-netbeans-modules-netserver.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.26
+#Version 1.27
 
 CLSS public abstract interface java.io.Serializable
 

--- a/webcommon/selenium2.webclient/nbproject/org-netbeans-modules-selenium2-webclient.sig
+++ b/webcommon/selenium2.webclient/nbproject/org-netbeans-modules-selenium2-webclient.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.20
+#Version 1.21
 
 CLSS public java.lang.Object
 cons public init()

--- a/webcommon/web.clientproject.api/nbproject/org-netbeans-modules-web-clientproject-api.sig
+++ b/webcommon/web.clientproject.api/nbproject/org-netbeans-modules-web-clientproject-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.117
+#Version 1.118
 
 CLSS public java.io.IOException
 cons public init()

--- a/webcommon/web.clientproject/nbproject/org-netbeans-modules-web-clientproject.sig
+++ b/webcommon/web.clientproject/nbproject/org-netbeans-modules-web-clientproject.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.100
+#Version 1.101
 
 CLSS public java.lang.Object
 cons public init()

--- a/websvccommon/websvc.jaxwsmodelapi/nbproject/org-netbeans-modules-websvc-jaxwsmodelapi.sig
+++ b/websvccommon/websvc.jaxwsmodelapi/nbproject/org-netbeans-modules-websvc-jaxwsmodelapi.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.40
+#Version 1.41
 
 CLSS public abstract interface java.awt.datatransfer.Transferable
 meth public abstract boolean isDataFlavorSupported(java.awt.datatransfer.DataFlavor)

--- a/websvccommon/websvc.saas.api/nbproject/org-netbeans-modules-websvc-saas-api.sig
+++ b/websvccommon/websvc.saas.api/nbproject/org-netbeans-modules-websvc-saas-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.44
+#Version 1.45
 
 CLSS public abstract interface java.awt.datatransfer.Transferable
 meth public abstract boolean isDataFlavorSupported(java.awt.datatransfer.DataFlavor)

--- a/websvccommon/websvc.saas.codegen/nbproject/org-netbeans-modules-websvc-saas-codegen.sig
+++ b/websvccommon/websvc.saas.codegen/nbproject/org-netbeans-modules-websvc-saas-codegen.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 1.43
+#Version 1.44
 
 CLSS public abstract java.awt.Component
 cons protected init()


### PR DESCRIPTION
Snapshot of APIs as of 12.6. We should have produced this earlier - had slipped my mind, anyway.

Had to build and produce these on JDK 8. Doing with JDK 11 is failing with an error.  Same for other people?  We'll need to fix that by NB13 - haven't looked at what is failing - some reference to JDK classes IIRC.

Also had to resolve following conflicts in merging - ignored the removed modules, left javacapi as in master.

```
deleted by us:   ide/libs.bytelist/nbproject/org-netbeans-libs-bytelist.sig
deleted by us:   ide/libs.jvyamlb/nbproject/org-netbeans-libs-jvyamlb.sig
both modified:   java/libs.javacapi/nbproject/org-netbeans-libs-javacapi.sig
```

Built in the usual way

```
# checkout branch (or release tag)
git checkout release126
ant clean
ant build
ant gen-sigtests-release
git add -A
git stash
git checkout master
git checkout -b apis-nb126
git stash pop
git add -A
git commit -m "Snapshot of APIs as of 12.6"
# remove getPeer() calls
find . -name "*.sig" -exec sed -i '/java.awt.peer.ComponentPeer/{N;d;}' {} \;
# check git diff
git add -A
git commit --amend
```