### PR TITLE
Change nb.sass.libsass to TRUE, to fix broken SASS

### DIFF
--- a/ide/css.prep/src/org/netbeans/modules/css/prep/sass/SassCli.java
+++ b/ide/css.prep/src/org/netbeans/modules/css/prep/sass/SassCli.java
@@ -51,9 +51,10 @@ public abstract class SassCli {
 
     // #247890
     /**
-     * System property to be set to "true" if <tt>libsass</tt> should be used.
+     * System property to be set to "false" if <tt>libsass</tt> should be not be used
+     * for legacy RubySass implementation (https://github.com/apache/netbeans/pull/1234)
      */
-    private static final boolean USE_LIBSASS = Boolean.getBoolean("nb.sass.libsass"); // NOI18N
+    private static final boolean USE_LIBSASS = Boolean.parseBoolean(System.getProperty("nb.sass.libsass", "true")); // NOI18N
 
     // version of the compiler set in ide options
     @NullAllowed


### PR DESCRIPTION
With default NetBeans modern sass implementations cannot be used, because it defaults to the unmaintained ruby-sass implementation, which supports the command line switch **--cache-location**.

There is a System property to switch that but it defaults to ruby sass. This PR just changes the default value, so most users can just use modern sass and the minority using ruby-sass can set the value to false expliciteley.

There is still an issue with the sourcemaps option, but until #1234 is sorted out, this PR will make Sass usable again for most users, which is IMHO priority.