### PR TITLE
Be able to resolve project problems in VSCode extension.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProject.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProject.java
@@ -101,11 +101,15 @@ public final class GradleProject implements Serializable, Lookup.Provider {
     }
 
     public final GradleProject invalidate(String... reasons) {
+        Set<String> problems = reasons.length > 0 ? new LinkedHashSet<>(Arrays.asList(reasons)) : Collections.emptySet();
         if (getQuality().worseThan(Quality.EVALUATED)) {
-            return this;
+            if (!problems.isEmpty()) {
+                return new GradleProject(getQuality(), problems, this);
+            } else {
+                return this;
+            }
         } else {
-            Set<String> p = new LinkedHashSet<>(Arrays.asList(reasons));
-            return new GradleProject(Quality.EVALUATED, p, this);
+            return new GradleProject(Quality.EVALUATED, problems, this);
         }
     }
 

--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectProblemProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectProblemProvider.java
@@ -26,6 +26,7 @@ import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Future;
 import org.netbeans.api.project.Project;
 import org.netbeans.spi.project.ProjectServiceProvider;
@@ -81,10 +82,11 @@ public class GradleProjectProblemProvider implements ProjectProblemsProvider {
         GradleProject gp = project.getLookup().lookup(NbGradleProjectImpl.class).getGradleProject();
         if (gp.getQuality().notBetterThan(EVALUATED)) {
             ret.add(ProjectProblem.createError(Bundle.LBL_PrimingRequired(), Bundle.TXT_PrimingRequired(), resolver));
-        }
-        for (String problem : gp.getProblems()) {
-            String[] lines = problem.split("\\n"); //NOI18N
-            ret.add(ProjectProblem.createWarning(lines[0], problem.replaceAll("\\n", "<br/>"), resolver)); //NOI18N
+        } else {
+            for (String problem : gp.getProblems()) {
+                String[] lines = problem.split("\\n"); //NOI18N
+                ret.add(ProjectProblem.createWarning(lines[0], problem.replaceAll("\\n", "<br/>"), resolver)); //NOI18N
+            }
         }
         return ret;
     }
@@ -98,7 +100,12 @@ public class GradleProjectProblemProvider implements ProjectProblemsProvider {
                 Quality q = gradleProject.getQuality();
                 Status st = q.worseThan(SIMPLE) ? Status.UNRESOLVED
                         : q.worseThan(FULL) ? Status.RESOLVED_WITH_WARNING : Status.RESOLVED;
-                return Result.create(st);
+                Set<String> problems = gradleProject.getProblems();
+                if (problems.isEmpty()) {
+                    return Result.create(st);
+                } else {
+                    return Result.create(st, problems.iterator().next());
+                }
             });
        }
     }

--- a/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/JavaErrorProvider.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/infrastructure/JavaErrorProvider.java
@@ -147,7 +147,13 @@ public class JavaErrorProvider implements ErrorProvider {
                 default: diagBuilder.setSeverity(Diagnostic.Severity.Information); break;
             }
 
-            String id = key(errorKind) + ":" + idx++ + "-" + err.getId();
+            String rangeString;
+            try {
+                rangeString = (range.getBegin().getLine()+1) + ":" + (range.getBegin().getColumn()+1) + "-" + (range.getEnd().getLine()+1) + ":" + (range.getEnd().getColumn()+1);
+            } catch (IOException ex) {
+                rangeString = null;
+            }
+            String id = key(errorKind) + "(" + ++idx + "): " + (rangeString != null ? rangeString : "");
 
             diagBuilder.setCode(id);
             diagBuilder.addActions(errorReporter -> convertFixes(err, errorReporter));
@@ -185,7 +191,8 @@ public class JavaErrorProvider implements ErrorProvider {
 
         for (Fix f : fixes) {
             if (f instanceof IncompleteClassPath.ResolveFix) {
-                CodeAction action = new CodeAction(f.getText(), new Command(f.getText(), "XXX"/*Server.JAVA_BUILD_WORKSPACE*/));
+                // We know that this is a project problem and that the problems reported by ProjectProblemsProvider should be resolved
+                CodeAction action = new CodeAction(f.getText(), new Command(f.getText(), "java.project.resolveProjectProblems"));
                 result.add(action);
             }
             if (f instanceof ImportClass.FixImport) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/Server.java
@@ -709,6 +709,7 @@ public final class Server {
                         JAVA_NEW_FROM_TEMPLATE,
                         JAVA_NEW_PROJECT,
                         JAVA_PROJECT_CONFIGURATION_COMPLETION,
+                        JAVA_PROJECT_RESOLVE_PROJECT_PROBLEMS,
                         JAVA_SUPER_IMPLEMENTATION,
                         JAVA_SOURCE_FOR,
                         JAVA_CLEAR_PROJECT_CACHES,
@@ -882,6 +883,10 @@ public final class Server {
      * Provides code-completion of configurations.
      */
     public static final String JAVA_PROJECT_CONFIGURATION_COMPLETION = "java.project.configuration.completion";
+    /**
+     * Provides resolution of project problems.
+     */
+    public static final String JAVA_PROJECT_RESOLVE_PROJECT_PROBLEMS = "java.project.resolveProjectProblems";
 
 
     /**

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -895,7 +895,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                             }
                             action.setKind(kind(err.getSeverity()));
                             if (inputAction.getCommand() != null) {
-                                action.setCommand(new Command(inputAction.getCommand().getTitle(), inputAction.getCommand().getCommand()));
+                                action.setCommand(new Command(inputAction.getCommand().getTitle(), inputAction.getCommand().getCommand(), Arrays.asList(params.getTextDocument().getUri())));
                             }
                             if (inputAction.getEdit() != null) {
                                 org.netbeans.api.lsp.WorkspaceEdit edit = inputAction.getEdit();

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -415,7 +415,7 @@
 				"command": "java.workspace.newproject",
 				"title": "New Project...",
 				"category": "Java",
-				"icon" : "$(new-folder)"
+				"icon": "$(new-folder)"
 			},
 			{
 				"command": "java.goto.super.implementation",
@@ -431,11 +431,11 @@
 				"command": "foundProjects.deleteEntry",
 				"title": "Delete"
 			},
-                        {
-                                "command": "db.add.connection",
-                                "title": "Add Database Connection",
- 				"category": "Database"
-                        },
+			{
+				"command": "db.add.connection",
+				"title": "Add Database Connection",
+				"category": "Database"
+			},
 			{
 				"command": "nbls:Database:netbeans.db.explorer.action.Connect",
 				"title": "Connect to Database"
@@ -494,8 +494,8 @@
 				"command": "java.workspace.configureRunSettings",
 				"title": "Edit",
 				"icon": "$(edit)"
-            },
-            {
+			},
+			{
 				"command": "testing.runAll",
 				"title": "Run All Tests",
 				"category": "Test"
@@ -606,7 +606,7 @@
 					"command": "workbench.action.debug.start",
 					"when": "nbJavaLSReady && view == foundProjects"
 				}
-				],
+			],
 			"view/item/context": [
 				{
 					"command": "foundProjects.deleteEntry",


### PR DESCRIPTION
When a project problem is detected, there is no way to resolve it from within VSCode extension.
This PR introduces `java.project.resolveProjectProblems` command, which attempts to resolve the project problems and when they are not resolved, it displays the resolution error.
`JavaErrorProvider` displays a dull `error(0): null` message, which we change to `error(1): <line:column range>`
The gradle project needs to be adapted to provide the resolution error message.