### PR TITLE
LSP: Allow to specify default DB connection

### DIFF
--- a/ide/db/apichanges.xml
+++ b/ide/db/apichanges.xml
@@ -85,6 +85,18 @@ is the proper place.
     <changes>
         <change>
             <api name="database_explorer_api"/>
+            <summary>Concept of preferred connection introduced</summary>
+            <version major="1" minor="83"/>
+            <author login="sdedic"/>
+            <compatibility addition="yes"/>
+            <description>
+                Preferred connection can be defined to be used throughout the IDE as the default
+                or fallback one.
+            </description>
+            <class package="org.netbeans.api.db.explorer" name="ConnectionManager"/>
+        </change>
+        <change>
+            <api name="database_explorer_api"/>
             <summary>Provided access to connection nodes list.</summary>
             <version major="1" minor="82"/>
             <author login="sdedic"/>

--- a/ide/db/nbproject/project.properties
+++ b/ide/db/nbproject/project.properties
@@ -20,7 +20,7 @@ javac.source=1.8
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 
-spec.version.base=1.82.0
+spec.version.base=1.83.0
 
 extra.module.files=modules/ext/ddl.jar
 

--- a/ide/db/src/org/netbeans/api/db/explorer/ConnectionManager.java
+++ b/ide/db/src/org/netbeans/api/db/explorer/ConnectionManager.java
@@ -19,6 +19,7 @@
 
 package org.netbeans.api.db.explorer;
 
+import java.util.Arrays;
 import java.util.logging.Logger;
 import javax.swing.SwingUtilities;
 import org.netbeans.lib.ddl.DBConnection;
@@ -409,5 +410,33 @@ public final class ConnectionManager {
      */
     public void removeConnectionListener(ConnectionListener listener) {
         ConnectionList.getDefault().removeConnectionListener(listener);
+    }
+    
+    /**
+     * Returns the preferred connection instance. This is the connection that has been specified by
+     * {@link #setPreferredConnection(org.netbeans.api.db.explorer.DatabaseConnection)}. If none was defined,
+     * the preferred connection is the first one defined. The method will return {@code null} if no connection 
+     * is specified (with fallback = false), or no connection is defined. Usually, fallback = true is the good
+     * choice, except connection management scenarios.
+     * @param fallback if false, returns {@code null} if no connection is explicitly defined.
+     * @return preferred connection or {@code null}.
+     */
+    public DatabaseConnection getPreferredConnection(boolean fallback) {
+        org.netbeans.modules.db.explorer.DatabaseConnection c = ConnectionList.getDefault().getPreferredConnection(fallback);
+        return c == null ? null : c.getDatabaseConnection();
+    }
+    
+    /**
+     * Sets the preferred DB connection for the IDE. Setting the preferred
+     * connection to {@code null} will return the 1st connection as the preferred.
+     * @param conn the preferred connection
+     */
+    public void setPreferredConnection(DatabaseConnection conn) {
+        ConnectionList.getDefault().setPreferredConnection(
+            Arrays.asList(ConnectionList.getDefault().getConnections()).stream().
+                    filter(c -> c.getDatabaseConnection() == conn).
+                    findAny().
+                    orElseThrow(() -> new IllegalArgumentException("Unknown connection"))
+        );
     }
 }

--- a/ide/db/src/org/netbeans/modules/db/explorer/ConnectionList.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/ConnectionList.java
@@ -19,17 +19,27 @@
 
 package org.netbeans.modules.db.explorer;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.IOException;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.WeakHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.prefs.PreferenceChangeEvent;
+import java.util.prefs.PreferenceChangeListener;
+import java.util.prefs.Preferences;
 import org.netbeans.api.db.explorer.ConnectionListener;
 import org.netbeans.api.db.explorer.DatabaseException;
 import org.openide.util.Lookup;
 import org.openide.util.LookupEvent;
 import org.openide.util.LookupListener;
 import org.openide.util.NbBundle;
+import org.openide.util.NbPreferences;
+import org.openide.util.WeakListeners;
 import org.openide.util.lookup.Lookups;
 
 
@@ -45,19 +55,26 @@ import org.openide.util.lookup.Lookups;
  * @author Andrei Badea
  */
 public class ConnectionList {
+    private static final String PREF_PREFERRED_CONNECTION_NAME = "preferredConnection"; // NOI18N
 
     private static ConnectionList DEFAULT;
 
     private final List<ConnectionListener> listeners = new CopyOnWriteArrayList<ConnectionListener>();
 
-    private Lookup.Result<DatabaseConnection> result = getLookupResult();
+    private final Preferences dbPreferences;
 
+    private Lookup.Result<DatabaseConnection> result = getLookupResult();
+    
+    private Reference<DatabaseConnection> preferred = new WeakReference<>(null);
+    
     /**
      * Set of connections that the listeners were notified about. Stored not to
      * fire change events if the list has not been actually changed.
      */
     private WeakHashMap<DatabaseConnection, Boolean> lastKnownConnections =
             new WeakHashMap<DatabaseConnection, Boolean>();
+    
+    private boolean prefChanged;
 
     public static ConnectionList getDefault(boolean initialize) {
         if (initialize) {
@@ -82,6 +99,28 @@ public class ConnectionList {
 
         result.addLookupListener(new LookupListener() {
             public void resultChanged(LookupEvent e) {
+                fireListeners();
+            }
+        });
+        dbPreferences = NbPreferences.forModule(ConnectionList.class);
+        dbPreferences.addPreferenceChangeListener(new PreferenceChangeListener() {
+            @Override
+            public void preferenceChange(PreferenceChangeEvent evt) {
+                if (evt.getNode() == null || !evt.getNode().absolutePath().equals(dbPreferences.absolutePath())) {
+                    return;
+                }
+                if (!PREF_PREFERRED_CONNECTION_NAME.equals(evt.getKey())) {
+                    return;
+                }
+                DatabaseConnection c = getPreferredConnection(true);
+                synchronized (ConnectionList.this) {
+                    Reference<DatabaseConnection> ref = preferred;
+                    DatabaseConnection pref = ref.get();
+                    if (c == pref) {
+                        return;
+                    }
+                    prefChanged = true;
+                }
                 fireListeners();
             }
         });
@@ -129,6 +168,12 @@ public class ConnectionList {
         if (dbconn == null) {
             throw new NullPointerException();
         }
+        synchronized (this) {
+            DatabaseConnection pref = preferred.get();
+            if (pref == dbconn) {
+                preferred.clear();
+            }
+        }
         try {
             DatabaseConnectionConvertor.remove(dbconn);
         } catch (IOException e) {
@@ -152,9 +197,17 @@ public class ConnectionList {
     private void fireListeners() {
         boolean theSame;
         DatabaseConnection[] connections = getConnections();
+        DatabaseConnection publicPref = getPreferredConnection(true);
         synchronized (this) {
+            // verify that the connection list actually contains the preferred one, and clear the ref if not
+            Reference<DatabaseConnection> ref = preferred;
+            DatabaseConnection pref = ref.get();
+            if (pref != null && pref != publicPref) {
+                ref.clear();
+                prefChanged = true;
+            }
             if (connections.length == lastKnownConnections.size()) {
-                theSame = true;
+                theSame = prefChanged;
                 for (int i = 0; i < connections.length; i++) {
                     if (!lastKnownConnections.containsKey(connections[i])) {
                         theSame = false;
@@ -164,7 +217,7 @@ public class ConnectionList {
             } else {
                 theSame = false;
             }
-            if (theSame) {
+            if (!prefChanged && theSame) {
                 return;
             } else {
                 lastKnownConnections.clear();
@@ -172,6 +225,7 @@ public class ConnectionList {
                     lastKnownConnections.put(dc, Boolean.TRUE);
                 }
             }
+            prefChanged = false;
         }
         for (ConnectionListener listener : listeners) {
             listener.connectionsChanged();
@@ -181,4 +235,73 @@ public class ConnectionList {
     private synchronized Lookup.Result<DatabaseConnection> getLookupResult() {
         return Lookups.forPath(DatabaseConnectionConvertor.CONNECTIONS_PATH).lookupResult(DatabaseConnection.class);
     }
+    
+    private class PreferredRef extends WeakReference<DatabaseConnection> implements PropertyChangeListener {
+        private final PropertyChangeListener l;
+        
+        public PreferredRef(DatabaseConnection referent) {
+            super(referent);
+            referent.addPropertyChangeListener(l = WeakListeners.propertyChange(this, referent));
+        }
+
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            DatabaseConnection c = get();
+            if (c != null && DatabaseConnection.PROP_NAME.equals(evt)) {
+                dbPreferences.put(PREF_PREFERRED_CONNECTION_NAME, c.getName());
+            }
+        }
+
+        @Override
+        public void clear() {
+            DatabaseConnection c = get();
+            super.clear(); 
+            if (c != null) {
+                c.removePropertyChangeListener(l);
+            }
+        }
+    }
+    
+    public void setPreferredConnection(DatabaseConnection c) {
+        if (!contains(c)) {
+            throw new IllegalArgumentException();
+        }
+        synchronized (this) {
+            Reference<DatabaseConnection> ref = preferred;
+            if (ref.get() == c) {
+                return;
+            }
+            ref.clear();
+            preferred = new PreferredRef(c);
+        }
+        dbPreferences.put(PREF_PREFERRED_CONNECTION_NAME, c.getName());
+        fireListeners();
+    }
+    
+    public DatabaseConnection getPreferredConnection(boolean selectFirst) {
+        DatabaseConnection p = preferred.get();
+        if (p != null) {
+            return p;
+        }
+        String prefName = dbPreferences.get(PREF_PREFERRED_CONNECTION_NAME, null);
+        DatabaseConnection[] conns = getConnections();
+        if (prefName == null) {
+            return conns.length == 0 || !selectFirst ? null : conns[0];
+        }
+        for (int i = 0; i < conns.length; i++) {
+            DatabaseConnection c = conns[i];
+            if (prefName.equals(c.getName())) {
+                synchronized (this) {
+                    p = preferred.get();
+                    if (p == null) {
+                        preferred = new PreferredRef(c);
+                        p = c;
+                    }
+                    return p;
+                }
+            }
+        }
+        return null;
+    }
+
 }

--- a/ide/db/src/org/netbeans/modules/db/explorer/action/MakePreferred.java
+++ b/ide/db/src/org/netbeans/modules/db/explorer/action/MakePreferred.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.db.explorer.action;
+
+import org.netbeans.api.db.explorer.ConnectionManager;
+import org.netbeans.lib.ddl.DBConnection;
+import org.netbeans.modules.db.explorer.DatabaseConnection;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.awt.ActionState;
+import org.openide.nodes.Node;
+import org.openide.util.HelpCtx;
+import org.openide.util.NbBundle;
+
+/**
+ *
+ * @author sdedic
+ */
+@ActionRegistration(
+        displayName = "#SetPreferred", 
+        lazy = false,
+        enabledOn = @ActionState(type = DatabaseConnection.class)
+)
+@ActionID(category = "Database", id = "netbeans.db.explorer.action.makepreferred")
+@ActionReference(path = "Databases/Explorer/Connection/Actions", position = 160)
+@NbBundle.Messages({
+    "SetPreferred=Make Preferred Connection"
+})
+public class MakePreferred extends BaseAction {
+
+    @Override
+    protected void performAction(Node[] activatedNodes) {
+        Node n = activatedNodes[0];
+        DBConnection c = n.getLookup().lookup(DBConnection.class);
+        ConnectionManager.getDefault().setPreferredConnection(((DatabaseConnection)c).getDatabaseConnection());
+    }
+
+    @Override
+    protected boolean enable(Node[] activatedNodes) {
+        if (activatedNodes.length != 1) {
+            return false;
+        }
+        Node n = activatedNodes[0];
+        DBConnection c = n.getLookup().lookup(DBConnection.class);
+        org.netbeans.api.db.explorer.DatabaseConnection prefC = ConnectionManager.getDefault().getPreferredConnection(true);
+        return c != null && (prefC == null || !prefC.getName().equals(c.getName()));
+    }
+
+    @Override
+    public String getName() {
+        return Bundle.SetPreferred();
+    }
+
+    @Override
+    public HelpCtx getHelpCtx() {
+        return new HelpCtx(MakePreferred.class);
+    }
+    
+}

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/layer.xml
@@ -31,6 +31,7 @@
                 <attr name="instanceCreate" methodvalue="org.netbeans.modules.java.lsp.server.explorer.NodeActionsProvider.forFile"/>
                 <attr name="action:netbeans.db.explorer.action.Connect" stringvalue="Database"/>
                 <attr name="action:netbeans.db.explorer.action.Disconnect" stringvalue="Database"/>
+                <attr name="action:netbeans.db.explorer.action.makepreferred" stringvalue="Database"/>
             </file>
         </folder>
     </folder>

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -162,7 +162,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>1</release-version>
-                        <specification-version>1.82</specification-version>
+                        <specification-version>1.83</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBCommandProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/db/DBCommandProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.db;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.netbeans.api.db.explorer.ConnectionManager;
+import org.netbeans.api.db.explorer.DatabaseConnection;
+import org.netbeans.modules.java.lsp.server.explorer.TreeItem;
+import org.netbeans.modules.java.lsp.server.explorer.TreeNodeRegistry;
+import org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider;
+import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
+import org.netbeans.modules.parsing.api.ResultIterator;
+import org.openide.nodes.Node;
+import org.openide.util.Lookup;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author sdedic
+ */
+@ServiceProvider(service = CodeActionsProvider.class)
+public class DBCommandProvider extends CodeActionsProvider {
+    private static final String  COMMAND_GET_PREFERRED_CONNECTION = "java.db.preferred.connection";
+    
+    private static final Set<String> COMMANDS = new HashSet<>(Arrays.asList(
+        COMMAND_GET_PREFERRED_CONNECTION
+    ));
+    
+    @Override
+    public List<CodeAction> getCodeActions(ResultIterator resultIterator, CodeActionParams params) throws Exception {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public CompletableFuture<Object> processCommand(NbCodeLanguageClient client, String command, List<Object> arguments) {
+        if (!COMMAND_GET_PREFERRED_CONNECTION.equals(command)) {
+            return null;
+        }
+        TreeNodeRegistry r = Lookup.getDefault().lookup(TreeNodeRegistry.class);
+        DatabaseConnection conn = ConnectionManager.getDefault().getPreferredConnection(true);
+        if (conn == null || r == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return r.createProvider(DBConnectionExplorer.ID).thenCompose((m) -> {
+                Node root = m.getExplorerManager().getRootContext();
+                for (Node n : root.getChildren().getNodes(true)) {
+                    DatabaseConnection d = n.getLookup().lookup(DatabaseConnection.class);
+                    if (d != null && d.getName().equals(conn.getName())) {
+                        return (CompletionStage<Object>)(CompletionStage)m.getNodeId(n);
+                    }
+                }
+                return CompletableFuture.completedFuture(null);
+            }).toCompletableFuture();
+    }
+
+    @Override
+    public Set<String> getCommands() {
+        return COMMANDS;
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistry.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistry.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.java.lsp.server.explorer;
 
 import java.awt.Image;
 import java.net.URI;
+import java.util.concurrent.CompletionStage;
 import org.openide.nodes.Node;
 
 /**
@@ -35,6 +36,8 @@ public interface TreeNodeRegistry {
     Node findNode(int id);
     TreeViewProvider providerOf(int id);
     ImageDataOrIndex imageOrIndex(Image im);
+    
+    CompletionStage<TreeViewProvider> createProvider(String id);
     
     public class ImageDataOrIndex {
         public final URI    imageURI;

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -407,8 +407,12 @@
 			{
 				"command": "nbls:Edit:org.openide.actions.DeleteAction",
 				"title": "Delete"
+			},
+			{
+				"command": "java.local.db.set.preferred.connection",
+				"title": "Make Default Connection"
 			}
-		],
+	],
 		"keybindings": [
 			{
 				"command": "java.workspace.compile",
@@ -462,8 +466,12 @@
 				{
 					"command": "graalvm.pause.script",
 					"when": "nbJavaLSReady"
+				},
+				{
+					"command": "java.local.db.set.preferred.connection",
+					"when": "false"
 				}
-			],
+				],
 			"view/item/context": [
 				{
 					"command": "foundProjects.deleteEntry",
@@ -480,6 +488,10 @@
 				{
 					"command": "nbls:Edit:org.openide.actions.DeleteAction",
 					"when": "nbJavaLSReady && viewItem =~ /class:ddl.DBConnection/"
+				},
+				{
+					"command": "java.local.db.set.preferred.connection",
+					"when": "viewItem =~ /class:ddl.DBConnection/"
 				}
 			]
 		}

--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -49,7 +49,7 @@ import { asRanges, StatusMessageRequest, ShowStatusMessageParams, QuickPickReque
          SetTextEditorDecorationParams
 } from './protocol';
 import * as launchConfigurations from './launchConfigurations';
-import { createTreeViewService, TreeViewService } from './explorer';
+import { createTreeViewService, TreeViewService, TreeItemDecorator, Visualizer, CustomizableTreeDataProvider } from './explorer';
 import { TLSSocket } from 'tls';
 
 const API_VERSION : string = "1.0";
@@ -721,13 +721,61 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
         
             // create project explorer:
             c.findTreeViewService().createView('foundProjects', 'Projects', { canSelectMany : false });
-            c.findTreeViewService().createView('database.connections', undefined , { canSelectMany : true });
+            createDatabaseView(c);
         }).catch(setClient[1]);
     }).catch((reason) => {
         activationPending = false;
         handleLog(log, reason);
         window.showErrorMessage('Error initializing ' + reason);
     });
+
+    class Decorator implements TreeItemDecorator<Visualizer> {
+        private provider : CustomizableTreeDataProvider<Visualizer>;
+        private serverPreferred : Thenable<any>;
+        private setCommand : vscode.Disposable;
+
+        constructor(provider : CustomizableTreeDataProvider<Visualizer>, client : NbLanguageClient) {
+            this.provider = provider;
+            this.serverPreferred = vscode.commands.executeCommand('java.db.preferred.connection');
+            this.setCommand = vscode.commands.registerCommand('java.local.db.set.preferred.connection', (n) => this.setPreferred(n));
+        }
+
+        async decorateTreeItem(vis : Visualizer, item : vscode.TreeItem) : Promise<vscode.TreeItem> {
+            return new Promise((resolve, reject) => {
+                this.serverPreferred.then((id) => {
+                    if (id == vis.id) {
+                        let s : string = typeof item.label == 'string' ? item.label : item.label?.label || '';
+                        const high : [number, number][] = [[0, s.length]];
+                        item.label = { label : s, highlights: high };
+                    }
+                    resolve(item);
+                });
+            })
+        }
+
+        setPreferred(...args : any[]) {
+            const id : number = args[0]?.id || -1;
+            this.serverPreferred = new  Promise((resolve, reject) => resolve(id));
+            vscode.commands.executeCommand('nbls:Database:netbeans.db.explorer.action.makepreferred', ...args);
+            // refresh all
+            this.provider.fireItemChange();
+        }
+
+        dispose() {
+            this.setCommand?.dispose();
+        }
+    }
+
+    function createDatabaseView(c : NbLanguageClient) {
+        let decoRegister : CustomizableTreeDataProvider<Visualizer>;
+        c.findTreeViewService().createView('database.connections', undefined , { 
+            canSelectMany : true,  
+            
+            providerInitializer : (customizable) => 
+                customizable.addItemDecorator(new Decorator(customizable, c))
+        });
+        
+    }
 
     async function showHtmlPage(params : HtmlPageParams): Promise<string> {
         function showUri(url: string, ok: any, err: any) {


### PR DESCRIPTION
![default-db-connection](https://user-images.githubusercontent.com/26788611/145721166-23648e56-7bb2-40e4-b5ff-e9a2e6f1d361.png)

This PR required an API change in `ConnectionManager` in the DB module - but IMHO quite beneficial, since the IDE code now can also use the 'preferred' connection for whatever features not originating from the DB Connection node. For example SQL embedded in Java / other code files may also benefit from the added API.

The LSP client may query the default connection and also set it - the value will be persisted by the NBLS.
