### PR TITLE
LSP: Do not produce CodeActions for errors with empty description.

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/suggestions/Lambda.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/suggestions/Lambda.java
@@ -181,7 +181,7 @@ public class Lambda {
     @Messages({
         "DN_expression2Return=Convert Lambda Body to Use a Block",
         "DESC_expression2Return=Converts lambda bodies to use blocks rather than expressions",
-        "ERR_expression2Return=",
+        "ERR_expression2Return=Block as the lambda's body can be used",
         "FIX_expression2Return=Use block as the lambda's body"
     })
     @TriggerPattern("($args$) -> $lambdaExpression")
@@ -202,7 +202,7 @@ public class Lambda {
     @Messages({
         "DN_memberReference2Lambda=Convert Member Reference to Lambda Expression",
         "DESC_memberReference2Lambda=Converts member references to lambda expressions",
-        "ERR_memberReference2Lambda=",
+        "ERR_memberReference2Lambda=Lambda expression can be used",
         "FIX_memberReference2Lambda=Use lambda expression"
     })
     @TriggerTreeKind(Kind.MEMBER_REFERENCE)
@@ -219,7 +219,7 @@ public class Lambda {
     @Messages({
         "DN_addExplicitLambdaParameters=Convert Lambda to Use Explicit Parameter Types",
         "DESC_addExplicitLambdaParameters=Converts lambdas to use explicit parameter types",
-        "ERR_addExplicitLambdaParameters=",
+        "ERR_addExplicitLambdaParameters=Explicit parameter types can be used",
         "FIX_addExplicitLambdaParameters=Use explicit parameter types"
     })
     @TriggerTreeKind(Kind.LAMBDA_EXPRESSION)

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -870,12 +870,17 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
             }
 
             ArrayList<Diagnostic> diagnostics = new ArrayList<>(params.getContext().getDiagnostics());
-            diagnostics.addAll(computeDiags(params.getTextDocument().getUri(), startOffset, ErrorProvider.Kind.HINTS, documentVersion(doc)));
+            if (diagnostics.isEmpty()) {
+                diagnostics.addAll(computeDiags(params.getTextDocument().getUri(), startOffset, ErrorProvider.Kind.HINTS, documentVersion(doc)));
+            }
 
             Map<String, org.netbeans.api.lsp.Diagnostic> id2Errors = (Map<String, org.netbeans.api.lsp.Diagnostic>) doc.getProperty("lsp-errors");
             if (id2Errors != null) {
                 for (Entry<String, org.netbeans.api.lsp.Diagnostic> entry : id2Errors.entrySet()) {
                     org.netbeans.api.lsp.Diagnostic err = entry.getValue();
+                    if (err.getDescription() == null || err.getDescription().isEmpty()) {
+                        continue;
+                    }
                     if (err.getSeverity() == org.netbeans.api.lsp.Diagnostic.Severity.Error) {
                         if (err.getEndPosition().getOffset() < startOffset || err.getStartPosition().getOffset() > endOffset) {
                             continue;


### PR DESCRIPTION
Do not produce CodeActions for errors with empty description as they prevents all CodeActions from displaying in VSCode client.