### PR TITLE
Follow LSP specification for null value for startCharacter in FoldingRange

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/FoldManagerImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/FoldManagerImpl.java
@@ -136,7 +136,13 @@ public class FoldManagerImpl implements FoldManager, BackgroundTask {
         List<FoldInfo> infos = new ArrayList<>();
         if (ranges != null) {
             for (FoldingRange r : ranges) {
-                int start = Utils.getOffset(doc, new Position(r.getStartLine(), r.getStartCharacter() != null ? r.getStartCharacter() : 0));
+                int start;
+                if(r.getStartCharacter() == null) {
+                    int endCharacter = Utils.getEndCharacter(doc, r.getStartLine());
+                    start = Utils.getOffset(doc, new Position(r.getStartLine(), endCharacter));
+                } else {
+                    start = Utils.getOffset(doc, new Position(r.getStartLine(), r.getStartCharacter()));
+                }
                 int end;
                 if (r.getEndCharacter() == null) {
                     int endCharacter = Utils.getEndCharacter(doc, r.getEndLine());

--- a/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/bindings/FoldManagerImplTest.java
+++ b/ide/lsp.client/test/unit/src/org/netbeans/modules/lsp/client/bindings/FoldManagerImplTest.java
@@ -65,7 +65,7 @@ public class FoldManagerImplTest {
 
         List<FoldInfo> infos = FoldManagerImpl.computeInfos(doc, ranges);
         assertEquals(1, infos.size());
-        assertEquals(0, infos.get(0).getStart());
+        assertEquals(6, infos.get(0).getStart());
         assertEquals(20, infos.get(0).getEnd());
     }
 
@@ -121,10 +121,10 @@ public class FoldManagerImplTest {
         assertNotNull(infos);
         assertEquals(2, infos.size());
         // first fold
-        assertEquals(31, infos.get(0).getStart());
+        assertEquals(51, infos.get(0).getStart());
         assertEquals(103, infos.get(0).getEnd());
         // second fold
-        assertEquals(52, infos.get(1).getStart());
+        assertEquals(59, infos.get(1).getStart());
         assertEquals(67, infos.get(1).getEnd());
     }
 


### PR DESCRIPTION
The LSP specification specifies for the startCharacter:

The zero-based character offset from where the folded range starts. If
not defined, defaults to the length of the start line.


In contrast to the specification the first character was choosen as the
start of the fold, hiding for example the function name.