### PR TITLE
Merge the code lens actions with the launch config properties and adapt Gradle to apply env.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
@@ -37,7 +37,6 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
     private static final String RUN_SINGLE_ARGS = "runArgs";
     private static final String RUN_SINGLE_JVM_ARGS = "runJvmArgs";
     private static final String RUN_SINGLE_CWD = "runWorkingDir";
-    private static final String RUN_SINGLE_ENV = "runEnvironment";
 
     @Override
     public void apply(Project project) {
@@ -47,13 +46,17 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
                     && project.hasProperty(RUN_SINGLE_MAIN)){
                 addTask(p);
             }
-            if(p.hasProperty(RUN_SINGLE_JVM_ARGS)) {
-                p.getTasks().withType(JavaExec.class).configureEach(je -> {
+            p.getTasks().withType(JavaExec.class).configureEach(je -> {
+                if (p.hasProperty(RUN_SINGLE_JVM_ARGS)) {
                     je.getJvmArgumentProviders().add(() -> {
                         return asList(p.property(RUN_SINGLE_JVM_ARGS).toString().split(" "));
                     });
-                });
-            }
+                }
+                je.setStandardInput(System.in);
+                if (project.hasProperty(RUN_SINGLE_CWD)) {
+                    je.setWorkingDir(project.property(RUN_SINGLE_CWD).toString());
+                }
+            });
         });
     }
 
@@ -64,112 +67,10 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
             // Using setMain to keep the backward compatibility
             je.setMain(project.property(RUN_SINGLE_MAIN).toString());
             je.setClasspath(sourceSets.findByName("main").getRuntimeClasspath());
-            je.setStandardInput(System.in);
             if (project.hasProperty(RUN_SINGLE_ARGS)) {
                 je.setArgs(asList(project.property(RUN_SINGLE_ARGS).toString().split(" ")));
-            }
-
-            if(project.hasProperty(RUN_SINGLE_CWD)) {
-                je.setWorkingDir(project.property(RUN_SINGLE_CWD).toString());
-            }
-
-            if (project.hasProperty(RUN_SINGLE_ENV)) {
-                // Quoted space-separated expressions of <ENV_VAR>=<ENV_VALUE>
-                // to set environment variables, or !<ENV_VAR>
-                // to remove environment variables
-                for (String env : unescapeParameters(project.property(RUN_SINGLE_ENV).toString())) {                    
-                    if (env.startsWith("!")) {
-                        je.getEnvironment().remove(env);
-                    } else {
-                        int i = env.indexOf('=');
-                        if (i > 0) {
-                            je.getEnvironment().put(env.substring(0, i), env.substring(i + 1));
-                        }
-                    }
-                }
             }
         });
     }
 
-    private String[] unescapeParameters(String s) {
-        final int NULL = 0x0;
-        final int IN_PARAM = 0x1;
-        final int IN_DOUBLE_QUOTE = 0x2;
-        final int IN_SINGLE_QUOTE = 0x3;
-        ArrayList<String> params = new ArrayList<>(5);
-        char c;
-
-        int state = NULL;
-        StringBuilder buff = new StringBuilder(20);
-        int slength = s.length();
-
-        for (int i = 0; i < slength; i++) {
-            c = s.charAt(i);
-            switch (state) {
-                case NULL:
-                    switch (c) {
-                        case '\'':
-                            state = IN_SINGLE_QUOTE;
-                            break;
-                        case '"':
-                            state = IN_DOUBLE_QUOTE;
-                            break;
-                        default:
-                            if (!Character.isWhitespace(c)) {
-                                buff.append(c);
-                                state = IN_PARAM;
-                            }
-                    }
-                    break;
-                case IN_SINGLE_QUOTE:
-                    if (c != '\'') {
-                        buff.append(c);
-                    } else {
-                        state = IN_PARAM;
-                    }
-                    break;
-                case IN_DOUBLE_QUOTE:
-                    switch (c) {
-                        case '\\':
-                            char peek = (i < slength - 1) ? s.charAt(i+1) : Character.MIN_VALUE;
-                            if (peek == '"' || peek =='\\') {
-                                buff.append(peek);
-                                i++;
-                            } else {
-                                buff.append(c);
-                            }
-                            break;
-                        case '"':
-                            state = IN_PARAM;
-                            break;
-                        default:
-                            buff.append(c);
-                    }
-                    break;
-                case IN_PARAM:
-                    switch (c) {
-                        case '\'':
-                            state = IN_SINGLE_QUOTE;
-                            break;
-                        case '"':
-                            state = IN_DOUBLE_QUOTE;
-                            break;
-                        default:
-                          if (Character.isWhitespace(c)) {
-                              params.add(buff.toString());
-                              buff.setLength(0);
-                              state = NULL;
-                          } else {
-                              buff.append(c);
-                          }
-                    }
-                    break;
-            }
-        }
-        if (buff.length() > 0) {
-            params.add(buff.toString());
-        }
-
-        return params.toArray(new String[params.size()]);
-    }
 }

--- a/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/execute/GradleDaemonExecutor.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StreamCorruptedException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -63,6 +64,7 @@ import org.netbeans.spi.project.ui.support.BuildExecutionSupport;
 import org.openide.awt.StatusDisplayer;
 import org.openide.execution.ExecutorTask;
 import org.openide.filesystems.FileUtil;
+import org.openide.util.BaseUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
@@ -81,6 +83,7 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
 
     private CancellationTokenSource cancelTokenSource;
     private static final Logger LOGGER = Logger.getLogger(GradleDaemonExecutor.class.getName());
+    private static final String JAVA_HOME = "JAVA_HOME";    // NOI18N
 
     private final ProgressHandle handle;
     private InputStream inStream;
@@ -208,17 +211,10 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
 
             printCommandLine(cmd);
             GradleJavaPlatformProvider platformProvider = config.getProject().getLookup().lookup(GradleJavaPlatformProvider.class);
-            if (platformProvider != null) {
-                try {
-                    buildLauncher.setJavaHome(platformProvider.getJavaHome());
-                    Map<String, String> envs = new HashMap<>(System.getenv());
-                    envs.put("JAVA_HOME", platformProvider.getJavaHome().getCanonicalPath());
-                    buildLauncher.setEnvironmentVariables(envs);
-                } catch (IOException ex) {
-                    io.getErr().println(Bundle.NO_PLATFORM(ex.getMessage()));
-                    gradleTask.finish(1);
-                    return;
-                }
+            String runEnvironment = cmd.getProperty(GradleCommandLine.Property.PROJECT, "runEnvironment");
+            boolean success = setPlatformAndEnv(buildLauncher, platformProvider, runEnvironment);
+            if (!success) {
+                return;
             }
 
             outStream = new EscapeProcessingOutputStream(new GradlePlainEscapeProcessor(io, config, false));
@@ -280,6 +276,50 @@ public final class GradleDaemonExecutor extends AbstractGradleExecutor {
             markFreeTab();
             actionStatesAtFinish();
         }
+    }
+
+    @NbBundle.Messages({"# {0} - JAVA_HOME", "# {1} - Java platform path", "MSG_JAVA_HOME_EnvWarning=Warning: {0} environment variable is replaced with the current Java platform path {1}."})
+    private boolean setPlatformAndEnv(BuildLauncher buildLauncher, GradleJavaPlatformProvider platformProvider, String runEnvironment) {
+        String javaHome = null;
+        if (platformProvider != null) {
+            try {
+                buildLauncher.setJavaHome(platformProvider.getJavaHome());
+                javaHome = platformProvider.getJavaHome().getCanonicalPath();
+            } catch (IOException ex) {
+                io.getErr().println(Bundle.NO_PLATFORM(ex.getMessage()));
+                gradleTask.finish(1);
+                return false;
+            }
+        }
+        if (javaHome != null || runEnvironment != null) {
+            Map<String, String> envs = new HashMap<>(System.getenv());
+            if (runEnvironment != null) {
+                // Quoted space-separated expressions of <ENV_VAR>=<ENV_VALUE>
+                // to set environment variables,
+                // or !<ENV_VAR> to remove environment variables
+                for (String env : BaseUtilities.parseParameters(runEnvironment)) {
+                    String name = null;
+                    if (env.startsWith("!")) {  // NOI18N
+                        name = env.substring(1);
+                        envs.remove(name);
+                    } else {
+                        int i = env.indexOf('=');   // NOI18N
+                        if (i > 0) {
+                            name = env.substring(0, i);
+                            envs.put(name, env.substring(i + 1));
+                        }
+                    }
+                    if (javaHome != null && JAVA_HOME.equals(name)) {
+                        io.getErr().println(Bundle.MSG_JAVA_HOME_EnvWarning(JAVA_HOME, javaHome));
+                    }
+                }
+            }
+            if (javaHome != null) {
+                envs.put(JAVA_HOME, javaHome);    // NOI18N
+            }
+            buildLauncher.setEnvironmentVariables(envs);
+        }
+        return true;
     }
 
     private String getProjectName() {

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -356,6 +356,27 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
             await commands.executeCommand(selected.userData.command.command, ...(selected.userData.command.arguments || []));
         }
     }));
+    const mergeWithLaunchConfig = (dconfig : vscode.DebugConfiguration) => {
+        const folder = vscode.workspace.workspaceFolders?.[0];
+        const uri = folder?.uri;
+        if (uri) {
+            const launchConfig = workspace.getConfiguration('launch', uri);
+            // retrieve values
+            const configurations = launchConfig.get('configurations') as (any[] | undefined);
+            if (configurations) {
+                for (let config of configurations) {
+                    if (config["type"] == dconfig.type) {
+                        for (let key in config) {
+                            if (!dconfig[key]) {
+                                dconfig[key] = config[key];
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
     const runDebug = async (noDebug: boolean, testRun: boolean, uri: string, methodName?: string, launchConfiguration?: string) => {
         const docUri = uri ? vscode.Uri.file(uri) : window.activeTextEditor?.document.uri;
         if (docUri) {
@@ -369,6 +390,7 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
                 launchConfiguration,
                 testRun
             };
+            mergeWithLaunchConfig(debugConfig);
             const debugOptions : vscode.DebugSessionOptions = {
                 noDebug: noDebug,
             }


### PR DESCRIPTION
Code lens actions are run via `runDebug` in `extension.ts` and they use a special launch configuration that did not inherit the configuration from `launch.json`. This is why any additional properties set in `launch.json` were not applied. We merge the launch configuration in `mergeWithLaunchConfig()`.

Gradle project run/debug now applies environment variables set via `runEnvironment` project's property.

`NetBeansRunSinglePlugin` can be simplified now, the set of the environment variables is removed and we set `System.in` and `runWorkingDir` for all Java executions.