### PR TITLE
Fixed processing env variables with '=' in value

### DIFF
--- a/java/java.lsp.server/vscode/src/runConfiguration.ts
+++ b/java/java.lsp.server/vscode/src/runConfiguration.ts
@@ -70,8 +70,11 @@ class RunConfigurationProvider implements vscode.DebugConfigurationProvider {
 					config.env = {};
 				}
 				for (let val of envs) {
-					const vals = val.trim().split('=');
-					config.env[vals[0]] = vals[1];
+					val = val.trim();
+					const div = val.indexOf('=');
+					if (div > 0) { // div === 0 means bad format (no ENV name)
+						config.env[val.substring(0, div)] = val.substring(div + 1, val.length);
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixed an issue with environment variables containing the '=' character in their values. Now only the first appearance of '=' is used as a separator identifying variable name and value.