### PR TITLE
Cache netbeanrelease.json for offline builds and source releases.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 /nbbuild/user.build.properties
 /nbbuild/gitinfo.properties
 /nbbuild/netbeansrelease.properties
+/nbbuild/netbeansrelease.json
 /nbi/engine/native/*/*/dist/
 /nb-javac/
 /java.source.nbjavac/test/test-nb-javac/nbproject/private/

--- a/nbbuild/antsrc/org/netbeans/nbbuild/ReleaseJsonProperties.java
+++ b/nbbuild/antsrc/org/netbeans/nbbuild/ReleaseJsonProperties.java
@@ -134,7 +134,7 @@ public class ReleaseJsonProperties extends Task {
         }
 
         if (requiredbranchinfo == null) {
-            throw new BuildException("No Release Information found for branch '" + branch + "', update json file section");
+            throw new BuildException("No Release Information found for branch '" + branch + "', update json file section with ant -Dneedjsondownload=true");
         }
         List<String> updateValues = new ArrayList<>();
         for (ReleaseInfo releaseInfo : ri) {

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -109,30 +109,8 @@
       <zipfileset dir="${nb_all}/nbbuild" includes="notice-stub.txt" fullpath="META-INF/NOTICE"/>
     </jar>
     <taskdef name="createlicensesummary" classname="org.netbeans.nbbuild.extlibs.CreateLicenseSummary" classpath="${nbantext.jar}"/>
-    <!-- get all json info we have on apache gitbox  -->
-    <property name="metabuild.releasejson" value="${nb_all}/nbbuild/build/netbeansrelease.json"/>
-    <condition property="metabuild.jsonurl" value="https://gitbox.apache.org/repos/asf?p=netbeans-jenkins-lib.git;a=blob_plain;f=meta/netbeansrelease.json">
-        <not>
-            <isset property="metabuild.jsonurl"/>
-        </not>
-    </condition>
-    <configureproxy connectTo="${metabuild.jsonurl}" hostProperty="proxyHost" portProperty="proxyPort"/>
-    <setproxy proxyhost="${proxyHost}" proxyPort="${proxyPort}"/>
-    <get dest="${metabuild.releasejson}" skipexisting="false" src="${metabuild.jsonurl}" />
-    <!-- read info from gitinfo.properties , if present in source bundle copy gitinfo-->
-    <copy file="${nb_all}/nbbuild/gitinfo.properties" tofile="${nb_all}/nbbuild/build/gitinfo.properties" failonerror="false"/>
-    <copy file="${nb_all}/nbbuild/netbeansrelease.properties" tofile="${nb_all}/nbbuild/build/netbeansrelease.properties" failonerror="false"/>
-    <!-- get branches and git information as previous not overrided this will take new-->
-    <antcall target="getgitinformation" />
-    <!-- javadoc content filtering -->
-    <taskdef name="setjavadoc" classname="org.netbeans.nbbuild.SetApidocClustersConfig" classpath="${nbantext.jar}"/>
-    <property file="${nb_all}/nbbuild/build/gitinfo.properties"/>
-    <property file="${nb_all}/nbbuild/build/netbeansrelease.properties"/>
-    <setjavadoc branch="${metabuild.branch}"/>
-    <echo message="Building branch: ${metabuild.branch}"/>
-    <property name="releasejson" value="${nb_all}/nbbuild/build/netbeansrelease.json"/>
-    <property name="xmlrelease" value="${nb_all}/nbbuild/build/netbeansrelease.xml"/>
-    <property name="propertiesrelease" value="${nb_all}/nbbuild/build/netbeansrelease.properties"/>
+
+    <!-- prepare task to create properties files-->
     <taskdef name="releasejson" classname="org.netbeans.nbbuild.ReleaseJsonProperties" >
         <classpath>
             <pathelement location="${nbantext.jar}"/>
@@ -141,11 +119,64 @@
             </fileset>
         </classpath>
     </taskdef>
+    <!-- task to alter cluster definition for javadoc -->
+    <taskdef name="setjavadoc" classname="org.netbeans.nbbuild.SetApidocClustersConfig" classpath="${nbantext.jar}"/>
+
+    <antcall target="getjsonfile" />
+    <!-- get branches and git information as previous not overrided this will take new-->
+    <antcall target="getgitinformation" />
+
+    <echo message="Building branch: ${metabuild.branch}"/>
+    <property name="releasejson" value="${nb_all}/nbbuild/build/netbeansrelease.json"/>
+    <property name="xmlrelease" value="${nb_all}/nbbuild/build/netbeansrelease.xml"/>
+    <property name="propertiesrelease" value="${nb_all}/nbbuild/build/netbeansrelease.properties"/>
+    <property file="${nb_all}/nbbuild/build/gitinfo.properties"/>
     <releasejson file="${releasejson}" xmloutput="${xmlrelease}" propertiesoutput="${propertiesrelease}" branch="${metabuild.branch}" hash="${metabuild.hash}"/>
+    <property file="${nb_all}/nbbuild/build/netbeansrelease.properties"/>
+    <!-- javadoc content filtering -->
+    <setjavadoc branch="${metabuild.branch}"/>
   </target>
+
+  <target name="getjsonfile">
+    <!-- copy all related release properties -->
+    <copy file="${nb_all}/nbbuild/netbeansrelease.json" tofile="${nb_all}/nbbuild/build/netbeansrelease.json" failonerror="false"/>
+    <!-- read info from gitinfo.properties , if present in source bundle copy gitinfo-->
+    <copy file="${nb_all}/nbbuild/gitinfo.properties" tofile="${nb_all}/nbbuild/build/gitinfo.properties" failonerror="false"/>
+
+    <property name="metabuild.releasejson" value="${nb_all}/nbbuild/build/netbeansrelease.json"/>
+    <!-- get all json info we have on apache gitbox  -->
+    <condition property="metabuild.jsonurl" value="https://gitbox.apache.org/repos/asf?p=netbeans-jenkins-lib.git;a=blob_plain;f=meta/netbeansrelease.json">
+        <not>
+            <isset property="metabuild.jsonurl"/>
+        </not>
+    </condition>
+    <condition property="needjsondownload" value="true" else="false">
+        <not>
+            <available file="${nb_all}/nbbuild/build/netbeansrelease.json" />
+        </not>
+    </condition>
+    <sequential if:true="${needjsondownload}" >
+        <configureproxy connectTo="${metabuild.jsonurl}" hostProperty="proxyHost" portProperty="proxyPort"/>
+        <setproxy proxyhost="${proxyHost}" proxyPort="${proxyPort}"/>
+        <get dest="${metabuild.releasejson}" skipexisting="false" src="${metabuild.jsonurl}" />
+    </sequential>
+  </target>
+
+  <target name="cache-release-json">
+      <property name="needjsondownload" value="true" />
+      <antcall target="getjsonfile" />
+      <copy file="${metabuild.releasejson}" tofile="${nb_all}/nbbuild/netbeansrelease.json" />
+  </target>
+
+  <target name="clear-release-json">
+      <delete file="${nb_all}/nbbuild/netbeansrelease.json" />
+      <delete file="${nb_all}/nbbuild/build/netbeansrelease.json" />
+  </target>
+
   <target name="-gitinfo.ispresent">
       <available file="${nb_all}/nbbuild/build/gitinfo.properties" property="gitinfo.present" />      
   </target>
+
   <target name="-git.down" unless="${gitinfo.present}" depends="-gitinfo.ispresent">
       <!-- try to get information from jenkins apache multi branch build or travis -->
       <taskdef name="gitbranchhash" classname="org.netbeans.nbbuild.GitBranchHash" classpath="${nbantext.jar}" />
@@ -190,11 +221,14 @@
       <echo if:set="metabuild.hash" file="${nb_all}/nbbuild/build/gitinfo.properties" >metabuild.branch=${metabuild.branch}
 metabuild.hash=${metabuild.hash}</echo>
   </target>
+
   <target name="-git.up" if="${gitinfo.present}" depends="-gitinfo.ispresent">
       <property file="${nb_all}/nbbuild/build/gitinfo.properties"/>
       <echo message="Processing build with branch ${metabuild.branch} and hash ${metabuild.hash}" />
   </target>
+
   <target name="getgitinformation" depends="-git.up,-git.down" />
+
   <target name="download-all-extbins" unless="ext.binaries.downloaded" depends="bootstrap">
     <echo>Downloading external binaries (*/external/ directories)...</echo>
     <!-- optionnal reporttofile used to speed resolving artefacts resolution for maven artefacts -->
@@ -205,6 +239,7 @@ metabuild.hash=${metabuild.hash}</echo>
     </downloadbinaries>
     <property name="ext.binaries.downloaded" value="true"/>
   </target>
+
   <!-- create list of all maven coordinate -->
   <target name="getallmavencoordinates">
       <concat destfile="${nb_all}/nbbuild/build/external.info">
@@ -1690,8 +1725,8 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
       <zipfileset file="${nb.build.dir}/LICENSE" />
       <zipfileset dir="${nb.build.dir}/licenses" includes="**" prefix="licenses" /> 
       <zipfileset file="${source.zip.readme}" fullpath="README.md" erroronmissingarchive="false" />
-      <zipfileset file="${nb_all}/nbbuild/build/netbeansrelease.properties" fullpath="nbbuild/netbeansrelease.properties" erroronmissingarchive="false"/>
       <zipfileset file="${nb_all}/nbbuild/build/gitinfo.properties" fullpath="nbbuild/gitinfo.properties" erroronmissingarchive="false" />
+      <zipfileset file="${nb_all}/nbbuild/build/netbeansrelease.json" fullpath="nbbuild/netbeansrelease.json" erroronmissingarchive="false" />
     </zip>
   </target>
 

--- a/nbbuild/rat-exclusions.txt
+++ b/nbbuild/rat-exclusions.txt
@@ -26,6 +26,7 @@ nbbuild/user.build.properties
 ###### generated build artifacts
 nbbuild/gitinfo.properties
 nbbuild/netbeansrelease.properties
+nbbuild/netbeansrelease.json
 enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/model_1_4/*
 enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/model_5/*
 enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/application/model_6/*


### PR DESCRIPTION
Cache netbeansrelease.json in nbbuild/ - use -Dneedjsondownload=true to force update.

Write netbeansrelease.json to same location in source release to ensure source builds not affected by future changes to file in repository.

Squashed and tidied up version of #2421 by @ebarboni for merging to delivery.  Didn't want to force push to that branch without consent and need to get in for rc2.

Should fix #3456 