### PR TITLE
Always call mx build before running the java.mx.projects tests

### DIFF
--- a/java/java.mx.project/build.xml
+++ b/java/java.mx.project/build.xml
@@ -24,7 +24,7 @@
     <property name="mx.dir" value="${graal.dir}/../mx"/>
     <available property="graal.dir.available" file="${graal.dir}/LICENSE"/>
 
-    <target name="test-preinit" unless="graal.dir.available">
+    <target name="-checkout-graalvm" unless="graal.dir.available">
         <delete dir="${graal.dir}"/>
         <mkdir dir="${graal.dir}/.."/>
         <exec dir="${graal.dir}/.." executable="git" failonerror="true">
@@ -45,6 +45,9 @@
             <arg value="--single-branch"/>
             <arg value="https://github.com/graalvm/mx"/>
         </exec>
+    </target>
+
+    <target name="test-preinit" depends="-checkout-graalvm">
         <exec dir="${graal.dir}/truffle" executable="${mx.dir}/mx" failonerror="true">
             <arg value="build"/>
         </exec>


### PR DESCRIPTION
@jlahoda reported that the `ant -f java/java.mx.projects test` is failing on subsequent executions - because the `mx build` is executed on 1st run and not then. This PR changes the build script to invoke `mx build` everytime `ant test` is invoked.