### PR TITLE
Various fixes of project / folder actions presence in vscode

### DIFF
--- a/java/java.lsp.server/arch.xml
+++ b/java/java.lsp.server/arch.xml
@@ -962,7 +962,8 @@
            <tbody>
                <tr><td>is:folder</td><td>the Node represents a folder, or a DataFolder</td><td></td></tr>
                <tr><td>is:project</td><td>the Node represents a project (the project's node itself)</td><td></td></tr>
-               <tr><td>is:projectRoot</td><td>the Node represents a root project: a single project, or a root project in a multi-project tree</td><td></td></tr>
+               <tr><td>is:projectRoot</td><td>the Node represents a root project in a multi-project tree</td><td></td></tr>
+               <tr><td>is:subProject</td><td>the Node represents a subproject in a multi-project tree</td><td></td></tr>
                <tr><td>cap:rename</td><td>the Node can be renamed (Rename action is available)</td><td></td></tr>
                <tr><td>cap:delete</td><td>the Node can be deleted (Delete action is available)</td><td></td></tr>
            </tbody>

--- a/java/java.lsp.server/arch.xml
+++ b/java/java.lsp.server/arch.xml
@@ -961,6 +961,8 @@
        <table>
            <tbody>
                <tr><td>is:folder</td><td>the Node represents a folder, or a DataFolder</td><td></td></tr>
+               <tr><td>is:project</td><td>the Node represents a project (the project's node itself)</td><td></td></tr>
+               <tr><td>is:projectRoot</td><td>the Node represents a root project: a single project, or a root project in a multi-project tree</td><td></td></tr>
                <tr><td>cap:rename</td><td>the Node can be renamed (Rename action is available)</td><td></td></tr>
                <tr><td>cap:delete</td><td>the Node can be deleted (Delete action is available)</td><td></td></tr>
            </tbody>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/URITranslator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/URITranslator.java
@@ -102,11 +102,26 @@ public final class URITranslator {
                 }
                 File cache = new File(foundSegment, FileUtil.getRelativePath(FileUtil.getArchiveRoot(archive), file));
                 cache.getParentFile().mkdirs();
-                try (OutputStream out = new FileOutputStream(cache)) {
-                    out.write(file.asBytes());
+                if (file.isFolder()) {
+                    if (cache.exists() && cache.isFile()) {
+                        if (!cache.delete()) {
+                            return uri;
+                        }
+                    }
+                    cache.mkdir();
                     return cache.toURI().toString();
-                } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
+                } else if (file.isData()) {
+                    try {
+                        if (cache.exists() && cache.isDirectory()) {
+                            FileUtil.toFileObject(cache).delete();
+                        }
+                        try (OutputStream out = new FileOutputStream(cache)) {
+                            out.write(file.asBytes());
+                            return cache.toURI().toString();
+                        }
+                    } catch (IOException ex) {
+                        Exceptions.printStackTrace(ex);
+                    }
                 }
             }
             if (uriUri.getScheme().equals("nbfs")) {            // NOI18N

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/DefaultDecorationsImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/DefaultDecorationsImpl.java
@@ -23,6 +23,7 @@ import org.netbeans.modules.java.lsp.server.explorer.api.TreeItemData;
 import org.netbeans.modules.java.lsp.server.explorer.api.TreeDataProvider;
 import java.awt.Image;
 import java.beans.BeanInfo;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -30,7 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
+import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.modules.java.lsp.server.Utils;
 import static org.netbeans.modules.java.lsp.server.explorer.NodeLookupContextValues.nodeLookup;
 import org.openide.filesystems.FileObject;
@@ -53,6 +56,8 @@ public class DefaultDecorationsImpl implements TreeDataProvider.Factory {
     public static final String COOKIES_EXT = "contextValues"; // NOI18N
     
     public static final String CTXVALUE_FOLDER = "is:folder"; // NOI18N
+    public static final String CTXVALUE_PROJECT = "is:project"; // NOI18N
+    public static final String CTXVALUE_PROJECT_ROOT = "is:projectRoot"; // NOI18N
     public static final String CTXVALUE_CAP_RENAME = "cap:rename"; // NOI18N
     public static final String CTXVALUE_CAP_DELETE = "cap:delete"; // NOI18N
 
@@ -88,7 +93,7 @@ public class DefaultDecorationsImpl implements TreeDataProvider.Factory {
         NodeLookupContextValues p = nodeLookup(lines.toArray(new String[lines.size()]));
         return new ProviderImpl(p);
     }
-
+    
     static class ProviderImpl implements TreeDataProvider {
 
         private final NodeLookupContextValues lookupValues;
@@ -114,7 +119,7 @@ public class DefaultDecorationsImpl implements TreeDataProvider.Factory {
                 d.setIconImage(i);
                 set = true;
             }
-
+            
             FileObject f = n.getLookup().lookup(FileObject.class);
             boolean nodeChecked = false;
             if (f == null) {
@@ -129,13 +134,35 @@ public class DefaultDecorationsImpl implements TreeDataProvider.Factory {
                 // Workaround for possible bug in data folder
                 nodeChecked = true;
             }
+            
+            boolean folder = false;
+            File physFile = null;
+            Project p = n.getLookup().lookup(Project.class);
+            
             if (f != null) {
                 // reverse check, if the file's node is proxied to by the node we got:
                 Node fn = f.getLookup().lookup(Node.class);
                 if (nodeChecked || fn != null) {
                     if (nodeChecked || n.getLookup().lookup(fn.getClass()) == fn) {
                         try {
-                            if (f.isFolder()) {
+                            // Workaround for prevailing folder usage in LSP clients: filter out
+                            // virtual or archive-based = readonly folders
+                            physFile = FileUtil.toFile(f);
+                            F: if (f.isFolder() && physFile != null) {
+                                // workaround^2: if the node represents the project directory, it may be some computed collection like
+                                // project files / buildscripts. Check the parent folder and if it yields the same project, then this node is
+                                // just a collection not a real project root -> not a "folder" for LSP.
+                                Project owner = FileOwnerQuery.getOwner(f);
+                                if (owner != null && owner.getProjectDirectory().equals(f)) {
+                                    Node parent = n.getParentNode();
+                                    if (parent != null) {
+                                        Project parentP = parent.getLookup().lookup(Project.class);
+                                        if (parentP == owner) {
+                                            break F;
+                                        }   
+                                    }
+                                }
+                                folder = true;
                                 d.addContextValues(CTXVALUE_FOLDER);
                             } else {
                                 // PENDING: this could be moved to the VSNetbeans module ?
@@ -150,14 +177,20 @@ public class DefaultDecorationsImpl implements TreeDataProvider.Factory {
                     }
                 }
             }
-            if (n.canDestroy()) {
+            
+            // special handling for project - just presence of ProjectCookie is not sufficient. 
+            // The Node must also expose a folder that is the project root folder itself:
+            if (p != null & folder && p.getProjectDirectory().equals(f)) {
+                d.addContextValues(CTXVALUE_PROJECT);
+                Project root = ProjectUtils.rootOf(p);
+                if (root == p) {
+                    d.addContextValues(CTXVALUE_PROJECT_ROOT);
+                }
+            } else if (f == null || physFile != null) { 
                 // TODO Hack: exclude projects from delete capability. The TreeItemData probably needs to support
                 // exclusion... Project delete UI is not suitable for LSP at the moment
-                Project p = n.getLookup().lookup(Project.class);
-                if (p == null || f == null || !p.getProjectDirectory().equals(f)) {
-                    d.addContextValues(CTXVALUE_CAP_DELETE);
-                    set = true;
-                }
+                d.addContextValues(CTXVALUE_CAP_DELETE);
+                set = true;
             }
             if (n.canRename()) {
                 d.addContextValues(CTXVALUE_CAP_RENAME);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/DefaultDecorationsImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/DefaultDecorationsImpl.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.netbeans.api.project.FileOwnerQuery;
@@ -58,6 +59,7 @@ public class DefaultDecorationsImpl implements TreeDataProvider.Factory {
     public static final String CTXVALUE_FOLDER = "is:folder"; // NOI18N
     public static final String CTXVALUE_PROJECT = "is:project"; // NOI18N
     public static final String CTXVALUE_PROJECT_ROOT = "is:projectRoot"; // NOI18N
+    public static final String CTXVALUE_PROJECT_SUBPROJECT = "is:subproject"; // NOI18N
     public static final String CTXVALUE_CAP_RENAME = "cap:rename"; // NOI18N
     public static final String CTXVALUE_CAP_DELETE = "cap:delete"; // NOI18N
 
@@ -184,7 +186,12 @@ public class DefaultDecorationsImpl implements TreeDataProvider.Factory {
                 d.addContextValues(CTXVALUE_PROJECT);
                 Project root = ProjectUtils.rootOf(p);
                 if (root == p) {
-                    d.addContextValues(CTXVALUE_PROJECT_ROOT);
+                    Set<Project> contained = ProjectUtils.getContainedProjects(root, false);
+                    if (contained != null && !contained.isEmpty()) {
+                        d.addContextValues(CTXVALUE_PROJECT_ROOT);
+                    }
+                } else {
+                    d.addContextValues(CTXVALUE_PROJECT_SUBPROJECT);
                 }
             } else if (f == null || physFile != null) { 
                 // TODO Hack: exclude projects from delete capability. The TreeItemData probably needs to support

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
@@ -234,7 +234,7 @@ public abstract class TreeViewProvider {
         synchronized (this) {
             Integer lspId = releaseNode(n);
             parentLspId = idMap.get(parent);
-            if (!(lspId instanceof Integer || parentLspId instanceof Integer)) {
+            if (!(lspId instanceof Integer && parentLspId instanceof Integer)) {
                 return;
             }
             NodeHolder nh = holdChildren.get(parentLspId);

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -494,6 +494,11 @@
 				"command": "java.workspace.configureRunSettings",
 				"title": "Edit",
 				"icon": "$(edit)"
+            },
+            {
+				"command": "testing.runAll",
+				"title": "Run All Tests",
+				"category": "Test"
 			}
 		],
 		"keybindings": [
@@ -590,7 +595,7 @@
 					"when": "nbJavaLSReady && view == foundProjects"
 				},
 				{
-					"command": "test-explorer.run-all",
+					"command": "testing.runAll",
 					"when": "nbJavaLSReady && view == foundProjects"
 				},
 				{

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -626,17 +626,17 @@
 				},
 				{
 					"command": "java.project.run",
-					"when": "view == foundProjects && viewItem =~ /is:project/",
+					"when": "view == foundProjects && viewItem =~ /is:project/ && viewItem =~ /^(?!.*is:projectRoot)/",
 					"group": "inline@10"
 				},
 				{
 					"command": "java.project.debug",
-					"when": "view == foundProjects && viewItem =~ /is:project/",
+					"when": "view == foundProjects && viewItem =~ /is:project/ && viewItem =~ /^(?!.*is:projectRoot)/",
 					"group": "inline@11"
 				},
 				{
 					"command": "java.project.test",
-					"when": "view == foundProjects && viewItem =~ /is:project/"
+					"when": "view == foundProjects && viewItem =~ /is:project/ && viewItem =~ /^(?!.*is:projectRoot)/"
 				},
 				{
 					"command": "java.project.compile",

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -626,25 +626,25 @@
 				},
 				{
 					"command": "java.project.run",
-					"when": "view == foundProjects && viewItem =~ /class:project.Project/",
+					"when": "view == foundProjects && viewItem =~ /is:project/",
 					"group": "inline@10"
 				},
 				{
 					"command": "java.project.debug",
-					"when": "view == foundProjects && viewItem =~ /class:project.Project/",
+					"when": "view == foundProjects && viewItem =~ /is:project/",
 					"group": "inline@11"
 				},
 				{
 					"command": "java.project.test",
-					"when": "view == foundProjects && viewItem =~ /class:project.Project/"
+					"when": "view == foundProjects && viewItem =~ /is:project/"
 				},
 				{
 					"command": "java.project.compile",
-					"when": "view == foundProjects && viewItem =~ /class:project.Project/"
+					"when": "view == foundProjects && viewItem =~ /is:project/"
 				},
 				{
 					"command": "java.project.clean",
-					"when": "view == foundProjects && viewItem =~ /class:project.Project/"
+					"when": "view == foundProjects && viewItem =~ /is:project/"
 				},
 				{
 					"command": "java.local.db.set.preferred.connection",


### PR DESCRIPTION
It turned out that simply o.n.api.project.Project 'cookie' exposed is not sufficient for presenting sensible actions. The PR makes some additional checks and adds `is:project` and `is:projectRoot` magic labels to LSP exported `contextValue`s.

Overview of changes made in LSP server:
- just physical folders - that is convertible to j.io.File are marked as `is:folder`. This prevents strange things as 'New from Template' on a folder in a JAR ;)
- `is:project` is placed on a Node that has `Project` in its Lookup, and also a `FileObject` that correspond to that project's root directory. Since there are some grouping nodes (i.e. Build Scripts) that **also** refer to the project root dir, there's an additional check that if a node represents a project root (implies a folder) then its immediate parent node must NOT expose the same project.
- `is:projectRoot` is put on projects that are root in their possible multi-project setup, `is:subproject` on projects that are nested.

`package.json` was updated to enable actions using these new semantics/tags.