### PR TITLE
lambda expression completion support.

### DIFF
--- a/java/java.completion/nbproject/org-netbeans-modules-java-completion.sig
+++ b/java/java.completion/nbproject/org-netbeans-modules-java-completion.sig
@@ -84,7 +84,7 @@ meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$It
 CLSS public abstract interface static org.netbeans.modules.java.completion.JavaCompletionTask$LambdaItemFactory<%0 extends java.lang.Object>
  outer org.netbeans.modules.java.completion.JavaCompletionTask
 intf org.netbeans.modules.java.completion.JavaCompletionTask$ItemFactory<{org.netbeans.modules.java.completion.JavaCompletionTask$LambdaItemFactory%0}>
-meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$LambdaItemFactory%0} createLambdaItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.TypeElement,javax.lang.model.type.DeclaredType,int,boolean)
+meth public abstract {org.netbeans.modules.java.completion.JavaCompletionTask$LambdaItemFactory%0} createLambdaItem(org.netbeans.api.java.source.CompilationInfo,javax.lang.model.element.TypeElement,javax.lang.model.type.DeclaredType,int,boolean,boolean)
 
 CLSS public abstract interface static org.netbeans.modules.java.completion.JavaCompletionTask$ModuleItemFactory<%0 extends java.lang.Object>
  outer org.netbeans.modules.java.completion.JavaCompletionTask

--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -119,7 +119,7 @@ public final class JavaCompletionTask<T> extends BaseTask {
     }
     
     public static interface LambdaItemFactory<T> extends ItemFactory<T> {
-        T createLambdaItem(CompilationInfo info, TypeElement elem, DeclaredType type, int substitutionOffset, boolean addSemicolon);
+        T createLambdaItem(CompilationInfo info, TypeElement elem, DeclaredType type, int substitutionOffset, boolean expression, boolean addSemicolon);
     }
     
     public static interface ModuleItemFactory<T> extends ItemFactory<T> {
@@ -3344,7 +3344,8 @@ public final class JavaCompletionTask<T> extends BaseTask {
                             addTypeDotClassMembers(env, type);
                         } else if (controller.getSourceVersion().compareTo(SourceVersion.RELEASE_8) >= 0
                                 && elements.isFunctionalInterface(element) && itemFactory instanceof LambdaItemFactory) {
-                            results.add(((LambdaItemFactory<T>)itemFactory).createLambdaItem(env.getController(), element, type, anchorOffset, env.addSemicolon()));
+                            results.add(((LambdaItemFactory<T>)itemFactory).createLambdaItem(env.getController(), element, type, anchorOffset, true, env.addSemicolon()));
+                            results.add(((LambdaItemFactory<T>)itemFactory).createLambdaItem(env.getController(), element, type, anchorOffset, false, env.addSemicolon()));
                         }
                         final boolean startsWith = startsWith(env, element.getSimpleName().toString());
                         final boolean withinScope = withinScope(env, element);

--- a/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
+++ b/java/java.completion/src/org/netbeans/modules/java/completion/JavaCompletionTask.java
@@ -31,11 +31,6 @@ import java.util.logging.Level;
 
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
-import static javax.lang.model.element.ElementKind.*;
-import static javax.lang.model.element.Modifier.*;
-import static javax.lang.model.SourceVersion.RELEASE_10;
-import static javax.lang.model.SourceVersion.RELEASE_11;
-import static javax.lang.model.SourceVersion.RELEASE_13;
 import javax.lang.model.type.*;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.ElementFilter;
@@ -55,6 +50,13 @@ import org.netbeans.api.lexer.TokenSequence;
 import org.netbeans.api.lexer.TokenUtilities;
 import org.netbeans.modules.parsing.api.Source;
 import org.openide.util.Pair;
+
+import static javax.lang.model.element.ElementKind.*;
+import static javax.lang.model.element.Modifier.*;
+import static javax.lang.model.SourceVersion.RELEASE_10;
+import static javax.lang.model.SourceVersion.RELEASE_11;
+import static javax.lang.model.SourceVersion.RELEASE_13;
+import static javax.lang.model.type.TypeKind.VOID;
 
 /**
  *
@@ -3345,7 +3347,9 @@ public final class JavaCompletionTask<T> extends BaseTask {
                         } else if (controller.getSourceVersion().compareTo(SourceVersion.RELEASE_8) >= 0
                                 && elements.isFunctionalInterface(element) && itemFactory instanceof LambdaItemFactory) {
                             results.add(((LambdaItemFactory<T>)itemFactory).createLambdaItem(env.getController(), element, type, anchorOffset, true, env.addSemicolon()));
-                            results.add(((LambdaItemFactory<T>)itemFactory).createLambdaItem(env.getController(), element, type, anchorOffset, false, env.addSemicolon()));
+                            if (controller.getElementUtilities().getDescriptorElement(element).getReturnType().getKind() != VOID) {
+                                results.add(((LambdaItemFactory<T>)itemFactory).createLambdaItem(env.getController(), element, type, anchorOffset, false, env.addSemicolon()));
+                            }
                         }
                         final boolean startsWith = startsWith(env, element.getSimpleName().toString());
                         final boolean withinScope = withinScope(env, element);

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionCollector.java
@@ -866,7 +866,7 @@ public class JavaCompletionCollector implements CompletionCollector {
         }
 
         @Override
-        public Completion createLambdaItem(CompilationInfo info, TypeElement elem, DeclaredType type, int substitutionOffset, boolean addSemicolon) {
+        public Completion createLambdaItem(CompilationInfo info, TypeElement elem, DeclaredType type, int substitutionOffset, boolean expression, boolean addSemicolon) {
             StringBuilder label = new StringBuilder();
             StringBuilder insertText = new StringBuilder();
             StringBuilder sortText = new StringBuilder();

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItem.java
@@ -86,6 +86,8 @@ import org.openide.util.NbBundle;
 import org.openide.xml.XMLUtil;
 import org.netbeans.swing.plaf.LFCustoms;
 
+import static javax.lang.model.type.TypeKind.VOID;
+
 /**
  *
  * @author Dusan Balek
@@ -256,8 +258,8 @@ public abstract class JavaCompletionItem implements CompletionItem {
         return new InitializeAllConstructorItem(info, isDefault, fields, superConstructor, parent, substitutionOffset);
     }
 
-    public static JavaCompletionItem createLambdaItem(CompilationInfo info, TypeElement elem, DeclaredType type, int substitutionOffset, boolean addSemicolon) {
-        return new LambdaCompletionItem(info, elem, type, substitutionOffset, addSemicolon);
+    public static JavaCompletionItem createLambdaItem(CompilationInfo info, TypeElement elem, DeclaredType type, int substitutionOffset, boolean expression, boolean addSemicolon) {
+        return new LambdaCompletionItem(info, elem, type, substitutionOffset, expression, addSemicolon);
     }
 
     private static CompletionItem createExcludeItem(CharSequence name) {
@@ -993,6 +995,7 @@ public abstract class JavaCompletionItem implements CompletionItem {
             return simpleName;
         }
 
+        @Override
         public List<CompletionItem> getSubItems() {
             return subItems;
         }
@@ -4147,13 +4150,14 @@ public abstract class JavaCompletionItem implements CompletionItem {
 
         private ElementHandle<ExecutableElement> handle;
         private ArrayList<ParamDesc> params;
-        private boolean addSemicolon;
-        private String typeName;
+        private final boolean expression;
+        private final boolean addSemicolon;
+        private final String typeName;
         private String sortText;
         private String leftText;
         private String rightText;
         
-        public LambdaCompletionItem(CompilationInfo info, TypeElement elem, DeclaredType type, int substitutionOffset, boolean addSemicolon) {
+        public LambdaCompletionItem(CompilationInfo info, TypeElement elem, DeclaredType type, int substitutionOffset, boolean expression, boolean addSemicolon) {
             super(substitutionOffset);
             ExecutableElement desc = info.getElementUtilities().getDescriptorElement(elem);
             this.handle = ElementHandle.create(desc);
@@ -4171,6 +4175,7 @@ public abstract class JavaCompletionItem implements CompletionItem {
             TypeMirror retType = descType.getReturnType();
             this.addSemicolon = addSemicolon && retType.getKind() == TypeKind.VOID;
             this.typeName = Utilities.getTypeName(info, retType, false).toString();
+            this.expression = expression;
         }
 
         @Override
@@ -4215,7 +4220,11 @@ public abstract class JavaCompletionItem implements CompletionItem {
                         lText.append(", "); //NOI18N
                     }
                 }
-                lText.append(") -> {...}"); //NOI18N
+                if (expression) {
+                    lText.append(") -> expr."); //NOI18N
+                } else {
+                    lText.append(") -> {...}"); //NOI18N
+                }
                 return lText.toString();
             }
             return leftText;
@@ -4249,8 +4258,8 @@ public abstract class JavaCompletionItem implements CompletionItem {
             boolean spaceAroundLambdaArrow = CodeStyle.getDefault(c.getDocument()).spaceAroundLambdaArrow();
             sb.append(spaceAroundLambdaArrow ? " ->" : "->"); //NOI18N
             sb.append(getIndent(c, spaceAroundLambdaArrow, false));                        
-            sb.append("{\n"); //NOI18N
-            sb.append(getIndent(c));
+            sb.append("{"); //NOI18N
+//            sb.append(getIndent(c));
             sb.append(addSemicolon ? "};" : "}"); //NOI18N
             return sb;
         }
@@ -4289,7 +4298,12 @@ public abstract class JavaCompletionItem implements CompletionItem {
                                     while (method != null && path.getLeaf() != path.getCompilationUnit()) {
                                         Tree tree = path.getLeaf();
                                         if (tree.getKind() == Tree.Kind.LAMBDA_EXPRESSION) {
-                                            BlockTree body = GeneratorUtilities.get(copy).createDefaultLambdaBody((LambdaExpressionTree)tree, method);
+                                            Tree body;
+                                            if (expression && method.getReturnType().getKind() != VOID) {
+                                                body = GeneratorUtilities.get(copy).createDefaultLambdaExpression((LambdaExpressionTree)tree, method);
+                                            } else {
+                                                body = GeneratorUtilities.get(copy).createDefaultLambdaBody((LambdaExpressionTree)tree, method);
+                                            }
                                             copy.rewrite(((LambdaExpressionTree)tree).getBody(), body);
                                             break;
                                         }

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItemFactory.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaCompletionItemFactory.java
@@ -177,7 +177,7 @@ public final class JavaCompletionItemFactory implements JavaCompletionTask.TypeC
     }
 
     @Override
-    public JavaCompletionItem createLambdaItem(CompilationInfo info, TypeElement elem, DeclaredType type, int substitutionOffset, boolean addSemicolon) {
-        return JavaCompletionItem.createLambdaItem(info, elem, type, substitutionOffset, addSemicolon);
+    public JavaCompletionItem createLambdaItem(CompilationInfo info, TypeElement elem, DeclaredType type, int substitutionOffset, boolean expression, boolean addSemicolon) {
+        return JavaCompletionItem.createLambdaItem(info, elem, type, substitutionOffset, expression, addSemicolon);
     }
 }

--- a/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/GeneratorUtilities.java
@@ -133,6 +133,8 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.Exceptions;
 
+import static javax.lang.model.type.TypeKind.VOID;
+
 /**
  *
  * @author Jan Lahoda, Dusan Balek
@@ -1047,6 +1049,22 @@ public final class GeneratorUtilities {
             return copy.getTreeMaker().createLambdaBody(lambda, bodyTemplate);
         } catch (Exception e) {}
         return copy.getTreeMaker().Block(Collections.emptyList(), false);
+    }
+
+    /**
+     * Creates a default lambda expression.
+     *
+     * @param lambda a lambda to generate the expression for
+     * @param method a method of a functional interface to be implemented by the lambda expression
+     * @return the lambda expression
+     * @since 2.57
+     */
+    public ExpressionTree createDefaultLambdaExpression(LambdaExpressionTree lambda, ExecutableElement method) {
+        try {
+            String bodyTemplate = readFromTemplate(LAMBDA_EXPRESSION, createBindings(null, method)); //NOI18N
+            return copy.getTreeMaker().createLambdaExpression(lambda, bodyTemplate);
+        } catch (Exception e) {}
+        return null;
     }
     
     private boolean isStarImport(ImportTree imp) {
@@ -2175,6 +2193,7 @@ public final class GeneratorUtilities {
     private static final String GENERATED_METHOD_BODY = "Templates/Classes/Code/GeneratedMethodBody"; //NOI18N
     private static final String OVERRIDDEN_METHOD_BODY = "Templates/Classes/Code/OverriddenMethodBody"; //NOI18N
     private static final String LAMBDA_BODY = "Templates/Classes/Code/LambdaBody"; //NOI18N
+    private static final String LAMBDA_EXPRESSION = "Templates/Classes/Code/LambdaExpression"; //NOI18N
     private static final String METHOD_RETURN_TYPE = "method_return_type"; //NOI18N
     private static final String DEFAULT_RETURN_TYPE_VALUE = "default_return_value"; //NOI18N
     private static final String SUPER_METHOD_CALL = "super_method_call"; //NOI18N

--- a/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
+++ b/java/java.source.base/src/org/netbeans/api/java/source/TreeMaker.java
@@ -3360,6 +3360,25 @@ public final class TreeMaker {
     }
 
     /**
+     * Creates a new ExpressionTree for provided <tt>bodyText</tt>.
+     * 
+     * @param   lambda    figures out the scope for attribution.
+     * @param   bodyText  text which will be used for lambda body creation.
+     * @return  a new tree for <tt>bodyText</tt>.
+     * @since 2.54
+     */
+    public ExpressionTree createLambdaExpression(LambdaExpressionTree lambda, String bodyText) {
+        SourcePositions[] positions = new SourcePositions[1];
+        final TreeUtilities treeUtils = copy.getTreeUtilities();
+        ExpressionTree body = treeUtils.parseExpression(bodyText, positions);
+        Scope scope = copy.getTrees().getScope(TreePath.getPath(copy.getCompilationUnit(), lambda));
+        treeUtils.attributeTree(body, scope);
+//        mapComments((BlockTree) body, bodyText, copy, handler, positions[0]);
+        new TreePosCleaner().scan(body, null);
+        return (ExpressionTree) body;
+    }
+
+    /**
      * Creates a new MethodTree.
      *
      * @param modifiers the modifiers of this method.

--- a/java/java.source/src/org/netbeans/modules/java/source/package-info.java
+++ b/java/java.source/src/org/netbeans/modules/java/source/package-info.java
@@ -20,10 +20,10 @@
 @TemplateRegistrations({
     @TemplateRegistration(folder = "Classes/Code", position = 100, content = "resources/GeneratedMethodBody.template", scriptEngine = "freemarker", displayName = "#GeneratedMethodBody", category = "java-code-snippet"),
     @TemplateRegistration(folder = "Classes/Code", position = 200, content = "resources/OverriddenMethodBody.template", scriptEngine = "freemarker", displayName = "#OverriddenMethodBody", category = "java-code-snippet"),
-    @TemplateRegistration(folder = "Classes/Code", position = 300, content = "resources/LambdaBody.template", scriptEngine = "freemarker", displayName = "#LambdaBody", category = "java-code-snippet")
+    /*see layer.xml for non-public templates*/
 })
 @NbBundle.Messages({
-    "GeneratedMethodBody=Generated Method Body", "OverriddenMethodBody=Overridden Method Body", "LambdaBody=Generated Lambda Body" //NOI18N
+    "GeneratedMethodBody=Generated Method Body", "OverriddenMethodBody=Overridden Method Body" //NOI18N
 })
 package org.netbeans.modules.java.source;
 

--- a/java/java.source/src/org/netbeans/modules/java/source/resources/LambdaExpression.template
+++ b/java/java.source/src/org/netbeans/modules/java/source/resources/LambdaExpression.template
@@ -18,12 +18,12 @@
 -->
 
 <#--
-Internal Apache FreeMarker template for lambda bodies inserted via code completion.
+Internal Apache FreeMarker template for lambda expressions inserted via code completion.
 ${method_return_type}       a return type of the functional interface method
 ${default_return_value}     a value returned by the method by default
 ${method_name}              name of the functional interface method
 -->
 <#if method_return_type?? && method_return_type != "void">
-return ${default_return_value};
+${default_return_value}
 <#else>
 </#if>

--- a/java/java.source/src/org/netbeans/modules/java/source/resources/layer.xml
+++ b/java/java.source/src/org/netbeans/modules/java/source/resources/layer.xml
@@ -27,6 +27,19 @@
       <folder name="Code">
         <attr name="displayName" bundlevalue="org.netbeans.modules.java.source.Bundle#Templates/Classes/Code"/>
         <attr name="position" intvalue="10000"/>
+        <!-- internal templates -->
+        <file name="LambdaExpression" url="LambdaExpression.template">
+            <attr name="position" intvalue="300"/>
+            <attr name="templateCategory" stringvalue="java-code-snippet"/>
+            <attr name="simple" boolvalue="false"/> <!--hide in Template Manager-->
+            <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
+        </file>
+        <file name="LambdaBody" url="LambdaBody.template">
+            <attr name="position" intvalue="400"/>
+            <attr name="templateCategory" stringvalue="java-code-snippet"/>
+            <attr name="simple" boolvalue="false"/> <!--hide in Template Manager-->
+            <attr name="javax.script.ScriptEngine" stringvalue="freemarker"/>
+        </file>
       </folder>
     </folder>
   </folder>

--- a/platform/api.templates/arch.xml
+++ b/platform/api.templates/arch.xml
@@ -134,7 +134,7 @@
             return real instance of <code>ScriptEngine</code> interface or
             a <code>String</code> name of the engine that is then used to
             search for it in the <code>javax.script.ScriptEngineManager</code>.
-            Usually the <a href="http://freemarker.sourceforge.net/">freemarker</a> engine is the one that is 
+            Usually the <a href="https://freemarker.apache.org/">freemarker</a> engine is the one that is
             supported by the NetBeans IDE - if your module wants to use it
             then include a token dependency <code>OpenIDE-Module-Needs: javax.script.ScriptEngine.freemarker</code>
             in your manifest file (also accessible through project customizer GUI)


### PR DESCRIPTION
Adds a completion item for inserting lambda expressions.
```java
Stream.of().filter();                // cursor between ()
Stream.of().filter((t) -> false);    // generated with new expression completion
Stream.of().filter((t) -> {          // old block completion item remains available
    return false;
});      
```

edit:
it works but it has a problem: user changing the template could easily break the code responsible to mark the replacement String with `${...}` to make the generated code tab-navigatable.


https://user-images.githubusercontent.com/114367/174423136-45b86da0-04ff-4c83-9f96-a21c092fcc22.mp4


