### PR TITLE
search/replace dialog: set shift+enter as line break and add multi-line info message.

### DIFF
--- a/platform/api.search/src/org/netbeans/modules/search/BasicSearchForm.java
+++ b/platform/api.search/src/org/netbeans/modules/search/BasicSearchForm.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.*;
+import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -216,7 +217,7 @@ final class BasicSearchForm extends JPanel implements ChangeListener,
 
         lblTextToFind = new JLabel();
         JComboBox<String> box = new JComboBox<>();
-        box.setEditor(new MultiLineComboBoxEditor());
+        box.setEditor(new MultiLineComboBoxEditor(box));
         cboxTextToFind = ComponentUtils.adjustComboForSearchPattern(box);
         lblTextToFind.setLabelFor(cboxTextToFind.getComponent());
         btnTestTextToFind = new JButton();
@@ -227,7 +228,7 @@ final class BasicSearchForm extends JPanel implements ChangeListener,
         if (searchAndReplace) {
             lblReplacement = new JLabel();
             cboxReplacement = new JComboBox<>();
-            cboxReplacement.setEditor(new MultiLineComboBoxEditor());
+            cboxReplacement.setEditor(new MultiLineComboBoxEditor(cboxReplacement));
             cboxReplacement.setEditable(true);
             cboxReplacement.setRenderer(new ShorteningCellRenderer());
             lblReplacement.setLabelFor(cboxReplacement);
@@ -1116,11 +1117,23 @@ final class BasicSearchForm extends JPanel implements ChangeListener,
 
         private final JTextArea area = new JTextArea();
 
-        public MultiLineComboBoxEditor() {
+        public MultiLineComboBoxEditor(JComboBox reference) {
             area.setWrapStyleWord(false);
             area.setLineWrap(false);
+
+            Border border = ((JComponent)reference.getEditor().getEditorComponent()).getBorder();
+            if (border == null) {
+                border = reference.getBorder();
+            }
+            area.setBorder(border);
+
+            // retain standard focus traversal behavior
             area.setFocusTraversalKeys(KeyboardFocusManager.FORWARD_TRAVERS‌​AL_KEYS, null);
             area.setFocusTraversalKeys(KeyboardFocusManager.BACKWARD_TRAVERS‌​AL_KEYS, null);
+
+            // dispatch enter to parent; set line breaks on shift+enter
+            area.getInputMap().put(KeyStroke.getKeyStroke("shift ENTER"), "insert-break");
+            area.getInputMap().put(KeyStroke.getKeyStroke("ENTER"), "text-submit");
         }
 
         @Override

--- a/platform/api.search/src/org/netbeans/modules/search/BasicSearchProvider.java
+++ b/platform/api.search/src/org/netbeans/modules/search/BasicSearchProvider.java
@@ -226,7 +226,8 @@ public class BasicSearchProvider extends SearchProvider {
                     notifySupport.setInformationMessage(UiUtils.getText(
                             "BasicSearchForm.txtInfoNoWildcards"));     //NOI18N
                 } else {
-                    notifySupport.clearMessages();
+                    notifySupport.setInformationMessage(UiUtils.getText(
+                            "BasicSearchForm.txtInfoMultiline"));     //NOI18N
                 }
             }
             return usable;

--- a/platform/api.search/src/org/netbeans/modules/search/Bundle.properties
+++ b/platform/api.search/src/org/netbeans/modules/search/Bundle.properties
@@ -248,6 +248,7 @@ BasicSearchForm.txtErrorTextPattern=Containing Text field contains invalid regul
 BasicSearchForm.txtErrorReplacePattern=Replace With field contains invalid expression
 BasicSearchForm.txtErrorFileName=File Name Patterns field contains invalid regular expression
 BasicSearchForm.txtInfoNoWildcards=File Name Pattern contains no wildcards. It may be a mistake.
+BasicSearchForm.txtInfoMultiline=Resize Window for multi-line search (SHIFT+ENTER for line breaks).
 
 LBL_OptionsPanelTitle=Options
 

--- a/platform/api.search/src/org/netbeans/modules/search/PatternSandbox.java
+++ b/platform/api.search/src/org/netbeans/modules/search/PatternSandbox.java
@@ -82,7 +82,7 @@ public abstract class PatternSandbox extends JPanel
     protected void initComponents() {
 
         cboxPattern = new JComboBox<String>();
-        cboxPattern.setEditor(new BasicSearchForm.MultiLineComboBoxEditor());
+        cboxPattern.setEditor(new BasicSearchForm.MultiLineComboBoxEditor(cboxPattern));
         cboxPattern.setEditable(true);
         cboxPattern.setRenderer(new ShorteningCellRenderer());
         lblPattern = new JLabel();

--- a/platform/api.search/src/org/netbeans/modules/search/ui/ShorteningCellRenderer.java
+++ b/platform/api.search/src/org/netbeans/modules/search/ui/ShorteningCellRenderer.java
@@ -37,7 +37,7 @@ public class ShorteningCellRenderer extends DefaultListCellRenderer {
     @Override
     public Component getListCellRendererComponent(JList<?> list, Object value,
             int index, boolean isSelected, boolean cellHasFocus) {
-        String s = value == null ? null : value.toString();
+        String s = value == null ? null : value.toString().replaceAll("[\r\n]+", " ");
         Component component = super.getListCellRendererComponent(list,
                 s, index, isSelected, cellHasFocus);
         if (s != null && s.length() > COMBO_TEXT_LENGHT_LIMIT


### PR DESCRIPTION
https://github.com/apache/netbeans/issues/3487

with this PR applied the following should be possible again:

1. press CTRL+SHIFT+H (or F)
2. type to enter search string
3. press ENTER to trigger search
(no mouse required)

which should be to my knowledge EXACTLY as it was before.