### PR TITLE
New From Template creates an invalid HTML page

### DIFF
--- a/ide/html/src/org/netbeans/modules/html/templates/html.html
+++ b/ide/html/src/org/netbeans/modules/html/templates/html.html
@@ -18,7 +18,7 @@
     under the License.
 
 -->
-${doctype}
+${doctype!""}
 <#assign licenseFirst = "<!--">
 <#assign licensePrefix = "">
 <#assign licenseLast = "-->">

--- a/ide/html/src/org/netbeans/modules/html/templates/xhtml.xhtml
+++ b/ide/html/src/org/netbeans/modules/html/templates/xhtml.xhtml
@@ -23,7 +23,7 @@
 <#assign licensePrefix = "">
 <#assign licenseLast = "-->">
 <#include "${project.licensePath}">
-${doctype}
+${doctype!""}
 <html xmlns="http://www.w3.org/1999/xhtml">
     <head>
         <title>TODO supply a title</title>


### PR DESCRIPTION
<!-- GR_35846 -->

Using the New from Template... action in a Micronaut / Gradle project to create a new HTML page results in an invalid html:

```
The following has evaluated to null or missing:
==> doctype  [in template "Templates/Other/html.html" at line 21, column 3]

----
Tip: If the failing expression is known to legally refer to something that's sometimes null or missing, either specify a default value like myOptionalVar!myDefault, or use <#if myOptionalVar??>when-present<#else>when-missing</#if>. (These only cover the last step of the expression; to cover the whole expression, use parenthesis: (myOptionalVar.foo)!myDefault, (myOptionalVar.foo)??
----

----
FTL stack trace ("~" means nesting-related):
	- Failed at: ${doctype}  [in template "Templates/Other/html.html" at line 21, column 1]
----
<!--
Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
Click nbfs://nbhost/SystemFileSystem/Templates/Other/html.html to edit this template
-->
<html>
  <head>
    <title>TODO supply a title</title>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
  </head>
  <body>
      <div>TODO write content</div>
  </body>
</html>
```