### PR TITLE
Add binaries.repos property to downloadbinaries call in projectized.xml.

### DIFF
--- a/nbbuild/templates/projectized.xml
+++ b/nbbuild/templates/projectized.xml
@@ -257,7 +257,7 @@
     <target name="-process.release.files"/>
     
     <target name="-download.release.files" depends="-define-downloadbinaries-task">
-        <downloadbinaries cache="${binaries.cache}" server="${binaries.server}">
+        <downloadbinaries cache="${binaries.cache}" server="${binaries.server}" repos="${binaries.repos}">
             <manifest dir=".">
                 <include name="external/binaries-list"/>
             </manifest>


### PR DESCRIPTION
Add binaries.repos property to downloadbinaries call in projectized.xml. This was accidentally left out in a #2710 Amongst other things, this helps with testing libraries only in local .m2 cache.

Tiny fix cherry picked from something else I was working on which I'm rewriting.