### PR TITLE
[#3466]  do not show Convert Type to Var hint for method references

### DIFF
--- a/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToVarHint.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/jdk/ConvertToVarHint.java
@@ -204,6 +204,8 @@ public class ConvertToVarHint {
                     break;
                 case LAMBDA_EXPRESSION:
                     return false;
+                case MEMBER_REFERENCE:
+                    return false;
                 default:
                     break;
             }

--- a/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToVarHintTest.java
+++ b/java/java.hints/test/unit/src/org/netbeans/modules/java/hints/jdk/ConvertToVarHintTest.java
@@ -122,6 +122,24 @@ public class ConvertToVarHintTest {
     }
     
     @Test
+    public void testMethodRefToVar() throws Exception {
+
+        HintTest.create()
+                .setCaretMarker('^')
+                .input("package test;\n"
+                        + "import java.util.function.Consumer;\n"
+                        + "public class Test {\n"
+                        + "    void m2() {\n"
+                        + "       final Consumer<String> println = System.out::println^;\n"
+                        + "    }\n"
+                        + "}\n")
+                .sourceLevel("1.10")
+                .run(ConvertToVarHint.class)
+                .assertNotContainsWarnings(VAR_CONV_DESC);
+
+    }
+    
+    @Test
     public void testArrayInitializerVar() throws Exception {
 
         HintTest.create()


### PR DESCRIPTION
Fix #3466 do not provide hint to convert type to var for method references.