### PR TITLE
[CND] small-1.3 Remaining licences in cnd cluster

### DIFF
--- a/cnd/cnd.makeproject/samples_src/fractal/readme.txt
+++ b/cnd/cnd.makeproject/samples_src/fractal/readme.txt
@@ -1,32 +1,4 @@
-/*
- * Copyright (c) 2009-2010, Oracle and/or its affiliates. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * * Redistributions of source code must retain the above copyright notice,
- *   this list of conditions and the following disclaimer.
- *
- * * Redistributions in binary form must reproduce the above copyright notice,
- *   this list of conditions and the following disclaimer in the documentation
- *   and/or other materials provided with the distribution.
- *
- * * Neither the name of Oracle nor the names of its contributors
- *   may be used to endorse or promote products derived from this software without
- *   specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- */
+Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
 
 Buddhabrot Fractal Demo
 

--- a/cnd/cnd.makeproject/samples_src/freeway/README.txt
+++ b/cnd/cnd.makeproject/samples_src/freeway/README.txt
@@ -1,32 +1,4 @@
-#
-# Copyright (c) 2009-2010, Oracle and/or its affiliates. All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are met:
-#
-# * Redistributions of source code must retain the above copyright notice,
-#   this list of conditions and the following disclaimer.
-#
-# * Redistributions in binary form must reproduce the above copyright notice,
-#   this list of conditions and the following disclaimer in the documentation
-#   and/or other materials provided with the distribution.
-#
-# * Neither the name of Oracle nor the names of its contributors
-#   may be used to endorse or promote products derived from this software without
-#   specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-# THE POSSIBILITY OF SUCH DAMAGE.
-#
+Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
 
 Description:
 	Freeway simulates traffic flow on a typical California highway.

--- a/cnd/cnd.makeproject/samples_src/quote/readme.txt
+++ b/cnd/cnd.makeproject/samples_src/quote/readme.txt
@@ -1,32 +1,4 @@
-/*
- * Copyright (c) 2009-2010, Oracle and/or its affiliates. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * * Redistributions of source code must retain the above copyright notice,
- *   this list of conditions and the following disclaimer.
- *
- * * Redistributions in binary form must reproduce the above copyright notice,
- *   this list of conditions and the following disclaimer in the documentation
- *   and/or other materials provided with the distribution.
- *
- * * Neither the name of Oracle nor the names of its contributors
- *   may be used to endorse or promote products derived from this software without
- *   specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- */
+Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
 
 // This sample program is named quote. It models a simple hardware support service. The program
 // runs in a console window. It is written in standard C++. For the user interface the

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/AddtlIncludeDirectories.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/AddtlIncludeDirectories.html
@@ -46,7 +46,7 @@
     </ol>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/AddtlLibraryDirectories.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/AddtlLibraryDirectories.html
@@ -37,7 +37,7 @@ Select.</li>
 </ol>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/ArchiverOptions.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/ArchiverOptions.html
@@ -64,7 +64,7 @@ Project Configurations</a>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Attaching.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Attaching.html
@@ -95,7 +95,7 @@ right-clicking the project in the Projects window and choosing Project Propertie
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/BalloonEvaluation.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/BalloonEvaluation.html
@@ -54,7 +54,7 @@ Expressions in the IDE</a><br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/BuildingCorC++Project.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/BuildingCorC++Project.html
@@ -126,7 +126,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++Breakpoints.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++Breakpoints.html
@@ -55,7 +55,7 @@ number.</p>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++BreakpointsWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++BreakpointsWindow.html
@@ -158,7 +158,7 @@ breakpoint.</td>
 </table>
 <hr>
 <small>
-<a href="nbdocs://org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs://org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++BuildingTasks.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++BuildingTasks.html
@@ -126,7 +126,7 @@ target that failed.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++CallStackWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++CallStackWindow.html
@@ -136,7 +136,7 @@ Debugger</a><br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++DebuggerContext.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++DebuggerContext.html
@@ -89,7 +89,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++DebuggingTasks.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++DebuggingTasks.html
@@ -209,7 +209,7 @@ select Make Current.
 <hr>
 <small>
 <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">
-    Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+    Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++DisassemblyWIndow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++DisassemblyWIndow.html
@@ -130,7 +130,7 @@ immediately following the call to that function.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++EvaluationWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++EvaluationWindow.html
@@ -71,7 +71,7 @@ the item. The right column describes the item.">
 </table>
 <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++LocalVariablesWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++LocalVariablesWindow.html
@@ -251,7 +251,7 @@ automatic (pointers in hexadecimal characters, all else in decimal)
     </table>
     <hr>
        <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++MemoryWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++MemoryWindow.html
@@ -82,7 +82,7 @@ the item. The right column describes the item.">
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++Options.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++Options.html
@@ -301,7 +301,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <p>
        &nbsp;

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++RegistersWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++RegistersWindow.html
@@ -66,7 +66,7 @@ the item. The right column describes the item.">
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++SessionsWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++SessionsWindow.html
@@ -139,7 +139,7 @@ Session</a><br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++ThreadsWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++ThreadsWindow.html
@@ -97,7 +97,7 @@ equivalent to double-clicking the thread.</td>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++WatchesWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CandC++WatchesWindow.html
@@ -181,7 +181,7 @@ Removes the selected object from the Watches window.</td>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CompilerOptions.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CompilerOptions.html
@@ -86,7 +86,7 @@
     </table>
     <hr>
         <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CompilingSingleCandC++File.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CompilingSingleCandC++File.html
@@ -50,7 +50,7 @@ type="text/css">
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CorC++VariablesandExpressions.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CorC++VariablesandExpressions.html
@@ -74,7 +74,7 @@ Program</a><br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CreatingCorC++Watch.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CreatingCorC++Watch.html
@@ -108,7 +108,7 @@ and Expressions in the IDE</a><br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CreatingDependencies.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/CreatingDependencies.html
@@ -99,7 +99,7 @@ the Build checkbox to add a check mark.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/DebuggerConsole.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/DebuggerConsole.html
@@ -44,7 +44,7 @@ program is paused.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/DebuggerWindows.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/DebuggerWindows.html
@@ -82,7 +82,7 @@ titles to select which columns to show or hide.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/DebuggingCorC++Project.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/DebuggingCorC++Project.html
@@ -67,7 +67,7 @@ the executable to run.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/DebuggingCoreFile.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/DebuggingCoreFile.html
@@ -66,7 +66,7 @@ right-clicking the project in the Projects window and choosing Project Propertie
 </ol>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/DebuggingOptions.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/DebuggingOptions.html
@@ -63,7 +63,7 @@ Project Configurations</a>
 </table>
 <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Environment.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Environment.html
@@ -48,7 +48,7 @@
     </ul>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/EvaluatingExpression.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/EvaluatingExpression.html
@@ -69,7 +69,7 @@ displayed using the Format drop-down list.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/FinishingCorC++DebugSession.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/FinishingCorC++DebugSession.html
@@ -69,7 +69,7 @@ Finish.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/GlobalDebuggingOptions.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/GlobalDebuggingOptions.html
@@ -105,7 +105,7 @@ Debugging</a>
 </table>
 <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/GroupingBreakpoints.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/GroupingBreakpoints.html
@@ -86,7 +86,7 @@ breakpoints for open projects, but you can change this to you see all breakpoint
 </dl>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Libraries.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Libraries.html
@@ -47,7 +47,7 @@ remove libraries, and select binding options. You can do the following:
 
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/LinkerOptions.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/LinkerOptions.html
@@ -65,7 +65,7 @@ Project Configurations</a>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Packaging.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Packaging.html
@@ -53,7 +53,7 @@ making the packages.</li>
 </ol>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/PackagingFiles.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/PackagingFiles.html
@@ -62,7 +62,7 @@ when the package is installed.</li>
 </ol>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/PoppingCorC++Stack.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/PoppingCorC++Stack.html
@@ -73,7 +73,7 @@ program execution, the call is repeated.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Projects.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Projects.html
@@ -45,7 +45,7 @@ the current project.</li>
 </ol>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/ResolveBuildTools.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/ResolveBuildTools.html
@@ -116,7 +116,7 @@ command in the Select Tool dialog box.</p></li>
 </ul>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/RunToCursor.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/RunToCursor.html
@@ -52,7 +52,7 @@ button <img src="../images/Run_To_Cursor.gif" alt="Run To Cursor button">.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/RunningCorC++Project.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/RunningCorC++Project.html
@@ -48,7 +48,7 @@ the executable to run.
 </p>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/RuntimeSearchDirectories.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/RuntimeSearchDirectories.html
@@ -37,7 +37,7 @@ Select.</li>
 </ol>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/SettingCorC++Breakpoint.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/SettingCorC++Breakpoint.html
@@ -111,7 +111,7 @@ choosing from the Breakpoint submenu.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/StartingLocalDebuggingSession.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/StartingLocalDebuggingSession.html
@@ -69,7 +69,7 @@ Process</a><br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/SteppingThroughCorC++.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/SteppingThroughCorC++.html
@@ -66,7 +66,7 @@ into the last function called from the current source line
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Threads.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Threads.html
@@ -62,7 +62,7 @@ current thread.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/UsingCorC++CallStack.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/UsingCorC++CallStack.html
@@ -79,7 +79,7 @@ Program</a>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Watch.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/Watch.html
@@ -62,7 +62,7 @@ Program</a>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/WorkingWithDebugging.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/WorkingWithDebugging.html
@@ -121,7 +121,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/preprocessor-definitions.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/preprocessor-definitions.html
@@ -46,7 +46,7 @@ Inherit from Project checkbox to remove the checkmark.
 </p>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/preprocessor-undefine.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CandC++ProjectBasics/preprocessor-undefine.html
@@ -40,7 +40,7 @@ Inherit from Project checkbox to remove the checkmark.
 </p>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/CreatingMakefile.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/CreatingMakefile.html
@@ -70,7 +70,7 @@ Click Next.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/advanced_options.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/advanced_options.html
@@ -78,7 +78,7 @@ For C++ on the Linux platforms, the default conformance level is Ansi + GNU exte
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/base_directory.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/base_directory.html
@@ -100,7 +100,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="150">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/basic_options.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/basic_options.html
@@ -110,7 +110,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="150">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/build_output_directory.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/build_output_directory.html
@@ -76,7 +76,7 @@ If you do not want the files created by the target stored in the default directo
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/compiler_paths.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/compiler_paths.html
@@ -95,7 +95,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="150">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/compiling_preference.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/compiling_preference.html
@@ -57,7 +57,7 @@ Code checkbox.</p>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/custom_make.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/custom_make.html
@@ -69,7 +69,7 @@ Targets page.</p>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/include_directories.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/include_directories.html
@@ -71,7 +71,7 @@ Recursive Make target or a Custom target.</p>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/libraries.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/libraries.html
@@ -73,7 +73,7 @@ standard libraries you selected on the Select Standard Libraries page.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/list_of_targets.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/list_of_targets.html
@@ -79,7 +79,7 @@ Press Enter or click Add to add the target to the Makefile Targets list.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/recursive_make.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/recursive_make.html
@@ -73,7 +73,7 @@ the Subdirectory text field.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/review_makefile.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/review_makefile.html
@@ -70,7 +70,7 @@ Click Finish when you are ready for the wizard to generate the makefile.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/source_files.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/source_files.html
@@ -87,7 +87,7 @@ To add source files from a directory other than the base directory:
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/standard_libraries.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/standard_libraries.html
@@ -70,7 +70,7 @@ you are using one of the simple makefile templates.</p>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/target_location.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/target_location.html
@@ -74,7 +74,7 @@ the makefile and the location to which you want it saved.</p>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/target_name.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/target_name.html
@@ -64,7 +64,7 @@ Type a name for the target in the Executable Name text field and click Next.</p>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/type_and_platform.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/CreatingMakefile/type_and_platform.html
@@ -71,7 +71,7 @@ Select the compiler set to use.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table cellpadding="150" border="0"> 
 <tr><td>&nbsp;</td></tr> 
 <tr><td>&nbsp;</td></tr> 

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/Docker/AboutDocker.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/Docker/AboutDocker.html
@@ -51,7 +51,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2017,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/Docker/AddingDockerInstance.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/Docker/AddingDockerInstance.html
@@ -54,7 +54,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2017,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/Docker/BuildImageDialog.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/Docker/BuildImageDialog.html
@@ -71,7 +71,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2017,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/Docker/RunningDockerContainers.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/Docker/RunningDockerContainers.html
@@ -83,7 +83,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2017,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/AbbreviationsQuickRef.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/AbbreviationsQuickRef.html
@@ -193,7 +193,7 @@ the abbreviation. The right column lists the code template.">
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/CandC++CodeFolding.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/CandC++CodeFolding.html
@@ -65,7 +65,7 @@ All levels of function definitions
 </ul>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/ChangeFunctionParameters.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/ChangeFunctionParameters.html
@@ -79,6 +79,6 @@ type="text/css">
 </tbody>
 </table>
 <hr>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
 </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/Commenting.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/Commenting.html
@@ -49,7 +49,7 @@ In a C++ file, select all the lines you want to uncomment.</li>
 </ol>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/CppDocumentation.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/CppDocumentation.html
@@ -44,7 +44,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/CreatingCodeTemplates.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/CreatingCodeTemplates.html
@@ -71,7 +71,7 @@ has been added to your code.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/DisablingAutoCodeCompletion.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/DisablingAutoCodeCompletion.html
@@ -58,7 +58,7 @@ Choose Tools &gt; Options and click Editor.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/Documenting.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/Documenting.html
@@ -80,7 +80,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/EditingFortranSourceFiles.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/EditingFortranSourceFiles.html
@@ -48,7 +48,7 @@ The following features are supported for Fortran:
 
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/EditingSourceFiles.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/EditingSourceFiles.html
@@ -87,7 +87,7 @@ declaration to the function definition.</li>
 </ul>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/EncapsulateFields.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/EncapsulateFields.html
@@ -153,7 +153,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/ErrorHighlighting.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/ErrorHighlighting.html
@@ -48,7 +48,7 @@ a mark in the error stripe to jump to the line the mark represents.
 </p>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/FindUsagesDialog.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/FindUsagesDialog.html
@@ -92,7 +92,7 @@ the Scope drop-down list.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/FindinProject.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/FindinProject.html
@@ -163,7 +163,7 @@ the drop-down list of previously used patterns.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/FindingUsages.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/FindingUsages.html
@@ -81,7 +81,7 @@ cursor on that line of code.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/GoToDeclaration.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/GoToDeclaration.html
@@ -66,7 +66,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/GoToFunction.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/GoToFunction.html
@@ -64,7 +64,7 @@ Sensitive check box.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/GoToInclude.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/GoToInclude.html
@@ -54,7 +54,7 @@ The included file is opened in the Source Editor.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/GoToOverride.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/GoToOverride.html
@@ -57,7 +57,7 @@ If a method is overridden by one or more descendent classes, and Overridden anno
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/GoToType.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/GoToType.html
@@ -61,7 +61,7 @@ The Source Editor displays the declaration of that type.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/Icons.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/Icons.html
@@ -514,7 +514,7 @@
     <hr>
     <p>
        <small><a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/IncludeView.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/IncludeView.html
@@ -102,7 +102,7 @@ tree view.</td>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/IntroduceMethod.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/IntroduceMethod.html
@@ -102,7 +102,7 @@ with the new variable.
 </ol>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 
     </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/MacroExpansionWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/MacroExpansionWindow.html
@@ -86,7 +86,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/NavigateToBuildLog.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/NavigateToBuildLog.html
@@ -57,7 +57,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
     <p>
        &nbsp;

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/RefactorInline.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/RefactorInline.html
@@ -67,7 +67,7 @@ type="text/css">
 </p>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 
     </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/Refactoring.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/Refactoring.html
@@ -60,7 +60,7 @@ occurrences that are still selected.
 <a href="RefactorInline.html">Refactoring Inline</a>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 
 </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/RefactoringWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/RefactoringWindow.html
@@ -86,7 +86,7 @@ the button. The right column lists the description.">
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/SettingCompletionBoxDelay.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/SettingCompletionBoxDelay.html
@@ -62,7 +62,7 @@ desired delay in milliseconds.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/SourceHeaderSwitch.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/SourceHeaderSwitch.html
@@ -62,7 +62,7 @@ extension is found in the project, the file is opened in the editor.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/TerminalExtensions.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/TerminalExtensions.html
@@ -63,7 +63,7 @@
  <hr>
  
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2017,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/TypeView.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/TypeView.html
@@ -89,7 +89,7 @@ subtypes of the class to the list of only the direct subtypes.</td>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsagesWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsagesWindow.html
@@ -97,7 +97,7 @@ active. When Find Usages is complete, the Stop button is replaced with the Refre
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingAbbreviations.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingAbbreviations.html
@@ -127,7 +127,7 @@ relevant to the code snippet, the IDE fills in that variable for you.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingBreadcrumbs.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingBreadcrumbs.html
@@ -75,7 +75,7 @@
     <hr>
     <p>
        <small><a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingCallGraph.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingCallGraph.html
@@ -152,7 +152,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingClassView.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingClassView.html
@@ -58,7 +58,7 @@ Window &gt; Classes.</p>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingCodeCompletion.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingCodeCompletion.html
@@ -140,7 +140,7 @@
       </tr>
     </table>
         <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingHyperlinks.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingHyperlinks.html
@@ -60,7 +60,7 @@ history of the cursor position. </p>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingNavigator.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingNavigator.html
@@ -142,7 +142,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingPairCompletion.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/EditingSourceFiles/UsingPairCompletion.html
@@ -58,7 +58,7 @@ point without moving the insertion point to the next line.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/CandC++Overview.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/CandC++Overview.html
@@ -132,7 +132,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     
   </body>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/CandC++ProjectsMakefiles.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/CandC++ProjectsMakefiles.html
@@ -135,7 +135,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/FilesWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/FilesWindow.html
@@ -142,7 +142,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/IDEToolsCandC++Development.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/IDEToolsCandC++Development.html
@@ -146,7 +146,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/KeyCandC++Concepts.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/KeyCandC++Concepts.html
@@ -97,7 +97,7 @@ Projects</a><br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/Memory.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/Memory.html
@@ -120,7 +120,7 @@ running, you can also add the garbage collector switches <tt>-J-XX:+UseConcMarkS
  <tt>solstudio.conf</tt> file.</p>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/ProjectsWindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/GettingStarted/ProjectsWindow.html
@@ -209,7 +209,7 @@ C/C++ Qt Static Library Project
       </tr>
     </table>
     <hr>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     <table cellpadding="20" border="0">
       <tr>
         <td>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-about.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-about.html
@@ -55,7 +55,7 @@ also add new scripts.</p>
 </tr>
 </table>
 <hr>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-createmodify.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-createmodify.html
@@ -111,7 +111,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-execute.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-execute.html
@@ -80,7 +80,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-script.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-script.html
@@ -61,7 +61,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-tab.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-tab.html
@@ -87,7 +87,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-vscript.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/SendTo/sendto-vscript.html
@@ -55,7 +55,7 @@ to all selected files as its parameters.
 No input or output is displayed in the IDE.
 <hr>
 
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/CreateCppUnitTestWizardP1.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/CreateCppUnitTestWizardP1.html
@@ -69,7 +69,7 @@
     </p>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/CreateCppUnitTestWizardP2.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/CreateCppUnitTestWizardP2.html
@@ -50,7 +50,7 @@
       to make useful tests for your project.</p>
    
     <hr>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     <table cellpadding="20" border="0">
       <tr>
         <td>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/CreateTestWizardP1.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/CreateTestWizardP1.html
@@ -72,7 +72,7 @@
     </p>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/CreateTestWizardP2.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/CreateTestWizardP2.html
@@ -66,7 +66,7 @@
     </p>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_about.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_about.html
@@ -124,7 +124,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="50">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_creatingtests.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_creatingtests.html
@@ -104,7 +104,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="50">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_debuggingtests.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_debuggingtests.html
@@ -75,7 +75,7 @@
     </table>
     <hr>
         <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="50">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_overview.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_overview.html
@@ -122,7 +122,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="50">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_quickref.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_quickref.html
@@ -146,7 +146,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="50">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_resultswindow.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_resultswindow.html
@@ -89,7 +89,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="50">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_runningtests.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/TestingCandC++Projects/c_unit_runningtests.html
@@ -102,7 +102,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="50">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/AboutCandC++Projects.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/AboutCandC++Projects.html
@@ -125,7 +125,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/AboutQtProjects.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/AboutQtProjects.html
@@ -80,7 +80,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/AddingFilesAndFolders.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/AddingFilesAndFolders.html
@@ -111,7 +111,7 @@
     </ol>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/AddingUnitTests.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/AddingUnitTests.html
@@ -39,7 +39,7 @@ more information.</p>
 
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CandC++BuildingTasks.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CandC++BuildingTasks.html
@@ -156,7 +156,7 @@ Package application.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CleanCache.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CleanCache.html
@@ -83,7 +83,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2017,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistance.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistance.html
@@ -131,7 +131,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceCache.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceCache.html
@@ -178,7 +178,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP1.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP1.html
@@ -82,7 +82,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP2.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP2.html
@@ -106,7 +106,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP3.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP3.html
@@ -82,7 +82,7 @@
       </tr>
     </table>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP4.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP4.html
@@ -67,7 +67,7 @@ project maintenance more difficult.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP5.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP5.html
@@ -61,7 +61,7 @@ and expand the Code Assistance node. Select the C compiler or C++ compiler.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP6.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeAssistanceWizardP6.html
@@ -64,7 +64,7 @@ project maintenance more difficult.</li></ul>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeCompletionOptions.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CodeCompletionOptions.html
@@ -88,7 +88,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <p>
        &nbsp;

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CompilingSingleCandC++File.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CompilingSingleCandC++File.html
@@ -47,7 +47,7 @@ Run &gt; Compile File.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/Configuring.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/Configuring.html
@@ -80,7 +80,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringBuildTools.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringBuildTools.html
@@ -211,7 +211,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringCodeStyle.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringCodeStyle.html
@@ -197,7 +197,7 @@ type="text/css">
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringFileExtensions.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringFileExtensions.html
@@ -108,7 +108,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringParsingSettings.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringParsingSettings.html
@@ -61,7 +61,7 @@ Properties</a>
 </tr>
 </table><hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringProjectDefaults.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringProjectDefaults.html
@@ -82,7 +82,7 @@
       </tr>
     </table>
     <hr>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     <table cellpadding="20" border="0">
       <tr>
         <td>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringProjectSettings.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringProjectSettings.html
@@ -127,7 +127,7 @@
       </tr>
     </table>
     <hr>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     <table border="0" cellpadding="20">
       <tr>
         <td>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringSemanticHighlighting.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ConfiguringSemanticHighlighting.html
@@ -104,7 +104,7 @@ Properties</a>
 </tr>
 </table><hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CppJavaDevelopment.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CppJavaDevelopment.html
@@ -49,7 +49,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <p>
        &nbsp;

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CreateProject.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CreateProject.html
@@ -63,7 +63,7 @@ you run the project.</p>
 </ul>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CreatingCorC++Project.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CreatingCorC++Project.html
@@ -63,7 +63,7 @@ see the following topics:
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CreatingCorC++ProjectBinary.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/CreatingCorC++ProjectBinary.html
@@ -53,6 +53,6 @@ Create Project</a> dialog box opens.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/DeletingCorC++Project.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/DeletingCorC++Project.html
@@ -46,7 +46,7 @@ Project</a>
 </tr>
 </table><hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ManageLaunchersDialog.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ManageLaunchersDialog.html
@@ -53,7 +53,7 @@
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2017,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ManagingProjectConfigurations.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ManagingProjectConfigurations.html
@@ -77,7 +77,7 @@ active configuration, which is used by default when you build or run your projec
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/MovingCorC++Project.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/MovingCorC++Project.html
@@ -63,7 +63,7 @@ Dependencies Between C or C++ Projects</a>
 </tr>
 </table><hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewAppWizard.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewAppWizard.html
@@ -72,7 +72,7 @@ The tool collection will be used to build and run the project.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewBinaryWizardP1.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewBinaryWizardP1.html
@@ -73,7 +73,7 @@ Project Name and Location</a><br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewBinaryWizardP2.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewBinaryWizardP2.html
@@ -59,7 +59,7 @@ Select Binary</a><br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewDynamicLibWizard.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewDynamicLibWizard.html
@@ -65,7 +65,7 @@ The tool collection will be used to build and run the project.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP0.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP0.html
@@ -74,7 +74,7 @@ sources that use a configure script, CMake command, or QMake command to create t
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP1.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP1.html
@@ -133,7 +133,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP2.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP2.html
@@ -73,7 +73,7 @@ execute the <tt>make</tt> and <tt>clean</tt> commands.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP3.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP3.html
@@ -74,7 +74,7 @@ use ^(nbproject|build|test|tests)$ to ignore files in build, test, and tests.</p
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP4.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP4.html
@@ -73,7 +73,7 @@ configuration. The configuration will be for the entire project.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP5.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardP5.html
@@ -66,7 +66,7 @@ project metadata is to be stored based on the project name specified.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP1.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP1.html
@@ -75,7 +75,7 @@ their availability.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP2.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP2.html
@@ -79,7 +79,7 @@
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP3.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP3.html
@@ -81,7 +81,7 @@
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP4.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP4.html
@@ -78,7 +78,7 @@ directory.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP5.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP5.html
@@ -80,7 +80,7 @@ wizard, deselect the Run 'configure' Script after Finish checkbox.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP6.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP6.html
@@ -69,7 +69,7 @@ the existing makefile or configuration script.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP7.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP7.html
@@ -76,7 +76,7 @@ in these folders. You can add other folders to this pattern.</p>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP8.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP8.html
@@ -68,7 +68,7 @@ configuration. The configuration will be for the entire project.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP9.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewMakeWizardRemoteHostP9.html
@@ -59,7 +59,7 @@ project metadata.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewRemoteDevelopmentHostWizardP1.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewRemoteDevelopmentHostWizardP1.html
@@ -78,7 +78,7 @@
       </tr>
     </table>
     <hr>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
 
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewRemoteDevelopmentHostWizardP2.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewRemoteDevelopmentHostWizardP2.html
@@ -86,7 +86,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewRemoteDevelopmentHostWizardP3.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewRemoteDevelopmentHostWizardP3.html
@@ -87,7 +87,7 @@ with the new remote host added.</p>
       </tr>
     </table>
     <hr>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     <table border="0" cellpadding="20">
       <tr>
         <td>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewStaticLibWizard.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/NewStaticLibWizard.html
@@ -65,7 +65,7 @@ The tool collection will be used to build and run the project.</li>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsArchiverGeneral.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsArchiverGeneral.html
@@ -62,7 +62,7 @@ diagnostics.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsBuild.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsBuild.html
@@ -90,7 +90,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsCompile.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsCompile.html
@@ -77,7 +77,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsCompilerGeneral.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsCompilerGeneral.html
@@ -137,7 +137,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsDebugging.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsDebugging.html
@@ -111,7 +111,7 @@ type="text/css">
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsGeneral.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsGeneral.html
@@ -68,7 +68,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsLinkerGeneral.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsLinkerGeneral.html
@@ -74,7 +74,7 @@ C/C++ Project Properties Dialog Box:<br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsMake.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsMake.html
@@ -90,7 +90,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsPackaging.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsPackaging.html
@@ -55,7 +55,7 @@ path, the files to include in the package, and whether to build the package in v
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsParser.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsParser.html
@@ -173,7 +173,7 @@ use /test/ to ignore files in a test directory.
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsPreBuild.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsPreBuild.html
@@ -79,7 +79,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</small></a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm"><small>Legal notice</small></a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsQt.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsQt.html
@@ -86,7 +86,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsRequired.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsRequired.html
@@ -53,7 +53,7 @@ C/C++ Project Properties Dialog Box:<br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsRunning.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectPropsRunning.html
@@ -112,7 +112,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectTasks.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/ProjectTasks.html
@@ -174,7 +174,7 @@ project and choose Debug Project.
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/PublicPrivateProperties.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/PublicPrivateProperties.html
@@ -76,7 +76,7 @@
     <hr>
     <p>
        <small><a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopment.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopment.html
@@ -120,7 +120,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentConfigureHost.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentConfigureHost.html
@@ -99,7 +99,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentFileSharing.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentFileSharing.html
@@ -131,7 +131,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentHostProperties.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentHostProperties.html
@@ -113,7 +113,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentManaging.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentManaging.html
@@ -216,7 +216,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentProjects.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentProjects.html
@@ -75,7 +75,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentTerminal.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentTerminal.html
@@ -155,7 +155,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentToolbar.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteDevelopmentToolbar.html
@@ -116,7 +116,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteModes.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteModes.html
@@ -200,7 +200,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteVCS.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RemoteVCS.html
@@ -114,7 +114,7 @@
     </table>
     <hr>
     <p>
-       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+       <a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RunningCorC++Project.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/RunningCorC++Project.html
@@ -38,7 +38,7 @@ Run.
 </ul>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/SavingTerminalSettings.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/SavingTerminalSettings.html
@@ -97,7 +97,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table border="0" cellpadding="20">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/SettingCandC++FileProperties.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/SettingCandC++FileProperties.html
@@ -89,7 +89,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/SettingCandC++FolderProperties.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/SettingCandC++FolderProperties.html
@@ -112,7 +112,7 @@
     </table>
     <hr>
     <p>
-       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+       <small><a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
     <table cellpadding="20" border="0">
       <tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/SettingCandC++ProjectProperties.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/SettingCandC++ProjectProperties.html
@@ -68,7 +68,7 @@ Linker Options</a><br>
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/SettingMainCorC++Project.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/SettingMainCorC++Project.html
@@ -39,7 +39,7 @@ type="text/css">
 </ul>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/UsingCandC++Launchers.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/UsingCandC++Launchers.html
@@ -86,7 +86,7 @@ launcher3.symbolFiles=${LINKER_OUTPUT}
 </table>
 <hr>
 <small>
-<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;&copy;&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+<a href="nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
 <table border="0" cellpadding="20">
 <tr><td>&nbsp;</td></tr>
 <tr><td>&nbsp;</td></tr>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/WorkingWithCandC++Projects.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/WorkingWithCandC++Projects.html
@@ -169,7 +169,7 @@
     <hr>
     <p>
        <small><a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a></small>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a></small>
     </p>
   </body>
 </html>

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/WorkingWithJNA.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/WorkingWithJNA.html
@@ -75,7 +75,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <p>
        &nbsp;

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/WorkingWithJNI.html
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/WorkingWithCandC++Projects/WorkingWithJNI.html
@@ -146,7 +146,7 @@
     <hr>
     <p>
        <a href=
-      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Copyright&nbsp;©&nbsp;2015,&nbsp;Oracle&nbsp;and/or&nbsp;its&nbsp;affiliates.&nbsp;All&nbsp;rights&nbsp;reserved.</a>
+      "nbdocs:/org/netbeans/modules/usersguide/legal_notice.htm">Legal notice</a>
     </p>
     <p>
        &nbsp;

--- a/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/legal_notice.htm
+++ b/cnd/cnd/javahelp/org/netbeans/modules/cnd/help/legal_notice.htm
@@ -27,34 +27,222 @@
 <link rel="stylesheet" href="ide.css" type="text/css" />
 </head>
 <body>
-<h1>Oracle Legal Notices </h1>
-<h3>Copyright Notice </h3>
-<p>Copyright © 2014, Oracle and/or its affiliates. All rights reserved. </p>
-<h3>Trademark Notice </h3>
-<p>Oracle and Java are registered trademarks of Oracle and/or its affiliates. Other names may be trademarks of their respective owners.</p>
-<p>Intel and Intel Xeon are trademarks or registered trademarks of Intel Corporation. All SPARC trademarks are used under license and are trademarks or registered trademarks of SPARC International, Inc. AMD, Opteron, the AMD logo, and the AMD Opteron logo are trademarks or registered trademarks of Advanced Micro Devices. UNIX is a registered trademark of The Open Group.</p>
-<h3>License Restrictions Warranty/Consequential Damages Disclaimer </h3>
-<p>This software and related documentation are provided under a license agreement containing restrictions on use and disclosure and are protected by intellectual property laws. Except as expressly permitted in your license agreement or allowed by law, you may not use, copy, reproduce, translate, broadcast, modify, license, transmit, distribute, exhibit, perform, publish, or display any part, in any form, or by any means. Reverse engineering, disassembly, or decompilation of this software, unless required by law for interoperability, is prohibited.</p>
-<p></p>
-<h3>Warranty Disclaimer </h3>
-<p>The information contained herein is subject to change without notice and is not warranted to be error-free. If you find any errors, please report them to us in writing. </p>
-<h3>Restricted Rights Notice </h3>
-<p>If this is software or related documentation that is delivered to the U.S. Government or anyone licensing it on behalf of the U.S. Government, the following notice is applicable:</p>
-<p>U.S. GOVERNMENT END USERS: Oracle programs, including any operating system, integrated software, any programs installed on the hardware, and/or documentation, delivered to U.S. Government end users are &quot;commercial computer software&quot; pursuant to the applicable Federal Acquisition Regulation and agency-specific supplemental regulations. As such, use, duplication, disclosure, modification, and adaptation of the programs, including any operating system, integrated software, any programs installed on the hardware, and/or documentation, shall be subject to license terms and license restrictions applicable to the programs. No other rights are granted to the U.S. Government.<br />
-</p>
-<h3>Hazardous Applications Notice </h3>
-<p>This software or hardware is developed for general use in a variety of information management applications. It is not developed or intended for use in any inherently dangerous applications, including applications that may create a risk of personal injury. If you use this software or hardware in dangerous applications, then you shall be responsible to take all appropriate fail-safe, backup, redundancy, and other measures to ensure its safe use. Oracle Corporation and its affiliates disclaim any liability for any damages caused by use of this software or hardware in dangerous applications.<br />
-</p>
-<h3>Third-Party Content, Products, and Services Disclaimer </h3>
-<p>This software or hardware and documentation may provide access to or information on content, products, and services from third parties. Oracle Corporation and its affiliates are not responsible for and expressly disclaim all warranties of any kind with respect to third-party content, products, and services. Oracle Corporation and its affiliates will not be responsible for any loss, costs, or damages incurred due to your access to or use of third-party content, products, or services.</p>
-<h3>Alpha and Beta Draft Documentation Notice </h3>
-<p>If this document is in prerelease status:</p>
-<p>This documentation is in preproduction status and is intended for demonstration and preliminary use only. It may not be specific to the hardware on which you are using the software. Oracle Corporation and its affiliates are not responsible for and expressly disclaim all warranties of any kind with respect to this documentation and will not be responsible for any loss, costs, or damages incurred due to the use of this documentation.</p>
-<p></p>
-<h3>Documentation Accessibility </h3>
-<p>For information about Oracle's commitment to accessibility, visit the Oracle Accessibility Program website at http://www.oracle.com/pls/topic/lookup?ctx=acc&amp;id=docacc.</p>
-<h3>Access to Oracle Support </h3>
-<p>Oracle customers have access to electronic support through My Oracle Support. For information, visit <code>http://www.oracle.com/pls/topic/lookup?ctx=acc&amp;id=info</code>  or visit <code>http://www.oracle.com/pls/topic/lookup?ctx=acc&amp;id=trs</code> if you are hearing impaired.</p>
-<p><img width="144" height="18" src="oracle.gif" alt="Oracle Logo" /></p>
+<pre>
+
+Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+license agreements.  See the NOTICE file distributed with this work for 
+additional information regarding copyright ownership. The ASF licenses this
+file to you under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations under the License.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+</pre>
 </body>
 </html>


### PR DESCRIPTION
- Removes pre-donation copyright notices from JavaHelp html files.
- Removes pre-donation copyright notices from user-facing readme files in samples.
- Removes previous license from legal_notice.htm 