### PR TITLE
[NETBEANS-6276] Groovy CC doesn't work on JDK 1.8

### DIFF
--- a/groovy/groovy.editor/nbproject/project.xml
+++ b/groovy/groovy.editor/nbproject/project.xml
@@ -92,7 +92,8 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>0.6</specification-version>
+                        <!--<specification-version>0.6</specification-version>-->
+                        <specification-version>8.37</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/groovy/groovy.editor/nbproject/project.xml
+++ b/groovy/groovy.editor/nbproject/project.xml
@@ -92,7 +92,6 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <!--<specification-version>0.6</specification-version>-->
                         <specification-version>8.37</specification-version>
                     </run-dependency>
                 </dependency>


### PR DESCRIPTION
There has to be used new version of nbjavac. 