### PR TITLE
[NETBEANS-6323] Fix Gradle popup menu Tasks.. action not working.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/ActionProviderImpl.java
@@ -549,7 +549,8 @@ public class ActionProviderImpl implements ActionProvider {
                             acts.add(act);
                         }
                     }
-                    acts.add(createCustomGradleAction(project, LBL_Custom_run_tasks(), new CustomActionMapping("name"), lookup, true));
+                    acts.add(createCustomGradleAction(project, LBL_Custom_run_tasks(),
+                            new CustomActionMapping(ActionMapping.CUSTOM_PREFIX), lookup, true));
                     SwingUtilities.invokeLater(() -> {
                         boolean selected = menu.isSelected();
                         menu.remove(loading);


### PR DESCRIPTION
Fixing another fallout of disabled custom tasks in the IDE UI. ActionToTaskUtils::isActionEnabled always reports the `Run Gradle / Tasks..` action in project menu as disabled, so the action does nothing.  Switch to using custom prefix for name as in TaskNode actions.

I initially used a hidden action name checked in ActionToTaskUtils, but then noticed that the working version of this in the navigator just uses the custom prefix.