### PR TITLE
[NETBEANS-6177] Fix an issue the stop command is not sent

### DIFF
--- a/php/php.dbgp/src/org/netbeans/modules/php/dbgp/SessionManager.java
+++ b/php/php.dbgp/src/org/netbeans/modules/php/dbgp/SessionManager.java
@@ -101,11 +101,6 @@ public class SessionManager {
 
     public synchronized void stopSession(Session session) {
         SessionId id = session.lookupFirst(null, SessionId.class);
-        // NETBEANS-5080 detach the request of the debug session to finish the task
-        DebugSession debugSession = session.lookupFirst(null, DebugSession.class);
-        if (debugSession != null) {
-            debugSession.cancel();
-        }
         DebugSession debSess = getSession(id);
         if (debSess != null) {
             debSess.stopSession();
@@ -122,6 +117,11 @@ public class SessionManager {
         }
         SessionManager.closeServerThread(session);
         resetBreakpoints();
+        // NETBEANS-5080 request cancellation to finish the task
+        DebugSession debugSession = session.lookupFirst(null, DebugSession.class);
+        if (debugSession != null) {
+            debugSession.cancel();
+        }
     }
 
     public static SessionId getSessionId(Project project) {


### PR DESCRIPTION
- https://issues.apache.org/jira/browse/NETBEANS-6177
- Related to NETBEANS-5080
- Use the `canceled` field instead of `detachRequest.set(true)` because
the stop command is not sent in `sendStopCommand()` if `detacheRequest` is `true`