### PR TITLE
Remove obsolete permgen flags.

### DIFF
--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/GlassFish.properties-dist
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/GlassFish.properties-dist
@@ -19,4 +19,4 @@ adminUser=admin
 adminPassword=admin123
 domainName=test
 glassFishArgs=-domain test
-javaArgs=-XX:MaxPermSize=192m -XX:PermSize=64m -client
+javaArgs=

--- a/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/server/ServerTasksTest.java
+++ b/enterprise/glassfish.tooling/test/unit/src/org/netbeans/modules/glassfish/tooling/server/ServerTasksTest.java
@@ -51,7 +51,7 @@ public class ServerTasksTest extends CommonTest {
         gfServer = createGlassfishServer();
         args = new StartupArgs() {
             
-            private List<String> javaArgs = Arrays.asList("-Xms128m", "-XX:PermSize=96m", "-Dtest=true");
+            private List<String> javaArgs = Arrays.asList("-Xms128m", "-Dtest=true");
             private List<String> glassfishArgs = Arrays.asList("--domaindir " + gfServer.getDomainsFolder() + File.separator + gfServer.getDomainName(),
                     "--domain " + gfServer.getDomainName());
             private HashMap<String, String> envVars;

--- a/enterprise/payara.tooling/test/unit/src/org/netbeans/modules/payara/tooling/Payara.properties
+++ b/enterprise/payara.tooling/test/unit/src/org/netbeans/modules/payara/tooling/Payara.properties
@@ -19,4 +19,4 @@ adminUser=admin
 adminPassword=admin123
 domainName=test
 payaraArgs=-domain test
-javaArgs=-XX:MaxPermSize=192m -XX:PermSize=64m -client
+javaArgs=

--- a/enterprise/performance.javaee/build.xml
+++ b/enterprise/performance.javaee/build.xml
@@ -33,7 +33,7 @@
         <os family="unix"/>
     </condition>
     <property name="test.run.args" value="-client
-            -Xss4m -Xms64m -Xmx512m -XX:PermSize=64m -XX:MaxPermSize=300m
+            -Xss4m -Xms64m -Xmx512m
             -Dnetbeans.keyring.no.master=true
             -Xverify:none -Dsun.java2d.noddraw=true
             -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;

--- a/enterprise/performance.scripting/build.xml
+++ b/enterprise/performance.scripting/build.xml
@@ -33,7 +33,7 @@
         <os family="unix"/>
     </condition>
     <property name="test.run.args" value="-client
-            -Xss4m -Xms64m -Xmx512m -XX:PermSize=64m -XX:MaxPermSize=300m
+            -Xss4m -Xms64m -Xmx512m
             -Dnetbeans.keyring.no.master=true
             -Xverify:none -Dsun.java2d.noddraw=true
             -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;

--- a/enterprise/performance.web/build.xml
+++ b/enterprise/performance.web/build.xml
@@ -34,7 +34,7 @@
     </condition>
 
     <property name="test.run.args" value="-client
-            -Xss4m -Xms64m -Xmx512m -XX:PermSize=64m -XX:MaxPermSize=300m
+            -Xss4m -Xms64m -Xmx512m
             -Dnetbeans.keyring.no.master=true
             -Xverify:none -Dsun.java2d.noddraw=true
             -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;

--- a/ide/ide.kit/test/whitelist/build.xml
+++ b/ide/ide.kit/test/whitelist/build.xml
@@ -126,7 +126,7 @@
             <arg value="test-qa-functional"/>
             <arg value="-Dtest.includes=**/WhitelistTest.class"/>
             <arg value="-Dpermit.jdk6.builds=true"/>
-            <arg value="-Dtest.run.args=-ea -XX:PermSize=64m -XX:MaxPermSize=400m -Xmx512m -Xverify:none -Dtest.whitelist.stage=1 -Dorg.netbeans.core.TimeableEventQueue.quantum=60000 ${debug.args}"/>
+            <arg value="-Dtest.run.args=-ea -Xmx512m -Xverify:none -Dtest.whitelist.stage=1 -Dorg.netbeans.core.TimeableEventQueue.quantum=60000 ${debug.args}"/>
             <arg value="-Dtest-qa-functional-sys-prop.allowed.violations=${allowed.violations}"/>
         </exec>
     </target>
@@ -141,7 +141,7 @@
             <arg value="test-qa-functional"/>
             <arg value="-Dtest.includes=**/WhitelistTest.class"/>
             <arg value="-Dpermit.jdk6.builds=true"/>
-            <arg value="-Dtest.run.args=-ea -XX:PermSize=64m -XX:MaxPermSize=400m -Xmx512m -Xverify:none -Dtest.whitelist.stage=2 -Dorg.netbeans.core.TimeableEventQueue.quantum=60000 ${debug.args}"/>
+            <arg value="-Dtest.run.args=-ea -Xmx512m -Xverify:none -Dtest.whitelist.stage=2 -Dorg.netbeans.core.TimeableEventQueue.quantum=60000 ${debug.args}"/>
             <arg value="-Dtest-qa-functional-sys-prop.allowed.violations=${allowed.violations}"/>
         </exec>
     </target>
@@ -156,7 +156,7 @@
             <arg value="test-qa-functional"/>
             <arg value="-Dtest.includes=**/WhitelistTest.class"/>
             <arg value="-Dpermit.jdk6.builds=true"/>
-            <arg value="-Dtest.run.args=-ea -XX:PermSize=64m -XX:MaxPermSize=400m -Xmx512m -Xverify:none -Dtest.whitelist.stage=3 -Dorg.netbeans.core.TimeableEventQueue.quantum=60000 ${debug.args}"/>
+            <arg value="-Dtest.run.args=-ea -Xmx512m -Xverify:none -Dtest.whitelist.stage=3 -Dorg.netbeans.core.TimeableEventQueue.quantum=60000 ${debug.args}"/>
             <arg value="-Dtest-qa-functional-sys-prop.allowed.violations=${allowed.violations}"/>
         </exec>
     </target>

--- a/java/java.kit/nbproject/project.properties
+++ b/java/java.kit/nbproject/project.properties
@@ -23,7 +23,7 @@ test.config.stableBTD.includes=\
     org/netbeans/test/ide/IDECommitValidationTest.class
 test.config.memoryvalidation.includes=\
     org/netbeans/test/ide/MemoryValidationTest.class
-test.run.args=-da -XX:MaxPermSize=300m
+test.run.args=-da
 # runs UI, but ignores its failures. Just seeks memory leaks
 # XXX #178071: disabling for now as it fails and the failure has not been evaluated
 #test.config.commit.includes=\

--- a/java/maven/test/unit/src/org/netbeans/modules/maven/api/customizer/ModelHandle2Test.java
+++ b/java/maven/test/unit/src/org/netbeans/modules/maven/api/customizer/ModelHandle2Test.java
@@ -165,7 +165,7 @@ public class ModelHandle2Test extends NbTestCase {
 "                <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>\n" +
 "            </goals>\n" +
 "            <properties>\n" +
-"                <exec.args>-XX:MaxPermSize=512m -classpath %classpath ${packageClassName}</exec.args>\n" +
+"                <exec.args>-classpath %classpath ${packageClassName}</exec.args>\n" +
 "                <exec.executable>java</exec.executable>\n" +
 "                <exec.classpathScope>${classPathScope}</exec.classpathScope>\n" +
 "            </properties>\n" +
@@ -180,7 +180,7 @@ public class ModelHandle2Test extends NbTestCase {
 "                <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>\n" +
 "            </goals>\n" +
 "            <properties>\n" +
-"                <exec.args>-XX:MaxPermSize=512m -agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>\n" +
+"                <exec.args>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>\n" +
 "                <exec.executable>java</exec.executable>\n" +
 "                <exec.classpathScope>${classPathScope}</exec.classpathScope>\n" +
 "                <jpda.listen>true</jpda.listen>\n" +
@@ -202,7 +202,7 @@ public class ModelHandle2Test extends NbTestCase {
 "                <goal>org.codehaus.mojo:exec-maven-plugin:3.0.0:exec</goal>\n" +
 "            </goals>\n" +
 "            <properties>\n" +
-"                <exec.args>-XX:MaxPermSize=512m -agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>\n" +
+"                <exec.args>-agentlib:jdwp=transport=dt_socket,server=n,address=${jpda.address} -classpath %classpath ${packageClassName}</exec.args>\n" +
 "                <exec.executable>java</exec.executable>\n" +
 "                <exec.classpathScope>${classPathScope}</exec.classpathScope>\n" +
 "                <jpda.listen>true</jpda.listen>\n" +

--- a/java/performance.java/build.xml
+++ b/java/performance.java/build.xml
@@ -24,7 +24,7 @@
 
     <property name="test.timeout" value="7200000"/>
     <property name="test.run.args" value="-client
-            -Xss4m -Xms64m -Xmx512m -XX:PermSize=64m -XX:MaxPermSize=300m
+            -Xss4m -Xms64m -Xmx512m
             -Dnetbeans.keyring.no.master=true
             -Xverify:none -Dsun.java2d.noddraw=true"/>
 

--- a/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build.xml
+++ b/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build.xml
@@ -53,7 +53,7 @@
         <os family="unix"/>
     </condition>
 
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -XX:PermSize=32m -XX:MaxPermSize=200m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
 
     <import file="nbproject/build-impl.xml"/>
 </project>

--- a/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_1.xml
+++ b/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_1.xml
@@ -33,7 +33,7 @@
         <os family="unix"/>
     </condition>
 
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -XX:PermSize=32m -XX:MaxPermSize=200m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m-Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
 
     <import file="nbproject/build-impl.xml"/>
 </project>

--- a/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_1_1.xml
+++ b/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_1_1.xml
@@ -33,7 +33,7 @@
         <os family="unix"/>
     </condition>
 
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -XX:PermSize=32m -XX:MaxPermSize=200m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
 
     <import file="nbproject/build-impl.xml"/>
 </project>

--- a/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_1_1_1.xml
+++ b/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_1_1_1.xml
@@ -33,7 +33,7 @@
         <os family="unix"/>
     </condition>
 
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -XX:PermSize=32m -XX:MaxPermSize=200m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
 
     <import file="nbproject/build-impl.xml"/>
 </project>

--- a/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_1_2.xml
+++ b/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_1_2.xml
@@ -33,7 +33,7 @@
         <os family="unix"/>
     </condition>
 
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -XX:PermSize=32m -XX:MaxPermSize=200m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
 
     <import file="nbproject/build-impl.xml"/>
 </project>

--- a/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_2.xml
+++ b/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_2.xml
@@ -33,7 +33,7 @@
         <os family="unix"/>
     </condition>
 
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -XX:PermSize=32m -XX:MaxPermSize=200m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
 
     <import file="nbproject/build-impl.xml"/>
 </project>

--- a/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_2_1.xml
+++ b/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_2_1.xml
@@ -33,7 +33,7 @@
         <os family="unix"/>
     </condition>
 
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -XX:PermSize=32m -XX:MaxPermSize=200m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
 
     <import file="nbproject/build-impl.xml"/>
 </project>

--- a/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_3.xml
+++ b/java/performance.java/test/qa-functional/data/PerformanceTestFoldersData/src/folders/xmlFolder100/build_3.xml
@@ -33,7 +33,7 @@
         <os family="unix"/>
     </condition>
 
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -XX:PermSize=32m -XX:MaxPermSize=200m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss2m -Xms32m -Xmx512m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;"/>
 
     <import file="nbproject/build-impl.xml"/>
 </project>

--- a/java/performance/build.xml
+++ b/java/performance/build.xml
@@ -25,7 +25,7 @@
 
     <property name="test.timeout" value="7200000"/>
     <property name="test.run.args" value="-client 
-            -Xss4m -Xms64m -Xmx512m -XX:PermSize=64m -XX:MaxPermSize=300m 
+            -Xss4m -Xms64m -Xmx512m
             -Dnetbeans.keyring.no.master=true 
             -Xverify:none -Dsun.java2d.noddraw=true
             -DBrokenReferencesSupport.suppressBrokenRefAlert=true"/>

--- a/java/performance/cnd/build.xml
+++ b/java/performance/cnd/build.xml
@@ -50,7 +50,7 @@
     </condition>
 
 
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss4m -Xms64m -Xmx1024m -XX:PermSize=64m -XX:MaxPermSize=300m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot; -Dorg.netbeans.performance.repeat=&quot;${repeat}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss4m -Xms64m -Xmx1024m -Xverify:none -Dsun.java2d.noddraw=true -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot; -Dorg.netbeans.performance.repeat=&quot;${repeat}&quot;"/>
 
     <import file="nbproject/build-impl.xml"/>
 </project>

--- a/java/performance/enterprise/build.xml
+++ b/java/performance/enterprise/build.xml
@@ -53,7 +53,7 @@
         <os family="unix"/>
     </condition>
 
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss4m -Xms64m -Xmx1024m -XX:PermSize=64m -XX:MaxPermSize=300m -Xverify:none -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;  -Dorg.netbeans.performance.repeat=&quot;${repeat}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss4m -Xms64m -Xmx1024m -Xverify:none -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;  -Dorg.netbeans.performance.repeat=&quot;${repeat}&quot;"/>
     <target name="test" description="Uses test-single to run each suite in different VM">
         <antcall target="test-single">         
             <param name="test.includes" value="**\MeasureEnterpriseSetupTest*"/>

--- a/java/performance/hudson/netbeans.conf
+++ b/java/performance/hudson/netbeans.conf
@@ -43,22 +43,16 @@ netbeans_default_cachedir="${HOME}/.cache/perfdev"
 
 # Options used by NetBeans launcher by default, can be overridden by explicit
 # command line switches:
-netbeans_default_options="-J-client -J-Xss2m -J-Xms32m -J-XX:PermSize=32m -J-Dnetbeans.logger.console=false -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dsun.zip.disableMemoryMapping=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.keyring.no.master=true -J-DSuspendSupport.disabled=true -J-DBrokenReferencesSupport.suppressBrokenRefAlert=true -J-Dnetbeans.full.hack=true -J-Dorg.netbeans.log.startup=print -J-Dorg.netbeans.editor.linewrap=true"
-# Note that default -Xmx and -XX:MaxPermSize are selected for you automatically.
+netbeans_default_options="-J-client -J-Xss2m -J-Xms32m -J-Dnetbeans.logger.console=false -J-Dapple.laf.useScreenMenuBar=true -J-Dapple.awt.graphics.UseQuartz=true -J-Dsun.java2d.noddraw=true -J-Dsun.zip.disableMemoryMapping=true -J-Dplugin.manager.check.updates=false -J-Dnetbeans.keyring.no.master=true -J-DSuspendSupport.disabled=true -J-DBrokenReferencesSupport.suppressBrokenRefAlert=true -J-Dnetbeans.full.hack=true -J-Dorg.netbeans.log.startup=print -J-Dorg.netbeans.editor.linewrap=true"
+# Note that default -Xmx is selected for you automatically.
 # You can find these values in var/log/messages.log file in your userdir.
-# The automatically selected value can be overridden by specifying -J-Xmx or
-# -J-XX:MaxPermSize= here or on the command line.
-
-# If you specify the heap size (-Xmx) explicitly, you may also want to enable
-# Concurrent Mark & Sweep garbage collector. In such case add the following
-# options to the netbeans_default_options:
-# -J-XX:+UseConcMarkSweepGC -J-XX:+CMSClassUnloadingEnabled -J-XX:+CMSPermGenSweepingEnabled
-# (see http://wiki.netbeans.org/FaqGCPauses)
+# The automatically selected value can be overridden by specifying -J-Xmx
+# here or on the command line.
 
 # Default location of JDK, can be overridden by using --jdkhome <dir>
 # Be careful when changing jdkhome. There are two launchers - 32-bit and 64-bit.
 # Which one is used depends on JVM architecture.
-netbeans_jdkhome="/space/hudson/jdks/jdk7"
+netbeans_jdkhome="/space/hudson/jdks/jdk8"
 
 # Additional module clusters, using ${path.separator} (';' on Windows or ':' on Unix):
 #netbeans_extraclusters="/absolute/path/to/cluster1:/absolute/path/to/cluster2"

--- a/java/performance/mobility/build.xml
+++ b/java/performance/mobility/build.xml
@@ -27,7 +27,7 @@
 
     <property name="nbextra.dir" location="../../../nbextra"/>
     <property name="test.timeout" value="3600000"/>
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss4m -Xms64m -Xmx1024m -XX:PermSize=64m -XX:MaxPermSize=300m -Xverify:none -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;  -Dorg.netbeans.performance.repeat=&quot;${repeat}&quot;"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -client -Xss4m -Xms64m -Xmx1024m -Xverify:none -Dcom.sun.aas.installRoot=&quot;${j2ee.appserver.path}&quot; -Dtomcat.installRoot=&quot;${tomcat.webserver.path}&quot;  -Dorg.netbeans.performance.repeat=&quot;${repeat}&quot;"/>
     <property environment="env"/>
     <property name="hudson.buildnumber" value="${env.BUILD_NUMBER}"/>
     <property name="hudson.jobname" value="${env.JOB_NAME}"/>

--- a/java/performance/src/org/netbeans/modules/performance/resources/netbeans.conf
+++ b/java/performance/src/org/netbeans/modules/performance/resources/netbeans.conf
@@ -20,18 +20,12 @@ netbeans_default_userdir="${HOME}/.netbeans/dev"
 
 # Options used by NetBeans launcher by default, can be overridden by explicit
 # command line switches:
-netbeans_default_options="-J-Dnetbeans.keyring.no.master=true -J-client -J-Xverify:none -J-Xss2m -J-Xms32m -J-XX:PermSize=32m -J-XX:MaxPermSize=200m -J-Dapple.laf.useScreenMenuBar=true -J-Dsun.java2d.noddraw=true"
-#netbeans_default_options="-J-client -J-Xss2m -J-Xms32m -J-XX:PermSize=32m -J-XX:MaxPermSize=200m -J-Xverify:none -J-Dapple.laf.useScreenMenuBar=true"
+netbeans_default_options="-J-Dnetbeans.keyring.no.master=true -J-client -J-Xverify:none -J-Xss2m -J-Xms32m -J-Dapple.laf.useScreenMenuBar=true -J-Dsun.java2d.noddraw=true"
+#netbeans_default_options="-J-client -J-Xss2m -J-Xms32m -J-Xverify:none -J-Dapple.laf.useScreenMenuBar=true"
 # Note that a default -Xmx is selected for you automatically.
 # You can find this value in var/log/messages.log file in your userdir.
 # The automatically selected value can be overridden by specifying -J-Xmx here
 # or on the command line.
-
-# If you specify the heap size (-Xmx) explicitely, you may also want to enable
-# Concurrent Mark & Sweep garbage collector. In such case add the following
-# options to the netbeans_default_options:
-# -J-XX:+UseConcMarkSweepGC -J-XX:+CMSClassUnloadingEnabled -J-XX:+CMSPermGenSweepingEnabled
-# (see http://wiki.netbeans.org/wiki/view/FaqGCPauses)
 
 # Default location of JDK, can be overridden by using --jdkhome <dir>:
 #netbeans_jdkhome="C:\Sun\Java\jdk1.6.0_02"

--- a/nbbuild/hudson/round-robin-push
+++ b/nbbuild/hudson/round-robin-push
@@ -76,7 +76,7 @@ if [ -z "$TMP" ]; then
   TMP="/tmp"
 fi
 
-ANT_OPTS="-Xmx512m -XX:MaxPermSize=128m"
+ANT_OPTS="-Xmx512m"
 export ANT_OPTS
 
 BASETIP=`hg log -r . --template '{node}'`

--- a/nbbuild/installer/engine/src/org/netbeans/installer/utils/applications/NetBeansUtils.java
+++ b/nbbuild/installer/engine/src/org/netbeans/installer/utils/applications/NetBeansUtils.java
@@ -710,7 +710,7 @@ public class NetBeansUtils {
             sysProp + nbHomeProp    + eq + nbHome,
             sysProp + nbUserdirProp + eq + nbUserdir,
             sysProp + nbDirsProp    + eq + nbDirsString,
-            "-Xms32m", "-XX:MaxPermSize=96m", "-Xverify:none", "-Xmx128m",
+            "-Xms32m", "-Xverify:none", "-Xmx128m",
             "-cp", classpath,
             UPDATER_FRAMENAME, "--nosplash"});
     }

--- a/nbbuild/newbuild/init.sh
+++ b/nbbuild/newbuild/init.sh
@@ -139,7 +139,7 @@ if [ -z ${DONT_PACK_LOCALIZATION_JARS_ON_MAC} ]; then
     export DONT_PACK_LOCALIZATION_JARS_ON_MAC
 fi
 
-export ANT_OPTS=$ANT_OPTS" -Xmx2G -XX:MaxPermSize=500m"
+export ANT_OPTS=$ANT_OPTS" -Xmx2G"
 
 if [ -n ${JDK_HOME} ] && [ -z ${JAVA_HOME} ] ; then
     export JAVA_HOME=$JDK_HOME

--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -295,7 +295,7 @@
         <condition property="test.run.args" value="-ea -Xmx480m">
             <istrue value="${have-jdk-1.8}"/>
         </condition>
-        <property name="test.run.args" value="-ea -XX:PermSize=32m -XX:MaxPermSize=200m -Xmx480m"/>
+        <property name="test.run.args" value="-ea -Xmx480m"/>
         <property name="extra.test.libs.dir" location="${test.dist.dir}/extralibs"/>
         <macrodef name="test-init-nborg">
             <attribute name="test.type"/>

--- a/nbbuild/testdist/release/one-module.xml
+++ b/nbbuild/testdist/release/one-module.xml
@@ -156,11 +156,7 @@
             </sequential>
         </macrodef>
         <property name="test.config" value="default"/>
-        <condition property="test.run.args" value="-ea -Xmx480m -Xss2m -Dnetbeans.keyring.no.master=true">
-            <!-- JDK8 dropped support for PermSize (and JDK9 does not start with it being specified). Don't specify such option when running on JDK8 and newer. -->
-            <available classname="java.lang.FunctionalInterface"/>
-        </condition>
-        <property name="test.run.args" value="-ea -XX:PermSize=32m -XX:MaxPermSize=200m -Xmx480m -Xss2m -Dnetbeans.keyring.no.master=true"/>
+        <property name="test.run.args" value="-ea -Xmx480m -Xss2m -Dnetbeans.keyring.no.master=true"/>
         <property name="custom.jvm.args" value=""/>
         <property name="custom.jvm.executable" value="java"/>
         <property name="test.run.args.full" value="${test.run.args} ${custom.jvm.args}"/>

--- a/platform/o.n.core/nbproject/project.properties
+++ b/platform/o.n.core/nbproject/project.properties
@@ -45,6 +45,4 @@ test.config.stableBTD.excludes=\
     **/NbKeymapTest.class,\
     **/SystemFileSystemTest.class
 
-# ValidateLayerConsistencyTest using standard settings failing on nbms-and-javadoc with "java.lang.OutOfMemoryError: PermGen space"
-# increased Xmx and MaxPermSize to prevent OOM on 64 bit system in 64 bit java mode
-test.run.args=-ea -XX:PermSize=32m -XX:MaxPermSize=400m -Xmx520m
+test.run.args=-ea -Xmx520m

--- a/platform/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateClassLinkageTest.java
+++ b/platform/o.n.core/test/qa-functional/src/org/netbeans/core/validation/ValidateClassLinkageTest.java
@@ -130,7 +130,6 @@ public class ValidateClassLinkageTest extends NbTestCase {
         }
         MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
         MemoryUsage usage = memoryBean.getNonHeapMemoryUsage();
-        // Note MaxPermSize in project.properties:
         System.err.println("Non-heap memory usage: " + (usage.getUsed() / 1024 / 1024) + "/" + (usage.getMax() / 1024 / 1024) + "M");
         if (!errorsByClazz.isEmpty()) {
             for (Map.Entry<String,Throwable> entry : errorsByClazz.entrySet()) {

--- a/profiler/profiler/build.xml
+++ b/profiler/profiler/build.xml
@@ -22,7 +22,7 @@
 <project basedir="." default="build" name="profiler/profiler">
     <description>Builds, tests, and runs the project org.yourorghere.main</description>
     <import file="../../nbbuild/templates/projectized.xml"/>
-    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -Dnetbeans.full.hack=true  -client -Xss4m -Xms64m -Xmx512m -XX:PermSize=64m -XX:MaxPermSize=300m -Dsun.java2d.noddraw=true"/>
+    <property name="test.run.args" value="-Dnetbeans.keyring.no.master=true -Dnetbeans.full.hack=true -client -Xss4m -Xms64m -Xmx512m -Dsun.java2d.noddraw=true"/>
     
   <target name="netbeans-extra-ml" depends="release-ml" if="locales"/>
 


### PR DESCRIPTION
Java 7 was the last release with a permgen, Java 8 replaced it with metaspace. Java 17 does not start if PermSize is set.

-> lets remove it, brings NB one small step closer to be testable on JDK 17