### PR TITLE
Honor MxLibrary.path() if specified

### DIFF
--- a/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteSources.java
+++ b/java/java.mx.project/src/org/netbeans/modules/java/mx/project/SuiteSources.java
@@ -970,7 +970,16 @@ final class SuiteSources implements Sources,
             int prefix = libName.indexOf(':');
             final String simpleName = libName.substring(prefix + 1);
 
-            File simpleJar = new File(mxCache, simpleName + "_" + lib.sha1() + ".jar");
+            File simpleJar = null;
+            if (lib.path() != null && !lib.path().isEmpty()) {
+                FileObject relativePath = dir.getFileObject(lib.path());
+                if (relativePath != null) {
+                    simpleJar = FileUtil.toFile(relativePath);
+                }
+            }
+            if (simpleJar == null) {
+                simpleJar = new File(mxCache, simpleName + "_" + lib.sha1() + ".jar");
+            }
             if (simpleJar.exists()) {
                 return simpleJar;
             }


### PR DESCRIPTION
Certain [mx](http://github.com/graalvm/mx) projects define libraries with `path()` relative to the suite location <!-- GR-36280 -->. So far the value of `MxLibrary.path()` has been ignored for regular (non-JDK) libraries. This PR checks the value and resolves it relatively to the root of the suite.

CCing @gilles-duboscq, @ansalond, @Ondrej-Douda 