### PR TITLE
failsafe:integration-test from contextual menu

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/TestChecker.java
+++ b/java/maven/src/org/netbeans/modules/maven/TestChecker.java
@@ -59,6 +59,17 @@ public class TestChecker implements PrerequisitesChecker {
                     config.setProperty("test", test + '#' + method);
                 }
         }
+        if (ActionProviderImpl.COMMAND_INTEGRATION_TEST_SINGLE.equals(action) ||
+            ActionProviderImpl.COMMAND_DEBUG_INTEGRATION_TEST_SINGLE.equals(action) ||
+            "profile-tests".equals(action)) //NOI18N - profile-tests is not really nice but well. 
+        {
+                String test = config.getProperties().get("it.test"); //NOI18N
+                String method = config.getProperties().get(DefaultReplaceTokenProvider.METHOD_NAME);
+                if (test != null && method != null) {
+                    config.setProperty(DefaultReplaceTokenProvider.METHOD_NAME, null);
+                    config.setProperty("it.test", test + '#' + method); //NOI18N
+                }
+        }
         if (MavenSettings.getDefault().isSkipTests()) {
             if (!String.valueOf(config.getGoals()).contains("test")) { // incl. integration-test
                 if (config.getProperties().get(PROP_SKIP_TEST) == null) {
@@ -67,9 +78,17 @@ public class TestChecker implements PrerequisitesChecker {
             }
         }
         if (ActionProvider.COMMAND_TEST_SINGLE.equals(action) ||
+            ActionProviderImpl.COMMAND_INTEGRATION_TEST_SINGLE.equals(action) ||
             ActionProvider.COMMAND_DEBUG_TEST_SINGLE.equals(action) ||
+            ActionProviderImpl.COMMAND_DEBUG_INTEGRATION_TEST_SINGLE.equals(action) ||
             ActionProvider.COMMAND_PROFILE_TEST_SINGLE.equals(action)) {
-            String test = config.getProperties().get("test");
+            String test;
+            if (ActionProviderImpl.COMMAND_INTEGRATION_TEST_SINGLE.equals(action) ||
+                ActionProviderImpl.COMMAND_DEBUG_INTEGRATION_TEST_SINGLE.equals(action)) {
+                test = config.getProperties().get("it.test"); //NOI18N
+            } else {
+                test = config.getProperties().get("test"); //NOI18N
+            }
             if (test != null) {
                 //#213783  when running tests validate that the test file exists
                 FileObject origFile = config.getSelectedFileObject();

--- a/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
+++ b/java/maven/src/org/netbeans/modules/maven/execute/DefaultReplaceTokenProvider.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.swing.ActionMap;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.java.project.JavaProjectConstants;
 import org.netbeans.api.java.queries.UnitTestForSourceQuery;
@@ -38,6 +39,7 @@ import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectUtils;
 import org.netbeans.api.project.SourceGroup;
 import org.netbeans.api.project.Sources;
+import org.netbeans.modules.maven.ActionProviderImpl;
 import org.netbeans.modules.maven.NbMavenProjectImpl;
 import org.netbeans.modules.maven.api.NbMavenProject;
 import org.netbeans.modules.maven.classpath.MavenSourcesImpl;
@@ -207,6 +209,7 @@ public class DefaultReplaceTokenProvider implements ReplaceTokenProvider, Action
             // not all of the selected files are under one source root, so maybe they were
             // selected from both source and test packages and "Test Files" action was invoked on them?
             if (ActionProvider.COMMAND_TEST_SINGLE.equals(actionName) ||
+                ActionProviderImpl.COMMAND_INTEGRATION_TEST_SINGLE.equals(actionName) ||
                 ActionProvider.COMMAND_DEBUG_TEST_SINGLE.equals(actionName)) 
             {
                 HashSet<String> test = new HashSet<String>();
@@ -337,13 +340,41 @@ public class DefaultReplaceTokenProvider implements ReplaceTokenProvider, Action
 //        return files.toArray(
 //                new FileObject[files.size()]);
 //    }
+    
+    private boolean isIntegrationTestFile(FileObject file) {
+        return file.getName().endsWith("IT") || file.getName().endsWith("ITCase"); //NOI18N
+    }
 
+    private boolean isIntegrationTestTarget(Lookup lookup) {
+        final SingleMethod targetMethod = lookup.lookup(SingleMethod.class); //JavaDataObject
+        if (targetMethod != null) {
+            return isIntegrationTestFile(targetMethod.getFile());
+        } 
+        final Collection<? extends FileObject> targetFiles = lookup.lookupAll(FileObject.class);
+        if (targetFiles != null) {
+            return targetFiles.stream().allMatch(file -> isIntegrationTestFile(file));
+        }
+        return false;
+    }
+    
     @Override public String convert(String action, Lookup lookup) {
         if (SingleMethod.COMMAND_DEBUG_SINGLE_METHOD.equals(action)) {
+            if (isIntegrationTestTarget(lookup)) {
+                return ActionProviderImpl.COMMAND_DEBUG_INTEGRATION_TEST_SINGLE;
+            }
             return ActionProvider.COMMAND_DEBUG_TEST_SINGLE;
         }
         if (SingleMethod.COMMAND_RUN_SINGLE_METHOD.equals(action)) {
+            if (isIntegrationTestTarget(lookup)) {
+                return ActionProviderImpl.COMMAND_INTEGRATION_TEST_SINGLE;
+            }
             return ActionProvider.COMMAND_TEST_SINGLE;
+        }
+        if (ActionProvider.COMMAND_TEST_SINGLE.equals(action) && isIntegrationTestTarget(lookup)) {
+            return ActionProviderImpl.COMMAND_INTEGRATION_TEST_SINGLE;
+        }
+        if (ActionProvider.COMMAND_DEBUG_TEST_SINGLE.equals(action) && isIntegrationTestTarget(lookup)) {
+            return ActionProviderImpl.COMMAND_DEBUG_INTEGRATION_TEST_SINGLE;
         }
         if (ActionProvider.COMMAND_RUN_SINGLE.equals(action) ||
             ActionProvider.COMMAND_DEBUG_SINGLE.equals(action) ||


### PR DESCRIPTION
When editing JUnit class of integration test, I expect "Test File", "Debug Test File", "Run Focused Test Method" or "Debug Focused Test Method" to run "integration-test.single" or "debug.integration-test.single" actions instead of "test.single" or "debug.test.single".
 
The goal of this feature is to run integration test during integration-test phase and so after pre-integration-test.