### PR TITLE
Fixes to LSP client/server related to semantic highlighting.

### DIFF
--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/LSPBindings.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -56,6 +57,8 @@ import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.ResourceOperationKind;
 import org.eclipse.lsp4j.SemanticTokens;
+import org.eclipse.lsp4j.SemanticTokensCapabilities;
+import org.eclipse.lsp4j.SemanticTokensClientCapabilitiesRequests;
 import org.eclipse.lsp4j.SemanticTokensLegend;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.SymbolCapabilities;
@@ -367,6 +370,7 @@ public class LSPBindings {
        dsc.setHierarchicalDocumentSymbolSupport(true);
        dsc.setSymbolKind(new SymbolKindCapabilities(Arrays.asList(SymbolKind.values())));
        tdcc.setDocumentSymbol(dsc);
+       tdcc.setSemanticTokens(new SemanticTokensCapabilities(new SemanticTokensClientCapabilitiesRequests(true), KNOWN_TOKEN_TYPES, KNOWN_TOKEN_MODIFIERS, Arrays.asList()));
        WorkspaceClientCapabilities wcc = new WorkspaceClientCapabilities();
        wcc.setWorkspaceEdit(new WorkspaceEditCapabilities());
        wcc.getWorkspaceEdit().setDocumentChanges(true);
@@ -387,6 +391,15 @@ public class LSPBindings {
            }
        }
     }
+    private static final List<String> KNOWN_TOKEN_TYPES = Collections.unmodifiableList(Arrays.asList(
+            "namespace", "package", "function", "method", "macro", "parameter",
+            "variable", "struct", "enum", "class", "typeAlias", "typeParameter",
+            "field", "enumMember", "keyword"
+    ));
+
+    private static final List<String> KNOWN_TOKEN_MODIFIERS = Collections.unmodifiableList(Arrays.asList(
+            "static", "definition", "declaration"
+    ));
 
     public static synchronized Set<LSPBindings> getAllBindings() {
         Set<LSPBindings> allBindings = Collections.newSetFromMap(new IdentityHashMap<>());

--- a/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
+++ b/ide/lsp.client/src/org/netbeans/modules/lsp/client/bindings/CompletionProviderImpl.java
@@ -42,6 +42,7 @@ import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InsertReplaceEdit;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.ParameterInformation;
 import org.eclipse.lsp4j.ServerCapabilities;
@@ -189,13 +190,14 @@ public class CompletionProviderImpl implements CompletionProvider {
                                 commit("");
                             }
                             private void commit(String appendText) {
-                                if (i.getTextEdit().isRight()) {
+                                Either<TextEdit, InsertReplaceEdit> edit = i.getTextEdit();
+                                if (edit != null && edit.isRight()) {
                                     //TODO: the NetBeans client does not current support InsertReplaceEdits, should not happen
                                     Completion.get().hideDocumentation();
                                     Completion.get().hideCompletion();
                                     return ;
                                 }
-                                TextEdit te = i.getTextEdit().getLeft();
+                                TextEdit te = edit != null ? edit.getLeft() : null;
                                 NbDocument.runAtomic((StyledDocument) doc, () -> {
                                     try {
                                         int endPos;

--- a/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/resources/fontsColors.xml
+++ b/ide/textmate.lexer/src/org/netbeans/modules/textmate/lexer/resources/fontsColors.xml
@@ -67,6 +67,7 @@
     <fontcolor name="mod-typeParameter" default="identifier"/>
     <fontcolor name="mod-field" default="field"/>
     <fontcolor name="mod-enumMember" default="field"/>
+    <fontcolor name="mod-keyword" default="keyword"/>
 
     <fontcolor name="mod-namespace-declaration" default="identifier"/>
     <fontcolor name="mod-package-declaration" default="identifier"/>
@@ -82,6 +83,7 @@
     <fontcolor name="mod-typeParameter-declaration" default="identifier"/>
     <fontcolor name="mod-field-declaration" default="field"/>
     <fontcolor name="mod-enumMember-declaration" default="field"/>
+    <fontcolor name="mod-keyword-declaration" default="keyword"/>
 
     <fontcolor name="mod-static" >
         <font style="italic" />

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
@@ -68,12 +68,14 @@ public class Utils {
             case ENUM:
                 return SymbolKind.Enum;
             case CLASS:
+            case RECORD:
                 return SymbolKind.Class;
             case ANNOTATION_TYPE:
                 return SymbolKind.Interface;
             case INTERFACE:
                 return SymbolKind.Interface;
             case ENUM_CONSTANT:
+            case RECORD_COMPONENT:
                 return SymbolKind.EnumMember;
             case FIELD:
                 return SymbolKind.Field; //TODO: constant
@@ -110,6 +112,7 @@ public class Utils {
             case INTERFACE:
             case ENUM:
             case ANNOTATION_TYPE:
+            case RECORD:
                 TypeElement te = (TypeElement) e;
                 StringBuilder sb = new StringBuilder();
                 sb.append(fqn ? te.getQualifiedName() : te.getSimpleName());
@@ -140,6 +143,7 @@ public class Utils {
                 return sb.toString();
             case FIELD:
             case ENUM_CONSTANT:
+            case RECORD_COMPONENT:
                 return e.getSimpleName().toString();
             case CONSTRUCTOR:
             case METHOD:

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -1947,8 +1947,8 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
     static BiConsumer<String, Object> HOOK_NOTIFICATION = null;
 
     private static final Map<ColoringAttributes, List<String>> COLORING_TO_TOKEN_TYPE_CANDIDATES = new HashMap<ColoringAttributes, List<String>>() {{
-        put(ColoringAttributes.FIELD, Arrays.asList("member"));
-        put(ColoringAttributes.RECORD_COMPONENT, Arrays.asList("member"));
+        put(ColoringAttributes.FIELD, Arrays.asList("field", "member"));
+        put(ColoringAttributes.RECORD_COMPONENT, Arrays.asList("field", "member"));
         put(ColoringAttributes.LOCAL_VARIABLE, Arrays.asList("variable"));
         put(ColoringAttributes.PARAMETER, Arrays.asList("parameter"));
         put(ColoringAttributes.METHOD, Arrays.asList("method", "function"));
@@ -1959,6 +1959,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
         put(ColoringAttributes.ANNOTATION_TYPE, Arrays.asList("interface"));
         put(ColoringAttributes.ENUM, Arrays.asList("enum"));
         put(ColoringAttributes.TYPE_PARAMETER_DECLARATION, Arrays.asList("typeParameter"));
+        put(ColoringAttributes.KEYWORD, Arrays.asList("keyword"));
     }};
 
     private static final Map<ColoringAttributes, List<String>> COLORING_TO_TOKEN_MODIFIERS_CANDIDATES = new HashMap<ColoringAttributes, List<String>>() {{
@@ -2011,7 +2012,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
                                                 modifiers |= mod;
                                             }
                                         }
-                                        if (tokenType.isPresent()) {
+                                        if (tokenType.isPresent() && tokenType.get() >= 0) {
                                             result.add(line - lastLine);
                                             result.add((int) (currentOffset - currentLineStart - column));
                                             result.add(e.getKey().length());


### PR DESCRIPTION
Trying to use the semantic highlighting in https://github.com/apache/netbeans/pull/1475, I've found a few bugs in the handling of the LSP semantic highlighting (and also a bug in the LSP client code completion update to a new LSP4J version). This patch should be fixing that. If possible, it would make sense to me to put it into NB 13.
