### PR TITLE
[jackpot] Add sourceVersion(int) to rule file utils and deprecate enum variant. (part 2)

### DIFF
--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Condition.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/Condition.java
@@ -122,6 +122,7 @@ public abstract class Condition {
         public enum ParameterKind {
             VARIABLE,
             STRING_LITERAL,
+            INT_LITERAL,
             ENUM_CONSTANT;
         }
     }

--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParser.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParser.java
@@ -508,6 +508,9 @@ public class DeclarativeHintsParser {
                         case STRING_LITERAL:
                             params.put(((LiteralTree) t).getValue().toString(), ParameterKind.STRING_LITERAL);
                             break;
+                        case INT_LITERAL:
+                            params.put(((LiteralTree) t).getValue().toString(), ParameterKind.INT_LITERAL);
+                            break;
                         case IDENTIFIER:
                             String name = ((IdentifierTree) t).getName().toString();
 

--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/MethodInvocationContext.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/MethodInvocationContext.java
@@ -34,7 +34,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.netbeans.api.annotations.common.NonNull;
 import org.netbeans.api.java.classpath.ClassPath;
-import org.netbeans.api.java.platform.JavaPlatform;
 import org.netbeans.modules.java.hints.declarative.Condition.MethodInvocation.ParameterKind;
 import org.netbeans.modules.java.hints.declarative.conditionapi.Context;
 import org.netbeans.modules.java.hints.declarative.conditionapi.DefaultRuleUtilities;
@@ -67,6 +66,9 @@ public class MethodInvocationContext {
                     break;
                 case STRING_LITERAL:
                     paramTypes.add(String.class);
+                    break;
+                case INT_LITERAL:
+                    paramTypes.add(int.class);
                     break;
                 case ENUM_CONSTANT:
                     Enum<?> constant = loadEnumConstant(e.getKey());
@@ -139,6 +141,9 @@ public class MethodInvocationContext {
                     break;
                 case STRING_LITERAL:
                     toAdd = e.getKey();
+                    break;
+                case INT_LITERAL:
+                    toAdd = Integer.valueOf(e.getKey());
                     break;
                 case ENUM_CONSTANT:
                     Enum<?> constant = loadEnumConstant(e.getKey());

--- a/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/Variable.java
+++ b/java/java.hints.declarative/src/org/netbeans/modules/java/hints/declarative/conditionapi/Variable.java
@@ -38,4 +38,9 @@ public class Variable {
         this.index = index;
     }
 
+    @Override
+    public String toString() {
+        return "Variable{" + "variableName=" + variableName + '}';
+    }
+
 }

--- a/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParserTest.java
+++ b/java/java.hints.declarative/test/unit/src/org/netbeans/modules/java/hints/declarative/DeclarativeHintsParserTest.java
@@ -20,7 +20,6 @@
 package org.netbeans.modules.java.hints.declarative;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,7 +38,6 @@ import org.netbeans.modules.java.hints.declarative.Condition.Instanceof;
 import org.netbeans.modules.java.hints.declarative.Condition.MethodInvocation;
 import org.netbeans.modules.java.hints.declarative.Condition.MethodInvocation.ParameterKind;
 import org.netbeans.modules.java.hints.declarative.DeclarativeHintsParser.FixTextDescription;
-import static org.junit.Assert.*;
 import org.netbeans.modules.java.hints.declarative.DeclarativeHintsParser.HintTextDescription;
 import org.netbeans.modules.java.hints.declarative.DeclarativeHintsParser.Result;
 import org.netbeans.modules.java.hints.declarative.conditionapi.Variable;
@@ -106,6 +104,19 @@ public class DeclarativeHintsParserTest extends NbTestCase {
         m.put("javax.lang.model.SourceVersion.RELEASE_6", ParameterKind.ENUM_CONSTANT);
 
         performTest("'test': $1 + $2 :: test($1, Modifier.VOLATILE, SourceVersion.RELEASE_6) => 1 + 1;;",
+                    StringHintDescription.create("$1 + $2 ")
+                                         .addCondition(new MethodInvocation(false, "test", m, null))
+                                         .addTos(" 1 + 1")
+                                         .setDisplayName("test"));
+    }
+
+    public void testMethodInvocationCondition3() throws Exception {
+        Map<String, ParameterKind> m = new LinkedHashMap<>();
+
+        m.put("$1", ParameterKind.VARIABLE);
+        m.put("42", ParameterKind.INT_LITERAL);
+
+        performTest("'test': $1 + $2 :: test($1, 42) => 1 + 1;;",
                     StringHintDescription.create("$1 + $2 ")
                                          .addCondition(new MethodInvocation(false, "test", m, null))
                                          .addTos(" 1 + 1")
@@ -506,6 +517,7 @@ public class DeclarativeHintsParserTest extends NbTestCase {
 
     public static final class TestConditionClass {
         public boolean test(String s, Variable v1, Variable v2) { return false; }
+        public boolean test(Variable var, int i) { return false; }
         public boolean test(Variable var, Modifier mod, SourceVersion sv) { return false; }
         public boolean test(Variable var, String... strings) { return false; }
    }


### PR DESCRIPTION
I forgot to add a commit to https://github.com/apache/netbeans/pull/3395

This is the actual support of int literals for rule conditions - the rule API of part 1 alone won't do anything.

sorry!