### PR TITLE
#3526: Retain traling / for non-existing directories.

### DIFF
--- a/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/NbMavenProjectImpl.java
@@ -26,6 +26,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,6 +65,8 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.netbeans.api.annotations.common.CheckForNull;
 import org.netbeans.api.annotations.common.NonNull;
+import org.netbeans.api.annotations.common.NullAllowed;
+import org.netbeans.api.annotations.common.NullUnknown;
 import org.netbeans.api.java.project.classpath.ProjectClassPathModifier;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.queries.VisibilityQuery;
@@ -550,10 +553,39 @@ public final class NbMavenProjectImpl implements Project {
         return auxprops;
     }
 
+    /**
+     * The method will migrate to regular FileUtilities after NB13 release. The issue is that the result of 
+     * {@link FileUtilities#convertStringToUri(java.lang.String)} result depends on whether the directory 
+     * identified by the string exists or not. If it exists, the URI ends with a "/". For non-existent directories
+     * the URI lacks the trailing "/". This can break URI keys in a Map (if the directory gets created) and prevents
+     * from creating a ClassPath from such URLs (/ is checked). But FileUtilities is API and this behaviour is there for
+     * ages, so the correction should be added with a parameter.
+     */
+    public static @NullUnknown URI convertStringToUri(@NullAllowed String str, boolean slashIfNotExist) {
+        if (str != null) {
+            File fil = new File(str);
+            fil = FileUtil.normalizeFile(fil);
+            // this conversion returns URIs that end with "/" if fil is an existing directory, but returns
+            // without the slash if the directory just does not exist yet.
+            URI uri = Utilities.toURI(fil);
+            String s = uri.toString();
+            if (slashIfNotExist && !s.endsWith("/") && (fil.isDirectory() || !fil.exists())) { // NOI18N
+                try {
+                    return new URI(s + "/"); // NOI18N
+                } catch (URISyntaxException ex) {
+                    throw new IllegalArgumentException(str);
+                }
+            } else {
+                return uri;
+            }
+        }
+        return null;
+    }
+
     public URI[] getSourceRoots(boolean test) {
         List<URI> uris = new ArrayList<URI>();
         for (String root : test ? getOriginalMavenProject().getTestCompileSourceRoots() : getOriginalMavenProject().getCompileSourceRoots()) {
-            uris.add(FileUtilities.convertStringToUri(root));
+            uris.add(convertStringToUri(root, true));
         }
         for (JavaLikeRootProvider rp : getLookup().lookupAll(JavaLikeRootProvider.class)) {
             // XXX for a few purposes (listening) it is desirable to list these even before they exist, but usually it is just noise (cf. #196414 comment #2)

--- a/java/maven/src/org/netbeans/modules/maven/classpath/RuntimeClassPathImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/RuntimeClassPathImpl.java
@@ -27,7 +27,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
 import org.netbeans.modules.maven.NbMavenProjectImpl;
-import org.netbeans.modules.maven.api.FileUtilities;
 import org.openide.util.Utilities;
 
 /**
@@ -57,7 +56,7 @@ public class RuntimeClassPathImpl extends AbstractProjectClassPathImpl {
         if (build != null) {
             String outputDirectory = build.getOutputDirectory();
             if (outputDirectory != null) {
-                lst.add(FileUtilities.convertStringToUri(outputDirectory));
+                lst.add(NbMavenProjectImpl.convertStringToUri(outputDirectory, true));
             }
         }
         List<Artifact> arts = prj.getRuntimeArtifacts();

--- a/java/maven/src/org/netbeans/modules/maven/classpath/TestRuntimeClassPathImpl.java
+++ b/java/maven/src/org/netbeans/modules/maven/classpath/TestRuntimeClassPathImpl.java
@@ -27,7 +27,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
 import org.netbeans.modules.maven.NbMavenProjectImpl;
-import org.netbeans.modules.maven.api.FileUtilities;
 import org.openide.util.Utilities;
 
 
@@ -66,11 +65,11 @@ public class TestRuntimeClassPathImpl extends AbstractProjectClassPathImpl {
         if (build != null) {
             String testOutputDirectory = build.getTestOutputDirectory();
             if (testOutputDirectory != null) {
-                lst.add(FileUtilities.convertStringToUri(testOutputDirectory));
+                lst.add(NbMavenProjectImpl.convertStringToUri(testOutputDirectory, true));
             }
             String outputDirectory = build.getOutputDirectory();
             if (outputDirectory != null) {
-                lst.add(FileUtilities.convertStringToUri(outputDirectory));
+                lst.add(NbMavenProjectImpl.convertStringToUri(outputDirectory, true));
             }
         }
         List<Artifact> arts = prj.getTestArtifacts();


### PR DESCRIPTION
I found the cause for #3526  : the implementation was changed in [bd4fd0e](https://github.com/apache/netbeans/commit/bd4fd0e4f6f323c458869ca4d77f6efd8b24f012#diff-d217c6a1644bb679cd1327c9fb77e539735b405f6874f62760a7522bda248172R54) -- the delegated-to implementation behaves differently depending on if the configured directories exist.

I fixed the `getSourceRoots` impl to always return URIs that end with "/". I found out that there's an API method `FileUtilities.convertStringToUri` which behaves this way which is not sometimes (always ?) preferred. As it is just before RCs, I don't want to add another API method, so I left a note in the code instead & will keep the issue for myself to finish after NB13 release is done to avoid different content in `delivery` and `master`.

- Maybe I can just create a new PR with a proper API change for ` master`, if merging from/to `delivery` is not an issue -- @neilcsmith-net  ?
- @dbalek  is it OK for LSP operations ?
