### PR TITLE
Maintain data identity for duplicit info requests

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ui/refactoring.css
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/refactoring/ui/refactoring.css
@@ -1,4 +1,4 @@
-<!--
+/*
 
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -17,7 +17,7 @@
     specific language governing permissions and limitations
     under the License.
 
--->
+*/
 
 html, body {
     height: 100%;


### PR DESCRIPTION
Sometimes an error "Element with id 15 is already registered" was printed. During debugging, it seems that children are requested several times in a row:

```
[Trace - 2:22:10 PM] Sending request 'nodes/children - (12)'.
Params: {
    "nodeId": 5
}


[Trace - 2:22:10 PM] Received response 'nodes/children - (12)' in 51ms.
Result: [
    9
]


[Trace - 2:22:10 PM] Sending request 'nodes/info - (13)'.
Params: {
    "nodeId": 9
}


[Trace - 2:22:11 PM] Received response 'nodes/info - (13)' in 87ms.
Result: {
    "collapsibleState": 1,
    "contextValue": "",
    "iconUri": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAASCAYAAABSO15qAAABHUlEQVR4XuWTQU7DMBBFc6PWMw7cp4GDJNykgitQVaikSLAB0TWCfVnAAhqxKGr8mRmnCNpIDUis+NLTeGzPH9lxkuT/aFCUOCimyPILDIozZEdTiRNs7mtVlk+k+FyKSxzmWlhasea2gTgFUR8sMcKSe5BnsO9hOL7ByegWx+MZhqNrG2v0lMKKERAVVgghfKY2Jcna0BNbA/LO2Kc9MZDOqpe391ZehVodQzRboYZOaCNOCYk6auffiKgxULe2zmu215YSl3IcpwZsZ36YL4QK98rjwohzMv4Wq2ZcoZ9+Mbi8e8LVTp4bYq618Q5Ep7P5j9Gv0hjUW4td8PEOnF3i5mIX9A3ZQ2JHdh511E9jL5B34WR/r9u/8Kf6AAYdPtEtmOMYAAAAAElFTkSuQmCC",
    "iconIndex": 8,
    "id": 9,
    "name": "resources",
    "label": "resources",
    "resourceUri": "file:/space/src/vscode/scratch/sedlacek/TestMicronaut_Maven/src/main/resources/",
    "tooltip": {
        "kind": "markdown",
        "value": "Configuration Directory  \n*Directory:* **/space/src/vscode/scratch/sedlacek/TestMicronaut_Maven/src/main/resources**   \n"
    }
}
[Trace - 2:22:11 PM] Sending request 'nodes/children - (14)'.
Params: {
    "nodeId": 5
}


[Trace - 2:22:11 PM] Received response 'nodes/children - (14)' in 45ms.
Result: [
    9
]


[Trace - 2:22:11 PM] Sending request 'nodes/info - (15)'.
Params: {
    "nodeId": 9
}


[Trace - 2:22:11 PM] Received response 'nodes/info - (15)' in 89ms.
Result: {
    "collapsibleState": 1,
    "contextValue": "",
    "iconIndex": 8,
    "id": 9,
    "name": "resources",
    "label": "resources",
    "resourceUri": "file:/space/src/vscode/scratch/sedlacek/TestMicronaut_Maven/src/main/resources/",
    "tooltip": {
        "kind": "markdown",
        "value": "Configuration Directory  \n*Directory:* **/space/src/vscode/scratch/sedlacek/TestMicronaut_Maven/src/main/resources**   \n"
    }
}
```

The deserialized item was returned as a child to `vscode` infrastructure, but even though it has the same `id` property, its object identity is different (and there's no equals contract in TS/JS).  In this case I've decided to update the old item in place - and return the same instance that has been already seen by the `vscode` library

The commit 34e02eb is unrelated, the file was just red/erroneous in my IDE - just fixed comment delimiters.