### PR TITLE
Formatted the templates to be inline with the default java formatting.

### DIFF
--- a/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/AppTemplate.java.template
+++ b/ide/projectui/test/unit/src/org/netbeans/modules/project/ui/AppTemplate.java.template
@@ -26,9 +26,9 @@ package ${package};
  * @author ${user}
  */
 public class ${name} {
-    public static void main( String[] args )
-    {
-        System.out.println( "Hello World!" );
+
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
     }
 }
 

--- a/java/maven/src/org/netbeans/modules/maven/resources/App.java.template
+++ b/java/maven/src/org/netbeans/modules/maven/resources/App.java.template
@@ -12,8 +12,8 @@ package ${package};
  * @author ${user}
  */
 public class ${name} {
-    public static void main( String[] args )
-    {
-        System.out.println( "Hello World!" );
+
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
     }
 }

--- a/java/maven/src/org/netbeans/modules/maven/resources/AppTest.java.template
+++ b/java/maven/src/org/netbeans/modules/maven/resources/AppTest.java.template
@@ -15,8 +15,8 @@ import org.junit.Test;
  * @author ${user}
  */
 public class ${name} {
-    public static void main( String[] args )
-    {
-        System.out.println( "Hello World!" );
+
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
     }
 }

--- a/platform/api.templates/test/unit/src/org/netbeans/modules/templates/AppTemplate.java.template
+++ b/platform/api.templates/test/unit/src/org/netbeans/modules/templates/AppTemplate.java.template
@@ -26,9 +26,9 @@ package ${package};
  * @author ${user}
  */
 public class ${name} {
-    public static void main( String[] args )
-    {
-        System.out.println( "Hello World!" );
+
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
     }
 }
 


### PR DESCRIPTION
The recently added new maven based java project templates use a formatting which is different to NetBeans' default formatting settings. I think they should be consistent to whatever the default formatter is configured with.

(had to fix multi-line search and replace first before i could find the templates :) see https://github.com/apache/netbeans/pull/3393)