### PR TITLE
Fix javascript2.editor tests and reenable testing in travis

### DIFF
--- a/.github/workflows/webcommon.yml
+++ b/.github/workflows/webcommon.yml
@@ -1,0 +1,144 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Apache Netbeans
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  linux-php:
+    name: web-common on Linux
+    runs-on: ubuntu-18.04
+    env:
+      DISPLAY: ":99.0"
+      ANT_OPTS: -Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json
+      OPTS: -Dcluster.config=php -Dtest-unit-sys-prop.ignore.random.failures=true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Caching dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.hgexternalcache
+          key: ${{ runner.os }}-${{ hashFiles('**/external/binaries-list') }}
+          restore-keys: ${{ runner.os }}-
+
+      - name: Launch Xvfb
+        run: Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+
+      - name: Clean
+        run: ant $OPTS clean
+
+      - name: Build
+        run: ant $OPTS build
+
+      - name: api.knockout
+        run: ant $OPTS -f webcommon/api.knockout test
+
+      - name: html.angular
+        run: ant $OPTS -f webcommon/html.angular test
+
+      - name: html.knockout
+        run: ant $OPTS -f webcommon/html.knockout test-unit
+
+      - name: javascript.bower
+        run: ant $OPTS -f webcommon/javascript.bower test
+
+      - name: javascript.cdnjs
+        run: ant $OPTS -f webcommon/javascript.cdnjs test
+
+      - name: javascript.grunt
+        run: ant $OPTS -f webcommon/javascript.grunt test
+
+      - name: javascript.karma
+        run: ant $OPTS -f webcommon/javascript.karma test
+
+      - name: javascript.nodejs
+        run: ant $OPTS -f webcommon/javascript.nodejs test
+
+      - name: javascript.v8debug
+        run: ant $OPTS -f webcommon/javascript.v8debug test
+
+      - name: javascript2.doc
+        run: ant $OPTS -f webcommon/javascript2.doc test
+
+      - name: javascript2.editor
+        run: ant $OPTS -f webcommon/javascript2.editor test
+
+      - name: javascript2.extdoc
+        run: ant $OPTS -f webcommon/javascript2.extdoc test
+
+      - name: javascript2.extjs
+        run: ant $OPTS -f webcommon/javascript2.extjs test
+
+      - name: javascript2.jade
+        run: ant $OPTS -f webcommon/javascript2.jade test
+
+      - name: javascript2.jquery
+        run: ant $OPTS -f webcommon/javascript2.jquery test
+
+      - name: javascript2.jsdoc
+        run: ant $OPTS -f webcommon/javascript2.jsdoc test
+
+      - name: javascript2.json
+        run: ant $OPTS -f webcommon/javascript2.json test
+
+      - name: javascript2.knockout
+        run: ant $OPTS -f webcommon/javascript2.knockout test
+
+      - name: javascript2.lexer
+        run: ant $OPTS -f webcommon/javascript2.lexer test
+
+      - name: javascript2.model
+        run: ant $OPTS -f webcommon/javascript2.model test
+
+      - name: javascript2.nodejs
+        run: ant $OPTS -f webcommon/javascript2.nodejs test
+
+      - name: javascript2.requirejs
+        run: ant $OPTS -f webcommon/javascript2.requirejs test
+
+      - name: javascript2.sdoc
+        run: ant $OPTS -f webcommon/javascript2.sdoc test
+
+      - name: languages.apacheconf
+        run: ant $OPTS -f webcommon/languages.apacheconf test
+
+      - name: languages.ini
+        run: ant $OPTS -f webcommon/languages.ini test
+
+      - name: libs.graaljs
+        run: ant $OPTS -f webcommon/libs.graaljs test
+
+      - name: selenium2.webclient
+        run: ant $OPTS -f webcommon/selenium2.webclient test
+
+      - name: web.clientproject
+        run: ant $OPTS -f webcommon/web.clientproject test-unit
+
+      - name: web.clientproject.api
+        run: ant $OPTS -f webcommon/web.clientproject.api test
+
+      - name: web.inspect
+        run: ant $OPTS -f webcommon/web.inspect test
+
+        #- hide-logs.sh ant $OPTS -f webcommon/cordova test
+        #- hide-logs.sh ant $OPTS -f webcommon/javascript2.prototypejs test
+        #- hide-logs.sh ant $OPTS -f webcommon/lib.v8debug test

--- a/.travis.yml
+++ b/.travis.yml
@@ -639,48 +639,6 @@ matrix:
           script:
             - ant $OPTS -f profiler/profiler.oql test
 
-        - name: Test webcommon modules
-          jdk: openjdk8
-          env:
-            - OPTS="-Dmetabuild.jsonurl=https://raw.githubusercontent.com/apache/netbeans-jenkins-lib/master/meta/netbeansrelease.json -quiet -Dcluster.config=php -Djavac.compilerargs=-nowarn -Dbuild.compiler.deprecation=false -Dtest-unit-sys-prop.ignore.random.failures=true"
-          before_script:
-            - ant $OPTS clean
-            - ant $OPTS build
-          script:
-            - hide-logs.sh ant $OPTS -f webcommon/api.knockout test
-            #- hide-logs.sh ant $OPTS -f webcommon/cordova test
-            - ant $OPTS -f webcommon/html.angular test
-            - hide-logs.sh ant $OPTS -f webcommon/html.knockout test-unit
-            - hide-logs.sh ant $OPTS -f webcommon/javascript.bower test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript.cdnjs test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript.grunt test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript.karma test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript.nodejs test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript.v8debug test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript2.doc test
-            - ant $OPTS -f webcommon/javascript2.editor test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript2.extdoc test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript2.extjs test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript2.jade test
-            - travis_retry hide-logs.sh ant $OPTS -f webcommon/javascript2.jquery test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript2.jsdoc test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript2.json test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript2.knockout test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript2.lexer test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript2.model test
-            - ant $OPTS -f webcommon/javascript2.nodejs test
-            #- hide-logs.sh ant $OPTS -f webcommon/javascript2.prototypejs test
-            - ant $OPTS -f webcommon/javascript2.requirejs test
-            - hide-logs.sh ant $OPTS -f webcommon/javascript2.sdoc test
-            - hide-logs.sh ant $OPTS -f webcommon/languages.apacheconf test
-            - hide-logs.sh ant $OPTS -f webcommon/languages.ini test
-            #- hide-logs.sh ant $OPTS -f webcommon/lib.v8debug test
-            - hide-logs.sh ant $OPTS -f webcommon/libs.graaljs test
-            - hide-logs.sh ant $OPTS -f webcommon/selenium2.webclient test
-            - hide-logs.sh ant $OPTS -f webcommon/web.clientproject test-unit
-            - hide-logs.sh ant $OPTS -f webcommon/web.clientproject.api test
-            - hide-logs.sh ant $OPTS -f webcommon/web.inspect test
-
         - name: "Versioning modules (ide/versioning and ide/versioning.core) tests"
           jdk: openjdk8
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -649,7 +649,7 @@ matrix:
           script:
             - hide-logs.sh ant $OPTS -f webcommon/api.knockout test
             #- hide-logs.sh ant $OPTS -f webcommon/cordova test
-            #- hide-logs.sh ant $OPTS -f webcommon/html.angular test
+            - ant $OPTS -f webcommon/html.angular test
             - hide-logs.sh ant $OPTS -f webcommon/html.knockout test-unit
             - hide-logs.sh ant $OPTS -f webcommon/javascript.bower test
             - hide-logs.sh ant $OPTS -f webcommon/javascript.cdnjs test
@@ -658,7 +658,7 @@ matrix:
             - hide-logs.sh ant $OPTS -f webcommon/javascript.nodejs test
             - hide-logs.sh ant $OPTS -f webcommon/javascript.v8debug test
             - hide-logs.sh ant $OPTS -f webcommon/javascript2.doc test
-            #- hide-logs.sh ant $OPTS -f webcommon/javascript2.editor test
+            - ant $OPTS -f webcommon/javascript2.editor test
             - hide-logs.sh ant $OPTS -f webcommon/javascript2.extdoc test
             - hide-logs.sh ant $OPTS -f webcommon/javascript2.extjs test
             - hide-logs.sh ant $OPTS -f webcommon/javascript2.jade test
@@ -668,9 +668,9 @@ matrix:
             - hide-logs.sh ant $OPTS -f webcommon/javascript2.knockout test
             - hide-logs.sh ant $OPTS -f webcommon/javascript2.lexer test
             - hide-logs.sh ant $OPTS -f webcommon/javascript2.model test
-            #- hide-logs.sh ant $OPTS -f webcommon/javascript2.nodejs test
+            - ant $OPTS -f webcommon/javascript2.nodejs test
             #- hide-logs.sh ant $OPTS -f webcommon/javascript2.prototypejs test
-            #- hide-logs.sh ant $OPTS -f webcommon/javascript2.requirejs test
+            - ant $OPTS -f webcommon/javascript2.requirejs test
             - hide-logs.sh ant $OPTS -f webcommon/javascript2.sdoc test
             - hide-logs.sh ant $OPTS -f webcommon/languages.apacheconf test
             - hide-logs.sh ant $OPTS -f webcommon/languages.ini test

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js
@@ -1,7 +1,7 @@
 var roman = new Man("Roman", "Php");
 
 roman.getFirstName();
-console.log();  
+console.log();
 with(roman) {
-   console.log(getFirstName()); 
+    console.log(getFirstName());
 }

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_01.occurrences
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_01.occurrences
@@ -1,2 +1,2 @@
 roman.|>MARK_OCCURRENCES:getFirstName<|();
-   console.log(|>MARK_OCCURRENCES:getFirst^Name<|()); 
+    console.log(|>MARK_OCCURRENCES:getFirst^Name<|());

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_02.occurrences
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_02.occurrences
@@ -1,2 +1,2 @@
-console.|>MARK_OCCURRENCES:log<|();  
-   console.|>MARK_OCCURRENCES:l^og<|(getFirstName()); 
+console.|>MARK_OCCURRENCES:log<|();
+    console.|>MARK_OCCURRENCES:l^og<|(getFirstName());

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_03.occurrences
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_03.occurrences
@@ -1,2 +1,2 @@
-|>MARK_OCCURRENCES:console<|.log();  
-   |>MARK_OCCURRENCES:conso^le<|.log(getFirstName()); 
+|>MARK_OCCURRENCES:console<|.log();
+    |>MARK_OCCURRENCES:conso^le<|.log(getFirstName());

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsTestBase.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsTestBase.java
@@ -19,12 +19,15 @@
 
 package org.netbeans.modules.javascript2.editor;
 
+import java.net.URL;
 import java.util.Collections;
 import java.util.Set;
 import org.netbeans.lib.lexer.test.TestLanguageProvider;
 import org.netbeans.modules.csl.api.test.CslTestBase;
 import org.netbeans.modules.csl.spi.DefaultLanguageConfig;
 import org.netbeans.modules.javascript2.lexer.api.JsTokenId;
+import org.netbeans.modules.parsing.impl.indexing.IndexingUtils;
+import org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater;
 
 /**
  * @author Tor Norbye
@@ -69,9 +72,76 @@ public abstract class JsTestBase extends CslTestBase {
     }
 
     @Override
-    protected void setUp() throws Exception {        
+    protected void setUp() throws Exception {
         TestLanguageProvider.register(getPreferredLanguage().getLexerLanguage());
         super.setUp();
     }
 
+    @Override
+    public void checkCompletion(String file, String caretLine, boolean includeModifiers) throws Exception {
+        waitScanningFinished();
+        super.checkCompletion(file, caretLine, includeModifiers);
+    }
+
+    @Override
+    protected void checkDeclaration(String relFilePath, String caretLine, String file, int offset) throws Exception {
+        waitScanningFinished();
+        super.checkDeclaration(relFilePath, caretLine, file, offset);
+    }
+
+    @Override
+    protected void checkDeclaration(String relFilePath, String caretLine, String declarationLine) throws Exception {
+        waitScanningFinished();
+        super.checkDeclaration(relFilePath, caretLine, declarationLine);
+    }
+
+    @Override
+    protected void checkDeclaration(String relFilePath, String caretLine, URL url) throws Exception {
+        waitScanningFinished();
+        super.checkDeclaration(relFilePath, caretLine, url);
+    }
+
+    @Override
+    protected void checkOccurrences(String relFilePath, String caretLine, boolean symmetric) throws Exception {
+        waitScanningFinished();
+        super.checkOccurrences(relFilePath, caretLine, symmetric);
+    }
+
+    @Override
+    protected void checkStructure(String relFilePath, boolean embedded, boolean inTestDir, boolean includePositions) throws Exception {
+        waitScanningFinished();
+        super.checkStructure(relFilePath, embedded, inTestDir, includePositions);
+    }
+
+    @Override
+    protected void checkStructure(String relFilePath) throws Exception {
+        waitScanningFinished();
+        super.checkStructure(relFilePath);
+    }
+
+    @Override
+    protected void checkSemantic(String relFilePath) throws Exception {
+        waitScanningFinished();
+        super.checkSemantic(relFilePath);
+    }
+
+    @Override
+    protected void checkSemantic(String relFilePath, String caretLine) throws Exception {
+        waitScanningFinished();
+        super.checkSemantic(relFilePath, caretLine);
+    }
+
+    @SuppressWarnings("SleepWhileInLoop")
+    protected void waitScanningFinished() {
+        while(IndexingUtils.isScanInProgress()) {
+            if(IndexingUtils.getIndexingState().contains(RepositoryUpdater.IndexingState.STARTING)) {
+                RepositoryUpdater.getDefault().start(true);
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException ex) {
+                return;
+            }
+        }
+    }
 }

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsWithFastTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsWithFastTest.java
@@ -29,15 +29,15 @@ public class JsWithFastTest extends JsWithBase {
     }
     
     public void testWith_01() throws Exception {
-        checkOccurrences("testfiles/with/test01.js", "console.log(getFirst^Name());", true);
+        checkOccurrences("testfiles/with/test01.js", "    console.log(getFirst^Name());", true);
     }
     
     public void testWith_02() throws Exception {
-        checkOccurrences("testfiles/with/test01.js", "console.l^og(getFirstName());", true);
+        checkOccurrences("testfiles/with/test01.js", "    console.l^og(getFirstName());", true);
     }
     
     public void testWith_03() throws Exception {
-        checkOccurrences("testfiles/with/test01.js", "conso^le.log(getFirstName());", true);
+        checkOccurrences("testfiles/with/test01.js", "    conso^le.log(getFirstName());", true);
     }
     
     public void testWith_04() throws Exception {

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsWithTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsWithTest.java
@@ -41,7 +41,7 @@ public class JsWithTest extends JsWithBase {
     }
     
     public void testGoTo_01() throws Exception {
-        checkDeclaration("testfiles/with/test01.js", "console.log(getFirs^tName()); ", "man.js", 141);
+        checkDeclaration("testfiles/with/test01.js", "console.log(getFirs^tName());", "man.js", 141);
     }
     
     public void testWith_05() throws Exception {


### PR DESCRIPTION
1) The tests, that rely on information from the JS classpath (stub
definitions fail if classpath scanning is still in progress, so this
change forces repository updates to happen and delay test running
until scanning is done.

2) Changes to test input cause golden files to be out of sync. Align
input and golden files to match.