### PR TITLE
Show Databases and Projects views only after NBLS extension activates.

### DIFF
--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -64,11 +64,13 @@
 			"explorer": [
 				{
 					"id": "foundProjects",
-					"name": "Projects"
+					"name": "Projects",
+					"when": "nbJavaLSReady"
 				},
 				{
 					"id": "database.connections",
-					"name": "Databases"
+					"name": "Databases",
+					"when": "nbJavaLSReady"
 				}
 			]
 		},


### PR DESCRIPTION
When vscode starts with a folder that do not contains any nice files like `.java` or `.groovy`, the Apache NBLS extension does not activate at all ! Still the UI shows `Projects` and `Databases` views, but empty - as the relevant `TreeDataProvider`s are not registered yet.
This PR will just make appearance of those views depend on NBLS extension to become ready (it sets up a context variable).