### PR TITLE
Fix for testPreTrusted gradle test failing on CI

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/NbGradleProjectImpl.java
@@ -312,7 +312,7 @@ public final class NbGradleProjectImpl implements Project {
         RELOAD_RP.post(() -> 
             loadOwnProject0(desc, false, interactive, aim, false, force)
                 .handle((p, e) -> {
-                   if (e != null) {
+                   if (e == null) {
                        toRet.complete(p);
                    } else {
                        toRet.completeExceptionally(e);
@@ -474,12 +474,13 @@ public final class NbGradleProjectImpl implements Project {
 
     @Override
     public String toString() {
-        synchronized (this) {
-            if (isGradleProjectLoaded()) {
-                return "Gradle: " + project.getBaseProject().getName() + "[" + project.getQuality() + "]";
-            } else {
-                return "Unloaded Gradle Project: " + gradleFiles.toString();
-            }
+        // synchronized was here, but is it may be called during Logger.log(), it may completely cause a deadlock
+        // between LogHandler (that calls this toString() and other thread that locked this and tries to use Logger).
+        GradleProject p = project;
+        if (p != null) {
+            return "Gradle: " + p.getBaseProject().getName() + "[" + p.getQuality() + "]";
+        } else {
+            return "Unloaded Gradle Project: " + gradleFiles.toString();
         }
     }
     

--- a/extide/gradle/src/org/netbeans/modules/gradle/ProjectTrust.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ProjectTrust.java
@@ -30,6 +30,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.prefs.Preferences;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -44,6 +46,8 @@ import org.openide.util.NbPreferences;
  * @author lkishalmi
  */
 public class ProjectTrust {
+    private static final Logger LOG = Logger.getLogger(ProjectTrust.class.getName());
+    
     private static final String KEY_SALT     = "secret";     //NOI18N
     private static final String NODE_PROJECT = "projects"; //NOI18N
     private static final String NODE_TRUST   = "trust";    //NOI18N
@@ -82,6 +86,7 @@ public class ProjectTrust {
     public boolean isTrusted(Project project) {
         synchronized (this) {
             if (temporaryTrustedIds.contains(getPathId(project))) {
+                LOG.log(Level.FINER, "Project {0} temporarily trusted.", project);
                 return true;
             }
         }
@@ -108,7 +113,9 @@ public class ProjectTrust {
             List<String> trust = Files.readAllLines(trustFile);
             String hash = hmacSha256(fromHex(projectId));
             ret = trust.size() == 1 && trust.iterator().next().equals(hash);
+            LOG.log(Level.FINER, "Trust for project {0} is: {1}", new Object[] { project, ret });
         } catch (IOException ex) {
+            LOG.log(Level.FINER, "Could not load trust file {0} for projec {1}.", new Object[] { trustFile, project});
         }
         return ret;        
     }

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/DiskCacheProjectLoader.java
@@ -39,6 +39,7 @@ public class DiskCacheProjectLoader extends AbstractProjectLoader {
     @Override
     public GradleProject load() {
         ProjectInfoDiskCache cache = ProjectInfoDiskCache.get(ctx.project.getGradleFiles());
+        LOG.log(Level.FINER, "Loaded from cache: {0}, valid: {1}", new Object[] { ctx.previous, cache.isValid() });
         if (cache.isCompatible()) {
             GradleProject prev = createGradleProject(cache.loadData());
             LOG.log(Level.FINER, "Loaded from cache: {0}, valid: {1}", new Object[] { prev, cache.isValid() });

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -49,6 +49,8 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
         LOGGER.info("Load aiming " +aim + " for "+ project);
         GradleCommandLine cmd = new GradleCommandLine(args);
         AbstractProjectLoader.ReloadContext ctx = new AbstractProjectLoader.ReloadContext((NbGradleProjectImpl) project, aim, cmd, descriptionOpt);
+        LOGGER.log(Level.FINER, "Load context: project = {0}, prev = {1}, aim = {2}, args = {3}", new Object[] { 
+            project, ctx.previous, aim, cmd});
         List<AbstractProjectLoader> loaders = new LinkedList<>();
 
         if (!ignoreCache) loaders.add(new DiskCacheProjectLoader(ctx));
@@ -85,6 +87,8 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
                 if (ret != null) {
                     break;
                 }
+            } else {
+                LOGGER.log(Level.FINER, "Loaded disabled: {0}", loader);
             }
         }
         if (ret == null) {

--- a/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
+++ b/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java
@@ -185,6 +185,7 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
     }
 
     private void updateGroups(Set<String> newGroups) {
+        // Note: ClassPathProviderImplTest timing relies on the provider instance locked
         synchronized(this) {
             Map<String, SourceSetCP> g = new HashMap<>(groups);
             Iterator<Map.Entry<String, SourceSetCP>> it = g.entrySet().iterator();
@@ -251,6 +252,7 @@ public final class ClassPathProviderImpl extends ProjectOpenedHook implements Cl
             }
         }
 
+        // Note: ClassPathProviderImplTest timing relies on the provider instance locked
         private synchronized ClassPath getCompileTimeClasspath() {
             if (compileTime == null) {
                 compileTime = createMultiplexClassPath(


### PR DESCRIPTION
This PR attempts to fix gradle test suite that is randomly failing just on CI. The root cause is that obviously I've written the test wrong ;) the original idea was to test what will happen if:
- the project is trusted
- it has been compiled, closed, IDE restarted
- the project is opened again.
Since I didn't want to bring all the NbModuleSuite machinery, the test just moved the original project, created a copy == new `FileObject` and opened the project again. New FileObject means new Project.

But some Gradle caches rely on `j.io.File`, not FileObjects, so [at this point](https://github.com/apache/netbeans/blob/master/java/gradle.java/test/unit/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImplTest.java#L248) the `prj2` was a new instance, but its `GradleFiles` key into the cache was **the same** as the `prj` key...
... so the project info was found in the cache loaded, and was returned. And the test was failing because **sometimes the timestamps of the copied files were different** from the timestamps of the in-memory loaded cache data, if CI was lucky to execute the two project loads in different seconds. Then the cache failed, and legacy project loader did not execute the script  because it should not do so implicitly on open, but only when (somehow) asked to load the real contents - that is intended and is being tested in Gradle core testsuite.

So I split the test into two cases:
1. reopening a trusted, closed project w/ caches: this should report proper classpath immediately from the cached data.
2. reopening a trusted project wil cleared caches: this should initially report some classpath, but as the project is trusted, it should execute the configuration and correct the classpath. This behaviour is desirable when Java files are opened, so that their compilation classpath (and editor underlines) are fixed if the trust allows to execute buildscript.

I need to [flush the project info cache](https://github.com/apache/netbeans/pull/3479/files#diff-fe8817b482b8cf192d5a3f06c1ed4cc2a186d7b38e0f4436a5366a8eb8fbe02bR60) from the test, and potentially [delete the cache data for project](https://github.com/apache/netbeans/pull/3479/files#diff-fe8817b482b8cf192d5a3f06c1ed4cc2a186d7b38e0f4436a5366a8eb8fbe02bR67)

During the debugging, I've noticed that access to the disk cache  [was not synchronized](https://github.com/apache/netbeans/pull/3479/files#diff-fe8817b482b8cf192d5a3f06c1ed4cc2a186d7b38e0f4436a5366a8eb8fbe02bR48) and while that did not cause the test failures, it could cause weird things in production (as the hashtable may become corrupted).

I've also encountered a **deadlock**  caused by [`toString()`](https://github.com/apache/netbeans/pull/3479/files#diff-e833b1ad0623c45c9af375ded2ba2f854c529638f4334c624969e3ea40a6e05eR477) was trying to synchronize on the project's instance. If the project object was just being formatted by a LogHandler, and some other thread was trying to use Logger in `synchronized` section using that same project instance, the two threads would block each other.

Then there was a [nasty typo](https://github.com/apache/netbeans/pull/3479/files#diff-e833b1ad0623c45c9af375ded2ba2f854c529638f4334c624969e3ea40a6e05eR315) that caused the `CompletableFuture` NOT to complete on success - and therefore Source Groups [were not refreshed[(https://github.com/apache/netbeans/blob/master/java/gradle.java/src/org/netbeans/modules/gradle/java/classpath/ClassPathProviderImpl.java#L159) after project load. This typo was not even noticed by tests ! So I added checks for `java2` directory that should appear after full load in `ClassPath.SOURCE`.

I left some logging tweaks in the test class: it enables FINER logging for the test that was randomly failing, so if this PR does not fix the problem, CI logs will hopefully contain some hints to analyse. I'll remove the setLevel later after the fix proves OK.


