### PR TITLE
[cnd] small-1.4 makeproject samples, editor/lexer tests

### DIFF
--- a/cnd/cnd.editor/test/unit/src/org/netbeans/modules/cnd/editor/cplusplus/CLangFormatTestCase.java
+++ b/cnd/cnd.editor/test/unit/src/org/netbeans/modules/cnd/editor/cplusplus/CLangFormatTestCase.java
@@ -20,6 +20,7 @@
 package org.netbeans.modules.cnd.editor.cplusplus;
 
 import javax.swing.text.Document;
+import org.junit.Ignore;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.modules.cnd.spi.CndDocumentCodeStyleProvider;
 
@@ -47,6 +48,11 @@ public class CLangFormatTestCase extends EditorBase {
     return doc;
   }
     
+  /**
+   * clang format is not available in Apache NetBeans CND as we've dropped
+   * a dependency with libclank.
+   */
+  @Ignore
     public void testLLVM_Style() {
         setLoadDocumentText(
                 "int main() {\n" 

--- a/cnd/cnd.lexer/test/unit/data/testfiles/apr_portable.h.txt
+++ b/cnd/cnd.lexer/test/unit/data/testfiles/apr_portable.h.txt
@@ -1,0 +1,544 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file taken from https://svn.apache.org/repos/asf/apr/apr/trunk/include/apr_portable.h
+
+/* This header file is where you should put ANY platform specific information.
+ * This should be the only header file that programs need to include that 
+ * actually has platform dependent code which refers to the .
+ */
+#ifndef APR_PORTABLE_H
+#define APR_PORTABLE_H
+/**
+ * @file apr_portable.h
+ * @brief APR Portability Routines
+ */
+
+#include "apr.h"
+#include "apr_pools.h"
+#include "apr_thread_proc.h"
+#include "apr_file_io.h"
+#include "apr_network_io.h"
+#include "apr_errno.h"
+#include "apr_global_mutex.h"
+#include "apr_proc_mutex.h"
+#include "apr_time.h"
+#include "apr_dso.h"
+#include "apr_shm.h"
+
+#if APR_HAVE_DIRENT_H
+#include <dirent.h>
+#endif
+#if APR_HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#if APR_HAVE_PTHREAD_H
+#include <pthread.h>
+#endif
+#if APR_HAVE_SEMAPHORE_H
+#include <semaphore.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @defgroup apr_portabile Portability Routines
+ * @ingroup APR 
+ * @{
+ */
+
+#ifdef WIN32
+/* The primitives for Windows types */
+typedef HANDLE                apr_os_file_t;
+typedef HANDLE                apr_os_dir_t;
+typedef SOCKET                apr_os_sock_t;
+typedef HANDLE                apr_os_proc_mutex_t;
+typedef HANDLE                apr_os_thread_t;
+typedef HANDLE                apr_os_proc_t;
+typedef DWORD                 apr_os_threadkey_t; 
+typedef FILETIME              apr_os_imp_time_t;
+typedef SYSTEMTIME            apr_os_exp_time_t;
+typedef HANDLE                apr_os_dso_handle_t;
+typedef HANDLE                apr_os_shm_t;
+
+#elif defined(OS2)
+typedef HFILE                 apr_os_file_t;
+typedef HDIR                  apr_os_dir_t;
+typedef int                   apr_os_sock_t;
+typedef HMTX                  apr_os_proc_mutex_t;
+typedef TID                   apr_os_thread_t;
+typedef PID                   apr_os_proc_t;
+typedef PULONG                apr_os_threadkey_t; 
+typedef struct timeval        apr_os_imp_time_t;
+typedef struct tm             apr_os_exp_time_t;
+typedef HMODULE               apr_os_dso_handle_t;
+typedef void*                 apr_os_shm_t;
+
+#elif defined(__BEOS__)
+#include <kernel/OS.h>
+#include <kernel/image.h>
+
+struct apr_os_proc_mutex_t {
+	sem_id sem;
+	int32  ben;
+};
+
+typedef int                   apr_os_file_t;
+typedef DIR                   apr_os_dir_t;
+typedef int                   apr_os_sock_t;
+typedef struct apr_os_proc_mutex_t  apr_os_proc_mutex_t;
+typedef thread_id             apr_os_thread_t;
+typedef thread_id             apr_os_proc_t;
+typedef int                   apr_os_threadkey_t;
+typedef struct timeval        apr_os_imp_time_t;
+typedef struct tm             apr_os_exp_time_t;
+typedef image_id              apr_os_dso_handle_t;
+typedef void*                 apr_os_shm_t;
+
+#elif defined(NETWARE)
+typedef int                   apr_os_file_t;
+typedef DIR                   apr_os_dir_t;
+typedef int                   apr_os_sock_t;
+typedef NXMutex_t *           apr_os_proc_mutex_t;
+typedef NXThreadId_t          apr_os_thread_t;
+typedef long                  apr_os_proc_t;
+typedef NXKey_t               apr_os_threadkey_t; 
+typedef struct timeval        apr_os_imp_time_t;
+typedef struct tm             apr_os_exp_time_t;
+typedef void *                apr_os_dso_handle_t;
+typedef void*                 apr_os_shm_t;
+
+#else
+/* Any other OS should go above this one.  This is the lowest common
+ * denominator typedefs for  all UNIX-like systems.  :)
+ */
+
+/** Basic OS process mutex structure. */
+struct apr_os_proc_mutex_t {
+#if APR_HAS_SYSVSEM_SERIALIZE || APR_HAS_FCNTL_SERIALIZE || APR_HAS_FLOCK_SERIALIZE
+    /** Value used for SYS V Semaphore, FCNTL and FLOCK serialization */
+    int crossproc;
+#endif
+#if APR_HAS_PROC_PTHREAD_SERIALIZE
+    /** Value used for PTHREAD serialization */
+    pthread_mutex_t *pthread_interproc;
+#endif
+#if APR_HAS_POSIXSEM_SERIALIZE
+    /** Value used for POSIX semaphores serialization */
+    sem_t *psem_interproc;
+#endif
+};
+
+typedef int                   apr_os_file_t;        /**< native file */
+typedef DIR                   apr_os_dir_t;         /**< native dir */
+typedef int                   apr_os_sock_t;        /**< native dir */
+typedef struct apr_os_proc_mutex_t  apr_os_proc_mutex_t; /**< native process
+                                                          *   mutex
+                                                          */
+#if APR_HAS_THREADS && APR_HAVE_PTHREAD_H 
+typedef pthread_t             apr_os_thread_t;      /**< native thread */
+typedef pthread_key_t         apr_os_threadkey_t;   /**< native thread address
+                                                     *   space */
+#endif
+typedef pid_t                 apr_os_proc_t;        /**< native pid */
+typedef struct timeval        apr_os_imp_time_t;    /**< native timeval */
+typedef struct tm             apr_os_exp_time_t;    /**< native tm */
+/** @var apr_os_dso_handle_t
+ * native dso types
+ */
+#if defined(HPUX) || defined(HPUX10) || defined(HPUX11)
+#include <dl.h>
+typedef shl_t                 apr_os_dso_handle_t;
+#elif defined(DARWIN)
+#include <mach-o/dyld.h>
+typedef NSModule              apr_os_dso_handle_t;
+#else
+typedef void *                apr_os_dso_handle_t;
+#endif
+typedef void*                 apr_os_shm_t;         /**< native SHM */
+
+#endif
+
+/**
+ * @typedef apr_os_sock_info_t
+ * @brief alias for local OS socket
+ */
+/**
+ * everything APR needs to know about an active socket to construct
+ * an APR socket from it; currently, this is platform-independent
+ */
+struct apr_os_sock_info_t {
+    apr_os_sock_t *os_sock; /**< always required */
+    struct sockaddr *local; /**< NULL if not yet bound */
+    struct sockaddr *remote; /**< NULL if not connected */
+    int family;             /**< always required (APR_INET, APR_INET6, etc.) */
+    int type;               /**< always required (SOCK_STREAM, SOCK_DGRAM, etc.) */
+    int protocol;           /**< 0 or actual protocol (APR_PROTO_SCTP, APR_PROTO_TCP, etc.) */
+};
+
+typedef struct apr_os_sock_info_t apr_os_sock_info_t;
+
+#if APR_PROC_MUTEX_IS_GLOBAL || defined(DOXYGEN)
+/** Opaque global mutex type */
+#define apr_os_global_mutex_t apr_os_proc_mutex_t
+/** @return apr_os_global_mutex */
+#define apr_os_global_mutex_get apr_os_proc_mutex_get
+#else
+    /** Thread and process mutex for those platforms where process mutexes
+     *  are not held in threads.
+     */
+    struct apr_os_global_mutex_t {
+        apr_pool_t *pool;
+        apr_proc_mutex_t *proc_mutex;
+#if APR_HAS_THREADS
+        apr_thread_mutex_t *thread_mutex;
+#endif /* APR_HAS_THREADS */
+    };
+    typedef struct apr_os_global_mutex_t apr_os_global_mutex_t;
+
+APR_DECLARE(apr_status_t) apr_os_global_mutex_get(apr_os_global_mutex_t *ospmutex, 
+                                                apr_global_mutex_t *pmutex);
+#endif
+
+
+/**
+ * convert the file from apr type to os specific type.
+ * @param thefile The os specific file we are converting to
+ * @param file The apr file to convert.
+ * @remark On Unix, it is only possible to get a file descriptor from 
+ *         an apr file type.
+ */
+APR_DECLARE(apr_status_t) apr_os_file_get(apr_os_file_t *thefile,
+                                          apr_file_t *file);
+
+/**
+ * convert the dir from apr type to os specific type.
+ * @param thedir The os specific dir we are converting to
+ * @param dir The apr dir to convert.
+ */   
+APR_DECLARE(apr_status_t) apr_os_dir_get(apr_os_dir_t **thedir, 
+                                         apr_dir_t *dir);
+
+/**
+ * Convert the socket from an apr type to an OS specific socket
+ * @param thesock The socket to convert.
+ * @param sock The os specific equivalent of the apr socket..
+ */
+APR_DECLARE(apr_status_t) apr_os_sock_get(apr_os_sock_t *thesock,
+                                          apr_socket_t *sock);
+
+/**
+ * Convert the proc mutex from apr type to os specific type
+ * @param ospmutex The os specific proc mutex we are converting to.
+ * @param pmutex The apr proc mutex to convert.
+ */
+APR_DECLARE(apr_status_t) apr_os_proc_mutex_get(apr_os_proc_mutex_t *ospmutex, 
+                                                apr_proc_mutex_t *pmutex);
+
+/**
+ * Convert the proc mutex from apr type to os specific type, also
+ * providing the mechanism used by the apr mutex.
+ * @param ospmutex The os specific proc mutex we are converting to.
+ * @param pmutex The apr proc mutex to convert.
+ * @param mech The mechanism used by the apr proc mutex (if not NULL).
+ * @remark Allows for disambiguation for platforms with multiple mechanisms
+ *         available.
+ */
+APR_DECLARE(apr_status_t) apr_os_proc_mutex_get_ex(apr_os_proc_mutex_t *ospmutex, 
+                                                   apr_proc_mutex_t *pmutex,
+                                                   apr_lockmech_e *mech);
+
+/**
+ * Get the exploded time in the platforms native format.
+ * @param ostime the native time format
+ * @param aprtime the time to convert
+ */
+APR_DECLARE(apr_status_t) apr_os_exp_time_get(apr_os_exp_time_t **ostime,
+                                 apr_time_exp_t *aprtime);
+
+/**
+ * Get the imploded time in the platforms native format.
+ * @param ostime  the native time format
+ * @param aprtime the time to convert
+ */
+APR_DECLARE(apr_status_t) apr_os_imp_time_get(apr_os_imp_time_t **ostime, 
+                                              apr_time_t *aprtime);
+
+/**
+ * convert the shm from apr type to os specific type.
+ * @param osshm The os specific shm representation
+ * @param shm The apr shm to convert.
+ */   
+APR_DECLARE(apr_status_t) apr_os_shm_get(apr_os_shm_t *osshm,
+                                         apr_shm_t *shm);
+
+#if APR_HAS_THREADS || defined(DOXYGEN)
+/** 
+ * @defgroup apr_os_thread Thread portability Routines
+ * @{ 
+ */
+/**
+ * convert the thread to os specific type from apr type.
+ * @param thethd The apr thread to convert
+ * @param thd The os specific thread we are converting to
+ */
+APR_DECLARE(apr_status_t) apr_os_thread_get(apr_os_thread_t **thethd, 
+                                            apr_thread_t *thd);
+
+/**
+ * convert the thread private memory key to os specific type from an apr type.
+ * @param thekey The apr handle we are converting from.
+ * @param key The os specific handle we are converting to.
+ */
+APR_DECLARE(apr_status_t) apr_os_threadkey_get(apr_os_threadkey_t *thekey,
+                                               apr_threadkey_t *key);
+
+/**
+ * convert the thread from os specific type to apr type.
+ * @param thd The apr thread we are converting to.
+ * @param thethd The os specific thread to convert
+ * @param cont The pool to use if it is needed.
+ */
+APR_DECLARE(apr_status_t) apr_os_thread_put(apr_thread_t **thd,
+                                            apr_os_thread_t *thethd,
+                                            apr_pool_t *cont);
+
+/**
+ * convert the thread private memory key from os specific type to apr type.
+ * @param key The apr handle we are converting to.
+ * @param thekey The os specific handle to convert
+ * @param cont The pool to use if it is needed.
+ */
+APR_DECLARE(apr_status_t) apr_os_threadkey_put(apr_threadkey_t **key,
+                                               apr_os_threadkey_t *thekey,
+                                               apr_pool_t *cont);
+/**
+ * Get the thread ID
+ */
+APR_DECLARE(apr_os_thread_t) apr_os_thread_current(void);
+
+/**
+ * Compare two thread id's
+ * @param tid1 1st Thread ID to compare
+ * @param tid2 2nd Thread ID to compare
+ * @return non-zero if the two threads are equal, zero otherwise
+ */ 
+APR_DECLARE(int) apr_os_thread_equal(apr_os_thread_t tid1, 
+                                     apr_os_thread_t tid2);
+
+/** @} */
+#endif /* APR_HAS_THREADS */
+
+/**
+ * convert the file from os specific type to apr type.
+ * @param file The apr file we are converting to.
+ * @param thefile The os specific file to convert
+ * @param flags The flags that were used to open this file.
+ * @param cont The pool to use if it is needed.
+ * @remark On Unix, it is only possible to put a file descriptor into
+ *         an apr file type.
+ */
+APR_DECLARE(apr_status_t) apr_os_file_put(apr_file_t **file,
+                                          apr_os_file_t *thefile,
+                                          apr_int32_t flags, apr_pool_t *cont); 
+
+/**
+ * convert the file from os specific type to apr type.
+ * @param file The apr file we are converting to.
+ * @param thefile The os specific pipe to convert
+ * @param cont The pool to use if it is needed.
+ * @remark On Unix, it is only possible to put a file descriptor into
+ *         an apr file type.
+ */
+APR_DECLARE(apr_status_t) apr_os_pipe_put(apr_file_t **file,
+                                          apr_os_file_t *thefile,
+                                          apr_pool_t *cont);
+
+/**
+ * convert the file from os specific type to apr type.
+ * @param file The apr file we are converting to.
+ * @param thefile The os specific pipe to convert
+ * @param register_cleanup A cleanup will be registered on the apr_file_t
+ *   to issue apr_file_close().
+ * @param cont The pool to use if it is needed.
+ * @remark On Unix, it is only possible to put a file descriptor into
+ *         an apr file type.
+ */
+APR_DECLARE(apr_status_t) apr_os_pipe_put_ex(apr_file_t **file,
+                                             apr_os_file_t *thefile,
+                                             int register_cleanup,
+                                             apr_pool_t *cont);
+
+/**
+ * convert the dir from os specific type to apr type.
+ * @param dir The apr dir we are converting to.
+ * @param thedir The os specific dir to convert
+ * @param cont The pool to use when creating to apr directory.
+ */
+APR_DECLARE(apr_status_t) apr_os_dir_put(apr_dir_t **dir,
+                                         apr_os_dir_t *thedir,
+                                         apr_pool_t *cont); 
+
+/**
+ * Convert a socket from the os specific type to the APR type. If
+ * sock points to NULL, a socket will be created from the pool
+ * provided. If **sock does not point to NULL, the structure pointed 
+ * to by sock will be reused and updated with the given socket.
+ * @param sock The pool to use.
+ * @param thesock The socket to convert to.
+ * @param cont The socket we are converting to an apr type.
+ * @remark If it is a true socket, it is best to call apr_os_sock_make()
+ *         and provide APR with more information about the socket.
+ */
+APR_DECLARE(apr_status_t) apr_os_sock_put(apr_socket_t **sock, 
+                                          apr_os_sock_t *thesock, 
+                                          apr_pool_t *cont);
+
+/**
+ * Create a socket from an existing descriptor and local and remote
+ * socket addresses.
+ * @param apr_sock The new socket that has been set up
+ * @param os_sock_info The os representation of the socket handle and
+ *        other characteristics of the socket
+ * @param cont The pool to use
+ * @remark If you only know the descriptor/handle or if it isn't really
+ *         a true socket, use apr_os_sock_put() instead.
+ */
+APR_DECLARE(apr_status_t) apr_os_sock_make(apr_socket_t **apr_sock,
+                                           apr_os_sock_info_t *os_sock_info,
+                                           apr_pool_t *cont);
+
+/**
+ * Convert the proc mutex from os specific type to apr type
+ * @param pmutex The apr proc mutex we are converting to.
+ * @param ospmutex The os specific proc mutex to convert.
+ * @param cont The pool to use if it is needed.
+ */
+APR_DECLARE(apr_status_t) apr_os_proc_mutex_put(apr_proc_mutex_t **pmutex,
+                                                apr_os_proc_mutex_t *ospmutex,
+                                                apr_pool_t *cont); 
+
+/**
+ * Convert the proc mutex from os specific type to apr type, using the
+ * specified mechanism.
+ * @param pmutex The apr proc mutex we are converting to.
+ * @param ospmutex The os specific proc mutex to convert.
+ * @param mech The apr mutex locking mechanism
+ * @param register_cleanup Whether to destroy the os mutex with the apr
+ *        one (either on explicit destroy or pool cleanup).
+ * @param cont The pool to use if it is needed.
+ * @remark Allows for disambiguation for platforms with multiple mechanisms
+ *         available.
+ */
+APR_DECLARE(apr_status_t) apr_os_proc_mutex_put_ex(apr_proc_mutex_t **pmutex,
+                                                apr_os_proc_mutex_t *ospmutex,
+                                                apr_lockmech_e mech,
+                                                int register_cleanup,
+                                                apr_pool_t *cont); 
+
+/**
+ * Put the imploded time in the APR format.
+ * @param aprtime the APR time format
+ * @param ostime the time to convert
+ * @param cont the pool to use if necessary
+ */
+APR_DECLARE(apr_status_t) apr_os_imp_time_put(apr_time_t *aprtime,
+                                              apr_os_imp_time_t **ostime,
+                                              apr_pool_t *cont); 
+
+/**
+ * Put the exploded time in the APR format.
+ * @param aprtime the APR time format
+ * @param ostime the time to convert
+ * @param cont the pool to use if necessary
+ */
+APR_DECLARE(apr_status_t) apr_os_exp_time_put(apr_time_exp_t *aprtime,
+                                              apr_os_exp_time_t **ostime,
+                                              apr_pool_t *cont); 
+
+/**
+ * convert the shared memory from os specific type to apr type.
+ * @param shm The apr shm representation of osshm
+ * @param osshm The os specific shm identity
+ * @param cont The pool to use if it is needed.
+ * @remark On fork()ed architectures, this is typically nothing more than
+ * the memory block mapped.  On non-fork architectures, this is typically
+ * some internal handle to pass the mapping from process to process.
+ */
+APR_DECLARE(apr_status_t) apr_os_shm_put(apr_shm_t **shm,
+                                         apr_os_shm_t *osshm,
+                                         apr_pool_t *cont); 
+
+
+#if APR_HAS_DSO || defined(DOXYGEN)
+/** 
+ * @defgroup apr_os_dso DSO (Dynamic Loading) Portability Routines
+ * @{
+ */
+/**
+ * convert the dso handle from os specific to apr
+ * @param dso The apr handle we are converting to
+ * @param thedso the os specific handle to convert
+ * @param pool the pool to use if it is needed
+ */
+APR_DECLARE(apr_status_t) apr_os_dso_handle_put(apr_dso_handle_t **dso,
+                                                apr_os_dso_handle_t thedso,
+                                                apr_pool_t *pool);
+
+/**
+ * convert the apr dso handle into an os specific one
+ * @param aprdso The apr dso handle to convert
+ * @param dso The os specific dso to return
+ */
+APR_DECLARE(apr_status_t) apr_os_dso_handle_get(apr_os_dso_handle_t *dso,
+                                                apr_dso_handle_t *aprdso);
+
+/** @} */
+#endif /* APR_HAS_DSO */
+
+
+#if APR_HAS_OS_UUID
+/**
+ * Private: apr-util's apr_uuid module when supported by the platform
+ */
+APR_DECLARE(apr_status_t) apr_os_uuid_get(unsigned char *uuid_data);
+#endif
+
+
+/**
+ * Get the name of the system default character set.
+ * @param pool the pool to allocate the name from, if needed
+ */
+APR_DECLARE(const char*) apr_os_default_encoding(apr_pool_t *pool);
+
+
+/**
+ * Get the name of the current locale character set.
+ * @param pool the pool to allocate the name from, if needed
+ * @remark Defers to apr_os_default_encoding() if the current locale's
+ * data can't be retrieved on this system.
+ */
+APR_DECLARE(const char*) apr_os_locale_encoding(apr_pool_t *pool);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* ! APR_PORTABLE_H */

--- a/cnd/cnd.lexer/test/unit/data/testfiles/istream.txt
+++ b/cnd/cnd.lexer/test/unit/data/testfiles/istream.txt
@@ -1,0 +1,639 @@
+// -*- C++ -*-
+/***************************************************************************
+ *
+ * istream - Declarations for the Standard Library istreams
+ *
+ * $Id$
+ *
+ ***************************************************************************
+ *
+ * Licensed to the Apache Software  Foundation (ASF) under one or more
+ * contributor  license agreements.  See  the NOTICE  file distributed
+ * with  this  work  for  additional information  regarding  copyright
+ * ownership.   The ASF  licenses this  file to  you under  the Apache
+ * License, Version  2.0 (the  "License"); you may  not use  this file
+ * except in  compliance with the License.   You may obtain  a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the  License is distributed on an  "AS IS" BASIS,
+ * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY  KIND, either  express or
+ * implied.   See  the License  for  the  specific language  governing
+ * permissions and limitations under the License.
+ *
+ * Copyright 1994-2006 Rogue Wave Software.
+ * 
+ **************************************************************************/
+
+// This file copied from http://svn.apache.org/repos/asf/stdcxx/trunk/include/istream
+
+#ifndef _RWSTD_ISTREAM_INCLUDED
+#define _RWSTD_ISTREAM_INCLUDED
+
+#if __GNUG__ >= 3
+#  pragma GCC system_header
+#endif   // gcc >= 3
+
+#ifndef _RWSTD_NO_REDUNDANT_DEFINITIONS
+#  include <ostream>
+#endif   // _RWSTD_NO_REDUNDANT_DEFINITIONS
+
+#include <loc/_num_get.h>
+#include <loc/_num_put.h>
+
+#include <rw/_basic_ios.h>
+#include <rw/_mutex.h>
+#include <rw/_traits.h>
+
+#include <rw/_defs.h>
+
+
+_RWSTD_NAMESPACE (__rw) {
+
+_EXPORT
+template <class _CharT, class _Traits, class _NativeType>
+_STD::basic_istream<_CharT, _Traits>&
+__rw_extract (_STD::basic_istream<_CharT, _Traits>&, _NativeType&);
+
+
+#ifdef _RWSTD_NO_EXT_NUM_GET
+
+template <class _CharT, class _Traits>
+inline _STD::basic_istream<_CharT, _Traits>&
+__rw_extract (_STD::basic_istream<_CharT, _Traits> &__strm,
+              short                                &__val)
+{
+    long __tmp = __val;
+    __rw_extract (__strm, __tmp);
+
+    _STD::ios_base::iostate __err = _STD::ios_base::goodbit;
+    __val = __rw_check_overflow_short (__tmp, __strm.flags (), __err);
+
+    if (_STD::ios_base::goodbit != __err)
+        __strm.setstate (__err);
+
+    return __strm;
+}
+
+template <class _CharT, class _Traits>
+inline _STD::basic_istream<_CharT, _Traits>&
+__rw_extract (_STD::basic_istream<_CharT, _Traits> &__strm,
+              int                                  &__val)
+{
+    long __tmp = __val;
+    __rw_extract (__strm, __tmp);
+
+    _STD::ios_base::iostate __err = _STD::ios_base::goodbit;
+    __val = __rw_check_overflow_int (__tmp, __strm.flags (), __err);
+
+    if (_STD::ios_base::goodbit != __err)
+        __strm.setstate (__err);
+
+    return __strm;
+}
+
+#endif   // _RWSTD_NO_EXT_NUM_GET
+
+}   // namespace __rw
+
+
+_RWSTD_NAMESPACE (std) {
+
+#ifndef _RWSTD_IOSFWD_INCLUDED
+
+_EXPORT
+template <class _CharT, class _Traits = char_traits<_CharT> >
+class basic_istream;
+
+_EXPORT
+template <class _CharT, class _Traits = char_traits<_CharT> >
+class basic_iostream;
+
+typedef basic_istream<char>  istream;
+typedef basic_iostream<char> iostream;
+
+#  ifndef _RWSTD_NO_WCHAR_T
+
+typedef basic_istream<wchar_t>  wistream;
+typedef basic_iostream<wchar_t> wiostream;
+
+#  endif   // _RWSTD_NO_WCHAR_T
+#endif   // _RWSTD_IOSFWD_INCLUDED
+
+
+_EXPORT
+template <class _CharT, class _Traits>
+class basic_istream: virtual public basic_ios<_CharT, _Traits>
+{
+public:
+
+    typedef _CharT                                    char_type;
+    typedef _Traits                                   traits_type;
+    typedef typename traits_type::int_type           int_type;
+    typedef typename traits_type::pos_type           pos_type;
+    typedef typename traits_type::off_type           off_type;
+      
+    // 27.6.1.1.1, p1
+    explicit basic_istream (basic_streambuf<char_type, traits_type> *__sb)
+        : _C_gcount (0) {
+        this->init (__sb);
+    }
+
+    // called from sentry's ctor to prepare stream before input
+    basic_istream&
+    _C_ipfx (bool, ios_base::iostate = ios_base::eofbit | ios_base::failbit);
+
+#ifdef _RWSTD_NO_NESTED_CLASS_ACCESS
+
+    // allow access to ios_base::_C_bufmutex() if the resolution
+    // of cwg issue 45 is not yet implemented
+    struct sentry;
+    friend struct sentry;
+
+#endif   // _RWSTD_NO_NESTED_CLASS_ACCESS
+
+    // 27.6.1.1.2
+    struct sentry: _RW::__rw_guard {
+
+        // 27.6.1.1.2, p2 - assumes 0 != __strm.rdbuf ()
+        explicit sentry (basic_istream &__strm, bool __noskipws = false)
+            : _RW::__rw_guard (__strm._C_bufmutex ()),
+              _C_ok (__strm._C_ipfx (__noskipws).good ()) { /* no-op */ }
+
+        // 27.6.1.1.2, p8
+        operator bool () const {
+            return _C_ok;
+        }
+
+    private:
+        bool _C_ok;
+
+        sentry (const sentry&);           // (normally) not defined
+        void operator= (const sentry&);   // (normally) not defined
+    };
+
+    // 27.6.1.2.3, p1, lwg issue 60
+    basic_istream& operator>> (basic_istream& (*__pf)(basic_istream&)) {
+        return (*__pf)(*this);
+    }
+
+    // 27.6.1.2.3, p2, lwg issue 60
+    basic_istream& operator>>(basic_ios<char_type, traits_type>& (*__pf)
+                              (basic_ios<char_type, traits_type>&)) {
+        return (*__pf)(*this), *this;
+    }
+
+    // 27.6.1.2.3, p4, lwg issue 60
+    basic_istream& operator>> (ios_base& (*__pf)(ios_base&)) {
+        return (*__pf)(*this), *this;
+    }
+
+
+    // 27.6.1.2.2 - Arithmetic Extractors
+
+#ifndef _RWSTD_NO_NATIVE_BOOL
+
+    basic_istream& operator>> (bool &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+#endif   // _RWSTD_NO_NATIVE_BOOL
+
+    basic_istream& operator>>(short &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+    basic_istream& operator>>(unsigned short &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+    basic_istream& operator>>(int &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+    basic_istream& operator>>(unsigned int &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+    basic_istream& operator>>(long &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+    basic_istream& operator>>(unsigned long &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+    basic_istream& operator>>(float &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+    basic_istream& operator>>(double &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+    basic_istream& operator>>(long double &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+#ifdef _RWSTD_LONG_LONG
+
+    basic_istream& operator>>(_RWSTD_LONG_LONG &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+    basic_istream& operator>>(unsigned _RWSTD_LONG_LONG &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+#endif   // _RWSTD_LONG_LONG
+
+    basic_istream& operator>>(void* &__val) {
+        return _RW::__rw_extract (*this, __val);
+    }
+
+    // 27.6.1.2.3, p13
+    basic_istream& operator>>(basic_streambuf<char_type, traits_type>*);
+
+    // 27.6.1.3 - Unformatted input functions
+
+    // 27.6.1.3, p3
+    int_type get ();
+
+    // 27.6.1.3, p5
+    basic_istream& get (char_type&);
+
+    // 27.6.1.3, p7: extract at most n - 1 chars, delim not extracted
+    //               always null-terminate, fail if no char extracted
+    basic_istream& get (char_type*, streamsize, char_type);
+
+    // 27.6.1.3, p9: extract at most n - 1 chars
+    //               always null-terminate, fail if no char extracted
+    basic_istream& get (char_type *__s, streamsize __n) {
+        return get (__s, __n, this->widen ('\n'));
+    }
+
+    // 27.6.1.3, p12: extract up to but not including delim or eof
+    basic_istream&
+    get (basic_streambuf<char_type, traits_type>& __sb, char_type __delim) {
+        return _C_get (__sb, traits_type::to_int_type (__delim));
+    }
+
+    // 27.6.1.3, p15
+    basic_istream& get (basic_streambuf<char_type, traits_type>& __sb) {
+        return get (__sb, this->widen ('\n'));
+    }
+
+    // 27.6.1.3, p16: extract at most n - 1, delim extracted but not stored
+    //                fail if either 0 or n - 1 chars have been extracted
+    basic_istream& getline (char_type*, streamsize, char_type);
+
+    // 27.6.1.3, p23
+    basic_istream& getline (char_type *__s, streamsize __n) {
+        return getline (__s, __n, this->widen ('\n'));
+    }
+
+    // 27.6.1.3, p24: extract at most n including delim
+    basic_istream& ignore (streamsize __n = 1,
+                           int_type __delim = traits_type::eof ()) {
+        // using extension - passing null pointer to ignore input
+        return read (0, __n, __delim, _C_eatdelim | _C_eatnull);
+    }
+
+    // extension
+    basic_istream& read (char_type*, streamsize, int_type, int);
+
+    // 27.6.1.3, p28: extract at most n, fail on eof
+    basic_istream& read (char_type*, streamsize);
+
+    // 27.6.1.3, p30: extract at most min (rdbuf()->in_avail(), n))
+    streamsize readsome (char_type*, streamsize);
+
+    // 27.6.1.3, p27
+    int_type peek ();
+      
+    // 27.6.1.3, p37
+    pos_type tellg ();
+
+    // 27.6.1.3, p38
+    basic_istream& seekg (pos_type);
+
+    // 27.6.1.3, p40
+    basic_istream& seekg (off_type, ios_base::seekdir);
+
+    // 27.6.1.3, p36
+    int sync ();
+
+    // 27.6.1.3, p32
+    basic_istream& putback (char_type);
+
+    // 27.6.1.3, p34
+    basic_istream& unget ();
+
+    // 27.6.1.3, p2
+    streamsize gcount () const {
+        return _C_gcount;
+    }
+
+    // flags used by read() extension, _C_ipfx(), and _C_unsafe_get()
+    enum {
+        _C_nullterm = 0x01,   // null-terminate input
+        _C_wsterm   = 0x02,   // terminate input on whitespace
+        _C_skipws   = 0x04,   // skip leading whitespace
+        _C_eatdelim = 0x08,   // extract delimiter
+        _C_faileof  = 0x10,   // set ios_base::failbit on eof
+        _C_failend  = 0x20,   // set ios_base::failbit on end of buffer
+        _C_failnoi  = 0x40,   // set ios_base::failbit on no input
+        _C_eatnull  = 0x80    // extract null char
+    };
+
+    // does not construct a sentry, does not affect gcount()
+    // extracts character unless it is equal to __delim
+    int_type _C_unsafe_get (streamsize* = 0,
+                            int_type    = traits_type::eof (),
+                            int         = 0);
+
+private:
+
+    basic_istream& _C_get (basic_streambuf<char_type, traits_type>&, int_type);
+
+    streamsize _C_gcount;   // number of chars extracted
+};
+
+
+
+template<class _CharT, class _Traits>
+inline typename basic_istream<_CharT, _Traits>::int_type
+basic_istream<_CharT, _Traits>::
+get ()
+{
+    const sentry __ipfx (*this, true /* noskipws */);
+
+    if (__ipfx)
+        return _C_unsafe_get (&_C_gcount, traits_type::eof (),
+                              _C_faileof | _C_eatnull);
+
+    return traits_type::eof ();
+}
+
+
+template<class _CharT, class _Traits>
+inline basic_istream<_CharT, _Traits>&
+basic_istream<_CharT, _Traits>::
+get (char_type &__ch)
+{
+    const int_type __c = get ();
+
+    if (!traits_type::eq_int_type (__c, traits_type::eof ()))
+        traits_type::assign (__ch, traits_type::to_char_type (__c));
+
+    return *this;
+}
+
+
+template<class _CharT, class _Traits>
+inline basic_istream<_CharT, _Traits>&
+basic_istream<_CharT, _Traits>::seekg (pos_type __pos)
+{
+    _RWSTD_ASSERT (0 != this->rdbuf ());
+
+    if (!this->fail ()) {
+        _RWSTD_MT_GUARD (this->_C_bufmutex ());
+
+        // 27.6.1.3, p 38 requires that pubseekpos be called with
+        // a single argument; the implemented behavior follows
+        // the proposed resolution of lwg issue 136
+        if (-1 == this->rdbuf ()->pubseekpos (__pos, ios_base::in))
+            this->setstate (ios_base::failbit);   // lwg issue 129
+    }
+
+    return *this;
+}
+
+
+template<class _CharT, class _Traits>
+inline basic_istream<_CharT, _Traits>&
+basic_istream<_CharT, _Traits>::seekg (off_type __off, ios_base::seekdir __dir)
+{
+    _RWSTD_ASSERT (0 != this->rdbuf ());
+
+    if (!this->fail ()) {
+        _RWSTD_MT_GUARD (this->_C_bufmutex ());
+
+        // 27.6.1.3, p 40 requires that pubseekoff be called with
+        // two arguments; the implemented behavior follows
+        // the proposed resolution of lwg issue 136
+        if (-1 == this->rdbuf ()->pubseekoff (__off, __dir, ios_base::in))
+            this->setstate (ios_base::failbit);   // lwg issue 129
+    }
+
+    return *this;
+}
+
+
+template<class _CharT, class _Traits>
+inline basic_istream<_CharT, _Traits>&
+basic_istream<_CharT, _Traits>::
+operator>>(basic_streambuf<char_type, traits_type> *__sb)
+{
+    // lwg issue 60: this is not a formatted input member function
+    if (__sb)
+        return _C_get (*__sb, traits_type::eof ());
+
+    this->setstate (ios_base::failbit);
+    return *this;
+}
+
+
+template<class _CharT, class _Traits>
+inline typename basic_istream<_CharT, _Traits>::int_type
+basic_istream<_CharT, _Traits>::peek ()
+{
+    _RWSTD_ASSERT (0 != this->rdbuf ());
+
+    const sentry __ipfx (*this, true /* noskipws */);
+
+    int_type __c = traits_type::eof ();
+
+    if (__ipfx) {
+        _TRY {
+            __c = this->rdbuf ()->sgetc ();
+        }
+        _CATCH (...) {
+            this->setstate (ios_base::badbit | _RW::__rw_rethrow);
+        }
+    }
+
+    if (traits_type::eq_int_type (__c, traits_type::eof ()))
+        this->setstate (ios_base::eofbit);
+
+    return __c;
+}
+
+
+// 27.6.1.2.3, p10
+template <class _Traits>
+inline basic_istream<char, _Traits>&
+operator>> (basic_istream<char, _Traits> &__strm, unsigned char &__c)
+{
+    return __strm >> _RWSTD_REINTERPRET_CAST (char&, __c);
+}
+
+template <class _Traits>
+inline basic_istream<char, _Traits>&
+operator>> (basic_istream<char, _Traits> &__strm,  signed char &__c)
+{
+    return __strm >> _RWSTD_REINTERPRET_CAST (char&, __c);
+}
+
+
+// 27.6.1.2.3, p6
+template <class _Traits>
+inline basic_istream<char, _Traits>&
+operator>> (basic_istream<char, _Traits> &__strm, unsigned char *__s)
+{
+    return __strm >> _RWSTD_REINTERPRET_CAST (char*, __s);
+}
+
+
+template <class _Traits>
+inline basic_istream<char, _Traits>&
+operator>> (basic_istream<char, _Traits> &__strm, signed char *__s)
+{
+    return __strm >> _RWSTD_REINTERPRET_CAST (char*, __s);
+}
+
+
+// 27.6.1.2.3, p10
+template<class _CharT, class _Traits>
+inline basic_istream<_CharT, _Traits>&
+operator>> (basic_istream<_CharT, _Traits> &__strm, _CharT &__c)
+{
+    // read the first non-space char, set failbit if none read
+    __strm.read (&__c, 1, _Traits::eof (),
+                 __strm._C_skipws | __strm._C_failnoi | __strm._C_eatnull);
+    return __strm;
+}
+
+
+// 27.6.1.2.3, p6
+template<class _CharT, class _Traits>
+inline basic_istream<_CharT, _Traits>&
+operator>> (basic_istream<_CharT, _Traits> &__strm, _CharT *__s)
+{
+    _RWSTD_ASSERT (0 != __s);
+
+    // store at most this many chars including terminating null
+    const streamsize __maxlen = __strm.width () ?
+        __strm.width () : streamsize (_RWSTD_LONG_MAX - 1);
+
+    // read at most __maxlen non-space chars up to the first whitespace
+    __strm.read (__s, __maxlen, _Traits::to_int_type (__strm.widen ('\n')),
+                   __strm._C_nullterm | __strm._C_wsterm
+                 | __strm._C_skipws   | __strm._C_failnoi);
+
+    __strm.width (0);
+
+    return __strm;
+}
+
+
+// 27.6.1.4, p1
+template<class _CharT, class _Traits>
+inline basic_istream<_CharT, _Traits>&
+ws (basic_istream<_CharT, _Traits> &__strm)
+{
+    // construct a sentry to flush tied stream (if any) and lock
+    const typename basic_istream<_CharT, _Traits>::sentry
+        __ipfx (__strm, true /* noskipws */);
+
+    // if sentry is okay, skip whitespace and set eofbit
+    // but not failbit if end-of-file is encountered
+    if (__ipfx) {
+        _TRY {
+            __strm._C_ipfx (false, ios_base::eofbit);
+        }
+        _CATCH (...) {
+            __strm.setstate (ios_base::badbit | _RW::__rw_rethrow);
+        }
+    }
+
+    return __strm;
+}
+
+
+// 27.6.1.5
+template<class _CharT, class _Traits /* = char_traits<_CharT> */>
+class basic_iostream
+    : public basic_istream<_CharT, _Traits>,
+      public basic_ostream<_CharT, _Traits> 
+{
+public:
+
+    // prevent ambiguity between types defined in the bases
+    typedef _CharT                          char_type;
+    typedef _Traits                         traits_type;
+    typedef typename traits_type::int_type int_type;
+    typedef typename traits_type::pos_type pos_type;
+    typedef typename traits_type::off_type off_type;
+
+    explicit basic_iostream (basic_streambuf<_CharT, _Traits> *__sb)
+        : basic_istream<_CharT, _Traits>(__sb), 
+          basic_ostream<_CharT, _Traits>(__sb)
+        { /* 27.6.1.5.1, p1 */ }
+};
+
+}   // namespace std
+
+
+#if _RWSTD_DEFINE_TEMPLATE_FIRST (_BASIC_ISTREAM)
+   // implementation file included here instead of at the end
+   // of the header to work around a IBM VAC++ 7.0 bug #448
+#  include <istream.cc>
+#endif   // _RWSTD_DEFINE_TEMPLATE_FIRST (_BASIC_ISTREAM)
+
+
+#ifdef _RWSTD_MSVC
+#  pragma warning (push)
+#  pragma warning (disable: 4231)
+#endif   // _RWSTD_MSVC
+
+
+_RWSTD_NAMESPACE (std) {
+
+#if _RWSTD_INSTANTIATE (_BASIC_ISTREAM, _CHAR)
+
+_RWSTD_INSTANTIATE_2 (class _RWSTD_TI_EXPORT
+                      basic_istream<char, char_traits<char> >);
+
+#endif   // _RWSTD_INSTANTIATE (_BASIC_ISTREAM, _CHAR)
+
+#if _RWSTD_INSTANTIATE (_BASIC_ISTREAM, _WCHAR_T)
+
+_RWSTD_INSTANTIATE_2 (class _RWSTD_TI_EXPORT
+                      basic_istream<wchar_t, char_traits<wchar_t> >);
+
+#endif   // _RWSTD_INSTANTIATE (_BASIC_ISTREAM, _WCHAR_T)
+
+}   // namespace std
+
+
+#ifdef _RWSTD_MSVC
+#  pragma warning (pop)
+#endif   // _RWSTD_MSVC
+
+
+#if _RWSTD_DEFINE_TEMPLATE_LAST (_BASIC_ISTREAM)
+#  include <istream.cc>
+#endif   // _RWSTD_DEFINE_TEMPLATE_LAST (_BASIC_ISTREAM)
+
+
+#ifndef _RWSTD_STRING_EXTRACTORS_INCLUDED
+#  define _RWSTD_INCLUDE_STRING_EXTRACTORS
+#  include <rw/_stringio.h>
+#endif   // _RWSTD_STRING_EXTRACTORS_INCLUDED
+
+
+#endif   // _RWSTD_ISTREAM_INCLUDED
+

--- a/cnd/cnd.lexer/test/unit/src/org/netbeans/modules/cnd/lexer/CppFlyTokensTestCase.java
+++ b/cnd/cnd.lexer/test/unit/src/org/netbeans/modules/cnd/lexer/CppFlyTokensTestCase.java
@@ -76,13 +76,13 @@ public class CppFlyTokensTestCase extends NbTestCase {
                     + "\nDistribution: " + LexerTestUtilities.flyweightDistribution(ts)
             );
         }
-        assertEquals(1606, LexerTestUtilities.flyweightTokenCount(ts));
-        assertEquals(2822, LexerTestUtilities.flyweightTextLength(ts));
-        assertEquals(2485, ts.tokenCount());         
+        assertEquals(2750, LexerTestUtilities.flyweightTokenCount(ts));
+        assertEquals(4228, LexerTestUtilities.flyweightTextLength(ts));
+        assertEquals(4073, ts.tokenCount());         
     }
     
     public void testHC() throws Exception {
-        File testJComponentFile = new File(getDataDir() + "/testfiles/stdio.h.txt");
+        File testJComponentFile = new File(getDataDir() + "/testfiles/apr_portable.h.txt");
         FileReader r = new FileReader(testJComponentFile);
         int fileLen = (int)testJComponentFile.length();
         CharBuffer cb = CharBuffer.allocate(fileLen);
@@ -101,9 +101,9 @@ public class CppFlyTokensTestCase extends NbTestCase {
             );
         }
         
-        assertEquals(2500, LexerTestUtilities.flyweightTokenCount(ts));
-        assertEquals(4656, LexerTestUtilities.flyweightTextLength(ts));
-        assertEquals(3577, ts.tokenCount());        
+        assertEquals(986, LexerTestUtilities.flyweightTokenCount(ts));
+        assertEquals(1497, LexerTestUtilities.flyweightTextLength(ts));
+        assertEquals(1647, ts.tokenCount());        
     }
     
     public void testC() throws Exception {
@@ -151,9 +151,9 @@ public class CppFlyTokensTestCase extends NbTestCase {
                     + "\nDistribution: " + distribution
             );
         }
-        assertEquals(52, fwTokenCount);
-        assertEquals(66, tokenCount);
-        assertEquals(114, fwTextLength);
+        assertEquals(207, fwTokenCount);
+        assertEquals(294, tokenCount);
+        assertEquals(417, fwTextLength);
         
     }    
 }

--- a/cnd/cnd.lexer/test/unit/src/org/netbeans/modules/cnd/lexer/CppLexerPerformanceTestCase.java
+++ b/cnd/cnd.lexer/test/unit/src/org/netbeans/modules/cnd/lexer/CppLexerPerformanceTestCase.java
@@ -138,7 +138,7 @@ public class CppLexerPerformanceTestCase extends NbTestCase {
     }
 
     private String readFile() throws Exception {
-        File testJComponentFile = new File(getDataDir() + "/testfiles/stdio.h.txt");
+        File testJComponentFile = new File(getDataDir() + "/testfiles/apr_portable.h.txt");
         FileReader r = new FileReader(testJComponentFile);
         try {
             int fileLen = (int)testJComponentFile.length();

--- a/cnd/cnd.makeproject/build.xml
+++ b/cnd/cnd.makeproject/build.xml
@@ -27,14 +27,14 @@
     <import file="../../nbbuild/templates/projectized.xml"/>
     
     <!-- zip up samples before creating the jar file -->
-    <property name="cnd/sample-src" value="samples_src"/>
-    <property name="cnd/sample-dist" value="build/classes/org/netbeans/modules/cnd/makeproject/resources/samples"/>
+    <property name="sample-src" value="samples_src"/>
+    <property name="sample-dist" value="build/classes/org/netbeans/modules/cnd/makeproject/resources/samples"/>
     <patternset id="sample-src-pattern-set">
-        <include name="cnd/**/*"/>
-        <exclude name="cnd/**/SCCS"/>
-        <exclude name="cnd/**/CVS"/>
+        <include name="**/*"/>
+        <exclude name="**/SCCS"/>
+        <exclude name="**/CVS"/>
     </patternset>
-    <target name="cnd/jar-prep" depends="projectized-common.jar-prep">
+    <target name="jar-prep" depends="projectized-common.jar-prep">
         <mkdir dir="${sample-dist}"/>
         <zip zipfile="${sample-dist}/args.zip" >
             <fileset dir="${sample-src}/args">


### PR DESCRIPTION
This one:
- Restores the C/C++ Samples.
- Passes cnd.lexer tests (includes new source from other ASF projects)
- Passes cnd.editor tests (ignores test with clang format not available through libclank now).