### PR TITLE
Cleanup warnings related to raw type Iterator..

### DIFF
--- a/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/GUIRegistrationPanel.java
+++ b/apisupport/apisupport.wizards/src/org/netbeans/modules/apisupport/project/ui/wizard/action/GUIRegistrationPanel.java
@@ -297,7 +297,7 @@ final class GUIRegistrationPanel extends BasicWizardIterator.Panel {
                         } else {
                             // create model
                             DefaultComboBoxModel model = new DefaultComboBoxModel();
-                            for (Iterator it = sorted.iterator(); it.hasNext(); ) {
+                            for (Iterator<LayerItemPresenter> it = sorted.iterator(); it.hasNext(); ) {
                                 model.addElement(it.next());
                             }
                             combo.setModel(model);

--- a/enterprise/api.web.webmodule/src/org/netbeans/modules/web/api/webmodule/WebModule.java
+++ b/enterprise/api.web.webmodule/src/org/netbeans/modules/web/api/webmodule/WebModule.java
@@ -105,7 +105,7 @@ public final class WebModule {
      */
     public static WebModule getWebModule (FileObject file) {
         Parameters.notNull("file", file); // NOI18N
-        Iterator it = implementations.allInstances().iterator();
+        Iterator<WebModuleProvider> it = implementations.allInstances().iterator();
         while (it.hasNext()) {
             WebModuleProvider impl = (WebModuleProvider)it.next();
             WebModule wm = impl.findWebModule (file);

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/AppClientProjectProperties.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/ui/customizer/AppClientProjectProperties.java
@@ -601,7 +601,7 @@ final public class AppClientProjectProperties {
         
         // 1. first remove all project references. The method will modify
         // project property files, so it must be done separately
-        for( Iterator it = removed.iterator(); it.hasNext(); ) {
+        for (Iterator<ClassPathSupport.Item> it = removed.iterator(); it.hasNext(); ) {
             ClassPathSupport.Item item = (ClassPathSupport.Item)it.next();
             if ( item.getType() == ClassPathSupport.Item.TYPE_ARTIFACT ||
                     item.getType() == ClassPathSupport.Item.TYPE_JAR ) {
@@ -616,7 +616,7 @@ final public class AppClientProjectProperties {
         EditableProperties ep = updateHelper.getProperties( AntProjectHelper.PROJECT_PROPERTIES_PATH );
         boolean changed = false;
         
-        for( Iterator it = removed.iterator(); it.hasNext(); ) {
+        for (Iterator<ClassPathSupport.Item> it = removed.iterator(); it.hasNext(); ) {
             ClassPathSupport.Item item = (ClassPathSupport.Item)it.next();
             if (item.getType() == ClassPathSupport.Item.TYPE_LIBRARY) {
                 // remove helper property pointing to library jar if there is any

--- a/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/wsclient/AppClientProjectWebServicesClientSupport.java
+++ b/enterprise/j2ee.clientproject/src/org/netbeans/modules/j2ee/clientproject/wsclient/AppClientProjectWebServicesClientSupport.java
@@ -327,7 +327,7 @@ public class AppClientProjectWebServicesClientSupport implements WebServicesClie
             
             if(newWscJars) {
                 StringBuffer newClasspathBuf = new StringBuffer(256);
-                for(Iterator iter = wscJars.iterator(); iter.hasNext(); ) {
+                for(Iterator<String> iter = wscJars.iterator(); iter.hasNext(); ) {
                     newClasspathBuf.append(iter.next().toString());
                     if(iter.hasNext()) {
                         newClasspathBuf.append(':');

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/client/AppClientProxy.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/client/AppClientProxy.java
@@ -60,9 +60,8 @@ public class AppClientProxy implements AppClient {
     
     public void setOriginal(AppClient app) {
         if (this.app != app) {
-            for (Iterator i = listeners.iterator(); i.hasNext();) {
-                java.beans.PropertyChangeListener pcl =
-                        (java.beans.PropertyChangeListener) i.next();
+            for (Iterator<PropertyChangeListener> i = listeners.iterator(); i.hasNext();) {
+                PropertyChangeListener pcl = (PropertyChangeListener) i.next();
                 if (this.app != null) this.app.removePropertyChangeListener(pcl);
                 if (app != null) app.addPropertyChangeListener(pcl);
                 
@@ -84,7 +83,7 @@ public class AppClientProxy implements AppClient {
             java.beans.PropertyChangeEvent evt =
                     new java.beans.PropertyChangeEvent(this, PROPERTY_VERSION, version, value);
             version=value;
-            for (Iterator i = listeners.iterator(); i.hasNext();) {
+            for (Iterator<PropertyChangeListener> i = listeners.iterator(); i.hasNext();) {
                 ((PropertyChangeListener) i.next()).propertyChange(evt);
             }
         }
@@ -189,8 +188,8 @@ public class AppClientProxy implements AppClient {
             java.beans.PropertyChangeEvent evt =
                     new java.beans.PropertyChangeEvent(this, PROPERTY_STATUS, ddStatus, value);
             ddStatus=value;
-            for (Iterator i = listeners.iterator(); i.hasNext();) {
-                ((java.beans.PropertyChangeListener) i.next()).propertyChange(evt);
+            for (Iterator<PropertyChangeListener> i = listeners.iterator(); i.hasNext();) {
+                ((PropertyChangeListener) i.next()).propertyChange(evt);
             }
         }
     }

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/ComponentBeanMultiple.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/ComponentBeanMultiple.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Logger;
 import org.netbeans.modules.schema2beans.Version;
@@ -93,7 +94,7 @@ public abstract class ComponentBeanMultiple extends DescriptionBeanMultiple impl
     public void setAllDisplayNames(Map displayNames) throws VersionNotSupportedException {
         removeAllDisplayNames();
         if (displayNames!=null) {
-            java.util.Iterator entries = displayNames.entrySet().iterator();
+            Iterator<Map.Entry> entries = displayNames.entrySet().iterator();
             int i=0;
             while (entries.hasNext()) {
                 Map.Entry entry = (Map.Entry) entries.next();

--- a/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/DescriptionBeanMultiple.java
+++ b/enterprise/j2ee.dd/src/org/netbeans/modules/j2ee/dd/impl/common/DescriptionBeanMultiple.java
@@ -27,6 +27,7 @@ package org.netbeans.modules.j2ee.dd.impl.common;
 
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Iterator;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -83,7 +84,7 @@ public abstract class DescriptionBeanMultiple extends EnclosingBean implements D
     public void setAllDescriptions(Map descriptions) throws VersionNotSupportedException {
         removeAllDescriptions();
         if (descriptions!=null) {
-            java.util.Iterator keys = descriptions.keySet().iterator();
+            Iterator<String> keys = descriptions.keySet().iterator();
             int i=0;
             while (keys.hasNext()) {
                 String key = (String) keys.next();

--- a/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/xmlutils/XMLJ2eeUtils.java
+++ b/enterprise/j2ee.ddloaders/src/org/netbeans/modules/j2ee/ddloaders/common/xmlutils/XMLJ2eeUtils.java
@@ -301,7 +301,7 @@ public class XMLJ2eeUtils {
        
         //if (elementPath.size()==0) return false;
         if (elementPath==null) return false;
-        Iterator it = elementPath.iterator();
+        Iterator<ElementAttrInfo> it = elementPath.iterator();
         Element element = root;
         String keyAttributeName=null;
         NodeList lastNodeList=null;
@@ -354,7 +354,7 @@ public class XMLJ2eeUtils {
     public static boolean changeAttribute (Element root, List elementPath, String elementName, int index, String attrName, String attrValue)
     throws org.w3c.dom.DOMException {
         if (elementPath.size()==0) return false;
-        Iterator it = elementPath.iterator();
+        Iterator<ElementAttrInfo> it = elementPath.iterator();
         Element element = root;
         //String keyAttributeName=null;
         NodeList lastNodeList=null;
@@ -402,7 +402,7 @@ public class XMLJ2eeUtils {
     public static boolean deleteElement (Element root, List elementPath)
     throws org.w3c.dom.DOMException {
         if (elementPath.size()==0) return false;
-        Iterator it = elementPath.iterator();
+        Iterator<ElementAttrInfo> it = elementPath.iterator();
         Element parent = null;
         Element element = root;
         while (it.hasNext()){
@@ -460,7 +460,7 @@ public class XMLJ2eeUtils {
      * @return true if method was succesful, false otherwise
      */ 
     public static boolean addElement (Element root, List elementPath, String elementName, String keyAttribute, String[] attrNames, String[] attrValues){
-        Iterator it = elementPath.iterator();
+        Iterator<ElementAttrInfo> it = elementPath.iterator();
         Element element = root;
         while (it.hasNext()){
             ElementAttrInfo info = (ElementAttrInfo)it.next();
@@ -553,7 +553,7 @@ public class XMLJ2eeUtils {
      * @return true if method was succesful, false otherwise
      */ 
     public static boolean addStringElement (Element root, List elementPath, String elementName, String elementValue){
-        Iterator it = elementPath.iterator();
+        Iterator<ElementAttrInfo> it = elementPath.iterator();
         Element element = root;
         
         while (it.hasNext()){
@@ -629,7 +629,7 @@ public class XMLJ2eeUtils {
     public static boolean deleteAllElements (Element root, List elementPath, String elementName)
     throws org.w3c.dom.DOMException {
         if (elementPath.size()==0) return false;
-        Iterator it = elementPath.iterator();
+        Iterator<ElementAttrInfo> it = elementPath.iterator();
         Element parent = null;
         Element element = root;
         while (it.hasNext()){

--- a/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/MultiTargetChooserPanel.java
+++ b/enterprise/j2ee.ejbcore/src/org/netbeans/modules/j2ee/ejbcore/ejb/wizard/MultiTargetChooserPanel.java
@@ -200,7 +200,7 @@ public final class MultiTargetChooserPanel implements WizardDescriptor.Panel, Ch
 
     private void fireChange() {
         ChangeEvent e = new ChangeEvent(this);
-        Iterator it = listeners.iterator();
+        Iterator<ChangeListener> it = listeners.iterator();
         while (it.hasNext()) {
             ((ChangeListener)it.next()).stateChanged(e);
         }

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarWebServicesClientSupport.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarWebServicesClientSupport.java
@@ -166,7 +166,7 @@ public class EjbJarWebServicesClientSupport implements WebServicesClientSupportI
             
             if(newWscJars) {
                 StringBuffer newClasspathBuf = new StringBuffer(256);
-                for(Iterator iter = wscJars.iterator(); iter.hasNext(); ) {
+                for(Iterator<String> iter = wscJars.iterator(); iter.hasNext(); ) {
                     newClasspathBuf.append(iter.next().toString());
                     if(iter.hasNext()) {
                         newClasspathBuf.append(":"); // NOI18N

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarWebServicesSupport.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/EjbJarWebServicesSupport.java
@@ -616,7 +616,7 @@ public class EjbJarWebServicesSupport implements WebServicesSupportImpl{
             
             if(newWscJars) {
                 StringBuffer newClasspathBuf = new StringBuffer(256);
-                for(Iterator iter = wscJars.iterator(); iter.hasNext(); ) {
+                for(Iterator<String> iter = wscJars.iterator(); iter.hasNext(); ) {
                     newClasspathBuf.append(iter.next().toString());
                     if(iter.hasNext()) {
                         newClasspathBuf.append(":");

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/Utils.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/Utils.java
@@ -105,7 +105,7 @@ public class Utils {
 
     public static boolean areInSameJ2EEApp(Project p1, Project p2) {
         Set globalPath = GlobalPathRegistry.getDefault().getSourceRoots();
-        Iterator iter = globalPath.iterator();
+        Iterator<FileObject> iter = globalPath.iterator();
         while (iter.hasNext()) {
             FileObject sourceRoot = (FileObject)iter.next();
             Project project = FileOwnerQuery.getOwner(sourceRoot);

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/CustomizerLibraries.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/CustomizerLibraries.java
@@ -231,7 +231,7 @@ public class CustomizerLibraries extends JPanel implements HelpCtx.Provider, Lis
         boolean broken = false;
         
         for( int i = 0; i < models.length; i++ ) {
-            for( Iterator it = ClassPathUiSupport.getIterator( models[i] ); it.hasNext(); ) {
+            for( Iterator<ClassPathSupport.Item> it = ClassPathUiSupport.getIterator( models[i] ); it.hasNext(); ) {
                 if ( ((ClassPathSupport.Item)it.next()).isBroken() ) {
                     broken = true;
                     break;

--- a/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/EjbJarProjectProperties.java
+++ b/enterprise/j2ee.ejbjarproject/src/org/netbeans/modules/j2ee/ejbjarproject/ui/customizer/EjbJarProjectProperties.java
@@ -606,7 +606,7 @@ final public class EjbJarProjectProperties {
         
         // 1. first remove all project references. The method will modify
         // project property files, so it must be done separately
-        for( Iterator it = removed.iterator(); it.hasNext(); ) {
+        for (Iterator<ClassPathSupport.Item> it = removed.iterator(); it.hasNext(); ) {
             ClassPathSupport.Item item = (ClassPathSupport.Item)it.next();
             if ( item.getType() == ClassPathSupport.Item.TYPE_ARTIFACT ||
                     item.getType() == ClassPathSupport.Item.TYPE_JAR ) {
@@ -621,7 +621,7 @@ final public class EjbJarProjectProperties {
         EditableProperties ep = updateHelper.getProperties( AntProjectHelper.PROJECT_PROPERTIES_PATH );
         boolean changed = false;
         
-        for( Iterator it = removed.iterator(); it.hasNext(); ) {
+        for (Iterator<ClassPathSupport.Item> it = removed.iterator(); it.hasNext(); ) {
             ClassPathSupport.Item item = (ClassPathSupport.Item)it.next();
             if (item.getType() == ClassPathSupport.Item.TYPE_LIBRARY) {
                 // remove helper property pointing to library jar if there is any

--- a/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/utils/StringPrefixTree.java
+++ b/enterprise/payara.tooling/src/org/netbeans/modules/payara/tooling/utils/StringPrefixTree.java
@@ -187,7 +187,7 @@ public class StringPrefixTree<Type> {
             sb.append("Value=");
             sb.append(value != null ? value.toString() : "null");
             sb.append(" Transitions=[");
-            for (Iterator i = next.keySet().iterator(); i.hasNext(); ) {
+            for (Iterator<Character> i = next.keySet().iterator(); i.hasNext(); ) {
                 sb.append(i.next());
                 if (i.hasNext()) {
                     sb.append(',');

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebModules.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebModules.java
@@ -150,7 +150,7 @@ public class WebModules implements WebModuleProvider, AntProjectListener, ClassP
             return mods;
         }
         List<Element> webModules = XMLUtil.findSubElements(web);
-        Iterator it = webModules.iterator();
+        Iterator<Element> it = webModules.iterator();
         while (it.hasNext()) {
             Element webModulesEl = (Element)it.next();
             assert webModulesEl.getLocalName().equals("web-module") : webModulesEl;

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebProjectGenerator.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/WebProjectGenerator.java
@@ -196,7 +196,7 @@ public class WebProjectGenerator {
         while (it.hasNext()) {
             Element wmEl = it.next();
             WebModule wm = new WebModule();
-            Iterator it2 = XMLUtil.findSubElements(wmEl).iterator();
+            Iterator<Element> it2 = XMLUtil.findSubElements(wmEl).iterator();
             while (it2.hasNext()) {
                 Element el = (Element)it2.next();
                 if (el.getLocalName().equals("doc-root")) { // NOI18N

--- a/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/NewWebFreeformProjectWizardIterator.java
+++ b/enterprise/web.freeform/src/org/netbeans/modules/web/freeform/ui/NewWebFreeformProjectWizardIterator.java
@@ -108,7 +108,6 @@ public class NewWebFreeformProjectWizardIterator implements WizardDescriptor.Ins
                     if (webModules != null) {
                         // Save the web classpath for the web module
                         String webClasspath = (String)wiz.getProperty(NewWebFreeformProjectWizardIterator.PROP_WEB_CLASSPATH);
-                        Iterator iter = webModules.iterator();
                         for (WebProjectGenerator.WebModule wm : webModules) {
                             wm.classpath = webClasspath;
                         }

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/actions/singlefilerun/JPDAStart.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/actions/singlefilerun/JPDAStart.java
@@ -81,8 +81,7 @@ public class JPDAStart implements Runnable {
             try {
 
                 ListeningConnector lc = null;
-                Iterator i = Bootstrap.virtualMachineManager().
-                        listeningConnectors().iterator();
+                Iterator<ListeningConnector> i = Bootstrap.virtualMachineManager().listeningConnectors().iterator();
                 for (; i.hasNext();) {
                     lc = (ListeningConnector) i.next();
                     Transport t = lc.transport();

--- a/harness/o.n.insane/src/org/netbeans/insane/impl/InsaneEngine.java
+++ b/harness/o.n.insane/src/org/netbeans/insane/impl/InsaneEngine.java
@@ -67,7 +67,7 @@ public final class InsaneEngine {
     
     public void traverse(Collection roots) throws Exception {
         // process all given roots first - remember them and put them into queue
-        for (Iterator it = roots.iterator(); it.hasNext(); ) recognize(it.next());
+        for (Iterator<?> it = roots.iterator(); it.hasNext(); ) recognize(it.next());
         
         while (!queue.isEmpty()) {
             process(queue.get());

--- a/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
+++ b/java/ant.debugger/src/org/netbeans/modules/ant/debugger/AntDebugger.java
@@ -106,7 +106,7 @@ public class AntDebugger extends ActionsProviderSupport {
             (null, DebuggerEngineProvider.class);
                 
         // init actions
-        for (Iterator it = actions.iterator(); it.hasNext(); ) {
+        for (Iterator<Object> it = actions.iterator(); it.hasNext(); ) {
             setEnabled (it.next(), true);
         }
                 

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/PersistenceMetadata.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/dd/PersistenceMetadata.java
@@ -38,10 +38,10 @@ import org.xml.sax.SAXException;
 public final class PersistenceMetadata {
     
     private static final PersistenceMetadata DEFAULT = new PersistenceMetadata();
-    private Map ddMap;
+    private Map<FileObject, Persistence> ddMap;
     
     private PersistenceMetadata() {
-        ddMap = new WeakHashMap(5);
+        ddMap = new WeakHashMap<>(5);
     }
     
     /**

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CCPaintComponent.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/CCPaintComponent.java
@@ -64,7 +64,7 @@ public class CCPaintComponent extends JPanel {
     
     private int ascent;
     
-    private Map widths;
+    private Map<String, Integer> widths;
     
     private FontMetrics fontMetrics;
     

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/JPACodeCompletionProvider.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/editor/completion/JPACodeCompletionProvider.java
@@ -205,7 +205,7 @@ public class JPACodeCompletionProvider implements CompletionProvider {
         private void run(CompilationController controller) {
             if (!hasTask || !isTaskCancelled()){
                 int startOffset = caretOffset;
-                Iterator resolversItr = resolvers.iterator();
+                Iterator<CompletionContextResolver> resolversItr = resolvers.iterator();
                 TreePath env = null;
                 try {
                     env = getCompletionTreePath(controller, caretOffset, CompletionProvider.COMPLETION_QUERY_TYPE);

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/CMPMappingModel.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/CMPMappingModel.java
@@ -178,7 +178,7 @@ public class CMPMappingModel {
             return false;
         }
         
-        Iterator keyIt = cmrFieldMapping.keySet().iterator();
+        Iterator<String> keyIt = cmrFieldMapping.keySet().iterator();
         while (keyIt.hasNext()) {
             String key = (String) keyIt.next();
             ColumnData[] value = (ColumnData[]) cmrFieldMapping.get(key);

--- a/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEjbGenerator.java
+++ b/java/j2ee.persistence/src/org/netbeans/modules/j2ee/persistence/entitygenerator/DbSchemaEjbGenerator.java
@@ -49,7 +49,7 @@ import org.netbeans.modules.j2ee.persistence.entitygenerator.EntityRelation.Coll
 public class DbSchemaEjbGenerator {
     
     private GeneratedTables genTables;
-    private Map beans = new HashMap();
+    private Map<String, EntityClass> beans = new HashMap<>();
     private List<EntityRelation> relations = new ArrayList<>();
     private SchemaElement schemaElement;
     private Set<String> tablesReferecedByOtherTables;
@@ -551,8 +551,8 @@ public class DbSchemaEjbGenerator {
     private void buildCMPSet() {
         reset();
         addAllTables();
-        for (Iterator it = beans.keySet().iterator(); it.hasNext();) {
-            String tableName = it.next().toString();
+        for (Iterator<String> it = beans.keySet().iterator(); it.hasNext();) {
+            String tableName = it.next();
             TableElement table = schemaElement.getTable(DBIdentifier.create(tableName));
             ColumnElement[] cols = table.getColumns();
             UniqueKeyElement pk = getPrimaryOrCandidateKey(table);
@@ -584,11 +584,11 @@ public class DbSchemaEjbGenerator {
     
     private List getFieldNames(EntityClass bean) {
         List<String> result = new ArrayList<>();
-        for (Iterator i = bean.getFields().iterator(); i.hasNext();) {
+        for (Iterator<EntityMember> i = bean.getFields().iterator(); i.hasNext();) {
             EntityMember member = (EntityMember)i.next();
             result.add(member.getMemberName());
         }
-        for (Iterator i = bean.getRoles().iterator(); i.hasNext();) {
+        for (Iterator<RelationshipRole> i = bean.getRoles().iterator(); i.hasNext();) {
             RelationshipRole role = (RelationshipRole)i.next();
             result.add(role.getFieldName());
         }

--- a/java/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/LocationAwareMavenXpp3Writer.java
+++ b/java/maven.grammar/src/org/netbeans/modules/maven/grammar/effpom/LocationAwareMavenXpp3Writer.java
@@ -458,7 +458,7 @@ public class LocationAwareMavenXpp3Writer {
             flush(serializer);
             int start2 = b.length();
             InputLocationTracker propTracker = contributor.getLocation("properties");
-            for (Iterator iter = contributor.getProperties().keySet().iterator(); iter.hasNext();) {
+            for (Iterator<?> iter = contributor.getProperties().keySet().iterator(); iter.hasNext();) {
                 String key = (String) iter.next();
                 String value = (String) contributor.getProperties().get(key);
                 writeValue(serializer, key, value, propTracker);
@@ -603,7 +603,7 @@ public class LocationAwareMavenXpp3Writer {
             flush(serializer);
             int start2 = b.length();
             InputLocationTracker propTracker = developer.getLocation("properties");
-            for (Iterator iter = developer.getProperties().keySet().iterator(); iter.hasNext();) {
+            for (Iterator<?> iter = developer.getProperties().keySet().iterator(); iter.hasNext();) {
                 String key = (String)iter.next();
                 String value = (String) developer.getProperties().get(key);
                 writeValue(serializer, key, value, propTracker);
@@ -862,7 +862,7 @@ public class LocationAwareMavenXpp3Writer {
             flush(serializer);
             int start2 = b.length();
             InputLocation tracker = model.getLocation("properties");
-            for (Iterator iter = model.getProperties().keySet().iterator(); iter.hasNext();) {
+            for (Iterator<?> iter = model.getProperties().keySet().iterator(); iter.hasNext();) {
                 String key = (String) iter.next();
                 String value = (String) model.getProperties().get(key);
                 writeValue(serializer, key, value, tracker);
@@ -943,7 +943,7 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((notifier.getConfiguration() != null) && (notifier.getConfiguration().size() > 0)) {
             serializer.startTag(NAMESPACE, "configuration");
-            for (Iterator iter = notifier.getConfiguration().keySet().iterator(); iter.hasNext();) {
+            for (Iterator<Object> iter = notifier.getConfiguration().keySet().iterator(); iter.hasNext();) {
                 String key = (String) iter.next();
                 String value = (String) notifier.getConfiguration().get(key);
                 serializer.startTag(NAMESPACE, "" + key + "").text(value).endTag(NAMESPACE, "" + key + "");
@@ -1020,7 +1020,7 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((plugin.getDependencies() != null) && (plugin.getDependencies().size() > 0)) {
             serializer.startTag(NAMESPACE, "dependencies");
-            for (Iterator iter = plugin.getDependencies().iterator(); iter.hasNext();) {
+            for (Iterator<Dependency> iter = plugin.getDependencies().iterator(); iter.hasNext();) {
                 Dependency o = (Dependency) iter.next();
                 writeDependency(o, "dependency", serializer);
             }
@@ -1084,7 +1084,7 @@ public class LocationAwareMavenXpp3Writer {
         int start = b.length();
         if ((pluginManagement.getPlugins() != null) && (pluginManagement.getPlugins().size() > 0)) {
             serializer.startTag(NAMESPACE, "plugins");
-            for (Iterator iter = pluginManagement.getPlugins().iterator(); iter.hasNext();) {
+            for (Iterator<Plugin> iter = pluginManagement.getPlugins().iterator(); iter.hasNext();) {
                 Plugin o = (Plugin) iter.next();
                 writePlugin(o, "plugin", serializer);
             }
@@ -1128,7 +1128,7 @@ public class LocationAwareMavenXpp3Writer {
             int start2 = b.length();
             int index = 0;
             InputLocation tracker = profile.getLocation("modules");
-            for (Iterator iter = profile.getModules().iterator(); iter.hasNext();) {
+            for (Iterator<String> iter = profile.getModules().iterator(); iter.hasNext();) {
                 String module = (String) iter.next();
                 writeValue(serializer, "module", module, tracker, index);
                 index = index + 1;
@@ -1144,7 +1144,7 @@ public class LocationAwareMavenXpp3Writer {
             flush(serializer);
             int start2 = b.length();
             InputLocation tracker = profile.getLocation("properties");
-            for (Iterator iter = profile.getProperties().keySet().iterator(); iter.hasNext();) {
+            for (Iterator<?> iter = profile.getProperties().keySet().iterator(); iter.hasNext();) {
                 String key = (String) iter.next();
                 String value = (String) profile.getProperties().get(key);
                 writeValue(serializer, key, value, tracker);
@@ -1173,7 +1173,7 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((profile.getPluginRepositories() != null) && (profile.getPluginRepositories().size() > 0)) {
             serializer.startTag(NAMESPACE, "pluginRepositories");
-            for (Iterator iter = profile.getPluginRepositories().iterator(); iter.hasNext();) {
+            for (Iterator<Repository> iter = profile.getPluginRepositories().iterator(); iter.hasNext();) {
                 Repository o = (Repository) iter.next();
                 writeRepository(o, "pluginRepository", serializer);
             }
@@ -1228,7 +1228,7 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((reportPlugin.getReportSets() != null) && (reportPlugin.getReportSets().size() > 0)) {
             serializer.startTag(NAMESPACE, "reportSets");
-            for (Iterator iter = reportPlugin.getReportSets().iterator(); iter.hasNext();) {
+            for (Iterator<ReportSet> iter = reportPlugin.getReportSets().iterator(); iter.hasNext();) {
                 ReportSet o = (ReportSet) iter.next();
                 writeReportSet(o, "reportSet", serializer);
             }
@@ -1259,7 +1259,7 @@ public class LocationAwareMavenXpp3Writer {
             int start2 = b.length();
             InputLocation tracker = reportSet.getLocation("reports");
             int index = 0;
-            for (Iterator iter = reportSet.getReports().iterator(); iter.hasNext();) {
+            for (Iterator<String> iter = reportSet.getReports().iterator(); iter.hasNext();) {
                 String report = (String) iter.next();
                 writeValue(serializer, "report", report, tracker, index);
                 index = index + 1;
@@ -1291,7 +1291,7 @@ public class LocationAwareMavenXpp3Writer {
         }
         if ((reporting.getPlugins() != null) && (reporting.getPlugins().size() > 0)) {
             serializer.startTag(NAMESPACE, "plugins");
-            for (Iterator iter = reporting.getPlugins().iterator(); iter.hasNext();) {
+            for (Iterator<ReportPlugin> iter = reporting.getPlugins().iterator(); iter.hasNext();) {
                 ReportPlugin o = (ReportPlugin) iter.next();
                 writeReportPlugin(o, "plugin", serializer);
             }
@@ -1369,7 +1369,7 @@ public class LocationAwareMavenXpp3Writer {
             int start2 = b.length();
             InputLocation inclTracker = resource.getLocation("includes");
             int index = 0;
-            for (Iterator iter = resource.getIncludes().iterator(); iter.hasNext();) {
+            for (Iterator<String> iter = resource.getIncludes().iterator(); iter.hasNext();) {
                 String include = (String) iter.next();
                 writeValue(serializer, "include", include, inclTracker, index);
                 index = index + 1;
@@ -1383,7 +1383,7 @@ public class LocationAwareMavenXpp3Writer {
             int start2 = b.length();
             InputLocation inclTracker = resource.getLocation("excludes");
             int index = 0;
-            for (Iterator iter = resource.getExcludes().iterator(); iter.hasNext();) {
+            for (Iterator<String> iter = resource.getExcludes().iterator(); iter.hasNext();) {
                 String exclude = (String) iter.next();
                 writeValue(serializer, "exclude", exclude, inclTracker, index);
                 index = index + 1;

--- a/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
+++ b/java/websvc.saas.codegen.java/src/org/netbeans/modules/websvc/saas/codegen/java/support/SourceGroupSupport.java
@@ -181,7 +181,7 @@ public class SourceGroupSupport {
         return testGroups;
     }
 
-    private static List<SourceGroup> getTestTargets(SourceGroup sourceGroup, Map foldersToSourceGroupsMap) {
+    private static List<SourceGroup> getTestTargets(SourceGroup sourceGroup, Map<FileObject, SourceGroup> foldersToSourceGroupsMap) {
         final URL[] rootURLs = UnitTestForSourceQuery.findUnitTests(sourceGroup.getRootFolder());
         if (rootURLs.length == 0) {
             return new ArrayList<>();

--- a/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewTopComponentLookup.java
+++ b/platform/core.multiview/src/org/netbeans/core/multiview/MultiViewTopComponentLookup.java
@@ -110,7 +110,7 @@ class MultiViewTopComponentLookup extends Lookup {
         public Collection allItems() {
             // remove duplicates..
             Set<Lookup.Item> s = new HashSet<>(delegate.allItems());
-            Iterator it = s.iterator();
+            Iterator<Lookup.Item> it = s.iterator();
             Set instances = new HashSet<>();
             while (it.hasNext()) {
                 Lookup.Item i = (Lookup.Item)it.next();

--- a/platform/openide.util/src/org/openide/util/TopologicalSortException.java
+++ b/platform/openide.util/src/org/openide/util/TopologicalSortException.java
@@ -36,7 +36,7 @@ public final class TopologicalSortException extends Exception {
     private Collection vertexes;
 
     /** map with edges */
-    private Map<?,? extends Collection<?>> edges;
+    private Map<?, ? extends Collection<?>> edges;
 
     /** result if called twice */
     private Set[] result;
@@ -180,7 +180,7 @@ public final class TopologicalSortException extends Exception {
         // computes value X and Y for each vertex
         counter = 0;
 
-        Iterator it = vertexes.iterator();
+        Iterator<?> it = vertexes.iterator();
 
         while (it.hasNext()) {
             constructDualGraph(counter, it.next(), vertexInfo);
@@ -239,7 +239,7 @@ public final class TopologicalSortException extends Exception {
             Collection<Set> setsTo = edgesBetweenSets.get(from);
 
             if (setsTo == null) {
-                setsTo = new ArrayList<Set>();
+                setsTo = new ArrayList<>();
                 edgesBetweenSets.put(from, setsTo);
             }
 
@@ -286,7 +286,7 @@ public final class TopologicalSortException extends Exception {
         Collection c = (Collection) edges.get(vertex);
 
         if (c != null) {
-            Iterator it = c.iterator();
+            Iterator<?> it = c.iterator();
 
             while (it.hasNext()) {
                 Vertex next = constructDualGraph(counter, it.next(), vertexInfo);


### PR DESCRIPTION
Remove warnings related to raw type Iterator

```
[repeat] /home/bwalker/src/netbeans/ide/jellytools.ide/src/org/netbeans/jellytools/EditorOperator.java:687: warning:
      [rawtypes] found raw type: Iterator [repeat] Iterator annotations = (Iterator) getAnnotationsMethod.invoke(lineAnnotations,
      (Object[]) null); [repeat] ^ [repeat] missing type arguments for generic class Iterator<E> [repeat] where E is a type-variable:
      [repeat] E extends Object declared in interface Iterator

```




---
**^Add meaningful description above**

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

