### PR TITLE
Convert source path to URI String.

### DIFF
--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbSourceProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbSourceProvider.java
@@ -125,7 +125,7 @@ public final class NbSourceProvider {
                 for (String path : sourcePaths) {
                     Path fullpath = Paths.get(path, relativeSourcePath);
                     if (Files.isRegularFile(fullpath)) {
-                        uri = fullpath.toString();
+                        uri = fullpath.toUri().toString();
                         break;
                     }
                 }


### PR DESCRIPTION
The Path can be treated as an URI on UNIX, but not on Windows. Paths starting with the drive letter are not valid URIs, this is why we need to convert the Path to URI and then to String to get a valid URI String representation.