### PR TITLE
Improve Gradle projects problem reporting.

### DIFF
--- a/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectProblemProvider.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/GradleProjectProblemProvider.java
@@ -80,12 +80,16 @@ public class GradleProjectProblemProvider implements ProjectProblemsProvider {
     public Collection<? extends ProjectProblem> getProblems() {
         List<ProjectProblem> ret = new ArrayList<>();
         GradleProject gp = project.getLookup().lookup(NbGradleProjectImpl.class).getGradleProject();
-        if (gp.getQuality().notBetterThan(EVALUATED)) {
-            ret.add(ProjectProblem.createError(Bundle.LBL_PrimingRequired(), Bundle.TXT_PrimingRequired(), resolver));
+        // untrusted project can't have 'real' problems: the execution could not happen
+        boolean trusted = ProjectTrust.getDefault().isTrusted(project);
+        if (!trusted || gp.getProblems().isEmpty()) {
+            if (gp.getQuality().notBetterThan(EVALUATED)) {
+                ret.add(ProjectProblem.createError(Bundle.LBL_PrimingRequired(), Bundle.TXT_PrimingRequired(), resolver));
+            }
         } else {
             for (String problem : gp.getProblems()) {
                 String[] lines = problem.split("\\n"); //NOI18N
-                ret.add(ProjectProblem.createWarning(lines[0], problem.replaceAll("\\n", "<br/>"), resolver)); //NOI18N
+                ret.add(ProjectProblem.createWarning(lines[0], problem.replaceAll("\\n", "<br/>"), null)); //NOI18N
             }
         }
         return ret;

--- a/extide/gradle/src/org/netbeans/modules/gradle/layer.xml
+++ b/extide/gradle/src/org/netbeans/modules/gradle/layer.xml
@@ -81,6 +81,10 @@
                     <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
                     <attr name="position" intvalue="1300"/>
                 </file>
+                <file name="org-netbeans-modules-project-ui-problems-BrokenProjectActionFactory.shadow">
+                    <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-problems-BrokenProjectActionFactory.instance"/>
+                    <attr name="position" intvalue="1770"/>
+                </file>
                 <file name="org-netbeans-modules-project-ui-SetMainProject.shadow">
                     <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-SetMainProject.instance"/>
                     <attr name="position" intvalue="1800"/>

--- a/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/loaders/GradleProjectLoaderImpl.java
@@ -30,6 +30,7 @@ import org.netbeans.modules.gradle.api.NbGradleProject;
 import org.netbeans.modules.gradle.api.execute.GradleCommandLine;
 import org.netbeans.modules.gradle.api.execute.RunUtils;
 import org.netbeans.modules.gradle.options.GradleExperimentalSettings;
+import org.openide.util.NbBundle;
 
 /**
  *
@@ -45,6 +46,9 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
     }
 
     @Override
+    @NbBundle.Messages({
+        "ERR_ProjectNotTrusted=Gradle execution is not trusted on this project."
+    })
     public GradleProject loadProject(NbGradleProject.Quality aim, String descriptionOpt, boolean ignoreCache, boolean interactive, String... args) {
         LOGGER.info("Load aiming " +aim + " for "+ project);
         GradleCommandLine cmd = new GradleCommandLine(args);
@@ -76,7 +80,7 @@ public class GradleProjectLoaderImpl implements GradleProjectLoader {
                     } else {
                         ret = ctx.getPrevious();
                         if (ret != null) {
-                            ret = ret.invalidate("Gradle execution is not trusted on this project.");
+                            ret = ret.invalidate(Bundle.ERR_ProjectNotTrusted());
                         }
                         LOGGER.log(Level.FINER, "Execution not allowed, invalidated {0}", ret);
                     }

--- a/ide/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesCustomizer.form
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesCustomizer.form
@@ -146,11 +146,9 @@
 
       <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
       <SubComponents>
-        <Component class="javax.swing.JTextArea" name="description">
+        <Component class="javax.swing.JTextPane" name="description">
           <Properties>
             <Property name="editable" type="boolean" value="false"/>
-            <Property name="lineWrap" type="boolean" value="true"/>
-            <Property name="wrapStyleWord" type="boolean" value="true"/>
           </Properties>
         </Component>
       </SubComponents>

--- a/ide/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesCustomizer.java
+++ b/ide/projectui/src/org/netbeans/modules/project/ui/problems/BrokenReferencesCustomizer.java
@@ -89,7 +89,7 @@ public class BrokenReferencesCustomizer extends javax.swing.JPanel {
         fix = new javax.swing.JButton();
         descriptionLabel = new javax.swing.JLabel();
         jScrollPane2 = new javax.swing.JScrollPane();
-        description = new javax.swing.JTextArea();
+        description = new javax.swing.JTextPane();
 
         setPreferredSize(new java.awt.Dimension(550, 350));
         setLayout(new java.awt.GridBagLayout());
@@ -146,8 +146,6 @@ public class BrokenReferencesCustomizer extends javax.swing.JPanel {
         descriptionLabel.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(BrokenReferencesCustomizer.class, "ACSD_BrokenLinksCustomizer_Description")); // NOI18N
 
         description.setEditable(false);
-        description.setLineWrap(true);
-        description.setWrapStyleWord(true);
         jScrollPane2.setViewportView(description);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -249,7 +247,16 @@ public class BrokenReferencesCustomizer extends javax.swing.JPanel {
         if (value instanceof BrokenReferencesModel.ProblemReference) {
             final BrokenReferencesModel.ProblemReference reference = (BrokenReferencesModel.ProblemReference) value;
             if (!reference.resolved) {
-                description.setText(reference.problem.getDescription());                
+                String s = reference.problem.getDescription();
+                // attempt to autodetect HTML tags in the description, switch content type appropriately.
+                if (s.contains("/>") || (s.contains("<") && s.contains(">"))) {
+                    description.setContentType("text/html");
+                } else {
+                    description.setContentType("text/plain");
+                }
+                description.setText(s);       
+                // avoid possible scroll down/left if the text does not fit in the default window
+                description.getCaret().setDot(0);
                 fix.setEnabled(reference.problem.isResolvable());
                 javax.swing.SwingUtilities.invokeLater(new Runnable() {
                    public void run() {
@@ -272,13 +279,14 @@ public class BrokenReferencesCustomizer extends javax.swing.JPanel {
     
     
     // Variables declaration - do not modify//GEN-BEGIN:variables
-    private javax.swing.JTextArea description;
+    private javax.swing.JTextPane description;
     private javax.swing.JLabel descriptionLabel;
     private javax.swing.JList errorList;
     private javax.swing.JLabel errorListLabel;
     private javax.swing.JButton fix;
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JScrollPane jScrollPane2;
+    private javax.swing.JScrollPane jScrollPane3;
     // End of variables declaration//GEN-END:variables
 
     private static final @StaticResource String BROKEN_REF = "org/netbeans/modules/project/ui/resources/broken-reference.gif";

--- a/java/maven/src/org/netbeans/modules/maven/layer.xml
+++ b/java/maven/src/org/netbeans/modules/maven/layer.xml
@@ -113,6 +113,10 @@
                     <attr name="instanceClass" stringvalue="javax.swing.JSeparator"/>
                     <attr name="position" intvalue="1600"/>
                 </file>
+                <file name="org-netbeans-modules-project-ui-problems-BrokenProjectActionFactory.shadow">
+                    <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-problems-BrokenProjectActionFactory.instance"/>
+                    <attr name="position" intvalue="1770"/>
+                </file>
                 <file name="org-netbeans-modules-project-ui-SetMainProject.shadow">
                     <attr name="originalFile" stringvalue="Actions/Project/org-netbeans-modules-project-ui-SetMainProject.instance"/>
                     <attr name="position" intvalue="1800"/>


### PR DESCRIPTION
I have noticed that an exception thrown from Gradle script execution is slightly mis-presented
- a notification is fired, project is marked as having errors
- the "Project Problems" dialog does not appear (sometimes)
- "Do priming build" fixable problem appears - but can't fix anything as the script is broken
- The **real** problem does not appear in the "Project problems" dialog

The notification itself is mangled: part of the text is duplicated (see the picture). 
![gradle-notification](https://user-images.githubusercontent.com/26788611/152153403-062b5c56-2a91-41a0-b0bb-2f2ad8521099.jpg)

I have tried to change that. I added some exception stack processing to ignore / reorder the information; the resulting notification is visible here:
![gradle-notification2](https://user-images.githubusercontent.com/26788611/152153449-5db66c64-78c1-4346-a4e8-f8c7a1b13ac0.jpg)

In addition, I have change the condition for replacing loaded projects, so that 'problematic' project instance is retained - then the project infrastructure starts to work properly, displaying "project problems" dialog. In some subsequent PR, I would like to remove Gradle's special code that makes a Notification and change the core project ui to do that - for all projects.

The Project UI 'broken references' dialog was changed to detect & respect possible HTML formatting: will change `JTextPane` content type accordingly, which results in much nicer formatting. Gradle's `GradleProjectProblemProvider` uses `<br/>` but there was noone interpreting HTML on the receiving side.

Gradle's 'priming build required' Problem is now only displayed if there are no errors reported. It works well for broken buildscripts, but perhaps may need more clever test, or maybe even an API change (i.e. a non-fatal Problem that does not prevent the script from being executed may allow priming build to happen).

This PR also adds "Resolve project problems" standard Project UI action to **Gradle + Maven** projects; this action declares 'hide-if-disabled', so it will not clutter the project context menu unless there are actually some problems on the project.