### PR TITLE
Disable client-side projects and nodejs support.

### DIFF
--- a/java/java.lsp.server/nbcode/nbproject/platform.properties
+++ b/java/java.lsp.server/nbcode/nbproject/platform.properties
@@ -127,6 +127,7 @@ disabled.modules=\
     org.netbeans.modules.debugger.jpda.js,\
     org.netbeans.modules.debugger.jpda.jsui,\
     org.netbeans.modules.debugger.jpda.kit,\
+    org.netbeans.modules.debugger.jpda.trufflenode,\
     org.netbeans.modules.debugger.jpda.visual,\
     org.netbeans.modules.derby,\
     org.netbeans.modules.dlight.nativeexecution.nb,\
@@ -204,6 +205,7 @@ disabled.modules=\
     org.netbeans.modules.javascript.gulp,\
     org.netbeans.modules.javascript.jstestdriver,\
     org.netbeans.modules.javascript.karma,\
+    org.netbeans.modules.javascript.nodejs,\
     org.netbeans.modules.javascript.v8debug.ui,\
     org.netbeans.modules.javascript2.debug.ui,\
     org.netbeans.modules.javascript2.extdoc,\
@@ -214,6 +216,7 @@ disabled.modules=\
     org.netbeans.modules.javascript2.jsdoc,\
     org.netbeans.modules.javascript2.kit,\
     org.netbeans.modules.javascript2.knockout,\
+    org.netbeans.modules.javascript2.nodejs,\
     org.netbeans.modules.javascript2.prototypejs,\
     org.netbeans.modules.javascript2.react,\
     org.netbeans.modules.javascript2.requirejs,\
@@ -297,6 +300,8 @@ disabled.modules=\
     org.netbeans.modules.versioning.ui,\
     org.netbeans.modules.versioning.util,\
     org.netbeans.modules.web.client.kit,\
+    org.netbeans.modules.web.clientproject,\
+    org.netbeans.modules.web.clientproject.api,\
     org.netbeans.modules.web.client.samples,\
     org.netbeans.modules.web.inspect,\
     org.netbeans.modules.web.javascript.debugger,\


### PR DESCRIPTION
The NBLS distribution contains a broken client-side project support: some modules are there, some are not, like HTML parser & co. Given the feature is not really used (vscode as the primary LSP client uses a different langserver for JS, Node) and it is broken anyway, I'd prefer to remove it form the NBLS distribution.

We can later add it back, but with all dependencies so that it really works. Now the client-side project errors out with an exception:
```
java.lang.IllegalArgumentException: No parser for mime type: text/html
        at org.netbeans.modules.parsing.nb.DataObjectEnvFactory.findMimeParser(DataObjectEnvFactory.java:78)
        at org.netbeans.modules.parsing.api.ParserManager.findParser(ParserManager.java:374)
        at org.netbeans.modules.parsing.api.ParserManager.parseWhenScanFinished(ParserManager.java:339)
        at org.netbeans.modules.web.clientproject.remotefiles.RemoteFiles.update(RemoteFiles.java:77)
        at org.netbeans.modules.web.clientproject.remotefiles.RemoteFiles.getRemoteFiles(RemoteFiles.java:112)
        at org.netbeans.modules.web.clientproject.remotefiles.RemoteFilesNodeFactoryImpl$RemoteFilesNodeListImpl.keys(RemoteFilesNodeFactoryImpl.java:64)
        at org.netbeans.spi.project.ui.support.NodeFactorySupport$DelegateChildren$1.run(NodeFactorySupport.java:177)
        at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
        at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
```