### PR TITLE
Remove unnecessary log entry from javadoc build

### DIFF
--- a/nbbuild/antsrc/org/netbeans/nbbuild/Arch.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/Arch.java
@@ -685,7 +685,6 @@ public class Arch extends Task implements ErrorHandler, EntityResolver, URIResol
         String last = systemId.substring(idx + 1);
         
         if (localDTDs.contains(last)) {
-            log("Resolved to embedded DTD");
             InputSource is = new InputSource(Arch.class.getResourceAsStream(last));
             is.setSystemId(systemId);
             return is;


### PR DESCRIPTION
There is too many occurrences of `[arch] Resolved to embedded DTD` in javadoc build log. Information value of this line is low, so removing to make log more concise and readable.