### PR TITLE
VSCode: Cannot run tests via when no file is opened in editor.

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -1157,7 +1157,9 @@ class NetBeansConfigurationResolver implements vscode.DebugConfigurationProvider
         if (!config.request) {
             config.request = 'launch';
         }
-        config.file = '${file}';
+        if (vscode.window.activeTextEditor) {
+            config.file = '${file}';
+        }
         if (!config.classPaths) {
             config.classPaths = ['any'];
         }


### PR DESCRIPTION
All actions to run/debug tests available in Test Explorer fail when no source is opened in editor with the message `Variable ${file} can not be resolved. Please open an editor.`. This is an attempt to fix that.