### PR TITLE
LSP console IO is made more reliable, output is not lost now.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -152,8 +152,8 @@ public abstract class NbLaunchDelegate {
                 }
             }
         };
-        Project prj = FileOwnerQuery.getOwner(toRun);
         if (nativeImageFile == null) {
+            Project prj = FileOwnerQuery.getOwner(toRun);
             class W extends Writer {
                 @Override
                 public void write(char[] cbuf, int off, int len) throws IOException {

--- a/platform/openide.io/src/org/openide/io/BridgingIOProvider.java
+++ b/platform/openide.io/src/org/openide/io/BridgingIOProvider.java
@@ -158,8 +158,7 @@ public class BridgingIOProvider<IO, S extends PrintWriter, P, F>
         @Override
         public OutputWriter getErr() {
             return new BridgingOutputWriter(ioDelegate,
-                    providerDelegate.getOut(ioDelegate)
-        );
+                    providerDelegate.getErr(ioDelegate));
         }
 
         @Override


### PR DESCRIPTION
The console is closed only when both standard and error outputs are closed.
Also a correct stream is referred in `BridgingIOProvider`.