### PR TITLE
[NETBEANS-6117] Fix Gradle project loading in template operations.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java
@@ -71,7 +71,7 @@ public abstract class AbstractProjectLoader {
 
         public ReloadContext(NbGradleProjectImpl project, NbGradleProject.Quality aim, GradleCommandLine cmd, String description) {
             this.project = project;
-            this.previous = project.isGradleProjectLoaded() ? project.getGradleProject() : FallbackProjectLoader.createFallbackProject(project.getGradleFiles());
+            this.previous = project.isGradleProjectLoaded() ? project.projectWithQuality(null, FALLBACK, false, false) : FallbackProjectLoader.createFallbackProject(project.getGradleFiles());
             this.aim = aim;
             this.cmd = cmd;
             this.description = description;

--- a/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/spi/newproject/TemplateOperation.java
@@ -50,6 +50,8 @@ import static org.netbeans.modules.gradle.spi.newproject.Bundle.*;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ProjectManager;
 import org.netbeans.modules.gradle.GradleProjectLoader;
@@ -65,6 +67,8 @@ import org.openide.util.NbBundle;
  * @author Laszlo Kishalmi
  */
 public final class TemplateOperation implements Runnable {
+    private static final Logger LOG = Logger.getLogger(TemplateOperation.class.getName());
+    
     public interface ProjectConfigurator {
         void configure(Project project);
     }
@@ -108,6 +112,7 @@ public final class TemplateOperation implements Runnable {
                 if (handle != null) {
                     handle.progress(step.getMessage(), work++);
                 }
+                LOG.log(Level.FINE, "Executing Gradle Project Template Operation {0}", step);
                 Set<FileObject> filesToOpen = step.execute();
                 if (filesToOpen != null) {
                     importantFiles.addAll(filesToOpen);
@@ -260,8 +265,7 @@ public final class TemplateOperation implements Runnable {
         public Set<FileObject> execute() {
             GradleConnector gconn = GradleConnector.newConnector();
             target.mkdirs();
-            ProjectConnection pconn = gconn.forProjectDirectory(target).connect();
-            try {
+            try (ProjectConnection pconn = gconn.forProjectDirectory(target).connect()) {
                 List<String> args = new ArrayList<>();
                 args.add("init");
                 // gradle init --type java-application --test-framework junit-jupiter --dsl groovy --package com.example --project-name example
@@ -293,8 +297,6 @@ public final class TemplateOperation implements Runnable {
             } catch (GradleConnectionException | IllegalStateException ex) {
                 // Well for some reason we were  not able to load Gradle.
                 // Ignoring that for now
-            } finally {
-                pconn.close();
             }
             return Collections.singleton(FileUtil.toFileObject(target));
         }
@@ -320,7 +322,14 @@ public final class TemplateOperation implements Runnable {
         steps.add(new PreloadProject(projectDir));
     }
 
-    private static class CreateDirStep implements OperationStep {
+    private static abstract class BaseOperationStep implements OperationStep {
+        @Override
+        public final String toString() {
+            return "Step: " + getMessage();
+        }
+    }
+    
+    private static final class CreateDirStep extends BaseOperationStep {
 
         final String message;
         final File dir;
@@ -344,9 +353,10 @@ public final class TemplateOperation implements Runnable {
             }
             return null;
         }
+        
     }
 
-    private static class ConfigureProjectStep implements OperationStep {
+    private static final class ConfigureProjectStep extends BaseOperationStep {
         final File dir;
         final ProjectConfigurator configurator;
 
@@ -367,9 +377,10 @@ public final class TemplateOperation implements Runnable {
                 try {
                     FileObject projectDir = FileUtil.toFileObject(dir);
                     Project project = ProjectManager.getDefault().findProject(projectDir);
+                    ProjectTrust.getDefault().trustProject(project);
                     NbGradleProjectImpl impl = project != null ? project.getLookup().lookup(NbGradleProjectImpl.class): null;
                     if (impl != null) {
-                        impl.fireProjectReload(true);
+                        impl.projectWithQuality(null, Quality.FULL, false, false);
                         configurator.configure(project);
                     }
 
@@ -380,7 +391,7 @@ public final class TemplateOperation implements Runnable {
         }
 
     }
-    private static class PreloadProject implements OperationStep {
+    private static final class PreloadProject extends BaseOperationStep {
 
         final File dir;
 
@@ -410,7 +421,7 @@ public final class TemplateOperation implements Runnable {
                     }
                     project = ProjectManager.getDefault().findProject(projectDir);
                     if (project != null) {
-                        //Let's trust the generate project
+                        //Let's trust the generated project
                         ProjectTrust.getDefault().trustProject(project);
                         NbGradleProjectImpl nbProject = project.getLookup().lookup(NbGradleProjectImpl.class);
                         if (nbProject != null) {
@@ -430,7 +441,7 @@ public final class TemplateOperation implements Runnable {
 
     }
 
-    private static class InitGradleWrapper implements OperationStep {
+    private static final class InitGradleWrapper extends BaseOperationStep {
 
         final File projectDir;
 
@@ -447,21 +458,18 @@ public final class TemplateOperation implements Runnable {
         @Override
         public Set<FileObject> execute() {
             GradleConnector gconn = GradleConnector.newConnector();
-            ProjectConnection pconn = gconn.forProjectDirectory(projectDir).connect();
-            try {
+            try (ProjectConnection pconn = gconn.forProjectDirectory(projectDir).connect()) {
                 pconn.newBuild().withArguments("--offline").forTasks("wrapper").run(); //NOI18N
             } catch (GradleConnectionException | IllegalStateException ex) {
                 // Well for some reason we were  not able to load Gradle.
                 // Ignoring that for now
-            } finally {
-                pconn.close();
             }
             return null;
         }
 
     }
 
-    private static class CopyFromFileTemplate implements OperationStep {
+    private static final class CopyFromFileTemplate extends BaseOperationStep {
         final File target;
         final Map<String, ? extends Object> tokens;
         final boolean important;
@@ -524,7 +532,7 @@ public final class TemplateOperation implements Runnable {
 
     }
 
-    private static class CopyFromTemplate implements OperationStep {
+    private static final class CopyFromTemplate extends BaseOperationStep {
         final File target;
         final Map<String, ? extends Object> tokens;
         final boolean important;


### PR DESCRIPTION
Well, in this case the isGradleProjectLoaded() and the getGradlePorject() in NbGradleProjectImpl does not really agree, if the project is only initialized with a FALLBACK grade project. That would result infinite nesting at [AbstractProjectLoader:74](https://github.com/apache/netbeans/blob/6146b70dd3d1b2a269f934c5a457b1aa876ceb88/extide/gradle/src/org/netbeans/modules/gradle/loaders/AbstractProjectLoader.java#L74)

Strangely it did not cause problems elsewhere so far. This fix may/may not be ported to NB13. @sdedic please evaluate what would happen with this change. (I keep this one on master for the time being).

I know the main reason of this change to load the info from disk cache if that would exists. A better solution would have been to get the Disk cache loader give back better than FALLBACK info if a cached data is already available on disk.

With all the options, the project load is getting quite convoluted. I'm going to give it a try and factor these out somehow. Will file another PR on that.
