### PR TITLE
Support icon resource fetch on LSP protocol, multiple content types.

### DIFF
--- a/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/UIDefaultsIconMetadata.java
+++ b/java/java.lsp.server/nbcode/integration/src/org/netbeans/modules/nbcode/integration/UIDefaultsIconMetadata.java
@@ -84,8 +84,21 @@ public class UIDefaultsIconMetadata implements Runnable {
                     LOG.log(Level.INFO, "Icon not used: {0}", uiKey);
                     continue;
                 }
-                String resImage = RESOURCE_PREFIX + uiKey + ".png"; // NOI18N
-                URL u = l.getResource(resImage);
+                String v = p.getProperty(uiKey);
+                String resImage;
+                URL u = null;
+                if (v == null || v.trim().isEmpty()) {
+                    String r = RESOURCE_PREFIX + uiKey + ".png"; // NOI18N
+                    u = l.getResource(r);
+                    if (u == null) {
+                        r = RESOURCE_PREFIX + uiKey + ".gif"; // NOI18N
+                    }
+                    resImage = r;
+                } else {
+                    resImage = v;
+                    u = l.getResource(resImage);
+                }
+                 
                 if (u == null) {
                     LOG.log(Level.WARNING, "Resource missing: {0}", resImage);
                     continue;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/URITranslator.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/URITranslator.java
@@ -177,7 +177,11 @@ public final class URITranslator {
         });
     }
 
-    private static File getCacheDir() {
+    /**
+     * Root of caches for NBLS server.
+     * @return cache root.
+     */
+    public static File getCacheDir() {
         return Places.getCacheSubfile("java-server");   // NOI18N
     }
 

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/LspTreeViewServiceImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/LspTreeViewServiceImpl.java
@@ -18,18 +18,29 @@
  */
 package org.netbeans.modules.java.lsp.server.explorer;
 
+import java.io.File;
 import org.netbeans.modules.java.lsp.server.explorer.api.TreeViewService;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
+import org.netbeans.modules.java.lsp.server.URITranslator;
 import org.netbeans.modules.java.lsp.server.explorer.api.ConfigureExplorerParams;
 import org.netbeans.modules.java.lsp.server.explorer.api.CreateExplorerParams;
+import org.netbeans.modules.java.lsp.server.explorer.api.GetResourceParams;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
 import org.netbeans.modules.java.lsp.server.explorer.api.NodeChangedParams;
 import org.netbeans.modules.java.lsp.server.explorer.api.NodeOperationParams;
+import org.netbeans.modules.java.lsp.server.explorer.api.ResourceData;
 import org.openide.nodes.Node;
 import org.openide.util.Lookup;
 
@@ -161,5 +172,16 @@ public class LspTreeViewServiceImpl implements TreeViewService, LanguageClientAw
             }
         }
         return CompletableFuture.completedFuture(false);
+    }
+    
+    @Override
+    public CompletableFuture<ResourceData> getResource(GetResourceParams params) {
+        URI uri = params.getUri();
+        if (params.getAcceptEncodings() != null) {
+            if (!Arrays.asList(params.getAcceptEncodings()).contains("base64")) { // NOI18N
+                throw new IllegalArgumentException("Base64 encoding must be accepted.");
+            }
+        }
+        return CompletableFuture.completedFuture(treeService.imageContents(uri));
     }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeItem.java
@@ -59,8 +59,6 @@ public class TreeItem {
     // NBLS-specific items, to be processed by the client:
     // Metadata for the icon.
     public IconDescriptor iconDescriptor;
-    // The icon's index
-    public int iconIndex;
     
     /**
      * Metadata that describe an icon origin or contents.

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistry.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistry.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.concurrent.CompletionStage;
+import org.netbeans.modules.java.lsp.server.explorer.api.ResourceData;
 import org.openide.nodes.Node;
 
 /**
@@ -38,6 +39,7 @@ public interface TreeNodeRegistry {
     Node findNode(int id);
     TreeViewProvider providerOf(int id);
     ImageDataOrIndex imageOrIndex(Image im);
+    ResourceData imageContents(URI imageUri);
     
     CompletionStage<TreeViewProvider> createProvider(String id);
     
@@ -52,27 +54,13 @@ public interface TreeNodeRegistry {
          */
         public String[]     composition;
         
-        /**
-         * Image URI, data: protocol.
-         */
-        public final URI    imageURI;
-        public final int    imageIndex;
+        public String       contentType;
+        public byte[]       imageData;
 
         public ImageDataOrIndex(URI imageURI) {
-            this.imageURI = imageURI;
-            this.imageIndex = -1;
+            this.baseURI = imageURI;
         }
 
-        public ImageDataOrIndex(URI imageUri, int imageIndex) {
-            this.imageIndex = imageIndex;
-            this.imageURI = imageUri;
-        }
-
-        public ImageDataOrIndex(int imageIndex) {
-            this.imageIndex = imageIndex;
-            this.imageURI = null;
-        }
-        
         public ImageDataOrIndex baseURL(URL u) {
             try {
                 baseURI = u == null ? null : u.toURI();
@@ -89,6 +77,12 @@ public interface TreeNodeRegistry {
         
         public ImageDataOrIndex composition(String[] composition) {
             this.composition = composition;
+            return this;
+        }
+        
+        public ImageDataOrIndex imageData(String contentType, byte[] imageData) {
+            this.contentType = contentType;
+            this.imageData = imageData;
             return this;
         }
     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistryImpl.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeNodeRegistryImpl.java
@@ -23,14 +23,24 @@ import org.netbeans.modules.java.lsp.server.explorer.api.ExplorerManagerFactory;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
+import static java.awt.image.ImageObserver.ABORT;
+import static java.awt.image.ImageObserver.ALLBITS;
+import static java.awt.image.ImageObserver.ERROR;
 import static java.awt.image.ImageObserver.HEIGHT;
 import static java.awt.image.ImageObserver.WIDTH;
 import java.beans.PropertyVetoException;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLConnection;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,8 +53,11 @@ import java.util.logging.Logger;
 import javax.imageio.ImageIO;
 import javax.swing.ActionMap;
 import javax.swing.text.DefaultEditorKit;
+import org.netbeans.modules.java.lsp.server.URITranslator;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
 import org.netbeans.modules.java.lsp.server.explorer.api.NodeChangedParams;
+import org.netbeans.modules.java.lsp.server.explorer.api.ResourceData;
+import org.netbeans.modules.java.lsp.server.explorer.api.TreeItemData;
 import org.openide.explorer.ExplorerManager;
 import org.openide.explorer.ExplorerUtils;
 import org.openide.filesystems.FileObject;
@@ -61,15 +74,22 @@ import org.openide.util.lookup.ProxyLookup;
  */
 public class TreeNodeRegistryImpl implements TreeNodeRegistry {
     private static final Logger LOG = Logger.getLogger(TreeNodeRegistryImpl.class.getName());
-    private static final String NODE_ATTR_LSP_ID = "lspId"; // NOI18N
-    
+
+    private static final String ENCODING_BASE64 = "base64"; // NOI18N
+    private static final String PROTO_LSPCACHE = "lspcache"; // NOI18N
+    private static final String CACHE_ICONS_NAME = "icons"; // NOI18N
+    private static final String EXT_PNG = ".png"; // NOI18N
+    private static final String MIME_PNG = "image/png"; // NOI18N
+    private static final String ICONS_PREFIX = "//icons/"; // NOI18N
+    private static final String URLPREFIX_LSPCACHE = PROTO_LSPCACHE + ":" + ICONS_PREFIX; // NOI18N
+
     private final Lookup sessionLookup;
     private final Map<String, TreeViewProvider> providers = new HashMap<>();
     private final Map<Integer, TreeViewProvider> node2Provider = new HashMap<>();
     private final Map<Image, ImageDataOrIndex> images = new WeakHashMap<>();
+    private final Map<URI, ImageDataOrIndex> imageData = new WeakHashMap<>();
     
     private int nodeCounter = 1;
-    private int imageCounter = 1;
     
     private NbCodeLanguageClient langClient;
 
@@ -171,109 +191,176 @@ public class TreeNodeRegistryImpl implements TreeNodeRegistry {
     }
 
     @Override
+    public ResourceData imageContents(URI uri) {
+        String scheme = uri.getScheme();
+        
+        ImageDataOrIndex d;
+        
+        synchronized (this) {
+            d = imageData.get(uri);
+            if (d != null && d.imageData != null) {
+                ResourceData rd = new ResourceData();
+                rd.setContentSize(d.imageData.length);
+                String base64Content = Base64.getEncoder().encodeToString(d.imageData).replace("\\n", ""); // NOI18N
+                rd.setContent(base64Content);
+                rd.setContentType(d.contentType);
+                rd.setEncoding(ENCODING_BASE64);
+                return rd;
+            }
+        }
+        
+        URL toOpen;
+        try {
+            // only accept certain schemes, so that the client can't reach entire local FS:
+            if ("nbres".equals(scheme)) { // NOI18N
+                toOpen = uri.toURL();
+            } else if (PROTO_LSPCACHE.equals(scheme) && uri.getSchemeSpecificPart().startsWith(ICONS_PREFIX)) { // NOI18N
+                // this branch is reached only iff the server stops after client receives image URI and before the client
+                // asks for image contents: otherwise it is cached in ImageDataOrIndex structure.
+                String fn = uri.getSchemeSpecificPart().substring(ICONS_PREFIX.length());
+                File iconFile = new File(new File(URITranslator.getCacheDir(), "icons"), fn) ; // NOI18N
+                toOpen = iconFile.toURI().toURL();
+            } else {
+                throw new IllegalArgumentException("Resource not found: " + uri);
+            }
+        } catch (MalformedURLException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+        
+        URLConnection c = null;
+        try {
+            c = toOpen.openConnection();
+            ResourceData rd = new ResourceData();
+            try (InputStream istm = c.getInputStream()) {
+                byte[] content = new byte[c.getContentLength()];
+                istm.read(content);
+                rd.setContentSize(content.length);
+                String base64Content = Base64.getEncoder().encodeToString(content).replace("\\n", ""); // NOI18N
+                rd.setContent(base64Content);
+                rd.setContentType(c.getContentType());
+                rd.setEncoding(ENCODING_BASE64);
+                
+                synchronized (this) {
+                    if (d != null) {
+                        // cache the image bits in the ImageDataOrIndex instance
+                        d.contentType = c.getContentType();
+                        d.imageData = content;
+                    }
+                }
+            }
+            return rd;
+        } catch (IOException ex) {
+            throw new IllegalArgumentException(ex);
+        }
+    }
+    
+    @Override
     public ImageDataOrIndex imageOrIndex(Image i) {
         ImageDataOrIndex res;
         synchronized (this) {
             res = images.get(i);
             if (res != null) {
-                return res.imageIndex == -1 ? null : new ImageDataOrIndex(res.imageIndex);
+                return res;
             }
         }
         String base64Content;
-        URI imageURI = null;
+        URL u = ImageUtilities.findImageBaseURL(i);
+        
         try {
-            BufferedImage bi;
-            if (i instanceof BufferedImage) {
-                bi = (BufferedImage)i;
+            if (u != null) {
+                URI u2 = TreeViewProvider.builtinURI2URI(TreeViewProvider.findImageURI(i));
+                res = new ImageDataOrIndex(u2);
             } else {
-                class IO implements ImageObserver {
-                    int bits;
-                    CountDownLatch cdl = new CountDownLatch(1);
-
-                    int height = -1;
-                    int width = -1;
-
-                    @Override
-                    public boolean imageUpdate(Image img, int infoflags, int x, int y, int width, int height) {
-                        bits |= (HEIGHT | WIDTH) & infoflags;
-                        synchronized (this) {
-                            if ((infoflags & WIDTH) > 0) {
-                                this.height = height;
-                            }
-                            if ((infoflags & HEIGHT) > 0) {
-                                this.width = width;
-                            }
-                        }
-                        if ((infoflags & (ABORT | ERROR)) > 0) {
-                            cdl.countDown();
-                            return false;
-                        }
-                        if ((infoflags & ALLBITS) > 0) {
-                            cdl.countDown();
-                            return false;
-                        } else {
-                            return true;
-                        }
-                    }
+                // write a cache file names using contents hash: in the case of server restart, the client
+                // can ask a new server instance and the URI will point to the cached image bits. Overwrite just
+                // once per session per image.
+                byte[] data = printImagePngData(i);
+                // I know it's old, but it's not for security, just as a semi-unique identifier.
+                MessageDigest md = MessageDigest.getInstance("SHA1"); // NOI18N
+                byte[] dg = md.digest(data);
+                base64Content = Base64.getUrlEncoder().encodeToString(dg).replace("\\n", ""); // NOI18N
+                String fname = base64Content + EXT_PNG; // NOI18N
+                FileObject iconsDir = FileUtil.createFolder(FileUtil.toFileObject(URITranslator.getCacheDir()), CACHE_ICONS_NAME); // NOI18N
+                FileObject fo = iconsDir.getFileObject(fname);
+                try (OutputStream ostm = fo == null ? iconsDir.createAndOpen(fname) : fo.getOutputStream()) {
+                    ostm.write(data);
                 }
-                IO observer = new IO();
-                int h = i.getHeight(observer);
-                int w = i.getWidth(observer);
-                if (h == -1 || w == -1) {
-                    try {
-                        observer.cdl.await();
-                    } catch (InterruptedException ex) {
-                    }
-                    synchronized (observer) {
-                        h = observer.height;
-                        w = observer.width;
-                        if (h == -1 || w == -1) {
-                            LOG.log(Level.WARNING, "Could not realize image to get its size: {0}", i);
-                            return null;
-                        }
-                    }
-                }
-                bi = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
-                Graphics2D bGr = bi.createGraphics();
-                bGr.drawImage(i, 0, 0, null);
-                bGr.dispose();
+                res = new ImageDataOrIndex(new URI(URLPREFIX_LSPCACHE + fname)).
+                        imageData(ENCODING_BASE64, data);
             }
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ImageIO.write(bi, "png", baos); // NOI18N
-            baos.flush();
-            base64Content = Base64.getEncoder().encodeToString(baos.toByteArray()).replace("\\n", ""); // NOI18N
-            imageURI = new URI("data:image/png;base64," + base64Content); // NOI18N
-        } catch (IOException | URISyntaxException ex) {
+        } catch (IOException | URISyntaxException | NoSuchAlgorithmException ex) {
             // log the error and cache failure
-            res = new ImageDataOrIndex(null, -1);
+            LOG.log(Level.WARNING, "Could not load or print image: {0}", i);
+            LOG.log(Level.WARNING, "Image content generation failed with exception:", ex);
+            res = new ImageDataOrIndex(TreeItemData.NO_URI);
         }
         synchronized (this) {
-            if (res == null) {
-                res = new ImageDataOrIndex(imageURI, imageCounter++).
-                        baseURL(findImageURI(i));
-            }
             images.put(i, res);
+            imageData.put(res.baseURI, res);
         }
         return res;
     }
-
-
-    public static URI findImageURI(Image i) {
-        URL u = ImageUtilities.findImageBaseURL(i);
-        if (u == null) {
-            return null;
-        }
-        String s = u.toString();
-        try {
-            if (s.contains(":")) {
-                return new URI(s);
-            } else {
-                return new URI("nbres:/" + s);
-            }
-        } catch (URISyntaxException ex) {
-            LOG.log(Level.WARNING, "Unable to interpret image ID: {0}", s);
-            return null;
-        }
-    }
     
+    private byte[] printImagePngData(Image i) throws IOException {
+        BufferedImage bi;
+        if (i instanceof BufferedImage) {
+            bi = (BufferedImage)i;
+        } else {
+            class IO implements ImageObserver {
+                int bits;
+                CountDownLatch cdl = new CountDownLatch(1);
+
+                int height = -1;
+                int width = -1;
+
+                @Override
+                public boolean imageUpdate(Image img, int infoflags, int x, int y, int width, int height) {
+                    bits |= (HEIGHT | WIDTH) & infoflags;
+                    synchronized (this) {
+                        if ((infoflags & WIDTH) > 0) {
+                            this.height = height;
+                        }
+                        if ((infoflags & HEIGHT) > 0) {
+                            this.width = width;
+                        }
+                    }
+                    if ((infoflags & (ABORT | ERROR)) > 0) {
+                        cdl.countDown();
+                        return false;
+                    }
+                    if ((infoflags & ALLBITS) > 0) {
+                        cdl.countDown();
+                        return false;
+                    } else {
+                        return true;
+                    }
+                }
+            }
+            IO observer = new IO();
+            int h = i.getHeight(observer);
+            int w = i.getWidth(observer);
+            if (h == -1 || w == -1) {
+                try {
+                    observer.cdl.await();
+                } catch (InterruptedException ex) {
+                }
+                synchronized (observer) {
+                    h = observer.height;
+                    w = observer.width;
+                    if (h == -1 || w == -1) {
+                        LOG.log(Level.WARNING, "Could not realize image to get its size: {0}", i);
+                        return null;
+                    }
+                }
+            }
+            bi = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D bGr = bi.createGraphics();
+            bGr.drawImage(i, 0, 0, null);
+            bGr.dispose();
+        }
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(bi, "png", baos); // NOI18N
+        baos.flush();
+        return baos.toByteArray();
+    }
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/TreeViewProvider.java
@@ -18,6 +18,7 @@
  */
 package org.netbeans.modules.java.lsp.server.explorer;
 
+import java.awt.Image;
 import java.beans.BeanInfo;
 import org.netbeans.modules.java.lsp.server.explorer.api.TreeDataListener;
 import org.netbeans.modules.java.lsp.server.explorer.api.TreeItemData;
@@ -53,6 +54,7 @@ import org.openide.nodes.NodeEvent;
 import org.openide.nodes.NodeListener;
 import org.openide.nodes.NodeMemberEvent;
 import org.openide.nodes.NodeReorderEvent;
+import org.openide.util.ImageUtilities;
 import org.openide.util.Lookup;
 import org.openide.util.RequestProcessor;
 
@@ -391,12 +393,10 @@ public abstract class TreeViewProvider {
         if (data.getIconImage() != null && data.getIconImage() != DUMMY_NODE.getIcon(BeanInfo.ICON_COLOR_16x16)) {
             TreeNodeRegistry.ImageDataOrIndex idoi = nodeRegistry.imageOrIndex(data.getIconImage());
             if (idoi != null) {
-                ti.iconIndex = idoi.imageIndex;
-                ti.iconUri = idoi.imageURI;
-                ti.iconDescriptor = new IconDescriptor();
                 try {
                     URI baseURI = builtinURI2URI(idoi.baseURI);
                     if (baseURI != null) {
+                        ti.iconDescriptor = new IconDescriptor();
                         ti.iconDescriptor.baseUri = baseURI;
                         ti.iconDescriptor.composition = idoi.composition;
                     }
@@ -404,8 +404,6 @@ public abstract class TreeViewProvider {
                     LOG.log(Level.WARNING, "Cannot convert URL: {0}", idoi.baseURI);
                 }
             }
-        } else if (data.getIconURI() != null) {
-            ti.iconUri = data.getIconURI();
         }
         ti.contextValue = v;
         ti.command = data.getCommand();
@@ -663,4 +661,23 @@ public abstract class TreeViewProvider {
         }
         return u;
     }
+
+    public static URI findImageURI(Image i) {
+        URL u = ImageUtilities.findImageBaseURL(i);
+        if (u == null) {
+            return null;
+        }
+        String s = u.toString();
+        try {
+            if (s.contains(":")) {
+                return new URI(s);
+            } else {
+                return new URI("nbres:/" + s);
+            }
+        } catch (URISyntaxException ex) {
+            LOG.log(Level.WARNING, "Unable to interpret image ID: {0}", s);
+            return null;
+        }
+    }
+    
 }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/GetResourceParams.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/GetResourceParams.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.explorer.api;
+
+import java.net.URI;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+
+/**
+ *
+ * @author sdedic
+ */
+public class GetResourceParams {
+    @NonNull
+    private URI uri;
+    
+    private String[] acceptEncoding;
+    
+    private String[] acceptContent;
+
+    public GetResourceParams() {
+    }
+
+    public GetResourceParams(URI uri) {
+        this.uri = uri;
+    }
+
+    @Pure
+    @NonNull
+    public URI getUri() {
+        return uri;
+    }
+
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+
+    public String[] getAcceptEncodings() {
+        return acceptEncoding;
+    }
+
+    public void setAcceptEncodings(String[] acceptEncoding) {
+        this.acceptEncoding = acceptEncoding;
+    }
+
+    public String[] getAcceptContent() {
+        return acceptContent;
+    }
+
+    public void setAcceptContent(String[] acceptContent) {
+        this.acceptContent = acceptContent;
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/ResourceData.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/ResourceData.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.netbeans.modules.java.lsp.server.explorer.api;
+
+/**
+ *
+ * @author sdedic
+ */
+public final class ResourceData {
+    private String  contentType;
+    private String  encoding;
+    private String  content;
+    private long    contentSize;
+
+    public ResourceData() {
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public long getContentSize() {
+        return contentSize;
+    }
+
+    public void setContentSize(long contentSize) {
+        this.contentSize = contentSize;
+    }
+}

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/TreeItemData.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/TreeItemData.java
@@ -36,7 +36,6 @@ public final class TreeItemData {
     public static final String NO_COMMAND = new String("<no command>"); // NOI18N
     
     private Image iconImage;
-    private URI iconURI;
     private String[] contextValues;
     private String command;
     private URI resourceURI;
@@ -99,20 +98,9 @@ public final class TreeItemData {
 
     public TreeItemData setIconImage(Image iconImage) {
         this.iconImage = iconImage;
-        this.iconURI = null;
         return this;
     }
 
-    public URI getIconURI() {
-        return iconURI;
-    }
-
-    public TreeItemData setIconURI(URI iconURI) {
-        this.iconURI = iconURI;
-        this.iconImage = null;
-        return this;
-    }
-    
     public TreeItemData merge(TreeItemData data) {
         if (data.getResourceURI() != null) {
             URI u = data.getResourceURI();
@@ -133,10 +121,6 @@ public final class TreeItemData {
         }
         if (data.getIconImage() != null) {
             setIconImage(data.getIconImage());
-        }
-        if (data.getIconURI() != null) {
-            URI u = data.getIconURI();
-            setIconURI(u == NO_URI ? null : u);
         }
         return this;
     }

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/TreeViewService.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/explorer/api/TreeViewService.java
@@ -45,4 +45,7 @@ public interface TreeViewService {
     
     @JsonRequest
     public CompletableFuture<Void> configure(ConfigureExplorerParams params);
+    
+    @JsonRequest("getresource")
+    public CompletableFuture<ResourceData> getResource(GetResourceParams params);
 }

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/explorer/ProjectViewTest.java
@@ -29,13 +29,17 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.ConfigurationParams;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
@@ -55,12 +59,12 @@ import org.netbeans.api.project.FileOwnerQuery;
 import org.netbeans.api.project.Project;
 import org.netbeans.api.project.ui.OpenProjects;
 import org.netbeans.api.sendopts.CommandLine;
-import org.netbeans.api.templates.CreateDescriptor;
 import org.netbeans.api.templates.FileBuilder;
 import org.netbeans.junit.NbTestCase;
 import org.netbeans.modules.java.lsp.server.explorer.api.CreateExplorerParams;
 import org.netbeans.modules.java.lsp.server.explorer.api.NodeChangedParams;
 import org.netbeans.modules.java.lsp.server.explorer.api.NodeOperationParams;
+import org.netbeans.modules.java.lsp.server.protocol.CodeActionsProvider;
 import org.netbeans.modules.java.lsp.server.protocol.DecorationRenderOptions;
 import org.netbeans.modules.java.lsp.server.protocol.HtmlPageParams;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeClientCapabilities;
@@ -72,10 +76,13 @@ import org.netbeans.modules.java.lsp.server.protocol.ShowInputBoxParams;
 import org.netbeans.modules.java.lsp.server.protocol.ShowQuickPickParams;
 import org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams;
 import org.netbeans.modules.java.lsp.server.protocol.TestProgressParams;
+import org.netbeans.modules.parsing.api.ResultIterator;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.filesystems.URLMapper;
 import org.openide.modules.DummyInstalledFileLocator;
+import org.openide.nodes.Node;
+import org.openide.util.Lookup;
 import org.openide.util.Utilities;
 import org.openide.util.test.MockLookup;
 
@@ -94,7 +101,7 @@ public class ProjectViewTest extends NbTestCase {
 
     @Override
     protected void setUp() throws Exception {
-        MockLookup.setLayersAndInstances();
+        MockLookup.setLayersAndInstances(new ServerLookupExtractionCommand());
         System.setProperty("java.awt.headless", Boolean.TRUE.toString());
         super.setUp();
         clearWorkDir();
@@ -328,6 +335,23 @@ public class ProjectViewTest extends NbTestCase {
         return findFirstProjectNode();
     }
     
+    volatile Lookup serverLookup;
+
+    public class ServerLookupExtractionCommand extends CodeActionsProvider {
+
+        @Override
+        public List<CodeAction> getCodeActions(ResultIterator resultIterator, CodeActionParams params) throws Exception {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public Set<String> getCommands() {
+            // this is called during server's initialization.
+            serverLookup = Lookup.getDefault();
+            return Collections.emptySet();
+        }
+    }
+    
     private TreeItem findFirstProjectNode() throws Exception {
         if (client == null) {
             client = new LspClient();
@@ -354,9 +378,30 @@ public class ProjectViewTest extends NbTestCase {
     }
     
     private TreeItem findChild(TreeItem parent, String... labelPath) throws Exception {
+        TreeNodeRegistry reg = serverLookup.lookup(TreeNodeRegistry.class);
         TreeItem item = parent;
         for (String l : labelPath) {
             TreeItem next = findChild(item, l);
+            if (next == null) {
+                Node n = reg.findNode(item.id);
+                Node[] ns = n.getChildren().getNodes(true);
+                StringBuilder sb = new StringBuilder();
+                for (Node a : ns) {
+                    if (sb.length() > 0) {
+                        sb.append(", ");
+                    }
+                    sb.append(a.getDisplayName());
+                }
+                System.out.println("*** Error - node " + l + " does not exist in " + item.label + ", node list: " + sb.toString());
+                sb = new StringBuilder();
+                for (TreeItem candidate : getChildren(parent)) {
+                    if (sb.length() > 0) {
+                        sb.append(", ");
+                    }
+                    sb.append(candidate.label);
+                }
+                System.out.println("TreeItem children: " + sb.toString());
+            }
             assertNotNull("There's no " + l + " in " + item.label, next);
             item = next;
         }

--- a/java/java.lsp.server/vscode/src/protocol.ts
+++ b/java/java.lsp.server/vscode/src/protocol.ts
@@ -161,6 +161,19 @@ export interface ProjectActionParams {
     fallback? : boolean;
 }
 
+export interface GetResourceParams {
+    uri : vscode.Uri;
+    acceptEncoding? : string[];
+    acceptContent? : string[];
+}
+
+export interface ResourceData {
+    contentType : string;
+    encoding : string;
+    content : string;
+    contentSize : number;
+}
+
 export namespace NodeInfoNotification {
     export const type = new ProtocolNotificationType<NodeChangedParams, void>('nodes/nodeChanged');
 }
@@ -171,9 +184,10 @@ export namespace NodeInfoRequest {
     export const children = new ProtocolRequestType<NodeOperationParams, number[], never, void, void>('nodes/children');
     export const destroy = new ProtocolRequestType<NodeOperationParams, boolean, never, void, void>('nodes/delete');
     export const collapsed = new ProtocolNotificationType<NodeOperationParams, void>('nodes/collapsed');
+    export const getresource = new ProtocolRequestType<GetResourceParams, ResourceData, never, void, void>('nodes/getresource');
     
     export interface IconDescriptor {
-        baseUri : string;
+        baseUri : vscode.Uri;
     }
     export interface Data {
         id : number; /* numeric ID of the node */


### PR DESCRIPTION
Originally, the TreeView in (vscode) LSP client fetched node information and it got icon resource bits encoded in data: URI. To make the payload smaller, **both** the LSP client **and** server implemented a cache: server sent only the entire icon data only the 1st time with an unique id, and sent only that id afterwards.

This PR only sends image URI, and lets the client to ask, if necessary, for the resource bits. The client may substitute the images from its local resources and never ask the server.

Icons that provide their resource URLs are served by reading that URL's contents and base64 encoding to the LSP protocol response. Icons without their own URL (typically from L&Fs) are still painted on a virtual surface, converted to PNG. To avoid situation where the client receives an URI, then the LSP server restarts (crashes), and then the client asks again the PNG bits are stored in the `var/cache` folder using name hashed from the contents. So even if the server never generated the icon, it can serve the bits from that cache after restart.

The image content type is taken from URL connection - works OK for gif, png, svg (image/svg+xml MIME type). Works OK in vscode client (URIs like `data:image/svg+xml;base64,.....`). Possibly rebranded images are supported - even a case when a SVG rebrands an original GIF seems to work OK.

There's an additional fix in the vscode client: if a Node disappears after the client receives `children` response with that node's ID and before it asks for node's `info`, the client receives an "invalid node" data (id: -1). This PR prevents the node from entering the child list - and if an already existing tree item is updated, this 'invalid' response results in parent's refresh request.
