### PR TITLE
Support CompletableFuture in DialogDisplayer

### DIFF
--- a/java/java.lsp.server/nbcode/integration/nbproject/project.xml
+++ b/java/java.lsp.server/nbcode/integration/nbproject/project.xml
@@ -104,7 +104,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.52</specification-version>
+                        <specification-version>7.60</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -545,7 +545,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.60</specification-version>
+                        <specification-version>7.61</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayer.java
@@ -20,6 +20,7 @@ package org.netbeans.modules.java.lsp.server.ui;
 
 import java.awt.Dialog;
 import java.awt.HeadlessException;
+import java.util.concurrent.CompletableFuture;
 import org.netbeans.modules.java.lsp.server.LspServerUtils;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
@@ -61,6 +62,16 @@ public class AbstractDialogDisplayer extends DialogDisplayer {
         adapter.clientNotifyLater();
     }
 
+    @Override
+    public <T extends NotifyDescriptor> CompletableFuture<T> notifyFuture(T descriptor) {
+        UIContext ctx = context.lookup(UIContext.class);
+        if (ctx == null) {
+            ctx = UIContext.find();
+        }
+        NotifyDescriptorAdapter adapter = new NotifyDescriptorAdapter(descriptor, ctx);
+        return adapter.clientNotifyCompletion();
+    }
+    
     @Override
     public Dialog createDialog(DialogDescriptor descriptor) {
         throw new HeadlessException();

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/ui/NotifyDescriptorAdapter.java
@@ -29,7 +29,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -277,6 +279,44 @@ class NotifyDescriptorAdapter {
     }
     
     public CompletableFuture<Object> clientNotifyLater() {
+        return clientNotifyCompletion().thenApply(d -> d.getValue()).exceptionally(t -> {
+            if (t instanceof CompletionException) {
+                t = t.getCause();
+            }
+            if (!(t instanceof CancellationException)) {
+                LOG.log(Level.WARNING, "Exception occurred for {0}", descriptor);
+                LOG.log(Level.WARNING, "Exception stacktrace", t);
+            }
+            return null;
+        });
+    }
+    
+    class Ctrl<T> extends CompletableFuture<T> {
+        private final CompletableFuture clientFuture;
+
+        public Ctrl(CompletableFuture clientFuture) {
+            this.clientFuture = clientFuture;
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            // this is not exactly well synchronized, but with no synchronization in 
+            // NotifyDescriptor the value cannot be set really atomically, but the dependents
+            // will be released during super.cancel() call.
+            boolean b = !isDone();
+            if (b) {
+                Object v = descriptor.getValue();
+                if (!(v == NotifyDescriptor.CANCEL_OPTION || v == NotifyDescriptor.CLOSED_OPTION)) {
+                    descriptor.setValue(NotifyDescriptor.CANCEL_OPTION);
+                }
+                b &= clientFuture.cancel(mayInterruptIfRunning);
+            }
+            return super.cancel(mayInterruptIfRunning) || b;
+        }
+    }
+    
+    public <T extends NotifyDescriptor> CompletableFuture<T> clientNotifyCompletion() {
+        // wrapper that allows to externally control the client's Future
         if (descriptor instanceof NotifyDescriptor.InputLine) {
             NotifyDescriptor.InputLine inp = (NotifyDescriptor.InputLine) descriptor;
             ShowInputBoxParams params = new ShowInputBoxParams();
@@ -284,13 +324,24 @@ class NotifyDescriptorAdapter {
             params.setValue(inp.getInputText());
             params.setPassword(descriptor instanceof NotifyDescriptor.PasswordLine);
             CompletableFuture<String> newText = client.showInputBox(params);
-            return newText.thenApply((item) -> {
+            Ctrl<T> ctrl = new Ctrl<>(newText);
+            newText.thenAccept((item) -> {
                 if (item == null) {
-                    return NotifyDescriptor.CLOSED_OPTION;
+                    descriptor.setValue(NotifyDescriptor.CLOSED_OPTION);
+                    ctrl.completeExceptionally(new CancellationException());
+                } else {
+                    inp.setInputText(item);
+                    descriptor.setValue(NotifyDescriptor.OK_OPTION);
+                    ctrl.complete((T)descriptor);
                 }
-                inp.setInputText(item);
-                return NotifyDescriptor.OK_OPTION;
+            }).exceptionally(t -> {
+                if (t instanceof CompletionException) {
+                    t = t.getCause();
+                }
+                ctrl.completeExceptionally(t);
+                return null;
             });
+            return ctrl;
         } else if (descriptor instanceof NotifyDescriptor.QuickPick) {
             NotifyDescriptor.QuickPick qp = (NotifyDescriptor.QuickPick) descriptor;
             Map<QuickPickItem, NotifyDescriptor.QuickPick.Item> items = new HashMap<>();
@@ -298,24 +349,53 @@ class NotifyDescriptorAdapter {
                 items.put(new QuickPickItem(item.getLabel(), item.getDescription(), null, item.isSelected(), null), item);
             }
             ShowQuickPickParams params = new ShowQuickPickParams(qp.getTitle(), qp.isMultipleSelection(), new ArrayList<>(items.keySet()));
-            return client.showQuickPick(params).thenApply(selected -> {
+            CompletableFuture<List<QuickPickItem>> qpF = client.showQuickPick(params);
+            Ctrl<T> ctrl = new Ctrl<>(qpF);
+            qpF.thenAccept(selected -> {
                 if (selected == null) {
-                    return NotifyDescriptor.CLOSED_OPTION;
+                    descriptor.setValue(NotifyDescriptor.CLOSED_OPTION);
+                    ctrl.completeExceptionally(new CancellationException());
+                } else {
+                    for (Map.Entry<QuickPickItem, NotifyDescriptor.QuickPick.Item> entry : items.entrySet()) {
+                        entry.getValue().setSelected(selected.contains(entry.getKey()));
+                    }
+                    descriptor.setValue(NotifyDescriptor.OK_OPTION);
+                    ctrl.complete((T)descriptor);
                 }
-                for (Map.Entry<QuickPickItem, NotifyDescriptor.QuickPick.Item> entry : items.entrySet()) {
-                    entry.getValue().setSelected(selected.contains(entry.getKey()));
+            }).exceptionally(t -> {
+                if (t instanceof CompletionException) {
+                    t = t.getCause();
                 }
-                return NotifyDescriptor.OK_OPTION;
+                ctrl.completeExceptionally(t);
+                return null;
             });
+            return ctrl;
         } else {
             ShowMessageRequestParams params = createShowMessageRequest();
             if (params == null) {
-                CompletableFuture<Object> x = new CompletableFuture<>();
-                x.complete(NotifyDescriptor.CLOSED_OPTION);
+                descriptor.setValue(NotifyDescriptor.CLOSED_OPTION);
+                CompletableFuture<T> x = new CompletableFuture<>();
+                x.complete((T)descriptor);
                 return x;
             }
             CompletableFuture<MessageActionItem> resultItem =  client.showMessageRequest(request);
-            return resultItem /*.exceptionally(this::handleClientException) */.thenApply(this::processActivatedOption);
+            Ctrl<T> ctrl = new Ctrl<>(resultItem);
+            resultItem /*.exceptionally(this::handleClientException) */.thenApply(this::processActivatedOption).thenAccept(o -> {
+                descriptor.setValue(o);
+                if (o == NotifyDescriptor.CLOSED_OPTION || o == NotifyDescriptor.CANCEL_OPTION) {
+                    ctrl.completeExceptionally(new CancellationException());
+                } else {
+                    ctrl.complete((T)descriptor);
+                }
+            }).exceptionally(t -> {
+                // JDK-8233050: this exceptionally is chained after .thenApply, it will receive earlier exceptions wrapped:
+                if (t instanceof CompletionException) {
+                    t = ((CompletionException)t).getCause();
+                }
+                ctrl.completeExceptionally(t);
+                return null;
+            });
+            return ctrl;
         }
     }
     

--- a/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayerTest.java
+++ b/java/java.lsp.server/test/unit/src/org/netbeans/modules/java/lsp/server/ui/AbstractDialogDisplayerTest.java
@@ -22,7 +22,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.swing.JPanel;
 import static junit.framework.TestCase.fail;
 import org.eclipse.lsp4j.MessageActionItem;
@@ -30,13 +37,13 @@ import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.netbeans.junit.NbTestCase;
-import org.netbeans.modules.java.lsp.server.protocol.HtmlPageParams;
 import org.netbeans.modules.java.lsp.server.protocol.QuickPickItem;
 import org.netbeans.modules.java.lsp.server.protocol.ShowInputBoxParams;
 import org.netbeans.modules.java.lsp.server.protocol.ShowQuickPickParams;
 import org.netbeans.modules.java.lsp.server.protocol.ShowStatusMessageParams;
 import org.openide.NotifyDescriptor;
 import org.openide.awt.StatusDisplayer;
+import org.openide.util.RequestProcessor;
 
 /**
  *
@@ -168,5 +175,154 @@ public class AbstractDialogDisplayerTest extends NbTestCase {
                 null, null);
         NotifyDescriptorAdapter adapter = new NotifyDescriptorAdapter(nd, cl);
         assertEquals(NotifyDescriptor.YES_OPTION, adapter.clientNotify());
+    }
+    
+    /**
+     * Checks that notifyFuture completes on user's input
+     */
+    public void testQuestionWaitedAndCompleted() throws Exception {
+        CountDownLatch releaseAnswer = new CountDownLatch(1);
+        
+        MockUIContext cl = new MockUIContext() { 
+            public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+                return CompletableFuture.supplyAsync(() -> {
+                    try {
+                        releaseAnswer.await();
+                    } catch (InterruptedException ex) {
+                        fail("Unexpected interrupt");
+                    }
+                    return requestParams.getActions().get(0);
+                }, RequestProcessor.getDefault());
+            }
+        };
+        NotifyDescriptor nd = new NotifyDescriptor("Hello, LSP client", "Unused", 
+                NotifyDescriptor.OK_CANCEL_OPTION, 
+                NotifyDescriptor.QUESTION_MESSAGE,
+                null, null);
+        NotifyDescriptorAdapter adapter = new NotifyDescriptorAdapter(nd, cl);
+        
+        CompletableFuture<NotifyDescriptor> cf = adapter.clientNotifyCompletion();
+        try {
+            cf.get(5, TimeUnit.SECONDS);
+            fail("Should time out");
+        } catch (TimeoutException ex) {
+            // OK
+        }
+        releaseAnswer.countDown();
+        assertSame(nd, cf.get());
+        assertEquals(NotifyDescriptor.OK_OPTION, nd.getValue());
+    }
+    
+    CountDownLatch releaseAnswer = new CountDownLatch(1);
+    AtomicBoolean clientCancelled = new AtomicBoolean();
+    volatile Object expectedAnswer;
+
+    class ResponseUIContext extends MockUIContext {
+        public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+            CompletableFuture<MessageActionItem> wrapper = new CompletableFuture<MessageActionItem>() {
+                @Override
+                public boolean cancel(boolean mayInterruptIfRunning) {
+                    clientCancelled.set(true);
+                    return super.cancel(mayInterruptIfRunning);
+                }
+            };
+            CompletableFuture.supplyAsync(() -> {
+                try {
+                    releaseAnswer.await();
+                } catch (InterruptedException ex) {
+                    fail("Unexpected interrupt");
+                }
+                MessageActionItem res = 
+                        requestParams.getActions().stream().filter(a -> a.getTitle().equals(expectedAnswer)).findAny().orElse(requestParams.getActions().get(0));
+                return res;
+            }, RequestProcessor.getDefault()).thenApply((a) -> {
+                wrapper.complete(a);
+                return null;
+            }).exceptionally(t -> {
+                // JDK-8233050: this exceptionally is chained after .thenApply, it will receive earlier exceptions wrapped:                    
+                if (t instanceof CompletionException) {
+                    t = t.getCause();
+                }
+                wrapper.completeExceptionally(t);
+                return null;
+            });
+            return wrapper;
+        }
+    }
+    
+    public void testForceCancelPendingQuestion() throws Exception {
+        MockUIContext cl = new ResponseUIContext();
+        NotifyDescriptor nd = new NotifyDescriptor("Hello, LSP client", "Unused", 
+                NotifyDescriptor.OK_CANCEL_OPTION, 
+                NotifyDescriptor.QUESTION_MESSAGE,
+                null, null);
+        NotifyDescriptorAdapter adapter = new NotifyDescriptorAdapter(nd, cl);
+        
+        CompletableFuture<NotifyDescriptor> cf = adapter.clientNotifyCompletion();
+        CompletableFuture<NotifyDescriptor> dep = cf.thenApply(n -> n);
+        try {
+            cf.get(5, TimeUnit.SECONDS);
+            fail("Should time out");
+        } catch (TimeoutException ex) {
+            // OK
+        }
+        
+        assertTrue(cf.cancel(true));
+        // now cancel the future:
+        
+        try {
+            cf.get();
+            fail("Exception expected");
+        } catch (CancellationException ex) {
+            // exepcted, this Future was cancelled
+        }
+        try {
+            dep.get();
+            fail("Exception expected");
+        } catch (ExecutionException ex) {
+            // expected, bcs some previous stage has thrown exception
+            assertTrue(ex.getCause() instanceof CancellationException);
+        }
+        
+        assertEquals(NotifyDescriptor.CANCEL_OPTION, nd.getValue());
+    }
+    
+    /**
+     * Checks that user cancel will complete the future exceptionally.
+     */
+    public void testUserCancelPendingQuestion() throws Exception {
+        MockUIContext cl = new ResponseUIContext();
+        NotifyDescriptor nd = new NotifyDescriptor("Hello, LSP client", "Unused", 
+                NotifyDescriptor.OK_CANCEL_OPTION, 
+                NotifyDescriptor.QUESTION_MESSAGE,
+                null, null);
+        NotifyDescriptorAdapter adapter = new NotifyDescriptorAdapter(nd, cl);
+        
+        CompletableFuture<NotifyDescriptor> cf = adapter.clientNotifyCompletion();
+        CompletableFuture<NotifyDescriptor> dep = cf.thenApply(n -> n);
+        try {
+            cf.get(5, TimeUnit.SECONDS);
+            fail("Should time out");
+        } catch (TimeoutException ex) {
+            // OK
+        }
+        expectedAnswer = "Cancel";
+        releaseAnswer.countDown();
+        
+        try {
+            Object o = cf.get();
+            fail("Exception expected");
+        } catch (CancellationException ex) {
+            // exepcted, this Future was cancelled
+        }
+        try {
+            dep.get();
+            fail("Exception expected");
+        } catch (ExecutionException ex) {
+            // expected, bcs some previous stage has thrown exception
+            assertTrue(ex.getCause() instanceof CancellationException);
+        }
+        
+        assertEquals(NotifyDescriptor.CANCEL_OPTION, nd.getValue());
     }
 }

--- a/platform/core.windows/nbproject/project.xml
+++ b/platform/core.windows/nbproject/project.xml
@@ -85,7 +85,7 @@
                     <build-prerequisite/>
                     <compile-dependency/>
                     <run-dependency>
-                        <specification-version>7.10</specification-version>
+                        <specification-version>7.61</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/platform/openide.dialogs/apichanges.xml
+++ b/platform/openide.dialogs/apichanges.xml
@@ -27,6 +27,20 @@
 </apidefs>
 <changes>
     <change>
+         <summary>Support for CompletableFutures in Dialog API</summary>
+         <version major="7" minor="61"/>
+         <date day="14" month="2" year="2022"/>
+         <author login="sdedic"/>
+         <compatibility addition="yes" binary="compatible" source="compatible" semantic="compatible" deprecation="no" deletion="no" modification="no"/>
+         <description>
+             <p>
+                 <a href="@TOP@/org/openide/DialogDisplayer.html#notifyFuture-T-">DialogDisplayer.notifyFuture</a> now allows to chain processing after user closes the 
+                 dialog without blocking a thread as with <a href="@TOP@/org/openide/DialogDisplayer.html#notify-org.openide.NotifyDescriptor-">DialogDisplayer.notify</a>.
+             </p>
+         </description>
+         <class package="org.openide" name="DialogDisplayer"/>
+    </change>
+    <change>
          <api name="dialogs"/>
          <summary>NotifyDescriptor.QuickPick added</summary>
          <version major="7" minor="60"/>

--- a/platform/openide.dialogs/manifest.mf
+++ b/platform/openide.dialogs/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 OpenIDE-Module: org.openide.dialogs
-OpenIDE-Module-Specification-Version: 7.60
+OpenIDE-Module-Specification-Version: 7.61
 OpenIDE-Module-Localizing-Bundle: org/openide/Bundle.properties
 AutoUpdate-Essential-Module: true
 

--- a/platform/openide.dialogs/nbproject/project.properties
+++ b/platform/openide.dialogs/nbproject/project.properties
@@ -17,7 +17,7 @@
 
 is.autoload=true
 javac.compilerargs=-Xlint:unchecked
-javac.source=1.6
+javac.source=1.8
 #javadoc.main.page=org/openide/doc-files/api.html
 javadoc.arch=${basedir}/arch.xml
 javadoc.apichanges=${basedir}/apichanges.xml

--- a/platform/openide.dialogs/test/unit/src/org/openide/DialogDisplayerTest.java
+++ b/platform/openide.dialogs/test/unit/src/org/openide/DialogDisplayerTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.openide;
+
+import java.awt.Dialog;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.netbeans.junit.MockServices;
+import org.netbeans.junit.NbTestCase;
+
+/**
+ *
+ * @author sdedic
+ */
+public class DialogDisplayerTest extends NbTestCase {
+
+    public DialogDisplayerTest(String name) {
+        super(name);
+    }
+    
+    public static class TestDisplayer extends DialogDisplayer {
+        private final List<String> inputs = new ArrayList<>();
+
+        @Override
+        public Object notify(NotifyDescriptor descriptor) {
+            if (!(descriptor instanceof NotifyDescriptor.InputLine)) {
+                throw new UnsupportedOperationException();
+            }
+            NotifyDescriptor.InputLine il = (NotifyDescriptor.InputLine)descriptor;
+            il.setInputText(inputs.remove(0));
+            il.setValue(NotifyDescriptor.OK_OPTION);
+            return NotifyDescriptor.OK_OPTION;
+        }
+
+        @Override
+        public Dialog createDialog(DialogDescriptor descriptor) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        MockServices.setServices();
+        super.tearDown(); 
+    }
+    
+    
+    
+    public void testExampleHandlingWithCancel() throws Exception {
+        class UserData {
+            String answer1;
+            String answer2;
+        }
+        MockServices.setServices(TestDisplayer.class);
+        
+        TestDisplayer td = (TestDisplayer)DialogDisplayer.getDefault();
+        td.inputs.add("Answer One");
+        td.inputs.add("Answer Two");
+
+        // BEGIN:dialogdisplayer-notifyFuture
+        NotifyDescriptor.InputLine nd = new NotifyDescriptor.InputLine("Question", "Title");
+        
+        CompletableFuture<UserData> resultFuture = DialogDisplayer.getDefault().notifyFuture(nd).
+                // compose with processing after dialog confirmation
+                thenCompose(d -> {
+                    UserData userData = new UserData();
+                    // this code will NOT execute, if user cancels "Question" dialog. Neither will execute subsequent steps.
+                    userData.answer1 = d.getInputText();
+                    // do something with user input and display another question
+                    NotifyDescriptor.InputLine nd2 = new NotifyDescriptor.InputLine("Question2", "Title");
+
+                    return DialogDisplayer.getDefault().notifyFuture(nd).
+                        thenApply(x -> {
+                        // pass userData to the next step. 
+                        // This code will NOT execute if the Question2 dialog is cancelled.
+                        userData.answer2 = x.getInputText();
+                        return userData;
+                    });
+                }).thenApply((data) -> {
+                    // This code will not execute if Question or Question2 is cancelled.
+                    // do some finalization steps. 
+                    return data;
+                }).exceptionally(ex -> {
+                    // JDK-8233050: JDK reports direct exception from the immediate stage, but wrapped one from earlier stages.
+                    if (ex instanceof CompletionException) {
+                        ex = ex.getCause();
+                    }
+                    // reached if Question, Question2 is cancelled or if some error occurs.
+                    if (!(ex instanceof CancellationException)) {
+                        // do error handling
+                    }
+                    return null;
+                });
+        // END:dialogdisplayer-notifyFuture
+        UserData d = resultFuture.get();
+        assertNotNull(d);
+    }
+
+}


### PR DESCRIPTION
`DialogDisplayer` API allows to wait for dialog's close when using `notify` method but that wasted a thread to wait for the `notify` method to return. And all the goodies that `CompletableFuture` API can't be used, while this is a perfect example of a Future.

So this PR adds 
```
public <T extends NotifyDescriptor> CompletableFuture<T> notifyCompletion(final T descriptor) {
```
that runs similar to `notifyLater`, but returns a Future that the continuation can chain after. There are important differences, hopefully described in the javadoc:
- the value is the `NotifyDescriptor` subclass itself. This is because for example `NotifyDescriptor.InputLine` has additional getters that are typically processed in the completion handler. This allows to pass NotifyDescriptors from one step to another wihtout a need for a variable in a upper scope or member variable that can be accessed from another closure.
- if the UI is cancelled / closed, this future **completes exceptionally** with a `CancellationException` (as if it was `Future.cancel()`ed). This allows the continuation chain to focus on the main job.
- chained processing runs in an **unspecified thread**, possibly the EDT; any long processing must be added using **async** methods of CompletableFuture so EDT is not blocked. Currently, when using and waiting for `notify`, the whole thread is dedicated.
