### PR TITLE
Support for image IDs, LSP client can redefine images/icons

### DIFF
--- a/java/java.lsp.server/arch.xml
+++ b/java/java.lsp.server/arch.xml
@@ -961,6 +961,7 @@
        <table>
            <tbody>
                <tr><td>is:folder</td><td>the Node represents a folder, or a DataFolder</td><td></td></tr>
+               <tr><td>is:file</td><td>the Node represents a file</td><td></td></tr>
                <tr><td>is:project</td><td>the Node represents a project (the project's node itself)</td><td></td></tr>
                <tr><td>is:projectRoot</td><td>the Node represents a root project in a multi-project tree</td><td></td></tr>
                <tr><td>is:subProject</td><td>the Node represents a subproject in a multi-project tree</td><td></td></tr>

--- a/java/java.lsp.server/licenseinfo.xml
+++ b/java/java.lsp.server/licenseinfo.xml
@@ -24,8 +24,9 @@
         <file>vscode/package-lock.json</file>
         <file>vscode/package.json</file>
         <file>vscode/tsconfig.json</file>
-        <file>vscode/src/extension.ts</file>
-        <license ref="MIT-vscode-ext" />
+        <file>vscode/schemas/package.schema.json</file>
+        <license ref="Apache-2.0" />
+        <comment type="COMMENT_UNSUPPORTED" />
     </fileset>
     <fileset>
         <file>src/org/netbeans/modules/java/lsp/server/refactoring/ui/codicon.ttf</file>
@@ -40,6 +41,7 @@
         <file>vscode/.vscode/tasks.json</file>
         <file>vscode/.vscode/settings.json</file>
         <license ref="Apache-2.0" />
+        <comment type="COMMENT_UNSUPPORTED" />
     </fileset>
     <fileset>
         <file>vscode/images/Apache_NetBeans_Logo.png</file>

--- a/java/java.lsp.server/nbcode/integration/nbproject/project.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/project.xml
@@ -36,6 +36,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.api.htmlui</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.23</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.api.io</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -58,14 +66,6 @@
                     <compile-dependency/>
                     <run-dependency>
                         <specification-version>1.19</specification-version>
-                    </run-dependency>
-                </dependency>
-                <dependency>
-                    <code-name-base>org.netbeans.api.htmlui</code-name-base>
-                    <build-prerequisite/>
-                    <compile-dependency/>
-                    <run-dependency>
-                        <specification-version>1.23</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>
@@ -116,6 +116,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.openide.modules</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.63</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.util</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>
@@ -136,7 +144,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.23</specification-version>
+                        <specification-version>9.24</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/UIDefaultsIconMetadata.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/UIDefaultsIconMetadata.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.nbcode.integration;
+
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Graphics;
+import java.awt.HeadlessException;
+import java.awt.Image;
+import java.awt.MediaTracker;
+import java.awt.Toolkit;
+import java.awt.Transparency;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.ImageObserver;
+import java.awt.image.WritableRaster;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.UIDefaults;
+import javax.swing.UIDefaults.ActiveValue;
+import javax.swing.UIDefaults.LazyValue;
+import javax.swing.UIManager;
+import org.openide.modules.OnStart;
+import org.openide.util.ImageUtilities;
+
+/**
+ * Goes through UIDefaults and replaces Icons and Images with variants that
+ * return image's URL from the 'url' property.
+ * @author sdedic
+ */
+@OnStart
+public class UIDefaultsIconMetadata implements Runnable {
+    private static final Logger LOG = Logger.getLogger(UIDefaultsIconMetadata.class.getName());
+    
+    // for diagnostic purposes only
+    public static final String PROP_ORIGINAL_ICON = "originalIcon"; // NOI18N
+    // for diagnostic purposes only
+    public static final String PROP_ORIGINAL_IMAGE = "originalImage"; // NOI18N
+    
+    private static final String URN_DEFAULTS_PREFIX = "uidefaults:"; // NOI18N
+    
+    private static Object wrapImage(String key, Image image, Icon icon, Object... meta) {
+        Object o = image.getProperty(ImageUtilities.PROPERTY_ID, null); // NOI18N
+        if (o instanceof URL) {
+            return image;
+        }
+        
+        o = image.getProperty(ImageUtilities.PROPERTY_ID, null);
+        if (o instanceof String || o instanceof URI) {
+            return image;
+        } else {
+            
+            Hashtable props = new Hashtable();
+            for (int i = 0; i < meta.length; i+= 2) {
+                props.put(meta[i], meta[i+1]);
+            }
+            props.put(ImageUtilities.PROPERTY_ID, URN_DEFAULTS_PREFIX + key);
+            return createNew(image, icon, props);
+        }
+    }
+    
+    @Override
+    public void run() {
+        EventQueue.invokeLater(() -> {
+            // force LaF initialization before the UIDefaults are read/patched.
+            UIManager.get("force.laf.initialization");
+            replaceIconsAndImages(UIManager.getDefaults());
+        });
+    }
+    
+    static void replaceIconsAndImages(UIDefaults defs) {
+        refreshUIDefaults(defs);
+        defs.addPropertyChangeListener(new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
+                if (null == evt.getPropertyName() || "UIDefaults".equals(evt.getPropertyName())) { // NOI18N
+                    LOG.log(Level.INFO, "Refreshing all UIDefaults");
+                    refreshUIDefaults(defs);
+                } else {
+                    String k = evt.getPropertyName();
+                    Object o = evt.getNewValue();
+                    if (o == null || o instanceof W) {
+                        return;
+                    }
+                    if (o instanceof LazyValue) {
+                        LOG.log(Level.INFO, "Patched lazy value {0}", k);
+                        defs.put(k, new LazyWrapper(k, (LazyValue)o));
+                    } else if (o instanceof ActiveWrapper) {
+                        LOG.log(Level.INFO, "Patched active value {0}", k);
+                        defs.put(k, new ActiveWrapper(k, (ActiveWrapper)o));
+                    } else if (o instanceof Icon || o instanceof Image) {
+                        LOG.log(Level.INFO, "Patched Icon/Image value {0}", k);
+                        defs.put(k, new SimpleWrapper(k, o));
+                    }
+                }
+            }
+        });
+    }
+    
+    public static void refreshUIDefaults(UIDefaults defs) {
+        for (Enumeration en = defs.keys(); en.hasMoreElements(); ) {
+            Object ok = en.nextElement();
+            
+            // Note: this actually instantiates the object, if it implements LazyValue.
+            Object o = defs.get(ok);
+            if (o instanceof W) {
+                continue;
+            }
+            if (o instanceof Icon || o instanceof Image) {
+                LOG.log(Level.INFO, "Replaced {0} with wrapped", ok);
+                defs.put(ok, new SimpleWrapper(ok.toString(), o));
+            }
+        }
+    }
+    
+    private static Object wrapInstance(Object ok, Object o) {
+        if (o instanceof W) {
+            return o;
+        }
+        try {
+            if (o instanceof ImageIcon) {
+                ImageIcon ii = (ImageIcon)o;
+                Object wrapper = wrapImage(ok.toString(), ii.getImage(), ii,
+                        PROP_ORIGINAL_IMAGE, ii.getImage(), PROP_ORIGINAL_ICON, ii);
+                if (wrapper != ii.getImage()) {
+                    return (Icon)wrapper;
+                } else {
+                    return o;
+                }
+            }
+
+            if (o instanceof Icon) {
+                final Icon ico = (Icon)o;
+                Image converted = ImageUtilities.icon2Image(ico);
+                Object wrapper = wrapImage(ok.toString(), converted, ico, PROP_ORIGINAL_ICON, ico);
+                if (wrapper != converted) {
+                    return (Icon)wrapper;
+                } else {
+                    return o;
+                }
+            }
+
+            if (o instanceof Image) {
+                Object wrapper = wrapImage(ok.toString(), (Image)o, null, PROP_ORIGINAL_IMAGE, o);
+                return wrapper;
+            }
+        } catch (RuntimeException ex) {
+            // setting to FINE as some icons cannot be image-converted (ClassCastEx during paintIcon).
+            LOG.log(Level.FINE, "Error wrapping default {0}: ", ok.toString());
+            LOG.log(Level.FINE, "Exception thrown", ex);
+        }
+        return o;
+    }
+    
+    private static void replace(UIDefaults defs, Object key, String type, Object replacement) {
+        LOG.log(Level.INFO, "Replaced {0}", key);
+        defs.put(key, replacement);
+    }
+    
+    public static final class MetadataImageIcon extends ImageIcon {
+        private final Icon delegateIcon;
+
+        public MetadataImageIcon(Icon delegateIcon, Image original) {
+            super(original);
+            this.delegateIcon = delegateIcon;
+        }
+
+        /**
+         * Get an {@link Icon} instance representing a scalable version of this {@code Image}.
+         *
+         * @return may be null
+         */
+        public Icon getDelegateIcon() {
+            return delegateIcon;
+        }
+
+        @Override
+        public int getIconHeight() {
+            return delegateIcon.getIconHeight();
+        }
+
+        @Override
+        public int getIconWidth() {
+            return delegateIcon.getIconWidth();
+        }
+
+        @Override
+        public void paintIcon(Component c, Graphics g, int x, int y) {
+            delegateIcon.paintIcon(c, g, x, y);
+        }
+    }
+    
+    /**
+     * Delegating Image which adds metadata to the original image's {@link Image#getProperty}.
+     * @author sdedic
+     */
+    public static class MetadataImage extends BufferedImage implements W {
+        private final Image original;
+
+        public MetadataImage(Image original, ColorModel cm,
+                          WritableRaster raster,
+                          boolean isRasterPremultiplied,
+                          Hashtable<?,?> properties) {
+            super(cm, raster, isRasterPremultiplied, properties);
+            this.original = original;
+        }
+
+        @Override
+        public Object getProperty(String name, ImageObserver observer) {
+            Object o = super.getProperty(name, observer);
+            return o != UndefinedProperty ? o : original.getProperty(name, observer);
+        }
+    }
+    
+    public static Object createNew(Image image, Icon icon, Hashtable props) {
+        ensureLoaded(image);
+        boolean bitmask = (image instanceof Transparency) && ((Transparency) image).getTransparency() != Transparency.TRANSLUCENT;
+        ColorModel model = colorModel(bitmask ? Transparency.BITMASK : Transparency.TRANSLUCENT);
+        int w = Math.max(1, image.getWidth(null));
+        int h = Math.max(1, image.getHeight(null));
+        if (icon == null && image instanceof Icon) {
+            icon = (Icon)image;
+        }
+        WritableRaster raster = model.createCompatibleWritableRaster(w, h);
+        BufferedImage newImage = new MetadataImage(image, model, raster, bitmask, props);
+
+        java.awt.Graphics g = newImage.createGraphics();
+        g.drawImage(image, 0, 0, null);
+        g.dispose();
+        if (icon != null) {
+            return new MetadataImageIcon(icon, newImage);
+        } else {
+            return newImage;
+        }
+    }
+    
+    private interface W {}
+    
+    private static final class LazyWrapper implements LazyValue, W {
+        private final String key;
+        private final LazyValue original;
+
+        public LazyWrapper(String key, LazyValue original) {
+            this.key = key;
+            this.original = original;
+        }
+        
+        @Override
+        public Object createValue(UIDefaults table) {
+            LOG.log(Level.INFO, "Resolved lazy wrapped for {0}", key);
+            return wrapInstance(key, original.createValue(table));
+        }
+    }
+    
+    private static final class ActiveWrapper implements ActiveValue, W {
+        private final String key;
+        private final ActiveValue original;
+
+        public ActiveWrapper(String key, ActiveValue original) {
+            this.key = key;
+            this.original = original;
+        }
+
+        @Override
+        public Object createValue(UIDefaults table) {
+            LOG.log(Level.INFO, "Resolved active wrapped for {0}", key);
+            return wrapInstance(key, original.createValue(table));
+        }
+    }
+    
+    private static final class SimpleWrapper implements LazyValue, W {
+        private final String key;
+        private final Object original;
+
+        public SimpleWrapper(String key, Object original) {
+            this.key = key;
+            this.original = original;
+        }
+        
+        @Override
+        public Object createValue(UIDefaults table) {
+            LOG.log(Level.INFO, "Resolved wrapped for {0}", key);
+            return wrapInstance(key, original);
+        }
+    }
+
+    // ---------- Copied from ImageUtilities - needed to render the image --------
+    
+    private static final Component component = new Component() {};
+
+    private static final MediaTracker tracker = new MediaTracker(component);
+
+    private static int mediaTrackerID;
+
+    private static void ensureLoaded(Image image) {
+        if (
+            (Toolkit.getDefaultToolkit().checkImage(image, -1, -1, null) &
+                (ImageObserver.ALLBITS | ImageObserver.FRAMEBITS)) != 0
+        ) {
+            return;
+        }
+
+        synchronized (tracker) {
+            int id = ++mediaTrackerID;
+            tracker.addImage(image, id);
+
+            try {
+                tracker.waitForID(id, 0);
+            } catch (InterruptedException e) {
+                System.out.println("INTERRUPTED while loading Image");
+            }
+
+            // #262804 assertation disabled because of error, when using ImageFilter
+            // assert (tracker.statusID(id, false) == MediaTracker.COMPLETE) : "Image loaded";
+            tracker.removeImage(image, id);
+        }
+    }
+
+    static private ColorModel colorModel(int transparency) {
+        ColorModel model;
+        try {
+            model = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .getDefaultScreenDevice().getDefaultConfiguration()
+                .getColorModel(transparency);
+        }
+        catch(ArrayIndexOutOfBoundsException | HeadlessException aioobE) {
+            //#226279
+            model = ColorModel.getRGBdefault();
+        }
+        return model;
+    }
+
+    // ---------- End copy
+}

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -617,7 +617,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>9.14</specification-version>
+                        <specification-version>9.24</specification-version>
                     </run-dependency>
                 </dependency>
             </module-dependencies>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/DefaultDecorationsImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/DefaultDecorationsImpl.java
@@ -56,6 +56,7 @@ public class DefaultDecorationsImpl implements TreeDataProvider.Factory {
     public static final String EXPLORER_ROOT = "Explorers"; // NOI18N
     public static final String COOKIES_EXT = "contextValues"; // NOI18N
     
+    public static final String CTXVALUE_FILE = "is:file"; // NOI18N
     public static final String CTXVALUE_FOLDER = "is:folder"; // NOI18N
     public static final String CTXVALUE_PROJECT = "is:project"; // NOI18N
     public static final String CTXVALUE_PROJECT_ROOT = "is:projectRoot"; // NOI18N
@@ -166,7 +167,8 @@ public class DefaultDecorationsImpl implements TreeDataProvider.Factory {
                                 }
                                 folder = true;
                                 d.addContextValues(CTXVALUE_FOLDER);
-                            } else {
+                            } else if ((f.isData() || f.isValid()) && !f.isVirtual()) {
+                                d.addContextValues(CTXVALUE_FILE);
                                 // PENDING: this could be moved to the VSNetbeans module ?
                                 d.setCommand("vscode.open"); // NOI18N
                             }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
@@ -43,7 +43,6 @@ public class TreeItem {
     public String description;
     // ?: string | Uri | {dark: string | Uri, light: string | Uri} | ThemeIcon
     public URI iconUri;
-    public int iconIndex;
     // id for the tree item that has to be unique across tree.
     // The id is used to preserve the selection and expansion state of the tree item.
     public int id;
@@ -56,6 +55,27 @@ public class TreeItem {
     public String resourceUri;
     // ?: string | MarkdownString | undefined
     public Object tooltip;
+    
+    // NBLS-specific items, to be processed by the client:
+    // Metadata for the icon.
+    public IconDescriptor iconDescriptor;
+    // The icon's index
+    public int iconIndex;
+    
+    /**
+     * Metadata that describe an icon origin or contents.
+     */
+    public static class IconDescriptor {
+        /**
+         * Base URI / imageId of the icon.
+         */
+        public URI baseUri;
+        
+        /**
+         * Supplemental IDs from composed merged-in images or applied filters.
+         */
+        public String[] composition;
+    }
 
     public TreeItem() {
     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistry.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistry.java
@@ -20,6 +20,8 @@ package org.netbeans.modules.java.lsp.server.explorer;
 
 import java.awt.Image;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.concurrent.CompletionStage;
 import org.openide.nodes.Node;
 
@@ -40,6 +42,19 @@ public interface TreeNodeRegistry {
     CompletionStage<TreeViewProvider> createProvider(String id);
     
     public class ImageDataOrIndex {
+        /**
+         * Base URL of the image, if it could be extracted from the Image object.
+         */
+        public URI          baseURI;
+        
+        /**
+         * URLs(?) of additional image constituents.
+         */
+        public String[]     composition;
+        
+        /**
+         * Image URI, data: protocol.
+         */
         public final URI    imageURI;
         public final int    imageIndex;
 
@@ -56,6 +71,25 @@ public interface TreeNodeRegistry {
         public ImageDataOrIndex(int imageIndex) {
             this.imageIndex = imageIndex;
             this.imageURI = null;
+        }
+        
+        public ImageDataOrIndex baseURL(URL u) {
+            try {
+                baseURI = u == null ? null : u.toURI();
+            } catch (URISyntaxException ex) {
+                throw new IllegalArgumentException(ex);
+            }
+            return this;
+        }
+        
+        public ImageDataOrIndex baseURL(URI u) {
+            this.baseURI = u;
+            return this;
+        }
+        
+        public ImageDataOrIndex composition(String[] composition) {
+            this.composition = composition;
+            return this;
         }
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistryImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistryImpl.java
@@ -259,21 +259,18 @@ public class TreeNodeRegistryImpl implements TreeNodeRegistry {
 
 
     public static URI findImageURI(Image i) {
-        Object o = i.getProperty("url", null);
+        String s = ImageUtilities.findImageBaseId(i);
+        if (s == null) {
+            return null;
+        }
         try {
-            if (o instanceof URL) {
-                return ((URL)o).toURI();
-            }
-            o = i.getProperty("uri", null);
-            if (o instanceof URI) {
-                return (URI)o;
-            } else if (o instanceof String) {
-                return new URI(o.toString());
+            if (s.contains(":")) {
+                return new URI(s);
             } else {
-                return null;
+                return new URI("nbres:/" + s);
             }
         } catch (URISyntaxException ex) {
-            LOG.log(Level.WARNING, "Unable to interpret image URL: {0}", o);
+            LOG.log(Level.WARNING, "Unable to interpret image ID: {0}", s);
             return null;
         }
     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistryImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistryImpl.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -49,6 +50,7 @@ import org.openide.explorer.ExplorerUtils;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.nodes.Node;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
 import org.openide.util.lookup.ProxyLookup;
@@ -220,7 +222,6 @@ public class TreeNodeRegistryImpl implements TreeNodeRegistry {
                 if (h == -1 || w == -1) {
                     try {
                         observer.cdl.await();
-                        Thread.sleep(1000);
                     } catch (InterruptedException ex) {
                     }
                     synchronized (observer) {
@@ -248,10 +249,33 @@ public class TreeNodeRegistryImpl implements TreeNodeRegistry {
         }
         synchronized (this) {
             if (res == null) {
-                res = new ImageDataOrIndex(imageURI, imageCounter++);
+                res = new ImageDataOrIndex(imageURI, imageCounter++).
+                        baseURL(findImageURI(i));
             }
             images.put(i, res);
         }
         return res;
     }
+
+
+    public static URI findImageURI(Image i) {
+        Object o = i.getProperty("url", null);
+        try {
+            if (o instanceof URL) {
+                return ((URL)o).toURI();
+            }
+            o = i.getProperty("uri", null);
+            if (o instanceof URI) {
+                return (URI)o;
+            } else if (o instanceof String) {
+                return new URI(o.toString());
+            } else {
+                return null;
+            }
+        } catch (URISyntaxException ex) {
+            LOG.log(Level.WARNING, "Unable to interpret image URL: {0}", o);
+            return null;
+        }
+    }
+    
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/TreeItemData.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/TreeItemData.java
@@ -83,7 +83,7 @@ public final class TreeItemData {
         this.contextValues = contextValues;
         return this;
     }
-
+    
     public String getCommand() {
         return command;
     }

--- a/java/java.lsp.server/vscode/package.json
+++ b/java/java.lsp.server/vscode/package.json
@@ -661,8 +661,79 @@
 					"group": "inline@1"
 				}
 			]
-		}
+		},
+		
+		"netbeans.iconMapping" : [
+			{
+				"uriExpression": "nbres:/org/netbeans/modules/gradle/resources/gradle.png",
+				"codeicon": "project"
+			},
+			{
+				"uriExpression": "nbres:/org/netbeans/modules/gradle/java/resources/javaseProjectIcon.png",
+				"codeicon": "project"
+			},
+			{
+				"uriExpression": "nbres:/org/netbeans/modules/maven/resources/jaricon.png",
+				"codeicon": "project"
+			},
+
+			{
+				"uriExpression": "nbres:/org/netbeans/modules/gradle/resources/libraries.png",
+				"codeicon": "settings-gear"
+			},
+			{
+				"uriExpression": "nbres:/org/netbeans/modules/gradle/resources/(empty.png|module-artifact.png)",
+				"codeicon": "file-zip"
+			},
+			{
+				"uriExpression": "nbres:/org/netbeans/modules/maven/DependencyIcon.png",
+				"codeicon": "file-zip"
+			},
+			{
+				"uriExpression": "nbres:/org/netbeans/modules/maven/TransitiveDependencyIcon.png",
+				"codeicon": "library"
+			},
+			{
+				"uriExpression": "nbres:/org/netbeans/spi/java/project/support/ui/package(Empty)?.gif",
+				"codeicon": "file-submodule"
+			},
+			{
+				"uriExpression": "nbres:/org/netbeans/modules/java/resources/(abstract_class_file|class|enum_file).png",
+				"codeicon": "symbol-class"
+			},
+			{
+				"uriExpression": "nbres:/org/netbeans/modules/java/resources/(annotation_file|interface_file).png",
+				"codeicon": "symbol-interface"
+			},
+			{
+				"uriExpression": "uidefaults:Tree.(open|closed)Icon",
+				"valueMatch": [ " [0-9]+([A-Z][A-z]+)?SourceRoot | Dependencies[A-Z]+ | OtherRoots | projectfiles | BootCPNode " ],
+				"codeicon": "file-submodule"
+			},
+			{
+				"uriExpression": "uidefaults:Tree.(open|closed)Icon",
+				"valueMatch": [ " [0-9]+([A-z]+).(java|groovy|generated|resources) " ],
+				"codeicon": "file-submodule"
+			},
+			{
+				"uriExpression": "uidefaults:Tree.(open|closed)Icon",
+				"codeicon": "*folder"
+			},
+			{
+				"uriExpression": "nbres:/org/netbeans/modules/java/api/common/project/ui/resources/platform.gif",
+				"codeicon": "vm"
+			}
+		],
+	
+		"jsonValidation": [
+			{
+				"fileMatch": "package.json",
+				"url": "./schemas/package.schema.json"
+			}
+		]
 	},
+
+
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",

--- a/java/java.lsp.server/vscode/schemas/package.schema.json
+++ b/java/java.lsp.server/vscode/schemas/package.schema.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "LSP Image Resource Mapping contributions to package.json",
+    "type": "object",
+    "properties": {
+            "contributes": {
+                    "type": "object",
+                    "properties": {
+                            "netbeans.iconMapping" : {
+                                "type" : "array",
+                                "description" : "Defines replacements for image URIs for vscode-provided product icons",
+                                "items": {
+                                    "type" : "object",
+                                    "properties": {
+                                        "uriExpression" : {
+                                            "type" : "string",
+                                            "description": "Regular expression that must fully match the resource URI"
+                                        },
+                                        "valueMatch" : {
+                                            "type" : "array",
+                                            "description": "Additional value(s) required for the replacement to match.",
+                                            "items": {
+                                                "type" : "string",
+                                                "description": "Regular expression that describes the required value"
+                                            }
+                                        },
+                                        "iconPath" : {
+                                            "type" : "string",
+                                            "description" : "Path to the replacement icon"
+                                        },
+                                        "codeicon" : {
+                                            "type" : "string",
+                                            "description" : "codeicon identifier that will be used instead of the server-provided image"
+                                        }
+                                    }
+                                }
+                            }
+                    }
+            }
+    }
+}
+

--- a/java/java.lsp.server/vscode/src/explorer.ts
+++ b/java/java.lsp.server/vscode/src/explorer.ts
@@ -1,4 +1,21 @@
-import { disconnect } from 'process';
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import * as vscode from 'vscode';
 import { ThemeIcon } from 'vscode';
 import {  LanguageClient } from 'vscode-languageclient/node';

--- a/java/java.lsp.server/vscode/src/protocol.ts
+++ b/java/java.lsp.server/vscode/src/protocol.ts
@@ -172,6 +172,9 @@ export namespace NodeInfoRequest {
     export const destroy = new ProtocolRequestType<NodeOperationParams, boolean, never, void, void>('nodes/delete');
     export const collapsed = new ProtocolNotificationType<NodeOperationParams, void>('nodes/collapsed');
     
+    export interface IconDescriptor {
+        baseUri : string;
+    }
     export interface Data {
         id : number; /* numeric ID of the node */
         name : string; /* Node.getName() */
@@ -182,6 +185,7 @@ export namespace NodeInfoRequest {
         collapsibleState : vscode.TreeItemCollapsibleState;
         canDestroy : boolean; /* Node.canDestroy() */
         contextValue : string; /* Node.getCookies() */
+        iconDescriptor? : IconDescriptor;
         iconUri : string | null;
         iconIndex : number;
         command? : string;

--- a/platform/openide.util.ui/arch.xml
+++ b/platform/openide.util.ui/arch.xml
@@ -298,6 +298,18 @@
 
 
  <answer id="exec-property">
+     <ul>
+         <li>
+             <api type="export" group="property" name="url" category="private">Images loaded by <a href="@TOP@/org/openide/util/ImageUtilities.html#loadImage__">ImageUtilities.loadImage</a>
+             defines <code>"url"</code> image property for the loaded image.
+             </api>
+         </li>
+         <li>
+             <api type="import" group="property" name="imageID" category="private"><a href="@TOP@/org/openide/util/ImageUtilities.html">ImageUtilities</a> methods try
+                 to preserve the value of <code>imageID</code> image property during icon to image to icon conversions.
+             </api>
+         </li>
+    </ul>
 <!--  <ul>
     <li><api type="export" group="systemproperty" name="netbeans.screen.insets" category="private">
     Influences results of Utilities.getUsableScreenBounds</api>.</li>

--- a/platform/openide.util.ui/manifest.mf
+++ b/platform/openide.util.ui/manifest.mf
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.util.ui
 OpenIDE-Module-Localizing-Bundle: org/openide/util/Bundle.properties
-OpenIDE-Module-Specification-Version: 9.23
+OpenIDE-Module-Specification-Version: 9.24
 


### PR DESCRIPTION
This PR allows LSP clients to "rebrand" or alter icons supplied byt he NBLS server for exported nodes. It's not exactly branding, since the LSP client may have its own ideas or icon schemes that do not fit to the NB Node implementations - which shall not be affected at all. The vscode client, in addition, uses fontified icons (bcs they scale), which more or less prevent branding - except maybe if I'd extract the font glyphs (possible license issues) and converted them to SVG branding resources.

Instead, the URL of the image's resource will be extracted from Node's icon and transmitted. As it acts like an unique ID (not exactly, see notes below), the client may replace it with its own icon. Icons that are the same on NB side (NB design) may be matched and replaced based on `contextValue` or `name` exported node's metadata (which is actually more powerful than just branding). Branding can be still used, if appropriate.

Note that certain prominent icons **do not come from URL resources**, but from `UIManager.getDefaults()` - the exact shape is defined by LaF. So these icons either do not have URLs at all, or their URLs differ between LaFs, which is unfortunate if the LaF-specific URL was used an ID.

The 1st commit in this PR changes openide `ImageUtilities`, it's probably the most important one from this PR.
* Images and icons produced by `ImageUtilities` maintain not only `url` (see `Image.getProperty` API) but also `uri`. As `url` property must be typed as URL, and non-location IDs cannot be represented as URLs (no URLStreamHandler registered, and the underlying resource bits are really not known) - another property is invented. Since the URI syntax is more flexible, even badges or filters can be represented as URIs (see at the end) in the future.

* During implementation it turned out that if `ToolkitImage` is wrapped in a delegating Image instance weird things happen: the SurfaceManager is not initialized properly so an attempt to `graphics.drawImage` will fail with `IllegalArgumentException`. So super-hacky `originalImage` or `originalIcon` backdoor is invented instead - so the anticipated delegating implementation may pass the surface-compatible real image as appropriate.

This part of impl is not finished: IMHO some convenience accessor methods for the URL (already was there) and URI should be added to `ImageUtilities`, the URI of regular resource-based icons should **not** be affected by branding or localization (it is now) and eventual badges should be somehow accessible as `URI[]` and also the possibly applied filter od disabled icon filter...
That's why I did not (yet) documented the added properties in `arch.xml`. I plan to do so after the implementation proves worthy hopefuly before NB13 finalizes.

The [UIDefaultsIconMetadata](https://github.com/apache/netbeans/pull/3414/files#diff-f39410866a776e64c3daf59786391b7fccf8d07adab3e9b89f61b88a9cd8a38eR50) is a NBLS startup hack, that replaces UIDefault images for delegates that provide the metadata (URL, URI). These are then preserved during `ImageUtilities.mergeImages` so a combined image inherits the base ID from the base image. 

Finally the URI is transmitted to the LSP client in a `ImageDescriptor` structure that will grow in the future (badge and filter URIs).

The vscode client reads icon replacement definitions from `package.json` of  all vscode extensions. It matches the transmitted image based on base URI and possibly `contextValue` items and also `name` as it is sometimes used as programmatic ID (in nodes that represent containers). If a match is found, icon data is ignored and vscode's `ThemeIcon` or a local icon (provided by an extension) is used.
This way the vscode can alter icons to match its visual style and ensure consistency if an icon was defined already in the vscode world. Other LSP clients can do just the same.

Note that the tree LSP messages need some optimization. For example, the server should only transmit image URI/descriptor - and the client should call back for URL's contents (image data) if it wants to display the original image. This will be solved in a future PRs.
