### PR TITLE
Hint/Inspection panel and dialog layout fixes

### DIFF
--- a/ide/code.analysis/src/org/netbeans/modules/analysis/RunAnalysisPanel.form
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/RunAnalysisPanel.form
@@ -36,7 +36,7 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,0,-109,0,0,2,71"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,0,-125,0,0,1,-96"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
@@ -47,6 +47,10 @@
           <ResourceString bundle="org/netbeans/modules/analysis/Bundle.properties" key="RunAnalysisPanel.jLabel1.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
           <GridBagConstraints gridX="0" gridY="0" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="1280" weightX="0.0" weightY="0.0"/>
@@ -61,7 +65,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="1" gridY="0" gridWidth="3" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="1280" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="1" gridY="0" gridWidth="3" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="1280" weightX="1.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -71,6 +75,10 @@
           <ResourceString bundle="org/netbeans/modules/analysis/Bundle.properties" key="RunAnalysisPanel.jLabel2.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
           <GridBagConstraints gridX="0" gridY="1" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="12" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="1280" weightX="0.0" weightY="0.0"/>
@@ -88,7 +96,7 @@
       </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="2" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="1280" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="2" gridY="1" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="1280" weightX="1.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -154,7 +162,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-          <GridBagConstraints gridX="2" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="256" weightX="0.0" weightY="0.0"/>
+          <GridBagConstraints gridX="2" gridY="2" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="12" insetsLeft="12" insetsBottom="0" insetsRight="0" anchor="256" weightX="1.0" weightY="0.0"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -173,5 +181,18 @@
         </Constraint>
       </Constraints>
     </Component>
+    <Container class="javax.swing.JPanel" name="emptyPanel">
+      <AuxValues>
+        <AuxValue name="JavaCodeGenerator_VariableLocal" type="java.lang.Boolean" value="true"/>
+        <AuxValue name="JavaCodeGenerator_VariableModifier" type="java.lang.Integer" value="0"/>
+      </AuxValues>
+      <Constraints>
+        <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+          <GridBagConstraints gridX="-1" gridY="3" gridWidth="4" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="0" insetsLeft="0" insetsBottom="0" insetsRight="0" anchor="10" weightX="0.0" weightY="1.0"/>
+        </Constraint>
+      </Constraints>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.DesignFlowLayout"/>
+    </Container>
   </SubComponents>
 </Form>

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/RunAnalysisPanel.java
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/RunAnalysisPanel.java
@@ -21,6 +21,7 @@ package org.netbeans.modules.analysis;
 import java.awt.CardLayout;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.GridBagConstraints;
@@ -682,6 +683,7 @@ public final class RunAnalysisPanel extends javax.swing.JPanel implements Lookup
             }
         };
         AdjustConfigurationPanel panel = new AdjustConfigurationPanel(analyzers, preselectedAnalyzer, preselected, configurationToSelect, errorListener);
+        panel.setPreferredSize(new Dimension(700, 300));
         DialogDescriptor nd = new DialogDescriptor(panel, Bundle.LBL_Configurations(), true, NotifyDescriptor.OK_CANCEL_OPTION, NotifyDescriptor.OK_OPTION, null);
         
         nls[0] = nd.createNotificationLineSupport();

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/RunAnalysisPanel.java
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/RunAnalysisPanel.java
@@ -101,7 +101,7 @@ import org.openide.util.RequestProcessor;
  */
 public final class RunAnalysisPanel extends javax.swing.JPanel implements LookupListener {
 
-    private static final String COMBO_PROTOTYPE = "999999999999999999999999999999999999999999999999999999999999";
+    private static final String COMBO_PROTOTYPE = "999999999999999999999999999999999999";
     private static final RequestProcessor WORKER = new RequestProcessor(RunAnalysisPanel.class.getName(), 1, false, false);
     private final JPanel progress;
     private final RequiredPluginsPanel requiredPlugins;
@@ -543,15 +543,16 @@ public final class RunAnalysisPanel extends javax.swing.JPanel implements Lookup
         java.awt.GridBagConstraints gridBagConstraints;
 
         radioButtons = new javax.swing.ButtonGroup();
-        jLabel1 = new javax.swing.JLabel();
+        javax.swing.JLabel jLabel1 = new javax.swing.JLabel();
         scopeCombo = new javax.swing.JComboBox();
-        jLabel2 = new javax.swing.JLabel();
+        javax.swing.JLabel jLabel2 = new javax.swing.JLabel();
         configurationCombo = new javax.swing.JComboBox();
         manage = new javax.swing.JButton();
         configurationRadio = new javax.swing.JRadioButton();
         singleInspectionRadio = new javax.swing.JRadioButton();
         inspectionCombo = new javax.swing.JComboBox();
         browse = new javax.swing.JButton();
+        javax.swing.JPanel emptyPanel = new javax.swing.JPanel();
 
         setLayout(new java.awt.GridBagLayout());
 
@@ -568,6 +569,7 @@ public final class RunAnalysisPanel extends javax.swing.JPanel implements Lookup
         gridBagConstraints.gridwidth = 3;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.ABOVE_BASELINE_LEADING;
+        gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(0, 12, 0, 0);
         add(scopeCombo, gridBagConstraints);
 
@@ -590,6 +592,7 @@ public final class RunAnalysisPanel extends javax.swing.JPanel implements Lookup
         gridBagConstraints.gridy = 1;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.ABOVE_BASELINE_LEADING;
+        gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(12, 12, 0, 0);
         add(configurationCombo, gridBagConstraints);
 
@@ -640,6 +643,7 @@ public final class RunAnalysisPanel extends javax.swing.JPanel implements Lookup
         gridBagConstraints.gridy = 2;
         gridBagConstraints.fill = java.awt.GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = java.awt.GridBagConstraints.BASELINE;
+        gridBagConstraints.weightx = 1.0;
         gridBagConstraints.insets = new java.awt.Insets(12, 12, 0, 0);
         add(inspectionCombo, gridBagConstraints);
 
@@ -656,6 +660,12 @@ public final class RunAnalysisPanel extends javax.swing.JPanel implements Lookup
         gridBagConstraints.anchor = java.awt.GridBagConstraints.BASELINE;
         gridBagConstraints.insets = new java.awt.Insets(12, 12, 0, 0);
         add(browse, gridBagConstraints);
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridy = 3;
+        gridBagConstraints.gridwidth = 4;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.weighty = 1.0;
+        add(emptyPanel, gridBagConstraints);
     }// </editor-fold>//GEN-END:initComponents
 
     private void configurationComboActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_configurationComboActionPerformed
@@ -727,8 +737,6 @@ public final class RunAnalysisPanel extends javax.swing.JPanel implements Lookup
     private javax.swing.JComboBox configurationCombo;
     private javax.swing.JRadioButton configurationRadio;
     private javax.swing.JComboBox inspectionCombo;
-    private javax.swing.JLabel jLabel1;
-    private javax.swing.JLabel jLabel2;
     private javax.swing.JButton manage;
     private javax.swing.ButtonGroup radioButtons;
     private javax.swing.JComboBox scopeCombo;

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/ui/AdjustConfigurationPanel.form
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/ui/AdjustConfigurationPanel.form
@@ -48,7 +48,7 @@
                       </Group>
                       <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="configurationCombo" pref="254" max="32767" attributes="0"/>
+                          <Component id="configurationCombo" pref="220" max="32767" attributes="0"/>
                           <Component id="analyzerCombo" max="32767" attributes="0"/>
                       </Group>
                   </Group>
@@ -70,8 +70,8 @@
                   <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="analyzerCombo" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="separate" max="-2" attributes="0"/>
-              <Component id="analyzerPanel" pref="198" max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="analyzerPanel" pref="180" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>

--- a/ide/code.analysis/src/org/netbeans/modules/analysis/ui/AdjustConfigurationPanel.java
+++ b/ide/code.analysis/src/org/netbeans/modules/analysis/ui/AdjustConfigurationPanel.java
@@ -20,7 +20,6 @@ package org.netbeans.modules.analysis.ui;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
-import java.awt.Dimension;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -41,7 +40,6 @@ import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JComponent;
 import javax.swing.JList;
-import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import org.netbeans.modules.analysis.Configuration;
 import org.netbeans.modules.analysis.ConfigurationsManager;
@@ -281,7 +279,7 @@ public class AdjustConfigurationPanel extends javax.swing.JPanel implements Prop
                             .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(configurationCombo, 0, 254, Short.MAX_VALUE)
+                            .addComponent(configurationCombo, 0, 220, Short.MAX_VALUE)
                             .addComponent(analyzerCombo, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
                 .addContainerGap())
         );
@@ -296,8 +294,8 @@ public class AdjustConfigurationPanel extends javax.swing.JPanel implements Prop
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel2)
                     .addComponent(analyzerCombo, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addGap(18, 18, 18)
-                .addComponent(analyzerPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 198, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(analyzerPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 180, Short.MAX_VALUE)
                 .addContainerGap())
         );
     }// </editor-fold>//GEN-END:initComponents

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanel.form
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanel.form
@@ -47,16 +47,13 @@
     <AuxValue name="FormSettings_listenerGenerationStyle" type="java.lang.Integer" value="0"/>
     <AuxValue name="FormSettings_variablesLocal" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_variablesModifier" type="java.lang.Integer" value="2"/>
-    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-116,0,0,3,9"/>
+    <AuxValue name="designerSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,1,-35,0,0,3,66"/>
   </AuxValues>
 
   <Layout class="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout"/>
   <SubComponents>
     <Container class="javax.swing.JSplitPane" name="jSplitPane1">
       <Properties>
-        <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
-          <Border info="null"/>
-        </Property>
         <Property name="dividerLocation" type="int" value="320"/>
       </Properties>
       <Constraints>
@@ -127,15 +124,15 @@
             <DimensionLayout dim="0">
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="optionsPanel" max="32767" attributes="0"/>
-                  <Component id="descriptionPanel" alignment="0" pref="430" max="32767" attributes="0"/>
+                  <Component id="descriptionPanel" alignment="0" max="32767" attributes="0"/>
               </Group>
             </DimensionLayout>
             <DimensionLayout dim="1">
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" attributes="0">
-                      <Component id="optionsPanel" pref="109" max="32767" attributes="0"/>
-                      <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
-                      <Component id="descriptionPanel" pref="186" max="32767" attributes="0"/>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Component id="optionsPanel" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                      <Component id="descriptionPanel" pref="314" max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -277,7 +274,7 @@
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Group type="102" alignment="1" attributes="0">
                               <Component id="openInEditor" min="-2" max="-2" attributes="0"/>
-                              <EmptySpace pref="195" max="32767" attributes="0"/>
+                              <EmptySpace pref="212" max="32767" attributes="0"/>
                               <Component id="saveButton" min="-2" max="-2" attributes="0"/>
                               <EmptySpace type="unrelated" max="-2" attributes="0"/>
                               <Component id="cancelEdit" min="-2" max="-2" attributes="0"/>
@@ -463,7 +460,7 @@
               <Group type="102" alignment="0" attributes="0">
                   <Component id="configLabel" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
-                  <Component id="configCombo" pref="683" max="32767" attributes="0"/>
+                  <Component id="configCombo" pref="719" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -503,7 +500,7 @@
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="1" attributes="0">
                   <Component id="refactoringsLabel" min="-2" max="-2" attributes="0"/>
-                  <EmptySpace pref="540" max="32767" attributes="0"/>
+                  <EmptySpace pref="576" max="32767" attributes="0"/>
                   <Component id="searchLabel" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="searchTextField" min="-2" pref="121" max="-2" attributes="0"/>

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/options/HintsPanel.java
@@ -39,16 +39,10 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.prefs.Preferences;
 import javax.swing.AbstractAction;
@@ -355,7 +349,7 @@ public final class HintsPanel extends javax.swing.JPanel   {
 
     private int getDividerLocation() {
         final int location = (int) ((jSplitPane1.getWidth() - jSplitPane1.getDividerSize()) * 0.4f);
-        return Math.min(320, location);
+        return Math.min(400, location);
     }
     
     /** This method is called from within the constructor to
@@ -405,7 +399,6 @@ public final class HintsPanel extends javax.swing.JPanel   {
         setBorder(javax.swing.BorderFactory.createEmptyBorder(8, 8, 8, 8));
         setLayout(new java.awt.GridBagLayout());
 
-        jSplitPane1.setBorder(null);
         jSplitPane1.setDividerLocation(320);
 
         treePanel.setOpaque(false);
@@ -516,7 +509,7 @@ public final class HintsPanel extends javax.swing.JPanel   {
             editingButtonsLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, editingButtonsLayout.createSequentialGroup()
                 .addComponent(openInEditor)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 198, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 212, Short.MAX_VALUE)
                 .addComponent(saveButton)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(cancelEdit))
@@ -560,9 +553,9 @@ public final class HintsPanel extends javax.swing.JPanel   {
         detailsPanelLayout.setVerticalGroup(
             detailsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(detailsPanelLayout.createSequentialGroup()
-                .addComponent(optionsPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 97, Short.MAX_VALUE)
-                .addGap(12, 12, 12)
-                .addComponent(descriptionPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 175, Short.MAX_VALUE))
+                .addComponent(optionsPanel, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(descriptionPanel, javax.swing.GroupLayout.DEFAULT_SIZE, 314, Short.MAX_VALUE))
         );
 
         jSplitPane1.setRightComponent(detailsPanel);
@@ -618,7 +611,7 @@ public final class HintsPanel extends javax.swing.JPanel   {
                 .addComponent(importButton)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(exportButton)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 329, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 292, Short.MAX_VALUE)
                 .addComponent(editScriptButton)
                 .addGap(35, 35, 35)
                 .addComponent(okButton)
@@ -660,7 +653,7 @@ public final class HintsPanel extends javax.swing.JPanel   {
             .addGroup(configurationsPanelLayout.createSequentialGroup()
                 .addComponent(configLabel)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(configCombo, 0, 642, Short.MAX_VALUE))
+                .addComponent(configCombo, 0, 719, Short.MAX_VALUE))
         );
         configurationsPanelLayout.setVerticalGroup(
             configurationsPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -684,7 +677,7 @@ public final class HintsPanel extends javax.swing.JPanel   {
             searchPanelLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, searchPanelLayout.createSequentialGroup()
                 .addComponent(refactoringsLabel)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 493, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 576, Short.MAX_VALUE)
                 .addComponent(searchLabel)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(searchTextField, javax.swing.GroupLayout.PREFERRED_SIZE, 121, javax.swing.GroupLayout.PREFERRED_SIZE))

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.form
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.form
@@ -50,27 +50,24 @@
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" attributes="0">
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="configurationRadio" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="singleRefactorRadio" alignment="0" min="-2" max="-2" attributes="0"/>
-                      </Group>
+                      <Component id="singleRefactorRadio" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="singleRefactoringCombo" pref="196" max="32767" attributes="0"/>
-                          <Component id="configurationCombo" alignment="0" pref="196" max="32767" attributes="0"/>
-                      </Group>
+                      <Component id="singleRefactoringCombo" max="32767" attributes="0"/>
                   </Group>
-                  <Component id="scopeCombo" alignment="1" pref="346" max="32767" attributes="0"/>
+                  <Group type="102" attributes="0">
+                      <Component id="configurationRadio" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace min="-2" pref="25" max="-2" attributes="0"/>
+                      <Component id="configurationCombo" pref="242" max="32767" attributes="0"/>
+                  </Group>
+                  <Component id="scopeCombo" alignment="1" pref="377" max="32767" attributes="0"/>
               </Group>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                      <Component id="manageSingleRefactoring" alignment="1" max="32767" attributes="1"/>
-                      <Component id="manageConfigurations" alignment="1" max="32767" attributes="1"/>
-                  </Group>
+              <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                  <Component id="manageConfigurations" max="32767" attributes="1"/>
                   <Component id="customScopeButton" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="manageSingleRefactoring" alignment="0" max="32767" attributes="1"/>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -90,12 +87,13 @@
                   <Component id="manageConfigurations" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="refactorUsingLabel" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace min="1" pref="1" max="1" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="singleRefactorRadio" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="singleRefactoringCombo" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="manageSingleRefactoring" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="singleRefactorRadio" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
+++ b/java/java.hints.ui/src/org/netbeans/modules/java/hints/spiimpl/refactoring/InspectAndRefactorPanel.java
@@ -328,8 +328,7 @@ public class InspectAndRefactorPanel extends javax.swing.JPanel implements Popup
 
         GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
-        layout.setHorizontalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setHorizontalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(Alignment.LEADING)
@@ -338,24 +337,22 @@ public class InspectAndRefactorPanel extends javax.swing.JPanel implements Popup
                 .addPreferredGap(ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(Alignment.LEADING)
                     .addGroup(layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(Alignment.LEADING)
-                            .addComponent(configurationRadio)
-                            .addComponent(singleRefactorRadio))
+                        .addComponent(singleRefactorRadio)
                         .addPreferredGap(ComponentPlacement.RELATED)
-                        .addGroup(layout.createParallelGroup(Alignment.LEADING)
-                            .addComponent(singleRefactoringCombo, 0, 196, Short.MAX_VALUE)
-                            .addComponent(configurationCombo, 0, 196, Short.MAX_VALUE)))
-                    .addComponent(scopeCombo, Alignment.TRAILING, 0, 346, Short.MAX_VALUE))
+                        .addComponent(singleRefactoringCombo, 0, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(configurationRadio)
+                        .addGap(25, 25, 25)
+                        .addComponent(configurationCombo, 0, 242, Short.MAX_VALUE))
+                    .addComponent(scopeCombo, Alignment.TRAILING, 0, 377, Short.MAX_VALUE))
                 .addPreferredGap(ComponentPlacement.UNRELATED)
-                .addGroup(layout.createParallelGroup(Alignment.LEADING)
-                    .addGroup(layout.createParallelGroup(Alignment.LEADING, false)
-                        .addComponent(manageSingleRefactoring, Alignment.TRAILING, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addComponent(manageConfigurations, Alignment.TRAILING, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                    .addComponent(customScopeButton))
+                .addGroup(layout.createParallelGroup(Alignment.LEADING, false)
+                    .addComponent(manageConfigurations, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(customScopeButton)
+                    .addComponent(manageSingleRefactoring, GroupLayout.DEFAULT_SIZE, GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                 .addContainerGap())
         );
-        layout.setVerticalGroup(
-            layout.createParallelGroup(Alignment.LEADING)
+        layout.setVerticalGroup(layout.createParallelGroup(Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(Alignment.BASELINE)
@@ -368,11 +365,12 @@ public class InspectAndRefactorPanel extends javax.swing.JPanel implements Popup
                     .addComponent(configurationCombo, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
                     .addComponent(manageConfigurations)
                     .addComponent(refactorUsingLabel))
-                .addGap(1, 1, 1)
+                .addPreferredGap(ComponentPlacement.UNRELATED)
                 .addGroup(layout.createParallelGroup(Alignment.BASELINE)
+                    .addComponent(singleRefactorRadio)
                     .addComponent(singleRefactoringCombo, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE)
-                    .addComponent(manageSingleRefactoring)
-                    .addComponent(singleRefactorRadio)))
+                    .addComponent(manageSingleRefactoring))
+                .addContainerGap(GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 

--- a/java/java.hints/src/org/netbeans/modules/java/hints/WrongStringComparisonCustomizer.form
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/WrongStringComparisonCustomizer.form
@@ -45,8 +45,8 @@
           <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="ternaryNullCheck" alignment="0" min="-2" pref="346" max="-2" attributes="0"/>
-                  <Component id="stringLiteralsFirst" alignment="0" min="-2" pref="346" max="-2" attributes="0"/>
+                  <Component id="ternaryNullCheck" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="stringLiteralsFirst" alignment="0" min="-2" pref="315" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
@@ -56,9 +56,9 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="ternaryNullCheck" min="-2" pref="30" max="-2" attributes="0"/>
+              <Component id="ternaryNullCheck" min="-2" pref="24" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
-              <Component id="stringLiteralsFirst" min="-2" pref="30" max="-2" attributes="0"/>
+              <Component id="stringLiteralsFirst" min="-2" max="-2" attributes="0"/>
               <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/WrongStringComparisonCustomizer.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/WrongStringComparisonCustomizer.java
@@ -29,7 +29,7 @@ import java.util.prefs.Preferences;
  */
 public class WrongStringComparisonCustomizer extends javax.swing.JPanel {
 
-    private Preferences p;
+    private final Preferences p;
 
     /** Creates new customizer WrongStringComparisonCustomizer */
     public WrongStringComparisonCustomizer(Preferences p) {
@@ -73,17 +73,17 @@ public class WrongStringComparisonCustomizer extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(ternaryNullCheck, javax.swing.GroupLayout.PREFERRED_SIZE, 346, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(stringLiteralsFirst, javax.swing.GroupLayout.PREFERRED_SIZE, 346, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addComponent(ternaryNullCheck)
+                    .addComponent(stringLiteralsFirst, javax.swing.GroupLayout.PREFERRED_SIZE, 315, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(ternaryNullCheck, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(ternaryNullCheck, javax.swing.GroupLayout.PREFERRED_SIZE, 24, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addComponent(stringLiteralsFirst, javax.swing.GroupLayout.PREFERRED_SIZE, 30, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(stringLiteralsFirst)
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/FinalFieldsFromCtorCustomiser.form
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/FinalFieldsFromCtorCustomiser.form
@@ -39,17 +39,17 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="finalCheckBox" min="-2" pref="222" max="-2" attributes="0"/>
-              <EmptySpace max="32767" attributes="0"/>
+              <Component id="finalCheckBox" max="32767" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace min="-2" pref="19" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Component id="finalCheckBox" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="24" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/FinalFieldsFromCtorCustomiser.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/FinalFieldsFromCtorCustomiser.java
@@ -59,15 +59,15 @@ public class FinalFieldsFromCtorCustomiser extends javax.swing.JPanel {
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
-                .addComponent(finalCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, 222, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addComponent(finalCheckBox)
+                .addContainerGap())
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addGap(19, 19, 19)
-                .addComponent(finalCheckBox)
-                .addContainerGap(24, Short.MAX_VALUE))
+                .addContainerGap()
+                .addComponent(finalCheckBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         finalCheckBox.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(FinalFieldsFromCtorCustomiser.class, "ACSN_Final_Checkbox")); // NOI18N

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ImportClassCustomizer.form
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ImportClassCustomizer.form
@@ -40,7 +40,7 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Component id="organizeImports" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="195" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -49,7 +49,7 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Component id="organizeImports" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="269" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/ImportClassCustomizer.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/ImportClassCustomizer.java
@@ -61,14 +61,14 @@ public class ImportClassCustomizer extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(organizeImports)
-                .addContainerGap(195, Short.MAX_VALUE))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(organizeImports)
-                .addContainerGap(269, Short.MAX_VALUE))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/LocalVariableFixCustomizer.form
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/LocalVariableFixCustomizer.form
@@ -25,6 +25,7 @@
   <AuxValues>
     <AuxValue name="FormSettings_autoResourcing" type="java.lang.Integer" value="1"/>
     <AuxValue name="FormSettings_autoSetComponentName" type="java.lang.Boolean" value="false"/>
+    <AuxValue name="FormSettings_generateFQN" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_generateMnemonicsCode" type="java.lang.Boolean" value="false"/>
     <AuxValue name="FormSettings_i18nAutoMode" type="java.lang.Boolean" value="true"/>
     <AuxValue name="FormSettings_layoutCodeTarget" type="java.lang.Integer" value="1"/>
@@ -39,7 +40,7 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Component id="inPlace" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="186" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -48,7 +49,7 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Component id="inPlace" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="269" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/LocalVariableFixCustomizer.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/LocalVariableFixCustomizer.java
@@ -60,14 +60,14 @@ public class LocalVariableFixCustomizer extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(inPlace)
-                .addContainerGap(186, Short.MAX_VALUE))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addComponent(inPlace)
-                .addContainerGap(269, Short.MAX_VALUE))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.form
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.form
@@ -52,7 +52,7 @@
                       </Group>
                   </Group>
               </Group>
-              <EmptySpace min="-2" pref="221" max="-2" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -71,7 +71,7 @@
               <Component id="rethrowRuntime" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="rethrow" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="134" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.java
+++ b/java/java.hints/src/org/netbeans/modules/java/hints/errors/SurroundWithTryCatchLog.java
@@ -112,7 +112,7 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
                             .addComponent(printStackTrace)
                             .addComponent(rethrowRuntime)
                             .addComponent(rethrow))))
-                .addGap(221, 221, 221))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -129,7 +129,7 @@ public class SurroundWithTryCatchLog extends javax.swing.JPanel {
                 .addComponent(rethrowRuntime)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(rethrow)
-                .addContainerGap(134, Short.MAX_VALUE))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/ui/customizers/SearchDependencyCustomizer.form
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/ui/customizers/SearchDependencyCustomizer.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <!--
 
@@ -47,14 +47,13 @@
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="lblHeader" alignment="0" pref="432" max="32767" attributes="0"/>
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="-2" pref="10" max="-2" attributes="0"/>
-                      <Component id="jrOptionInplace" pref="422" max="32767" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <EmptySpace min="-2" pref="10" max="-2" attributes="0"/>
-                      <Component id="jrOptionDialog" pref="422" max="32767" attributes="0"/>
+                  <Component id="lblHeader" alignment="0" max="32767" attributes="0"/>
+                  <Group type="102" attributes="0">
+                      <EmptySpace min="10" pref="10" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="jrOptionInplace" alignment="0" max="32767" attributes="0"/>
+                          <Component id="jrOptionDialog" alignment="0" max="32767" attributes="0"/>
+                      </Group>
                   </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
@@ -70,7 +69,7 @@
               <Component id="jrOptionDialog" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="jrOptionInplace" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="219" max="32767" attributes="0"/>
+              <EmptySpace max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -91,7 +90,6 @@
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/maven/hints/ui/customizers/Bundle.properties" key="LBL_Option_Dialog" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
-        <Property name="opaque" type="boolean" value="false"/>
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jrOptionDialogActionPerformed"/>
@@ -105,7 +103,6 @@
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/modules/maven/hints/ui/customizers/Bundle.properties" key="LBL_Option_InPlace" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
-        <Property name="opaque" type="boolean" value="false"/>
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jrOptionInplaceActionPerformed"/>

--- a/java/maven.hints/src/org/netbeans/modules/maven/hints/ui/customizers/SearchDependencyCustomizer.java
+++ b/java/maven.hints/src/org/netbeans/modules/maven/hints/ui/customizers/SearchDependencyCustomizer.java
@@ -65,7 +65,6 @@ public class SearchDependencyCustomizer extends javax.swing.JPanel {
 
         buttonGroup1.add(jrOptionDialog);
         jrOptionDialog.setText(org.openide.util.NbBundle.getMessage(SearchDependencyCustomizer.class, "LBL_Option_Dialog")); // NOI18N
-        jrOptionDialog.setOpaque(false);
         jrOptionDialog.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jrOptionDialogActionPerformed(evt);
@@ -74,7 +73,6 @@ public class SearchDependencyCustomizer extends javax.swing.JPanel {
 
         buttonGroup1.add(jrOptionInplace);
         jrOptionInplace.setText(org.openide.util.NbBundle.getMessage(SearchDependencyCustomizer.class, "LBL_Option_InPlace")); // NOI18N
-        jrOptionInplace.setOpaque(false);
         jrOptionInplace.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jrOptionInplaceActionPerformed(evt);
@@ -88,13 +86,12 @@ public class SearchDependencyCustomizer extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(lblHeader, javax.swing.GroupLayout.DEFAULT_SIZE, 432, Short.MAX_VALUE)
+                    .addComponent(lblHeader)
                     .addGroup(layout.createSequentialGroup()
                         .addGap(10, 10, 10)
-                        .addComponent(jrOptionInplace, javax.swing.GroupLayout.DEFAULT_SIZE, 422, Short.MAX_VALUE))
-                    .addGroup(layout.createSequentialGroup()
-                        .addGap(10, 10, 10)
-                        .addComponent(jrOptionDialog, javax.swing.GroupLayout.DEFAULT_SIZE, 422, Short.MAX_VALUE)))
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(jrOptionInplace, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(jrOptionDialog, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -106,7 +103,7 @@ public class SearchDependencyCustomizer extends javax.swing.JPanel {
                 .addComponent(jrOptionDialog)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(jrOptionInplace)
-                .addContainerGap(219, Short.MAX_VALUE))
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 


### PR DESCRIPTION
- `source -> inspect` dialog did not resize properly
- `refactor -> inspect and refactor` dialog had no separation between row two and three (very similar dialog to the one above but uses a different layout manager :) )
- layout fixes to HintPanel as used in `options -> editor -> hints` or from various configuration dialogs
  - description resizes now vertically, required updates to many customizer components so that they only take as much space as they need
  - made dialogs which use the HintPanel a little larger