### PR TITLE
Don't check non existing Parser.Result for being finshed

### DIFF
--- a/ide/parsing.api/src/org/netbeans/modules/parsing/api/ParserManager.java
+++ b/ide/parsing.api/src/org/netbeans/modules/parsing/api/ParserManager.java
@@ -168,7 +168,8 @@ public final class ParserManager {
                 try {
                     TaskProcessor.callUserTask(userTask, resultIterator);
                 } finally {
-                    if (ParserAccessor.getINSTANCE().processingFinished(resultIterator.getParserResult())) {
+                    if (resultIterator.getParserResult() == null
+                            || ParserAccessor.getINSTANCE().processingFinished(resultIterator.getParserResult())) {
                         i++;
                     }
                     ResultIteratorAccessor.getINSTANCE().invalidate(resultIterator);


### PR DESCRIPTION
The changes introduced by 416e6fbc28e6bc17f88f49f12be0260a8ec7df63

Parse Indexables under a source root as a group while running EmbeddedIndexers

causes Exceptions when parsing angular projects:

java.lang.NullPointerException
	at org.netbeans.modules.parsing.spi.Parser$MyAccessor.processingFinished(Parser.java:202)
	at org.netbeans.modules.parsing.api.ParserManager$MultiUserTaskAction.run(ParserManager.java:171)
	at org.netbeans.modules.parsing.api.ParserManager$MultiUserTaskAction.run(ParserManager.java:140)
	at org.netbeans.modules.parsing.impl.TaskProcessor$2.call(TaskProcessor.java:181)
	at org.netbeans.modules.parsing.impl.TaskProcessor$2.call(TaskProcessor.java:178)
	at org.netbeans.modules.masterfs.filebasedfs.utils.FileChangedManager.priorityIO(FileChangedManager.java:153)
	at org.netbeans.modules.masterfs.providers.ProvidedExtensions.priorityIO(ProvidedExtensions.java:335)
	at org.netbeans.modules.parsing.nb.DataObjectEnvFactory.runPriorityIO(DataObjectEnvFactory.java:118)
	at org.netbeans.modules.parsing.impl.Utilities.runPriorityIO(Utilities.java:67)
	at org.netbeans.modules.parsing.impl.TaskProcessor.runUserTask(TaskProcessor.java:178)
Caused: org.netbeans.modules.parsing.spi.ParseException
	at org.netbeans.modules.parsing.impl.TaskProcessor.runUserTask(TaskProcessor.java:186)
	at org.netbeans.modules.parsing.api.ParserManager.parse(ParserManager.java:85)

The problem occurs, when a file without a corresponding parser is
processed. Before that change source files are parsed individually and
the code runs through UserTaskAction and afterwards the code path runs
through MultiUserTaskAction.

The missing parser leads to a missing Parser.Result. The
MultiUserTaskAction does more post processing of the parser result and
tries to invoke processingFinished on it (though an accessor helper) and
this fails either with an AssertionError (debug case) or a
NullPointerException.

The fix just does not call processingFinished on the null reference.