### PR TITLE
javafx ide.ergonomics config should not try to load the old nb-javac.

### DIFF
--- a/ergonomics/ide.ergonomics/javafx.properties
+++ b/ergonomics/ide.ergonomics/javafx.properties
@@ -22,6 +22,3 @@ project.xpath.pom.xml=//bootclasspath[contains(text(),'jfxrt')],//executable[con
 
 extra.modules=org\\.netbeans\\.libs\\.javafx\\.(linux|win|macosx)
 extra.modules.recommended.max.jdk=11
-
-extra.modules.1=org.netbeans.modules.nbjavac.*
-extra.modules.1.recommended.min.jdk=9


### PR DESCRIPTION
as discovered on the dev-list, the "Java Frontend Application" wizzard is trying install/load the old nb-javac plugin.

This should fix it. (tested it once as described on the mail to verify)

@neilcsmith-net ping