### PR TITLE
Rewrite lambda to an inner class to prevent from Gradle warning about execution optimizations.

### DIFF
--- a/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
+++ b/extide/gradle/netbeans-gradle-tooling/src/main/java/org/netbeans/modules/gradle/tooling/NetBeansRunSinglePlugin.java
@@ -25,6 +25,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.process.CommandLineArgumentProvider;
 
 /**
  *
@@ -48,8 +49,14 @@ class NetBeansRunSinglePlugin implements Plugin<Project> {
             }
             p.getTasks().withType(JavaExec.class).configureEach(je -> {
                 if (p.hasProperty(RUN_SINGLE_JVM_ARGS)) {
-                    je.getJvmArgumentProviders().add(() -> {
-                        return asList(p.property(RUN_SINGLE_JVM_ARGS).toString().split(" "));
+                    // Property jvmArgumentProviders should not be implemented as a lambda to allow execution optimizations.
+                    // See https://docs.gradle.org/current/userguide/validation_problems.html#implementation_unknown
+                    je.getJvmArgumentProviders().add(new CommandLineArgumentProvider() {
+                        // Do not convert to lambda.
+                        @Override
+                        public Iterable<String> asArguments() {
+                            return asList(p.property(RUN_SINGLE_JVM_ARGS).toString().split(" "));
+                        }
                     });
                 }
                 je.setStandardInput(System.in);


### PR DESCRIPTION
When a Micronaut Gradle app is run, following message is printed:
```
> Task :run
Execution optimizations have been disabled for task ':run' to ensure correctness due to the following reasons:
  - Property 'jvmArgumentProviders.$0' was implemented by the Java lambda 'org.netbeans.modules.gradle.tooling.NetBeansRunSinglePlugin$$Lambda$1154/0x00000008409ea840'. Reason: Using Java lambdas is not supported as task inputs. Please refer to https://docs.gradle.org/7.3.1/userguide/validation_problems.html#implementation_unknown for more details about this problem.
```
While this is not a severe issue, it's distracting and the user has a little chance to understand what this means.
We need to replace the lambda with an anonymous class in `NetBeansRunSinglePlugin` to get rid of the message.