### PR TITLE
[cnd] small-1.5 More cnd tests

### DIFF
--- a/cnd/cnd.remote/nbproject/project.xml
+++ b/cnd/cnd.remote/nbproject/project.xml
@@ -225,10 +225,6 @@
                         <test/>
                     </test-dependency>
                     <test-dependency>
-                        <code-name-base>org.netbeans.modules.cnd.api.model</code-name-base>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
                         <code-name-base>org.netbeans.modules.cnd.api.project</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
@@ -244,19 +240,6 @@
                     <test-dependency>
                         <code-name-base>org.netbeans.modules.cnd.makeproject.ui</code-name-base>
                         <recursive/>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.cnd.modelimpl</code-name-base>
-                        <recursive/>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.cnd.repository</code-name-base>
-                        <compile-dependency/>
-                    </test-dependency>
-                    <test-dependency>
-                        <code-name-base>org.netbeans.modules.cnd.repository.api</code-name-base>
                         <compile-dependency/>
                     </test-dependency>
                     <test-dependency>

--- a/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/fs/FullRemoteCodeModelTestCase.java
+++ b/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/fs/FullRemoteCodeModelTestCase.java
@@ -19,16 +19,26 @@
 package org.netbeans.modules.cnd.remote.fs;
 
 import java.io.OutputStreamWriter;
+import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import junit.framework.Test;
+import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
+//import org.netbeans.modules.cnd.api.model.CsmFile;
+//import org.netbeans.modules.cnd.api.model.CsmModelAccessor;
+//import org.netbeans.modules.cnd.api.model.CsmOffsetableDeclaration;
+//import org.netbeans.modules.cnd.api.model.CsmProject;
+//import org.netbeans.modules.cnd.indexing.impl.TextIndexStorageManager;
 import org.netbeans.modules.cnd.makeproject.api.MakeProject;
+//import org.netbeans.modules.cnd.modelimpl.csm.core.ModelImpl;
+//import org.netbeans.modules.cnd.modelimpl.platform.ModelSupport;
 import org.netbeans.modules.cnd.remote.test.RemoteBuildTestBase;
 import org.netbeans.modules.cnd.remote.test.RemoteDevelopmentTest;
+//import org.netbeans.modules.cnd.repository.support.RepositoryTestUtils;
 import org.netbeans.modules.nativeexecution.api.ExecutionEnvironment;
 import org.netbeans.modules.nativeexecution.api.util.CommonTasksSupport;
 import org.netbeans.modules.nativeexecution.api.util.ConnectionManager;
@@ -36,6 +46,9 @@ import org.netbeans.modules.nativeexecution.test.ForAllEnvironments;
 import org.netbeans.modules.remote.spi.FileSystemProvider;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
+
+// NOTE: Some tests commented out since Apache NetBeans does not use the
+// donated cnd.api.model, cnd.indexing, cnd.modelimpl and cnd.repository modules.
 
 /**
  *
@@ -49,10 +62,32 @@ public class FullRemoteCodeModelTestCase extends RemoteBuildTestBase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+//        startupModel();
         System.setProperty("cnd.mode.unittest", "true");
         System.setProperty("org.netbeans.modules.cnd.apt.level", "OFF"); // NOI18N
         Logger.getLogger("org.netbeans.modules.editor.settings.storage.Utils").setLevel(Level.SEVERE);
     }
+
+//    @Override
+//    protected void tearDown() throws Exception {
+//        super.tearDown();
+//        shutdownModel();
+//    }
+//
+//    private void shutdownModel() {
+//        ModelImpl model = (ModelImpl) CsmModelAccessor.getModel();
+//        model.shutdown();
+//        ModelSupport.instance().shutdown();
+//        TextIndexStorageManager.shutdown();
+//        RepositoryTestUtils.deleteDefaultCacheLocation();
+//    }
+//
+//    private void startupModel() {
+//        RepositoryTestUtils.deleteDefaultCacheLocation();
+//        ModelImpl model = (ModelImpl) CsmModelAccessor.getModel();
+//        model.startup();
+//        ModelSupport.instance().startup();
+//    }
 
     protected void processSample(String sampleName) throws Exception {
         final ExecutionEnvironment execEnv = getTestExecutionEnvironment();
@@ -67,6 +102,7 @@ public class FullRemoteCodeModelTestCase extends RemoteBuildTestBase {
             assertTrue("Should be remote: " + makeProject.getProjectDirectory(), FileSystemProvider.getExecutionEnvironment(makeProject.getProjectDirectory()).isRemote());
             assertTrue("Host should be connected at this point", ConnectionManager.getInstance().isConnectedTo(execEnv));
             OpenProjects.getDefault().open(new Project[]{makeProject}, false);
+//            checkCodeModel(makeProject);
         } finally {
             if (remoteTempDir != null) {
                 CommonTasksSupport.rmDir(execEnv, remoteTempDir, true, new OutputStreamWriter(System.err));
@@ -74,6 +110,21 @@ public class FullRemoteCodeModelTestCase extends RemoteBuildTestBase {
         }        
     }
     
+//    @Override
+//    protected void checkCodeModel(MakeProject makeProject) throws Exception {
+//        CsmProject csmProject = getCsmProject(makeProject);
+//        assertNotNull("Null CsmProject", csmProject);
+//        csmProject.waitParse();
+//        Collection<CsmFile> allFiles = csmProject.getAllFiles();
+//        assertEquals("Expected amount of csm files ", 1, allFiles.size());
+//        CsmFile mainFile = allFiles.iterator().next();
+//        Collection<CsmOffsetableDeclaration> decls = mainFile.getDeclarations();
+//        assertEquals("Excpected amount of declarations", 1, decls.size());
+//        CsmOffsetableDeclaration decl = decls.iterator().next();
+//        assertEquals("Declaration name", "main", decl.getName().toString());
+//        assertTrue("File object should be remote", FileSystemProvider.getExecutionEnvironment(mainFile.getFileObject()).isRemote());
+//    }
+
     @ForAllEnvironments
     public void testArguments() throws Exception {
         processSample("Arguments");

--- a/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/fs/FullRemoteCodeModelTestCase.java
+++ b/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/fs/FullRemoteCodeModelTestCase.java
@@ -19,26 +19,16 @@
 package org.netbeans.modules.cnd.remote.fs;
 
 import java.io.OutputStreamWriter;
-import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import junit.framework.Test;
-import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.api.project.ui.OpenProjects;
-import org.netbeans.modules.cnd.api.model.CsmFile;
-import org.netbeans.modules.cnd.api.model.CsmModelAccessor;
-import org.netbeans.modules.cnd.api.model.CsmOffsetableDeclaration;
-import org.netbeans.modules.cnd.api.model.CsmProject;
-import org.netbeans.modules.cnd.indexing.impl.TextIndexStorageManager;
 import org.netbeans.modules.cnd.makeproject.api.MakeProject;
-import org.netbeans.modules.cnd.modelimpl.csm.core.ModelImpl;
-import org.netbeans.modules.cnd.modelimpl.platform.ModelSupport;
 import org.netbeans.modules.cnd.remote.test.RemoteBuildTestBase;
 import org.netbeans.modules.cnd.remote.test.RemoteDevelopmentTest;
-import org.netbeans.modules.cnd.repository.support.RepositoryTestUtils;
 import org.netbeans.modules.nativeexecution.api.ExecutionEnvironment;
 import org.netbeans.modules.nativeexecution.api.util.CommonTasksSupport;
 import org.netbeans.modules.nativeexecution.api.util.ConnectionManager;
@@ -59,31 +49,9 @@ public class FullRemoteCodeModelTestCase extends RemoteBuildTestBase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        startupModel();
         System.setProperty("cnd.mode.unittest", "true");
         System.setProperty("org.netbeans.modules.cnd.apt.level", "OFF"); // NOI18N
         Logger.getLogger("org.netbeans.modules.editor.settings.storage.Utils").setLevel(Level.SEVERE);
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-        shutdownModel();
-    }
-
-    private void shutdownModel() {
-        ModelImpl model = (ModelImpl) CsmModelAccessor.getModel();
-        model.shutdown();
-        ModelSupport.instance().shutdown();
-        TextIndexStorageManager.shutdown();
-        RepositoryTestUtils.deleteDefaultCacheLocation();
-    }
-
-    private void startupModel() {
-        RepositoryTestUtils.deleteDefaultCacheLocation();
-        ModelImpl model = (ModelImpl) CsmModelAccessor.getModel();
-        model.startup();
-        ModelSupport.instance().startup();
     }
 
     protected void processSample(String sampleName) throws Exception {
@@ -99,7 +67,6 @@ public class FullRemoteCodeModelTestCase extends RemoteBuildTestBase {
             assertTrue("Should be remote: " + makeProject.getProjectDirectory(), FileSystemProvider.getExecutionEnvironment(makeProject.getProjectDirectory()).isRemote());
             assertTrue("Host should be connected at this point", ConnectionManager.getInstance().isConnectedTo(execEnv));
             OpenProjects.getDefault().open(new Project[]{makeProject}, false);
-            checkCodeModel(makeProject);
         } finally {
             if (remoteTempDir != null) {
                 CommonTasksSupport.rmDir(execEnv, remoteTempDir, true, new OutputStreamWriter(System.err));
@@ -107,21 +74,6 @@ public class FullRemoteCodeModelTestCase extends RemoteBuildTestBase {
         }        
     }
     
-    @Override
-    protected void checkCodeModel(MakeProject makeProject) throws Exception {
-        CsmProject csmProject = getCsmProject(makeProject);
-        assertNotNull("Null CsmProject", csmProject);
-        csmProject.waitParse();
-        Collection<CsmFile> allFiles = csmProject.getAllFiles();
-        assertEquals("Expected amount of csm files ", 1, allFiles.size());
-        CsmFile mainFile = allFiles.iterator().next();
-        Collection<CsmOffsetableDeclaration> decls = mainFile.getDeclarations();
-        assertEquals("Excpected amount of declarations", 1, decls.size());
-        CsmOffsetableDeclaration decl = decls.iterator().next();
-        assertEquals("Declaration name", "main", decl.getName().toString());
-        assertTrue("File object should be remote", FileSystemProvider.getExecutionEnvironment(mainFile.getFileObject()).isRemote());
-    }
-
     @ForAllEnvironments
     public void testArguments() throws Exception {
         processSample("Arguments");

--- a/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/fs/RemoteCodeModelTestCase.java
+++ b/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/fs/RemoteCodeModelTestCase.java
@@ -26,11 +26,19 @@ import junit.framework.Test;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.junit.RandomlyFails;
+//import org.netbeans.modules.cnd.api.model.CsmModelAccessor;
+//import org.netbeans.modules.cnd.indexing.impl.TextIndexStorageManager;
 import org.netbeans.modules.cnd.makeproject.api.MakeProject;
+//import org.netbeans.modules.cnd.modelimpl.csm.core.ModelImpl;
+//import org.netbeans.modules.cnd.modelimpl.platform.ModelSupport;
 import org.netbeans.modules.cnd.remote.test.RemoteDevelopmentTest;
+//import org.netbeans.modules.cnd.repository.support.RepositoryTestUtils;
 import org.netbeans.modules.nativeexecution.api.ExecutionEnvironment;
 import org.netbeans.modules.nativeexecution.api.util.ConnectionManager;
 import org.netbeans.modules.nativeexecution.test.ForAllEnvironments;
+
+// NOTE: Some tests commented out since Apache NetBeans does not use the
+// donated "cnd.api.model, cnd.indexing, cnd.modelimpl and cnd.repository modules.
 
 /**
  *
@@ -46,6 +54,7 @@ public class RemoteCodeModelTestCase extends RemoteBuildTestBase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+//        startupModel();
         System.setProperty("cnd.mode.unittest", "true");
         System.setProperty("org.netbeans.modules.cnd.apt.level","OFF"); // NOI18N
         Logger.getLogger("org.netbeans.modules.editor.settings.storage.Utils").setLevel(Level.SEVERE);
@@ -54,8 +63,25 @@ public class RemoteCodeModelTestCase extends RemoteBuildTestBase {
     @Override
     protected void tearDown() throws Exception {
         super.tearDown(); 
+//        shutdownModel();
     }
     
+    
+//    private void shutdownModel() {
+//        ModelImpl model = (ModelImpl) CsmModelAccessor.getModel();
+//        model.shutdown();
+//        ModelSupport.instance().shutdown();
+//        TextIndexStorageManager.shutdown();
+//        RepositoryTestUtils.deleteDefaultCacheLocation();
+//    }    
+//
+//    private void startupModel() {
+//        RepositoryTestUtils.deleteDefaultCacheLocation();
+//        ModelImpl model = (ModelImpl) CsmModelAccessor.getModel();
+//        model.startup();
+//        ModelSupport.instance().startup();        
+//    }
+
     @Override
     protected void clearRemoteSyncRoot() {
         super.clearRemoteSyncRoot();
@@ -74,6 +100,7 @@ public class RemoteCodeModelTestCase extends RemoteBuildTestBase {
         }
         OpenProjects.getDefault().open(new Project[]{ makeProject }, false);
         changeProjectHost(makeProject, execEnv);
+//        checkCodeModel(makeProject);
         if (testReconnect) {
             ConnectionManager.getInstance().connectTo(execEnv);
             assertTrue("Can not reconnect to host", ConnectionManager.getInstance().isConnectedTo(execEnv));

--- a/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/fs/RemoteCodeModelTestCase.java
+++ b/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/fs/RemoteCodeModelTestCase.java
@@ -26,13 +26,8 @@ import junit.framework.Test;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.junit.RandomlyFails;
-import org.netbeans.modules.cnd.api.model.CsmModelAccessor;
-import org.netbeans.modules.cnd.indexing.impl.TextIndexStorageManager;
 import org.netbeans.modules.cnd.makeproject.api.MakeProject;
-import org.netbeans.modules.cnd.modelimpl.csm.core.ModelImpl;
-import org.netbeans.modules.cnd.modelimpl.platform.ModelSupport;
 import org.netbeans.modules.cnd.remote.test.RemoteDevelopmentTest;
-import org.netbeans.modules.cnd.repository.support.RepositoryTestUtils;
 import org.netbeans.modules.nativeexecution.api.ExecutionEnvironment;
 import org.netbeans.modules.nativeexecution.api.util.ConnectionManager;
 import org.netbeans.modules.nativeexecution.test.ForAllEnvironments;
@@ -51,7 +46,6 @@ public class RemoteCodeModelTestCase extends RemoteBuildTestBase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        startupModel();
         System.setProperty("cnd.mode.unittest", "true");
         System.setProperty("org.netbeans.modules.cnd.apt.level","OFF"); // NOI18N
         Logger.getLogger("org.netbeans.modules.editor.settings.storage.Utils").setLevel(Level.SEVERE);
@@ -60,25 +54,8 @@ public class RemoteCodeModelTestCase extends RemoteBuildTestBase {
     @Override
     protected void tearDown() throws Exception {
         super.tearDown(); 
-        shutdownModel();
     }
     
-    
-    private void shutdownModel() {
-        ModelImpl model = (ModelImpl) CsmModelAccessor.getModel();
-        model.shutdown();
-        ModelSupport.instance().shutdown();
-        TextIndexStorageManager.shutdown();
-        RepositoryTestUtils.deleteDefaultCacheLocation();
-    }    
-
-    private void startupModel() {
-        RepositoryTestUtils.deleteDefaultCacheLocation();
-        ModelImpl model = (ModelImpl) CsmModelAccessor.getModel();
-        model.startup();
-        ModelSupport.instance().startup();        
-    }
-
     @Override
     protected void clearRemoteSyncRoot() {
         super.clearRemoteSyncRoot();
@@ -97,7 +74,6 @@ public class RemoteCodeModelTestCase extends RemoteBuildTestBase {
         }
         OpenProjects.getDefault().open(new Project[]{ makeProject }, false);
         changeProjectHost(makeProject, execEnv);
-        checkCodeModel(makeProject);
         if (testReconnect) {
             ConnectionManager.getInstance().connectTo(execEnv);
             assertTrue("Can not reconnect to host", ConnectionManager.getInstance().isConnectedTo(execEnv));

--- a/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/full/FullRemoteBuildTestCase.java
+++ b/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/full/FullRemoteBuildTestCase.java
@@ -28,6 +28,7 @@ import junit.framework.AssertionFailedError;
 import org.netbeans.modules.cnd.remote.test.RemoteBuildTestBase;
 import junit.framework.Test;
 import org.netbeans.api.project.ProjectManager;
+//import org.netbeans.modules.cnd.api.model.CsmProject;
 import org.netbeans.modules.cnd.makeproject.api.MakeProject;
 import org.netbeans.modules.cnd.remote.test.RemoteDevelopmentTest;
 import org.netbeans.modules.nativeexecution.api.ExecutionEnvironment;
@@ -38,6 +39,9 @@ import org.netbeans.modules.nativeexecution.test.ForAllEnvironments;
 import org.netbeans.modules.remote.spi.FileSystemProvider;
 import org.netbeans.spi.project.ActionProvider;
 import org.openide.filesystems.FileObject;
+
+// NOTE: Some tests commented out since Apache NetBeans does not use the
+// donated "cnd.api.model, cnd.indexing, cnd.modelimpl and cnd.repository modules.
 
 /**
  */
@@ -97,6 +101,31 @@ public class FullRemoteBuildTestCase extends RemoteBuildTestBase {
     }
 
     @ForAllEnvironments
+    public void test_iz_249533() throws Exception {
+        MakeProject makeProject = importProject("simple_make_project_to_import", false);
+        final String origHeaderName = "change_case.h";
+        final FileObject parentFO = makeProject.getProjectDirectory();
+        FileObject headerFO = parentFO.getFileObject(origHeaderName);
+        assertNotNull(headerFO);
+        headerFO.delete();
+//        CsmProject csmProject = getCsmProject(makeProject);
+        AtomicReference<AssertionFailedError> exRef = new AtomicReference<>();
+//        try {
+//            checkCodeModel(makeProject);
+//        } catch (AssertionFailedError ex) {
+//            exRef.set(ex);
+//        }
+        AssertionFailedError ex = exRef.get();
+        assertNotNull(ex);
+        String messageStart = "Unresolved include";
+        assertTrue("Unexpected exception " + ex.getMessage() + ", expected " + messageStart  , ex.getMessage().startsWith(messageStart));
+        headerFO = parentFO.createData(origHeaderName);
+        sleep(1);
+//        csmProject.waitParse();
+//        checkCodeModel(makeProject);
+    }
+
+    @ForAllEnvironments
     public void testFullRemoteBuildSimple() throws Exception {
         MakeProject makeProject = importProject("simple_make_project_to_import", false);
         buildProject(makeProject, ActionProvider.COMMAND_BUILD, getSampleBuildTimeout(), TimeUnit.SECONDS);
@@ -111,11 +140,13 @@ public class FullRemoteBuildTestCase extends RemoteBuildTestBase {
     @ForAllEnvironments
     public void testFullRemoteCodeModelSimple() throws Exception {
         MakeProject makeProject = importProject("simple_make_project_to_import", false);
+//        checkCodeModel(makeProject);
     }
     
     @ForAllEnvironments
     public void testFullRemoteCodeModelLink() throws Exception {
         MakeProject makeProject = importProject("simple_make_project_to_import", true);
+//        checkCodeModel(makeProject);
     }
     
     // hg filters out "nbproject/private", for that reason we have to rewname it and restore correct name while copying

--- a/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/full/FullRemoteBuildTestCase.java
+++ b/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/full/FullRemoteBuildTestCase.java
@@ -28,7 +28,6 @@ import junit.framework.AssertionFailedError;
 import org.netbeans.modules.cnd.remote.test.RemoteBuildTestBase;
 import junit.framework.Test;
 import org.netbeans.api.project.ProjectManager;
-import org.netbeans.modules.cnd.api.model.CsmProject;
 import org.netbeans.modules.cnd.makeproject.api.MakeProject;
 import org.netbeans.modules.cnd.remote.test.RemoteDevelopmentTest;
 import org.netbeans.modules.nativeexecution.api.ExecutionEnvironment;
@@ -98,31 +97,6 @@ public class FullRemoteBuildTestCase extends RemoteBuildTestBase {
     }
 
     @ForAllEnvironments
-    public void test_iz_249533() throws Exception {
-        MakeProject makeProject = importProject("simple_make_project_to_import", false);
-        final String origHeaderName = "change_case.h";
-        final FileObject parentFO = makeProject.getProjectDirectory();
-        FileObject headerFO = parentFO.getFileObject(origHeaderName);
-        assertNotNull(headerFO);
-        headerFO.delete();
-        CsmProject csmProject = getCsmProject(makeProject);
-        AtomicReference<AssertionFailedError> exRef = new AtomicReference<>();
-        try {
-            checkCodeModel(makeProject);
-        } catch (AssertionFailedError ex) {
-            exRef.set(ex);
-        }
-        AssertionFailedError ex = exRef.get();
-        assertNotNull(ex);
-        String messageStart = "Unresolved include";
-        assertTrue("Unexpected exception " + ex.getMessage() + ", expected " + messageStart  , ex.getMessage().startsWith(messageStart));
-        headerFO = parentFO.createData(origHeaderName);
-        sleep(1);
-        csmProject.waitParse();
-        checkCodeModel(makeProject);
-    }
-
-    @ForAllEnvironments
     public void testFullRemoteBuildSimple() throws Exception {
         MakeProject makeProject = importProject("simple_make_project_to_import", false);
         buildProject(makeProject, ActionProvider.COMMAND_BUILD, getSampleBuildTimeout(), TimeUnit.SECONDS);
@@ -137,13 +111,11 @@ public class FullRemoteBuildTestCase extends RemoteBuildTestBase {
     @ForAllEnvironments
     public void testFullRemoteCodeModelSimple() throws Exception {
         MakeProject makeProject = importProject("simple_make_project_to_import", false);
-        checkCodeModel(makeProject);
     }
     
     @ForAllEnvironments
     public void testFullRemoteCodeModelLink() throws Exception {
         MakeProject makeProject = importProject("simple_make_project_to_import", true);
-        checkCodeModel(makeProject);
     }
     
     // hg filters out "nbproject/private", for that reason we have to rewname it and restore correct name while copying

--- a/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/test/RemoteBuildTestBase.java
+++ b/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/test/RemoteBuildTestBase.java
@@ -24,20 +24,12 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.SwingUtilities;
 import org.netbeans.api.annotations.common.SuppressWarnings;
 import org.netbeans.api.project.ProjectManager;
-import org.netbeans.modules.cnd.api.model.CsmFile;
-import org.netbeans.modules.cnd.api.model.CsmInclude;
-import org.netbeans.modules.cnd.api.model.CsmModel;
-import org.netbeans.modules.cnd.api.model.CsmModelAccessor;
-import org.netbeans.modules.cnd.api.model.CsmProject;
-import org.netbeans.modules.cnd.api.project.NativeProject;
 import org.netbeans.modules.cnd.api.remote.RemoteFileUtil;
 import org.netbeans.modules.cnd.api.remote.ServerList;
 import org.netbeans.modules.cnd.api.remote.ServerRecord;
@@ -56,7 +48,6 @@ import org.netbeans.modules.cnd.makeproject.api.configurations.MakeConfiguration
 import org.netbeans.modules.cnd.makeproject.api.configurations.MakeConfigurationDescriptor;
 import org.netbeans.modules.cnd.makeproject.api.ui.wizard.WizardConstants;
 import org.netbeans.modules.cnd.makeproject.ui.wizards.MakeSampleProjectIterator;
-import org.netbeans.modules.cnd.modelimpl.csm.core.ModelImpl;
 import org.netbeans.modules.cnd.remote.server.RemoteServerRecord;
 import org.netbeans.modules.cnd.spi.remote.RemoteSyncFactory;
 import org.netbeans.modules.cnd.utils.FSPath;
@@ -365,6 +356,10 @@ public class RemoteBuildTestBase extends RemoteTestBase {
         }
     }
 
+    /*
+    NOTE: Dependency with CSM (Code Source Model/code model api) has been
+    dropped during the migration to Apache NetBeans.
+
     protected CsmProject getCsmProject(MakeProject makeProject) throws Exception {
         NativeProject np = makeProject.getLookup().lookup(NativeProject.class);
         assertNotNull("Null NativeProject", np);
@@ -395,12 +390,12 @@ public class RemoteBuildTestBase extends RemoteTestBase {
             }
         }
     }
-
     protected void checkIncludes(CsmProject csmProject, boolean recursive) throws Exception {
         for (CsmFile csmFile : csmProject.getAllFiles()) {
             checkIncludes(csmFile, recursive, new HashSet<CsmFile>());
         }
     }
+    */
     
     protected void trace(String pattern, Object... args) {
         if (trace) {

--- a/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/test/RemoteBuildTestBase.java
+++ b/cnd/cnd.remote/test/unit/src/org/netbeans/modules/cnd/remote/test/RemoteBuildTestBase.java
@@ -24,12 +24,20 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.SwingUtilities;
 import org.netbeans.api.annotations.common.SuppressWarnings;
 import org.netbeans.api.project.ProjectManager;
+//import org.netbeans.modules.cnd.api.model.CsmFile;
+//import org.netbeans.modules.cnd.api.model.CsmInclude;
+//import org.netbeans.modules.cnd.api.model.CsmModel;
+//import org.netbeans.modules.cnd.api.model.CsmModelAccessor;
+//import org.netbeans.modules.cnd.api.model.CsmProject;
+import org.netbeans.modules.cnd.api.project.NativeProject;
 import org.netbeans.modules.cnd.api.remote.RemoteFileUtil;
 import org.netbeans.modules.cnd.api.remote.ServerList;
 import org.netbeans.modules.cnd.api.remote.ServerRecord;
@@ -48,6 +56,7 @@ import org.netbeans.modules.cnd.makeproject.api.configurations.MakeConfiguration
 import org.netbeans.modules.cnd.makeproject.api.configurations.MakeConfigurationDescriptor;
 import org.netbeans.modules.cnd.makeproject.api.ui.wizard.WizardConstants;
 import org.netbeans.modules.cnd.makeproject.ui.wizards.MakeSampleProjectIterator;
+//import org.netbeans.modules.cnd.modelimpl.csm.core.ModelImpl;
 import org.netbeans.modules.cnd.remote.server.RemoteServerRecord;
 import org.netbeans.modules.cnd.spi.remote.RemoteSyncFactory;
 import org.netbeans.modules.cnd.utils.FSPath;
@@ -65,6 +74,9 @@ import org.openide.loaders.DataObject;
 import org.openide.loaders.DataObjectNotFoundException;
 import org.openide.loaders.TemplateWizard;
 import org.openide.nodes.Node;
+
+// NOTE: Some tests commented out since Apache NetBeans does not use the
+// donated cnd.api.model, cnd.indexing, cnd.modelimpl and cnd.repository modules.
 
 /**
  * A common base class for tests that build remote project
@@ -356,46 +368,42 @@ public class RemoteBuildTestBase extends RemoteTestBase {
         }
     }
 
-    /*
-    NOTE: Dependency with CSM (Code Source Model/code model api) has been
-    dropped during the migration to Apache NetBeans.
-
-    protected CsmProject getCsmProject(MakeProject makeProject) throws Exception {
-        NativeProject np = makeProject.getLookup().lookup(NativeProject.class);
-        assertNotNull("Null NativeProject", np);
-        CsmModel model = CsmModelAccessor.getModel();
-        ((ModelImpl) model).enableProject(np);
-        CsmProject csmProject = model.getProject(makeProject);
-        return csmProject;
-    }
-    
-    protected void checkCodeModel(MakeProject makeProject) throws Exception {
-        CsmProject csmProject = getCsmProject(makeProject);
-        assertNotNull("Null CsmProject", csmProject);
-        csmProject.waitParse();
-        checkIncludes(csmProject, true);
-    }
-        
-    protected void checkIncludes(CsmFile csmFile, boolean recursive, Set<CsmFile> antiLoop) throws Exception {
-        if (!antiLoop.contains(csmFile)) {
-            antiLoop.add(csmFile);
-            trace("Checking %s\n", csmFile.getAbsolutePath());
-            for (CsmInclude incl : csmFile.getIncludes()) {
-                CsmFile includedFile = incl.getIncludeFile();
-                trace("\t%s -> %s\n", incl.getIncludeName(), includedFile);
-                assertNotNull("Unresolved include: " + incl.getIncludeName() + " in " + csmFile.getAbsolutePath(), includedFile);
-                if (recursive) {
-                    checkIncludes(includedFile, true, antiLoop);
-                }
-            }
-        }
-    }
-    protected void checkIncludes(CsmProject csmProject, boolean recursive) throws Exception {
-        for (CsmFile csmFile : csmProject.getAllFiles()) {
-            checkIncludes(csmFile, recursive, new HashSet<CsmFile>());
-        }
-    }
-    */
+//    protected CsmProject getCsmProject(MakeProject makeProject) throws Exception {
+//        NativeProject np = makeProject.getLookup().lookup(NativeProject.class);
+//        assertNotNull("Null NativeProject", np);
+//        CsmModel model = CsmModelAccessor.getModel();
+//        ((ModelImpl) model).enableProject(np);
+//        CsmProject csmProject = model.getProject(makeProject);
+//        return csmProject;
+//    }
+//    
+//    protected void checkCodeModel(MakeProject makeProject) throws Exception {
+//        CsmProject csmProject = getCsmProject(makeProject);
+//        assertNotNull("Null CsmProject", csmProject);
+//        csmProject.waitParse();
+//        checkIncludes(csmProject, true);
+//    }
+//        
+//    protected void checkIncludes(CsmFile csmFile, boolean recursive, Set<CsmFile> antiLoop) throws Exception {
+//        if (!antiLoop.contains(csmFile)) {
+//            antiLoop.add(csmFile);
+//            trace("Checking %s\n", csmFile.getAbsolutePath());
+//            for (CsmInclude incl : csmFile.getIncludes()) {
+//                CsmFile includedFile = incl.getIncludeFile();
+//                trace("\t%s -> %s\n", incl.getIncludeName(), includedFile);
+//                assertNotNull("Unresolved include: " + incl.getIncludeName() + " in " + csmFile.getAbsolutePath(), includedFile);
+//                if (recursive) {
+//                    checkIncludes(includedFile, true, antiLoop);
+//                }
+//            }
+//        }
+//    }
+//
+//    protected void checkIncludes(CsmProject csmProject, boolean recursive) throws Exception {
+//        for (CsmFile csmFile : csmProject.getAllFiles()) {
+//            checkIncludes(csmFile, recursive, new HashSet<CsmFile>());
+//        }
+//    }
     
     protected void trace(String pattern, Object... args) {
         if (trace) {

--- a/cnd/cnd.toolchain/test/unit/src/org/netbeans/modules/cnd/toolchain/api/ValidateRegistryTestCase.java
+++ b/cnd/cnd.toolchain/test/unit/src/org/netbeans/modules/cnd/toolchain/api/ValidateRegistryTestCase.java
@@ -87,6 +87,10 @@ public class ValidateRegistryTestCase extends NbTestCase {
             public void error(SAXParseException exception) throws SAXException {
                 if ("Document is invalid: no grammar found.".equals(exception.getMessage())) {
                     return;
+                } else if ("El documento no es válido: no se ha encontrado la gramática.".equals(exception.getMessage())) {
+                    return;
+                } else if ("El elemento raíz del documento \"toolchaindefinition\", debe coincidir con la raíz DOCTYPE \"null\".".equals(exception.getMessage()) ) {
+                    return;
                 } else if ("Document root element \"toolchaindefinition\", must match DOCTYPE root \"null\".".equals(exception.getMessage())) {
                     return;
                 }

--- a/cnd/cnd/test/unit/src/org/netbeans/modules/cnd/test/CndCoreTestUtils.java
+++ b/cnd/cnd/test/unit/src/org/netbeans/modules/cnd/test/CndCoreTestUtils.java
@@ -33,7 +33,6 @@ import javax.swing.text.StyledDocument;
 import org.netbeans.editor.BaseDocument;
 import org.netbeans.editor.Utilities;
 import org.netbeans.junit.Manager;
-import org.netbeans.modules.cnd.modelutil.CsmUtilities;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
@@ -73,6 +72,31 @@ public class CndCoreTestUtils {
         } 
         return editor[0];
     }
+
+    /**
+     * This method taken from from contrib/cnd.modelutil:
+     * opens document even if it is very big by silently confirming open
+     * @param cookie
+     * @return
+     */
+    private static StyledDocument openDocument(EditorCookie cookie) {
+        if (cookie == null) {
+            return null;
+        }
+        StyledDocument document = null;
+        try {
+            try {
+                document = cookie.openDocument();
+            } catch (Exception e) {
+                document = cookie.openDocument();
+            }
+        } catch(Exception e) {
+            // no need to report
+        }
+        cookie.prepareDocument().waitFinished();
+        return document;
+    }
+
     
     public static BaseDocument getBaseDocument(final DataObject dob) throws Exception {
         EditorCookie  cookie = dob.getCookie(EditorCookie.class);
@@ -81,7 +105,7 @@ public class CndCoreTestUtils {
             throw new IllegalStateException("Given file (\"" + dob.getName() + "\") does not have EditorCookie."); // NOI18N
         }
         
-        StyledDocument doc = CsmUtilities.openDocument(cookie);
+        StyledDocument doc = openDocument(cookie);
         return doc instanceof BaseDocument ? (BaseDocument)doc : null;
     }
     


### PR DESCRIPTION
This adds more passing tests to the cnd cluster (cnd.remote, cnd, cnd.toolchain)

cnd.remote depended on "cnd.model.api", which we have not integrated in Apache NetBeans (to be replaced with LSP). Tests that required validating the model 
- FullRemoteCodeModelTestCase, 
- RemoteCodeModelTestCase, 
- FullRemoteBuildTestCase, 
- RemoteBuildTestBase
are modified accordingly dropping this dependency.

After this the cnd cluster should test properly (dlight cluster requires some extra care, though).


