### PR TITLE
mx now defaults to building under the jdk prefix

### DIFF
--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteActionProvider.java
@@ -242,6 +242,7 @@ final class SuiteActionProvider implements ActionProvider {
         processBuilder.setWorkingDirectory(suiteDir.getPath());
         processBuilder.setExecutable("mx"); // NOI18N
         processBuilder.setArguments(Arrays.asList(args));
+        processBuilder.getEnvironment().setVariable("MX_OUTPUT_ROOT_INCLUDES_CONFIG", "false"); // NOI18N
         ExecutionService service = ExecutionService.newService(processBuilder, descriptor, taskName);
         Future<Integer> task = service.run();
         taskResult.complete(task);

--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteSources.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteSources.java
@@ -134,7 +134,12 @@ final class SuiteSources implements Sources,
             }
             String prevName = null;
             Group firstGroup = null;
-            String binPrefix = "mxbuild/";
+            String binPrefix;
+            if (mxPrj.subDir() != null) {
+                binPrefix = "mxbuild/" + mxPrj.subDir() + "/";
+            } else {
+                binPrefix = "mxbuild/";
+            }
             for (String rel : mxPrj.sourceDirs()) {
                 FileObject srcDir = prjDir.getFileObject(rel);
                 FileObject binDir = getSubDir(dir, binPrefix + name + "/bin");


### PR DESCRIPTION
setting MX_OUTPUT_ROOT_INCLUDES_CONFIG=false when running mx avoids
this. however, the generated sources are placed not directly under mxbuild if a
subDir is specified, so the subDir needs to be considered as well in the
binPrefix

/cc @jtulach 