### PR TITLE
LSP: java.source.save.CasualDiff: Illegal values after using CodeCompletion.

### DIFF
--- a/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
+++ b/java/java.source.base/src/org/netbeans/modules/java/source/save/CasualDiff.java
@@ -3055,12 +3055,15 @@ public class CasualDiff {
         // called.
     }
 
-    protected void diffErroneous(JCErroneous oldT, JCErroneous newT, int[] bounds) {
-        JCTree oldTident = oldT.getErrorTrees().get(0);
-        JCTree newTident = newT.getErrorTrees().get(0);
-        if (oldTident.getKind() == Kind.IDENTIFIER && newTident.getKind() == Kind.IDENTIFIER) {
-            diffIdent((JCIdent) oldTident, (JCIdent) newTident, bounds);
-        }
+    protected int diffErroneous(JCErroneous oldT, JCErroneous newT, int[] bounds) {
+        JCTree oldTerr = oldT.getErrorTrees().get(0);
+        JCTree newTerr = newT.getErrorTrees().get(0);
+        int localPointer = bounds[0];
+        int[] errBounds = getBounds(oldTerr);
+        copyTo(localPointer, errBounds[0]);
+        localPointer = diffTree(oldTerr, newTerr, errBounds);
+        copyTo(localPointer, bounds[1]);
+        return bounds[1];
     }
     
     protected int diffLambda(JCLambda oldT, JCLambda newT, int[] bounds) {
@@ -5714,7 +5717,7 @@ public class CasualDiff {
               retVal = diffAssignop((JCAssignOp)oldT, (JCAssignOp)newT, elementBounds);
               break;
           case ERRONEOUS:
-              diffErroneous((JCErroneous)oldT, (JCErroneous)newT, elementBounds);
+              retVal = diffErroneous((JCErroneous)oldT, (JCErroneous)newT, elementBounds);
               break;
           case MODIFIERS:
               retVal = diffModifiers((JCModifiers) oldT, (JCModifiers) newT, parent, elementBounds[0]);


### PR DESCRIPTION
After using code completion for e.g. `System.out`, a syntax error due to unfinished statement is usually reported. At the same time VSCode client asks for all available CodeActions (Hints) at the current line. One of the hints offers creating a static import for `System.out` and therefore a diff computation for such change touches the `ErroneousTree` representing the unfinished statement. Change to the `CasualDiff` was necessary to correctly handle this situation.