### PR TITLE
[#3511] workaround for extends/implements panel not showing any results.

### DIFF
--- a/java/java.project.ui/src/org/netbeans/modules/java/project/ui/ExtensionAndImplementationVisualPanel.java
+++ b/java/java.project.ui/src/org/netbeans/modules/java/project/ui/ExtensionAndImplementationVisualPanel.java
@@ -240,14 +240,15 @@ public class ExtensionAndImplementationVisualPanel extends JPanel implements Doc
     }
 
     private boolean isNotFinalExceptionType(ElementHandle<TypeElement> typeHandle) {
+        // TODO: this should not use Class.forName!
         try {
             Class<?> clazz = Class.forName(typeHandle.getQualifiedName());
             return typeHandle.getKind() == ElementKind.CLASS
                     && Exception.class.isAssignableFrom(clazz)
                     && !Modifier.isFinal(clazz.getModifiers());
         } catch (ClassNotFoundException ex) {
+            return true; // we don't know
         }
-        return false;
     }
 
     private boolean isInterface(ElementHandle<TypeElement> typeHandle) {
@@ -255,12 +256,13 @@ public class ExtensionAndImplementationVisualPanel extends JPanel implements Doc
     }
 
     private boolean isNotFinalClass(ElementHandle<TypeElement> typeHandle) {
+        // TODO: this should not use Class.forName!
         try {
             Class<?> clazz = Class.forName(typeHandle.getQualifiedName());
             return typeHandle.getKind() == ElementKind.CLASS && !Modifier.isFinal(clazz.getModifiers());
         } catch (ClassNotFoundException ex) {
+            return true; // we don't know
         }
-        return false;
     }
 
     private void browseInterfacesButtonActionPerformed(ActionEvent evt) {


### PR DESCRIPTION
workaround for #3511 lets trade a big bug against a small bug to improve the situation :)

commit msg:
 - this is not a clean fix, it only improves the situation by making the
   wizzard actually usable
 - logic should not use Class.forName since it doesn't know anything
   about the opened projects or used JDKs
 - proper fix would either require calling ElementHandle.resolve off
   EDT and getting CompiltaionInfo from somewhere or to add modifiers
   to ElementHandle itself which would be a fairly large change