### PR TITLE
[NETBEANS-6425] Provide outline view for Groovy file in VSCode.

### DIFF
--- a/ide/api.lsp/apichanges.xml
+++ b/ide/api.lsp/apichanges.xml
@@ -51,6 +51,20 @@
 <!-- ACTUAL CHANGES BEGIN HERE: -->
 
 <changes>
+    <change id="StructureProvider">
+        <api name="LSP_API"/>
+        <summary>Adding StructeProvider and StructureElement</summary>
+        <version major="1" minor="8"/>
+        <date day="24" month="1" year="2022"/>
+        <author login="ppisl"/>
+        <compatibility binary="compatible" source="compatible" addition="yes" deletion="no"/>
+        <description>
+            A <code>StructureProvider</code> interface allows to compute structure (tree of <code>SourceElement</code>s)
+            of the given file. 
+        </description>
+        <class package="org.netbeans.api.lsp" name="StructureElement"/>
+        <class package="org.netbeans.spi.lsp" name="StructureProvider"/>
+    </change>
     <change id="ErrorProvider.Context.getOffset">
         <api name="LSP_API"/>
         <summary>Adding ErrorProvider.Context.getOffset() method</summary>

--- a/ide/api.lsp/src/org/netbeans/api/lsp/StructureElement.java
+++ b/ide/api.lsp/src/org/netbeans/api/lsp/StructureElement.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.api.lsp;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * StructureElement is a tree item that shows the structure of the source code.
+ * 
+ * @author Petr Pisl
+ * @since 1.8
+ */
+public interface StructureElement {
+   
+    /**
+     * Kind of the structure element. 
+     */
+    public static enum Kind {
+        File,
+	Module,
+	Namespace,
+	Package,
+	Class,
+	Method,
+	Property,
+	Field,
+	Constructor,
+	Enum,
+	Interface,
+	Function,
+	Variable,
+	Constant,
+	String,
+	Number,
+	Boolean,
+	Array,
+	Object,
+	Key,
+	Null,
+	EnumMember,
+	Struct,
+	Event,
+	Operator,
+	TypeParameter
+    }
+    
+    /**
+     * Tags are extra annotations that tweak the rendering of a symbol.
+     */
+    public static enum Tag {
+        Deprecated;
+    }
+    
+    /**
+     * The name is displayed in the structure tree and other ui.
+     * @return The name of this element.
+     */
+    public String getName();
+    
+    /**
+     * The start of offset range where this element should be selected and revealed 
+     * when selected.
+     * @return start offset of the selection
+     */
+    public int getSelectionStartOffset();
+    
+    /**
+     * The end of offset range where this element should be selected and revealed 
+     * when selected.
+     * @return end offset of the selection
+     */
+    public int getSelectionEndOffset();
+    
+    
+    /**
+     * The expanded range is offset range that is typically used to determine if the cursors
+     * inside the element to reveal in the element in the UI. 
+     * @return start of the enclosed range
+     */
+    public int getExpandedStartOffset();
+    
+    /**
+     * The expanded range is offset range that is typically used to determine if the cursors
+     * inside the element to reveal in the element in the UI. 
+     * @return end of the enclosed range
+     */
+    public int getExpandedEndOffset();
+    
+    /**
+     * Kind of this symbol
+     * @return Kind of this symbol
+     */
+    public Kind getKind();
+    
+    /**
+     * Tags for this element.
+     * @return list of tags
+     */
+    public Set<Tag> getTags();
+    
+   /**
+   * More detail for this symbol, e.g the signature of a function.If not provided the name is used.
+   * @return the detail text for this element
+   */
+    public String getDetail();
+    
+    /**
+     * Children of this element, e.g. method and fields of a class. 
+     * @return 
+     */
+    public List<? extends StructureElement> getChildren();
+    
+}

--- a/ide/api.lsp/src/org/netbeans/api/lsp/StructureElement.java
+++ b/ide/api.lsp/src/org/netbeans/api/lsp/StructureElement.java
@@ -20,111 +20,172 @@ package org.netbeans.api.lsp;
 
 import java.util.List;
 import java.util.Set;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.modules.lsp.StructureElementAccessor;
 
 /**
  * StructureElement is a tree item that shows the structure of the source code.
- * 
+ *
  * @author Petr Pisl
  * @since 1.8
  */
-public interface StructureElement {
-   
+public final class StructureElement {
+
+    static {
+        StructureElementAccessor.setDefault(new StructureElementAccessor() {
+            @Override
+            public StructureElement createStructureElement(String name, String detail, int selectionStartOffset, int selectionEndOffset, int expandedStartOffset, int expandedEndOffset, Kind kind, Set<Tag> tags, List<StructureElement> children) {
+                return new StructureElement(name, detail, selectionStartOffset, selectionEndOffset, expandedStartOffset, expandedEndOffset, kind, tags, children);
+            }
+        });
+    }
+
+    private final String name;
+    private final String detail;
+    private final int selectionStartOffset;
+    private final int selectionEndOffset;
+    private final int expandedStartOffset;
+    private final int expandedEndOffset;
+    private final Kind kind;
+    private final Set<Tag> tags;
+    private final List<StructureElement> children;
+
     /**
-     * Kind of the structure element. 
+     * Kind of the structure element.
      */
     public static enum Kind {
         File,
-	Module,
-	Namespace,
-	Package,
-	Class,
-	Method,
-	Property,
-	Field,
-	Constructor,
-	Enum,
-	Interface,
-	Function,
-	Variable,
-	Constant,
-	String,
-	Number,
-	Boolean,
-	Array,
-	Object,
-	Key,
-	Null,
-	EnumMember,
-	Struct,
-	Event,
-	Operator,
-	TypeParameter
+        Module,
+        Namespace,
+        Package,
+        Class,
+        Method,
+        Property,
+        Field,
+        Constructor,
+        Enum,
+        Interface,
+        Function,
+        Variable,
+        Constant,
+        String,
+        Number,
+        Boolean,
+        Array,
+        Object,
+        Key,
+        Null,
+        EnumMember,
+        Struct,
+        Event,
+        Operator,
+        TypeParameter
     }
-    
+
     /**
      * Tags are extra annotations that tweak the rendering of a symbol.
      */
     public static enum Tag {
         Deprecated;
     }
-    
+
+    private StructureElement(@NonNull String name, String detail, int selectionStartOffset, int selectionEndOffset, int expandedStartOffset, int expandedEndOffset, @NonNull Kind kind, Set<Tag> tags, List<StructureElement> children) {
+        this.name = name;
+        this.detail = detail;
+        this.selectionStartOffset = selectionStartOffset;
+        this.selectionEndOffset = selectionEndOffset;
+        this.expandedStartOffset = expandedStartOffset;
+        this.expandedEndOffset = expandedEndOffset;
+        this.kind = kind;
+        this.tags = tags;
+        this.children = children;
+    }
+
     /**
      * The name is displayed in the structure tree and other ui.
+     *
      * @return The name of this element.
      */
-    public String getName();
-    
+    @NonNull
+    public String getName() {
+        return name;
+    }
+
     /**
-     * The start of offset range where this element should be selected and revealed 
-     * when selected.
+     * The start of offset range where this element should be selected and
+     * revealed in document when selected in outline view.
+     *
      * @return start offset of the selection
      */
-    public int getSelectionStartOffset();
-    
+    public int getSelectionStartOffset() {
+        return selectionStartOffset;
+    }
+
     /**
-     * The end of offset range where this element should be selected and revealed 
-     * when selected.
+     * The end of offset range where this element should be selected and
+     * revealed in document when selected.
+     *
      * @return end offset of the selection
      */
-    public int getSelectionEndOffset();
-    
-    
+    public int getSelectionEndOffset() {
+        return selectionEndOffset;
+    }
+
     /**
-     * The expanded range is offset range that is typically used to determine if the cursors
-     * inside the element to reveal in the element in the UI. 
+     * The expanded range is offset range that is typically used to determine if
+     * the cursors inside the element to reveal in the element in the UI.
+     *
      * @return start of the enclosed range
      */
-    public int getExpandedStartOffset();
-    
+    public int getExpandedStartOffset() {
+        return expandedStartOffset;
+    }
+
     /**
-     * The expanded range is offset range that is typically used to determine if the cursors
-     * inside the element to reveal in the element in the UI. 
+     * The expanded range is offset range that is typically used to determine if
+     * the cursors inside the element to reveal in the element in the UI.
+     *
      * @return end of the enclosed range
      */
-    public int getExpandedEndOffset();
-    
+    public int getExpandedEndOffset() {
+        return expandedEndOffset;
+    }
+
     /**
-     * Kind of this symbol
+     * Kind of this structure element.
+     *
      * @return Kind of this symbol
      */
-    public Kind getKind();
-    
+    public Kind getKind() {
+        return kind;
+    }
+
     /**
      * Tags for this element.
+     *
      * @return list of tags
      */
-    public Set<Tag> getTags();
-    
-   /**
-   * More detail for this symbol, e.g the signature of a function.If not provided the name is used.
-   * @return the detail text for this element
-   */
-    public String getDetail();
-    
+    public Set<Tag> getTags() {
+        return tags;
+    }
+
     /**
-     * Children of this element, e.g. method and fields of a class. 
-     * @return 
+     * More detail for this symbol, e.g the signature of a function. If not
+     * provided only the name is used.
+     *
+     * @return the detail text for this element
      */
-    public List<? extends StructureElement> getChildren();
-    
+    public String getDetail() {
+        return detail;
+    }
+
+    /**
+     * Children of this element, e.g. method and fields of a class.
+     *
+     * @return list of sub elements.
+     */
+    public List<StructureElement> getChildren() {
+        return children;
+    }
+  
 }

--- a/ide/api.lsp/src/org/netbeans/modules/lsp/StructureElementAccessor.java
+++ b/ide/api.lsp/src/org/netbeans/modules/lsp/StructureElementAccessor.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.lsp;
+
+import java.util.List;
+import java.util.Set;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.lsp.StructureElement;
+import org.openide.util.Exceptions;
+import org.openide.util.Parameters;
+
+/**
+ *
+ * @author Petr Pisl
+ */
+public abstract class StructureElementAccessor {
+    
+    private static volatile StructureElementAccessor DEFAULT;
+    
+    public static synchronized StructureElementAccessor getDefault () {
+        StructureElementAccessor instance = DEFAULT;
+        if (instance == null) {
+            Class<?> c = StructureElement.class;
+            try {
+                Class.forName(c.getName(), true, c.getClassLoader());
+                instance = DEFAULT;
+                assert instance != null;
+            } catch (Exception ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+        return instance;
+    }
+    
+    public static void setDefault(@NonNull final StructureElementAccessor accessor) {
+        Parameters.notNull("accessor", accessor);
+        DEFAULT = accessor;
+    }
+    
+    public abstract StructureElement createStructureElement(@NonNull String name, String detail, int selectionStartOffset, int selectionEndOffset, int expandedStartOffset, int expandedEndOffset, @NonNull StructureElement.Kind kind, Set<StructureElement.Tag> tags, List<StructureElement> children);
+    
+}

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
@@ -18,12 +18,15 @@
  */
 package org.netbeans.spi.lsp;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import org.netbeans.api.lsp.StructureElement;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import javax.swing.text.Document;
 import org.netbeans.api.annotations.common.NonNull;
-import org.netbeans.spi.editor.mimelookup.MimeLocation;
+import org.netbeans.modules.lsp.StructureElementAccessor;
 
 /**
  * Interface for building structure of symbols at a given document.
@@ -40,18 +43,202 @@ import org.netbeans.spi.editor.mimelookup.MimeLocation;
  * @author Petr Pisl
  * @since 1.8
  */
-
-//@MimeLocation(subfolderName = "StructureProviders")
 public interface StructureProvider {
-    
+
     /**
      * Resolves a structure tree of symbols at the given document.
      *
      * @param doc document on which to operate.
      * @return a list of top level structure elements
-     * 
+     *
      * @since 1.8
      */
     @NonNull
-    CompletableFuture<List<? extends StructureElement>> getStructure(@NonNull Document doc);
+    CompletableFuture<List<StructureElement>> getStructure(@NonNull Document doc);
+
+    /**
+     * Create builder for {@link StructureElement} instances.
+     *
+     * @param name the name of the structure element
+     * @param kind the kind of structure element
+     * @return newly created builder
+     *
+     * @since 1.8
+     */
+    public static Builder newBuilder(@NonNull String name, @NonNull StructureElement.Kind kind) {
+        return new Builder(name, kind);
+    }
+
+    /**
+     * Builder for {@link StructureElement} instances.
+     *
+     * @since 1.8
+     */
+    public static final class Builder {
+
+        private String name;
+        private String detail;
+        private int selectionStartOffset;
+        private int selectionEndOffset;
+        private int expandedStartOffset;
+        private int expandedEndOffset;
+        private StructureElement.Kind kind;
+        private Set<StructureElement.Tag> tags;
+        private List<StructureElement> children;
+
+        private Builder(@NonNull String name, @NonNull StructureElement.Kind kind) {
+            this.name = name;
+            this.kind = kind;
+        }
+
+        /**
+         * The name of {@link StructureElement} is displayed in the structure
+         * tree and other ui.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public Builder name(@NonNull String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Kind of this structure element.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public Builder kind(@NonNull StructureElement.Kind name) {
+            this.kind = kind;
+            return this;
+        }
+
+        /**
+         * The detail of {@link StructureElement}, e.g the signature of a
+         * function. If not provided only the name is used.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public Builder detail(@NonNull String detail) {
+            this.detail = detail;
+            return this;
+        }
+
+        /**
+         * The start of offset range where this element should be selected and
+         * revealed in document when selected in outline view.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public Builder selectionStartOffset(int selectionStartOffset) {
+            this.selectionStartOffset = selectionStartOffset;
+            return this;
+        }
+
+        /**
+         * The end of offset range where this element should be selected and
+         * revealed in document when selected in outline view.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public Builder selectionEndOffset(int selectionEndOffset) {
+            this.selectionEndOffset = selectionEndOffset;
+            return this;
+        }
+
+        /**
+         * The expanded range is offset range that is typically used to
+         * determine if the cursors inside the element to reveal in the element
+         * in the UI.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public Builder expandedStartOffset(int expandedStartOffset) {
+            this.expandedStartOffset = expandedStartOffset;
+            return this;
+        }
+
+        /**
+         * The expanded range is offset range that is typically used to
+         * determine if the cursors inside the element to reveal in the element
+         * in the UI.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public Builder expandedEndOffset(int expandedEndOffset) {
+            this.expandedEndOffset = expandedEndOffset;
+            return this;
+        }
+
+        /**
+         * Adds tag for this structure element.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public Builder addTag(@NonNull StructureElement.Tag tag) {
+            if (this.tags == null) {
+                this.tags = new HashSet<>();
+            }
+            this.tags.add(tag);
+            return this;
+        }
+        
+        /**
+         * Tags for this structure element.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public Builder tags(@NonNull Set<StructureElement.Tag> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        /**
+         * Adds sub element for this structure element.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public Builder addChild(@NonNull StructureElement child) {
+            if (this.children == null) {
+                this.children = new ArrayList<>();
+            }
+            this.children.add(child);
+            return this;
+        }
+        
+        /**
+         * Sub elements of this structure element. 
+         * 
+         * @since 1.8
+         */
+        @NonNull
+        public Builder children(@NonNull List<StructureElement> children) {
+            this.children = children;
+            return this;
+            
+        }
+        
+        /**
+         * Builds structure element.
+         *
+         * @since 1.8
+         */
+        @NonNull
+        public StructureElement build() {
+            return StructureElementAccessor.getDefault()
+                    .createStructureElement(name, detail, selectionStartOffset, 
+                            selectionEndOffset, expandedStartOffset, expandedEndOffset, 
+                            kind, tags, children);
+        }
+        
+    }
 }

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
@@ -70,6 +70,20 @@ public interface StructureProvider {
     }
 
     /**
+     * Create builder for {@link StructureElement} instances from copy of input element. 
+     * 
+     * @param from element that is copied
+     * @return newly created builder with all attributes as input structure element
+     */
+    public static Builder copy(@NonNull StructureElement from) {
+        Builder builder = new Builder(from.getName(), from.getKind());
+        builder.detail(from.getDetail()).children(from.getChildren());
+        builder.selectionStartOffset(from.getSelectionStartOffset()).selectionEndOffset(from.getSelectionEndOffset());
+        builder.expandedStartOffset(from.getExpandedStartOffset()).expandedEndOffset(from.getExpandedEndOffset());
+        builder.tags(from.getTags());
+        return builder;
+    }
+    /**
      * Builder for {@link StructureElement} instances.
      *
      * @since 1.8

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
@@ -33,7 +33,7 @@ import org.netbeans.modules.lsp.StructureElementAccessor;
  * Implementations of the interface should be registered in MimeLookup.
  * <pre>
  *
- *  {@code @MimeRegistration(mimeType = "text/foo", service = StructureProvider.class)
+ *  {@codesnippet @MimeRegistration(mimeType = "text/foo", service = StructureProvider.class)
  *   public class FooStructureProvider implements StructureProvider {
  *     ...
  *   }
@@ -207,11 +207,13 @@ public interface StructureProvider {
          * @since 1.8
          */
         @NonNull
-        public Builder addChild(@NonNull StructureElement child) {
+        public Builder children(@NonNull StructureElement ... children) {
             if (this.children == null) {
                 this.children = new ArrayList<>();
             }
-            this.children.add(child);
+            for (StructureElement structureElement : children) {
+                this.children.add(structureElement);
+            }
             return this;
         }
         
@@ -222,7 +224,10 @@ public interface StructureProvider {
          */
         @NonNull
         public Builder children(@NonNull List<StructureElement> children) {
-            this.children = children;
+            if (this.children == null) {
+                this.children = new ArrayList<>();
+            }
+            this.children.addAll(children);
             return this;
             
         }

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
@@ -54,7 +54,7 @@ public interface StructureProvider {
      * @since 1.8
      */
     @NonNull
-    CompletableFuture<List<StructureElement>> getStructure(@NonNull Document doc);
+    List<StructureElement> getStructure(@NonNull Document doc);
 
     /**
      * Create builder for {@link StructureElement} instances.

--- a/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
+++ b/ide/api.lsp/src/org/netbeans/spi/lsp/StructureProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.spi.lsp;
+
+import org.netbeans.api.lsp.StructureElement;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.swing.text.Document;
+import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.spi.editor.mimelookup.MimeLocation;
+
+/**
+ * Interface for building structure of symbols at a given document.
+ * Implementations of the interface should be registered in MimeLookup.
+ * <pre>
+ *
+ *  {@code @MimeRegistration(mimeType = "text/foo", service = StructureProvider.class)
+ *   public class FooStructureProvider implements StructureProvider {
+ *     ...
+ *   }
+ *  }
+ * </pre>
+ *
+ * @author Petr Pisl
+ * @since 1.8
+ */
+
+//@MimeLocation(subfolderName = "StructureProviders")
+public interface StructureProvider {
+    
+    /**
+     * Resolves a structure tree of symbols at the given document.
+     *
+     * @param doc document on which to operate.
+     * @return a list of top level structure elements
+     * 
+     * @since 1.8
+     */
+    @NonNull
+    CompletableFuture<List<? extends StructureElement>> getStructure(@NonNull Document doc);
+}

--- a/ide/api.lsp/test/unit/src/org/netbeans/api/lsp/StructureElementTest.java
+++ b/ide/api.lsp/test/unit/src/org/netbeans/api/lsp/StructureElementTest.java
@@ -1,0 +1,157 @@
+package org.netbeans.api.lsp;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DefaultStyledDocument;
+import javax.swing.text.Document;
+import org.netbeans.api.editor.mimelookup.MimeLookup;
+import org.netbeans.api.editor.mimelookup.MimePath;
+import org.netbeans.api.editor.mimelookup.test.MockMimeLookup;
+import org.netbeans.junit.NbTestCase;
+import org.netbeans.lib.editor.util.swing.DocumentUtilities;
+import org.netbeans.spi.lsp.StructureProvider;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ *
+ * @author Petr Pisl
+ */
+public class StructureElementTest extends NbTestCase {
+    
+    private FileObject srcFile;
+
+    public StructureElementTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        clearWorkDir();
+        FileObject workDir = FileUtil.toFileObject(getWorkDir());
+        srcFile = FileUtil.createData(workDir, "mytest.test");
+        MockMimeLookup.setInstances(MimePath.get("text/haha"), new HahaStructureProvider());
+    }
+    
+    
+    public void testStructureElements() {
+        Document doc = createDocument("text/haha", "");
+        
+        StructureProvider structureProvider = MimeLookup.getLookup(DocumentUtilities.getMimeType(doc)).lookup(StructureProvider.class);
+        
+        CompletableFuture<List<StructureElement>> future = structureProvider.getStructure(doc);
+        
+        List<StructureElement> structure = future.getNow(null);
+        assertNotNull(structure);
+        assertEquals(1, structure.size());
+        
+        // root
+        StructureElement root = structure.get(0);
+        assertEquals("Root1", root.getName());
+        assertEquals(StructureElement.Kind.Class, root.getKind());
+        assertEquals(10, root.getSelectionStartOffset());
+        assertEquals(50, root.getSelectionEndOffset());
+        assertEquals(5, root.getExpandedStartOffset());
+        assertEquals(51, root.getExpandedEndOffset());
+        assertEquals("detail", root.getDetail());
+        assertNull(root.getTags());
+        
+        // children
+        structure = root.getChildren();
+        assertNotNull(structure);
+        assertEquals(2, structure.size());
+        
+        StructureElement child1 = structure.get(0);
+        assertEquals("field1", child1.getName());
+        assertEquals(StructureElement.Kind.Field, child1.getKind());
+        assertEquals(20, child1.getSelectionStartOffset());
+        assertEquals(25, child1.getSelectionEndOffset());
+        assertEquals(15, child1.getExpandedStartOffset());
+        assertEquals(25, child1.getExpandedEndOffset());
+        assertNull(child1.getDetail());
+        assertNull(child1.getChildren());
+        assertNotNull(child1.getTags());
+        assertTrue(child1.getTags().contains(StructureElement.Tag.Deprecated));
+        
+        StructureElement child2 = structure.get(1);
+        assertEquals("method1", child2.getName());
+        assertEquals(StructureElement.Kind.Method, child2.getKind());
+        assertEquals(30, child2.getSelectionStartOffset());
+        assertEquals(45, child2.getSelectionEndOffset());
+        assertEquals(26, child2.getExpandedStartOffset());
+        assertEquals(46, child2.getExpandedEndOffset());
+        assertEquals(": int", child2.getDetail());
+        assertNull(child2.getChildren());
+        assertNull(child2.getTags());
+    }
+    
+    private Document createDocument(String mimeType, String contents) {
+        Document doc = new DefaultStyledDocument();
+        doc.putProperty("mimeType", mimeType);
+        try {
+            doc.insertString(0, contents, null);
+            return doc;
+        } catch (BadLocationException ble) {
+            throw new IllegalStateException(ble);
+        }
+    }
+    
+    private class HahaStructureProvider implements StructureProvider {
+        List<StructureElement> elements;
+
+        public HahaStructureProvider() {
+            elements = new ArrayList<>();
+            addStructure();
+        }
+        
+        @Override
+        public CompletableFuture<List<StructureElement>> getStructure(Document doc) {
+            return CompletableFuture.completedFuture(elements);
+        }
+        
+        private void addStructure() {
+           Builder root = StructureProvider.newBuilder("Root1", StructureElement.Kind.Class);
+           root.detail("detail");
+           root.selectionStartOffset(10).selectionEndOffset(50);
+           root.expandedStartOffset(5).expandedEndOffset(51);
+           
+           Builder child1 = StructureProvider.newBuilder("field1", StructureElement.Kind.Field);
+           child1.selectionStartOffset(20).selectionEndOffset(25);
+           child1.expandedStartOffset(15).expandedEndOffset(25);
+           child1.addTag(StructureElement.Tag.Deprecated);
+           root.addChild(child1.build());
+           
+           Builder child2 = StructureProvider.newBuilder("method1", StructureElement.Kind.Method);
+           child2.selectionStartOffset(30).selectionEndOffset(45);
+           child2.expandedStartOffset(26).expandedEndOffset(46);
+           child2.detail(": int");
+           root.addChild(child2.build());
+           elements.add(root.build());
+        }
+        
+    } 
+    
+    
+}

--- a/ide/api.lsp/test/unit/src/org/netbeans/api/lsp/StructureElementTest.java
+++ b/ide/api.lsp/test/unit/src/org/netbeans/api/lsp/StructureElementTest.java
@@ -61,9 +61,8 @@ public class StructureElementTest extends NbTestCase {
         
         StructureProvider structureProvider = MimeLookup.getLookup(DocumentUtilities.getMimeType(doc)).lookup(StructureProvider.class);
         
-        CompletableFuture<List<StructureElement>> future = structureProvider.getStructure(doc);
+        List<StructureElement> structure = structureProvider.getStructure(doc);
         
-        List<StructureElement> structure = future.getNow(null);
         assertNotNull(structure);
         assertEquals(1, structure.size());
         
@@ -127,8 +126,8 @@ public class StructureElementTest extends NbTestCase {
         }
         
         @Override
-        public CompletableFuture<List<StructureElement>> getStructure(Document doc) {
-            return CompletableFuture.completedFuture(elements);
+        public List<StructureElement> getStructure(Document doc) {
+            return elements;
         }
         
         private void addStructure() {

--- a/ide/api.lsp/test/unit/src/org/netbeans/api/lsp/StructureElementTest.java
+++ b/ide/api.lsp/test/unit/src/org/netbeans/api/lsp/StructureElementTest.java
@@ -141,13 +141,13 @@ public class StructureElementTest extends NbTestCase {
            child1.selectionStartOffset(20).selectionEndOffset(25);
            child1.expandedStartOffset(15).expandedEndOffset(25);
            child1.addTag(StructureElement.Tag.Deprecated);
-           root.addChild(child1.build());
+           root.children(child1.build());
            
            Builder child2 = StructureProvider.newBuilder("method1", StructureElement.Kind.Method);
            child2.selectionStartOffset(30).selectionEndOffset(45);
            child2.expandedStartOffset(26).expandedEndOffset(46);
            child2.detail(": int");
-           root.addChild(child2.build());
+           root.children(child2.build());
            elements.add(root.build());
         }
         

--- a/ide/csl.api/src/org/netbeans/modules/csl/core/LanguageRegistrationProcessor.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/core/LanguageRegistrationProcessor.java
@@ -48,6 +48,7 @@ import org.netbeans.modules.csl.editor.semantic.OccurrencesMarkProviderCreator;
 import org.netbeans.modules.csl.hints.GsfErrorProvider;
 import org.netbeans.modules.csl.hints.GsfUpToDateStateProviderFactory;
 import org.netbeans.modules.csl.navigation.ClassMemberPanel;
+import org.netbeans.modules.csl.navigation.GsfStructureProvider;
 import org.netbeans.modules.csl.spi.LanguageRegistration;
 import org.netbeans.modules.editor.errorstripe.privatespi.MarkProviderCreator;
 import org.netbeans.modules.editor.indent.spi.IndentTask;
@@ -327,6 +328,7 @@ public class LanguageRegistrationProcessor extends LayerGeneratingProcessor {
                .intvalue("position", 5238)
                .boolvalue("scrollable", false)
                .write();
+        instanceFile(b, "Editors/" + mimeType, null, GsfStructureProvider.class, null).write(); // NOI18N
 //
 //        Element navigatorFolder = mkdirs(doc, "Navigator/Panels/" + mimeType); // NOI18N
 //        createFile(doc, navigatorFolder, "org-netbeans-modules-csl-navigation-ClassMemberPanel.instance"); // NOI18N

--- a/ide/csl.api/src/org/netbeans/modules/csl/navigation/GsfStructureProvider.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/navigation/GsfStructureProvider.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.csl.navigation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.Document;
+import org.netbeans.api.editor.document.LineDocument;
+import org.netbeans.api.editor.document.LineDocumentUtils;
+import org.netbeans.modules.csl.api.StructureItem;
+import org.netbeans.modules.csl.api.StructureScanner;
+import org.netbeans.modules.csl.core.Language;
+import org.netbeans.modules.csl.core.LanguageRegistry;
+import org.netbeans.modules.csl.spi.ParserResult;
+import org.netbeans.modules.parsing.api.ParserManager;
+import org.netbeans.modules.parsing.api.ResultIterator;
+import org.netbeans.modules.parsing.api.Source;
+import org.netbeans.modules.parsing.api.UserTask;
+import org.netbeans.modules.parsing.spi.ParseException;
+import org.netbeans.modules.parsing.spi.Parser;
+import org.netbeans.api.lsp.StructureElement;
+import org.netbeans.modules.csl.api.ElementKind;
+import org.netbeans.modules.csl.api.HtmlFormatter;
+import org.netbeans.modules.csl.api.Modifier;
+import org.netbeans.spi.lsp.StructureProvider;
+
+/**
+ * Implementation of StructureProvider to supply outline view in VSCode
+ * @author Petr Pisl
+ */
+public class GsfStructureProvider implements StructureProvider {
+
+    private static final Logger LOGGER = Logger.getLogger(GsfStructureProvider.class.getName());
+    
+    /** The structure element implementation. Some properties are counted lazy. 
+     * 
+     */
+    private static class GsfStructureElement implements StructureElement {
+        
+        private final static Set<StructureElement.Tag> DEPRECATED_TAG = Collections.singleton(StructureElement.Tag.Deprecated);
+        
+        private final Document doc;         // The children are counted lazily and we need the document for it. 
+        private final StructureItem origItem;
+        private List<GsfStructureElement> children;
+        private String signature;
+        private int expandedStartOffset;
+        private int expandedEndOffset;
+        
+
+        public GsfStructureElement(Document doc, StructureItem origItem) {
+            this.doc = doc;
+            this.origItem = origItem;
+            this.signature = null;
+            this.children = null;
+            this.expandedStartOffset = (int)origItem.getPosition();
+            this.expandedEndOffset = (int)origItem.getEndPosition();
+        }
+        
+        @Override
+        public String getName() {
+            return origItem.getName();
+        }
+
+        @Override
+        public int getSelectionStartOffset() {
+            return (int)origItem.getPosition();
+        }
+
+        @Override
+        public int getSelectionEndOffset() {
+            return (int)origItem.getEndPosition();
+        }
+        
+        @Override
+        public int getExpandedStartOffset() {
+            return expandedStartOffset;
+        }
+
+        protected void setExpandedStartOffset(int enclosedStartOffset) {
+            this.expandedStartOffset = enclosedStartOffset;
+        }
+
+        @Override
+        public int getExpandedEndOffset() {
+            return expandedEndOffset;
+        }
+        
+        protected void setExpandedEndOffset(int enclosedEndOffset) {
+            this.expandedEndOffset = enclosedEndOffset;
+        }
+
+        
+        @Override
+        public String getDetail() { 
+            if (signature == null) {
+                createSignature();
+            }
+            return signature;
+        }
+
+        private void createSignature() {
+            NoHtmlFormatter formatter = new NoHtmlFormatter();
+            String s = origItem.getHtml(formatter);
+            signature = s.substring(getName().length()).trim();
+        }
+        
+        @Override
+        public StructureElement.Kind getKind() {
+            switch(origItem.getKind()) {
+                case ATTRIBUTE: return Kind.Property;
+                case CALL: return Kind.Event;
+                case CLASS: return Kind.Class;
+                case CONSTANT: return Kind.Constant;
+                case CONSTRUCTOR: return Kind.Constructor;
+                case DB: return Kind.File;
+                case ERROR: return Kind.Event;
+                case METHOD: return Kind.Method;
+                case FILE: return Kind.File;
+                case FIELD: return Kind.Field;
+                case MODULE: return Kind.Module;
+                case VARIABLE: return Kind.Variable;
+                case GLOBAL: return Kind.Module;
+                case INTERFACE: return Kind.Interface;
+                case KEYWORD: return Kind.Key;
+                case OTHER: return Kind.Object;
+                case PACKAGE: return Kind.Package;
+                case PARAMETER: return Kind.TypeParameter;
+                case PROPERTY: return Kind.Property;
+                case RULE: return Kind.Event;
+                case TAG: return Kind.Operator;
+                case TEST: return Kind.Function;
+            }
+            return Kind.Object;
+        }
+        
+        @Override
+        public Set<Tag> getTags() {
+            if (origItem.getModifiers().contains(Modifier.DEPRECATED)) {
+                return DEPRECATED_TAG;
+            }
+            return null;
+        }
+        
+        @Override
+        public List<? extends StructureElement> getChildren() {
+            if (children == null) {
+                if (origItem.isLeaf()) {
+                    children = Collections.EMPTY_LIST;
+                } else {
+                    List <? extends StructureItem> origChildren = origItem.getNestedItems();
+                    if (origChildren.isEmpty()) {
+                        children = Collections.EMPTY_LIST;
+                    } else {
+                        children = new ArrayList<>(origChildren.size());
+                        convertStructureItems(doc, origChildren, children);
+                    }
+                    
+                }
+            }
+            return children;
+        }
+        
+    }
+    
+    /** A formatter that strips the html elements from the text */
+    static private class NoHtmlFormatter extends HtmlFormatter {
+        StringBuilder sb = new StringBuilder();
+        
+        @Override
+        public void reset() {
+            sb = new StringBuilder();
+        }
+
+        static String stripHtml( String htmlText ) {
+            if( null == htmlText )
+                return null;
+            String res = htmlText.replaceAll( "<[^>]*>", "" ); // NOI18N // NOI18N
+            res = res.replaceAll( "&nbsp;", " " ); // NOI18N // NOI18N
+            res = res.trim();
+            return res;
+        }
+        
+        @Override
+        public void appendHtml(String html) {
+            sb.append(stripHtml(html));
+        }
+
+        @Override
+        public void appendText(String text, int fromInclusive, int toExclusive) {
+            int l = toExclusive - fromInclusive;
+            if (sb.length() + l < maxLength) {
+                sb.append(text.subSequence(fromInclusive, toExclusive));
+            } else {
+                sb.append(text.subSequence(fromInclusive, toExclusive - (l - maxLength)));
+                sb.append("...");   //NOI18N
+            }
+        }
+
+        @Override
+        public void emphasis(boolean start) {
+        }
+
+        @Override
+        public void name(ElementKind kind, boolean start) {
+        }
+
+        @Override
+        public void parameters(boolean start) {
+        }
+
+        @Override
+        public void active(boolean start) {
+        }
+
+        @Override
+        public void type(boolean start) {
+        }
+
+        @Override
+        public void deprecated(boolean start) {
+        }
+
+        @Override
+        public String getText() {
+            return sb.toString();
+        }
+    }
+    
+    @Override
+    public CompletableFuture<List<? extends StructureElement>> getStructure(Document doc) {
+        final List<GsfStructureElement> sElements = new ArrayList<>();
+        try {
+            ParserManager.parse(Collections.singletonList(Source.create(doc)), new UserTask() {
+                @Override
+                public void run(ResultIterator resultIterator) throws Exception {
+                    Parser.Result result = resultIterator.getParserResult(-1);
+                    if(result instanceof ParserResult) {
+                        ParserResult parserResult = (ParserResult) result;
+                        Language language = LanguageRegistry.getInstance().getLanguageByMimeType(resultIterator.getSnapshot().getMimeType());
+                        if (language != null) {
+                            StructureScanner scanner = language.getStructure();
+                            if (scanner != null) {
+                                List<? extends StructureItem> items = scanner.scan(parserResult);
+                                convertStructureItems(doc, items, sElements);
+                            }
+                        }
+                    }
+                }
+
+            });
+            return CompletableFuture.completedFuture(sElements);
+        } catch (ParseException ex) {
+            LOGGER.log(Level.FINE, null, ex);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+    
+    private static void convertStructureItems(Document doc, List<? extends StructureItem> items, List<GsfStructureElement> sElements) {
+        GsfStructureElement lastElement = null;
+        if (doc instanceof LineDocument) {
+            //  if it's line document, we can set the enclosing range for whole line
+            LineDocument ldoc = (LineDocument)doc;
+            for (StructureItem item : items) {
+                int startOffset = (int)item.getPosition();
+                int lineStart = startOffset;
+                int lineEnd = (int)item.getEndPosition();
+                try {
+                    String prefix = doc.getText(lineStart, startOffset);
+                    lineStart = LineDocumentUtils.getLineStart(ldoc, lineStart);
+                    if (prefix.trim().isEmpty()) {
+                        lineEnd = LineDocumentUtils.getLineEnd(ldoc, lineEnd);
+                    } else {
+                        lineStart = startOffset;
+                    }
+                    
+                } catch (BadLocationException ex) {
+                    lineStart = (int)item.getPosition();
+                    lineEnd = (int)item.getEndPosition();
+                }
+                GsfStructureElement el = new GsfStructureElement(ldoc, item);
+                sElements.add(el);
+                if (lastElement == null) {
+                    el.setExpandedStartOffset(lineStart);
+                    el.setExpandedEndOffset(lineEnd);
+                } else {
+                    if (lastElement.getExpandedEndOffset() < lineStart) {
+                        el.setExpandedStartOffset(lineStart);
+                        el.setExpandedEndOffset(lineEnd);
+                    } else if (lastElement.getExpandedStartOffset() <= lineStart && lineEnd == lastElement.getExpandedEndOffset()) {
+                        // The same line
+                        lastElement.setExpandedEndOffset(el.getSelectionStartOffset() - 1);
+                        lineStart = el.getSelectionStartOffset();
+                    }
+                }
+                el.setExpandedStartOffset(lineStart);
+                el.setExpandedEndOffset(lineEnd);
+                lastElement = el;
+            }
+        } else {
+            for (StructureItem item : items) {
+                sElements.add(new GsfStructureElement(null, item));
+            }
+        }
+    }
+    
+}

--- a/ide/csl.api/src/org/netbeans/modules/csl/navigation/GsfStructureProvider.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/navigation/GsfStructureProvider.java
@@ -219,12 +219,9 @@ public class GsfStructureProvider implements StructureProvider {
                     lineStart = LineDocumentUtils.getLineStart(ldoc, lineStart);
                     if (prefix.trim().isEmpty()) {
                         lineEnd = LineDocumentUtils.getLineEnd(ldoc, lineEnd);
-                    } else {
-                        lineStart = startOffset;
                     }
-                    
                 } catch (BadLocationException ex) {
-                    lineStart = (int)item.getPosition();
+                    lineStart = startOffset;
                     lineEnd = (int)item.getEndPosition();
                 }
                 if (lastElement == null) {
@@ -237,11 +234,8 @@ public class GsfStructureProvider implements StructureProvider {
                     } else if (lastElement.getExpandedStartOffset() <= lineStart && lineEnd == lastElement.getExpandedEndOffset()) {
                         // The same line
                         sElements.remove(lastElement);
-                        Builder leBuilder = StructureProvider.newBuilder(lastElement.getName(), lastElement.getKind());
-                        leBuilder.detail(lastElement.getDetail());
-                        leBuilder.selectionStartOffset(lastElement.getSelectionStartOffset()).selectionEndOffset(lastElement.getSelectionEndOffset());
-                        leBuilder.expandedStartOffset(lastElement.getExpandedStartOffset()).expandedEndOffset(startOffset - 1);
-                        leBuilder.children(lastElement.getChildren()).tags(lastElement.getTags());
+                        Builder leBuilder = StructureProvider.copy(lastElement);
+                        leBuilder.expandedEndOffset(startOffset - 1);
                         sElements.add(leBuilder.build());
                     }
                 }

--- a/ide/csl.api/src/org/netbeans/modules/csl/navigation/GsfStructureProvider.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/navigation/GsfStructureProvider.java
@@ -172,7 +172,7 @@ public class GsfStructureProvider implements StructureProvider {
     }
     
     @Override
-    public CompletableFuture<List<StructureElement>> getStructure(Document doc) {
+    public List<StructureElement> getStructure(Document doc) {
         final List<StructureElement> sElements = new ArrayList<>();
         try {
             ParserManager.parse(Collections.singletonList(Source.create(doc)), new UserTask() {
@@ -193,10 +193,10 @@ public class GsfStructureProvider implements StructureProvider {
                 }
 
             });
-            return CompletableFuture.completedFuture(sElements);
+            return sElements;
         } catch (ParseException ex) {
             LOGGER.log(Level.FINE, null, ex);
-            return CompletableFuture.completedFuture(null);
+            return Collections.EMPTY_LIST;
         }
     }
     

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
@@ -118,7 +118,7 @@ public class JavaStructureProvider implements StructureProvider {
         for (Element child : el.getEnclosedElements()) {
             StructureElement jse = element2StructureElement(info, child);
             if (jse != null) {
-                builder.addChild(jse);
+                builder.children(jse);
             }
         }
         if (path.getLeaf().getKind() == Tree.Kind.METHOD || path.getLeaf().getKind() == Tree.Kind.VARIABLE) {
@@ -302,7 +302,7 @@ public class JavaStructureProvider implements StructureProvider {
                         if (te != null) {
                             StructureElement jse = element2StructureElement(info, te);
                             if (jse != null) {
-                                builder.addChild(jse);
+                                builder.children(jse);
                             }
                         }
                     }

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
@@ -29,10 +29,8 @@ import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -57,288 +55,20 @@ import org.netbeans.spi.lsp.StructureProvider;
 /**
  * Implementation of StructureProvider from LSP API. It's used for displaying
  * outline view and GoTo File Symbols in VSCode.
+ *
  * @author Petr Pisl
  */
 @MimeRegistration(mimeType = "text/x-java", service = StructureProvider.class)
 public class JavaStructureProvider implements StructureProvider {
-    
+
     private static final Logger LOGGER = Logger.getLogger(JavaStructureProvider.class.getName());
-    
-    /**
-     * One element in the structure. The bulk of properties is counted lazily. 
-     */
-    private static class JavaStructureElement implements StructureElement {
-
-        private final Element original;
-        private final CompilationInfo ci;
-        private String name;
-        private String detail;
-        private int expandedStart;
-        private int expandedEnd;
-        private int selectionStart;
-        private int selectionEnd;
-        private List<JavaStructureElement> children;
-
-        public JavaStructureElement(CompilationInfo ci, Element original) {
-            this.original = original;
-            this.ci = ci;
-            this.name = null;
-            this.detail = null;
-            this.children = null;
-            setOffsets();
-        }
-
-        @Override
-        public String getName() {
-            if (name == null) {
-                name = createName();
-            }
-            return name;
-        }
-
-        @Override
-        public int getSelectionStartOffset() {
-            return selectionStart;
-        }
-
-        @Override
-        public int getSelectionEndOffset() {
-            return selectionEnd;
-        }
-
-        @Override
-        public int getExpandedStartOffset() {
-            return expandedStart;
-        }
-
-        @Override
-        public int getExpandedEndOffset() {
-            return expandedEnd;
-        }
-
-        @Override
-        public StructureElement.Kind getKind() {
-            switch (original.getKind()) {
-                case PACKAGE:
-                    return StructureElement.Kind.Package;
-                case ENUM:
-                    return StructureElement.Kind.Enum;
-                case CLASS:
-                    return StructureElement.Kind.Class;
-                case ANNOTATION_TYPE:
-                    return StructureElement.Kind.Interface;
-                case INTERFACE:
-                    return StructureElement.Kind.Interface;
-                case ENUM_CONSTANT:
-                    return StructureElement.Kind.EnumMember;
-                case FIELD:
-                    return StructureElement.Kind.Field; //TODO: constant
-                case PARAMETER:
-                    return StructureElement.Kind.Variable;
-                case LOCAL_VARIABLE:
-                    return StructureElement.Kind.Variable;
-                case EXCEPTION_PARAMETER:
-                    return StructureElement.Kind.Variable;
-                case METHOD:
-                    return StructureElement.Kind.Method;
-                case CONSTRUCTOR:
-                    return StructureElement.Kind.Constructor;
-                case TYPE_PARAMETER:
-                    return StructureElement.Kind.TypeParameter;
-                case RESOURCE_VARIABLE:
-                    return StructureElement.Kind.Variable;
-                case MODULE:
-                    return StructureElement.Kind.Module;
-                case STATIC_INIT:
-                case INSTANCE_INIT:
-                case OTHER:
-                default:
-                    return StructureElement.Kind.File; //XXX: what here?
-            }
-        }
-
-        @Override
-        public Set<StructureElement.Tag> getTags() {
-            if (ci.getElements().isDeprecated(original)) {
-                return Collections.singleton(StructureElement.Tag.Deprecated);
-            }
-            return null;
-        }
-
-        @Override
-        public String getDetail() {
-            ElementKind kind = original.getKind();
-            if (detail == null && (kind == ElementKind.FIELD || kind == ElementKind.METHOD)) {
-                StringBuilder sb = new StringBuilder();
-                if (kind == ElementKind.FIELD) {
-                    sb.append(": ");
-                    sb.append(Utilities.getTypeName(ci, original.asType(), false));
-                    detail = sb.toString();
-                } else {
-                    // METHOD   
-                    TypeMirror rt = ((ExecutableElement) original).getReturnType();
-                    if (rt.getKind() == TypeKind.VOID) {
-                        sb.append(": void");
-                    } else {
-                        sb.append(": ");
-                        sb.append(Utilities.getTypeName(ci, rt, false));
-                    }
-                }
-                detail = sb.toString();
-            }
-            return detail;
-        }
-
-        @Override
-        public List<? extends StructureElement> getChildren() {
-            if (children == null) {
-                children = new ArrayList<>();
-                for (Element child : original.getEnclosedElements()) {
-                    JavaStructureElement jse = element2StructureElement(ci, child);
-                    if (jse != null) {
-                        children.add(jse);
-                    }
-                }
-                TreePath path = ci.getTrees().getPath(original);
-                if (path.getLeaf().getKind() == Tree.Kind.METHOD || path.getLeaf().getKind() == Tree.Kind.VARIABLE) {
-                    children.addAll(getAnonymousInnerClasses(ci, path));
-                }
-            }
-            return children;
-        }
-
-        private static List<JavaStructureElement> getAnonymousInnerClasses(CompilationInfo info, TreePath path) {
-            List<JavaStructureElement> inner = new ArrayList<>();
-            new TreePathScanner<Void, Void>() {
-                @Override
-                public Void visitNewClass(NewClassTree node, Void p) {
-                    if (node.getClassBody() != null) {
-                        Element e = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getClassBody()));
-                        if (e != null) {
-                            Element te = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getIdentifier()));
-                            if (te != null) {
-                                JavaStructureElement jse = element2StructureElement(info, te);
-                                if (jse != null) {
-                                    inner.add(new JavaStructureElement(info, te));
-                                }
-                            }
-                        }
-                    }
-                    return null;
-                }
-            }.scan(path, null);
-            return inner;
-        }
-
-        private void setOffsets() {
-            TreePath path = ci.getTrees().getPath(original);
-            Tree tree = path.getLeaf();
-            long start = ci.getTrees().getSourcePositions().getStartPosition(ci.getCompilationUnit(), tree);
-            expandedStart = (int) start;
-            long end = ci.getTrees().getSourcePositions().getEndPosition(ci.getCompilationUnit(), tree);
-            if (end == -1) {
-                end = start;
-            }
-            expandedEnd = (int) end;
-            int[] span = null;
-            switch (tree.getKind()) {
-                case CLASS:
-                    span = ci.getTreeUtilities().findNameSpan((ClassTree) tree);
-                    break;
-                case METHOD:
-                    span = ci.getTreeUtilities().findNameSpan((MethodTree) tree);
-                    break;
-                case VARIABLE:
-                    span = ci.getTreeUtilities().findNameSpan((VariableTree) tree);
-                    break;
-            }
-            if (span == null) {
-                selectionStart = expandedStart;
-                selectionEnd = expandedEnd;
-            } else {
-                selectionStart = span[0];
-                selectionEnd = span[1];
-            }
-        }
-
-        private String createName() {
-            switch (original.getKind()) {
-                case PACKAGE:
-                    PackageElement pe = (PackageElement) original;
-                    return pe.getSimpleName().toString();
-                case CLASS:
-                case INTERFACE:
-                case ENUM:
-                case ANNOTATION_TYPE:
-                    TypeElement te = (TypeElement) original;
-                    StringBuilder sb = new StringBuilder();
-                    sb.append(te.getSimpleName());
-                    List<? extends TypeParameterElement> typeParams = te.getTypeParameters();
-                    if (typeParams != null && !typeParams.isEmpty()) {
-                        sb.append("<"); // NOI18N
-                        for (Iterator<? extends TypeParameterElement> it = typeParams.iterator(); it.hasNext();) {
-                            TypeParameterElement tp = it.next();
-                            sb.append(tp.getSimpleName());
-                            List<? extends TypeMirror> bounds = tp.getBounds();
-                            if (!bounds.isEmpty()) {
-                                if (bounds.size() > 1 || !"java.lang.Object".equals(bounds.get(0).toString())) { // NOI18N
-                                    sb.append(" extends "); // NOI18N
-                                    for (Iterator<? extends TypeMirror> bIt = bounds.iterator(); bIt.hasNext();) {
-                                        sb.append(Utilities.getTypeName(ci, bIt.next(), false));
-                                        if (bIt.hasNext()) {
-                                            sb.append(" & "); // NOI18N
-                                        }
-                                    }
-                                }
-                            }
-                            if (it.hasNext()) {
-                                sb.append(", "); // NOI18N
-                            }
-                        }
-                        sb.append(">"); // NOI18N
-                    }
-                    return sb.toString();
-                case FIELD:
-                case ENUM_CONSTANT:
-                    return original.getSimpleName().toString();
-                case CONSTRUCTOR:
-                case METHOD:
-                    ExecutableElement ee = (ExecutableElement) original;
-                    sb = new StringBuilder();
-                    if (ee.getKind() == ElementKind.CONSTRUCTOR) {
-                        sb.append(ee.getEnclosingElement().getSimpleName());
-                    } else {
-                        sb.append(ee.getSimpleName());
-                    }
-                    sb.append("("); // NOI18N
-                    for (Iterator<? extends VariableElement> it = ee.getParameters().iterator(); it.hasNext();) {
-                        VariableElement param = it.next();
-                        if (!it.hasNext() && ee.isVarArgs() && param.asType().getKind() == TypeKind.ARRAY) {
-                            sb.append(Utilities.getTypeName(ci, ((ArrayType) param.asType()).getComponentType(), false, false));
-                            sb.append("...");
-                        } else {
-                            sb.append(Utilities.getTypeName(ci, param.asType(), false, false));
-                        }
-                        sb.append(" "); // NOI18N
-                        sb.append(param.getSimpleName());
-                        if (it.hasNext()) {
-                            sb.append(", "); // NOI18N
-                        }
-                    }
-                    sb.append(")"); // NOI18N
-                    return sb.toString();
-            }
-            return null;
-        }
-
-    }
 
     @Override
-    public CompletableFuture<List<? extends StructureElement>> getStructure(Document doc) {
+    public CompletableFuture<List<StructureElement>> getStructure(Document doc) {
         JavaSource js = JavaSource.forDocument(doc);
 
         if (js != null) {
-            List<JavaStructureElement> result = new ArrayList<>();
+            List<StructureElement> result = new ArrayList<>();
             try {
                 js.runUserActionTask(cc -> {
                     cc.toPhase(JavaSource.Phase.RESOLVED);
@@ -348,14 +78,14 @@ public class JavaStructureProvider implements StructureProvider {
                         TreePath tp = trees.getPath(cu, cu.getPackage());
                         Element el = trees.getElement(tp);
                         if (el != null && el.getKind() == ElementKind.PACKAGE) {
-                            JavaStructureElement jse = element2StructureElement(cc, el);
+                            StructureElement jse = element2StructureElement(cc, el);
                             if (jse != null) {
                                 result.add(jse);
                             }
                         }
                     }
                     for (Element tel : cc.getTopLevelElements()) {
-                        JavaStructureElement jse = element2StructureElement(cc, tel);
+                        StructureElement jse = element2StructureElement(cc, tel);
                         if (jse != null) {
                             result.add(jse);
                         }
@@ -369,7 +99,7 @@ public class JavaStructureProvider implements StructureProvider {
         return CompletableFuture.completedFuture(null);
     }
 
-    private static JavaStructureElement element2StructureElement(CompilationInfo info, Element el) {
+    private static StructureElement element2StructureElement(CompilationInfo info, Element el) {
         TreePath path = info.getTrees().getPath(el);
         if (path == null) {
             return null;
@@ -378,6 +108,207 @@ public class JavaStructureProvider implements StructureProvider {
         if (tu.isSynthetic(path)) {
             return null;
         }
-        return new JavaStructureElement(info, el);
+
+        Builder builder = StructureProvider.newBuilder(createName(info, el), convertKind(el.getKind()));
+        builder.detail(createDetail(info, el));
+        setOffsets(info, el, builder);
+        if (info.getElements().isDeprecated(el)) {
+            builder.addTag(StructureElement.Tag.Deprecated);
+        }
+        for (Element child : el.getEnclosedElements()) {
+            StructureElement jse = element2StructureElement(info, child);
+            if (jse != null) {
+                builder.addChild(jse);
+            }
+        }
+        if (path.getLeaf().getKind() == Tree.Kind.METHOD || path.getLeaf().getKind() == Tree.Kind.VARIABLE) {
+            getAnonymousInnerClasses(info, path, builder);
+        }
+        return builder.build();
+    }
+
+    private static String createName(CompilationInfo ci, Element original) {
+        switch (original.getKind()) {
+            case PACKAGE:
+                PackageElement pe = (PackageElement) original;
+                return pe.getSimpleName().toString();
+            case CLASS:
+            case INTERFACE:
+            case ENUM:
+            case ANNOTATION_TYPE:
+                TypeElement te = (TypeElement) original;
+                StringBuilder sb = new StringBuilder();
+                sb.append(te.getSimpleName());
+                List<? extends TypeParameterElement> typeParams = te.getTypeParameters();
+                if (typeParams != null && !typeParams.isEmpty()) {
+                    sb.append("<"); // NOI18N
+                    for (Iterator<? extends TypeParameterElement> it = typeParams.iterator(); it.hasNext();) {
+                        TypeParameterElement tp = it.next();
+                        sb.append(tp.getSimpleName());
+                        List<? extends TypeMirror> bounds = tp.getBounds();
+                        if (!bounds.isEmpty()) {
+                            if (bounds.size() > 1 || !"java.lang.Object".equals(bounds.get(0).toString())) { // NOI18N
+                                sb.append(" extends "); // NOI18N
+                                for (Iterator<? extends TypeMirror> bIt = bounds.iterator(); bIt.hasNext();) {
+                                    sb.append(Utilities.getTypeName(ci, bIt.next(), false));
+                                    if (bIt.hasNext()) {
+                                        sb.append(" & "); // NOI18N
+                                    }
+                                }
+                            }
+                        }
+                        if (it.hasNext()) {
+                            sb.append(", "); // NOI18N
+                        }
+                    }
+                    sb.append(">"); // NOI18N
+                }
+                return sb.toString();
+            case FIELD:
+            case ENUM_CONSTANT:
+                return original.getSimpleName().toString();
+            case CONSTRUCTOR:
+            case METHOD:
+                ExecutableElement ee = (ExecutableElement) original;
+                sb = new StringBuilder();
+                if (ee.getKind() == ElementKind.CONSTRUCTOR) {
+                    sb.append(ee.getEnclosingElement().getSimpleName());
+                } else {
+                    sb.append(ee.getSimpleName());
+                }
+                sb.append("("); // NOI18N
+                for (Iterator<? extends VariableElement> it = ee.getParameters().iterator(); it.hasNext();) {
+                    VariableElement param = it.next();
+                    if (!it.hasNext() && ee.isVarArgs() && param.asType().getKind() == TypeKind.ARRAY) {
+                        sb.append(Utilities.getTypeName(ci, ((ArrayType) param.asType()).getComponentType(), false, false));
+                        sb.append("...");
+                    } else {
+                        sb.append(Utilities.getTypeName(ci, param.asType(), false, false));
+                    }
+                    sb.append(" "); // NOI18N
+                    sb.append(param.getSimpleName());
+                    if (it.hasNext()) {
+                        sb.append(", "); // NOI18N
+                    }
+                }
+                sb.append(")"); // NOI18N
+                return sb.toString();
+        }
+        return null;
+    }
+
+    private static StructureElement.Kind convertKind(ElementKind kind) {
+        switch (kind) {
+            case PACKAGE:
+                return StructureElement.Kind.Package;
+            case ENUM:
+                return StructureElement.Kind.Enum;
+            case CLASS:
+                return StructureElement.Kind.Class;
+            case ANNOTATION_TYPE:
+                return StructureElement.Kind.Interface;
+            case INTERFACE:
+                return StructureElement.Kind.Interface;
+            case ENUM_CONSTANT:
+                return StructureElement.Kind.EnumMember;
+            case FIELD:
+                return StructureElement.Kind.Field; //TODO: constant
+            case PARAMETER:
+                return StructureElement.Kind.Variable;
+            case LOCAL_VARIABLE:
+                return StructureElement.Kind.Variable;
+            case EXCEPTION_PARAMETER:
+                return StructureElement.Kind.Variable;
+            case METHOD:
+                return StructureElement.Kind.Method;
+            case CONSTRUCTOR:
+                return StructureElement.Kind.Constructor;
+            case TYPE_PARAMETER:
+                return StructureElement.Kind.TypeParameter;
+            case RESOURCE_VARIABLE:
+                return StructureElement.Kind.Variable;
+            case MODULE:
+                return StructureElement.Kind.Module;
+            case STATIC_INIT:
+            case INSTANCE_INIT:
+            case OTHER:
+            default:
+                return StructureElement.Kind.File; //XXX: what here?
+            }
+    }
+    
+    private static String createDetail(CompilationInfo ci, Element original) {
+        ElementKind kind = original.getKind();
+        String detail = null;
+        if (kind == ElementKind.FIELD || kind == ElementKind.METHOD) {
+            StringBuilder sb = new StringBuilder();
+            if (kind == ElementKind.FIELD) {
+                sb.append(": ");
+                sb.append(Utilities.getTypeName(ci, original.asType(), false));
+                detail = sb.toString();
+            } else {
+                // METHOD   
+                TypeMirror rt = ((ExecutableElement) original).getReturnType();
+                if (rt.getKind() == TypeKind.VOID) {
+                    sb.append(": void");
+                } else {
+                    sb.append(": ");
+                    sb.append(Utilities.getTypeName(ci, rt, false));
+                }
+            }
+            detail = sb.toString();
+        }
+        return detail;
+    }
+    
+    private static void setOffsets(CompilationInfo ci, Element original, Builder builder) {
+        TreePath path = ci.getTrees().getPath(original);
+        Tree tree = path.getLeaf();
+        long start = ci.getTrees().getSourcePositions().getStartPosition(ci.getCompilationUnit(), tree);
+        int expandedStart = (int) start;
+        long end = ci.getTrees().getSourcePositions().getEndPosition(ci.getCompilationUnit(), tree);
+        if (end == -1) {
+            end = start;
+        }
+        int expandedEnd = (int) end;
+        builder.expandedStartOffset(expandedStart).expandedEndOffset(expandedEnd);
+        int[] span = null;
+        switch (tree.getKind()) {
+            case CLASS:
+                span = ci.getTreeUtilities().findNameSpan((ClassTree) tree);
+                break;
+            case METHOD:
+                span = ci.getTreeUtilities().findNameSpan((MethodTree) tree);
+                break;
+            case VARIABLE:
+                span = ci.getTreeUtilities().findNameSpan((VariableTree) tree);
+                break;
+        }
+        if (span == null) {
+            builder.selectionStartOffset(expandedStart).selectionEndOffset(expandedEnd);
+        } else {
+            builder.selectionStartOffset(span[0]).selectionEndOffset(span[1]);
+        }
+    }
+    
+    private static void getAnonymousInnerClasses(CompilationInfo info, TreePath path, Builder builder) {
+        new TreePathScanner<Void, Void>() {
+            @Override
+            public Void visitNewClass(NewClassTree node, Void p) {
+                if (node.getClassBody() != null) {
+                    Element e = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getClassBody()));
+                    if (e != null) {
+                        Element te = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getIdentifier()));
+                        if (te != null) {
+                            StructureElement jse = element2StructureElement(info, te);
+                            if (jse != null) {
+                                builder.addChild(jse);
+                            }
+                        }
+                    }
+                }
+                return null;
+            }
+        }.scan(path, null);
     }
 }

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.editor.java;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.NewClassTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.swing.text.Document;
+import org.netbeans.api.editor.mimelookup.MimeRegistration;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.TreeUtilities;
+import org.netbeans.api.lsp.StructureElement;
+import org.netbeans.spi.lsp.StructureProvider;
+
+/**
+ * Implementation of StructureProvider from LSP API. It's used for displaying
+ * outline view and GoTo File Symbols in VSCode.
+ * @author Petr Pisl
+ */
+@MimeRegistration(mimeType = "text/x-java", service = StructureProvider.class)
+public class JavaStructureProvider implements StructureProvider {
+    
+    private static final Logger LOGGER = Logger.getLogger(JavaStructureProvider.class.getName());
+    
+    /**
+     * One element in the structure. The bulk of properties is counted lazily. 
+     */
+    private static class JavaStructureElement implements StructureElement {
+
+        private final Element original;
+        private final CompilationInfo ci;
+        private String name;
+        private String detail;
+        private int expandedStart;
+        private int expandedEnd;
+        private int selectionStart;
+        private int selectionEnd;
+        private List<JavaStructureElement> children;
+
+        public JavaStructureElement(CompilationInfo ci, Element original) {
+            this.original = original;
+            this.ci = ci;
+            this.name = null;
+            this.detail = null;
+            this.children = null;
+            setOffsets();
+        }
+
+        @Override
+        public String getName() {
+            if (name == null) {
+                name = createName();
+            }
+            return name;
+        }
+
+        @Override
+        public int getSelectionStartOffset() {
+            return selectionStart;
+        }
+
+        @Override
+        public int getSelectionEndOffset() {
+            return selectionEnd;
+        }
+
+        @Override
+        public int getExpandedStartOffset() {
+            return expandedStart;
+        }
+
+        @Override
+        public int getExpandedEndOffset() {
+            return expandedEnd;
+        }
+
+        @Override
+        public StructureElement.Kind getKind() {
+            switch (original.getKind()) {
+                case PACKAGE:
+                    return StructureElement.Kind.Package;
+                case ENUM:
+                    return StructureElement.Kind.Enum;
+                case CLASS:
+                    return StructureElement.Kind.Class;
+                case ANNOTATION_TYPE:
+                    return StructureElement.Kind.Interface;
+                case INTERFACE:
+                    return StructureElement.Kind.Interface;
+                case ENUM_CONSTANT:
+                    return StructureElement.Kind.EnumMember;
+                case FIELD:
+                    return StructureElement.Kind.Field; //TODO: constant
+                case PARAMETER:
+                    return StructureElement.Kind.Variable;
+                case LOCAL_VARIABLE:
+                    return StructureElement.Kind.Variable;
+                case EXCEPTION_PARAMETER:
+                    return StructureElement.Kind.Variable;
+                case METHOD:
+                    return StructureElement.Kind.Method;
+                case CONSTRUCTOR:
+                    return StructureElement.Kind.Constructor;
+                case TYPE_PARAMETER:
+                    return StructureElement.Kind.TypeParameter;
+                case RESOURCE_VARIABLE:
+                    return StructureElement.Kind.Variable;
+                case MODULE:
+                    return StructureElement.Kind.Module;
+                case STATIC_INIT:
+                case INSTANCE_INIT:
+                case OTHER:
+                default:
+                    return StructureElement.Kind.File; //XXX: what here?
+            }
+        }
+
+        @Override
+        public Set<StructureElement.Tag> getTags() {
+            if (ci.getElements().isDeprecated(original)) {
+                return Collections.singleton(StructureElement.Tag.Deprecated);
+            }
+            return null;
+        }
+
+        @Override
+        public String getDetail() {
+            ElementKind kind = original.getKind();
+            if (detail == null && (kind == ElementKind.FIELD || kind == ElementKind.METHOD)) {
+                StringBuilder sb = new StringBuilder();
+                if (kind == ElementKind.FIELD) {
+                    sb.append(": ");
+                    sb.append(Utilities.getTypeName(ci, original.asType(), false));
+                    detail = sb.toString();
+                } else {
+                    // METHOD   
+                    TypeMirror rt = ((ExecutableElement) original).getReturnType();
+                    if (rt.getKind() == TypeKind.VOID) {
+                        sb.append(": void");
+                    } else {
+                        sb.append(": ");
+                        sb.append(Utilities.getTypeName(ci, rt, false));
+                    }
+                }
+                detail = sb.toString();
+            }
+            return detail;
+        }
+
+        @Override
+        public List<? extends StructureElement> getChildren() {
+            if (children == null) {
+                children = new ArrayList<>();
+                for (Element child : original.getEnclosedElements()) {
+                    JavaStructureElement jse = element2StructureElement(ci, child);
+                    if (jse != null) {
+                        children.add(jse);
+                    }
+                }
+                TreePath path = ci.getTrees().getPath(original);
+                if (path.getLeaf().getKind() == Tree.Kind.METHOD || path.getLeaf().getKind() == Tree.Kind.VARIABLE) {
+                    children.addAll(getAnonymousInnerClasses(ci, path));
+                }
+            }
+            return children;
+        }
+
+        private static List<JavaStructureElement> getAnonymousInnerClasses(CompilationInfo info, TreePath path) {
+            List<JavaStructureElement> inner = new ArrayList<>();
+            new TreePathScanner<Void, Void>() {
+                @Override
+                public Void visitNewClass(NewClassTree node, Void p) {
+                    if (node.getClassBody() != null) {
+                        Element e = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getClassBody()));
+                        if (e != null) {
+                            Element te = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getIdentifier()));
+                            if (te != null) {
+                                JavaStructureElement jse = element2StructureElement(info, te);
+                                if (jse != null) {
+                                    inner.add(new JavaStructureElement(info, te));
+                                }
+                            }
+                        }
+                    }
+                    return null;
+                }
+            }.scan(path, null);
+            return inner;
+        }
+
+        private void setOffsets() {
+            TreePath path = ci.getTrees().getPath(original);
+            Tree tree = path.getLeaf();
+            long start = ci.getTrees().getSourcePositions().getStartPosition(ci.getCompilationUnit(), tree);
+            expandedStart = (int) start;
+            long end = ci.getTrees().getSourcePositions().getEndPosition(ci.getCompilationUnit(), tree);
+            if (end == -1) {
+                end = start;
+            }
+            expandedEnd = (int) end;
+            int[] span = null;
+            switch (tree.getKind()) {
+                case CLASS:
+                    span = ci.getTreeUtilities().findNameSpan((ClassTree) tree);
+                    break;
+                case METHOD:
+                    span = ci.getTreeUtilities().findNameSpan((MethodTree) tree);
+                    break;
+                case VARIABLE:
+                    span = ci.getTreeUtilities().findNameSpan((VariableTree) tree);
+                    break;
+            }
+            if (span == null) {
+                selectionStart = expandedStart;
+                selectionEnd = expandedEnd;
+            } else {
+                selectionStart = span[0];
+                selectionEnd = span[1];
+            }
+        }
+
+        private String createName() {
+            switch (original.getKind()) {
+                case PACKAGE:
+                    PackageElement pe = (PackageElement) original;
+                    return pe.getSimpleName().toString();
+                case CLASS:
+                case INTERFACE:
+                case ENUM:
+                case ANNOTATION_TYPE:
+                    TypeElement te = (TypeElement) original;
+                    StringBuilder sb = new StringBuilder();
+                    sb.append(te.getSimpleName());
+                    List<? extends TypeParameterElement> typeParams = te.getTypeParameters();
+                    if (typeParams != null && !typeParams.isEmpty()) {
+                        sb.append("<"); // NOI18N
+                        for (Iterator<? extends TypeParameterElement> it = typeParams.iterator(); it.hasNext();) {
+                            TypeParameterElement tp = it.next();
+                            sb.append(tp.getSimpleName());
+                            List<? extends TypeMirror> bounds = tp.getBounds();
+                            if (!bounds.isEmpty()) {
+                                if (bounds.size() > 1 || !"java.lang.Object".equals(bounds.get(0).toString())) { // NOI18N
+                                    sb.append(" extends "); // NOI18N
+                                    for (Iterator<? extends TypeMirror> bIt = bounds.iterator(); bIt.hasNext();) {
+                                        sb.append(Utilities.getTypeName(ci, bIt.next(), false));
+                                        if (bIt.hasNext()) {
+                                            sb.append(" & "); // NOI18N
+                                        }
+                                    }
+                                }
+                            }
+                            if (it.hasNext()) {
+                                sb.append(", "); // NOI18N
+                            }
+                        }
+                        sb.append(">"); // NOI18N
+                    }
+                    return sb.toString();
+                case FIELD:
+                case ENUM_CONSTANT:
+                    return original.getSimpleName().toString();
+                case CONSTRUCTOR:
+                case METHOD:
+                    ExecutableElement ee = (ExecutableElement) original;
+                    sb = new StringBuilder();
+                    if (ee.getKind() == ElementKind.CONSTRUCTOR) {
+                        sb.append(ee.getEnclosingElement().getSimpleName());
+                    } else {
+                        sb.append(ee.getSimpleName());
+                    }
+                    sb.append("("); // NOI18N
+                    for (Iterator<? extends VariableElement> it = ee.getParameters().iterator(); it.hasNext();) {
+                        VariableElement param = it.next();
+                        if (!it.hasNext() && ee.isVarArgs() && param.asType().getKind() == TypeKind.ARRAY) {
+                            sb.append(Utilities.getTypeName(ci, ((ArrayType) param.asType()).getComponentType(), false, false));
+                            sb.append("...");
+                        } else {
+                            sb.append(Utilities.getTypeName(ci, param.asType(), false, false));
+                        }
+                        sb.append(" "); // NOI18N
+                        sb.append(param.getSimpleName());
+                        if (it.hasNext()) {
+                            sb.append(", "); // NOI18N
+                        }
+                    }
+                    sb.append(")"); // NOI18N
+                    return sb.toString();
+            }
+            return null;
+        }
+
+    }
+
+    @Override
+    public CompletableFuture<List<? extends StructureElement>> getStructure(Document doc) {
+        JavaSource js = JavaSource.forDocument(doc);
+
+        if (js != null) {
+            List<JavaStructureElement> result = new ArrayList<>();
+            try {
+                js.runUserActionTask(cc -> {
+                    cc.toPhase(JavaSource.Phase.RESOLVED);
+                    Trees trees = cc.getTrees();
+                    CompilationUnitTree cu = cc.getCompilationUnit();
+                    if (cu.getPackage() != null) {
+                        TreePath tp = trees.getPath(cu, cu.getPackage());
+                        Element el = trees.getElement(tp);
+                        if (el != null && el.getKind() == ElementKind.PACKAGE) {
+                            JavaStructureElement jse = element2StructureElement(cc, el);
+                            if (jse != null) {
+                                result.add(jse);
+                            }
+                        }
+                    }
+                    for (Element tel : cc.getTopLevelElements()) {
+                        JavaStructureElement jse = element2StructureElement(cc, tel);
+                        if (jse != null) {
+                            result.add(jse);
+                        }
+                    }
+                }, true);
+            } catch (IOException ex) {
+                LOGGER.log(Level.FINE, null, ex);
+            }
+            return CompletableFuture.completedFuture(result);
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private static JavaStructureElement element2StructureElement(CompilationInfo info, Element el) {
+        TreePath path = info.getTrees().getPath(el);
+        if (path == null) {
+            return null;
+        }
+        TreeUtilities tu = info.getTreeUtilities();
+        if (tu.isSynthetic(path)) {
+            return null;
+        }
+        return new JavaStructureElement(info, el);
+    }
+}

--- a/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
+++ b/java/java.editor/src/org/netbeans/modules/editor/java/JavaStructureProvider.java
@@ -29,9 +29,9 @@ import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.lang.model.element.Element;
@@ -64,7 +64,7 @@ public class JavaStructureProvider implements StructureProvider {
     private static final Logger LOGGER = Logger.getLogger(JavaStructureProvider.class.getName());
 
     @Override
-    public CompletableFuture<List<StructureElement>> getStructure(Document doc) {
+    public List<StructureElement> getStructure(Document doc) {
         JavaSource js = JavaSource.forDocument(doc);
 
         if (js != null) {
@@ -94,9 +94,9 @@ public class JavaStructureProvider implements StructureProvider {
             } catch (IOException ex) {
                 LOGGER.log(Level.FINE, null, ex);
             }
-            return CompletableFuture.completedFuture(result);
+            return result;
         }
-        return CompletableFuture.completedFuture(null);
+        return Collections.EMPTY_LIST;
     }
 
     private static StructureElement element2StructureElement(CompilationInfo info, Element el) {
@@ -136,6 +136,7 @@ public class JavaStructureProvider implements StructureProvider {
             case INTERFACE:
             case ENUM:
             case ANNOTATION_TYPE:
+            case RECORD:
                 TypeElement te = (TypeElement) original;
                 StringBuilder sb = new StringBuilder();
                 sb.append(te.getSimpleName());
@@ -166,6 +167,7 @@ public class JavaStructureProvider implements StructureProvider {
                 return sb.toString();
             case FIELD:
             case ENUM_CONSTANT:
+            case RECORD_COMPONENT:
                 return original.getSimpleName().toString();
             case CONSTRUCTOR:
             case METHOD:
@@ -204,12 +206,14 @@ public class JavaStructureProvider implements StructureProvider {
             case ENUM:
                 return StructureElement.Kind.Enum;
             case CLASS:
+            case RECORD:
                 return StructureElement.Kind.Class;
             case ANNOTATION_TYPE:
                 return StructureElement.Kind.Interface;
             case INTERFACE:
                 return StructureElement.Kind.Interface;
             case ENUM_CONSTANT:
+            case RECORD_COMPONENT:
                 return StructureElement.Kind.EnumMember;
             case FIELD:
                 return StructureElement.Kind.Field; //TODO: constant

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/Utils.java
@@ -29,8 +29,10 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -45,9 +47,11 @@ import javax.swing.text.StyledDocument;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
 import org.netbeans.api.editor.document.LineDocument;
 import org.netbeans.api.editor.document.LineDocumentUtils;
 import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.lsp.StructureElement;
 import org.netbeans.modules.editor.java.Utilities;
 import org.openide.cookies.EditorCookie;
 import org.openide.filesystems.FileObject;
@@ -61,6 +65,46 @@ import org.openide.util.Exceptions;
  */
 public class Utils {
 
+    public static SymbolKind structureElementKind2SymbolKind (StructureElement.Kind kind) {
+        switch (kind) {
+            case Array : return SymbolKind.Array;
+            case Boolean: return SymbolKind.Boolean;
+            case Class: return SymbolKind.Class;
+            case Constant: return SymbolKind.Constant;
+            case Constructor: return SymbolKind.Constructor;
+            case Enum: return SymbolKind.Enum;
+            case EnumMember: return SymbolKind.EnumMember;
+            case Event: return SymbolKind.Event;
+            case Field: return SymbolKind.Field;
+            case File: return SymbolKind.File;
+            case Function: return SymbolKind.Function;
+            case Interface: return SymbolKind.Interface;
+            case Key: return SymbolKind.Key;
+            case Method: return SymbolKind.Method;
+            case Module: return SymbolKind.Module;
+            case Namespace: return SymbolKind.Namespace;
+            case Null: return SymbolKind.Null;
+            case Number: return SymbolKind.Number;
+            case Object: return SymbolKind.Object;
+            case Operator: return SymbolKind.Operator;
+            case Package: return SymbolKind.Package;
+            case Property: return SymbolKind.Property;
+            case String: return SymbolKind.String;
+            case Struct: return SymbolKind.Struct;
+            case TypeParameter: return SymbolKind.TypeParameter;
+            case Variable: return SymbolKind.Variable;
+        }
+        return SymbolKind.Object;
+    }
+    
+    public static List<SymbolTag> elementTags2SymbolTags (Set<StructureElement.Tag> tags) {
+        if (tags != null) {
+            // we now have only deprecated tag
+            return Collections.singletonList(SymbolTag.Deprecated);
+        }
+        return null;
+    }
+    
     public static SymbolKind elementKind2SymbolKind(ElementKind kind) {
         switch (kind) {
             case PACKAGE:
@@ -204,26 +248,6 @@ public class Utils {
         }
         return new Range(createPosition(info.getCompilationUnit(), (int) start),
                          createPosition(info.getCompilationUnit(), (int) end));
-    }
-
-    public static Range selectionRange(CompilationInfo info, Tree tree) {
-        int[] span = null;
-        switch (tree.getKind()) {
-            case CLASS:
-                span = info.getTreeUtilities().findNameSpan((ClassTree) tree);
-                break;
-            case METHOD:
-                span = info.getTreeUtilities().findNameSpan((MethodTree)tree);
-                break;
-            case VARIABLE:
-                span = info.getTreeUtilities().findNameSpan((VariableTree)tree);
-                break;
-        }
-        if (span == null) {
-            return null;
-        }
-        return new Range(createPosition(info.getCompilationUnit(), (int) span[0]),
-                         createPosition(info.getCompilationUnit(), (int) span[1]));
     }
 
     public static Position createPosition(CompilationUnitTree cut, int offset) {

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/TextDocumentServiceImpl.java
@@ -34,8 +34,6 @@ import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.Trees;
 import com.vladsch.flexmark.html2md.converter.FlexmarkHtmlConverter;
 import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.time.Instant;
@@ -143,6 +141,7 @@ import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SignatureHelpParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextEdit;
@@ -224,9 +223,11 @@ import org.netbeans.modules.refactoring.plugins.FileRenamePlugin;
 import org.netbeans.modules.refactoring.spi.RefactoringCommit;
 import org.netbeans.modules.refactoring.spi.RefactoringElementImplementation;
 import org.netbeans.modules.refactoring.spi.Transaction;
+import org.netbeans.api.lsp.StructureElement;
 import org.netbeans.spi.editor.hints.ErrorDescription;
 import org.netbeans.spi.editor.hints.Fix;
 import org.netbeans.spi.lsp.ErrorProvider;
+import org.netbeans.spi.lsp.StructureProvider;
 import org.netbeans.spi.project.ActionProvider;
 import org.netbeans.spi.project.ProjectConfiguration;
 import org.netbeans.spi.project.ProjectConfigurationProvider;
@@ -813,97 +814,61 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
     @Override
     public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> documentSymbol(DocumentSymbolParams params) {
         return server.openedProjects().thenCompose(projects -> {
-            JavaSource js = getJavaSource(params.getTextDocument().getUri());
-            if (js == null) {
+            List<Either<SymbolInformation, DocumentSymbol>> result = new ArrayList<>();
+        
+            String uri = params.getTextDocument().getUri();
+            FileObject file = fromURI(uri);
+            Document doc = server.getOpenedDocuments().getDocument(uri);
+            if (file == null || !(doc instanceof LineDocument)) {
                 return CompletableFuture.completedFuture(Collections.emptyList());
             }
-            List<Either<SymbolInformation, DocumentSymbol>> result = new ArrayList<>();
-            try {
-                js.runUserActionTask(cc -> {
-                    cc.toPhase(JavaSource.Phase.RESOLVED);
-                    Trees trees = cc.getTrees();
-                    CompilationUnitTree cu = cc.getCompilationUnit();
-                    if (cu.getPackage() != null) {
-                        TreePath tp = trees.getPath(cu, cu.getPackage());
-                        Element el = trees.getElement(tp);
-                        if (el != null && el.getKind() == ElementKind.PACKAGE) {
-                            String name = Utils.label(cc, el, true);
-                            SymbolKind kind = Utils.elementKind2SymbolKind(el.getKind());
-                            Range range = Utils.treeRange(cc, tp.getLeaf());
-                            result.add(Either.forRight(new DocumentSymbol(name, kind, range, range)));
+            StructureProvider structureProvider = MimeLookup.getLookup(DocumentUtilities.getMimeType(doc)).lookup(StructureProvider.class);
+            if (structureProvider != null) {
+                return structureProvider.getStructure(doc).thenApply(structureElements -> {
+                    LineDocument lDoc = (LineDocument)doc;
+                    for (StructureElement structureElement : structureElements) {
+                        DocumentSymbol ds = structureElement2DocumentSymbol(lDoc, structureElement);
+                        if (ds != null){
+                            result.add(Either.forRight(ds));
                         }
                     }
-                    for (Element tel : cc.getTopLevelElements()) {
-                        DocumentSymbol ds = element2DocumentSymbol(cc, tel);
-                        if (ds != null)
-                            result.add(Either.forRight(ds));
-                    }
-                }, true);
-            } catch (IOException ex) {
-                client.logMessage(new MessageParams(MessageType.Error, ex.getMessage()));
+                    return result;
+                });
             }
             return CompletableFuture.completedFuture(result);
         });
     }
 
-    private static DocumentSymbol element2DocumentSymbol(CompilationInfo info, Element el) {
-        TreePath path = info.getTrees().getPath(el);
-        if (path == null)
-            return null;
-        TreeUtilities tu = info.getTreeUtilities();
-        if (tu.isSynthetic(path))
-            return null;
-        Range range = Utils.treeRange(info, path.getLeaf());
-        if (range == null)
-            return null;
-        Range selection = Utils.selectionRange(info, path.getLeaf());
-        List<DocumentSymbol> children = new ArrayList<>();
-        for (Element c : el.getEnclosedElements()) {
-            DocumentSymbol ds = element2DocumentSymbol(info, c);
-            if (ds != null) {
-                children.add(ds);
-            }
-        }
-        if (path.getLeaf().getKind() == Kind.METHOD || path.getLeaf().getKind() == Kind.VARIABLE) {
-            children.addAll(getAnonymousInnerClasses(info, path));
-        }
-        String name = Utils.label(info, el, false);
-        String detail = Utils.detail(info, el, false);
-        return new DocumentSymbol(name, Utils.elementKind2SymbolKind(el.getKind()), range, selection != null ? selection : range, detail, children);
-    }
-
-    private static List<DocumentSymbol> getAnonymousInnerClasses(CompilationInfo info, TreePath path) {
-        List<DocumentSymbol> inner = new ArrayList<>();
-        new TreePathScanner<Void, Void>() {
-            @Override
-            public Void visitNewClass(NewClassTree node, Void p) {
-                if (node.getClassBody() != null) {
-                    Range range = Utils.treeRange(info, node);
-                    if (range != null) {
-                        Range selectionRange = Utils.treeRange(info, node.getIdentifier());
-                        Element e = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getClassBody()));
-                        if (e != null) {
-                            Element te = info.getTrees().getElement(new TreePath(getCurrentPath(), node.getIdentifier()));
-                            if (te != null) {
-                                String name = "new " + te.getSimpleName() + "() {...}";
-                                List<DocumentSymbol> children = new ArrayList<>();
-                                for (Element c : e.getEnclosedElements()) {
-                                    DocumentSymbol ds = element2DocumentSymbol(info, c);
-                                    if (ds != null) {
-                                        children.add(ds);
-                                    }
-                                }
-                                inner.add(new DocumentSymbol(name, Utils.elementKind2SymbolKind(e.getKind()), range, selectionRange, null, children));
-                            }
-                        }
+    private static DocumentSymbol structureElement2DocumentSymbol (LineDocument doc, StructureElement el) {
+        try {
+            Position selectionStartPos = new Position(LineDocumentUtils.getLineIndex(doc, el.getSelectionStartOffset()), el.getSelectionStartOffset() - LineDocumentUtils.getLineStart(doc, el.getSelectionStartOffset()));
+            Position selectionEndPos = new Position(LineDocumentUtils.getLineIndex(doc, el.getSelectionEndOffset()), el.getSelectionEndOffset() - LineDocumentUtils.getLineStart(doc, el.getSelectionEndOffset()));
+            Range selectionRange = new Range(selectionStartPos, selectionEndPos);
+            Position enclosedStartPos = new Position(LineDocumentUtils.getLineIndex(doc, el.getExpandedStartOffset()), el.getExpandedStartOffset() - LineDocumentUtils.getLineStart(doc, el.getExpandedStartOffset()));
+            Position enclosedEndPos = new Position(LineDocumentUtils.getLineIndex(doc, el.getExpandedEndOffset()), el.getExpandedEndOffset() - LineDocumentUtils.getLineStart(doc, el.getExpandedEndOffset()));
+            Range expandedRange = new Range(enclosedStartPos, enclosedEndPos);
+            DocumentSymbol ds;
+            if (el.getChildren() != null && !el.getChildren().isEmpty()) {
+                List<DocumentSymbol> children = new ArrayList<>();
+                for (StructureElement child: el.getChildren()) {
+                    ds = structureElement2DocumentSymbol(doc, child);
+                    if (ds != null) {
+                        children.add(ds);
                     }
                 }
-                return null;
+                ds = new DocumentSymbol(el.getName(), Utils.structureElementKind2SymbolKind(el.getKind()), expandedRange, selectionRange, el.getDetail(), children);
+                ds.setTags(Utils.elementTags2SymbolTags(el.getTags()));
+                return ds;
             }
-        }.scan(path, null);
-        return inner;
-    }
+            ds = new DocumentSymbol(el.getName(), Utils.structureElementKind2SymbolKind(el.getKind()), expandedRange, selectionRange, el.getDetail());
+            ds.setTags(Utils.elementTags2SymbolTags(el.getTags()));
+            return ds;
+        } catch (BadLocationException ex) {
 
+        }
+        return null;
+    }
+    
     @Override
     public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
         // shortcut: if the projects are not yet initialized, return empty:
@@ -1863,6 +1828,7 @@ public class TextDocumentServiceImpl implements TextDocumentService, LanguageCli
 
     @CheckForNull
     public JavaSource getJavaSource(String fileUri) {
+        
         Document doc = server.getOpenedDocuments().getDocument(fileUri);
         if (doc == null) {
             FileObject file = fromURI(fileUri);

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/protocol/ServerTest.java
@@ -824,13 +824,18 @@ public class ServerTest extends NbTestCase {
     }
 
     private String toString(DocumentSymbol sym) {
-        return sym.getKind().toString() + ":" +
+        String result = sym.getKind().toString() + ":" +
                sym.getName() + ":" +
-               sym.getRange() + ":" +
-               sym.getChildren()
-                  .stream()
-                  .map(this::toString)
-                  .collect(Collectors.joining(", ", "(", ")"));
+               sym.getRange() + ":";
+        if (sym.getChildren() != null) {
+               result = result + sym.getChildren()
+                    .stream()
+                    .map(this::toString)
+                    .collect(Collectors.joining(", ", "(", ")"));
+        } else {
+            result = result + "()";
+        }
+        return result;
     }
 
     public void testGoToDefinition() throws Exception {


### PR DESCRIPTION
This is the outlineview implementation not only for Groovy files, but for all GSF languages that are/will be enabled in the Vs Code extension. At the moment it is for Groovy files and YAML files that have `application` or `bootstrap` prefix.

The implementation requires adding two interfaces to the LSP API. Clients can implement and register a `StructureProvider` into `MimeLookup` for a given mimetype. `StructureProvider` provides a list of top symbols to be displayed in the outline view. The symbol structure is composed of `StrctureElements`. 

StructureElements are then translated into `DocumentSymbol`s on the VSCode API side, which are displayed in the outline view and also in Go to a symbol (CTRL+SHIFT+O by default). `DocumentSymbol`  has two methods `getName()` and `getDetail()`, which both return `String` and the resulting compound text is displayed in the outline view, where the text returned by `getName()` is slightly larger than the text returned by `getDetail()`. On the other hand, only the text returned by `getName()` is displayed in **Go to a symbol**. The `DocumentSymbol` documentation says that `getName()` should return the name of the symbol and `getDetail()` should return the detail of the symbol, such as the signature of the function. 

Currently in outline view we display the signature as the symbol name and the type as the symbol detail for java files. This means that in Go to a symbol we display not only the names but the symbol, but also signatures with the types of the function parameters, which can affect the symbol search. You can see on this picture, what I mean: https://issues.apache.org/jira/secure/attachment/13039469/Screenshot%20from%202022-01-28%2011-05-32.png

On the other hand, the java extension offered by Microsoft does the same. However, in my opinion, `getName` should really return only the name of the symbols and this would make the search in Go to symbol easier. 

This PR also moves the existing functionality that provided outline view for java files outside the LSP server. The JavaStructureProvider implementation is now in the java.editor module, which already has a dependency on the LSP API.  Provider should logically belong to java.navigation module, but this module is not enabled for VsCode extension and if we enable it, it brings with it dependency on WindowsSystem.API, which is not sufficient now.  