### PR TITLE
Dispose/disconnect tree view after client stop.

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -70,6 +70,14 @@ export class NbLanguageClient extends LanguageClient {
     findTreeViewService(): TreeViewService {
         return this._treeViewService;
     }
+
+    stop(): Promise<void> {
+        // stop will be called even in case of external close & client restart, so OK.
+        const r: Promise<void> = super.stop();
+        this._treeViewService.dispose();
+        return r;
+    }
+    
 }
 
 function handleLog(log: vscode.OutputChannel, msg: string): void {


### PR DESCRIPTION
When a JDK is switched, and the lang client is restarted, the old TreeViewService is still active as well as any handlers it hooked to the vscode. This PR adds unregistration/disposal of the service on Lang client stop.