### PR TITLE
Fix html.angular, js2.editor, js2.nodejs and js2.requirejs tests

### DIFF
--- a/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js
@@ -1,7 +1,7 @@
 var roman = new Man("Roman", "Php");
 
 roman.getFirstName();
-console.log();  
+console.log();
 with(roman) {
-   console.log(getFirstName()); 
+    console.log(getFirstName());
 }

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_01.occurrences
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_01.occurrences
@@ -1,2 +1,2 @@
 roman.|>MARK_OCCURRENCES:getFirstName<|();
-   console.log(|>MARK_OCCURRENCES:getFirst^Name<|()); 
+    console.log(|>MARK_OCCURRENCES:getFirst^Name<|());

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_02.occurrences
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_02.occurrences
@@ -1,2 +1,2 @@
-console.|>MARK_OCCURRENCES:log<|();  
-   console.|>MARK_OCCURRENCES:l^og<|(getFirstName()); 
+console.|>MARK_OCCURRENCES:log<|();
+    console.|>MARK_OCCURRENCES:l^og<|(getFirstName());

--- a/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_03.occurrences
+++ b/webcommon/javascript2.editor/test/unit/data/testfiles/with/test01.js.testWith_03.occurrences
@@ -1,2 +1,2 @@
-|>MARK_OCCURRENCES:console<|.log();  
-   |>MARK_OCCURRENCES:conso^le<|.log(getFirstName()); 
+|>MARK_OCCURRENCES:console<|.log();
+    |>MARK_OCCURRENCES:conso^le<|.log(getFirstName());

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsTestBase.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsTestBase.java
@@ -19,12 +19,15 @@
 
 package org.netbeans.modules.javascript2.editor;
 
+import java.net.URL;
 import java.util.Collections;
 import java.util.Set;
 import org.netbeans.lib.lexer.test.TestLanguageProvider;
 import org.netbeans.modules.csl.api.test.CslTestBase;
 import org.netbeans.modules.csl.spi.DefaultLanguageConfig;
 import org.netbeans.modules.javascript2.lexer.api.JsTokenId;
+import org.netbeans.modules.parsing.impl.indexing.IndexingUtils;
+import org.netbeans.modules.parsing.impl.indexing.RepositoryUpdater;
 
 /**
  * @author Tor Norbye
@@ -69,9 +72,76 @@ public abstract class JsTestBase extends CslTestBase {
     }
 
     @Override
-    protected void setUp() throws Exception {        
+    protected void setUp() throws Exception {
         TestLanguageProvider.register(getPreferredLanguage().getLexerLanguage());
         super.setUp();
     }
 
+    @Override
+    public void checkCompletion(String file, String caretLine, boolean includeModifiers) throws Exception {
+        waitScanningFinished();
+        super.checkCompletion(file, caretLine, includeModifiers);
+    }
+
+    @Override
+    protected void checkDeclaration(String relFilePath, String caretLine, String file, int offset) throws Exception {
+        waitScanningFinished();
+        super.checkDeclaration(relFilePath, caretLine, file, offset);
+    }
+
+    @Override
+    protected void checkDeclaration(String relFilePath, String caretLine, String declarationLine) throws Exception {
+        waitScanningFinished();
+        super.checkDeclaration(relFilePath, caretLine, declarationLine);
+    }
+
+    @Override
+    protected void checkDeclaration(String relFilePath, String caretLine, URL url) throws Exception {
+        waitScanningFinished();
+        super.checkDeclaration(relFilePath, caretLine, url);
+    }
+
+    @Override
+    protected void checkOccurrences(String relFilePath, String caretLine, boolean symmetric) throws Exception {
+        waitScanningFinished();
+        super.checkOccurrences(relFilePath, caretLine, symmetric);
+    }
+
+    @Override
+    protected void checkStructure(String relFilePath, boolean embedded, boolean inTestDir, boolean includePositions) throws Exception {
+        waitScanningFinished();
+        super.checkStructure(relFilePath, embedded, inTestDir, includePositions);
+    }
+
+    @Override
+    protected void checkStructure(String relFilePath) throws Exception {
+        waitScanningFinished();
+        super.checkStructure(relFilePath);
+    }
+
+    @Override
+    protected void checkSemantic(String relFilePath) throws Exception {
+        waitScanningFinished();
+        super.checkSemantic(relFilePath);
+    }
+
+    @Override
+    protected void checkSemantic(String relFilePath, String caretLine) throws Exception {
+        waitScanningFinished();
+        super.checkSemantic(relFilePath, caretLine);
+    }
+
+    @SuppressWarnings("SleepWhileInLoop")
+    protected void waitScanningFinished() {
+        while(IndexingUtils.isScanInProgress()) {
+            if(IndexingUtils.getIndexingState().contains(RepositoryUpdater.IndexingState.STARTING)) {
+                RepositoryUpdater.getDefault().start(true);
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException ex) {
+                return;
+            }
+        }
+    }
 }

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsWithFastTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsWithFastTest.java
@@ -29,15 +29,15 @@ public class JsWithFastTest extends JsWithBase {
     }
     
     public void testWith_01() throws Exception {
-        checkOccurrences("testfiles/with/test01.js", "console.log(getFirst^Name());", true);
+        checkOccurrences("testfiles/with/test01.js", "    console.log(getFirst^Name());", true);
     }
     
     public void testWith_02() throws Exception {
-        checkOccurrences("testfiles/with/test01.js", "console.l^og(getFirstName());", true);
+        checkOccurrences("testfiles/with/test01.js", "    console.l^og(getFirstName());", true);
     }
     
     public void testWith_03() throws Exception {
-        checkOccurrences("testfiles/with/test01.js", "conso^le.log(getFirstName());", true);
+        checkOccurrences("testfiles/with/test01.js", "    conso^le.log(getFirstName());", true);
     }
     
     public void testWith_04() throws Exception {

--- a/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsWithTest.java
+++ b/webcommon/javascript2.editor/test/unit/src/org/netbeans/modules/javascript2/editor/JsWithTest.java
@@ -41,7 +41,7 @@ public class JsWithTest extends JsWithBase {
     }
     
     public void testGoTo_01() throws Exception {
-        checkDeclaration("testfiles/with/test01.js", "console.log(getFirs^tName()); ", "man.js", 141);
+        checkDeclaration("testfiles/with/test01.js", "console.log(getFirs^tName());", "man.js", 141);
     }
     
     public void testWith_05() throws Exception {


### PR DESCRIPTION
1) The tests, that rely on information from the JS classpath (stub
definitions fail if classpath scanning is still in progress, so this
change forces repository updates to happen and delay test running
until scanning is done.

2) Changes to test input cause golden files to be out of sync. Align
input and golden files to match.

Tests were not actives for travis or github as execution takes to long.