### PR TITLE
[NETBEANS-6410] - Upgrade JAXB from 2.3.3 to 2.3.5

### DIFF
--- a/ide/libs.jaxb/external/binaries-list
+++ b/ide/libs.jaxb/external/binaries-list
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-3758E8C1664979749E647A9CA8C7EA1CD83C9B1E com.sun.xml.bind:jaxb-impl:2.3.3
-77E5784F53E865904BF91CFCD72CFC0AFD070486 com.sun.xml.bind:jaxb-xjc:2.3.3
+D32308BAD0B8B259A3DE55641C365E1AE9372505 com.sun.xml.bind:jaxb-impl:2.3.5
+6F47B124B356A218EBBD5ECBF6BB959D8C37525F com.sun.xml.bind:jaxb-xjc:2.3.5
 5685A1E75F9135DCC71E73A690B378E90FCD3B53 jakarta.xml.bind:jakarta.xml.bind-api:2.3.3:javadoc

--- a/ide/libs.jaxb/external/jaxb-2.3.5-xjc-license.txt
+++ b/ide/libs.jaxb/external/jaxb-2.3.5-xjc-license.txt
@@ -1,10 +1,37 @@
 Name: JAXB
 Description: JAXB Reference Implementation
-Version: 2.3.3
+Version: 2.3.5
 Origin: Oracle
 URL: https://github.com/javaee/jaxb-v2
-License: CDDL-1.1
-Files: jaxb-impl-2.3.3.jar
+License: CDDL-1.1-MIT-jaxb-xjc
+Files: jaxb-xjc-2.3.5.jar
+
+Parts of the work are:
+
+Copyright (c) 2004 Kohsuke Kawaguchi
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom
+the Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall
+be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Parts of the work are:
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/ide/libs.jaxb/external/jaxb-impl-2.3.5-license.txt
+++ b/ide/libs.jaxb/external/jaxb-impl-2.3.5-license.txt
@@ -1,37 +1,10 @@
 Name: JAXB
 Description: JAXB Reference Implementation
-Version: 2.3.3
+Version: 2.3.5
 Origin: Oracle
 URL: https://github.com/javaee/jaxb-v2
-License: CDDL-1.1-MIT-jaxb-xjc
-Files: jaxb-xjc-2.3.3.jar
-
-Parts of the work are:
-
-Copyright (c) 2004 Kohsuke Kawaguchi
-
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the "Software"), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or
-sell copies of the Software, and to permit persons to whom
-the Software is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice shall
-be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
-KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-Parts of the work are:
+License: CDDL-1.1
+Files: jaxb-impl-2.3.5.jar
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1
 

--- a/ide/libs.jaxb/nbproject/project.properties
+++ b/ide/libs.jaxb/nbproject/project.properties
@@ -27,8 +27,8 @@ jnlp.indirect.jars=\
 # pack200 bug in JDK 7 (#7131266)
 pack200.excludes=modules/ext/jaxb/jaxb-xjc.jar
 
-release.external/jaxb-impl-2.3.3.jar=modules/ext/jaxb/jaxb-impl.jar
-release.external/jaxb-xjc-2.3.3.jar=modules/ext/jaxb/jaxb-xjc.jar
+release.external/jaxb-impl-2.3.5.jar=modules/ext/jaxb/jaxb-impl.jar
+release.external/jaxb-xjc-2.3.5.jar=modules/ext/jaxb/jaxb-xjc.jar
 
 # JAXB Javadoc
 release.external/jakarta.xml.bind-api-2.3.3-javadoc.jar=docs/jaxb-api-doc.jar

--- a/ide/libs.jaxb/src/org/netbeans/libs/jaxb/Bundle.properties
+++ b/ide/libs.jaxb/src/org/netbeans/libs/jaxb/Bundle.properties
@@ -16,5 +16,5 @@
 # under the License.
 
 OpenIDE-Module-Name=JAXB 2.3 Library
-jaxb=JAXB 2.3.3
+jaxb=JAXB 2.3.5
 

--- a/ide/libs.jaxb/src/org/netbeans/libs/jaxb/jaxb.xml
+++ b/ide/libs.jaxb/src/org/netbeans/libs/jaxb/jaxb.xml
@@ -40,7 +40,7 @@
         <!-- please check with mkleint@netbeans.org before/after updating this or "classpath" section -->
         <property>
             <name>maven-dependencies</name>
-            <value>com.sun.xml.bind:jaxb-impl:2.3.3:jar</value>
+            <value>com.sun.xml.bind:jaxb-impl:2.3.5:jar</value>
         </property>
     </properties>    
 </library>


### PR DESCRIPTION
Library notes:
- Bug fixes and improvements
- Tests fixes
- Updated dependencies
- Code cleanup
- Remove use of soon to be deleted Java APIs. See [PR-1463](https://github.com/eclipse-ee4j/jaxb-ri/pull/1463/files)

Testing:
- Full build done
- Verify successfull execution of unit tests for modules `/ide/libs.jaxb` & `/ide/xml.jaxb.api`
- Verify successfull execution of `ant verify-libs-and-licenses`
- Successfully create project that bind WSDL to Java with JAXB as per [NetBeans Documentation](https://web.archive.org/web/20201028123508/https://netbeans.org/kb/74/websvc/jaxb.html)(Used web.archive.org)
- Verify that the files generated used the Eclipse implementation of JAXB
![NETBEANS-6410](https://user-images.githubusercontent.com/9832133/151891622-3e5bcfd4-e7bc-42ab-8f86-fca4e6ee1b7b.png)


[JAXB Web Page](https://projects.eclipse.org/projects/ee4j.jaxb-impl)
[Release Notes](https://github.com/eclipse-ee4j/jaxb-ri/compare/2.3.3-RI...2.3.5-RI)