### PR TITLE
Updated Gradle CLI option support.

### DIFF
--- a/extide/gradle/apichanges.xml
+++ b/extide/gradle/apichanges.xml
@@ -83,6 +83,18 @@ is the proper place.
     <!-- ACTUAL CHANGES BEGIN HERE: -->
 
     <changes>
+        <change id="gradle-cli-update">
+            <api name="general"/>
+            <summary>GradleCommandLine Flag, Parameter, and Property implements GradleOptionItem interface</summary>
+            <version major="2" minor="23"/>
+            <date day="17" month="2" year="2022"/>
+            <author login="lkishalmi"/>
+            <compatibility semantic="compatible" addition="yes"/>
+            <description>
+                Added GradleOptionItem interface to <code><a href="@TOP@/org/netbeans/modules/gradle/api/execute/GradleCommandLine.html">GradleCommandLine</a></code> 
+                in order to support a common interface for Flaf, Parameter, and Property enums.
+            </description>
+        </change>
         <change id="tooling-runWorkingDir-runEnvironment">
             <api name="general"/>
             <summary>NetBeans Tooling plugin recognizes "runWorkingDir" and "runEnvironment" properties.</summary>

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/Bundle.properties
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/Bundle.properties
@@ -15,45 +15,64 @@
 # specific language governing permissions and limitations
 # under the License.
 
-NO_REBUILD_DSC=Do not rebuild project dependencies. [deprecated]
-CONFIGURE_ON_DEMAND_DSC=Configure necessary projects only. Gradle will attempt to reduce configuration time for large multi-project builds. [incubating]
-NO_CONFIGURE_ON_DEMAND_DSC=Disables the use of configuration on demand. [incubating]
-CONTINUE_DSC=Continue task execution after a task failure.
-DRY_RUN_DSC=Run the builds with all task actions disabled.
-OFFLINE_DSC=Execute the build without accessing network resources.
-PARALLEL_DSC=Build projects in parallel. Gradle will attempt to determine the optimal number of executor threads to use. [incubating]
-NO_PARALLEL_DSC=Disables parallel execution to build projects. [incubating]
-RECOMPILE_SCRIPTS_DSC= Force build script recompiling. [deprecated]
-REFRESH_DEPENDENCIES_DSC=Refresh the state of dependencies.
-RERUN_TASKS_DSC= Ignore previously cached task results.
-MAX_WORKERS_DSC=Configure the number of concurrent workers Gradle is allowed to use. [incubating]
-INCLUDE_BUILD_DSC=Include the specified build in the composite. [incubating]
+BUILD_CACHE_DSC=<p>Enables the Gradle build cache.<br/>Gradle will try to reuse outputs from previous builds.</p>
+BUILD_FILE_DSC=<p>Specify the build file.</p><b>[deprecated]</b>
+CONFIGURATION_CACHE_DSC=<p>Enables the configuration cache.<br/>Gradle will try to reuse the build configuration from previous builds.</p><b>[incubating]</b>
+CONFIGURATION_CACHE_PROBLEMS_DSC=<p>Configures how the configuration cache handles problems (<b>fail</b> or <b>warn</b>). Defaults to <b>fail</b>.</p><b>[incubating]</b>
+CONFIGURE_ON_DEMAND_DSC=<p>Configure necessary projects only.<br/>Gradle will attempt to reduce configuration time for large multi-project builds.</p><b>[incubating]</b>
+CONSOLE_DSC=<p>Specifies which type of console output to generate. Values are <b>'plain'</b>, <b>'auto'</b> (default), <b>'rich'</b> or <b>'verbose'</b>.</p>
+CONTINUE_DSC=<p>Continue task execution after a task failure.</p>
+CONTINUOUS_DSC=<p>Enables continuous build.<br/>Gradle does not exit and will re-execute tasks when task file inputs change.</p>
+DAEMON_DSC=<p>Uses the Gradle Daemon to run the build. Starts the Daemon if not running.</p><p>Builds running through the IDE are always using a daemon.</p>
+DEPENDENCY_VERIFICATION_DSC=<p>Configures the dependency verification mode.<br/>Values are '<b>strict</b>', '<b>lenient</b>' or '<b>off</b>'.</p>
+DRY_RUN_DSC=<p>Run the builds with all task actions disabled.</p>
+EXCLUDE_TASK_DSC=<p>Specify a task to be excluded from execution.</p>
+EXPORT_KEYS_DSC=<p>Exports the public keys used for dependency verification.</p>
+FOREGROUND_DSC=<p>Starts the Gradle Daemon in the foreground.</p>
+GUI_DSC=<p>The Gradle GUI has been removed in Gradle 4.0.</p>
+GRADLE_USER_HOME_DSC=<p>Specifies the Gradle user home directory.</p>
+HELP_DSC=<p>Shows the help message.</p>
+INCLUDE_BUILD_DSC=<p>Include the specified build in the composite.</p>
+INIT_SCRIPT_DSC=<p>Specify an initialization script.</p>
+LOG_DEBUG_DSC=<p>Log in <b>debug</b> mode (includes normal stacktrace)</p>
+LOG_INFO_DSC=<p>Set log level to <b>info</b>.</p>
+LOG_QUIET_DSC=<p>Log errors only.</p>
+LOG_WARN_DSC=<p>Set log level to <b>warn</b>.</p>
+MAX_WORKER_DSC=<p>Configure the number of concurrent workers Gradle is allowed to use.</p>
+NO_BUILD_CACHE_DSC=<p>Disables the Gradle build cache.</p>
+NO_CONFIGURATION_CACHE_DSC=<p>Disables the configuration cache.</p><b>[incubating]</b>
+NO_CONFIGURE_ON_DEMAND_DSC=<p>Disables the use of configuration on demand.</p><b>[incubating]</b>
+NO_DAEMON_DSC=<p>Do not use the Gradle daemon to run the build.<br/>Useful occasionally if you have configured Gradle to always run with the daemon by default.</p><p>Builds running through the IDE are always using a daemon.</p>
+NO_PARALLEL_DSC=<p>Disables parallel execution to build projects.</p>
+NO_REBUILD_DSC=<p>Do not rebuild project dependencies.</p><p>Useful for debugging and fine-tuning buildSrc, but can lead to wrong results. Use with caution!</p>
+NO_SCAN_DSC=<p>Disables the creation of a build scan. For more information about build scans, please visit <a href="https://gradle.com/build-scans">https://gradle.com/build-scans</a>.</p>
+NO_SEARCH_UPWARD_DSC=<p>Don't search in parent folders for a settings file.</p><p>Removed in Gradle 5.0</p>
+NO_WATCH_FS_DSC=<p>Disables watching the file system.</p>
+OFFLINE_DSC=<p>Execute the build without accessing network resources.</p>
+PARALLEL_DSC=<p>Build projects in parallel.<br/>Gradle will attempt to determine the optimal number of executor threads to use.</p>
+PRIORITY_DSC=<p>Specifies the scheduling priority for the Gradle daemon and all processes launched by it. Values are '<b>normal</b>' (default) or '<b>low</b>'
+PROJECT_DSC=<p>Set project property for the build script (e.g. -Pmyprop=myvalue)</p>
+PROJECT_CACHE_DIR_DSC=<p>Specify the project-specific cache directory. Defaults to .gradle in the root project directory.</p>
+PROJECT_DIR_DSC=<p>Specifies the start directory for Gradle. Defaults to current directory.</p>
+PROFILE_DSC=<p>Profile build execution time and generates a report in the <build_dir>/reports/profile directory.</p>
+RECOMPILE_SCRIPTS_DSC=<p>Force build script recompiling.</p><p>Removed in Gradle 5.0</p>
+REFRESH_DEPENDENCIES_DSC=<p>Refresh the state of dependencies.</p>
+REFRESH_KEYS_DSC=<p>Refresh the public keys used for dependency verification.</p>
+RERUN_TASKS_DSC=<p>Ignore previously cached task results.</p>
+SCAN_DSC=<p>Creates a build scan.<br/>Gradle will emit a warning if the build scan plugin has not been applied. (<a href="https://gradle.com/build-scans">https://gradle.com/build-scans</a>)</p>
+SETTINGS_FILE_DSC=<p>Specify the settings file.</p><b>[deprecated]</b>
+STATUS_DSC=<p>Shows status of running and recently stopped Gradle Daemon(s).</p>
+STACKTRACE_DSC=<p>Print out the stacktrace for all exceptions.</p>
+STACKTRACE_FULL_DSC=<p>Print out the full (very verbose) stacktrace for all exceptions.</p>
+STOP_DSC=<p>Stops the Gradle Daemon if it is running.</p>
+SYSTEM_DSC=<p>Set system property of the JVM (e.g. -D<b>myprop</b>=<b>myvalue</b>).</b>
+UPDATE_LOCKS_DSC=<p>Perform a partial update of the dependency lock, letting passed in module notations change version.</p><b>[incubating]</b>
+VERSION_DSC=<p>Print version info.</p>
+WARNING_MODE_DSC=<p>Specifies which mode of warnings to generate. Values are '<b>all</b>', '<b>fail</b>', '<b>summary</b>'(default) or '<b>none</b>'
+WATCH_FS_DSC=<p>Enables watching the file system for changes, allowing data about the file system to be re-used for the next build.</p>
+WRITE_LOCKS_DSC=<p>Persists dependency resolution for locked configurations, ignoring existing locking information if it exists.</p>
+WRITE_VERIFICATION_METADATA_DSC=<p>Generates checksums for dependencies used in the project (comma-separated list)</p><p><b>Example:</b><code>./gradlew --write-verification-metadata sha256</code></p>
 
-BUILD_CACHE_DSC=Enables the Gradle build cache. Gradle will try to reuse outputs from previous builds.
-NO_BUILD_CACHE_DSC=Disables the Gradle build cache.
-LOG_DEBUG_DSC=Log in debug mode (includes normal stacktrace)
-LOG_INFO_DSC= Set log level to info.
-LOG_QUIET_DSC=Log errors only.
-LOG_WARN_DSC=Set log level to warn.
-
-STACKTRACE_DSC= Print out the stacktrace for all exceptions.
-STACKTRACE_FULL_DSC=Print out the full (very verbose) stacktrace for all exceptions.
-
-DAEMON_DSC= Uses the Gradle Daemon to run the build. Starts the Daemon if not running.
-NO_DAEMON_DSC= Do not use the Gradle daemon to run the build. Useful occasionally if you have configured Gradle to always run with the daemon by default.
-HELP_DSC=Shows this help message.
-FOREGROUND_DSC= Starts the Gradle Daemon in the foreground. [incubating]
-
-GUI_DSC=Launches the Gradle GUI.
-PROFILE_DSC=Profile build execution time and generates a report in the <build_dir>/reports/profile directory.
-STATUS_DSC=Shows status of running and recently stopped Gradle Daemon(s).
-STOP_DSC=Stops the Gradle Daemon if it is running.
-CONTINUOUS_DSC= Enables continuous build. Gradle does not exit and will re-execute tasks when task file inputs change. [incubating]
-NO_SEARCH_UPWARD_DSC=Don't search in parent folders for a settings file.
-VERSION_DSC=Set log level to warn.
-
-SCAN_DSC=Creates a build scan. Gradle will emit a warning if the build scan plugin has not been applied. (https://gradle.com/build-scans) [incubating]
-NO_SCAN_DSC=Disables the creation of a build scan. For more information about build scans, please visit https://gradle.com/build-scans. [incubating]
 
 # A distribution can choose policy on presence / ordering of options.
 # 0, missing, or non-numeric value means the option is not presented. 

--- a/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleCommandLine.java
+++ b/extide/gradle/src/org/netbeans/modules/gradle/api/execute/GradleCommandLine.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.HashSet;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -83,41 +84,58 @@ public final class GradleCommandLine implements Serializable {
     public static final String CHECK_TASK = "check"; //NOI18N
 
     /**
+     * 
+     * @since 2.23
+     */
+    public interface GradleOptionItem {
+        boolean isSupported();
+        List<String> getFlags();
+        String getDescription();
+    }
+    /**
      * Gradle command line flags
      */
-    public enum Flag {
-        NO_REBUILD(PARAM, "-a", "--no-rebuild"),
+    public enum Flag implements GradleOptionItem {
         BUILD_CACHE(PARAM, "--build-cache"),
+        CONFIGURATION_CACHE(PARAM, "--configuration-cache"),
         CONFIGURE_ON_DEMAND(PARAM, "--configure-on-demand"),
         CONTINUE(PARAM, "--continue"),
-        DRY_RUN(PARAM, "-m", "--dry-run"),
-        OFFLINE(PARAM, "--offline"),
-        PARALLEL(PARAM, "--parallel"),
-        REFRESH_DEPENDENCIES(PARAM, "--refresh-dependencies"),
-        RERUN_TASKS(PARAM, "--rerun-tasks"),
-        LOG_DEBUG(PARAM, "-d", "--debug"),
-        LOG_INFO(PARAM, "-i", "--info"),
-        LOG_WARN(PARAM, "-w", "--warn"),
-        LOG_QUIET(PARAM, "-q", "--quiet"),
-        STACKTRACE(PARAM, "-s", "--stacktrace"),
-        STACKTRACE_FULL(PARAM, "-S", "--full-stacktrace"),
-        PROFILE(PARAM, "--profile"),
-        NO_BUILD_CACHE(PARAM, "--no-build-cache"),
-        NO_CONFIGURE_ON_DEMAND(PARAM, "--no-configure-on-demand"),
-        NO_PARALLEL(PARAM, "--no-parallel"),
         CONTINUOUS(PARAM, "--continuous", "-t"),
-        SCAN(PARAM, "--scan"),
-        NO_SCAN(PARAM, "--no-scan"),
-        DAEMON(UNSUPPORTED, "--no-daemon"),
-        NO_DAEMON(UNSUPPORTED, "--daemon"),
-        HELP(UNSUPPORTED, "--help", "-h", "-?"),
+        DAEMON(UNSUPPORTED, "--daemon"),
+        DRY_RUN(PARAM, "-m", "--dry-run"),
+        EXPORT_KEYS(PARAM, "--export-keys"),
         FOREGROUND(UNSUPPORTED, "--foreground"),
         GUI(UNSUPPORTED, "--gui"),
+        HELP(UNSUPPORTED, "--help", "-h", "-?"),
+        LOG_DEBUG(PARAM, "-d", "--debug"),
+        LOG_INFO(PARAM, "-i", "--info"),
+        LOG_QUIET(PARAM, "-q", "--quiet"),
+        LOG_WARN(PARAM, "-w", "--warn"),
+        NO_BUILD_CACHE(PARAM, "--no-build-cache"),
+        NO_CONFIGURATION_CACHE(PARAM, "--no-configuration-cache"),
+        NO_CONFIGURE_ON_DEMAND(PARAM, "--no-configure-on-demand"),
+        NO_DAEMON(UNSUPPORTED, "--no-daemon"),
+        NO_PARALLEL(PARAM, "--no-parallel"),
+        NO_REBUILD(PARAM, "-a", "--no-rebuild"),
+        NO_SCAN(PARAM, "--no-scan"),
+        NO_SEARCH_UPWARD(UNSUPPORTED, "--no-search-upward", "-u"),
+        NO_WATCH_FS(PARAM, "--no-watch-fs"),
+        OFFLINE(PARAM, "--offline"),
+        PARALLEL(PARAM, "--parallel"),
+        PROFILE(PARAM, "--profile"),
+        RECOMPILE_SCRIPTS(UNSUPPORTED, "--recompile-scripts"),
+        REFRESH_DEPENDENCIES(PARAM, "--refresh-dependencies"),
+        REFRESH_KEYS(PARAM, "--refresh-keys"),
+        RERUN_TASKS(PARAM, "--rerun-tasks"),
+        SCAN(PARAM, "--scan"),
+        STACKTRACE(PARAM, "-s", "--stacktrace"),
+        STACKTRACE_FULL(PARAM, "-S", "--full-stacktrace"),
         STATUS(UNSUPPORTED, "--status"),
         STOP(UNSUPPORTED, "--stop"),
-        NO_SEARCH_UPWARD(UNSUPPORTED, "--no-search-upward", "-u"),
-        RECOMPILE_SCRIPTS(UNSUPPORTED, "--recompile-scripts"),
-        VERSION(UNSUPPORTED, "--version", "-v");
+        UPDATE_LOCKS(PARAM, "--update-locks"),
+        VERSION(UNSUPPORTED, "--version", "-v"),
+        WATCH_FS(PARAM, "--watch-fs"),
+        WRITE_LOCKS(PARAM,"--write-locks");
 
         private Set<Flag> incompatible = Collections.emptySet();
         private final Argument.Kind kind;
@@ -138,6 +156,9 @@ public final class GradleCommandLine implements Serializable {
             SCAN.incompatibleWith(NO_SCAN);
             NO_SCAN.incompatibleWith(SCAN);
 
+            CONFIGURATION_CACHE.incompatibleWith(NO_CONFIGURATION_CACHE);
+            NO_CONFIGURATION_CACHE.incompatibleWith(CONFIGURATION_CACHE);
+            
             CONFIGURE_ON_DEMAND.incompatibleWith(NO_CONFIGURE_ON_DEMAND);
             NO_CONFIGURE_ON_DEMAND.incompatibleWith(CONFIGURE_ON_DEMAND);
 
@@ -146,6 +167,9 @@ public final class GradleCommandLine implements Serializable {
 
             PARALLEL.incompatibleWith(NO_PARALLEL);
             NO_PARALLEL.incompatibleWith(PARALLEL);
+            
+            WATCH_FS.incompatibleWith(NO_WATCH_FS);
+            NO_WATCH_FS.incompatibleWith(WATCH_FS);
         }
 
         private Flag(Argument.Kind kind, String... flags) {
@@ -157,20 +181,23 @@ public final class GradleCommandLine implements Serializable {
             incompatible = Collections.unmodifiableSet(EnumSet.of(first, rest));
         }
 
+        @Override
         public boolean isSupported() {
             return kind != UNSUPPORTED;
         }
 
+        @Override
         public List<String> getFlags() {
             return flags;
         }
 
+        @Override
         public final String getDescription() {
             return NbBundle.getMessage(GradleCommandLine.class, this.name() + "_DSC");
         }
     }
 
-    public enum Property {
+    public enum Property implements GradleOptionItem {
         PROJECT(PARAM, "-P", "--project-prop"),
         SYSTEM(Argument.Kind.SYSTEM, "-D", "--system-prop");
 
@@ -184,27 +211,75 @@ public final class GradleCommandLine implements Serializable {
             this.flag = flag;
         }
 
+        @Override
+        public boolean isSupported() {
+            return true;
+        }
+
+        @Override
+        public List<String> getFlags() {
+            return Collections.singletonList(flag);
+        }
+
+        @Override
+        public String getDescription() {
+            return NbBundle.getMessage(GradleCommandLine.class, this.name() + "_DSC");
+        }
+
     }
 
-    public enum Parameter {
+    public enum Parameter implements GradleOptionItem {
 
-        SETTINGS_FILE(UNSUPPORTED, "-c", "--settings-file"),
-        CONSOLE(UNSUPPORTED, "--console"),
+        BUILD_FILE(UNSUPPORTED, "-b", "--build-file"),
+        CONFIGURATION_CACHE_PROBLEMS(PARAM, argValues("fail", "warn"), "--configuration-cache-problems"),
+        CONSOLE(UNSUPPORTED, argValues("plain", "auto", "rich", "verbose"), "--console"),
+        DEPENDENCY_VERIFICATION(PARAM, argValues("strict", "lenient", "off"), "-F", "--dependency-verification"),
+        EXCLUDE_TASK(PARAM, "-x", "--exclude-task"),
         GRADLE_USER_HOME(UNSUPPORTED, "-g", "--gradle-user-home"),
         INIT_SCRIPT(PARAM, "-I", "--init-script"),
-        MAX_WORKER(PARAM, "--max-worker"),
-        PROJECT_DIR(PARAM, "-p", "--project-dir"),
-        PROJECT_CACHE_DIR(UNSUPPORTED, "--project-cache-dir"),
-        EXCLUDE_TASK(PARAM, "-x", "--exclude-task"),
+        @Deprecated
         IMPORT_BUILD(UNSUPPORTED),
-        INCLUDE_BUILD(PARAM, "--include-build");
+        INCLUDE_BUILD(PARAM, "--include-build"),
+        MAX_WORKER(PARAM, "--max-worker"),
+        PRIORITY(PARAM, argValues("normal", "low"), "--priority"),
+        PROJECT_CACHE_DIR(UNSUPPORTED, "--project-cache-dir"),
+        PROJECT_DIR(PARAM, "-p", "--project-dir"),
+        @Deprecated
+        SETTINGS_FILE(UNSUPPORTED, "-c", "--settings-file"),
+        WARNING_MODE(PARAM, argValues("all", "fail", "summary", "none"),"--warning-mode"),
+        WRITE_VERIFICATION_METADATA(PARAM, "-M", "write-verification-metadata");
 
         final Argument.Kind kind;
         final List<String> flags;
+        final Argument.Values values;
 
         Parameter(Argument.Kind kind, String... flags) {
+            this(kind, Argument.Values.ANY, flags);
+        }
+        
+        Parameter(Argument.Kind kind, Argument.Values values, String... flags) {
             this.kind = kind;
+            this.values = values;
             this.flags = Arrays.asList(flags);
+        }
+        
+        private static Argument.Values argValues(String... values) {
+            return new Argument.Values(values);
+        }
+
+        @Override
+        public boolean isSupported() {
+            return kind != UNSUPPORTED;
+        }
+
+        @Override
+        public List<String> getFlags() {
+            return flags;
+        }
+
+        @Override
+        public String getDescription() {
+            return NbBundle.getMessage(GradleCommandLine.class, this.name() + "_DSC");
         }
     }
 
@@ -215,6 +290,15 @@ public final class GradleCommandLine implements Serializable {
             PARAM, SYSTEM, UNSUPPORTED
         }
 
+        static final class Values {
+            public static final Values ANY = new Values();
+            final String[] values;
+            
+            private Values(String... values) {
+                this.values = values;
+            }
+        }
+        
         Kind getKind();
 
         List<String> getArgs();
@@ -536,8 +620,12 @@ public final class GradleCommandLine implements Serializable {
         arguments.add(FlagArgument.of(flag));
     }
 
-    public boolean canAdd(Flag f) {
-        EnumSet<Flag> reserved = EnumSet.noneOf(Flag.class);
+    public boolean canAdd(Flag flag) {
+        return canAdd((GradleOptionItem) flag);
+    }
+    
+    public boolean canAdd(GradleOptionItem item) {
+        Set<GradleOptionItem> reserved = new HashSet<>();
         Iterator<Argument> it = arguments.iterator();
         while (it.hasNext()) {
             Argument arg = it.next();
@@ -547,7 +635,7 @@ public final class GradleCommandLine implements Serializable {
                 reserved.addAll(farg.flag.incompatible);
             }
         }
-        return !reserved.contains(f);
+        return !reserved.contains(item);
     }
 
     public void removeFlag(Flag flag) {

--- a/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/execute/GradleCommandLineTest.java
+++ b/extide/gradle/test/unit/src/org/netbeans/modules/gradle/api/execute/GradleCommandLineTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.MissingResourceException;
 import java.util.Set;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -303,5 +304,23 @@ public class GradleCommandLineTest {
         List<String> jvmargs = new ArrayList<>();
         GradleCommandLine.addGradleSettingJvmargs(root.getRoot(), jvmargs);
         assertEquals(Arrays.asList("-Dfile.encoding=UTF-8", "-Dsomething=space value"), jvmargs);
+    }
+    
+    @Test
+    public void testDescriptions() {
+        Set<GradleCommandLine.GradleOptionItem> all = new HashSet<>();
+        all.addAll(Arrays.asList(GradleCommandLine.Flag.values()));
+        all.addAll(Arrays.asList(GradleCommandLine.Parameter.values()));
+        all.addAll(Arrays.asList(GradleCommandLine.Property.values()));
+        all.remove(GradleCommandLine.Parameter.IMPORT_BUILD);
+        List<GradleCommandLine.GradleOptionItem> missing = new ArrayList<>();
+        for (GradleCommandLine.GradleOptionItem item : all) {
+            try {
+                assertNotNull(item.getDescription());
+            } catch (MissingResourceException ex){
+                missing.add(item);
+            }
+        }
+        assertTrue(missing.toString(), missing.isEmpty());
     }
 }


### PR DESCRIPTION
Updated GradleCommandLine to support options according to Gradle 7.4

Even if it not nice regarding binary compatibility, I has to arrange the enums in alphabetic order, in order not to get mixed up when working on them.

Also Gradle options which expecting parameters are shown in the code completion. Those options which expect well defined values are stored in the parameter enum. Later on I plan to expand the code completion to use them as well.
