### PR TITLE
nb-javac checks cleanup and dialog removal.

### DIFF
--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -33,6 +33,9 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
 import static javax.lang.model.element.ElementKind.*;
 import static javax.lang.model.element.Modifier.*;
+import static javax.lang.model.SourceVersion.RELEASE_10;
+import static javax.lang.model.SourceVersion.RELEASE_11;
+import static javax.lang.model.SourceVersion.RELEASE_13;
 import javax.lang.model.type.*;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.ElementFilter;
@@ -237,49 +240,6 @@ public final class JavaCompletionTask<T> extends BaseTask {
         PUBLIC_KEYWORD, STATIC_KEYWORD, STRICT_KEYWORD, SYNCHRONIZED_KEYWORD,
         TRANSIENT_KEYWORD, VOID_KEYWORD, VOLATILE_KEYWORD
     };
-
-    private static final SourceVersion SOURCE_VERSION_RELEASE_10;
-    private static final SourceVersion SOURCE_VERSION_RELEASE_11;
-    private static final SourceVersion SOURCE_VERSION_RELEASE_13;
-    private static final SourceVersion SOURCE_VERSION_RELEASE_14;
-    private static final SourceVersion SOURCE_VERSION_RELEASE_15;
-
-    static {
-        SourceVersion r10, r11, r13, r14, r15;
-
-        try {
-            r10 = SourceVersion.valueOf("RELEASE_10");
-        } catch (IllegalArgumentException ex) {
-            r10 = null;
-        }
-        try {
-            r11 = SourceVersion.valueOf("RELEASE_11");
-        } catch (IllegalArgumentException ex) {
-            r11 = null;
-        }
-        try {
-            r13 = SourceVersion.valueOf("RELEASE_13");
-        } catch (IllegalArgumentException ex) {
-            r13 = null;
-        }
-         try {
-            r14 = SourceVersion.valueOf("RELEASE_14");
-        } catch (IllegalArgumentException ex) {
-            r14 = null;
-        }
-         
-        try {
-            r15 = SourceVersion.valueOf("RELEASE_15");
-        } catch (IllegalArgumentException ex) {
-            r15 = null;
-        }
-
-        SOURCE_VERSION_RELEASE_10 = r10;
-        SOURCE_VERSION_RELEASE_11 = r11;
-        SOURCE_VERSION_RELEASE_13 = r13;
-        SOURCE_VERSION_RELEASE_14 = r14;
-        SOURCE_VERSION_RELEASE_15 = r15;
-   }
 
     private final ItemFactory<T> itemFactory;
     private final Set<Options> options;
@@ -1585,8 +1545,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
         addKeywordsForBlock(env);
         
         String prefix = env.getPrefix();
-        if (SOURCE_VERSION_RELEASE_13 != null && env.getController().getSourceVersion().compareTo(SOURCE_VERSION_RELEASE_13) >= 0
-                && Utilities.startsWith(YIELD_KEYWORD, prefix)) {
+        if (env.getController().getSourceVersion().compareTo(RELEASE_13) >= 0 && Utilities.startsWith(YIELD_KEYWORD, prefix)) {
             TreePath parentPath = env.getPath().getParentPath();
             if (parentPath.getLeaf().getKind() == Tree.Kind.CASE && parentPath.getParentPath().getLeaf().getKind() == Kind.SWITCH_EXPRESSION) {
                 addKeyword(env, YIELD_KEYWORD, null, false);
@@ -4748,9 +4707,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
             }
             tp = tp.getParentPath();
         }
-        if (SOURCE_VERSION_RELEASE_10 != null &&
-            env.getController().getSourceVersion().compareTo(SOURCE_VERSION_RELEASE_10) >= 0 &&
-            Utilities.startsWith(VAR_KEYWORD, prefix)) {
+        if (env.getController().getSourceVersion().compareTo(RELEASE_10) >= 0 && Utilities.startsWith(VAR_KEYWORD, prefix)) {
             results.add(itemFactory.createKeywordItem(VAR_KEYWORD, SPACE, anchorOffset, false));
         }
     }
@@ -6314,7 +6271,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
     }
 
     private void addVarTypeForLambdaParam(final Env env) throws IOException {
-        if (SOURCE_VERSION_RELEASE_11 == null || env.getController().getSourceVersion().compareTo(SOURCE_VERSION_RELEASE_11) < 0) {
+        if (env.getController().getSourceVersion().compareTo(RELEASE_11) < 0) {
             return;
         }
         results.add(itemFactory.createKeywordItem(VAR_KEYWORD, SPACE, anchorOffset, false));

--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -4862,7 +4862,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
             if (!modifiers.contains(ABSTRACT)) {
                 kws.add(ABSTRACT_KEYWORD);
             }
-            if (!contains(modifiers, "SEALED") && !contains(modifiers, "NON_SEALED")) {
+            if (!modifiers.contains(SEALED) && !modifiers.contains(NON_SEALED)) {
                 if (!modifiers.contains(ABSTRACT)) {
                     kws.add(FINAL_KEYWORD);
                 }
@@ -4882,14 +4882,6 @@ public final class JavaCompletionTask<T> extends BaseTask {
             if (Utilities.startsWith(kw, prefix)) {
                 results.add(itemFactory.createKeywordItem(kw, SPACE, anchorOffset, false));
             }
-        }
-    }
-
-    private static boolean contains(Set<Modifier> modifiers, String modifier) {
-        try {
-            return modifiers.contains(Modifier.valueOf(modifier));
-        } catch (IllegalArgumentException ex) {
-            return false;
         }
     }
 

--- a/java/java.source.base/manifest.mf
+++ b/java/java.source.base/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.netbeans.modules.java.source.base
-OpenIDE-Module-Implementation-Version: 5
+OpenIDE-Module-Implementation-Version: 6
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/java/source/base/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/java/source/base/layer.xml
 OpenIDE-Module-Recommends: org.netbeans.libs.nbjavac

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeUtilities.java
@@ -35,17 +35,14 @@ import com.sun.source.util.DocTreePathScanner;
 import com.sun.source.util.SourcePositions;
 import com.sun.source.util.TreePath;
 import org.netbeans.api.java.source.support.ErrorAwareTreePathScanner;
-import org.netbeans.api.java.source.support.ErrorAwareTreeScanner;
 import com.sun.source.util.Trees;
 import com.sun.tools.javac.api.JavacScope;
-import com.sun.tools.javac.api.JavacTrees;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.comp.AttrContext;
 import com.sun.tools.javac.comp.Enter;
 import com.sun.tools.javac.comp.Env;
-import com.sun.tools.javac.comp.Resolve;
 import com.sun.tools.javac.tree.DCTree.DCReference;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCMethodDecl;
@@ -72,26 +69,16 @@ import javax.tools.SimpleJavaFileObject;
 
 import com.sun.source.util.DocTrees;
 import com.sun.tools.javac.api.JavacTaskImpl;
-import com.sun.tools.javac.code.Kinds;
-import com.sun.tools.javac.comp.ArgumentAttr;
 import com.sun.tools.javac.comp.Attr;
-import com.sun.tools.javac.comp.Check.CheckContext;
-import com.sun.tools.javac.comp.DeferredAttr;
-import com.sun.tools.javac.comp.InferenceContext;
 import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.parser.JavacParser;
 import com.sun.tools.javac.parser.Parser;
 import com.sun.tools.javac.parser.ParserFactory;
-import com.sun.tools.javac.parser.ScannerFactory;
-import com.sun.tools.javac.tree.JCTree.JCBlock;
 import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
-import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.JCDiagnostic;
 import com.sun.tools.javac.util.Log;
-import com.sun.tools.javac.util.Names;
-import com.sun.tools.javac.util.Warner;
 import java.lang.reflect.Method;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
@@ -100,19 +87,15 @@ import org.netbeans.api.java.lexer.JavaTokenId;
 import org.netbeans.api.java.lexer.JavadocTokenId;
 import org.netbeans.api.java.source.JavaSource.Phase;
 import org.netbeans.api.lexer.TokenSequence;
-import org.netbeans.lib.nbjavac.services.CancelService;
 import org.netbeans.lib.nbjavac.services.NBAttr;
-import org.netbeans.lib.nbjavac.services.NBParserFactory;
 import org.netbeans.lib.nbjavac.services.NBResolve;
 import org.netbeans.modules.java.source.TreeUtilitiesAccessor;
 import org.netbeans.modules.java.source.builder.CommentHandlerService;
 import org.netbeans.modules.java.source.builder.CommentSetImpl;
-import org.netbeans.modules.java.source.matching.CopyFinder;
 import org.netbeans.modules.java.source.matching.CopyFinder.HackScope;
 import org.netbeans.modules.java.source.pretty.ImportAnalysis2;
 import org.netbeans.modules.java.source.transform.ImmutableDocTreeTranslator;
 import org.netbeans.modules.java.source.transform.ImmutableTreeTranslator;
-import org.openide.util.Exceptions;
 
 /**
  *
@@ -906,9 +889,6 @@ public final class TreeUtilities {
             Env<AttrContext> env = getEnv(scope);
             if (tree instanceof JCExpression)
                 return attr.attribExpr((JCTree) tree,env, Type.noType);
-            if (env.tree != null && env.tree.getKind() == Kind.VARIABLE && !VARIABLE_CAN_OWN_VARIABLES) {
-                env = env.next;
-            }
             return attr.attribStat((JCTree) tree,env);
         } finally {
             unenter(jti.getContext(), (JCCompilationUnit) cut, (JCTree) tree);
@@ -927,18 +907,6 @@ public final class TreeUtilities {
         } catch (Throwable t) {
             LOG.log(Level.FINE, null, t);
         }
-    }
-
-    private static boolean VARIABLE_CAN_OWN_VARIABLES;
-    static {
-        boolean result;
-        try {
-            SourceVersion.valueOf("RELEASE_12");
-            result = true;
-        } catch (IllegalArgumentException ex) {
-            result = false;
-        }
-        VARIABLE_CAN_OWN_VARIABLES = result;
     }
 
     private static Scope attributeTreeTo(JavacTaskImpl jti, CompilationUnitTree cut, Tree tree, Scope scope, Tree to, final List<Diagnostic<? extends JavaFileObject>> errors) {

--- a/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/NoJavacHelper.java
@@ -21,7 +21,6 @@ package org.netbeans.modules.java.source;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.security.ProtectionDomain;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.lang.model.SourceVersion;
@@ -35,33 +34,24 @@ import org.openide.modules.OnStart;
  */
 public class NoJavacHelper {
 
-    private static final AtomicReference<Boolean> hasWorkingJavac = new AtomicReference<>();
-    public static boolean hasWorkingJavac() {
-        Boolean res = hasWorkingJavac.get();
-        if (res != null) {
-            return res;
-        }
+    private static final boolean hasWorkingJavac;
+
+    static {
+        boolean res;
         try {
             SourceVersion.valueOf("RELEASE_17");
             res = true;
         } catch (IllegalArgumentException ex) {
-            //OK
             res = false;
         }
-        hasWorkingJavac.compareAndSet(null, res);
-        return hasWorkingJavac.get();
+        hasWorkingJavac = res;
     }
 
-    public static boolean hasNbJavac() {
-        try {
-            Class.forName("com.sun.tools.javac.comp.Repair");
-            return true;
-        } catch (ClassNotFoundException ex) {
-            //OK
-            return false;
-        }
+    public static boolean hasWorkingJavac() {
+        return hasWorkingJavac;
     }
 
+    // safety net if someone manages to start NB on JDK 8 with nb-javac uninstalled
     @OnStart
     public static class FixClasses implements Runnable {
 
@@ -106,7 +96,7 @@ public class NoJavacHelper {
                 Class targetClass = Class.forName(injectToClass);  //NOI18N
 
                 Method defineClass = unsafeClass.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class, ClassLoader.class, ProtectionDomain.class);  //NOI18N
-                defineClass.invoke(unsafe, fqn, classData, 0, classData.length, targetClass.getClassLoader(), targetClass.getProtectionDomain());  //NOI18N 
+                defineClass.invoke(unsafe, fqn, classData, 0, classData.length, targetClass.getClassLoader(), targetClass.getProtectionDomain());  //NOI18N
             } catch (Throwable t) {
                 //ignore...
                 Logger.getLogger(NoJavacHelper.class.getName()).log(Level.WARNING, null, t);

--- a/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/indexing/JavaCustomIndexer.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.java.source.indexing;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -59,6 +58,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.lang.model.SourceVersion;
 
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ModuleElement;
@@ -82,7 +82,6 @@ import org.netbeans.api.java.source.ClasspathInfo;
 import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
-import org.netbeans.modules.classfile.ClassFile;
 import org.netbeans.modules.java.source.ElementHandleAccessor;
 import org.netbeans.modules.java.source.JavaSourceTaskFactoryManager;
 import org.netbeans.modules.java.source.ModuleNames;
@@ -115,7 +114,6 @@ import org.netbeans.spi.java.classpath.support.ClassPathSupport;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
-import org.openide.modules.InstalledFileLocator;
 import org.openide.util.Exceptions;
 //import org.openide.util.NbBundle;
 import org.openide.util.Pair;
@@ -1395,15 +1393,7 @@ public class JavaCustomIndexer extends CustomIndexer {
     private static Pair<Object,Method> heapDumper;
 
     private static String computeJavacVersion() {
-        if (NoJavacHelper.hasNbJavac()) {
-            File nbJavac = InstalledFileLocator.getDefault().locate("modules/ext/nb-javac-impl.jar", "org.netbeans.modules.nbjavac.impl", false);
-            if (nbJavac != null) {
-                return String.valueOf(nbJavac.lastModified());
-            }
-            return "-1";
-        } else {
-            return System.getProperty("java.vm.version", "unknown");
-        }
+        return SourceVersion.latest().toString();
     }
 
     private static class FilterOutJDK7AndLaterWarnings implements Comparable<Diagnostic<? extends JavaFileObject>> {

--- a/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TryTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/api/java/source/gen/TryTest.java
@@ -1039,15 +1039,6 @@ public class TryTest extends GeneratorTestMDRCompat {
             "    }\n" +
             "}\n"
             );
-        String extraSemicolon;
-        //XXX: a difference between vanilla javac and nb-javac:
-        if (NoJavacHelper.hasNbJavac()) {
-            //with nb-javac wil preserve the semicolon:
-            extraSemicolon = ";";
-        } else {
-            //with vanilla javac, we don't:
-            extraSemicolon = "";
-        }
         String golden =
             "package hierbas.del.litoral;\n" +
             "\n" +
@@ -1055,7 +1046,7 @@ public class TryTest extends GeneratorTestMDRCompat {
             "\n" +
             "public class Test {\n" +
             "    public void taragui() {\n" +
-            "        try (InputStream in = new FileInputStream(\"\")" + extraSemicolon + ") {\n" +
+            "        try (InputStream in = new FileInputStream(\"\")) {\n" +
             "        }\n" +
             "    }\n" +
             "}\n";

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/indexing/VanillaCompileWorkerTest.java
@@ -37,8 +37,10 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import java.util.stream.Collectors;
 import junit.framework.Test;
+
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
+
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.java.source.ClassIndex;
 import org.netbeans.api.java.source.ClassIndex.SearchKind;
@@ -48,7 +50,6 @@ import org.netbeans.api.java.source.ElementHandle;
 import org.netbeans.api.java.source.JavaSource;
 import org.netbeans.junit.NbTestSuite;
 import org.netbeans.modules.classfile.ClassFile;
-import org.netbeans.modules.java.source.NoJavacHelper;
 import org.netbeans.modules.java.source.indexing.CompileWorker.ParsingOutput;
 import org.netbeans.modules.java.source.indexing.JavaCustomIndexer.CompileTuple;
 import org.netbeans.modules.parsing.spi.indexing.Context;
@@ -1958,13 +1959,7 @@ public class VanillaCompileWorkerTest extends CompileWorkerTestBase {
     }
 
     public static Test suite() {
-        if (NoJavacHelper.hasNbJavac()) {
-            return new VanillaCompileWorkerTest("noop");
-        } else {
-//            return new VanillaCompileWorkerTest("testAnonymousClasses");
-//            return new VanillaCompileWorkerTest("testPreserveValidInitializers");
-            return new NbTestSuite(VanillaCompileWorkerTest.class);
-        }
+        return new NbTestSuite(VanillaCompileWorkerTest.class);
     }
 
     static {

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/JavacParserTest.java
@@ -146,9 +146,6 @@ public class JavacParserTest extends NbTestCase {
     }
 
     public void testMultiSourceOutOfMemory() throws Exception {
-        if (NoJavacHelper.hasNbJavac()) {
-            return ;
-        }
 
         FileObject f1 = createFile("test/Test1.java", "package test; class Test1 {}");
         FileObject f2 = createFile("test/Test2.java", "package test; class Test2 {}");

--- a/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PartialReparseTest.java
+++ b/java/java.source.base/test/unit/src/org/netbeans/modules/java/source/parsing/PartialReparseTest.java
@@ -262,10 +262,6 @@ public class PartialReparseTest extends NbTestCase {
     }
 
     public void testDocComments() throws Exception {
-        if (NoJavacHelper.hasNbJavac()) {
-            //this test fails with nb-javac on coupling abort, skip
-            return ;
-        }
         doRunTest("package test;\n" +
                   "public class Test {\n" +
                   "        /**javadoc1*/" +

--- a/java/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
+++ b/java/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
@@ -29,12 +29,9 @@ import org.netbeans.modules.autoupdate.ui.api.PluginManager;
 import org.netbeans.modules.java.source.usages.ClassIndexManager;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
-import org.openide.awt.NotificationDisplayer;
-import org.openide.awt.NotificationDisplayer.Priority;
 import org.openide.modules.ModuleInstall;
 import org.openide.util.Exceptions;
 import org.openide.util.HelpCtx;
-import org.openide.util.ImageUtilities;
 import org.openide.util.NbBundle;
 import org.openide.util.NbPreferences;
 import org.openide.windows.WindowManager;
@@ -86,7 +83,7 @@ public class JBrowseModule extends ModuleInstall {
                         Dialog[] d = new Dialog[1];
                         DialogDescriptor dd = new DialogDescriptor(Bundle.DESC_FeaturesLimited(), Bundle.TITLE_FeaturesLimited(), true, new Object[] {install, DialogDescriptor.CANCEL_OPTION}, install, DialogDescriptor.DEFAULT_ALIGN, HelpCtx.DEFAULT_HELP, evt -> {
                             if (install.equals(evt.getActionCommand())) {
-                                PluginManager.installSingle("org.netbeans.modules.nbjavac", Bundle.DN_nbjavac());
+                                PluginManager.installSingle("org.netbeans.lib.nbjavac", Bundle.DN_nbjavac());
                             }
                             d[0].setVisible(false);
                         });
@@ -95,13 +92,6 @@ public class JBrowseModule extends ModuleInstall {
                     } catch (HeadlessException ex) {
                         Exceptions.printStackTrace(Exceptions.attachSeverity(ex, Level.FINE));
                     }
-                    prefs.putBoolean(KEY_WARNING_SHOWN, true);
-                }
-
-                if (!NoJavacHelper.hasNbJavac()) {
-                    NotificationDisplayer.getDefault().notify("Install nb-javac Library", ImageUtilities.loadImageIcon(WARNING_ICON, false), Bundle.DESC_InstallNbJavac(), evt -> {
-                        PluginManager.installSingle("org.netbeans.modules.nbjavac", Bundle.DN_nbjavac());
-                    }, prefs.getBoolean(KEY_WARNING_SHOWN, false) ? Priority.SILENT : Priority.HIGH);
                     prefs.putBoolean(KEY_WARNING_SHOWN, true);
                 }
             });

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JackpotTrees.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/JackpotTrees.java
@@ -34,24 +34,13 @@ import com.sun.tools.javac.tree.JCTree.JCIdent;
 import com.sun.tools.javac.tree.JCTree.JCModifiers;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.tree.JCTree.JCCase;
+import com.sun.tools.javac.tree.JCTree.JCCaseLabel;
+import com.sun.tools.javac.tree.JCTree.JCStatement;
 import com.sun.tools.javac.tree.JCTree.Visitor;
 import com.sun.tools.javac.tree.TreeMaker;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Name;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.description.modifier.Visibility;
-import net.bytebuddy.implementation.FieldAccessor;
-import net.bytebuddy.implementation.FixedValue;
-import net.bytebuddy.implementation.MethodCall;
-import net.bytebuddy.matcher.ElementMatchers;
-
 
 /**
  *
@@ -59,84 +48,81 @@ import net.bytebuddy.matcher.ElementMatchers;
  */
 public class JackpotTrees {
 
-    private static final Map<Class<?>, Class<?>> baseClass2Impl = new HashMap<>();
 
-    // JDK 8-11
-    public static JCCase createJCCase(Name ident, JCIdent jcIdent, List<?> stats) {
-        return createInstance(JCCase.class, ident, jcIdent,
-                new Class<?>[] {JCExpression.class, List.class},
-                new Object[] {jcIdent, stats});
-    }
+    public static class VariableDeclWildcard extends JCVariableDecl implements IdentifierTree {
 
-    // JDK 12-17+
-    public static JCCase createJCCase(Name ident, JCIdent jcIdent, String caseKind, List<?> labels, List<?> stats, JCTree body) throws ReflectiveOperationException {
-        
-        @SuppressWarnings("rawtypes")
-        Class kindClass = Class.forName("com.sun.source.tree.CaseTree$CaseKind", false, JCCase.class.getClassLoader());
-        @SuppressWarnings("unchecked")
-        Object caseKindValue = Enum.valueOf(kindClass, caseKind);
+        private final Name ident;
+        private final JCIdent jcIdent;
 
-        return createInstance(JCCase.class, ident, jcIdent,
-                    new Class<?>[] {kindClass, List.class, List.class, JCTree.class},
-                    new Object[] {caseKindValue, labels, stats, body});
-    }
-
-    // JDK 8-17+
-    public static JCVariableDecl createJCVariableDecl(Name ident, JCIdent jcIdent, JCModifiers mods, Name param2, JCExpression vartype, JCExpression init, VarSymbol sym) {
-        return createInstance(JCVariableDecl.class, ident, jcIdent,
-                new Class<?>[] {JCModifiers.class, Name.class, JCExpression.class, JCExpression.class, VarSymbol.class},
-                new Object[] {mods, param2, vartype, init, sym});
-    }
-
-    private static <T> T createInstance(Class<T> clazz, Name ident, JCIdent jcIdent, Class<?>[] requiredConstructor, Object[] params) {
-        try {
-            Class<?> fake = baseClass2Impl.get(clazz);
-
-            if (fake == null) {
-                Method visitIdent = Visitor.class.getDeclaredMethod("visitIdent", JCIdent.class);
-                Method visitIdentifier = TreeVisitor.class.getDeclaredMethod("visitIdentifier", IdentifierTree.class, Object.class);
-                Method toString = Object.class.getDeclaredMethod("toString");
-                fake = Utilities.load(new ByteBuddy()
-                        .subclass(clazz)
-                        .implement(IdentifierTree.class)
-                        .defineField("ident", Name.class, Visibility.PUBLIC)
-                        .defineField("jcIdent", JCIdent.class, Visibility.PUBLIC)
-                        .method(ElementMatchers.named("getName")).intercept(FieldAccessor.ofField("ident"))
-                        .method(ElementMatchers.named("getKind")).intercept(FixedValue.value(Kind.IDENTIFIER))
-                        .method(ElementMatchers.named("accept").and(ElementMatchers.takesArguments(Visitor.class))).intercept(MethodCall.invoke(visitIdent).onArgument(0).withField("jcIdent"))
-                        .method(ElementMatchers.named("accept").and(ElementMatchers.takesArgument(0, TreeVisitor.class))).intercept(MethodCall.invoke(visitIdentifier).onArgument(0).withThis().withArgument(1))
-                        .method(ElementMatchers.named("toString")).intercept(MethodCall.invoke(toString).onField("ident"))
-                        .name(JackpotTrees.class.getCanonicalName() + "$" + clazz.getCanonicalName().replace('.', '$'))
-                        .make())
-                        .getLoaded();
-                baseClass2Impl.put(clazz, fake);
-            }
-            
-            Constructor<?> compatible = null;
-            for (Constructor<?> constructor : fake.getDeclaredConstructors()) {
-                if (Arrays.equals(constructor.getParameterTypes(), requiredConstructor)) {
-                    compatible = constructor;
-                    break;
-                }
-            }
-            
-            if (compatible != null) {
-                
-                JCTree tree = (JCTree) compatible.newInstance(params);
-
-                Field identField = fake.getDeclaredField("ident");
-                identField.set(tree, ident);
-
-                Field jcIdentField = fake.getDeclaredField("jcIdent");
-                jcIdentField.set(tree, jcIdent);
-
-                return clazz.cast(tree);
-            } else {
-                throw new IllegalStateException("no compatible constructors found in: "+Arrays.asList(fake.getDeclaredConstructors()).toString());
-            }
-        } catch (ReflectiveOperationException | IllegalArgumentException | IllegalStateException | SecurityException ex) {
-            throw new IllegalStateException("can't instantiate "+Arrays.asList(requiredConstructor).toString()+" of "+clazz, ex);
+        public VariableDeclWildcard(Name ident, JCIdent jcIdent, JCModifiers mods, Name name, JCExpression vartype, JCExpression init, VarSymbol sym) {
+            super(mods, name, vartype, init, sym);  // JDK 12-17+
+            this.ident = ident;
+            this.jcIdent = jcIdent;
         }
+
+        @Override
+        public Name getName() {
+            return ident;
+        }
+
+        @Override
+        public Kind getKind() {
+            return Kind.IDENTIFIER;
+        }
+
+        @Override
+        public void accept(Visitor v) {
+            v.visitIdent(jcIdent);
+        }
+
+        @Override
+        public <R, D> R accept(TreeVisitor<R, D> v, D d) {
+            return v.visitIdentifier(this, d);
+        }
+
+        @Override
+        public String toString() {
+            return ident.toString();
+        }
+
+    }
+
+    public static class CaseWildcard extends JCCase implements IdentifierTree {
+
+        private final Name ident;
+        private final JCIdent jcIdent;
+
+        public CaseWildcard(Name ident, JCIdent jcIdent, CaseKind caseKind, List<JCCaseLabel> labels, List<JCStatement> stats, JCTree body) {
+            super(caseKind, labels, stats, body);  // JDK 8-17+
+            this.ident = ident;
+            this.jcIdent = jcIdent;
+        }
+
+        @Override
+        public Name getName() {
+            return ident;
+        }
+
+        @Override
+        public Kind getKind() {
+            return Kind.IDENTIFIER;
+        }
+
+        @Override
+        public void accept(Visitor v) {
+            v.visitIdent(jcIdent);
+        }
+
+        @Override
+        public <R, D> R accept(TreeVisitor<R, D> v, D d) {
+            return v.visitIdentifier(this, d);
+        }
+
+        @Override
+        public String toString() {
+            return ident.toString();
+        }
+
     }
 
     public static class AnnotationWildcard extends JCAnnotation implements IdentifierTree {
@@ -223,7 +209,7 @@ public class JackpotTrees {
 
         err.type = Symtab.instance(ctx).errType;
 
-        JCVariableDecl var = createJCVariableDecl(name, jcIdent, new FakeModifiers(), name, err, null, null);
+        JCVariableDecl var = new VariableDeclWildcard(name, jcIdent, new FakeModifiers(), name, err, null, null);
 
         var.sym = new VarSymbol(0, name, var.vartype.type, Symtab.instance(ctx).errSymbol);
         var.type = var.vartype.type;

--- a/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
+++ b/java/spi.java.hints/src/org/netbeans/modules/java/hints/spiimpl/Utilities.java
@@ -91,10 +91,8 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.CharBuffer;
 import java.util.Arrays;
@@ -127,12 +125,9 @@ import javax.tools.Diagnostic;
 import javax.tools.JavaCompiler.CompilationTask;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
-import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.DynamicType.Loaded;
 import net.bytebuddy.dynamic.DynamicType.Unloaded;
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
-import net.bytebuddy.implementation.MethodCall;
-import net.bytebuddy.matcher.ElementMatchers;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
@@ -168,6 +163,8 @@ import org.openide.util.Lookup;
 import org.openide.util.NbCollections;
 import org.openide.util.WeakListeners;
 import org.openide.util.lookup.ServiceProvider;
+
+import static com.sun.source.tree.CaseTree.CaseKind.STATEMENT;
 
 /**
  *
@@ -580,7 +577,7 @@ public class Utilities {
             ParserFactory factory = ParserFactory.instance(context);
             ScannerFactory scannerFactory = ScannerFactory.instance(context);
             Names names = Names.instance(context);
-            Parser parser = newParser(context, (NBParserFactory) factory, scannerFactory.newScanner(buf, false), false, false, CancelService.instance(context), names);
+            Parser parser = new JackpotJavacParser(context, (NBParserFactory) factory, scannerFactory.newScanner(buf, false), false, false, CancelService.instance(context), names);
             if (parser instanceof JavacParser) {
                 if (pos != null)
                     pos[0] = new ParserSourcePositions((JavacParser)parser);
@@ -610,7 +607,7 @@ public class Utilities {
             ScannerFactory scannerFactory = ScannerFactory.instance(context);
             Names names = Names.instance(context);
             Scanner scanner = scannerFactory.newScanner(buf, false);
-            Parser parser = newParser(context, (NBParserFactory) factory, scanner, false, false, CancelService.instance(context), names);
+            Parser parser = new JackpotJavacParser(context, (NBParserFactory) factory, scanner, false, false, CancelService.instance(context), names);
             if (parser instanceof JavacParser) {
                 if (pos != null)
                     pos[0] = new ParserSourcePositions((JavacParser)parser);
@@ -1287,33 +1284,6 @@ public class Utilities {
         return true;
     }
 
-    private static Class<?> parserClass;
-    private static synchronized Parser newParser(Context ctx, NBParserFactory fac,
-                                                 Lexer S, boolean keepDocComments,
-                                                 boolean keepLineMap, CancelService cancelService,
-                                                 Names names) {
-        try {
-            if (parserClass == null) {
-                Method switchBlockStatementGroup = JavacParser.class.getDeclaredMethod("switchBlockStatementGroup");
-                Method delegate;
-                if (switchBlockStatementGroup.getReturnType().equals(com.sun.tools.javac.util.List.class)) {
-                    delegate = JackpotJavacParser.class.getDeclaredMethod("switchBlockStatementGroupListImpl");
-                } else {
-                    delegate = JackpotJavacParser.class.getDeclaredMethod("switchBlockStatementGroupImpl");
-                }
-                parserClass = load(new ByteBuddy()
-                                    .subclass(JackpotJavacParser.class)
-                                    .method(ElementMatchers.named("switchBlockStatementGroup")).intercept(MethodCall.invoke(delegate))
-                                    .make())
-                            .getLoaded();
-            }
-            return (Parser) parserClass.getConstructor(Context.class, NBParserFactory.class, Lexer.class, boolean.class, boolean.class, CancelService.class, Names.class)
-                    .newInstance(ctx, fac, S, keepDocComments, keepLineMap, cancelService, names);
-        } catch (ReflectiveOperationException ex) {
-            throw new IllegalStateException(ex);
-        }
-    }
-
     static <T> Loaded<T> load(Unloaded<T> unloaded) {
         ClassLoadingStrategy<ClassLoader> strategy;
 
@@ -1452,37 +1422,8 @@ public class Utilities {
             return super.checkExprStat(t);
         }
 
-        protected JCCase switchBlockStatementGroupImpl() throws Throwable {
-            if (token.kind == TokenKind.CASE) {
-                Token peeked = S.token(1);
-
-                if (peeked.kind == TokenKind.IDENTIFIER) {
-                    String ident = peeked.name().toString();
-
-                    if (ident.startsWith("$") && ident.endsWith("$")) {
-                        nextToken();
-                        
-                        int pos = token.pos;
-                        com.sun.tools.javac.util.Name name = token.name();
-
-                        nextToken();
-
-                        if (token.kind == TokenKind.SEMI) {
-                            nextToken();
-                        }
-
-                        JCIdent identTree = F.at(pos).Ident(name);
-                        return JackpotTrees.createJCCase(name, identTree, com.sun.tools.javac.util.List.nil());
-                    }
-                }
-            }
-
-            return (JCCase) MethodHandles.lookup()
-                                         .findSpecial(NBJavacParser.class, "switchBlockStatementGroup", MethodType.methodType(JCCase.class), JackpotJavacParser.class)
-                                         .invoke(this);
-        }
-
-        protected com.sun.tools.javac.util.List<JCCase> switchBlockStatementGroupListImpl() throws Throwable {
+        @Override
+        protected com.sun.tools.javac.util.List<JCCase> switchBlockStatementGroup() {
             if (token.kind == TokenKind.CASE) {
                 Token peeked = S.token(1);
 
@@ -1502,16 +1443,14 @@ public class Utilities {
                         }
 
                         JCIdent identTree = F.at(pos).Ident(name);
+
                         return com.sun.tools.javac.util.List.of(
-                                    JackpotTrees.createJCCase(name, identTree, "STATEMENT", com.sun.tools.javac.util.List.of(identTree), com.sun.tools.javac.util.List.nil(), null)
-                                );
+                                new JackpotTrees.CaseWildcard(name, identTree, STATEMENT, com.sun.tools.javac.util.List.of(identTree), com.sun.tools.javac.util.List.nil(), null)
+                        );
                     }
                 }
             }
-
-            return (com.sun.tools.javac.util.List<JCCase>) MethodHandles.lookup()
-                        .findSpecial(NBJavacParser.class, "switchBlockStatementGroup", MethodType.methodType(com.sun.tools.javac.util.List.class), JackpotJavacParser.class)
-                        .invoke(this);
+            return super.switchBlockStatementGroup();
         }
 
         @Override


### PR DESCRIPTION
post nb-javac 17 on-by-default refactoring
- removed "get nb-javac" dialog and nb-javac checks
- removed sealed class workaround added in #3228
- trees cleanup after #3283 
  - removes ByteBuddy interceptors and reflection code
- some SourceVersion related cleanup