### PR TITLE
Better report of failures, append stderr/out.

### DIFF
--- a/nbbuild/travis/print-junit-report.sh
+++ b/nbbuild/travis/print-junit-report.sh
@@ -17,18 +17,47 @@
 # specific language governing permissions and limitations
 # under the License.
 
-echo junit report / failed tests:
+# 
+files=$(grep -L 'errors="0".*failures="0"' ./*/*/build/test/*/results/TEST-*.xml 2> /dev/null) || exit 0
 
-ls ./*/*/build/test/*/results/TEST-*.xml | while read file ;
-do
-    TEST=$(xmllint --xpath '//testsuite[@failures>0]/@name' $file 2>/dev/null)
+echo =================== JUnit Report Summary / failed tests ===================
+realfiles=''
+for file in $files ; do 
+    TEST=$(xmllint --xpath '//testsuite[@errors>0 or @failures>0]/@name' $file 2>/dev/null)
     status=$?
 
     if [ $status -eq 0 ]; then
+        realfiles="$realfiles $file"
         echo
         echo $TEST | cut -f2 -d '=' | tr -d '"'
-        xmllint --xpath '//testsuite/testcase[./failure]/@name' $file | cut -f2 -d '=' | xargs -L1 echo "    failed:"
+        xmllint --xpath '//testsuite/testcase[./failure]/@name' $file 2> /dev/null | sed -r 's/name="([^"]+)"/     failed: \1\n/g' 
+        xmllint --xpath '//testsuite/testcase[./error]/@name' $file 2> /dev/null | sed -r 's/name="([^"]+)"/     errored: \1\n/g' 
     fi
 done
 
-echo end of report
+echo
+echo ====================== JUnit failure details ===============================
+echo
+for file in $realfiles ; do 
+    classname=$(xmllint --xpath '//testsuite[@errors>0 or @failures>0]/@name' $file 2>/dev/null | cut -f2 -d '=' | tr -d '"')
+    echo Suite: $classname 
+    
+    for err in $(xmllint --xpath "//testsuite/testcase[@classname='${classname}'][./error]/@name" $file 2> /dev/null | sed -r 's/name="([^"]+)"/\1/g') ; do 
+        msg=$(xmllint --xpath "//testsuite/testcase[@classname='${classname}' and @name='${err}']/error/@message" $file 2> /dev/null | sed -r 's/message="([^"]+)"/\1/g' )
+        echo "      $err ERRORED : $msg"
+        xmllint --xpath "//testsuite/testcase[@classname='${classname}' and @name='${err}']/error/text()" $file 2> /dev/null | sed -r 's/^(.*$)/          \1/g'
+    done 
+    for err in $(xmllint --xpath "//testsuite/testcase[@classname='${classname}'][./failure]/@name" $file 2> /dev/null | sed -r 's/name="([^"]+)"/\1/g') ; do 
+        msg=$(xmllint --xpath "//testsuite/testcase[@classname='${classname}' and @name='${err}']/failure/@message" $file 2> /dev/null | sed -r 's/message="([^"]+)"/\1/g' )
+        echo "      $err FAILED : $msg"
+        xmllint --xpath "//testsuite/testcase[@classname='${classname}' and @name='${err}']/failure/text()" $file 2> /dev/null | sed -r 's/^(.*$)/          \1/g'
+    done 
+    text=$(xmllint --nocdata --xpath "//testsuite//system-out/text()" $file)
+    [ -n "$text" ] && { echo "Stdout ----------%<----------%<-------------%<-------------%<---------------" ; echo "$text" ; }
+    text=$(xmllint --nocdata --xpath "//testsuite//system-err/text()" $file)
+    [ -n "$text" ] && { echo "Stderr ----------%<----------%<-------------%<-------------%<---------------" ; echo "$text" ; }
+    echo "------------- End suite $classname ------------"
+    
+done
+echo
+echo ======================= End of JUnit report ===============================


### PR DESCRIPTION
This is a follow-up to #3403 -- I've noticed that the `xmllint --xpath '//testsuite/testcase[./failure]/@name' $file | cut -f2 -d '='`  only selects the 1st failed test, in case there are more failed cases in the testsuite.

During last hunt for a CI-failing test (that did not fail on local at all), I've also missed stderr/out for the failed suite. And also the actual assert stacktrace, since not all asserts have String message, the stacktrace can help to identify the exact failure.

Now the output is as follows:
```
=================== JUnit Report Summary / failed tests ===================

org.netbeans.modules.java.lsp.server.protocol.ServerTest
      failed: testCancelProgressHandle
      failed: testAnnotationCompletion

org.netbeans.modules.java.lsp.server.UtilsTest
      failed: testEncode2JSON
      errored: testEscapeScompletionSnippetSpceialChars

====================== JUnit failure details ===============================

Suite: org.netbeans.modules.java.lsp.server.protocol.ServerTest
      testCancelProgressHandle FAILED : 
          junit.framework.AssertionFailedError
                at org.netbeans.modules.java.lsp.server.protocol.ServerTest.testCancelProgressHandle(ServerTest.java:4932)
                at org.netbeans.junit.NbTestCase.access$200(NbTestCase.java:77)
                at org.netbeans.junit.NbTestCase$2.doSomething(NbTestCase.java:476)
                at org.netbeans.junit.NbTestCase$1Guard.run(NbTestCase.java:402)
                at java.lang.Thread.run(Thread.java:748)
      testAnnotationCompletion FAILED :  Test failure.
          junit.framework.AssertionFailedError: Test failure.
                at org.netbeans.modules.java.lsp.server.protocol.ServerTest.testAnnotationCompletion(ServerTest.java:4591)
                at org.netbeans.junit.NbTestCase.access$200(NbTestCase.java:77)
                at org.netbeans.junit.NbTestCase$2.doSomething(NbTestCase.java:476)
                at org.netbeans.junit.NbTestCase$1Guard.run(NbTestCase.java:402)
                at java.lang.Thread.run(Thread.java:748)
Stderr ----------%<----------%<-------------%<-------------%<---------------
....
------------- End suite org.netbeans.modules.java.lsp.server.protocol.ServerTest ------------
```
I broke several files so that this PR's checks output will show the effect.