### PR TITLE
Use ToolProvider from libs.javacapi, not from bootclasspath

### DIFF
--- a/java/java.hints.declarative/nbproject/project.xml
+++ b/java/java.hints.declarative/nbproject/project.xml
@@ -66,7 +66,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>0.8.0.1</specification-version>
+                        <specification-version>8.37</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -294,14 +294,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.openide.util.ui</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>9.3</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.openide.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -315,6 +307,14 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>8.0.0.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.openide.util.ui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>9.3</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Hacks.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Hacks.java
@@ -56,7 +56,6 @@ import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.modules.java.hints.spiimpl.Utilities;
 import org.openide.filesystems.FileUtil;
-import org.openide.util.Exceptions;
 
 /**
  *
@@ -80,13 +79,7 @@ public class Hacks {
         DiagnosticListener<JavaFileObject> devNull = new DiagnosticListener<JavaFileObject>() {
             public void report(Diagnostic<? extends JavaFileObject> diagnostic) {}
         };
-        StandardJavaFileManager sjfm;
-        try {
-            sjfm = ToolProvider.getSystemJavaCompiler().getStandardFileManager(devNull, null, null);
-        } catch (Error err) {
-            Exceptions.printStackTrace(err);
-            return Collections.emptyMap();
-        }
+        StandardJavaFileManager sjfm = ToolProvider.getSystemJavaCompiler().getStandardFileManager(devNull, null, null);
 
         final Map<String, ByteArrayOutputStream> class2BAOS = new HashMap<String, ByteArrayOutputStream>();
         sjfm.setLocation(StandardLocation.CLASS_PATH, toFiles(compile));

--- a/java/java.j2seplatform/nbproject/project.xml
+++ b/java/java.j2seplatform/nbproject/project.xml
@@ -79,6 +79,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.libs.javacapi</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>8.19</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.classfile</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/java/libs.javacapi/external/binaries-list
+++ b/java/libs.javacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-B195FD4F74CA4BA8BF5985E9103B96C6F0D9079D com.dukescript.nbjavac:nb-javac:jdk-17+35:api
-E748E597EACD349D65869A26FCB99A8B4DF887C2 com.dukescript.nbjavac:nb-javac:jdk-17+35
+D201700827FE5767B2022E284E796E3F2614007E com.dukescript.nbjavac:nb-javac:jdk-17.0.1-ga:api
+9D66EEDA42EEBFEB17FEABE51DB92438AB71D934 com.dukescript.nbjavac:nb-javac:jdk-17.0.1-ga

--- a/java/libs.javacapi/external/nb-javac-jdk-17.0.1-ga-license.txt
+++ b/java/libs.javacapi/external/nb-javac-jdk-17.0.1-ga-license.txt
@@ -1,12 +1,12 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Version: jdk-17+35
-Files: nb-javac-jdk-17+35-api.jar nb-javac-jdk-17+35.jar
+Files: nb-javac-jdk-17.0.1-ga-api.jar nb-javac-jdk-17.0.1-ga.jar
+Version: jdk-17.0.1-ga
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk17)
 Source: https://github.com/openjdk/jdk17
-Type: optional,reviewed
-Comment: The binary has been reviewed to be under the Classpath Exception as a whole. Optional at runtime, but used by default.
+Type: compile-time,optional
+Comment: Used at compile and design time to compile against; optional at runtime.
 
 The GNU General Public License (GPL)
 

--- a/java/libs.javacapi/nbproject/project.properties
+++ b/java/libs.javacapi/nbproject/project.properties
@@ -21,6 +21,6 @@ javac.source=1.6
 javadoc.title=Javac API
 nbm.homepage=http://jackpot.netbeans.org/
 nbm.module.author=Petr Hrebejk
-spec.version.base=8.36.0
+spec.version.base=8.37.0
 javadoc.arch=${basedir}/arch.xml
 module.javadoc.packages=com.sun.source.tree,com.sun.source.util

--- a/java/libs.javacapi/nbproject/project.xml
+++ b/java/libs.javacapi/nbproject/project.xml
@@ -40,11 +40,11 @@
             </public-packages>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-17+35-api.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-17.0.1-ga-api.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path />
-                <binary-origin>external/nb-javac-jdk-17+35.jar</binary-origin>
+                <binary-origin>external/nb-javac-jdk-17.0.1-ga.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/java/libs.nbjavacapi/external/binaries-list
+++ b/java/libs.nbjavacapi/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-B195FD4F74CA4BA8BF5985E9103B96C6F0D9079D com.dukescript.nbjavac:nb-javac:jdk-17+35:api
-E748E597EACD349D65869A26FCB99A8B4DF887C2 com.dukescript.nbjavac:nb-javac:jdk-17+35
+D201700827FE5767B2022E284E796E3F2614007E com.dukescript.nbjavac:nb-javac:jdk-17.0.1-ga:api
+9D66EEDA42EEBFEB17FEABE51DB92438AB71D934 com.dukescript.nbjavac:nb-javac:jdk-17.0.1-ga

--- a/java/libs.nbjavacapi/external/nb-javac-jdk-17.0.1-ga-license.txt
+++ b/java/libs.nbjavacapi/external/nb-javac-jdk-17.0.1-ga-license.txt
@@ -1,12 +1,12 @@
 Name: Javac Compiler Implementation
 Description: Javac Compiler Implementation
-Files: nb-javac-jdk-17+35-api.jar nb-javac-jdk-17+35.jar
-Version: jdk-17+35
+Version: jdk-17.0.1-ga
+Files: nb-javac-jdk-17.0.1-ga-api.jar nb-javac-jdk-17.0.1-ga.jar
 License: GPL-2-CP
 Origin: OpenJDK (https://github.com/openjdk/jdk17)
 Source: https://github.com/openjdk/jdk17
-Type: compile-time,optional
-Comment: Used at compile and design time to compile against; optional at runtime.
+Type: optional,reviewed
+Comment: The binary has been reviewed to be under the Classpath Exception as a whole. Optional at runtime, but used by default.
 
 The GNU General Public License (GPL)
 

--- a/java/libs.nbjavacapi/manifest.mf
+++ b/java/libs.nbjavacapi/manifest.mf
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: true
 OpenIDE-Module: org.netbeans.libs.nbjavacapi
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/nbjavac/api/Bundle.properties
-OpenIDE-Module-Specification-Version: 17.0
+OpenIDE-Module-Specification-Version: 17.0.1
 OpenIDE-Module-Hide-Classpath-Packages: com.sun.javadoc.**, com.sun.source.**, javax.annotation.processing.**, javax.lang.model.**, javax.tools.**, com.sun.tools.javac.** com.sun.tools.javac.**, com.sun.tools.javadoc.**, com.sun.tools.javap.**, com.sun.tools.classfile.**, com.sun.tools.doclint.**
 OpenIDE-Module-Fragment-Host: org.netbeans.libs.javacapi
 OpenIDE-Module-Provides: org.netbeans.libs.nbjavac

--- a/java/libs.nbjavacapi/nbproject/project.properties
+++ b/java/libs.nbjavacapi/nbproject/project.properties
@@ -18,5 +18,5 @@
 javac.source=1.7
 javac.compilerargs=-Xlint -Xlint:-serial
 license.file.override=${nb_all}/nbbuild/licenses/GPL-2-CP
-release.external/nb-javac-jdk-17+35-api.jar=modules/ext/nb-javac-jdk-17-api.jar
-release.external/nb-javac-jdk-17+35.jar=modules/ext/nb-javac-jdk-17.jar
+release.external/nb-javac-jdk-17.0.1-ga-api.jar=modules/ext/nb-javac-jdk-17-api.jar
+release.external/nb-javac-jdk-17.0.1-ga.jar=modules/ext/nb-javac-jdk-17.jar

--- a/java/libs.nbjavacapi/nbproject/project.xml
+++ b/java/libs.nbjavacapi/nbproject/project.xml
@@ -30,7 +30,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>8.36</specification-version>
+                        <specification-version>8.37</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/extlibs/ignored-overlaps
@@ -113,5 +113,5 @@ webcommon/javascript2.jsdoc/external/testfiles-jsdoc-1.zip webcommon/javascript2
 harness/apisupport.harness/external/launcher-12.5-distribution.zip platform/o.n.bootstrap/external/launcher-12.5-distribution.zip
 
 # only one is part of the product:
-java/libs.javacapi/external/nb-javac-jdk-17+35-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-17+35-api.jar
-java/libs.javacapi/external/nb-javac-jdk-17+35.jar java/libs.nbjavacapi/external/nb-javac-jdk-17+35.jar
+java/libs.javacapi/external/nb-javac-jdk-17.0.1-ga-api.jar java/libs.nbjavacapi/external/nb-javac-jdk-17.0.1-ga-api.jar
+java/libs.javacapi/external/nb-javac-jdk-17.0.1-ga.jar java/libs.nbjavacapi/external/nb-javac-jdk-17.0.1-ga.jar


### PR DESCRIPTION
<!-- GR-35512 contains: -->

Run on JDK-8.  Try to invoke Go To Declaration on a class that comes from Java platform or a library jar. The following exception is thrown:
```
java.lang.NoSuchMethodError: com.sun.source.tree.CompilationUnitTree.getPackage()Lcom/sun/source/tree/PackageTree;
	at org.netbeans.modules.java.j2seplatform.queries.DefaultSourceLevelQueryImpl.parsePackage(DefaultSourceLevelQueryImpl.java:203)
	at org.netbeans.modules.java.j2seplatform.queries.DefaultSourceLevelQueryImpl.lambda$isModular$1(DefaultSourceLevelQueryImpl.java:148)
	at java.util.Optional.orElseGet(Optional.java:267)
	at org.netbeans.modules.java.j2seplatform.queries.DefaultSourceLevelQueryImpl.isModular(DefaultSourceLevelQueryImpl.java:147)
	at org.netbeans.modules.java.j2seplatform.queries.DefaultSourceLevelQueryImpl.getSourceLevel(DefaultSourceLevelQueryImpl.java:90)
	at org.netbeans.api.java.queries.SourceLevelQuery.getSourceLevel(SourceLevelQuery.java:105)
	at org.netbeans.api.java.queries.SourceLevelQuery$Result.getSourceLevel(SourceLevelQuery.java:309)
	at org.netbeans.modules.java.source.parsing.JavacParser.createJavacTask(JavacParser.java:894)
	at org.netbeans.modules.java.source.parsing.CompilationInfoImpl.getJavacTask(CompilationInfoImpl.java:460)
	at org.netbeans.modules.java.source.parsing.JavacParser.moveToPhase(JavacParser.java:661)
	at org.netbeans.modules.java.source.parsing.CompilationInfoImpl.toPhase(CompilationInfoImpl.java:426)
	at org.netbeans.api.java.source.CompilationController.toPhase(CompilationController.java:88)
	at org.netbeans.api.java.source.WorkingCopy.toPhase(WorkingCopy.java:193)
	at org.netbeans.modules.java.classfile.CodeGenerator$1.run(CodeGenerator.java:155)
	at org.netbeans.modules.java.classfile.CodeGenerator$1.run(CodeGenerator.java:152)
```

I am able to get rid of the exception by returning back the dependency on `libs.javacapi` in `java.j2seplatform` project.