### PR TITLE
print simple junit report on travis job failure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
       - xvfb
       - openjfx
       - libgfortran3
+      - libxml2-utils
 
 install:
   - export PATH="$PATH:$TRAVIS_BUILD_DIR/nbbuild/travis"
@@ -34,6 +35,10 @@ install:
 cache:
   directories:
   - $HOME/.hgexternalcache
+
+git:
+  quiet: true
+  depth: 3
 
 matrix:
     include:
@@ -717,3 +722,7 @@ matrix:
           script:
             - export JAVA_HOME=$TEST_JDK
             - hide-logs.sh ant $OPTS commit-validation
+
+after_failure:
+  - nbbuild/travis/print-junit-report.sh
+  - sleep 3

--- a/nbbuild/travis/print-junit-report.sh
+++ b/nbbuild/travis/print-junit-report.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+echo junit report / failed tests:
+
+ls ./*/*/build/test/*/results/TEST-*.xml | while read file ;
+do
+    TEST=$(xmllint --xpath '//testsuite[@failures>0]/@name' $file 2>/dev/null)
+    status=$?
+
+    if [ $status -eq 0 ]; then
+        echo
+        echo $TEST | cut -f2 -d '=' | tr -d '"'
+        xmllint --xpath '//testsuite/testcase[./failure]/@name' $file | cut -f2 -d '=' | xargs -L1 echo "    failed:"
+    fi
+done
+
+echo end of report


### PR DESCRIPTION
This should hopefully print a list of failed tests if a job fails and make reading the travis log about 20% less painful.