### PR TITLE
LSP + VSCode extension: Run/Debug via project actions.

### DIFF
--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -166,9 +166,6 @@
 				],
 				"configurationAttributes": {
 					"launch": {
-						"required": [
-							"mainClass"
-						],
 						"properties": {
 							"mainClass": {
 								"type": "string",
@@ -264,8 +261,7 @@
 					{
 						"type": "java8+",
 						"request": "launch",
-						"name": "Launch Java 8+ App",
-						"mainClass": "${file}"
+						"name": "Launch Java 8+ App"
 					}
 				],
 				"configurationSnippets": [
@@ -275,8 +271,7 @@
 						"body": {
 							"type": "java8+",
 							"request": "launch",
-							"name": "Launch Java 8+ App",
-							"mainClass": "^\"${1:\\${file\\}}\""
+							"name": "Launch Java 8+ App"
 						}
 					}
 				]

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -873,7 +873,6 @@ class NetBeansConfigurationInitialProvider implements vscode.DebugConfigurationP
                     name: cname,
                     type: "java8+",
                     request: "launch",
-                    mainClass: '${file}',
                     launchConfiguration: cn,
                 };
                 result.push(debugConfig);
@@ -951,9 +950,7 @@ class NetBeansConfigurationResolver implements vscode.DebugConfigurationProvider
         if (!config.request) {
             config.request = 'launch';
         }
-        if ('launch' == config.request && !config.mainClass) {
-            config.mainClass = '${file}';
-        }
+        config.file = '${file}';
         if (!config.classPaths) {
             config.classPaths = ['any'];
         }

--- a/java/java.lsp.server/vscode/src/test/suite/testutils.ts
+++ b/java/java.lsp.server/vscode/src/test/suite/testutils.ts
@@ -40,6 +40,7 @@ export async function prepareProject(folder: string) {
 <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <exec.mainClass>pkg.Main</exec.mainClass>
 </properties>
 <build>
 <plugins>


### PR DESCRIPTION
For consistency reasons we execute project Run/Debug actions instead of file Run/Debug in VSCode. File-sensitive actions are provided as code lenses. Via project's Run/Debug actions users get consistent behavior.

Currently there was `mainClass` property set to `${file}` in VSCode's `launch.json`. We are changing `mainClass` property to be optional, it's not set in newly created `launch.json` and we're using `file` property set to `${file}` to get the context. `mainClass` allows to set a specific file as a context to Run/Debug. When not set, we use `file` to determine the current project to run Run/Debug on.

We need to adjust Maven projects to be able to Run/Debug without `mainClass` set. The project should know it's entry point. Currently, when you create a new Maven project from template, it asks you for the main class before Run/Debug. This is an unexpected behavior for the user, as the newly created project should know its main class. This is why we set `exec.mainClass` in Maven now.