### PR TITLE
javac wrapper module should clean its "external" folder.

### DIFF
--- a/java/libs.javacapi/build.xml
+++ b/java/libs.javacapi/build.xml
@@ -32,4 +32,11 @@
         <antcall target="projectized.-release.files" />
     </target>
     <target name="-release.files" depends="-check-nb-javac-exists,-release.files-build-javac,-release.files-delegate" />
+    <target name="clean" depends="projectized.clean">
+        <delete failonerror="false">
+            <fileset dir="external">
+                <include name="*.jar"/>
+            </fileset>
+        </delete>
+    </target>
 </project>

--- a/java/libs.javacapi/nbproject/project.properties
+++ b/java/libs.javacapi/nbproject/project.properties
@@ -17,7 +17,6 @@
 build.compiler.debug=false
 build.compiler.deprecation=false
 is.autoload=true
-javac.source=1.6
 javadoc.title=Javac API
 nbm.homepage=http://jackpot.netbeans.org/
 nbm.module.author=Petr Hrebejk


### PR DESCRIPTION
 - caused compiler errors since several javac versions were in cp (if the local copy is old)
 - removed javac.source property since the module has no sources anyway