### PR TITLE
[NETBEANS-6058]

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.form
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/ActionMappings.form
@@ -355,6 +355,9 @@
         </Property>
         <Property name="name" type="java.lang.String" value="" noResource="true"/>
       </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnDisableActionPerformed"/>
+      </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
           <GridBagConstraints gridX="10" gridY="6" gridWidth="1" gridHeight="1" fill="2" ipadX="0" ipadY="0" insetsTop="6" insetsLeft="6" insetsBottom="0" insetsRight="12" anchor="18" weightX="0.0" weightY="0.0"/>


### PR DESCRIPTION
1) Fix Jira NETBEANS-6058: new maven action is disabled permanently
2) Related updates:
- Add handler for "Disable" button. Only allow custom actions to be disabled.
- Disable "Disable" button for default actions.
- When removing custom action, automatically select previous action in list.
- When disabling action, don't clear other text fields.
- When adding new action, and immediately switching configuration via comboBox, properly save/load actions for new configuration (don't remove action listener).