### PR TITLE
Native Image debugger does not set print objects on. Checks added to prevent from exceptions.

### DIFF
--- a/cpplite/cpplite.debugger/nbproject/project.xml
+++ b/cpplite/cpplite.debugger/nbproject/project.xml
@@ -75,7 +75,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>0</release-version>
-                        <specification-version>0.5</specification-version>
+                        <specification-version>0.8</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteDebugger.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteDebugger.java
@@ -111,7 +111,7 @@ public final class CPPLiteDebugger {
         engineProvider = (CPPLiteDebuggerEngineProvider) contextProvider.lookupFirst(null, DebuggerEngineProvider.class);
     }
 
-    void setDebuggee(Process debuggee) {
+    void setDebuggee(Process debuggee, boolean printObjects) {
         this.debuggee = debuggee;
 
         CPPLiteInjector injector = new CPPLiteInjector(debuggee.getOutputStream());
@@ -139,7 +139,9 @@ public final class CPPLiteDebugger {
         proxy.send(new Command("-gdb-set target-async"));
         //proxy.send(new Command("-gdb-set scheduler-locking on"));
         proxy.send(new Command("-gdb-set non-stop on"));
-        proxy.send(new Command("-gdb-set print object on"));
+        if (printObjects) {
+            proxy.send(new Command("-gdb-set print object on"));
+        }
     }
 
     public void execRun() {
@@ -843,7 +845,7 @@ public final class CPPLiteDebugger {
                 }
             }
         });
-        debugger.setDebuggee(debuggee);
+        debugger.setDebuggee(debuggee, configuration.isPrintObjects());
         AtomicInteger exitCode = debugger.exitCode;
 
         return new Process() {

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteDebuggerConfig.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/CPPLiteDebuggerConfig.java
@@ -34,11 +34,12 @@ public final class CPPLiteDebuggerConfig {
 
     private final List<String> executable;
     private final ExplicitProcessParameters processParameters;
+    private final boolean printObjects;
     @NullAllowed
     private final Long processId;
     private final String debugger;
 
-    public CPPLiteDebuggerConfig(List<String> executable, ExplicitProcessParameters processParameters, @NullAllowed Long processId, String debugger) {
+    public CPPLiteDebuggerConfig(List<String> executable, ExplicitProcessParameters processParameters, boolean printObjects, @NullAllowed Long processId, String debugger) {
         this.processParameters = processParameters;
         this.processId = processId;
         this.debugger = debugger;
@@ -60,6 +61,7 @@ public final class CPPLiteDebuggerConfig {
         if (processParameters.getLauncherArguments() != null) {
             Exceptions.printStackTrace(new IllegalStateException("Launcher arguments " + processParameters.getLauncherArguments() + " can not be accepted by CPPLite debugger"));
         }
+        this.printObjects = printObjects;
     }
 
     public String getDisplayName() {
@@ -103,5 +105,9 @@ public final class CPPLiteDebuggerConfig {
 
     public String getDebugger() {
         return debugger;
+    }
+
+    public boolean isPrintObjects() {
+        return printObjects;
     }
 }

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/api/Debugger.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/api/Debugger.java
@@ -41,7 +41,7 @@ public class Debugger {
         CPPLiteDebugger[] debugger = new CPPLiteDebugger[] { null };
         ExplicitProcessParameters processParameters = ExplicitProcessParameters.builder().workingDirectory(directory).build();
         Process engineProcess = CPPLiteDebugger.startDebugging(
-                new CPPLiteDebuggerConfig(command, processParameters, null, "gdb"),
+                new CPPLiteDebuggerConfig(command, processParameters, true, null, "gdb"),
                 engine -> {
                     debugger[0] = engine.lookupFirst(null, CPPLiteDebugger.class);
                 });

--- a/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/ni/NIDebuggerProviderImpl.java
+++ b/cpplite/cpplite.debugger/src/org/netbeans/modules/cpplite/debugger/ni/NIDebuggerProviderImpl.java
@@ -95,6 +95,8 @@ public class NIDebuggerProviderImpl implements NIDebuggerProvider {
         List<String> command = debugParameters.getCommand();
         String miDebugger = debugParameters.getDebugger();
         String displayName = debugParameters.getDisplayName();
+        boolean printObjects = debugParameters.isDebuggerDisplayObjects();
+        Long processId = debugParameters.getProcessId();
         ExecutionDescriptor executionDescriptor = debugParameters.getExecutionDescriptor();
         Lookup contextLookup = debugParameters.getContextLookup();
         ExplicitProcessParameters explicitParameters = contextLookup != null ? ExplicitProcessParameters.buildExplicitParameters(contextLookup) : null;
@@ -117,7 +119,7 @@ public class NIDebuggerProviderImpl implements NIDebuggerProvider {
             try {
                 LifecycleManager.getDefault().saveAll();
                 engineProcess = CPPLiteDebugger.startDebugging(
-                        new CPPLiteDebuggerConfig(command, processParameters, null, miDebugger),
+                        new CPPLiteDebuggerConfig(command, processParameters, printObjects, processId, miDebugger),
                         engine -> {
                             debugger[0] = engine.lookupFirst(null, CPPLiteDebugger.class);
                             this.debugger = debugger[0];
@@ -143,6 +145,9 @@ public class NIDebuggerProviderImpl implements NIDebuggerProvider {
                         },
                         frameDisplayer,
                         variablesDisplayer);
+            } catch (Exception ex) {
+                completed.completeExceptionally(ex);
+                throw ex;
             } finally {
                 started.release();
             }
@@ -152,48 +157,6 @@ public class NIDebuggerProviderImpl implements NIDebuggerProvider {
         // Wait for the debugger to actually start up.
         // This is necessary to be able to safely call other methods on the NIDebuggerProvider.
         started.acquireUninterruptibly();
-        return completed;
-    }
-
-    @Override
-    public CompletableFuture<Void> attach(String executablePath, long processId, String miDebugger, Consumer<DebuggerEngine> startedEngine) {
-        if (debugger != null) {
-            throw new IllegalStateException("Debugger has started already.");
-        }
-        ExplicitProcessParameters processParameters = ExplicitProcessParameters.builder().workingDirectory(new File(System.getProperty("user.dir", ""))).build();   // NOI18N
-        CompletableFuture<Void> completed = new CompletableFuture<>();
-        try {
-            CPPLiteDebugger.startDebugging(
-                    new CPPLiteDebuggerConfig(Collections.singletonList(executablePath), processParameters, processId, miDebugger),
-                    engine -> {
-                        CPPLiteDebugger debugger = engine.lookupFirst(null, CPPLiteDebugger.class);
-                        this.debugger = debugger;
-                        if (startedEngine != null) {
-                            startedEngine.accept(engine);
-                        }
-                        debugger.addStateListener(new CPPLiteDebugger.StateListener() {
-                            @Override
-                            public void currentThread(CPPThread thread) {}
-
-                            @Override
-                            public void currentFrame(CPPFrame frame) {}
-
-                            @Override
-                            public void suspended(boolean suspended) {}
-
-                            @Override
-                            public void finished() {
-                                breakpointsHandler.dispose();
-                                completed.complete(null);
-                            }
-                        });
-                    },
-                    frameDisplayer,
-                    variablesDisplayer);
-        } catch (IOException ex) {
-            completed.completeExceptionally(ex);
-            return completed;
-        }
         return completed;
     }
 

--- a/cpplite/cpplite.debugger/test/unit/src/org/netbeans/modules/cpplite/debugger/AbstractDebugTest.java
+++ b/cpplite/cpplite.debugger/test/unit/src/org/netbeans/modules/cpplite/debugger/AbstractDebugTest.java
@@ -83,7 +83,7 @@ public abstract class AbstractDebugTest extends NbTestCase {
 
     protected final void startDebugging(List<String> executable, ExplicitProcessParameters processParameters) throws IOException {
         this.process = CPPLiteDebugger.startDebugging(
-                new CPPLiteDebuggerConfig(executable, processParameters, null, "gdb"),
+                new CPPLiteDebuggerConfig(executable, processParameters, true, null, "gdb"),
                 engine -> this.engine = engine);
         stdOut = outputFrom(process.getInputStream());
         stdErr = outputFrom(process.getErrorStream());

--- a/ide/nativeimage.api/manifest.mf
+++ b/ide/nativeimage.api/manifest.mf
@@ -2,5 +2,5 @@ Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
 OpenIDE-Module: org.netbeans.modules.nativeimage.api/0
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/nativeimage/api/Bundle.properties
-OpenIDE-Module-Specification-Version: 0.7
+OpenIDE-Module-Specification-Version: 0.8
 

--- a/ide/nativeimage.api/src/org/netbeans/modules/nativeimage/api/debug/NIDebugger.java
+++ b/ide/nativeimage.api/src/org/netbeans/modules/nativeimage/api/debug/NIDebugger.java
@@ -152,7 +152,9 @@ public final class NIDebugger {
      * @param startedEngine the corresponding DebuggerEngine is passed to this consumer
      * @return future that completes on the execution finish
      * @since 0.4
+     * @deprecated Use {@link #start(StartDebugParameters, Consumer) and set {@link StartDebugParameters.Builder#processID(long)}.
      */
+    @Deprecated
     public CompletableFuture<Void> attach(String executablePath, long processId, String debugger, Consumer<DebuggerEngine> startedEngine) {
         return provider.attach(executablePath,  processId, debugger, startedEngine);
     }

--- a/ide/nativeimage.api/src/org/netbeans/modules/nativeimage/api/debug/StartDebugParameters.java
+++ b/ide/nativeimage.api/src/org/netbeans/modules/nativeimage/api/debug/StartDebugParameters.java
@@ -20,6 +20,8 @@ package org.netbeans.modules.nativeimage.api.debug;
 
 import java.io.File;
 import java.util.List;
+import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NullAllowed;
 import org.netbeans.api.extexecution.ExecutionDescriptor;
 import org.openide.util.Lookup;
 
@@ -34,14 +36,20 @@ public final class StartDebugParameters {
     private final File workingDirectory;
     private final String debugger;
     private final String displayName;
+    private final boolean displayObjects;
+    private final Long processId;
     private final ExecutionDescriptor executionDescriptor;
     private final Lookup contextLookup;
 
-    private StartDebugParameters(List<String> command, File workingDirectory, String debugger, String displayName, ExecutionDescriptor executionDescriptor, Lookup contextLookup) {
+    private StartDebugParameters(List<String> command, File workingDirectory, String debugger,
+                                 String displayName, boolean displayObjects, Long processId,
+                                 ExecutionDescriptor executionDescriptor, Lookup contextLookup) {
         this.command = command;
         this.workingDirectory = workingDirectory;
         this.debugger = debugger;
         this.displayName = displayName;
+        this.displayObjects = displayObjects;
+        this.processId = processId;
         this.executionDescriptor = executionDescriptor;
         this.contextLookup = contextLookup;
     }
@@ -83,6 +91,30 @@ public final class StartDebugParameters {
     }
 
     /**
+     * Check whether debugger may display objects using it's own rules.
+     *
+     * @return <code>true</code> if debugger may display objects using it's own rules,
+     *         <code>false</code> otherwise.
+     * @since 0.8
+     */
+    public boolean isDebuggerDisplayObjects() {
+        return displayObjects;
+    }
+
+    /**
+     * Get a process ID to attach to.
+     * When <code>null</code>, the command is to be launched. Otherwise,
+     * the debugger is attached to process with that ID.
+     *
+     * @return the process ID to attach to, or <code>null</code> to launch the command.
+     * @since 0.8
+     */
+    @CheckForNull
+    public Long getProcessId() {
+        return processId;
+    }
+
+    /**
      * Execution descriptor that describes the runtime attributes.
      *
      * @return the execution descriptor
@@ -121,6 +153,8 @@ public final class StartDebugParameters {
         private File workingDirectory;
         private String debugger;
         private String displayName;
+        private boolean displayObjects = true;
+        private Long processId = null;
         private ExecutionDescriptor executionDescriptor;
         private Lookup contextLookup;
 
@@ -157,6 +191,29 @@ public final class StartDebugParameters {
         }
 
         /**
+         * Set whether debugger may display objects using it's own rules.
+         * It's <code>true</code> by default.
+         *
+         * @since 0.8
+         */
+        public Builder debuggerDisplayObjects(boolean displayObjects) {
+            this.displayObjects = displayObjects;
+            return this;
+        }
+
+        /**
+         * Set a process ID to attach to instead of launching the command. The command
+         * should correspond to the process.
+         * Use <code>null</code> to launch the command. It's <code>null</code> by default.
+         *
+         * @since 0.8
+         */
+        public Builder processID(@NullAllowed Long processId) { 
+            this.processId = processId;
+            return this;
+        }
+
+        /**
          * Set execution descriptor that describes the runtime attributes.
          *
          * @return the builder
@@ -182,7 +239,7 @@ public final class StartDebugParameters {
          * @return a new instance of {@link StartDebugParameters}.
          */
         public StartDebugParameters build() {
-            return new StartDebugParameters(command, workingDirectory, debugger, displayName, executionDescriptor, contextLookup);
+            return new StartDebugParameters(command, workingDirectory, debugger, displayName, displayObjects, processId, executionDescriptor, contextLookup);
         }
     }
 }

--- a/ide/nativeimage.api/src/org/netbeans/modules/nativeimage/spi/debug/NIDebuggerProvider.java
+++ b/ide/nativeimage.api/src/org/netbeans/modules/nativeimage/spi/debug/NIDebuggerProvider.java
@@ -127,7 +127,9 @@ public interface NIDebuggerProvider {
      * @param startedEngine the corresponding DebuggerEngine is passed to this consumer
      * @return future that completes on the execution finish
      * @since 0.4
+     * @deprecated Use {@link #start(StartDebugParameters, Consumer)} and set {@link StartDebugParameters.Builder#processID(long)}.
      */
+    @Deprecated
     default CompletableFuture<Void> attach(String executablePath, long processId, String debugger, Consumer<DebuggerEngine> startedEngine) {
         CompletableFuture cf = new CompletableFuture();
         cf.completeExceptionally(new UnsupportedOperationException());

--- a/java/java.lsp.server/nbproject/project.xml
+++ b/java/java.lsp.server/nbproject/project.xml
@@ -407,7 +407,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>0</release-version>
-                        <specification-version>0.5</specification-version>
+                        <specification-version>0.8</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/NbProtocolServer.java
@@ -523,6 +523,11 @@ public final class NbProtocolServer implements IDebugProtocolServer, LspSession.
                 evaluateJPDA(debugger, expression, threadId, response);
             } else {
                 NIDebugger niDebugger = context.getDebugSession().getNIDebugger();
+                if (niDebugger == null) {
+                    throw ErrorUtilities.createResponseErrorException(
+                        "No active debugger is found.",
+                        ResponseErrorCode.RequestCancelled);
+                }
                 evaluateNative(niDebugger, expression, threadId, response);
             }
             return response;

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/NbAttachRequestHandler.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/attach/NbAttachRequestHandler.java
@@ -24,6 +24,7 @@ import com.sun.jdi.connect.Connector.Argument;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -50,6 +51,7 @@ import org.netbeans.modules.java.lsp.server.debugging.utils.ErrorUtilities;
 import org.netbeans.modules.java.lsp.server.protocol.NbCodeLanguageClient;
 import org.netbeans.modules.java.nativeimage.debugger.api.NIDebugRunner;
 import org.netbeans.modules.nativeimage.api.debug.NIDebugger;
+import org.netbeans.modules.nativeimage.api.debug.StartDebugParameters;
 import org.openide.util.NbBundle;
 import org.openide.util.NbBundle.Messages;
 import org.openide.util.RequestProcessor;
@@ -122,7 +124,13 @@ public final class NbAttachRequestHandler {
         NIDebugger niDebugger;
         resultFuture.complete(null);
         try {
-            niDebugger = NIDebugRunner.attach(nativeImageFile, processId, miDebugger, null, engine -> {
+            StartDebugParameters startParams = StartDebugParameters.newBuilder(Collections.singletonList(nativeImageFile.getAbsolutePath()))
+                    .debugger(miDebugger)
+                    .debuggerDisplayObjects(false)
+                    .processID(processId)
+                    .workingDirectory(new File(System.getProperty("user.dir", ""))) // NOI18N
+                    .build();
+            niDebugger = NIDebugRunner.start(nativeImageFile, startParams, null, engine -> {
                 Session session = engine.lookupFirst(null, Session.class);
                 NbDebugSession debugSession = new NbDebugSession(session);
                 debugSessionRef.set(debugSession);

--- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
+++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/debugging/launch/NbLaunchDelegate.java
@@ -436,6 +436,7 @@ public abstract class NbLaunchDelegate {
         List<String> command = join(nativeImageFile.getAbsolutePath(), args);
         StartDebugParameters.Builder parametersBuilder = StartDebugParameters.newBuilder(command)
                 .debugger(miDebugger)
+                .debuggerDisplayObjects(false)
                 .executionDescriptor(executionDescriptor)
                 .lookup(contextLookup);
         StartDebugParameters parameters = parametersBuilder.build();

--- a/java/java.nativeimage.debugger/nbproject/project.xml
+++ b/java/java.nativeimage.debugger/nbproject/project.xml
@@ -85,7 +85,7 @@
                     <compile-dependency/>
                     <run-dependency>
                         <release-version>0</release-version>
-                        <specification-version>0.5</specification-version>
+                        <specification-version>0.8</specification-version>
                     </run-dependency>
                 </dependency>
                 <dependency>

--- a/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/actions/NIAttachCustomizer.java
+++ b/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/actions/NIAttachCustomizer.java
@@ -422,11 +422,14 @@ public class NIAttachCustomizer extends javax.swing.JPanel {
                 }
                 File file = new File(filePath);
                 String displayName = COMMAND_DEBUG + " " + file.getName();
-                if (attach2Process != null) {
-                    NIDebugRunner.attach(file, attach2Process.getPid(), debuggerCommand, null, null);
-                } else {
-                    NIDebugRunner.start(file, Collections.emptyList(), debuggerCommand, null, displayName, null, null);
-                }
+                StartDebugParameters startParams = StartDebugParameters.newBuilder(Collections.singletonList(file.getAbsolutePath()))
+                        .debugger(debuggerCommand)
+                        .debuggerDisplayObjects(false)
+                        .displayName(displayName)
+                        .processID(attach2Process != null ? attach2Process.getPid() : null)
+                        .workingDirectory(new File(System.getProperty("user.dir", ""))) // NOI18N
+                        .build();
+                NIDebugRunner.start(file, startParams, null, null);
             });
             return true;
         }

--- a/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/api/NIDebugRunner.java
+++ b/java/java.nativeimage.debugger/src/org/netbeans/modules/java/nativeimage/debugger/api/NIDebugRunner.java
@@ -127,7 +127,9 @@ public final class NIDebugRunner {
      * @return an instance of {@link NIDebugger}.
      * @throws IllegalStateException when the native debugger is not available.
      * @since 0.3
+     * @deprecated Use {@link #start(File, StartDebugParameters, Project, Consumer) and set {@link StartDebugParameters.Builder#processID(long)}.
      */
+    @Deprecated
     public static NIDebugger attach(File niFile, long processId, String debuggerCommand, Project project, Consumer<DebuggerEngine> startedEngine) throws IllegalStateException {
         JavaVariablesDisplayer variablesDisplayer = new JavaVariablesDisplayer();
         JavaFrameDisplayer frameDisplayer = new JavaFrameDisplayer(project);


### PR DESCRIPTION
In order to be able to retrieve runtime type information from native image, we must not set "print objects" GDB setting to "on". When it's on, we get some memory access issues from GDB.
To be able to turn it off for native image debugging (we want to have it on for C/C++), we need to add `displayObjects` flag into `StartDebugParameters`. We need to have it for both launch and attach, thus I've added `processId` as well and deprecated `attach` method.
Retrieval of runtime type information is added into `JavaVariablesDisplayer` and some additional checks are added to prevent from exceptions.