### PR TITLE
Exposing simple UI action to open next segment of a heap dump

### DIFF
--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/CacheDirectory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/CacheDirectory.java
@@ -28,16 +28,19 @@ import java.io.IOException;
  */
 class CacheDirectory {
     
-    private static final String DIR_EXT = ".hwcache";   // NOI18N
+    private static final String DIR_EXT = ".nbcache";   // NOI18N
     private static final String DUMP_AUX_FILE = "NBProfiler.nphd";   // NOI18N
     
     private final File.Factory io;
     private File cacheDirectory;
     
-    static CacheDirectory getHeapDumpCacheDirectory(File.Factory io, File heapDump) {
+    static CacheDirectory getHeapDumpCacheDirectory(File.Factory io, File heapDump, int segment) {
         String dumpName = heapDump.getName();
+        if (segment != 0) {
+            dumpName += "_" + segment;
+        }
         File parent = heapDump.getParentFile();
-        File dir = io.newFile(parent, dumpName+DIR_EXT);
+        File dir = io.newFile(parent, dumpName + DIR_EXT);
         return new CacheDirectory(io, dir);
     }
     

--- a/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
+++ b/profiler/lib.profiler/src/org/netbeans/lib/profiler/heap/HeapFactory.java
@@ -62,7 +62,7 @@ public class HeapFactory {
     public static Heap createHeap(java.io.File heapDump, int segment)
                            throws FileNotFoundException, IOException {
         File hd = JavaIoFile.IO.newFile(heapDump);
-        CacheDirectory cacheDir = CacheDirectory.getHeapDumpCacheDirectory(JavaIoFile.IO, hd);
+        CacheDirectory cacheDir = CacheDirectory.getHeapDumpCacheDirectory(JavaIoFile.IO, hd, segment);
         if (!cacheDir.isTemporary()) {
             File savedDump = cacheDir.getHeapDumpAuxFile();
 

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapFragmentWalker.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapFragmentWalker.java
@@ -64,6 +64,7 @@ public class HeapFragmentWalker {
 
     private List<StateListener> stateListeners;
     private int retainedSizesStatus;
+    private final int heapSegment;
 
     //~ Constructors -------------------------------------------------------------------------------------------------------------
 
@@ -73,7 +74,12 @@ public class HeapFragmentWalker {
     }
 
     public HeapFragmentWalker(Heap heapFragment, HeapWalker heapWalker, boolean supportsRetainedSizes) {
+        this(heapFragment, 0, heapWalker, supportsRetainedSizes);
+    }
+
+    HeapFragmentWalker(Heap heapFragment, int heapSegment, HeapWalker heapWalker, boolean supportsRetainedSizes) {
         this.heapFragment = heapFragment;
+        this.heapSegment = heapSegment;
         this.heapWalker = heapWalker;
 
         this.retainedSizesStatus = supportsRetainedSizes ? RETAINED_SIZES_UNKNOWN :
@@ -193,6 +199,10 @@ public class HeapFragmentWalker {
 
     public Heap getHeapFragment() {
         return heapFragment;
+    }
+    
+    public int getHeapSegment() {
+        return heapSegment;
     }
 
     public InstancesController getInstancesController() {

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapWalker.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapWalker.java
@@ -56,19 +56,29 @@ public class HeapWalker {
     private TopComponent heapWalkerUI;
     private Lookup.Provider heapDumpProject;
     private String heapWalkerName;
+    private final int segment;
 
     //~ Constructors -------------------------------------------------------------------------------------------------------------
 
     // --- Constructors ----------------------------------------------------------
     public HeapWalker(Heap heap) {
+        this(heap, 0);
+    }
+    
+    private HeapWalker(Heap heap, int segment) {
+        this.segment = segment;
         heapWalkerName = Bundle.ClassesListController_HeapWalkerDefaultName();
-        createMainFragment(heap);
+        createMainFragment(heap, segment);
         
 //        computeRetainedSizes();
     }
 
     public HeapWalker(File heapFile) throws FileNotFoundException, IOException {
-        this(createHeap(heapFile));
+        this(heapFile, 0);
+    }
+
+    HeapWalker(File heapFile, int segment) throws FileNotFoundException, IOException {
+        this(createHeap(heapFile, segment), segment);
 
         heapDumpFile = heapFile;
         heapDumpProject = computeHeapDumpProject(heapDumpFile);
@@ -84,6 +94,10 @@ public class HeapWalker {
 
     public File getHeapDumpFile() {
         return heapDumpFile;
+    }
+
+    public int getHeapDumpSegment() {
+        return segment;
     }
 
     public Lookup.Provider getHeapDumpProject() {
@@ -119,8 +133,8 @@ public class HeapWalker {
         return heapWalkerUI;
     }
 
-    void createMainFragment(Heap heap) {
-        mainHeapWalker = new HeapFragmentWalker(heap, this, true);
+    void createMainFragment(Heap heap, int segment) {
+        mainHeapWalker = new HeapFragmentWalker(heap, segment, this, true);
     }
 
     void createReachableFragment(Instance instance) {
@@ -170,7 +184,7 @@ public class HeapWalker {
         return ProfilerStorage.getProjectFromFolder(heapDumpDirObj);
     }
 
-    private static Heap createHeap(File heapFile) throws FileNotFoundException, IOException {
+    private static Heap createHeap(File heapFile, int segment) throws FileNotFoundException, IOException {
         ProgressHandle pHandle = null;
 
         try {
@@ -179,7 +193,7 @@ public class HeapWalker {
             pHandle.start(HeapProgress.PROGRESS_MAX*2);
             
             setProgress(pHandle,0);
-            Heap heap = HeapFactory.createHeap(heapFile);
+            Heap heap = HeapFactory.createHeap(heapFile, segment);
             setProgress(pHandle,HeapProgress.PROGRESS_MAX);
             heap.getSummary(); // Precompute HeapSummary within progress
 

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapWalkerManager.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/HeapWalkerManager.java
@@ -54,7 +54,6 @@ public class HeapWalkerManager {
     //~ Instance fields ----------------------------------------------------------------------------------------------------------
 
     private Set dumpsBeingDeleted = new HashSet();
-    private List<File> heapDumps = new ArrayList();
     private List<HeapWalker> heapWalkers = new ArrayList();
 
     final private RequestProcessor heapwalkerRp = new RequestProcessor(HeapWalkerManager.class);
@@ -75,7 +74,7 @@ public class HeapWalkerManager {
     }
 
     public boolean isHeapWalkerOpened(File file) {
-        return getHeapWalker(file) != null;
+        return getHeapWalker(file, 0) != null;
     }
 
     public void closeAllHeapWalkers() {
@@ -109,7 +108,7 @@ public class HeapWalkerManager {
     }
 
     public void deleteHeapDump(final File file) {
-        HeapWalker hw = getHeapWalker(file);
+        HeapWalker hw = getHeapWalker(file, 0);
 
         if (hw != null) {
             dumpsBeingDeleted.add(file);
@@ -128,7 +127,6 @@ public class HeapWalkerManager {
         }
 
         final File file = hw.getHeapDumpFile();
-        heapDumps.remove(file);
         heapWalkers.remove(hw);
 
         if (dumpsBeingDeleted.remove(file)) {
@@ -142,6 +140,10 @@ public class HeapWalkerManager {
     }
 
     public void openHeapWalker(final File heapDump) {
+        openHeapWalker(heapDump, 0);
+    }
+
+    public void openHeapWalker(final File heapDump, int segment) {
         String heapDumpPath;
         
         try {
@@ -151,11 +153,11 @@ public class HeapWalkerManager {
             return;
         }
         synchronized (heapDumpPath.intern()) {
-            HeapWalker hw = getHeapWalker(heapDump);
+            HeapWalker hw = getHeapWalker(heapDump, segment);
 
             if (hw == null) {
                 try {
-                    hw = new HeapWalker(heapDump);
+                    hw = new HeapWalker(heapDump, segment);
                 } catch (IOException e) {
                     ProfilerDialogs.displayError(Bundle.HeapWalkerManager_CannotOpenHeapWalkerMsg(), null, e.getLocalizedMessage());
                 } catch (Exception e) {
@@ -173,7 +175,6 @@ public class HeapWalkerManager {
 
     public synchronized void openHeapWalker(final HeapWalker hw) {
         if (!heapWalkers.contains(hw)) {
-            heapDumps.add(hw.getHeapDumpFile());
             heapWalkers.add(hw);
         }
         SwingUtilities.invokeLater(new Runnable() {
@@ -204,10 +205,13 @@ public class HeapWalkerManager {
         }
     }
 
-    private synchronized HeapWalker getHeapWalker(File heapDump) {
-        int hdIndex = heapDumps.indexOf(heapDump);
-
-        return (hdIndex == -1) ? null : heapWalkers.get(hdIndex);
+    private synchronized HeapWalker getHeapWalker(File heapDump, int segment) {
+        for (HeapWalker hw : heapWalkers) {
+            if (hw.getHeapDumpFile().equals(heapDump) && hw.getHeapDumpSegment() == segment) {
+                return hw;
+            }
+        }
+        return null;
     }
 
     private TopComponent getTopComponent(HeapWalker hw) {

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OverviewController.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/OverviewController.java
@@ -87,6 +87,7 @@ import org.openide.util.NbBundle;
 public class OverviewController extends AbstractController {
 
     public static final String SHOW_SYSPROPS_URL = "file:/sysprops"; // NOI18N
+    public static final String SHOW_NEXT_SEGMENT_URL = "file:/next"; // NOI18N
     public static final String SHOW_THREADS_URL = "file:/threads"; // NOI18N
     private static final String OPEN_THREADS_URL = "file:/stackframe/";     // NOI18N
     private static final String CLASS_URL_PREFIX = "file://class/"; // NOI18N
@@ -178,6 +179,9 @@ public class OverviewController extends AbstractController {
                           Bundle.OverviewController_NotAvailableMsg()
                 );
 
+        String segmentInfo = LINE_PREFIX + "<b>Segment:</b> " + heapFragmentWalker.getHeapSegment() +  " try " // NOI18N
+                + "<a href='" + SHOW_NEXT_SEGMENT_URL + "'>next</a>...<br>&nbsp;";
+
         String oomeString = "";
         if (oome != null) {
             Instance thread = oome.getInstance();
@@ -190,7 +194,8 @@ public class OverviewController extends AbstractController {
         String memoryRes = Icons.getResource(ProfilerIcons.HEAP_DUMP);
         return "<b><img border='0' align='bottom' src='nbresloc:/" + memoryRes + "'>&nbsp;&nbsp;" // NOI18N
                 + Bundle.OverviewController_SummaryString() + "</b><br><hr>" + dateTaken + "<br>" + filename + "<br>" + filesize + "<br><br>" + liveBytes // NOI18N
-                + "<br>" + liveClasses + "<br>" + liveInstances + "<br>" + classloaders + "<br>" + gcroots + "<br>" + finalizersInfo + oomeString; // NOI18N
+                + "<br>" + liveClasses + "<br>" + liveInstances + "<br>" + classloaders + "<br>" + gcroots + "<br>" + finalizersInfo + oomeString // NOI18N
+                + "<br>" + segmentInfo; // NOI18N
     }
 
     public String computeEnvironment() {
@@ -644,4 +649,11 @@ public class OverviewController extends AbstractController {
     private final static int JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER = 0x0400;
     private final static int JVMTI_THREAD_STATE_WAITING_INDEFINITELY = 0x0010;
     private final static int JVMTI_THREAD_STATE_WAITING_WITH_TIMEOUT = 0x0020;
+
+    public void showNextSegment() {
+        HeapWalkerManager.getDefault().openHeapWalker(
+            heapFragmentWalker.getHeapDumpFile(),
+            heapFragmentWalker.getHeapSegment() + 1
+        );
+    }
 }

--- a/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/OverviewControllerUI.java
+++ b/profiler/profiler.heapwalker/src/org/netbeans/modules/profiler/heapwalk/ui/OverviewControllerUI.java
@@ -155,6 +155,8 @@ public class OverviewControllerUI extends JTitledPanel {
                 } else if (urls.equals(OverviewController.SHOW_THREADS_URL)) {
                     showThreads = true;
                     refreshSummary();
+                } else if (urls.equals(OverviewController.SHOW_NEXT_SEGMENT_URL)) {
+                    overviewController.showNextSegment();
                 } else {
                     overviewController.showURL(urls);
                 }


### PR DESCRIPTION
I've created a simple library to generate `.hprof` files: [HeapDump](https://www.graalvm.org/tools/javadoc/org/graalvm/tools/insight/heap/HeapDump.html). It follows the [Java Profiler Heap Dump Format](http://hg.openjdk.java.net/jdk6/jdk6/jdk/raw-file/tip/src/share/demo/jvmti/hprof/manual.html) specification, however it allows more than regular JVMs do. Regular JVMs always dump the whole heap in a single round, while the [HeapDump](https://www.graalvm.org/tools/javadoc/org/graalvm/tools/insight/heap/HeapDump.html) allows one to generate _multiple segments_.

There already is support for reading these multisegment files in the Apache NetBeans Profiler library - it just isn't exposed in the heapwalker UI. This PR fixes that. The fix isn't "fancy", but it does its job. When an additional segment is detected, there is a little _link_ in the UI to open it in a new window. 

![obrazek](https://user-images.githubusercontent.com/26887752/151282603-bba87e5b-3843-45a7-903c-29255af05cb9.png)

Simple, but functional. I'd be delighted if the support for _multisegment_ `.hprof` files landed in the NetBeans 13.