### PR TITLE
NETBEANS-6347: Disabled user actions fixed

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.form
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.form
@@ -355,6 +355,9 @@
         </Property>
         <Property name="name" type="java.lang.String" value="" noResource="true"/>
       </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnDisableActionPerformed"/>
+      </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
           <GridBagConstraints gridX="10" gridY="6" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>

--- a/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.java
@@ -580,6 +580,11 @@ public class ActionMappings extends javax.swing.JPanel implements HelpCtx.Provid
 
         org.openide.awt.Mnemonics.setLocalizedText(btnDisable, org.openide.util.NbBundle.getMessage(ActionMappings.class, "ActionMappings.btnDisable.text")); // NOI18N
         btnDisable.setName(""); // NOI18N
+        btnDisable.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnDisableActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 10;
         gridBagConstraints.gridy = 6;
@@ -669,7 +674,8 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
             cbRecursively.setEnabled(true);
             cbBuildWithDeps.setEnabled(true);
             btnAddProps.setEnabled(true);
-            btnDisable.setEnabled(true);
+            // custom actions cannot be disabled at the moment, see NETBEANS-6387
+            btnDisable.setEnabled(!wr.getActionName().startsWith(CUSTOM_ACTION_PREFIX));
             if (isGlobal()) {
                 txtPackagings.setEnabled(true);
             }
@@ -790,6 +796,13 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
             }
         }
     }//GEN-LAST:event_jButton1ActionPerformed
+
+    private void btnDisableActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnDisableActionPerformed
+        MappingWrapper wr = initUserWrapper();
+        wr.getMapping().setGoals(Collections.emptyList());
+        txtGoals.setText(""); // NOI18N
+        updateEnabledControls(wr);
+    }//GEN-LAST:event_btnDisableActionPerformed
     
     @Messages({"LBL_SetIcon=Set Icon:",
                "LBL_No_More_Icons=<No more slots available>",
@@ -1162,6 +1175,27 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         
     }
     
+    private MappingWrapper initUserWrapper() {
+        MappingWrapper map = (MappingWrapper)lstMappings.getSelectedValue();
+        if (map != null) {
+            if (!map.isUserDefined()) {
+                NetbeansActionMapping mapping = map.getMapping();
+                if (mapping == null) {
+                    mapping = new NetbeansActionMapping();
+                    mapping.setActionName(map.getActionName());
+                    map.setMapping(mapping);
+                }
+                getActionMappings().addAction(mapping);
+                if (handle != null) {
+                    handle.markAsModified(getActionMappings());
+                }
+                map.setUserDefined(true);
+                updateColor(map);
+            }
+        }
+        return map;
+    }
+    
     private abstract class TextFieldListener implements DocumentListener {
         @Override public void insertUpdate(DocumentEvent e) {
             doUpdate();
@@ -1176,24 +1210,7 @@ private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-HEADER
         }
         
         protected MappingWrapper doUpdate() {
-            MappingWrapper map = (MappingWrapper)lstMappings.getSelectedValue();
-            if (map != null) {
-                if (!map.isUserDefined()) {
-                    NetbeansActionMapping mapping = map.getMapping();
-                    if (mapping == null) {
-                        mapping = new NetbeansActionMapping();
-                        mapping.setActionName(map.getActionName());
-                        map.setMapping(mapping);
-                    }
-                    getActionMappings().addAction(mapping);
-                    if (handle != null) {
-                        handle.markAsModified(getActionMappings());
-                    }
-                    map.setUserDefined(true);
-                    updateColor(map);
-                }
-            }
-            return map;
+            return initUserWrapper();
         }
     }
     

--- a/java/maven/src/org/netbeans/modules/maven/execute/ActionToGoalUtils.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/ActionToGoalUtils.java
@@ -198,7 +198,7 @@ public final class ActionToGoalUtils {
      * @since 2.149
      */
     public static boolean isDisabledMapping(NetbeansActionMapping am) {
-        return am == null || am.getGoals().isEmpty();
+        return am == null || (!am.getActionName().startsWith("CUSTOM-") && am.getGoals().isEmpty());
     }
 
     public static boolean isActionEnable(String action, NbMavenProjectImpl project, ProjectConfiguration c, Lookup lookup) {


### PR DESCRIPTION
Actions without any goals are identified as disabled. That means that any unfinished, but saved or freshly created actions become disabled. This PR fixes that by assuming that all user-defined actions are enabled always. [NETBEANS-6387](https://issues.apache.org/jira/browse/NETBEANS-6387) was filed for further improvement / consistency between Maven and Gradle.