### PR TITLE
Use the blessed modifier order in projects located in groovy projects

### DIFF
--- a/groovy/groovy.editor/test/qa-functional/src/org/netbeans/test/groovy/GeneralGroovy.java
+++ b/groovy/groovy.editor/test/qa-functional/src/org/netbeans/test/groovy/GeneralGroovy.java
@@ -45,7 +45,7 @@ public class GeneralGroovy extends JellyTestCase {
     static final String JAVA_CATEGORY_NAME = "Java";
     static final String GROOVY_CATEGORY_NAME = "Groovy";
     static final String JAVA_PROJECT_NAME = "Java Application";
-    static protected final int COMPLETION_LIST_THRESHOLD = 5000;
+    protected static final int COMPLETION_LIST_THRESHOLD = 5000;
     protected static final String GROOVY_EXTENSION = ".groovy";
     protected static final String SAMPLES = "Samples";
     protected static final String SAMPLES_CATEGORY = "Groovy";

--- a/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/ui/WhereUsedPanel.java
+++ b/groovy/groovy.refactoring/src/org/netbeans/modules/groovy/refactoring/ui/WhereUsedPanel.java
@@ -284,7 +284,7 @@ public class WhereUsedPanel extends JPanel implements CustomRefactoringPanel {
         }
     }
 
-    static abstract class WhereUsedInnerPanel extends JPanel {
+    abstract static class WhereUsedInnerPanel extends JPanel {
         abstract boolean isSearchInComments();
         abstract void initialize(RefactoringElement element);
     }

--- a/groovy/groovy.support/src/org/netbeans/modules/groovy/support/actions/singlefilerun/SingleGroovySourceRunActionProvider.java
+++ b/groovy/groovy.support/src/org/netbeans/modules/groovy/support/actions/singlefilerun/SingleGroovySourceRunActionProvider.java
@@ -97,7 +97,7 @@ public class SingleGroovySourceRunActionProvider implements ActionProvider {
         return isSingleSourceFile(getGroovyFile(context));
     }
 
-    static private boolean isSingleSourceFile(FileObject fileObject) {
+    private static boolean isSingleSourceFile(FileObject fileObject) {
         if (fileObject == null) {
             return false;
         }
@@ -105,7 +105,7 @@ public class SingleGroovySourceRunActionProvider implements ActionProvider {
         return p == null;
     }
     
-    static private FileObject getGroovyFile(Lookup lookup) {
+    private static FileObject getGroovyFile(Lookup lookup) {
         for (DataObject dObj : lookup.lookupAll(DataObject.class)) {
             FileObject fObj = dObj.getPrimaryFile();
             if (GROOVY_EXTENSION.equals(fObj.getExt().toLowerCase())) {


### PR DESCRIPTION
This replaces patterns such as "final public" with "public final" to bring the modifiers in the standard order for the projects in the groovy folder.

See: https://rules.sonarsource.com/java/RSPEC-1124

---

By opening a pull request you confirm that, unless explicitly stated otherwise, the changes -

 - are all your own work, and you have the right to contribute them.
 - are contributed solely under the terms and conditions of the Apache License 2.0 (see section 5 of the license for more information).

Please make sure (eg. `git log`) that all commits have a valid name and email address for you in the Author field.

If you're a first time contributor, see the Contributing guidelines for more information.

