### PR TITLE
[jackpot] Add sourceVersion(int) to rule file utils and deprecate enum variant.

### DIFF
--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/DefaultRuleUtilities.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/DefaultRuleUtilities.java
@@ -46,8 +46,30 @@ public final class DefaultRuleUtilities {
         return matcher.referencedIn(variable, in);
     }
 
+    /**
+     * @deprecated Use {@link #sourceVersionGE(int)} instead.
+     */
+    @Deprecated
     public boolean sourceVersionGE(SourceVersion source) {
         return context.sourceVersion().compareTo(source) >= 0;
+    }
+
+    /**
+     * Returns true if the provided feature version is less or equals the
+     * source version of the inspected file.
+     * @see Runtime.Version#feature()
+     */
+    public boolean sourceVersionLE(int feature) {
+        return context.sourceVersion().ordinal() <= feature;
+    }
+
+    /**
+     * Returns true if the provided feature version is greater or equals the
+     * source version of the inspected file.
+     * @see Runtime.Version#feature()
+     */
+    public boolean sourceVersionGE(int feature) {
+        return context.sourceVersion().ordinal() >= feature;
     }
 
     public boolean hasModifier(Variable variable, Modifier modifier) {


### PR DESCRIPTION
 - version enums cause problems if the enum value can not be resolved
 - shorter
 
With nb-javac 17 installed by default, having a version check API like https://github.com/apache/netbeans/pull/3274 became less of a priority. However the same issue still persists for rule files. Loading a rule file with a JDK 18 version check on nb-javac 17 would throw an exception and no hints are shown. Comparing versions without the enum would avoid this issue entirely.