### PR TITLE
Update FlatLaf from 1.6.1 to 2.0

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-DF181FADB3050FE3CF38A13C519D56E69329CEE3 com.formdev:flatlaf:1.6.1
+A45856E4115136977C662298BAC02F3B428082DB com.formdev:flatlaf:2.0

--- a/platform/libs.flatlaf/external/flatlaf-2.0-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-2.0-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 1.6.1
-Files: flatlaf-1.6.1.jar
+Version: 2.0
+Files: flatlaf-2.0.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-1.6.1.jar=modules/ext/flatlaf-1.6.1.jar
+release.external/flatlaf-2.0.jar=modules/ext/flatlaf-2.0.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-1.6.1.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-1.6.1.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-2.0.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-2.0.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Update FlatLaf to v2: https://github.com/JFormDesigner/FlatLaf/releases/tag/2.0

There are (nearly) no visual differences compared to previous used version, except the slightly changed [check boxes and radio buttons](https://github.com/JFormDesigner/FlatLaf/pull/414).

The main benefits of FlatLaf v2 for NetBeans are the reworked [core themes](https://github.com/JFormDesigner/FlatLaf/pull/390) (easier changing colors), the possibility to [change the accent color](https://github.com/JFormDesigner/FlatLaf/pull/375) and the [FlatLaf Theme Editor](https://www.formdev.com/flatlaf/theme-editor/). This should it make it relative easy to change colors/style of the light and dark themes to differentiate more from IntelliJ IDEA look.

E.g. adding following to `platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatLightLaf.properties`
~~~
@background = #f3f3f3
@accentColor = #007aff
~~~

would change the look to (blue accent color; background minimally lighter):

![image](https://user-images.githubusercontent.com/5604048/148990227-2b6e9ba3-4ae5-4917-8dba-b7eea54ffc69.png)


Or adding following to `platform/o.n.swing.laf.flatlaf/src/org/netbeans/swing/laf/flatlaf/FlatDarkLaf.properties`

~~~
@background = #333
@foreground = #c4c4c4
@accentColor = darken(#007aff,5%)

Button.default.foreground = #ddd
~~~

would make NetBeans darker and give text more contrast:

![image](https://user-images.githubusercontent.com/5604048/148990745-0c0c2c64-2213-46c8-8bc7-e73cbc3edb5a.png)

Not sure how to "organize" work/ideas on such theme changes...
Maybe create two "Draft PRs" (for light and dark) where interested people can comment and add commits?