### PR TITLE
[NETBEANS-6312] Assure that TokenHierarchy is called with Document's read lock.

### DIFF
--- a/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/SyntaxHighlighting.java
+++ b/ide/editor.lib2/src/org/netbeans/modules/editor/lib2/highlighting/SyntaxHighlighting.java
@@ -27,6 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import javax.swing.text.AbstractDocument;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.Document;
 import org.netbeans.api.editor.mimelookup.MimeLookup;
@@ -110,10 +111,15 @@ implements TokenHierarchyListener, ChangeListener {
 
     public @Override HighlightsSequence getHighlights(int startOffset, int endOffset) {
         long lVersion = getVersion();
-        if (hierarchy.isActive()) {
-            return new HSImpl(lVersion, hierarchy, startOffset, endOffset);
-        } else {
-            return HighlightsSequence.EMPTY;
+        ((AbstractDocument) document).readLock();
+        try {
+            if (hierarchy.isActive()) {
+                return new HSImpl(lVersion, hierarchy, startOffset, endOffset);
+            } else {
+                return HighlightsSequence.EMPTY;
+            }
+        } finally {
+            ((AbstractDocument) document).readUnlock();
         }
     }
 

--- a/ide/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
+++ b/ide/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
@@ -472,24 +472,21 @@ public final class DocumentUtilities {
      */
     public static boolean isReadLocked(Document doc) {
         if (checkAbstractDoc(doc)) {
-            if (isWriteLocked(doc))
+            if (isWriteLocked(doc)) {
                 return true;
-            if (numReadersField == null) {
-                Field f = null;
+            }
+            Field f = numReadersField;
+            if (f == null) {
                 try {
                     f = AbstractDocument.class.getDeclaredField("numReaders"); // NOI18N
                 } catch (NoSuchFieldException ex) {
                     throw new IllegalStateException(ex);
                 }
                 f.setAccessible(true);
-                synchronized (doc) {
-                    numReadersField = f;
-                }
+                numReadersField = f;
             }
             try {
-                synchronized (doc) {
-                    return numReadersField.getInt(doc) > 0;
-                }
+                return f.getInt(doc) > 0;
             } catch (IllegalAccessException ex) {
                 throw new IllegalStateException(ex);
             }
@@ -516,22 +513,18 @@ public final class DocumentUtilities {
      */
     public static boolean isWriteLocked(Document doc) {
         if (checkAbstractDoc(doc)) {
-            if (currWriterField == null) {
-                Field f = null;
+            Field f = currWriterField;
+            if (f == null) {
                 try {
                     f = AbstractDocument.class.getDeclaredField("currWriter"); // NOI18N
                 } catch (NoSuchFieldException ex) {
                     throw new IllegalStateException(ex);
                 }
                 f.setAccessible(true);
-                synchronized (doc) {
-                    currWriterField = f;
-                }
+                currWriterField = f;
             }
             try {
-                synchronized (doc) {
-                    return currWriterField.get(doc) == Thread.currentThread();
-                }
+                return f.get(doc) == Thread.currentThread();
             } catch (IllegalAccessException ex) {
                 throw new IllegalStateException(ex);
             }

--- a/ide/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
+++ b/ide/editor.util/src/org/netbeans/lib/editor/util/swing/DocumentUtilities.java
@@ -65,9 +65,9 @@ public final class DocumentUtilities {
     
     private static final Object TYPING_MODIFICATION_KEY = new Object();
     
-    private static Field numReadersField;
+    private static volatile Field numReadersField;
     
-    private static Field currWriterField;
+    private static volatile Field currWriterField;
     
     
     private DocumentUtilities() {

--- a/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/SyntaxHighlighting.java
+++ b/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/SyntaxHighlighting.java
@@ -30,6 +30,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import javax.swing.text.AbstractDocument;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.Document;
 import javax.swing.text.SimpleAttributeSet;
@@ -119,10 +120,15 @@ implements TokenHierarchyListener, ChangeListener {
 
     public @Override HighlightsSequence getHighlights(int startOffset, int endOffset) {
         long lVersion = getVersion();
-        if (hierarchy.isActive()) {
-            return new HSImpl(lVersion, hierarchy, startOffset, endOffset);
-        } else {
-            return HighlightsSequence.EMPTY;
+        ((AbstractDocument) document).readLock();
+        try {
+            if (hierarchy.isActive()) {
+                return new HSImpl(lVersion, hierarchy, startOffset, endOffset);
+            } else {
+                return HighlightsSequence.EMPTY;
+            }
+        } finally {
+            ((AbstractDocument) document).readUnlock();
         }
     }
 


### PR DESCRIPTION
The `TokenHierarchy.isActive()` is not called with the associated Document's read lock, as can be seen from the stack trace in the associated issue.
This change adds read lock to `SyntaxHighlighting`, which makes `TokenHierarchy.isActive()` to be called with the read lock.