### PR TITLE
Allow searching for multi-line Strings.

### DIFF
--- a/platform/api.search/src/org/netbeans/modules/search/PatternSandbox.java
+++ b/platform/api.search/src/org/netbeans/modules/search/PatternSandbox.java
@@ -82,6 +82,7 @@ public abstract class PatternSandbox extends JPanel
     protected void initComponents() {
 
         cboxPattern = new JComboBox<String>();
+        cboxPattern.setEditor(new BasicSearchForm.MultiLineComboBoxEditor());
         cboxPattern.setEditable(true);
         cboxPattern.setRenderer(new ShorteningCellRenderer());
         lblPattern = new JLabel();
@@ -92,7 +93,7 @@ public abstract class PatternSandbox extends JPanel
         textPane = new JTextPane();
         textScrollPane = new JScrollPane();
         textScrollPane.setViewportView(textPane);
-        textScrollPane.setPreferredSize(new Dimension(350, 100));
+        textScrollPane.setPreferredSize(new Dimension(400, 100));
         textScrollPane.setBorder(new BevelBorder(BevelBorder.LOWERED));
         searchCriteria = new BasicSearchCriteria();
         initSpecificComponents();
@@ -186,14 +187,10 @@ public abstract class PatternSandbox extends JPanel
         JPanel buttonsPanel = createButtonsPanel();
 
         mainHelper.addRow(GroupLayout.DEFAULT_SIZE,
-                form.getPreferredSize().height,
-                form.getPreferredSize().height,
-                form);
-        mainHelper.addRow(
-                GroupLayout.DEFAULT_SIZE,
                 200,
                 Short.MAX_VALUE,
-                textScrollPane);
+                new JSplitPane(JSplitPane.VERTICAL_SPLIT, form, textScrollPane));
+
         mainHelper.addRow(
                 GroupLayout.DEFAULT_SIZE,
                 buttonsPanel.getPreferredSize().height,
@@ -224,13 +221,22 @@ public abstract class PatternSandbox extends JPanel
                 FormLayoutHelper.DEFAULT_COLUMN,
                 FormLayoutHelper.EAGER_COLUMN);
         formHelper.setInlineGaps(true);
-        formHelper.addRow(lblPattern, cboxPattern);
+        formHelper.addRow(
+                GroupLayout.DEFAULT_SIZE,
+                cboxPattern.getPreferredSize().height,
+                Short.MAX_VALUE,
+                lblPattern, cboxPattern);
+        
         if (lblHint.getText() != null
                 && !"".equals(lblHint.getText())) {                     //NOI18N
             formHelper.addRow(new JLabel(), lblHint);
         }
 
-        formHelper.addRow(lblOptions, pnlOptions);
+        formHelper.addRow(
+                GroupLayout.DEFAULT_SIZE,
+                0,
+                pnlOptions.getPreferredSize().height,
+                lblOptions, pnlOptions);
         return form;
     }
 
@@ -1011,7 +1017,7 @@ public abstract class PatternSandbox extends JPanel
     private static class TimeoutExeption extends RuntimeException {
     }
 
-    private class ShorteningCellRenderer extends DefaultListCellRenderer {
+    private static class ShorteningCellRenderer extends DefaultListCellRenderer {
 
         private static final int MAX_LENGTH = 50;
         private static final String THREE_DOTS = "...";                 //NOI18N

--- a/platform/api.search/src/org/netbeans/modules/search/TextRegexpUtil.java
+++ b/platform/api.search/src/org/netbeans/modules/search/TextRegexpUtil.java
@@ -231,8 +231,6 @@ public final class TextRegexpUtil {
         assert sp.getSearchExpression() != null;
         assert sp.isRegExp();
 
-        boolean multiline = canBeMultilinePattern(sp.getSearchExpression());
-
         if (LOG.isLoggable(Level.FINEST)) {
             LOG.log(Level.FINEST, " - textPatternExpr = \"{0}{1}",
                     new Object[]{sp.getSearchExpression(), '"'});   //NOI18N
@@ -375,12 +373,12 @@ public final class TextRegexpUtil {
 
     /**
      * Check if multi-line matching should be used for passed regular
-     * expression.
+     * expression or if the expression itself is multi-line.
      */
-    public static boolean canBeMultilinePattern(String expr) {
+    public static boolean isMultilineOrMatchesMultiline(String expr) {
         if (expr == null) {
             return false;
         }
-        return expr.matches(MULTILINE_REGEXP_PATTERN);
+        return expr.contains("\n") || expr.contains("\r") || expr.matches(MULTILINE_REGEXP_PATTERN);
     }
 }

--- a/platform/api.search/src/org/netbeans/modules/search/matcher/DefaultMatcher.java
+++ b/platform/api.search/src/org/netbeans/modules/search/matcher/DefaultMatcher.java
@@ -73,7 +73,7 @@ public class DefaultMatcher extends AbstractMatcher {
         if (trivial) {
             realMatcher = new TrivialFileMatcher();
         } else {
-            boolean multiline = TextRegexpUtil.canBeMultilinePattern(
+            boolean multiline = TextRegexpUtil.isMultilineOrMatchesMultiline(
                     searchPattern.getSearchExpression());
 
             realMatcher = multiline

--- a/platform/api.search/src/org/netbeans/modules/search/matcher/FastMatcher.java
+++ b/platform/api.search/src/org/netbeans/modules/search/matcher/FastMatcher.java
@@ -84,7 +84,7 @@ public class FastMatcher extends AbstractMatcher {
             this.searchPattern = searchPattern;
             String expr = searchPattern.getSearchExpression();
             this.pattern = TextRegexpUtil.makeTextPattern(searchPattern);
-            this.multiline = TextRegexpUtil.canBeMultilinePattern(expr);
+            this.multiline = TextRegexpUtil.isMultilineOrMatchesMultiline(expr);
             asciiPattern = expr.matches("\\p{ASCII}+") //NOI18N
                     && !expr.contains(".") //NOI18N
                     && !expr.matches(".*\\\\[0xXuU].*");                //NOI18N

--- a/platform/api.search/test/unit/src/org/netbeans/modules/search/TextRegexpUtilTest.java
+++ b/platform/api.search/test/unit/src/org/netbeans/modules/search/TextRegexpUtilTest.java
@@ -302,17 +302,20 @@ public class TextRegexpUtilTest extends NbTestCase {
     }
     
     public void testCanBeMultilinePattern() {
-        assertFalse(TextRegexpUtil.canBeMultilinePattern("a\\d\\d\\da"));
-        assertFalse(TextRegexpUtil.canBeMultilinePattern(".*"));
-        assertFalse(TextRegexpUtil.canBeMultilinePattern("(?m)^x.*y$"));
-        assertTrue(TextRegexpUtil.canBeMultilinePattern("(?ms-x)test.*test"));
-        assertTrue(TextRegexpUtil.canBeMultilinePattern("test\\ntest"));
-        assertTrue(TextRegexpUtil.canBeMultilinePattern("test\\rtest"));
-        assertTrue(TextRegexpUtil.canBeMultilinePattern("test\\r\\ntest"));
-        assertTrue(TextRegexpUtil.canBeMultilinePattern("test\\ftest"));
-        assertTrue(TextRegexpUtil.canBeMultilinePattern("test\\u000Btest"));
-        assertTrue(TextRegexpUtil.canBeMultilinePattern("test\\x85test"));
-        assertTrue(TextRegexpUtil.canBeMultilinePattern("test\\s*86test"));
+        assertFalse(TextRegexpUtil.isMultilineOrMatchesMultiline("a\\d\\d\\da"));
+        assertFalse(TextRegexpUtil.isMultilineOrMatchesMultiline(".*"));
+        assertFalse(TextRegexpUtil.isMultilineOrMatchesMultiline("(?m)^x.*y$"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("(?ms-x)test.*test"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("test\\ntest"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("test\\rtest"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("test\\r\\ntest"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("test\\ftest"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("test\\u000Btest"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("test\\x85test"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("test\\s*86test"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("test\ntest"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("test\rtest"));
+        assertTrue(TextRegexpUtil.isMultilineOrMatchesMultiline("test\r\ntest"));
     }
 
     public void testLiteralMatches() {


### PR DESCRIPTION
The search dialog (`ctrl+shift+F or ctrl+shift+H `) didn't support searching for multi-line Strings since it used the wrong matcher for the task when a multi-line String was provided.

Updated the UI too. Its now resizable and the combo box editors are now multi-line capable.

Dialog looks identical on first open:
![default](https://user-images.githubusercontent.com/114367/147838164-1d236a02-3926-438e-9f3b-11efe66b5cee.png)

but when the window is resized vertically:
![resized](https://user-images.githubusercontent.com/114367/147838183-4d5de1c4-571d-4eff-b91d-13f6ed9fe803.png)

