### PR TITLE
Avoid spurious exception in log. Warn if perf counters are enabled on incompatible JDK

### DIFF
--- a/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/PerfStatCompilationUnit.java
+++ b/groovy/groovy.editor/src/org/netbeans/modules/groovy/editor/compiler/PerfStatCompilationUnit.java
@@ -101,14 +101,17 @@ public class PerfStatCompilationUnit extends CompilationUnit {
             modifiersField.setAccessible(true);
             modifiersField.setInt(f, f.getModifiers() & ~Modifier.FINAL);
         } catch (ReflectiveOperationException | SecurityException ex) {
-            Exceptions.printStackTrace(ex);
+            if (PERFLOG.isLoggable(Level.FINER)) {
+                PERFLOG.log(Level.WARNING, "Unable to patch Groovy compiler for timimg. Use JDK 11.", ex);
+            }
         }
         doPhaseOperation = m;
         resolverVisitor = f;
     }
 
     private void overrideClassNodeResolver() {
-        if (!PERFLOG.isLoggable(Level.FINER)) {
+        // revolve visitor override does not work on JDK17
+        if (!PERFLOG.isLoggable(Level.FINER) || resolverVisitor == null) {
             return;
         }
         classNodeResolver = new NbClassNodeResolver() {


### PR DESCRIPTION
Groovy editor's internal performance counters override `final` groovy compiler's member field's value using reflection, which does not work on JDK17. These performance counters are likely to become obsolete so the easiest way how to avoid mostly harmless notification in the `message.log` is to log it only if the performance dumps are enabled.

// cc: @ppisl 