### PR TITLE
Really convert IDs to numbers to use with Map. Re-fetch items that have been marked as changed.

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -478,7 +478,7 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
     context.subscriptions.push(commands.registerCommand('java.project.debug', async (node, launchConfiguration?) => {
         return runDebug(false, false, contextUri(node)?.toString() || '',  undefined, launchConfiguration, true);
     }));
-    context.subscriptions.push(commands.registerCommand('java.project.tet', async (node, launchConfiguration?) => {
+    context.subscriptions.push(commands.registerCommand('java.project.test', async (node, launchConfiguration?) => {
         return runDebug(true, true, contextUri(node)?.toString() || '',  undefined, launchConfiguration, true);
     }));
     context.subscriptions.push(commands.registerCommand('java.package.test', async (uri, launchConfiguration?) => {


### PR DESCRIPTION
This PR fixes two bugs. First - call me an idiot, but I used just syntax-sugar conversion instead of `Number(x)` to convert item IDs (which are numeric) to numbers. I did not notice it during var inspection in the debugger (just '9' vs 9) ... therefore items were not matched and updated properly, the items were never found in the `treeData` Map.

Second is a race condition: sometimes, especially with lazy-initialized Nodes in NBLS, a query for Children started to initialize the Children, and so a certain `nodes/nodeChanged` could be received **before** the vscode even received the first `nodes/info` response for the node; the node change was then simply ignored. That results in dangling nodes, nodes like 'Please wait...' which are in the tree indefinitely etc.

The fix is to track those pending changes, and delay `Promise<TreeItem>` completion after a new `nodes/info` response arrives.