### PR TITLE
Hint wizzard module dependency fix.

### DIFF
--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahint/NewJavaHintIterator.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/javahint/NewJavaHintIterator.java
@@ -72,8 +72,8 @@ public class NewJavaHintIterator extends BasicWizardIterator {
         cmf.add(cmf.addTestModuleDependency("org.netbeans.modules.java.hints.test", "java"));
         cmf.add(cmf.addTestModuleDependency("org.netbeans.libs.junit4", "extra"));
         cmf.add(cmf.addTestModuleDependency("org.netbeans.modules.nbjunit", "harness")); // NOI18N
-        cmf.add(cmf.addTestModuleDependency("org.netbeans.modules.parsing.nb", "ide")); // NOI18N
-        cmf.add(cmf.addTestModuleDependency("org.netbeans.modules.projectapi.nb", "ide")); // NOI18N
+        cmf.add(cmf.addTestModuleDependency("org.netbeans.modules.parsing.api", "ide")); // NOI18N
+        cmf.add(cmf.addTestModuleDependency("org.netbeans.modules.projectapi", "ide")); // NOI18N
         
         NbProjectProvider nbProjectProvider = getProjectProvider(model.getProject());
 
@@ -129,7 +129,6 @@ public class NewJavaHintIterator extends BasicWizardIterator {
             cmf.add(cmf.addModuleToTargetPlatform("org.netbeans.modules.parsing.api", "ide")); // NOI18N
             cmf.add(cmf.addModuleToTargetPlatform("org.netbeans.modules.parsing.indexing", "ide")); // NOI18N
             cmf.add(cmf.addModuleToTargetPlatform("org.netbeans.modules.parsing.lucene", "ide")); // NOI18N
-            cmf.add(cmf.addModuleToTargetPlatform("org.netbeans.modules.parsing.nb", "ide")); // NOI18N
             cmf.add(cmf.addModuleToTargetPlatform("org.netbeans.modules.projectapi", "ide")); // NOI18N
             cmf.add(cmf.addModuleToTargetPlatform("org.netbeans.modules.project.indexingbridge", "ide")); // NOI18N
             cmf.add(cmf.addModuleToTargetPlatform("org.netbeans.modules.project.spi.intern", "ide")); // NOI18N


### PR DESCRIPTION
New "Java Hint" Wizzard added test dependencies to the pom which did not exist (`org-netbeans-modules-parsing-nb` and `org-netbeans-modules-projectapi-nb`).

PR changes it to `org-netbeans-modules-parsing-api` and `org-netbeans-modules-projectapi`.