### PR TITLE
dlight.nativeexecution test documentation

### DIFF
--- a/ide/dlight.nativeexecution/README-tests.txt
+++ b/ide/dlight.nativeexecution/README-tests.txt
@@ -1,0 +1,29 @@
+Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+
+* dlight.nativeexecution tests
+
+dlight.nativeexecution module includes support for remote connection testing.
+
+In order to test remote connections you have to set up two files, used in NativeExecutionTestSupport.java:
+
+** cndtestrc file
+
+This file specifies the remote platforms available. See test/unit/data/cndtestrc for an example.
+
+Can be set using the system property
+
+-Dcnd.remote.rcfile=test/unit/data/cndtestrc
+
+If not set then $HOME/.cndtestrc is used.
+
+** testuserinfo
+
+This file specifies the user/password/host used in each platform. See test/unit/data/testuserinfo for an example.
+
+Can be set using the system property
+
+-Dcnd.remote.testuserinfo=test/unit/data/testuserinfo
+
+Or the CND_REMOTE_TESTUSERINFO environment variable.
+
+If not set then $HOME/.testuserinfo is used.

--- a/ide/dlight.nativeexecution/test/unit/data/cndtestrc
+++ b/ide/dlight.nativeexecution/test/unit/data/cndtestrc
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+#
+# Example "$HOME/.cndtestrc" file used in NativeExecutionTestSupport
+#
+
+# Note: Remote platform names must define OS+Architecture after the first '-'
+# Example: dummy-Linux-x86_64
+[remote.platforms]
+dummy-Linux-x86_64
+
+[remote]
+vcstck.mspec=TEST
+
+[dummy-section]
+dummy-key=dummy-value

--- a/ide/dlight.nativeexecution/test/unit/data/testuserinfo
+++ b/ide/dlight.nativeexecution/test/unit/data/testuserinfo
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+#
+# Example "$HOME/.testuserinfo" file used in NativeExecutionTestSupport
+#
+
+# platform-id user:password@host
+dummy-Linux-x86_64 user:password@localhost
+
+# platform-id key@host
+another-PlatformType key@host
+


### PR DESCRIPTION
One can test the "dlight.nativeexecution" module doing real connections to a remote server. The tests do then real ssh and sftp connections to the server, and perform different tests.

This isn't documented elsewhere, this PR details what is needed to run these tests.