### PR TITLE
Use combobox vs checkbox on issue template to avoid to issue tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/netbeans_bug_report.yml
@@ -27,9 +27,9 @@ body:
         Latest releases are always available from https://netbeans.apache.org/download/
       multiple: false
       options:
-        - "Latest release"
-        - "Latest release candidate"
-        - "Latest daily build"
+        - "Apache NetBeans 12.6"
+        - "Apache NetBeans 13 release candidate"
+        - "Apache NetBeans latest daily build"
     validations:
       required: true
   - type: textarea
@@ -54,15 +54,22 @@ body:
         Please make sure you provide a reproducible step-by-step case of how to reproduce the problem
         as minimally and precisely as possible. Remember that non-reproducible issues may be closed or
         converted into discussions. If we cannot reproduce an issue we cannot fix it!
-  - type: checkboxes
+  - type: dropdown
     attributes:
       label: Did this work correctly in an earlier version?
       description: >
         It's important to know whether bugs have been introduced by recent changes. If this used
-        to work, tick this and make sure you've specified the last version that worked correctly
-        in your issue description.
+        to work, select the last version that worked correctly from the list. Older versions can be 
+        specified in the description. 
+      multiple: false
       options:
-        - label: This used to work!
+        - "No"
+        - "Apache NetBeans 12.6"
+        - "Apache NetBeans 12.5"
+        - "Apache NetBeans 12.4"
+        - "Apache NetBeans 12.3 or earlier"
+    validations:
+      required: true
   - type: input
     attributes:
       label: Operating System
@@ -103,24 +110,30 @@ body:
         Any relevant logs to include? Put them here inside fenced
         ``` ``` blocks or inside a foldable details tag if it's long:
         <details><summary>x.log</summary> lots of stuff </details>
-  - type: checkboxes
+        
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  - type: dropdown
     attributes:
       label: Are you willing to submit a pull request?
       description: >
         This is absolutely not required, but we are happy to guide you in the contribution process,
-        especially if you already have a good understanding of how to implement the fix.
+        especially if you already have a good understanding of how to implement the fix. <br>
         Apache NetBeans is a community-managed project and we love to bring new contributors in.
+        
       options:
-        - label: Yes I am willing to submit a PR!
-  - type: checkboxes
+        - "Yes"
+        - "No"
+  - type: dropdown
     attributes:
       label: Code of Conduct
-      description: The Code of Conduct helps create a safe space for everyone.
+      description: > 
+         The Code of Conduct helps create a safe space for everyone.
+         I agree to follow the Apache Software Foundation's
+         [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)
       options:
-        - label: >
-            I agree to follow the Apache Software Foundation's
-            [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)
-          required: true
+        - "Yes"
+    validations:
+        required: true
   - type: markdown
     attributes:
       value: "Thank you for completing our form!"


### PR DESCRIPTION
Currently checkboxes in issue templates are converted to issue tasks. Since most of the checkboxes are not actual tasks this PR changes those to use comboboxes instead.

I left the accept code of conduct since it might make sense as a task.

In the future, GitHub may fix this or provide a better alternative.
https://github.com/github/feedback/discussions/4319
https://github.com/github/feedback/discussions/4318
https://github.com/github/feedback/discussions/5197
https://github.com/github/feedback/discussions/5238
