### PR TITLE
build.xml and run.xml: fixed detection of 64 bit architecture for Java 9+ (on Windows)

### DIFF
--- a/harness/apisupport.harness/release/run.xml
+++ b/harness/apisupport.harness/release/run.xml
@@ -54,8 +54,11 @@
         </delete>
         
         <!-- architecture of jvm on which app will run -->
-        <condition property="jvm.arch.string" value="64" else="">
-            <available file="${run.jdkhome}\jre\lib\amd64" />
+        <condition property="jvm.arch.string" value="" else="64">
+            <or>
+                <available file="${run.jdkhome}\bin\javaaccessbridge-32.dll" />      <!-- 32-bit Java 9+ -->
+                <available file="${run.jdkhome}\jre\bin\JavaAccessBridge-32.dll" />  <!-- 32-bit Java 8 -->
+            </or>
         </condition>  
         
         <!-- use nb.exe if exists (old platform), netbeans.exe otherwise -->

--- a/nbbuild/build.xml
+++ b/nbbuild/build.xml
@@ -1182,8 +1182,11 @@ It is possible to use -Ddebug.port=3234 -Ddebug.pause=y to start the system in d
     </condition>
     
     <!-- architecture of jvm on which app will run -->
-    <condition property="jvm.arch.string" value="64" else="">
-      <available file="${nbjdk.home}\jre\lib\amd64" />
+    <condition property="jvm.arch.string" value="" else="64">
+        <or>
+            <available file="${nbjdk.home}\bin\javaaccessbridge-32.dll" />      <!-- 32-bit Java 9+ -->
+            <available file="${nbjdk.home}\jre\bin\JavaAccessBridge-32.dll" />  <!-- 32-bit Java 8 -->
+        </or>
     </condition>
 
     <condition property="tryme.launcher.prefix" value="${netbeans.dest.dir}/bin/netbeans" else="${netbeans.dest.dir}/platform/lib/nbexec">


### PR DESCRIPTION
When using Java 9+ for debugging/running NetBeans from NetBeans on Windows,
then the 64-bit architecture of the JVM was not detected correctly and
`netbeans.exe` was used instead of `netbeans64.exe` to launch NetBeans.
This affects not only NetBeans core development, but also NetBeans module development.

This PR detects 32-bit JVMs and otherwise defaults to 64-bit.

See https://lists.apache.org/thread/5v5gb40tj3t4y06qtzxhjncowtm290t1