### PR TITLE
[#3593] Fix csl elementhandle

### DIFF
--- a/ide/csl.api/src/org/netbeans/modules/csl/navigation/ElementNode.java
+++ b/ide/csl.api/src/org/netbeans/modules/csl/navigation/ElementNode.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import javax.swing.Action;
 import javax.swing.Icon;
@@ -242,7 +243,15 @@ public class ElementNode extends AbstractNode {
             Node[] children = ch.getNodes();
             for (int i = 0; i < children.length; i++) {
                 ElementNode c = (ElementNode) children[i];
-                if (this.getFileObject() != c.getDescription().getElementHandle().getFileObject()) {
+                // The promise of the API is broken at several places in the
+                // codebase and thus this needs to be guarded. The assert is in
+                // place to find the violating places.
+                assert c.getDescription().getElementHandle() != null;
+                @SuppressWarnings("null")
+                FileObject childFileObject = c.getDescription().getElementHandle() != null
+                        ? c.getDescription().getElementHandle().getFileObject()
+                        : null;
+                if (! Objects.equals(this.getFileObject(), childFileObject)) {
                     // e.g. inherited items may be in another file
                     // in such a case, incorrect item is highlighted on the navigator window if the FileObjects are not checked
                     continue;

--- a/ide/css.prep/src/org/netbeans/modules/css/prep/editor/CPCssEditorModule.java
+++ b/ide/css.prep/src/org/netbeans/modules/css/prep/editor/CPCssEditorModule.java
@@ -712,7 +712,7 @@ public class CPCssEditorModule extends CssEditorModule {
         }
 
         if (!vars.isEmpty()) {
-            result.add(new CPCategoryStructureItem.Variables(vars));
+            result.add(new CPCategoryStructureItem.Variables(vars, context));
         }
         if (!mixins.isEmpty()) {
             result.add(new CPCategoryStructureItem.Mixins(mixins, context));


### PR DESCRIPTION
The contract for StructureItem#getElementHandle is not always honored and implementors return `null`.
This causes NullPointer Exceptions in `ElementNode` which relies on it being present.

This changesets adds a guard to prevent invalid implementations to raise exceptions and fixes the CSS
code to provide the required `ElementHandle` implementations.