### PR TITLE
[NETBEANS-6372] [cnd] small-2.2 commit-validation tests

### DIFF
--- a/cnd/cnd.makeproject.ui/src/org/netbeans/modules/cnd/makeproject/ui/resources/layer.xml
+++ b/cnd/cnd.makeproject.ui/src/org/netbeans/modules/cnd/makeproject/ui/resources/layer.xml
@@ -27,7 +27,7 @@
                 <attr name="SystemFileSystem.localizingBundle" stringvalue="org.netbeans.modules.cnd.makeproject.ui.wizards.Bundle"/>
                 <attr name="instantiatingWizardURL" urlvalue="nbresloc:/org/netbeans/modules/cnd/makeproject/ui/resources/desktop.html"/>
 
-                <attr name="position" intvalue="850"/>
+                <attr name="position" intvalue="650"/>
                 <file name="makefile.xml">
                     <attr name="position" intvalue="100"/>
                     <attr name="template" boolvalue="true"/>

--- a/cnd/cnd.toolchain.ui/manifest.mf
+++ b/cnd/cnd.toolchain.ui/manifest.mf
@@ -1,6 +1,7 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.cnd.toolchain.ui
+OpenIDE-Module-Layer: org/netbeans/modules/cnd/toolchain/ui/resources/layer.xml
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/cnd/toolchain/ui/resources/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.1.1
 

--- a/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/compiler/CodeAssistancePanelController.java
+++ b/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/compiler/CodeAssistancePanelController.java
@@ -26,12 +26,14 @@ import org.netbeans.spi.options.OptionsPanelController;
 import org.openide.util.HelpCtx;
 import org.openide.util.Lookup;
 
-@OptionsPanelController.SubRegistration(
-    id=CndUIConstants.TOOLS_OPTIONS_CND_CODE_ASSISTANCE_ID,
-    location=CndUIConstants.TOOLS_OPTIONS_CND_CATEGORY_ID,
-    displayName="#TAB_CodeAssistanceTab", // NOI18N
-    position=300
-)
+// Overriden with a manually generated layer.xml file.
+// See https://issues.apache.org/jira/browse/NETBEANS-6372
+//@OptionsPanelController.SubRegistration(
+//    id=CndUIConstants.TOOLS_OPTIONS_CND_CODE_ASSISTANCE_ID,
+//    location=CndUIConstants.TOOLS_OPTIONS_CND_CATEGORY_ID,
+//    displayName="#TAB_CodeAssistanceTab", // NOI18N
+//    position=300
+//)
 public final class CodeAssistancePanelController extends OptionsPanelController {
     public static final boolean TRACE_CODEASSIST = Boolean.getBoolean("trace.codeassist.controller");
 //    private CodeAssistancePanel panel = new CodeAssistancePanel();

--- a/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/options/ToolsPanelController.java
+++ b/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/options/ToolsPanelController.java
@@ -26,12 +26,14 @@ import org.netbeans.spi.options.OptionsPanelController;
 import org.openide.util.HelpCtx;
 import org.openide.util.Lookup;
 
-@OptionsPanelController.SubRegistration(
-    id=CndUIConstants.TOOLS_OPTIONS_CND_TOOLS_ID,
-    location=CndUIConstants.TOOLS_OPTIONS_CND_CATEGORY_ID,
-    displayName="#TAB_ToolsTab", // NOI18N
-    position=100
-)
+// Overriden with a manually generated layer.xml file.
+// See https://issues.apache.org/jira/browse/NETBEANS-6372
+//@OptionsPanelController.SubRegistration(
+//    id=CndUIConstants.TOOLS_OPTIONS_CND_TOOLS_ID,
+//    location=CndUIConstants.TOOLS_OPTIONS_CND_CATEGORY_ID,
+//    displayName="#TAB_ToolsTab", // NOI18N
+//    position=100
+//)
 public final class ToolsPanelController extends OptionsPanelController {
 
     private ToolsPanel panel = new ToolsPanel("ConfiguringBuildTools"); // NOI18N

--- a/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/options/package-info.java
+++ b/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/options/package-info.java
@@ -17,13 +17,15 @@
  * under the License.
  */
 
-@OptionsPanelController.ContainerRegistration(
-    id=CndUIConstants.TOOLS_OPTIONS_CND_CATEGORY_ID,
-    categoryName="#CndOptionsCategory_Name", // NOI18N
-//    title="#CndOptions_Title"
-    iconBase="org/netbeans/modules/cnd/toolchain/ui/options/cnd_32.png", // NOI18N
-    position=700
-)
+// Overriden with a manually generated layer.xml file.
+// See https://issues.apache.org/jira/browse/NETBEANS-6372
+//@OptionsPanelController.ContainerRegistration(
+//    id=CndUIConstants.TOOLS_OPTIONS_CND_CATEGORY_ID,
+//    categoryName="#CndOptionsCategory_Name", // NOI18N
+////    title="#CndOptions_Title"
+//    iconBase="org/netbeans/modules/cnd/toolchain/ui/options/cnd_32.png", // NOI18N
+//    position=700
+//)
 package org.netbeans.modules.cnd.toolchain.ui.options;
 
 import org.netbeans.modules.cnd.utils.ui.CndUIConstants;

--- a/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/resources/layer.xml
+++ b/cnd/cnd.toolchain.ui/src/org/netbeans/modules/cnd/toolchain/ui/resources/layer.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.2//EN"
+                            "http://www.netbeans.org/dtds/filesystem-1_2.dtd">
+<filesystem>
+    <folder name="OptionsDialog">
+        <folder name="CPlusPlus">
+            <file name="CodeAssistanceTab.instance">
+                <!--org.netbeans.modules.cnd.toolchain.ui.compiler.CodeAssistancePanelController-->
+                <attr
+                    methodvalue="org.netbeans.spi.options.AdvancedOption.createSubCategory" name="instanceCreate"/>
+                <attr name="controller" newvalue="org.netbeans.modules.cnd.toolchain.ui.compiler.CodeAssistancePanelController"/>
+                <attr
+                    bundlevalue="org.netbeans.modules.cnd.toolchain.ui.compiler.Bundle#TAB_CodeAssistanceTab" name="displayName"/>
+                <attr intvalue="300" name="position"/>
+            </file>
+            <file name="ToolsTab.instance">
+                <!--org.netbeans.modules.cnd.toolchain.ui.options.ToolsPanelController-->
+                <attr
+                    methodvalue="org.netbeans.spi.options.AdvancedOption.createSubCategory" name="instanceCreate"/>
+                <attr name="controller" newvalue="org.netbeans.modules.cnd.toolchain.ui.options.ToolsPanelController"/>
+                <attr
+                    bundlevalue="org.netbeans.modules.cnd.toolchain.ui.options.Bundle#TAB_ToolsTab" name="displayName"/>
+                <attr intvalue="100" name="position"/>
+            </file>
+            <!--org.netbeans.modules.cnd.toolchain.ui.options-->
+            <attr intvalue="0" name="position"/>
+            <attr intvalue="0" name="weight" />
+        </folder>
+        <folder name="Keywords">
+            <file name="org.netbeans.modules.cnd.toolchain.ui.compiler.ParserSettingsPanel">
+                <!--org.netbeans.modules.cnd.toolchain.ui.compiler.ParserSettingsPanel-->
+                <attr name="location" stringvalue="CPlusPlus"/>
+                <attr
+                    bundlevalue="org.netbeans.modules.cnd.toolchain.ui.compiler.Bundle#TAB_CodeAssistanceTab" name="tabTitle"/>
+                <attr
+                    bundlevalue="org.netbeans.modules.cnd.toolchain.ui.compiler.Bundle#ParserSettingsKeywords" name="keywords-1"/>
+            </file>
+            <file name="org.netbeans.modules.cnd.toolchain.ui.options.ToolsPanel">
+                <!--org.netbeans.modules.cnd.toolchain.ui.options.ToolsPanel-->
+                <attr name="location" stringvalue="CPlusPlus"/>
+                <attr
+                    bundlevalue="org.netbeans.modules.cnd.toolchain.ui.options.Bundle#TAB_ToolsTab" name="tabTitle"/>
+                <attr
+                    bundlevalue="org.netbeans.modules.cnd.toolchain.ui.options.Bundle#ToolsPanelKeywords" name="keywords-1"/>
+            </file>
+        </folder>
+        <file name="CPlusPlus.instance">
+            <!--org.netbeans.modules.cnd.toolchain.ui.options-->
+            <attr
+                methodvalue="org.netbeans.spi.options.OptionsCategory.createCategory" name="instanceCreate"/>
+            <attr name="advancedOptionsFolder" stringvalue="OptionsDialog/CPlusPlus"/>
+            <attr
+                bundlevalue="org.netbeans.modules.cnd.toolchain.ui.options.Bundle#CndOptionsCategory_Name" name="categoryName"/>
+            <attr intvalue="700" name="position"/>
+            <attr name="iconBase" stringvalue="org/netbeans/modules/cnd/toolchain/ui/options/cnd_32.png"/>
+            <attr name="weight" intvalue="100" />
+        </file>
+    </folder>
+</filesystem>

--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/options/CPPLiteOptionsPanelController.java
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/options/CPPLiteOptionsPanelController.java
@@ -31,7 +31,8 @@ import org.openide.util.Lookup;
         displayName = "#OptionsCategory_DisplayName",
         keywords = "#OptionsCategory_Keywords_CPPLite",
         keywordsCategory = "CPPLite",
-        location = "CPlusPlus"
+        location = "CPlusPlus",
+        position = 1000,
 )
 @org.openide.util.NbBundle.Messages({"OptionsCategory_DisplayName=ccls configuration", "OptionsCategory_Keywords_CPPLite=C C++ ccls"})
 public final class CPPLiteOptionsPanelController extends OptionsPanelController {

--- a/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/options/CPPLiteOptionsPanelController.java
+++ b/cpplite/cpplite.editor/src/org/netbeans/modules/cpplite/editor/lsp/options/CPPLiteOptionsPanelController.java
@@ -32,7 +32,7 @@ import org.openide.util.Lookup;
         keywords = "#OptionsCategory_Keywords_CPPLite",
         keywordsCategory = "CPPLite",
         location = "CPlusPlus",
-        position = 1000,
+        position = 1000
 )
 @org.openide.util.NbBundle.Messages({"OptionsCategory_DisplayName=ccls configuration", "OptionsCategory_Keywords_CPPLite=C C++ ccls"})
 public final class CPPLiteOptionsPanelController extends OptionsPanelController {

--- a/dlight/dlight.libs.common/src/org/netbeans/modules/dlight/libs/common/PathUtilities.java
+++ b/dlight/dlight.libs.common/src/org/netbeans/modules/dlight/libs/common/PathUtilities.java
@@ -24,7 +24,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
 import java.nio.charset.CodingErrorAction;
-import sun.nio.cs.ThreadLocalCoders;
+import java.nio.charset.StandardCharsets;
 
 /**
  *
@@ -414,7 +414,7 @@ public class PathUtilities {
         StringBuffer sb = new StringBuffer(n);
         ByteBuffer bb = ByteBuffer.allocate(n);
         CharBuffer cb = CharBuffer.allocate(n);
-        CharsetDecoder dec = ThreadLocalCoders.decoderFor("UTF-8") // NOI18N
+        CharsetDecoder dec = StandardCharsets.UTF_8.newDecoder()
                 .onMalformedInput(CodingErrorAction.REPLACE)
                 .onUnmappableCharacter(CodingErrorAction.REPLACE);
 

--- a/nbbuild/cluster.properties
+++ b/nbbuild/cluster.properties
@@ -27,6 +27,8 @@ clusters.config.release.list=\
         nb.cluster.groovy,\
         nb.cluster.enterprise,\
         nb.cluster.cpplite,\
+        nb.cluster.dlight,\
+        nb.cluster.cnd,\
         nb.cluster.ergonomics
 # ergonomics must be last
 


### PR DESCRIPTION
This PR:

- Removes a dependency with sun.io in dlight.libs.common
- Aligns a "position" attribute in cnd.makeproject.ui with cpplite (for commit-validation tests)
- Replaces @OptionsPanel.SubRegistration annotations (that do not currently support the weight attribute) with a manual "layer.xml" file.
- Adds both "cnd" and "dlight" to the "release" configuration to be able to check the "commit-validation" tests.

Expected result:

The commit-validation phase will fail with a weird error, that we'll have to handle in a future PR.

