### PR TITLE
Avoid using word failed in non-fatal debug messages

### DIFF
--- a/ide/projectui/src/org/netbeans/modules/project/ui/ProjectsRootNode.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/ProjectsRootNode.java
@@ -370,7 +370,7 @@ public class ProjectsRootNode extends AbstractNode {
             if (!data.hasFirst()) {
                 LOG.log(
                         Level.WARNING,
-                        "Warning - project of {0} in {1} failed to supply a LogicalViewProvider in its lookup",  // NOI18N
+                        "Warning - project of {0} in {1} doesn't supply a LogicalViewProvider in its lookup",  // NOI18N
                         new Object[]{
                             project.getClass(),
                             FileUtil.getFileDisplayName(project.getProjectDirectory())

--- a/java/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/ModificationResult.java
@@ -236,7 +236,7 @@ public final class ModificationResult {
                     }
                 });
                 if (exceptions [0] != null) {
-                    LOG.log(Level.INFO, "ModificationResult commit failed with an exception: ", exceptions[0]);
+                    LOG.log(Level.INFO, "Cannot commit changes into " + fo, exceptions[0]);
                     int s = lastCommitted.size();
                     for (Throwable t : lastCommitted) {
                         LOG.log(Level.INFO, "Previous commit number " + s--, t);

--- a/platform/openide.util/src/org/openide/util/RequestProcessor.java
+++ b/platform/openide.util/src/org/openide/util/RequestProcessor.java
@@ -2124,7 +2124,7 @@ outer:  do {
             if (SLOW) {
                 Item item = todo.item;
                 if (item != null && item.message == null) {
-                    item.message = "task failed due to: " + ex;
+                    item.message = ex.toString();
                     item.initCause(ex);
                     ex = item;
                 }


### PR DESCRIPTION
How do you search for failures in Travis and GitHubActions runs? I search for `failed` like in `The test XYZTest failed`. However there are other, disturbing occurrences of that word in the test logs. There was [52 occurrences in a recent log](https://github.com/apache/netbeans/runs/4729484163). Here are three examples:

```
 [junit] WARNING: Warning - project of class org.netbeans.modules.java.source.usages.TestSupport$TestProject in /home/runner/work/netbeans/netbeans/java/java.source.base/build/test/unit/work/o.n.m.j.s.u.S/sipwop/prj0 failed to supply a LogicalViewProvider in its lookup
```

```
     [junit] SEVERE: Error in RequestProcessor org.netbeans.modules.editor.settings.storage.preferences.PreferencesImpl$1
    [junit] org.openide.util.RequestProcessor$SlowItem: task failed due to: java.lang.NullPointerException: The folder parameter cannot be null
    [junit] 	at org.openide.util.RequestProcessor$Task.schedule(RequestProcessor.java:1459)
    [junit] 	at org.netbeans.modules.editor.settings.storage.preferences.PreferencesImpl.asyncInvocationOfFlushSpi(PreferencesImpl.java:478)
    [junit] 	at org.netbeans.modules.editor.settings.storage.preferences.PreferencesImpl.putSpi(PreferencesImpl.java:274)
```

and 

```
   INFO: ModificationResult commit failed with an exception: 
    [junit] java.io.IOException
    [junit] 	at org.netbeans.api.java.source.ModificationResult.processDocument(ModificationResult.java:385)
    [junit] 	at org.netbeans.api.java.source.ModificationResult.commit2(ModificationResult.java:330)
    [junit] 	at org.netbeans.api.java.source.ModificationResult.access$000(ModificationResult.java:71)
```

This PR changes the wording, so the search is easier. Hopefully none of these messages form an important API and no test fails because of changing them.