### PR TITLE
[NETBEANS-6315] Escape HTML entities in PHPStan report

### DIFF
--- a/php/php.code.analysis/manifest.mf
+++ b/php/php.code.analysis/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.php.code.analysis
 OpenIDE-Module-Layer: org/netbeans/modules/php/analysis/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/php/analysis/resources/Bundle.properties
-OpenIDE-Module-Specification-Version: 0.28
+OpenIDE-Module-Specification-Version: 0.29

--- a/php/php.code.analysis/nbproject/project.xml
+++ b/php/php.code.analysis/nbproject/project.xml
@@ -44,6 +44,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.modules.editor.util</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>1.80</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.extexecution</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/PHPStanReportParser.java
+++ b/php/php.code.analysis/src/org/netbeans/modules/php/analysis/parsers/PHPStanReportParser.java
@@ -34,6 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.lib.editor.util.StringEscapeUtils;
 import org.netbeans.modules.php.analysis.results.Result;
 import org.netbeans.modules.php.api.util.FileUtils;
 import org.openide.filesystems.FileObject;
@@ -165,7 +166,8 @@ public class PHPStanReportParser extends DefaultHandler {
         currentResult.setColumn(getInt(attributes, "column")); // NOI18N
         String message = attributes.getValue("message"); // NOI18N
         currentResult.setCategory(String.format("%s: %s", attributes.getValue("severity"), message)); // NOI18N
-        currentResult.setDescription(message);
+        // Message can contain types like "array<string>" and description is renderd as HTML so it has to be properly escaped.
+        currentResult.setDescription(StringEscapeUtils.escapeHtml(message));
     }
 
     private void processResultEnd() {

--- a/php/php.code.analysis/test/unit/data/phpstan/phpstan-log-html-entities.xml
+++ b/php/php.code.analysis/test/unit/data/phpstan/phpstan-log-html-entities.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<checkstyle>
+<file name="HelloWorld.php">
+  <error line="7" column="1" severity="error" message="Function count() should return int but returns array&lt;string&gt;." />
+</file>
+</checkstyle>

--- a/php/php.code.analysis/test/unit/src/org/netbeans/modules/php/analysis/parsers/PHPStanReportParserTest.java
+++ b/php/php.code.analysis/test/unit/src/org/netbeans/modules/php/analysis/parsers/PHPStanReportParserTest.java
@@ -98,6 +98,20 @@ public class PHPStanReportParserTest extends NbTestCase {
         assertEquals(3, results.size());
     }
 
+    public void testParseWithHtmlEntities() throws Exception {
+        FileObject root = getDataDir("phpstan/PHPStanSupport");
+        FileObject workDir = root;
+        List<Result> results = PHPStanReportParser.parse(getLogFile("phpstan-log-html-entities.xml"), root, workDir);
+        assertNotNull(results);
+
+        assertEquals(1, results.size());
+        Result result = results.get(0);
+        assertEquals(FileUtil.toFile(root.getFileObject("HelloWorld.php")).getAbsolutePath(), result.getFilePath());
+        assertEquals(7, result.getLine());
+        assertEquals("error: Function count() should return int but returns array<string>.", result.getCategory());
+        assertEquals("Function count() should return int but returns array&lt;string&gt;.", result.getDescription());
+    }
+
     private File getLogFile(String name) throws Exception {
         assertNotNull(name);
         File phpstan = new File(getDataDir(), "phpstan");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-6315

- Escapes HTML entities in message from PHPStan report

Before - message on right side of Inspector does not show `<string>`:
![netbeans-phpstan-message-before](https://user-images.githubusercontent.com/4249184/146637421-461046d8-1ba6-408e-a2a9-89d93bc741e1.png)

After - message on right side is complete:
![netbeans-phpstan-message-after](https://user-images.githubusercontent.com/4249184/146637433-13e3da38-ca39-4877-9432-5bcad655e581.png)
