### PR TITLE
[NETBEANS-6347] Revert "UI support for disabled actions."

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.form
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.form
@@ -32,7 +32,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,2,26,0,0,2,-102"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-42,0,0,2,-102"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
@@ -345,19 +345,6 @@
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
           <GridBagConstraints gridX="10" gridY="5" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
-        </Constraint>
-      </Constraints>
-    </Component>
-    <Component class="javax.swing.JButton" name="btnDisable">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/modules/maven/customizer/Bundle.properties" key="ActionMappings.btnDisable.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-        <Property name="name" type="java.lang.String" value="" noResource="true"/>
-      </Properties>
-      <Constraints>
-        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="10" gridY="6" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>

--- a/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
@@ -19,7 +19,6 @@
 
 package org.netbeans.modules.maven.customizer;
 
-import java.awt.Color;
 import org.netbeans.modules.maven.runjar.PropertySplitter;
 import java.awt.Component;
 import java.awt.FlowLayout;
@@ -43,6 +42,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
+import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
@@ -332,7 +332,6 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         lblPackagings = new javax.swing.JLabel();
         txtPackagings = new javax.swing.JTextField();
         jButton1 = new javax.swing.JButton();
-        btnDisable = new javax.swing.JButton();
 
         setLayout(new java.awt.GridBagLayout());
 
@@ -577,16 +576,6 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
         gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
         gridBagConstraints.insets = new java.awt.Insets(6, 6, 0, 12);
         add(jButton1, gridBagConstraints);
-
-        org.openide.awt.Mnemonics.setLocalizedText(btnDisable, org.openide.util.NbBundle.getMessage(ActionMappings.class, "ActionMappings.btnDisable.text")); // NOI18N
-        btnDisable.setName(""); // NOI18N
-        gridBagConstraints = new java.awt.GridBagConstraints();
-        gridBagConstraints.gridx = 10;
-        gridBagConstraints.gridy = 6;
-        gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.anchor = java.awt.GridBagConstraints.NORTHWEST;
-        gridBagConstraints.insets = new java.awt.Insets(6, 6, 0, 12);
-        add(btnDisable, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
     
 //GEN-FIRST:event_btnAddActionPerformed
@@ -652,42 +641,16 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         }
     }//GEN-LAST:event_btnRemoveActionPerformed
     
-    private void updateEnabledControls(MappingWrapper wr) {
-        boolean notEmpty = wr != null;
-        boolean enable = notEmpty && !ActionToGoalUtils.isDisabledMapping(wr.getMapping());
-
-        if (enable) {
-            lblGoals.setEnabled(true);
-            lblHint.setEnabled(true);
-            lblPackagings.setEnabled(true);
-            lblProfiles.setEnabled(true);
-            lblProperties.setEnabled(true);
-            
+    private void lstMappingsValueChanged(javax.swing.event.ListSelectionEvent evt) {//GEN-FIRST:event_lstMappingsValueChanged
+        Object obj = lstMappings.getSelectedValue();//GEN-HEADEREND:event_lstMappingsValueChanged
+        if (obj == null) {
+            clearFields();
+        } else {
+            MappingWrapper wr = (MappingWrapper)obj;
+            NetbeansActionMapping mapp = wr.getMapping();
             txtGoals.setEnabled(true);
             epProperties.setEnabled(true);
             txtProfiles.setEnabled(true);
-            cbRecursively.setEnabled(true);
-            cbBuildWithDeps.setEnabled(true);
-            btnAddProps.setEnabled(true);
-            btnDisable.setEnabled(true);
-            if (isGlobal()) {
-                txtPackagings.setEnabled(true);
-            }
-        } else {
-            clearFields();
-        }
-        if (notEmpty) {
-            btnRemove.setEnabled(true);
-        } else {
-            btnRemove.setEnabled(false);
-        }
-    }
-    
-    private void lstMappingsValueChanged(javax.swing.event.ListSelectionEvent evt) {//GEN-FIRST:event_lstMappingsValueChanged
-        MappingWrapper wr = (MappingWrapper)lstMappings.getSelectedValue();
-        updateEnabledControls(wr);
-        if (wr != null) {
-            NetbeansActionMapping mapp = wr.getMapping();
             
             txtGoals.getDocument().removeDocumentListener(goalsListener);
             txtProfiles.getDocument().removeDocumentListener(profilesListener);
@@ -696,6 +659,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
             cbBuildWithDeps.removeActionListener(depsListener);
             
             if (isGlobal()) {
+                txtPackagings.setEnabled(true);
                 txtPackagings.getDocument().removeDocumentListener(packagingsListener);
                 txtPackagings.setText(createSpaceSeparatedList(mapp != null ? mapp.getPackagings() : Collections.<String>emptyList()));
                 txtPackagings.getDocument().addDocumentListener(packagingsListener);
@@ -903,20 +867,12 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         txtPackagings.setEnabled(false);
         updateColor(null);
         cbRecursively.setEnabled(false);
-        cbBuildWithDeps.setEnabled(false);
         btnAddProps.setEnabled(false);
-        btnDisable.setEnabled(false);
         if (handle == null) { //only global settings
             jButton1.setEnabled(false);
             jButton1.setIcon(null);
             jButton1.setText(BTN_ShowToolbar());
         }
-        
-        lblGoals.setEnabled(false);
-        lblHint.setEnabled(false);
-        lblPackagings.setEnabled(false);
-        lblProfiles.setEnabled(false);
-        lblProperties.setEnabled(false);
     }
     
     private void updateColor(MappingWrapper wr) {
@@ -953,7 +909,6 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnAdd;
     private javax.swing.JButton btnAddProps;
-    private javax.swing.JButton btnDisable;
     private javax.swing.JButton btnRemove;
     private javax.swing.JCheckBox cbBuildWithDeps;
     private javax.swing.JCheckBox cbRecursively;
@@ -1058,11 +1013,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                 
                 
     }
-
-    @NbBundle.Messages({
-        "# {0} - disabled action name",
-        "FMT_DisabledAction={0} - disabled"
-    })
+    
     private static class Renderer extends DefaultListCellRenderer {
         
     
@@ -1078,10 +1029,6 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
                     lbl.setFont(lbl.getFont().deriveFont(Font.BOLD));
                 } else {
                     lbl.setFont(lbl.getFont().deriveFont(Font.PLAIN));
-                }
-                if (ActionToGoalUtils.isDisabledMapping(wr.getMapping())) {
-                    lbl.setForeground(Color.lightGray);
-                    lbl.setText(Bundle.FMT_DisabledAction(lbl.getText()));
                 }
             }
             return supers;

--- a/java/maven/src/org/netbeans/modules/maven/customizer/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/Bundle.properties
@@ -148,4 +148,3 @@ ActionMappings.jButton1.text=Show in Toolbar
 RunJarPanel.txtVMOptions.AccessibleContext.accessibleDescription=VM options
 RunJarPanel.customizeOptionsButton.text=C&ustomize...
 RunJarPanel.wrapCheckBox.text=Wrap text
-ActionMappings.btnDisable.text=&Disable


### PR DESCRIPTION
https://issues.apache.org/jira/browse/NETBEANS-6347

This reverts commit a401cec52837866eaf67e7a60bddd71da89730a0.

This commit appears to be the root cause of NETBEANS-6347 - adding global and project custom actions is completely broken in Maven.

I did ask about this on #3016 I'm not sure what the desired effect in the UI is.  I looked into trying to keep the renderer and disabled button, but the renderer needs adapting to handle empty added actions, and the disabled button doesn't seem to be hooked up to anything?!

Think we need to revert and rethink, as it's causing major issues for users.  cc @sdedic 