### PR TITLE
[NETBEANS-6384] Detect another Java support ext and recommend to Disable one.

### DIFF
--- a/java/java.lsp.server/vscode/src/extension.ts
+++ b/java/java.lsp.server/vscode/src/extension.ts
@@ -274,17 +274,15 @@ export function activate(context: ExtensionContext): VSNetBeansAPI {
 
     let conf = workspace.getConfiguration();
     if (conf.get("netbeans.conflict.check")) {
-        let e = vscode.extensions.getExtension('redhat.java');
+        const id = 'redhat.java';
+        let e = vscode.extensions.getExtension(id);
         function disablingFailed(reason: any) {
             handleLog(log, 'Disabling some services failed ' + reason);
         }
         if (e && workspace.name) {
-            vscode.window.showInformationMessage(`redhat.java found at ${e.extensionPath} - Suppressing some services to not clash with Apache NetBeans Language Server.`);
-            conf.update('java.completion.enabled', false, false).then(() => {
-                vscode.window.showInformationMessage('Usage of only one Java extension is recommended. Certain services of redhat.java have been disabled. ');
-                conf.update('java.debug.settings.enableRunDebugCodeLens', false, false).then(() => {}, disablingFailed);
-                conf.update('java.test.editor.enableShortcuts', false, false).then(() => {}, disablingFailed);
-            }, disablingFailed);
+            vscode.window.showInformationMessage(`Another Java support extension is already installed. It is recommended to use only one Java support per workspace.`, `Manually disable`).then(() => {
+                vscode.commands.executeCommand('workbench.extensions.action.showInstalledExtensions');
+            });
         }
     }
 


### PR DESCRIPTION
VSNetBeans currently detects installation of MS Java ext pack and informs user it disables some services of it, code lenses and code completion. See [extension.ts:284](https://github.com/apache/netbeans/blob/f9c75266d97f86c4ae7eaa214ee31bb6164a283e/java/java.lsp.server/vscode/src/extension.ts#L284):
```js
conf.update('java.test.editor.enableShortcuts', false, false).then(() => {}, disablingFailed);
conf.update('java.debug.settings.enableRunDebugCodeLens', false, false).then(() => {}, disablingFailed);
```
This PR changes the behavior to more politely coexist with M$ Java extension. It asks the user to disable one of the extensions manually.
