### PR TITLE
disabled uihandler modules (exception+statistics reporter).

### DIFF
--- a/ide/utilities/src/org/netbeans/modules/utilities/Bundle.properties
+++ b/ide/utilities/src/org/netbeans/modules/utilities/Bundle.properties
@@ -26,3 +26,5 @@ which helps you open a file in a previously unmounted filesystem.
 
 Loaders/application/pdf/Factories/org-netbeans-modules-pdf-PDFDataLoader.instance=PDF Documents
 Loaders/text/url/Factories/org-netbeans-modules-url-URLDataLoader.instance=URL Files
+
+CTL_ReportIssueAction=&Report Issue

--- a/ide/utilities/src/org/netbeans/modules/utilities/ReportNBIssueAction.java
+++ b/ide/utilities/src/org/netbeans/modules/utilities/ReportNBIssueAction.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.netbeans.modules.bugzilla.exceptionreporter;
+package org.netbeans.modules.utilities;
 
 import org.openide.util.actions.SystemAction;
 import org.openide.util.HelpCtx;
@@ -35,7 +35,7 @@ import org.openide.util.NbBundle;
  * 
  * @author Tomas Stupka
  */
-@ActionID(id = "org.netbeans.modules.bugzilla.exceptionreporter.ReportNBIssueAction", category = "Help")
+@ActionID(id = "org.netbeans.modules.utilities.ReportNBIssueAction", category = "Help")
 @ActionRegistration(lazy = false, displayName = "#CTL_ReportIssueAction")
 @ActionReference(path = "Menu/Help", position = 450)
 public class ReportNBIssueAction extends SystemAction {

--- a/nb/bugzilla.exceptionreporter/nbproject/project.properties
+++ b/nb/bugzilla.exceptionreporter/nbproject/project.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-is.eager=true
-javac.source=1.6
+javac.source=1.8
+is.autoload=true
 javac.compilerargs=-Xlint -Xlint:-serial

--- a/nb/bugzilla.exceptionreporter/src/org/netbeans/modules/bugzilla/exceptionreporter/Bundle.properties
+++ b/nb/bugzilla.exceptionreporter/src/org/netbeans/modules/bugzilla/exceptionreporter/Bundle.properties
@@ -19,5 +19,3 @@ OpenIDE-Module-Display-Category=Team
 OpenIDE-Module-Name=Bugzilla-Exception Reporter Bridge
 
 OpenIDE-Module-Short-Description=Providess exception reporter access to the netbeans.org bugzilla
-
-CTL_ReportIssueAction=&Report Issue

--- a/nb/ide.branding.kit/nbproject/project.xml
+++ b/nb/ide.branding.kit/nbproject/project.xml
@@ -51,12 +51,6 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
-                    <code-name-base>org.netbeans.modules.uihandler.exceptionreporter</code-name-base>
-                    <run-dependency>
-                        <specification-version>1.0</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
                     <code-name-base>org.netbeans.modules.welcome</code-name-base>
                     <run-dependency>
                         <release-version>1</release-version>

--- a/nb/uihandler.exceptionreporter/nbproject/project.properties
+++ b/nb/uihandler.exceptionreporter/nbproject/project.properties
@@ -15,3 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
+javac.source=1.8
+is.autoload=true

--- a/platform/lib.uihandler/nbproject/project.properties
+++ b/platform/lib.uihandler/nbproject/project.properties
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
+is.autoload=true
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml
 

--- a/platform/uihandler/nbproject/project.properties
+++ b/platform/uihandler/nbproject/project.properties
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-is.autoload=true
 javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
+is.autoload=true
 javadoc.arch=${basedir}/arch.xml
 
 test.config.stableBTD.includes=**/*Test.class


### PR DESCRIPTION
disabling the module does two things:
 - removes the "Help us improve NetBeans" dialog which appears on second start (and counterpart in general options)
 - and the exception reporter functionality (window -> ide tools -> exception reporter)

non of this worked anymore anyway as far as I can tell.

todo: travis might fail if it has a test config for it, we will see.