### PR TITLE
Single file Groovy Run and Debug in VSCode.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/breakpoints/GroovyBreakpointFactory.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/breakpoints/GroovyBreakpointFactory.java
@@ -87,6 +87,11 @@ public class GroovyBreakpointFactory {
                     b.setSourcePath(relativePath);
                     return relativePath;
                 }
+            } else {
+                // Suppose the current folder
+                String relativePath = fo.getNameExt();
+                b.setSourcePath(relativePath);
+                return relativePath;
             }
         }
         return null;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -542,13 +542,13 @@ public abstract class NbLaunchDelegate {
         ActionProvider provider = null;
         String command = null;
         Collection<ActionProvider> actionProviders = findActionProviders(prj);
-        Lookup testLookup = preferProjActions ? Lookups.singleton(prj) : (singleMethod != null) ? Lookups.fixed(toRun, singleMethod) : Lookups.singleton(toRun);
+        Lookup testLookup = preferProjActions && prj != null ? Lookups.singleton(prj) : (singleMethod != null) ? Lookups.fixed(toRun, singleMethod) : Lookups.singleton(toRun);
         String[] actions;
         if (!mainSource && singleMethod != null) {
             actions = debug ? new String[] {SingleMethod.COMMAND_DEBUG_SINGLE_METHOD}
                             : new String[] {SingleMethod.COMMAND_RUN_SINGLE_METHOD};
         } else {
-            if (preferProjActions) {
+            if (preferProjActions && prj != null) {
                 actions = debug ? mainSource ? new String[] {ActionProvider.COMMAND_DEBUG}
                                              : new String[] {ActionProvider.COMMAND_DEBUG_TEST_SINGLE, ActionProvider.COMMAND_DEBUG}
                                 : mainSource ? new String[] {ActionProvider.COMMAND_RUN}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/WorkspaceServiceImpl.java
@@ -426,7 +426,7 @@ public final class WorkspaceServiceImpl implements WorkspaceService, LanguageCli
     private CompletableFuture<Object> findProjectConfigurations(FileObject ownedFile) {
         return server.asyncOpenFileOwner(ownedFile).thenApply(p -> {
             if (p == null) {
-                return CompletableFuture.completedFuture(Collections.emptyList());
+                return Collections.emptyList();
             }
             ProjectConfigurationProvider<ProjectConfiguration> provider = p.getLookup().lookup(ProjectConfigurationProvider.class);
             List<String> configDispNames = new ArrayList<>();


### PR DESCRIPTION
1. When we get no ClassPath in `GroovyBreakpointFactory.java`, we suppose the file name for single-file execution.
2. Prevent from NPE when project is null in `WorkspaceServiceImpl.java`
3. `findProjectConfigurations` need to return the desired value and not wrap it in the Future.