### PR TITLE
Add a pull request template with confirmation of submission terms

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+
+
+
+
+---
+**^Add meaningful description above**
+
+By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -
+
+ - are all your own work, and you have the right to contribute them.
+ - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).
+
+Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.
+
+If you're a first time contributor, see the Contributing guidelines for more information.
+


### PR DESCRIPTION
Add a pull request template with confirmation of submission terms and guidance.

Following on from @matthiasblaesing comments on easing the process for including code from new contributors, and making sure there's no need to get confirmation related to ASL section 5, could add it as text in the template.  It shows up as plain text in the submission box, so (unlike Airflow) I've removed most of the markdown.  Text could be shorter. Thoughts?

Will look similar to ...

![Screenshot from 2022-01-08 18-35-03](https://user-images.githubusercontent.com/3975960/148655708-0269414b-1e10-46ee-abbc-bfadd0eb7d81.png)
 
Our contribution guidelines could do with a look, but that can happen next.

EDIT : Following comments and wording elsewhere, text updated from the image to be -

```

---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

```

I'm not convinced we have to have this at all, but it's an option we have if we want to have that info more obvious. Shame no form templates like issues yet though!

