### PR TITLE
Updated Subversion support to 1.14.0

### DIFF
--- a/ide/libs.svnClientAdapter.javahl/external/adapter-javahl-1.14.0-license.txt
+++ b/ide/libs.svnClientAdapter.javahl/external/adapter-javahl-1.14.0-license.txt
@@ -1,6 +1,6 @@
 Name: SVNClientAdapter Library
 Description: Integration library for subversion client
-Version: 1.10.12
+Version: 1.14.0
 Origin: Subclipse
 License: Apache-2.0
 URL: http://subclipse.tigris.org/svnClientAdapter.html
@@ -206,3 +206,4 @@ URL: http://subclipse.tigris.org/svnClientAdapter.html
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+

--- a/ide/libs.svnClientAdapter.javahl/external/binaries-list
+++ b/ide/libs.svnClientAdapter.javahl/external/binaries-list
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-DAAEFA7A5F3AF75FE4CDC86A1B5904C9F3B5BBF8 svnClientAdapter-javahl-1.10.12.jar
-5C47A97F05F761F190D87ED5FCBB08D1E05A7FB5 svnjavahl-1.9.3.jar
+50BDFE2ACBC4FD267A3E57D437C2A84A339F2806 adapter-javahl-1.14.0.jar
+F30B0E06CDC52C77F556E76044CDFD005CC5AD2F javahl-1.14.0.jar

--- a/ide/libs.svnClientAdapter.javahl/external/javahl-1.14.0-license.txt
+++ b/ide/libs.svnClientAdapter.javahl/external/javahl-1.14.0-license.txt
@@ -1,9 +1,10 @@
-Name: SVNClientAdapter Library
-Description: Integration library for subversion client
-Version: 1.10.12
-Origin: Subclipse
+Name: Subversion Java-HL bindings
+Description: Java bindings library for subversion client
+Version: 1.14.0
+Origin: Apache Software Foundation
 License: Apache-2.0
-URL: http://subclipse.tigris.org/svnClientAdapter.html
+URL: http://subversion.apache.org/
+
 
                                  Apache License
                            Version 2.0, January 2004

--- a/ide/libs.svnClientAdapter.javahl/nbproject/project.properties
+++ b/ide/libs.svnClientAdapter.javahl/nbproject/project.properties
@@ -18,8 +18,8 @@
 
 is.eager=true
 javac.source=1.6
-release.external/svnClientAdapter-javahl-1.10.12.jar=modules/ext/svnClientAdapter-javahl.jar
-release.external/svnjavahl-1.9.3.jar=modules/ext/svnjavahl.jar
+release.external/adapter-javahl-1.14.0.jar=modules/ext/adapter-javahl.jar
+release.external/javahl-1.14.0.jar=modules/ext/javahl.jar
 
 # Hidden class found: org.tigris.subversion.svnclientadapter.commandline.CommandLine$CmdArguments in method protected byte[] org.tigris.subversion.svnclientadapter.commandline.SvnCommandLine.execBytes(org.tigris.subversion.svnclientadapter.commandline.CommandLine$CmdArguments,boolean) throws java.lang.Exception in class org.tigris.subversion.svnclientadapter.commandline.SvnCommandLine
 # Hidden class found: org.tigris.subversion.svnclientadapter.commandline.CommandLine$CmdArguments in method protected java.lang.String org.tigris.subversion.svnclientadapter.commandline.SvnAdminCommandLine.execString(org.tigris.subversion.svnclientadapter.commandline.CommandLine$CmdArguments,boolean) throws java.lang.Exception in class org.tigris.subversion.svnclientadapter.commandline.SvnAdminCommandLine

--- a/ide/libs.svnClientAdapter.javahl/nbproject/project.xml
+++ b/ide/libs.svnClientAdapter.javahl/nbproject/project.xml
@@ -79,12 +79,12 @@
             </test-dependencies>
             <public-packages/>
             <class-path-extension>
-                <runtime-relative-path>ext/svnClientAdapter-javahl.jar</runtime-relative-path>
-                <binary-origin>external/svnClientAdapter-javahl-1.10.12.jar</binary-origin>
+                <runtime-relative-path>ext/adapter-javahl.jar</runtime-relative-path>
+                <binary-origin>external/adapter-javahl-1.14.0.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
-                <runtime-relative-path>ext/svnjavahl.jar</runtime-relative-path>
-                <binary-origin>external/svnjavahl-1.9.3.jar</binary-origin>
+                <runtime-relative-path>ext/javahl.jar</runtime-relative-path>
+                <binary-origin>external/javahl-1.14.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>

--- a/ide/libs.svnClientAdapter.javahl/src/org/netbeans/libs/svnclientadapter/javahl/JavaHlClientAdapterFactory.java
+++ b/ide/libs.svnClientAdapter.javahl/src/org/netbeans/libs/svnclientadapter/javahl/JavaHlClientAdapterFactory.java
@@ -124,8 +124,8 @@ public class JavaHlClientAdapterFactory extends SvnClientAdapterFactory {
         boolean retval = false;
         if (version != null) {
             version = version.toLowerCase();
-            if (version.startsWith("1.9") ||                                                        // NOI18N
-                version.contains("version 1.9"))                                                    // NOI18N
+            if (version.startsWith("1.14") ||                                                        // NOI18N
+                version.contains("version 1.14"))                                                    // NOI18N
             {
                 retval = true;
             }

--- a/ide/libs.svnClientAdapter/external/adapter-base-1.14.0-license.txt
+++ b/ide/libs.svnClientAdapter/external/adapter-base-1.14.0-license.txt
@@ -1,10 +1,9 @@
-Name: Subversion Java-HL bindings
-Description: Java bindings library for subversion client
-Version: 1.9.3
-Origin: Apache Software Foundation
+Name: SVNClientAdapter Library
+Description: Integration library for subversion client
+Version: 1.14.0
+Origin: Subclipse
 License: Apache-2.0
-URL: http://subversion.apache.org/
-
+URL: http://subclipse.tigris.org/svnClientAdapter.html
 
                                  Apache License
                            Version 2.0, January 2004
@@ -207,4 +206,3 @@ URL: http://subversion.apache.org/
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/ide/libs.svnClientAdapter/external/binaries-list
+++ b/ide/libs.svnClientAdapter/external/binaries-list
@@ -14,4 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-C47ED3BCD8CEAECDE3BDEEB7D8D14B577B26F9C8 svnClientAdapter-main-1.10.12.jar
+0C7B101C71719B0AE54282EB69878116B8D8D9F5 adapter-base-1.14.0.jar
+#8E94F3F1CCCF0E9D9A0B09CA9D4B5ABADEEE4000  adapter-cli-1.14.0.jar

--- a/ide/libs.svnClientAdapter/nbproject/project.properties
+++ b/ide/libs.svnClientAdapter/nbproject/project.properties
@@ -17,8 +17,8 @@
 
 is.autoload=true
 
-javac.source=1.6
-release.external/svnClientAdapter-main-1.10.12.jar=modules/ext/svnClientAdapter-main.jar
+javac.source=1.8
+release.external/adapter-base-1.14.0.jar=modules/ext/adapter-base.jar
 
 # Hidden class found: org.tigris.subversion.svnclientadapter.commandline.CommandLine$CmdArguments in method protected byte[] org.tigris.subversion.svnclientadapter.commandline.SvnCommandLine.execBytes(org.tigris.subversion.svnclientadapter.commandline.CommandLine$CmdArguments,boolean) throws java.lang.Exception in class org.tigris.subversion.svnclientadapter.commandline.SvnCommandLine
 # Hidden class found: org.tigris.subversion.svnclientadapter.commandline.CommandLine$CmdArguments in method protected java.lang.String org.tigris.subversion.svnclientadapter.commandline.SvnAdminCommandLine.execString(org.tigris.subversion.svnclientadapter.commandline.CommandLine$CmdArguments,boolean) throws java.lang.Exception in class org.tigris.subversion.svnclientadapter.commandline.SvnAdminCommandLine

--- a/ide/libs.svnClientAdapter/nbproject/project.xml
+++ b/ide/libs.svnClientAdapter/nbproject/project.xml
@@ -58,17 +58,14 @@
                     </run-dependency>
                 </dependency>
             </module-dependencies>
-            <friend-packages>
-                <friend>org.netbeans.modules.subversion</friend>
-                <friend>org.netbeans.libs.svnClientAdapter.javahl</friend>
-                <friend>org.netbeans.libs.svnClientAdapter.svnkit</friend>
+            <public-packages>                
                 <package>org.netbeans.libs.svnclientadapter</package>
                 <package>org.tigris.subversion.svnclientadapter</package>
                 <package>org.tigris.subversion.svnclientadapter.utils</package>
-            </friend-packages>
+            </public-packages>    
             <class-path-extension>
-                <runtime-relative-path>ext/svnClientAdapter-main.jar</runtime-relative-path>
-                <binary-origin>external/svnClientAdapter-main-1.10.12.jar</binary-origin>
+                <runtime-relative-path>ext/adapter-base.jar</runtime-relative-path>
+                <binary-origin>external/adapter-base-1.14.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Well, let's see if we could just update to SubVersion 1.14 on JavaHL.
Also made the SvnClientAdapterFactory so it would be easier to re-implement the SvnKit adapter, whoever would do that.

I'd also like to test if the current (1.14.0) JavaHL would also work with version 1.13 (Ubuntu 20.04) and 1.9 (Ubuntu 18.04) as well.