### PR TITLE
fixed wrong nb-javac module name so that it can be installed.

### DIFF
--- a/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/Bundle.properties
+++ b/java/java.j2semodule/src/org/netbeans/modules/java/j2semodule/ui/customizer/Bundle.properties
@@ -601,7 +601,7 @@ ACSD_librariesLocation=Folder containing location of the library definition file
 ACSD_jButtonEdit=Edit classpath items
 ACSD_BuildJarAfterCompile=Build JAR after compiling option
 LBL_CustomizeRun_Enable_Quick_Run=Enable Quick Run
-CustomizerCompile.CompileOnSave=Compile on &Save (requires nb-javac plugin)
+CustomizerCompile.CompileOnSave=Compile on &Save
 AD_CustomizerCompile.CompileOnSave=If selected, files are compiled when you save them. This option saves you time when you run or debug your application in the IDE.
 LBL_CompileOnSaveDescription=<html>If selected, files are compiled when you save them.<br>\
     This option saves you time when you run or debug your application in the IDE.<br>\

--- a/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/Bundle.properties
+++ b/java/java.j2seproject/src/org/netbeans/modules/java/j2seproject/ui/customizer/Bundle.properties
@@ -601,7 +601,7 @@ ACSD_librariesLocation=Folder containing location of the library definition file
 ACSD_jButtonEdit=Edit classpath items
 ACSD_BuildJarAfterCompile=Build JAR after compiling option
 LBL_CustomizeRun_Enable_Quick_Run=Enable Quick Run
-CustomizerCompile.CompileOnSave=Compile on &Save (requires nb-javac plugin)
+CustomizerCompile.CompileOnSave=Compile on &Save
 AD_CustomizerCompile.CompileOnSave=If selected, files are compiled when you save them. This option saves you time when you run or debug your application in the IDE.
 LBL_CompileOnSaveDescription=<html>If selected, files are compiled when you save them.<br>\
     This option saves you time when you run or debug your application in the IDE.<br>\

--- a/java/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
+++ b/java/java.source/src/org/netbeans/modules/java/source/JBrowseModule.java
@@ -83,7 +83,7 @@ public class JBrowseModule extends ModuleInstall {
                         Dialog[] d = new Dialog[1];
                         DialogDescriptor dd = new DialogDescriptor(Bundle.DESC_FeaturesLimited(), Bundle.TITLE_FeaturesLimited(), true, new Object[] {install, DialogDescriptor.CANCEL_OPTION}, install, DialogDescriptor.DEFAULT_ALIGN, HelpCtx.DEFAULT_HELP, evt -> {
                             if (install.equals(evt.getActionCommand())) {
-                                PluginManager.installSingle("org.netbeans.lib.nbjavac", Bundle.DN_nbjavac());
+                                PluginManager.installSingle("org.netbeans.libs.nbjavacapi", Bundle.DN_nbjavac());
                             }
                             d[0].setVisible(false);
                         });
@@ -92,7 +92,7 @@ public class JBrowseModule extends ModuleInstall {
                     } catch (HeadlessException ex) {
                         Exceptions.printStackTrace(Exceptions.attachSeverity(ex, Level.FINE));
                     }
-                    prefs.putBoolean(KEY_WARNING_SHOWN, true);
+//                    prefs.putBoolean(KEY_WARNING_SHOWN, true); // show warning on every boot until fixed
                 }
             });
         });

--- a/java/maven/src/org/netbeans/modules/maven/customizer/Bundle.properties
+++ b/java/maven/src/org/netbeans/modules/maven/customizer/Bundle.properties
@@ -142,7 +142,7 @@ HINT_ApplicationCoS=<html>Classes compiled with the Compile on Save feature in t
 RunJarPanel.lblConfiguration.text=&Configuration:
 ActionMappings.txtPackagings.text=
 ActionMappings.lblPackagings.text=Supported Packagings:
-CompilePanel.cbCompileOnSave.text=Compile on &Save (requires nb-javac plugin)
+CompilePanel.cbCompileOnSave.text=Compile on &Save
 CompilePanel.btnLearnMore.text=<html><a href="">Learn More about Compile On Save feature in Maven projects</a></html>
 ActionMappings.jButton1.text=Show in Toolbar
 RunJarPanel.txtVMOptions.AccessibleContext.accessibleDescription=VM options


### PR DESCRIPTION
when nb-javac is uninstalled by the user and NB is started on a JDK < 17 this dialog will show up:
![install-nb-javac](https://user-images.githubusercontent.com/114367/153100286-687b668c-0946-426d-af87-68493bccc39e.png)

However, pressing install did nothing since the module name was wrong (!). This fixes it.

PR is based on delivery branch. I think we should add this even if there won't be another rc.

how to test:
1) start NB, load java cluster
2) uninstall nb-javac
3) start again on JDK 8, dialog should show up
4) install nb-javac via dalog, restart -> everything should be working again (no dialog)