### PR TITLE
[NETBEANS-6337] - remove annotation warnings related to deprecating

### DIFF
--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/ServerAdmin.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/admin/ServerAdmin.java
@@ -62,6 +62,7 @@ public class ServerAdmin {
      * @param ide IDE Context object (not used).
      * @deprecated {@link IdeContext} class will be removed.
      */
+    @Deprecated
     public static <E extends Result> Future<E> exec(
             final GlassFishServer srv, final Command cmd,
             final IdeContext ide) {
@@ -82,6 +83,7 @@ public class ServerAdmin {
      * @param listeners Listeners that are called when command execution status changes.
      * @deprecated {@link IdeContext} class will be removed.
      */
+    @Deprecated
     public static <E extends Result> Future<E> exec(
             final GlassFishServer srv, final Command cmd, final IdeContext ide,
             final TaskStateListener... listeners) {
@@ -115,6 +117,7 @@ public class ServerAdmin {
      * @param ide      IDE Context object (not used).
      * @deprecated {@link IdeContext} class will be removed.
      */
+    @Deprecated
     public static <E extends Result> Future<E> exec(
             final ExecutorService executor, final GlassFishServer srv,
             final Command cmd, final IdeContext ide) {
@@ -133,6 +136,7 @@ public class ServerAdmin {
      * @param listeners Listeners that are called when command execution status changes.
      * @deprecated {@link IdeContext} class will be removed.
      */
+    @Deprecated
     public static <E extends Result> Future<E> exec(
             final ExecutorService executor, final GlassFishServer srv, 
             final Command cmd, final IdeContext ide,

--- a/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/IdeContext.java
+++ b/enterprise/glassfish.tooling/src/org/netbeans/modules/glassfish/tooling/data/IdeContext.java
@@ -24,6 +24,7 @@ package org.netbeans.modules.glassfish.tooling.data;
  * @author Tomas Kraus, Peter Benedikovic
  * @deprecated IDE context support was removed. DO NOT USE!
  */
+@Deprecated
 public class IdeContext {
 
     ////////////////////////////////////////////////////////////////////////////
@@ -35,6 +36,7 @@ public class IdeContext {
      * <p/>
      * @deprecated IDE context support was removed. DO NOT USE!
      */
+    @Deprecated
     public IdeContext() {
     }
 

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/api/ejbjar/Car.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/api/ejbjar/Car.java
@@ -110,6 +110,7 @@ public final class Car {
      * @return J2EE platform version
      * @deprecated use {@link #getJ2eeProfile()}
      */
+    @Deprecated
     public String getJ2eePlatformVersion () {
         if (impl2 != null) {
             return impl2.getJ2eeProfile().toPropertiesString();

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/api/ejbjar/Ear.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/api/ejbjar/Ear.java
@@ -96,6 +96,7 @@ public final class Ear {
      * @return J2EE platform version
      * @deprecated use {@link #getJ2eeProfile()}
      */
+    @Deprecated
     public String getJ2eePlatformVersion () {
         if (impl2 != null) {
             // TODO null happens when EAR is deleted and getApplication is called

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/api/ejbjar/EjbJar.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/api/ejbjar/EjbJar.java
@@ -108,6 +108,7 @@ public final class EjbJar {
      * @return J2EE platform version
      * @deprecated use {@link #getJ2eeProfile()}
      */
+    @Deprecated
     public String getJ2eePlatformVersion () {
         if (impl2 != null) {
             return impl2.getJ2eeProfile().toPropertiesString();

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/spi/ejbjar/CarImplementation.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/spi/ejbjar/CarImplementation.java
@@ -28,6 +28,7 @@ import org.openide.filesystems.FileObject;
  * @author Lukas Jungmann
  * @deprecated implement {@link CarImplementation2}
  */
+@Deprecated
 public interface CarImplementation {
     
     /** J2EE platform version - one of the constants 

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/spi/ejbjar/EarImplementation.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/spi/ejbjar/EarImplementation.java
@@ -28,6 +28,7 @@ import org.netbeans.modules.web.api.webmodule.WebModule;
  * @see EjbJarFactory
  * @deprecated implement {@link EarImplementation2}
  */
+@Deprecated
 public interface EarImplementation {
 
     /** J2EE platform version - one of the constants

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/spi/ejbjar/EjbJarFactory.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/spi/ejbjar/EjbJarFactory.java
@@ -42,6 +42,7 @@ public final class EjbJarFactory {
      * @return instance of API webmodule
      * @deprecated use {@link #create }
      */
+    @Deprecated
     public static EjbJar createEjbJar(EjbJarImplementation spiWebmodule) {
         return EjbJarAccessor.getDefault().createEjbJar (spiWebmodule);
     }

--- a/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/spi/ejbjar/EjbJarImplementation.java
+++ b/enterprise/j2ee.api.ejbmodule/src/org/netbeans/modules/j2ee/spi/ejbjar/EjbJarImplementation.java
@@ -29,6 +29,7 @@ import org.openide.filesystems.FileObject;
  * @see EjbJarFactory
  * @deprecated implement {@link EjbJarImplementation2}
  */
+@Deprecated
 public interface EjbJarImplementation {
 
     /** J2EE platform version - one of the constants

--- a/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/BrokenServerSupport.java
+++ b/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/BrokenServerSupport.java
@@ -70,6 +70,7 @@ public class BrokenServerSupport {
      * @return selected application server. Might be <code>null</code>.
      * @deprecated
      */
+    @Deprecated
     public static String selectServer(final String j2eeSpec, final Object moduleType) {
         return NoSelectedServerWarning.selectServerDialog(
                 new Object[] { moduleType }, j2eeSpec,

--- a/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/NoSelectedServerWarning.java
+++ b/enterprise/j2ee.common/src/org/netbeans/modules/j2ee/common/ui/NoSelectedServerWarning.java
@@ -89,6 +89,7 @@ final class NoSelectedServerWarning extends JPanel {
      *         if canceled.
      * @deprecated
      */
+    @Deprecated
     public static String selectServerDialog(Object[] moduleTypes, String j2eeSpec, String title, String description) {
         List<J2eeModule.Type> types = new ArrayList<J2eeModule.Type>(moduleTypes.length);
         for (Object obj : moduleTypes) {

--- a/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/api/webservices/DDProvider.java
+++ b/enterprise/j2ee.dd.webservice/src/org/netbeans/modules/j2ee/dd/api/webservices/DDProvider.java
@@ -162,6 +162,7 @@ public final class DDProvider {
     /**  Convenient method for getting the BaseBean object from CommonDDBean object
      * @deprecated DO NOT USE - TEMPORARY WORKAROUND !!!!
      */
+    @Deprecated
     public org.netbeans.modules.schema2beans.BaseBean getBaseBean(org.netbeans.modules.j2ee.dd.api.common.CommonDDBean bean) {
         if (bean instanceof org.netbeans.modules.schema2beans.BaseBean) return (org.netbeans.modules.schema2beans.BaseBean)bean;
         else if (bean instanceof WebServicesProxy) return (org.netbeans.modules.schema2beans.BaseBean) ((WebServicesProxy)bean).getOriginal();

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/client/DDProvider.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/client/DDProvider.java
@@ -198,6 +198,7 @@ public final class DDProvider {
      * or the implementation in j2eeserver gets changed.
      * @deprecated do not use - temporary workaround that exposes the schema2beans implementation
      */
+    @Deprecated
     public BaseBean getBaseBean(CommonDDBean bean) {
         BaseBean result;
         if (bean instanceof BaseBean) {

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/web/DDProvider.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/api/web/DDProvider.java
@@ -233,6 +233,7 @@ public final class DDProvider {
      * or the implementation in j2eeserver gets changed.
      * @deprecated do not use - temporary workaround that exposes the schema2beans implementation
      */
+    @Deprecated
     public org.netbeans.modules.schema2beans.BaseBean getBaseBean(org.netbeans.modules.j2ee.dd.api.common.CommonDDBean bean) {
         if (bean instanceof org.netbeans.modules.schema2beans.BaseBean) {
             return (org.netbeans.modules.schema2beans.BaseBean) bean;

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarProvider.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarProvider.java
@@ -112,6 +112,7 @@ public final class EjbJarProvider extends J2eeModuleProvider
     }
     
     /** @deprecated use getJavaSources */
+    @Deprecated
     public ClassPath getClassPath() {
         ClassPathProvider cpp = project.getClassPathProvider();
         if (cpp != null) {

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/api/EjbJarProjectGenerator.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/api/EjbJarProjectGenerator.java
@@ -94,6 +94,7 @@ public class EjbJarProjectGenerator {
      * @throws IOException in case something went wrong
      * @deprecated 
      */
+    @Deprecated
     public static AntProjectHelper createProject(File dir, final String name, 
             final String j2eeLevel, final String serverInstanceID) throws IOException {
 

--- a/enterprise/payara.common/src/org/netbeans/modules/payara/common/ui/JavaPlatformsComboBox.java
+++ b/enterprise/payara.common/src/org/netbeans/modules/payara/common/ui/JavaPlatformsComboBox.java
@@ -173,6 +173,7 @@ public class JavaPlatformsComboBox
      * @throws UnsupportedOperationException is thrown any time
      *         this constructor is called.
      */
+    @Deprecated
     public JavaPlatformsComboBox(final ComboBoxModel comboBoxModel)
             throws UnsupportedOperationException {
         throw new UnsupportedOperationException(CONSTRUCTOR_EXCEPTION_MSG);
@@ -188,6 +189,7 @@ public class JavaPlatformsComboBox
      * @throws UnsupportedOperationException is thrown any time
      *         this constructor is called.
      */
+    @Deprecated
     public JavaPlatformsComboBox(final Object items[])
             throws UnsupportedOperationException {
         throw new UnsupportedOperationException(CONSTRUCTOR_EXCEPTION_MSG);
@@ -203,6 +205,7 @@ public class JavaPlatformsComboBox
      * @throws UnsupportedOperationException is thrown any time
      *         this constructor is called.
      */
+    @Deprecated
     public JavaPlatformsComboBox(final Vector<?> items)
             throws UnsupportedOperationException {
         throw new UnsupportedOperationException(CONSTRUCTOR_EXCEPTION_MSG);

--- a/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/loader/PayaraDDProvider.java
+++ b/enterprise/payara.eecommon/src/org/netbeans/modules/payara/eecommon/dd/loader/PayaraDDProvider.java
@@ -745,6 +745,7 @@ public final class PayaraDDProvider {
      * determined.
      * @deprecated
      */
+    @Deprecated
     public static ASDDVersion getASDDVersion(RootInterface rootDD) {
         return getASDDVersion(rootDD, null);
     }

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/ServerAdmin.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/admin/ServerAdmin.java
@@ -62,6 +62,7 @@ public class ServerAdmin {
      * @param ide IDE Context object (not used).
      * @deprecated {@link IdeContext} class will be removed.
      */
+    @Deprecated
     public static <E extends Result> Future<E> exec(
             final PayaraServer srv, final Command cmd,
             final IdeContext ide) {
@@ -82,6 +83,7 @@ public class ServerAdmin {
      * @param listeners Listeners that are called when command execution status changes.
      * @deprecated {@link IdeContext} class will be removed.
      */
+    @Deprecated
     public static <E extends Result> Future<E> exec(
             final PayaraServer srv, final Command cmd, final IdeContext ide,
             final TaskStateListener... listeners) {
@@ -115,6 +117,7 @@ public class ServerAdmin {
      * @param ide      IDE Context object (not used).
      * @deprecated {@link IdeContext} class will be removed.
      */
+    @Deprecated
     public static <E extends Result> Future<E> exec(
             final ExecutorService executor, final PayaraServer srv,
             final Command cmd, final IdeContext ide) {
@@ -133,6 +136,7 @@ public class ServerAdmin {
      * @param listeners Listeners that are called when command execution status changes.
      * @deprecated {@link IdeContext} class will be removed.
      */
+    @Deprecated
     public static <E extends Result> Future<E> exec(
             final ExecutorService executor, final PayaraServer srv, 
             final Command cmd, final IdeContext ide,

--- a/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/JsfComponentUtils.java
+++ b/enterprise/web.jsf/src/org/netbeans/modules/web/jsf/api/JsfComponentUtils.java
@@ -73,6 +73,7 @@ public class JsfComponentUtils {
      * java.lang.String[])} instead.
      * @see #createMavenDependencyLibrary(java.lang.String, java.lang.String[], java.lang.String[]) 
      */
+    @Deprecated
     public static Library enhanceLibraryWithPomContent(final Library library, final List<URI> poms) throws IOException {
         Parameters.notNull("library", library);     //NOI18N
         Parameters.notNull("poms", poms);           //NOI18N

--- a/ide/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/FormatterIndentEngine.java
+++ b/ide/editor.deprecated.pre65formatting/src/org/netbeans/modules/editor/FormatterIndentEngine.java
@@ -38,7 +38,7 @@ import org.openide.util.NbBundle;
  * @deprecated Please use Editor Indentation API instead, for details see
  *   <a href="@org-netbeans-modules-editor-indent@/overview-summary.html">Editor Indentation</a>.
  */
-
+@Deprecated
 public abstract class FormatterIndentEngine extends IndentEngine {
 
     public static final String EXPAND_TABS_PROP = "expandTabs"; //NOI18N
@@ -92,6 +92,7 @@ public abstract class FormatterIndentEngine extends IndentEngine {
      * @deprecated use {@link #setValue(java.lang.String, java.lang.Object, java.lang.String)} instead 
      * with properly specified propertyName
      */
+    @Deprecated
     public void setValue(String settingName, Object newValue) {
         setValue(settingName, newValue, null);
     }

--- a/ide/editor.plain.lib/src/org/netbeans/editor/ext/plain/PlainSyntax.java
+++ b/ide/editor.plain.lib/src/org/netbeans/editor/ext/plain/PlainSyntax.java
@@ -29,6 +29,7 @@ import org.netbeans.editor.TokenID;
  * @deprecated If you need this class you are doing something wrong, 
  *   please ask on nbdev@netbeans.org.
  */
+@Deprecated
 public class PlainSyntax extends Syntax {
 
     /* Internal states used internally by analyzer. There

--- a/ide/editor.plain.lib/src/org/netbeans/editor/ext/plain/PlainTokenContext.java
+++ b/ide/editor.plain.lib/src/org/netbeans/editor/ext/plain/PlainTokenContext.java
@@ -32,6 +32,7 @@ import org.netbeans.editor.Utilities;
  * @deprecated If you need this class you are doing something wrong, 
  *   please ask on nbdev@netbeans.org.
  */
+@Deprecated
 public class PlainTokenContext extends TokenContext {
 
     // Numeric-ids for token-ids

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/lib/StreamEnvironment.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/lib/StreamEnvironment.java
@@ -31,6 +31,7 @@ import org.openide.text.*;
  * @version
  * @deprecated in favour of URLEnvironment. It can reopen the stream.
  */
+@Deprecated
 public abstract class StreamEnvironment implements CloneableEditorSupport.Env {
 
     /** Serial Version UID */

--- a/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/spi/CatalogDescriptor.java
+++ b/ide/xml.catalog.ui/src/org/netbeans/modules/xml/catalog/spi/CatalogDescriptor.java
@@ -28,6 +28,7 @@ import java.awt.Image;
  * @version 1.0
  * @deprecated Use {@link CatalogDescriptor2}
  */
+@Deprecated
 public interface CatalogDescriptor extends CatalogDescriptorBase {
     /**
      * Return visuaized state of given catalog.

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/EntityMember.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/EntityMember.java
@@ -110,6 +110,7 @@ public abstract class EntityMember {
      * @return The nicer name
      * @deprecated it was a fix for bad name, use makeRelationshipFieldName with collection type parameter to generate proper name initially
      */
+    @Deprecated
     public static String fixRelationshipFieldName(String orgName, CollectionType colType) {
         String newName = orgName;
         if (orgName.endsWith("Collection")) { // NOI18N

--- a/java/maven/src/org/netbeans/modules/maven/api/output/OutputUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/api/output/OutputUtils.java
@@ -67,6 +67,7 @@ public final class OutputUtils {
      * @deprecated use {@link #matchStackTraceLine(java.lang.String, org.openide.filesystems.FileObject)}  
      *              or {@link #matchStackTraceLine(java.lang.String, org.netbeans.api.project.Project)} instead.
      */
+    @Deprecated
     public static OutputListener matchStackTraceLine(String line, ClassPath classPath) {
         StacktraceAttributes sa = matchStackTraceLine(line);
         return sa != null ? new ClassPathStacktraceOutputListener(classPath, sa) : null;

--- a/platform/api.progress.nb/src/org/netbeans/api/progress/ProgressHandleFactory.java
+++ b/platform/api.progress.nb/src/org/netbeans/api/progress/ProgressHandleFactory.java
@@ -167,7 +167,9 @@ public final class ProgressHandleFactory {
     /**
      * Create a cancelable handle for a task that is not triggered by explicit user action.
      * Such tasks have lower priority in the UI.
-     * Since {@code 1.59}, the functionality moves to basic {@link ProgressHandle Progress API}; this method is retained for smooth transition of older API clients.
+     * Since {@code 1.59}, the functionality moves to basic {@link ProgressHandle Progress API}; this method is retained
+     * for smooth transition of older API clients.
+     *
      * @param displayName to be shown in the progress UI
      * @param allowToCancel either null, if the task cannot be cancelled or 
      *          an instance of {@link org.openide.util.Cancellable} that will be called when user 
@@ -175,6 +177,7 @@ public final class ProgressHandleFactory {
      * @return an instance of {@link org.netbeans.api.progress.ProgressHandle}, initialized but not started.
      * @deprecated Use {@link ProgressHandle#createSystemHandle(java.lang.String, org.openide.util.Cancellable)}.
      */
+    @Deprecated
     public static ProgressHandle createSystemHandle(String displayName, Cancellable allowToCancel) {
         return createSystemHandle(displayName, allowToCancel, null);
     }
@@ -191,8 +194,8 @@ public final class ProgressHandleFactory {
      * @param displayName to be shown in the progress UI
      * @return an instance of {@link org.netbeans.api.progress.ProgressHandle}, initialized but not started.
      * @deprecated Please use {@link ProgressHandle#createSystemHandle(java.lang.String, org.openide.util.Cancellable, javax.swing.Action)}
-     * @Deprecated
      */
+    @Deprecated
     public static ProgressHandle createSystemHandle(String displayName, Cancellable allowToCancel, Action linkOutput) {
         return ProgressHandle.createSystemHandle(displayName, allowToCancel, linkOutput);
     }    

--- a/platform/openide.loaders/src/org/openide/loaders/CreateFromTemplateAttributesProvider.java
+++ b/platform/openide.loaders/src/org/openide/loaders/CreateFromTemplateAttributesProvider.java
@@ -39,6 +39,7 @@ import java.util.Map;
  * @since deprecated from 7.59
  * @deprecated Use {@link CreateFromTemplateAttributes} in {@code openide.filesystems.templates} instead.
  */
+@Deprecated
 public interface CreateFromTemplateAttributesProvider {
     /** Called when a template is about to be instantiated to provide additional
      * values to the {@link CreateFromTemplateHandler} that will handle the 


### PR DESCRIPTION
Cleanup warnings related to improper deprecation annotation..

Like this..

   [repeat] /home/bwalker/src/netbeans/platform/openide.options/src/org/openide/text/NbDocument$Colors.java:31: warning: [dep-ann] deprecated item is not annotated with @Deprecated
   [repeat] public final class NbDocument$Colors extends org.openide.options.SystemOption {
   [repeat]              ^
   [repeat] 48 warnings
     [copy] Copying 1 file to /home/bwalker/src/netbeans/platform/openide.options/build/classes