### PR TITLE
Ensure BufferedInputStream is not initialized with a buffer size of 0

### DIFF
--- a/platform/api.search/src/org/netbeans/modules/search/matcher/BufferedCharSequence.java
+++ b/platform/api.search/src/org/netbeans/modules/search/matcher/BufferedCharSequence.java
@@ -559,7 +559,7 @@ public class BufferedCharSequence implements CharSequence {
             try {
                 istream = fo.getInputStream();
                 try {
-                    bstream = new BufferedInputStream(istream, bufferSize);
+                    bstream = new BufferedInputStream(istream, Math.max(1, bufferSize));
                 } catch (Throwable t) {
                     if (istream != null) {
                         istream.close();


### PR DESCRIPTION
With an empty file the BufferedCharSequence fails to be initialized:

```
java.lang.IllegalArgumentException: Buffer size <= 0
	at java.base/java.io.BufferedInputStream.<init>(BufferedInputStream.java:207)
	at org.netbeans.modules.search.matcher.BufferedCharSequence$Source.initStreams(BufferedCharSequence.java:562)
Caused: java.io.IOException
Caused: org.netbeans.modules.search.matcher.BufferedCharSequence$SourceIOException
	at org.netbeans.modules.search.matcher.BufferedCharSequence$Source.initStreams(BufferedCharSequence.java:570)
	at org.netbeans.modules.search.matcher.BufferedCharSequence$Source.<init>(BufferedCharSequence.java:494)
	at org.netbeans.modules.search.matcher.BufferedCharSequence.<init>(BufferedCharSequence.java:145)
[catch] at org.netbeans.modules.search.matcher.MultiLineStreamMatcher.checkMeasuredInternal(MultiLineStreamMatcher.java:84)
	at org.netbeans.modules.search.matcher.AbstractMatcher.check(AbstractMatcher.java:53)
	at org.netbeans.modules.search.matcher.DefaultMatcher.checkMeasuredInternal(DefaultMatcher.java:93)
	at org.netbeans.modules.search.matcher.AbstractMatcher.check(AbstractMatcher.java:53)
	at org.netbeans.modules.search.BasicComposition.start(BasicComposition.java:78)
	at org.netbeans.modules.search.SearchTask.run(SearchTask.java:93)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)
```

So ensure, that at least a 1 byte buffer is used.