### PR TITLE
Native image breakpoints work with shared libraries.

### DIFF
--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteDebugger.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteDebugger.java
@@ -968,7 +968,7 @@ public final class CPPLiteDebugger {
         private void addBreakpoint(CPPLiteBreakpoint breakpoint) {
             String path = breakpoint.getFilePath();
             int lineNumber = breakpoint.getLineNumber();
-            String disabled = breakpoint.isEnabled() ? "" : "-d ";
+            String disabled = breakpoint.isEnabled() ? "-f " : "-d ";
             Command command = new Command("-break-insert " + disabled + path + ":" + lineNumber) {
                 @Override
                 protected void onDone(MIRecord record) {

--- a/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/breakpoints/JPDABreakpointsHandler.java
+++ b/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/breakpoints/JPDABreakpointsHandler.java
@@ -46,6 +46,8 @@ import org.openide.filesystems.URLMapper;
  */
 public class JPDABreakpointsHandler extends DebuggerManagerAdapter implements PropertyChangeListener {
 
+    private static final String SOURCES_FOLDER = "sources"; // NOI18N
+
     private final File niFileSources;
     private final NIDebugger debugger;
     private final Set<JPDABreakpoint> attachedBreakpoints = new HashSet<>();
@@ -62,7 +64,7 @@ public class JPDABreakpointsHandler extends DebuggerManagerAdapter implements Pr
     }
 
     private static File getNativeSources(File niFile) {
-        File sources = new File(niFile.getParentFile(), "sources");
+        File sources = new File(niFile.getParentFile(), SOURCES_FOLDER);
         if (sources.isDirectory()) {
             return sources;
         } else {
@@ -124,16 +126,12 @@ public class JPDABreakpointsHandler extends DebuggerManagerAdapter implements Pr
                 return null;
             }
             String filePath = null;
-            if (niFileSources != null) {
-                FileObject fo;
-                fo = URLMapper.findFileObject(url);
-                for (FileObject root : GlobalPathRegistry.getDefault().getSourceRoots()) {
-                    if (FileUtil.isParentOf(root, fo)) {
-                        String path = FileUtil.getRelativePath(root, fo);
-                        File sourcesFile = new File(niFileSources, path);
-                        filePath = sourcesFile.getAbsolutePath();
-                        break;
-                    }
+            FileObject fo = URLMapper.findFileObject(url);
+            for (FileObject root : GlobalPathRegistry.getDefault().getSourceRoots()) {
+                if (FileUtil.isParentOf(root, fo)) {
+                    String path = FileUtil.getRelativePath(root, fo);
+                    filePath = SOURCES_FOLDER + File.separator + path;
+                    break;
                 }
             }
             if (filePath == null) {


### PR DESCRIPTION
When submitting a breakpoint into a Java native image, we consult the list of source files from the executable to determine the correct destination file.

The breakpoint's file is resolved relative to the `sources` folder, which is expected to be the sibling of the executable file.
When the `sources` folder is not found, breakpoints are resolved to locations that do not exist in the executable.
To verify the correctness of file paths, we use a newly introduced `NIDebugger.listSources()` method.