### PR TITLE
Modified to prevent IllegalStateExceptions from CasualDiff.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/PositionEstimator.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/PositionEstimator.java
@@ -968,7 +968,7 @@ public abstract class PositionEstimator {
                     if (seq.movePrevious() && seq.offset() >= sectionStart && nonRelevant.contains(seq.token().id())) {
                         moveToSrcRelevantBounded(seq, Direction.BACKWARD);
                         seq.moveNext();
-                        treeEnd = seq.offset();
+                        treeEnd = Math.max(seq.offset(), treeStart);
                     }
                 }
 


### PR DESCRIPTION
Prevents IllegalStateExceptions from CasualDiff caused by wrong estimated positions of certain ErroneousTrees in a syntactically broken source (where endPosition < startPosition).