### PR TITLE
Update FlatLaf from 2.0 to 2.0.1

### DIFF
--- a/platform/libs.flatlaf/external/binaries-list
+++ b/platform/libs.flatlaf/external/binaries-list
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-A45856E4115136977C662298BAC02F3B428082DB com.formdev:flatlaf:2.0
+5CD4AE96F6B538FB784549F2636E50122FDBB5D8 com.formdev:flatlaf:2.0.1

--- a/platform/libs.flatlaf/external/flatlaf-2.0.1-license.txt
+++ b/platform/libs.flatlaf/external/flatlaf-2.0.1-license.txt
@@ -1,7 +1,7 @@
 Name: FlatLaf Look and Feel
 Description: FlatLaf Look and Feel
-Version: 2.0
-Files: flatlaf-2.0.jar
+Version: 2.0.1
+Files: flatlaf-2.0.1.jar
 License: Apache-2.0
 Origin: FormDev Software GmbH.
 URL: https://www.formdev.com/flatlaf/

--- a/platform/libs.flatlaf/nbproject/project.properties
+++ b/platform/libs.flatlaf/nbproject/project.properties
@@ -20,4 +20,4 @@ javac.compilerargs=-Xlint:unchecked
 javac.source=1.8
 nbm.target.cluster=platform
 
-release.external/flatlaf-2.0.jar=modules/ext/flatlaf-2.0.jar
+release.external/flatlaf-2.0.1.jar=modules/ext/flatlaf-2.0.1.jar

--- a/platform/libs.flatlaf/nbproject/project.xml
+++ b/platform/libs.flatlaf/nbproject/project.xml
@@ -30,8 +30,8 @@
                 <package>com.formdev.flatlaf.util</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/flatlaf-2.0.jar</runtime-relative-path>
-                <binary-origin>external/flatlaf-2.0.jar</binary-origin>
+                <runtime-relative-path>ext/flatlaf-2.0.1.jar</runtime-relative-path>
+                <binary-origin>external/flatlaf-2.0.1.jar</binary-origin>
             </class-path-extension>
         </data>
     </configuration>


### PR DESCRIPTION
Unfortunately there is a memory leak in FlatLaf 2.0, which is fixed in 2.0.1.

The memory leak is in UI delegates for components `JPanel`, `JSeparator` and `JToolBar.Separator`.
There is always a reference from a static hash map to the **last created component** of that type.
So if e.g. a dialog (that uses `JPanel`) is closed, it can not released until a new `JPanel` is created somewhere else...

Memory leak issue: https://github.com/JFormDesigner/FlatLaf/issues/471